### PR TITLE
fix: run pre-commit through uv in justfile precommit recipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`just precommit` recipe** - Run pre-commit through `uv run` to ensure it uses the virtual environment ([#46](https://github.com/vig-os/devcontainer/issues/46))
 - **Pytest test collection** - Exclude `tests/tmp/` directory (integration test workspaces) from test discovery to prevent import errors
 
 ### Security

--- a/assets/workspace/.devcontainer/justfile.base
+++ b/assets/workspace/.devcontainer/justfile.base
@@ -22,7 +22,7 @@ format:
 # Run pre-commit hooks on all files
 [group('quality')]
 precommit:
-    pre-commit run --all-files
+    uv run pre-commit run --all-files
 
 # ───────────────────────────────────────────────────────────────────────────────
 # TESTING

--- a/assets/workspace/justfile
+++ b/assets/workspace/justfile
@@ -8,10 +8,13 @@ help:
     @just --list
 
 # Import devcontainer-managed base recipes (replaced on upgrade)
+
 import '.devcontainer/justfile.base'
 
 # Import team-shared project recipes (git-tracked, preserved on upgrade)
+
 import? 'justfile.project'
 
 # Import personal recipes (gitignored, preserved on upgrade)
+
 import? 'justfile.local'

--- a/justfile.base
+++ b/justfile.base
@@ -22,7 +22,7 @@ format:
 # Run pre-commit hooks on all files
 [group('quality')]
 precommit:
-    pre-commit run --all-files
+    uv run pre-commit run --all-files
 
 # ───────────────────────────────────────────────────────────────────────────────
 # TESTING


### PR DESCRIPTION
## Description

Fix the `just precommit` recipe to run `pre-commit` through `uv run`, ensuring it uses the project's virtual environment where pre-commit is installed.

## Related Issue(s)

Closes #46

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Test updates

## Changes Made

- **justfile.base** (+1/-1): Changed `pre-commit run --all-files` → `uv run pre-commit run --all-files`
- **assets/workspace/.devcontainer/justfile.base** (+1/-1): Same fix for workspace template
- **assets/workspace/justfile** (+3): Linting/formatting fixes
- **CHANGELOG.md** (+1): Documented fix under Unreleased > Fixed

## Testing

- [x] Tests pass locally (`just test`)
- [x] Manual testing performed (describe below)

### Manual Testing Details

```bash
just precommit  # Now works correctly with uv-managed pre-commit
```

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have updated the CHANGELOG.md in the `[Unreleased]` section
- [x] My changes generate no new warnings or errors