### PR TITLE
feat: add agent-friendly issue templates, changelog rule, and PR template enhancements (#61)

### DIFF
--- a/.cursor/commands/commit-msg.md
+++ b/.cursor/commands/commit-msg.md
@@ -16,6 +16,7 @@ git status && echo "=== STAGED CHANGES ===" && git diff --cached
 - What files are staged vs un-staged
 - Change types and scope (additions/deletions)
 - Which changes will actually be committed
+- Break down into smaller commits if no common type and scope
 
 3. **Write accurate commit message** based on staged changes only:
 - Follow rules in [.commit-messages.mdc](../rules/commit-messages.mdc)

--- a/.cursor/rules/changelog.mdc
+++ b/.cursor/rules/changelog.mdc
@@ -1,0 +1,72 @@
+---
+description: When and how to update CHANGELOG.md during development
+alwaysApply: true
+---
+
+# Changelog Update Rules
+
+When making code changes, follow these rules for updating [CHANGELOG.md](CHANGELOG.md).
+
+## When to update
+
+- **Always update** for `feat`, `fix`, `refactor`, `build`, `revert`, `style`, `test`, `docs` changes that affect user-visible behavior, public API, or developer workflow.
+- **Skip** for `chore` commits that are purely internal (dependency bumps, CI-only config tweaks, formatting) unless they have user-visible impact.
+- When in doubt, add an entry — it's easier to remove during review than to add later.
+
+## Where to update
+
+- Edit **only** the `## Unreleased` section at the top of `CHANGELOG.md`.
+- Place the entry under the correct category heading. Create the heading if it doesn't exist yet.
+- **Never** modify entries below `## Unreleased` (those are released versions).
+- **Never** change the release date or version number of any section.
+
+## Category headings (in order)
+
+Use these [Keep a Changelog](https://keepachangelog.com/) categories:
+
+```
+### Added       — new features, capabilities, tools
+### Changed     — changes to existing functionality
+### Deprecated  — features that will be removed
+### Removed     — features that were removed
+### Fixed       — bug fixes
+### Security    — vulnerability fixes or security improvements
+```
+
+## Entry format
+
+Follow the existing style in the file:
+
+```markdown
+- **Bold short title** ([#<issue>](https://github.com/vig-os/devcontainer/issues/<issue>))
+  - Detail bullet explaining what was done
+  - Additional detail bullet if needed
+```
+
+Rules:
+- Start with `- **Bold title**` followed by the issue link in parentheses.
+- Use sub-bullets (indented with two spaces) for implementation details.
+- Reference the GitHub issue number from the `Refs:` line in the commit.
+- If multiple issues are related, list them: `([#12](url), [#13](url))`.
+- Keep descriptions concise and user-focused (what changed, not how).
+
+## Example
+
+```markdown
+## Unreleased
+
+### Added
+
+- **SSH agent forwarding** ([#42](https://github.com/vig-os/devcontainer/issues/42))
+  - Forward host SSH agent into devcontainer for seamless git authentication
+  - Integration tests for SSH socket availability
+
+### Fixed
+
+- **Broken venv prompt after rename** ([#43](https://github.com/vig-os/devcontainer/issues/43))
+  - Post-create script now correctly updates the activate script prompt
+```
+
+## Relationship to issue templates
+
+If the issue has a **Changelog Category** field (e.g. "Added", "Fixed"), use that as the category. If the field says "No changelog needed", skip the changelog update.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -72,3 +72,17 @@ body:
       description: |
         If you have ideas on how to fix this, please describe them here
       placeholder: Optional - describe potential solutions...
+  - type: dropdown
+    id: changelog-category
+    attributes:
+      label: Changelog Category
+      description: |
+        Under which CHANGELOG.md section should this fix appear?
+      options:
+        - Fixed
+        - Security
+        - Changed
+        - No changelog needed
+      default: 0
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/ci_build.yml
+++ b/.github/ISSUE_TEMPLATE/ci_build.yml
@@ -1,0 +1,102 @@
+---
+name: CI / Build Change
+description: Propose a change to CI workflows, GitHub Actions, or build configuration
+title: '[CI] '
+labels: ['ci']
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for changes to CI/CD pipelines, GitHub Actions
+        workflows, composite actions, or build configuration. These changes
+        are high-risk — please be specific about which files are affected
+        and what behavior should change.
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: |
+        A clear description of the CI/build change and its motivation
+      placeholder: Describe the change and why it's needed...
+    validations:
+      required: true
+  - type: textarea
+    id: target-workflows
+    attributes:
+      label: Target Workflows / Actions
+      description: |
+        Which workflow files or composite actions are affected?
+      placeholder: |
+        - .github/workflows/ci.yml
+        - .github/actions/test-project/action.yml
+        - justfile
+    validations:
+      required: true
+  - type: checkboxes
+    id: trigger-types
+    attributes:
+      label: Trigger Types Affected
+      description: Which event triggers does this change affect?
+      options:
+        - label: Push to branch
+        - label: Pull request
+        - label: Schedule (cron)
+        - label: Manual dispatch (workflow_dispatch)
+        - label: Release / tag
+        - label: Not applicable
+  - type: dropdown
+    id: release-impact
+    attributes:
+      label: Release Pipeline Impact
+      description: |
+        Does this change affect the release pipeline
+        (prepare-release, finalize-release, post-release)?
+      options:
+        - 'No — does not affect the release pipeline'
+        - 'Yes — modifies release workflows or steps'
+    validations:
+      required: true
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected Behavior (Before → After)
+      description: |
+        Describe the current CI behavior and the desired behavior after
+        the change
+      placeholder: |
+        Before: CI runs all tests sequentially
+        After: CI runs image and integration tests in parallel
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance Criteria
+      description: Define what "done" looks like
+      placeholder: |
+        - [ ] CI pipeline passes on the PR
+        - [ ] No regressions in existing workflows
+        - [ ] New workflow tested with act or manual dispatch
+    validations:
+      required: true
+  - type: dropdown
+    id: changelog-category
+    attributes:
+      label: Changelog Category
+      description: |
+        Under which CHANGELOG.md section should this appear?
+      options:
+        - Changed
+        - Added
+        - Fixed
+        - No changelog needed
+      default: 3
+    validations:
+      required: true
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context
+      description: Any other relevant information
+      placeholder: Error logs, workflow run links, related issues...

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Documentation
+    url: https://github.com/vig-os/devcontainer/tree/dev/docs
+    about: Browse project documentation before opening an issue

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,85 @@
+---
+name: Documentation
+description: Request a documentation update or addition
+title: '[DOCS] '
+labels: ['docs']
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for documentation changes. Important: editable
+        documentation lives in `docs/templates/`. Generated files like
+        `CONTRIBUTE.md` and `README.md` must not be edited directly —
+        run `just docs` to regenerate them after editing the template.
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: |
+        Describe the documentation change or addition needed
+      placeholder: Describe what needs to be documented...
+    validations:
+      required: true
+  - type: dropdown
+    id: doc-type
+    attributes:
+      label: Documentation Type
+      description: What kind of documentation change is this?
+      options:
+        - Update existing documentation
+        - Add new documentation
+        - Fix incorrect or outdated content
+        - Improve clarity or structure
+    validations:
+      required: true
+  - type: textarea
+    id: target-files
+    attributes:
+      label: Target Files
+      description: |
+        Which files need to be modified? Remember: edit templates in
+        `docs/templates/`, not generated files.
+      placeholder: |
+        - docs/templates/CONTRIBUTE.md.j2 (source template)
+        - docs/RELEASE_CYCLE.md
+    validations:
+      required: true
+  - type: textarea
+    id: related-code-changes
+    attributes:
+      label: Related Code Changes
+      description: |
+        If this docs update accompanies a code change, reference the
+        issue or PR
+      placeholder: 'Related to #123, follows up on PR #456'
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance Criteria
+      description: Define what "done" looks like for this documentation change
+      placeholder: |
+        - [ ] Template updated in docs/templates/
+        - [ ] Generated files regenerated with `just docs`
+        - [ ] Content is accurate and complete
+    validations:
+      required: true
+  - type: dropdown
+    id: changelog-category
+    attributes:
+      label: Changelog Category
+      description: |
+        Under which CHANGELOG.md section should this appear?
+      options:
+        - Changed
+        - Added
+        - No changelog needed
+      default: 2
+    validations:
+      required: true
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context
+      description: Any other relevant information
+      placeholder: Screenshots, examples, links to related documentation...

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -58,3 +58,16 @@ body:
       placeholder: |
         - Who would benefit from this feature?
         - Is this a breaking change or backward compatible?
+  - type: dropdown
+    id: changelog-category
+    attributes:
+      label: Changelog Category
+      description: |
+        Under which CHANGELOG.md section should this feature appear?
+      options:
+        - Added
+        - Changed
+        - No changelog needed
+      default: 0
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/refactor.yml
+++ b/.github/ISSUE_TEMPLATE/refactor.yml
@@ -1,0 +1,82 @@
+---
+name: Refactor
+description: Propose a code refactoring (no behavior change)
+title: '[REFACTOR] '
+labels: ['refactor']
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for code refactoring tasks. Refactors must not
+        change observable behavior — all existing tests must continue to pass.
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: |
+        A clear description of what should be refactored and why
+      placeholder: Describe the refactoring goal...
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: Files / Modules in Scope
+      description: |
+        List the files, directories, or modules that should be modified
+      placeholder: |
+        - scripts/install.sh
+        - tests/test_install.py
+    validations:
+      required: true
+  - type: textarea
+    id: out-of-scope
+    attributes:
+      label: Out of Scope
+      description: |
+        List files, modules, or behaviors that must NOT be changed
+      placeholder: |
+        - Do not modify the public API of install.sh
+        - Do not touch CI workflows
+  - type: textarea
+    id: invariants
+    attributes:
+      label: Invariants / Constraints
+      description: |
+        What must remain true after the refactoring? (e.g., tests pass,
+        no behavior change, backward compatibility)
+      placeholder: |
+        - All existing tests must pass without modification
+        - No changes to user-facing CLI flags
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance Criteria
+      description: Define what "done" looks like for this refactoring
+      placeholder: |
+        - [ ] Code is restructured as described
+        - [ ] All existing tests pass
+        - [ ] No new warnings or linter errors
+    validations:
+      required: true
+  - type: dropdown
+    id: changelog-category
+    attributes:
+      label: Changelog Category
+      description: |
+        Under which CHANGELOG.md section should this appear?
+      options:
+        - Changed
+        - No changelog needed
+      default: 1
+    validations:
+      required: true
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context
+      description: Any other relevant information
+      placeholder: Related issues, motivation, technical debt references...

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -55,6 +55,22 @@ body:
         - Critical
     validations:
       required: true
+  - type: dropdown
+    id: changelog-category
+    attributes:
+      label: Changelog Category
+      description: |
+        Under which CHANGELOG.md section should this appear?
+      options:
+        - Added
+        - Changed
+        - Fixed
+        - Removed
+        - Security
+        - No changelog needed
+      default: 0
+    validations:
+      required: true
   - type: textarea
     id: additional-context
     attributes:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,11 +19,22 @@ Closes #
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Documentation update
 - [ ] Refactoring (no functional changes)
+- [ ] CI / Build change
 - [ ] Test updates
 
 ## Changes Made
 
 <!-- Describe the changes in detail -->
+
+## Changelog Entry
+
+<!-- Paste the exact entry you added to CHANGELOG.md under ## Unreleased.
+     If no changelog update is needed, write "No changelog needed" and explain why.
+     Example:
+     ### Added
+     - **SSH agent forwarding** ([#42](https://github.com/vig-os/devcontainer/issues/42))
+       - Forward host SSH agent into devcontainer for seamless git authentication
+-->
 
 ## Testing
 
@@ -41,8 +52,8 @@ Closes #
 - [ ] My code follows the project's style guidelines
 - [ ] I have performed a self-review of my code
 - [ ] I have commented my code, particularly in hard-to-understand areas
-- [ ] I have updated the documentation accordingly (README.md, CONTRIBUTE.md, etc.)
-- [ ] I have updated the CHANGELOG.md in the `[Unreleased]` section
+- [ ] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
+- [ ] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
 - [ ] My changes generate no new warnings or errors
 - [ ] I have added tests that prove my fix is effective or that my feature works
 - [ ] New and existing unit tests pass locally with my changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Agent-friendly issue templates, changelog rule, and PR template enhancements** ([#61](https://github.com/vig-os/devcontainer/issues/61))
+  - Cursor rule `.cursor/rules/changelog.mdc` (always applied) guiding agents on when, where, and how to update CHANGELOG.md
+  - Changelog Category dropdown added to `bug_report.yml`, `feature_request.yml`, and `task.yml` issue templates
+  - New issue templates: `refactor.yml` (scope/invariants), `documentation.yml` (docs/templates workflow), `ci_build.yml` (target workflows/triggers/release impact)
+  - Template chooser `config.yml` disabling blank issues and linking to project docs
+  - PR template enhanced with explicit Changelog Entry section, CI/Build change type, and updated checklist referencing `docs/templates/` and `just docs`
 - **`--org` flag for install script** ([#33](https://github.com/vig-os/devcontainer/issues/33))
   - Allows overriding the default organization name (default: `vigOS`)
   - Passes `ORG_NAME` as environment variable to the container


### PR DESCRIPTION
# Pull Request

## Description

Add agent-friendly issue templates, a Cursor rule for changelog updates, and PR template enhancements to close the coding agent workflow loop — from issue creation through commit to pull request.

Currently, coding agents have no guidance on when/how to update the changelog, no signal for which changelog category applies, and no structured templates for refactoring, documentation, or CI/build work. This PR addresses all of those gaps.

## Related Issue(s)

Closes #61

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI / Build change
- [ ] Test updates

## Changes Made

### New files
- **`.cursor/rules/changelog.mdc`** — Always-applied Cursor rule guiding agents on when, where, and how to update CHANGELOG.md (categories, entry format, relationship to issue template fields)
- **`.github/ISSUE_TEMPLATE/refactor.yml`** — Refactoring template with scope/out-of-scope/invariants/acceptance criteria
- **`.github/ISSUE_TEMPLATE/documentation.yml`** — Documentation template encoding `docs/templates/` + `just docs` workflow
- **`.github/ISSUE_TEMPLATE/ci_build.yml`** — CI/Build template with target workflows, trigger types, release pipeline impact
- **`.github/ISSUE_TEMPLATE/config.yml`** — Template chooser: disables blank issues, links to project docs

### Modified files
- **`.github/ISSUE_TEMPLATE/bug_report.yml`** — Added Changelog Category dropdown (default: Fixed)
- **`.github/ISSUE_TEMPLATE/feature_request.yml`** — Added Changelog Category dropdown (default: Added)
- **`.github/ISSUE_TEMPLATE/task.yml`** — Added Changelog Category dropdown (full category list)
- **`.github/pull_request_template.md`** — Added Changelog Entry section, CI/Build change type, updated checklist to reference `docs/templates/` and `just docs`
- **`CHANGELOG.md`** — Added entry under `## Unreleased / ### Added`

## Changelog Entry

### Added

- **Agent-friendly issue templates, changelog rule, and PR template enhancements** ([#61](https://github.com/vig-os/devcontainer/issues/61))
  - Cursor rule `.cursor/rules/changelog.mdc` (always applied) guiding agents on when, where, and how to update CHANGELOG.md
  - Changelog Category dropdown added to `bug_report.yml`, `feature_request.yml`, and `task.yml` issue templates
  - New issue templates: `refactor.yml` (scope/invariants), `documentation.yml` (docs/templates workflow), `ci_build.yml` (target workflows/triggers/release impact)
  - Template chooser `config.yml` disabling blank issues and linking to project docs
  - PR template enhanced with explicit Changelog Entry section, CI/Build change type, and updated checklist referencing `docs/templates/` and `just docs`

## Testing

- [x] Tests pass locally (`just test`) — no test changes; this is template/config only
- [x] Manual testing performed (describe below)

### Manual Testing Details

- All pre-commit hooks passed (yaml lint, pymarkdown, branch-name, commit message validation)
- Verified YAML syntax of all new/modified issue templates
- Verified changelog entry follows existing format

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

- The `feature_request.yml` template currently uses `labels: ['enhancement']` but the repo label is `feature`. This mismatch predates this PR and is not addressed here — consider a follow-up to align template labels with repo labels.
- No test changes are needed since this is purely templates and Cursor rules (no executable code).
