### PR TITLE
chore: merge main into dev to apply changes from #91

### DIFF
--- a/.github/workflows/sync-issues.yml
+++ b/.github/workflows/sync-issues.yml
@@ -6,9 +6,9 @@
 name: Sync Issues and PRs
 
 on:  # yamllint disable-line rule:truthy
-  # Run on a schedule (daily at midnight UTC)
+  # Run on a schedule (daily at 2:00 AM UTC)
   schedule:
-    - cron: '0 0 * * *'
+    - cron: '0 2 * * *'
   # Allow manual triggering
   workflow_dispatch:
     inputs:
@@ -18,23 +18,10 @@ on:  # yamllint disable-line rule:truthy
         default: false
         type: boolean
       target-branch:
-        description: 'Target branch to commit changes to (e.g., main, dev). If not provided, uses automatic detection.'
+        description: 'Target branch to commit changes to (e.g., dev, release/x.y.z).'
         required: false
-        default: ''
+        default: 'dev'
         type: string
-  # Run on issue creation/updates
-  issues:
-    types:
-      - opened
-      - edited
-      - reopened
-      - closed
-  # Run on PR creation and closure
-  pull_request:
-    types:
-      - opened
-      - edited
-      - closed
 
 jobs:
   sync:
@@ -57,30 +44,10 @@ jobs:
           app-id: ${{ secrets.APP_SYNC_ISSUES_ID }}
           private-key: ${{ secrets.APP_SYNC_ISSUES_PRIVATE_KEY }}
 
-      - name: Determine target branch
-        id: branch
-        run: |
-          # Use manual input if provided (workflow_dispatch), otherwise use automatic detection
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ github.event.inputs.target-branch }}" ]; then
-            TARGET_BRANCH="${{ github.event.inputs.target-branch }}"
-            echo "✓ Using manual target branch: $TARGET_BRANCH"
-          # If PR was merged into main, commit to main; otherwise use dev
-          elif [ "${{ github.event_name }}" = "pull_request" ] && \
-               [ "${{ github.event.pull_request.merged }}" = "true" ] && \
-               [ "${{ github.event.pull_request.base.ref }}" = "main" ]; then
-            TARGET_BRANCH="main"
-            echo "✓ PR merged into main - will commit to main"
-          else
-            TARGET_BRANCH="dev"
-            echo "✓ Will commit to dev (default for issues, scheduled, or non-main PRs)"
-          fi
-          echo "branch=$TARGET_BRANCH" >> $GITHUB_OUTPUT
-          echo "Target branch: $TARGET_BRANCH"
-
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ steps.branch.outputs.branch || 'dev' }}
+          ref: ${{ github.event.inputs.target-branch }}
           persist-credentials: false
 
       - name: Restore sync state (last synced timestamp)
@@ -134,7 +101,7 @@ jobs:
           # Use App token so push can bypass branch protection when App is in bypass list
           GH_TOKEN: ${{ steps.generate-token.outputs.token || github.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
-          TARGET_BRANCH: refs/heads/${{ steps.branch.outputs.branch }}
+          TARGET_BRANCH: refs/heads/${{ github.event.inputs.target-branch }}
           COMMIT_MESSAGE: "chore: sync issues and PRs"
           FILE_PATHS: ${{ steps.sync.outputs.modified-files }}
 


### PR DESCRIPTION
## Summary

Merge `main` back into `dev` to synchronize changes that landed on `main` via #91:

- **Reduce sync-issues workflow frequency** — removed `issues` and `pull_request` event triggers from `sync-issues.yml`, keeping only the daily schedule (`0 2 * * *`) and `workflow_dispatch`. Simplifies target branch logic by removing the now-dead PR-merged-into-main code path.

## Context

After PR #91 was merged into `main`, the `dev` branch is missing the workflow schedule update (`adafdc5`). This PR brings `dev` in sync with `main` to prevent the sync-issues workflow from continuing to fire on every issue/PR state change on `dev`-based branches.

## Tests

- [x] Verify the `sync-issues.yml` workflow no longer triggers on issue/PR events
- [x] Verify `workflow_dispatch` with `target-branch` input still works (used by `release.yml` and `post-release.yml`)

Refs: #91