### PR TITLE
ci: fix release validation and test action checkout refs

### DIFF
--- a/.github/actions/build-image/action.yml
+++ b/.github/actions/build-image/action.yml
@@ -153,7 +153,8 @@ runs:
         fi
 
         # Verify file size is reasonable (at least 100MB for a valid image)
-        FILE_SIZE=$(stat -f%z "${{ inputs.output-file }}" 2>/dev/null || stat -c%s "${{ inputs.output-file }}" 2>/dev/null)
+        # Using Linux stat syntax since this action only runs on ubuntu-22.04
+        FILE_SIZE=$(stat -c%s "${{ inputs.output-file }}")
         MIN_SIZE=$((100 * 1024 * 1024))  # 100 MB
 
         if [ "$FILE_SIZE" -lt "$MIN_SIZE" ]; then

--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -125,6 +125,7 @@ runs:
 
     # ── Just (task runner) ──────────────────────────────────────────────
     - name: Install just
+      if: inputs.install-just == 'true'
       uses: taiki-e/install-action@3035223527de4d6eb6207d7b9f901df966359a8e  # just
       with:
         tool: just

--- a/.github/actions/test-image/action.yml
+++ b/.github/actions/test-image/action.yml
@@ -54,6 +54,10 @@ inputs:
     description: 'Set PYTEST_SKIP_CONTAINER_CHECK=1'
     required: false
     default: 'true'
+  ref:
+    description: 'Git ref to checkout (e.g., commit SHA, branch, tag)'
+    required: false
+    default: ''
 
 outputs:
   test-result:
@@ -65,6 +69,8 @@ runs:
   steps:
     - name: Checkout code
       uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      with:
+        ref: ${{ inputs.ref || github.ref }}
 
     - name: Set up test environment
       uses: ./.github/actions/setup-env

--- a/.github/actions/test-integration/action.yml
+++ b/.github/actions/test-integration/action.yml
@@ -32,6 +32,10 @@ inputs:
     description: 'Container registry URL'
     required: false
     default: 'ghcr.io/vig-os/devcontainer'
+  ref:
+    description: 'Git ref to checkout (e.g., commit SHA, branch, tag)'
+    required: false
+    default: ''
 
 outputs:
   test-result:
@@ -43,6 +47,8 @@ runs:
   steps:
     - name: Checkout code
       uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      with:
+        ref: ${{ inputs.ref || github.ref }}
 
     - name: Set up test environment
       uses: ./.github/actions/setup-env

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -182,11 +182,20 @@ jobs:
 
           # Check CI status
           STATUS_ROLLUP=$(echo "$PR_JSON" | jq -r '.[0].statusCheckRollup // []')
-          CI_FAILED=$(echo "$STATUS_ROLLUP" | jq '[.[] | select(.conclusion == "FAILURE" or .conclusion == "ERROR")] | length')
 
+          # Reject if any checks have failed or errored
+          CI_FAILED=$(echo "$STATUS_ROLLUP" | jq '[.[] | select(.conclusion == "FAILURE" or .conclusion == "ERROR")] | length')
           if [ "$CI_FAILED" != "0" ]; then
             echo "ERROR: PR #$PR_NUMBER has failed CI checks"
             echo "Fix CI issues before releasing"
+            exit 1
+          fi
+
+          # Reject if any checks are still pending, in progress, queued, or null (non-terminal state)
+          CI_PENDING=$(echo "$STATUS_ROLLUP" | jq '[.[] | select(.conclusion == null or .conclusion == "" or .conclusion == "PENDING" or .conclusion == "IN_PROGRESS" or .conclusion == "QUEUED")] | length')
+          if [ "$CI_PENDING" != "0" ]; then
+            echo "ERROR: PR #$PR_NUMBER has $CI_PENDING checks still in progress"
+            echo "Wait for all CI checks to complete before releasing"
             exit 1
           fi
 
@@ -420,11 +429,13 @@ jobs:
           image-tag: ${{ needs.validate.outputs.version }}-${{ matrix.arch }}
           image-source: tar
           tar-file: /tmp/image.tar
+          ref: ${{ needs.finalize.outputs.finalize_sha }}
 
       - name: Run integration tests
         uses: ./.github/actions/test-integration
         with:
           image-tag: ${{ needs.validate.outputs.version }}-${{ matrix.arch }}
+          ref: ${{ needs.finalize.outputs.finalize_sha }}
 
       - name: Scan image for vulnerabilities
         uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8  # v0.33.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -203,6 +203,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Non-ASCII characters in justfiles** - Replaced Unicode box-drawing characters (═, ───) and emojis with ASCII equivalents for just-lsp compatibility ([#49](https://github.com/vig-os/devcontainer/issues/49))
 - **Pre-commit exclusion pattern** for pymarkdown updated to correct regex ([#50](https://github.com/vig-os/devcontainer/issues/50))
 - **Pytest test collection** - Exclude `tests/tmp/` directory (integration test workspaces) from test discovery to prevent import errors
+- **CI/CD release validation and test action checkout refs** ([#72](https://github.com/vig-os/devcontainer/issues/72))
+  - Block release if CI checks are still pending, in progress, queued, or in other non-terminal states
+  - Add `ref` input to `test-image` and `test-integration` composite actions to pin checkout commit
+  - Pass `finalize_sha` to test actions ensuring tests always run against the correct built commit
+  - Fix `install-just` conditional in `setup-env` to respect input flag; was unconditionally running
+  - Remove dead macOS `stat` fallback from `build-image` verification step (action only runs on ubuntu-22.04)
 
 ### Security
 


### PR DESCRIPTION
## Summary

Implements all four findings from issue #72 code review to improve CI/CD reliability:

- **High Priority:** Block release workflow if CI checks are still pending/in-progress
- **Medium Priority:** Fix test actions silently switching commits during release
- **Low Priority:** Fix install-just conditional and remove dead macOS code

## Changes

### 1. Release Validation (High Priority)
- In `release.yml`: Added check to reject releases when CI checks are in non-terminal states (PENDING, IN_PROGRESS, QUEUED, or null)
- Prevents releases proceeding while checks are still running

### 2. Test Action Checkout Pinning (Medium Priority)
- Added `ref` input parameter to both `test-image` and `test-integration` composite actions
- Both actions now accept `ref` input to pin Git checkout to specific commit
- In `release.yml`: Pass `finalize_sha` to both test actions to ensure tests run against the exact commit that was built
- Eliminates silent commit switching if release branch receives commits during finalization

### 3. Install-just Conditional (Low Priority)
- Added missing `if: inputs.install-just == 'true'` condition to install-just step in `setup-env`
- Now respects the input flag like all other optional tools (podman, node, devcontainer-cli, bats)

### 4. Dead Code Cleanup (Low Priority)
- Removed macOS `stat -f%z` fallback from `build-image` tar verification
- Added clarifying comment that action only runs on ubuntu-22.04
- Improves code clarity by removing misleading platform-specific logic

## Related Issue

Refs: #72