### PR TITLE
fix(setup): use local npm install for devcontainer CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -313,6 +313,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`just init` fails to install devcontainer CLI on Linux** ([#111](https://github.com/vig-os/devcontainer/issues/111))
   - `npm install -g` requires root access to `/usr/local/lib/node_modules`, causing EACCES permission denied
   - Switched to local `npm install` (package already declared in `package.json`), matching the existing `bats` pattern
+  - Updated pytest fixtures in `conftest.py` to also check `node_modules/.bin/devcontainer`
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -310,6 +310,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **BATS test failures in init-workspace and prepare-build suites** ([#67](https://github.com/vig-os/devcontainer/issues/67))
   - Removed premature init-workspace.bats tests for unimplemented `is_git_dirty` feature (9 tests)
   - Fixed prepare-build.bats grep pattern for `sync_manifest.py` invocation to handle shell quoting
+- **`just init` fails to install devcontainer CLI on Linux** ([#111](https://github.com/vig-os/devcontainer/issues/111))
+  - `npm install -g` requires root access to `/usr/local/lib/node_modules`, causing EACCES permission denied
+  - Switched to local `npm install` (package already declared in `package.json`), matching the existing `bats` pattern
 
 ### Security
 

--- a/scripts/requirements.yaml
+++ b/scripts/requirements.yaml
@@ -139,17 +139,17 @@ dependencies:
       all: npm install
       manual: https://bats-core.readthedocs.io/en/stable/installation.html#any-os-npm
 
-  # DevContainer CLI (auto-installed by setup.sh)
+  # DevContainer CLI (auto-installed by npm install)
   - name: devcontainer
     version: "0.81.1"
     purpose: DevContainer CLI for testing devcontainer functionality
     required: true
     check:
-      command: command -v devcontainer
-      version_command: devcontainer --version
+      command: command -v devcontainer || test -x node_modules/.bin/devcontainer
+      version_command: npx devcontainer --version
       version_regex: '(\d+\.\d+\.\d+)'
     install:
-      all: npm install -g @devcontainers/cli@{{version}}
+      all: npm install
       manual: https://github.com/devcontainers/cli
 
   # Parallel (auto-installed by npm install)

--- a/tests/bats/init.bats
+++ b/tests/bats/init.bats
@@ -381,3 +381,15 @@ setup() {
     run grep "NC=" "$INIT_SH"
     assert_success
 }
+
+# ── devcontainer local install ───────────────────────────────────────────────
+
+@test "requirements.yaml devcontainer check falls back to node_modules/.bin" {
+    run grep 'node_modules/.bin/devcontainer' "$REQUIREMENTS_YAML"
+    assert_success
+}
+
+@test "requirements.yaml devcontainer does not use npm install -g" {
+    run grep 'npm install -g.*devcontainer' "$REQUIREMENTS_YAML"
+    assert_failure
+}

--- a/tests/bats/init.bats
+++ b/tests/bats/init.bats
@@ -393,3 +393,13 @@ setup() {
     run grep 'npm install -g.*devcontainer' "$REQUIREMENTS_YAML"
     assert_failure
 }
+
+@test "conftest.py devcontainer check falls back to node_modules/.bin" {
+    run grep 'node_modules/.bin/devcontainer' "$PROJECT_ROOT/tests/conftest.py"
+    assert_success
+}
+
+@test "conftest.py devcontainer skip message does not reference npm install -g" {
+    run grep 'npm install -g.*devcontainer' "$PROJECT_ROOT/tests/conftest.py"
+    assert_failure
+}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -881,11 +881,10 @@ def devcontainer_up(initialized_workspace):
     workspace_path, workspace_path_for_cli, in_container = (
         _resolve_devcontainer_cli_workspace(initialized_workspace)
     )
-    if not shutil.which("devcontainer"):
-        pytest.skip(
-            "devcontainer CLI not available. "
-            "Install with: npm install -g @devcontainers/cli"
-        )
+    if not shutil.which("devcontainer") and not (
+        Path("node_modules/.bin/devcontainer").is_file()
+    ):
+        pytest.skip("devcontainer CLI not available. Install with: npm install")
 
     docker_path = "podman"
     env, original_config = _prepare_devcontainer_env(
@@ -995,11 +994,10 @@ def devcontainer_with_sidecar(initialized_workspace, sidecar_image):
     workspace_path, workspace_path_for_cli, in_container = (
         _resolve_devcontainer_cli_workspace(initialized_workspace)
     )
-    if not shutil.which("devcontainer"):
-        pytest.skip(
-            "devcontainer CLI not available. "
-            "Install with: npm install -g @devcontainers/cli"
-        )
+    if not shutil.which("devcontainer") and not (
+        Path("node_modules/.bin/devcontainer").is_file()
+    ):
+        pytest.skip("devcontainer CLI not available. Install with: npm install")
 
     docker_path = "podman"
     env, _ = _prepare_devcontainer_env(


### PR DESCRIPTION
## Description

Fix `just init` failing to install the `devcontainer` CLI on Linux due to npm global install permission error (`EACCES: permission denied` on `/usr/local/lib/node_modules`). The `@devcontainers/cli` package is already declared in `package.json`, so this switches from `npm install -g` to a local `npm install`, matching the existing `bats` dependency pattern.

## Related Issue(s)

Closes #111

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI / Build change
- [x] Test updates

## Changes Made

- `scripts/requirements.yaml`: Changed devcontainer entry to use local `npm install` instead of `npm install -g`, added `node_modules/.bin/devcontainer` fallback to check command, switched version command to `npx devcontainer --version`
- `tests/bats/init.bats`: Added 2 tests asserting the local install pattern and absence of global install
- `CHANGELOG.md`: Added Fixed entry under Unreleased

## Changelog Entry

### Fixed

- **`just init` fails to install devcontainer CLI on Linux** ([#111](https://github.com/vig-os/devcontainer/issues/111))
  - `npm install -g` requires root access to `/usr/local/lib/node_modules`, causing EACCES permission denied
  - Switched to local `npm install` (package already declared in `package.json`), matching the existing `bats` pattern

## Testing

- [x] Tests pass locally (`just test`)
- [x] Manual testing performed (describe below)

### Manual Testing Details

1. `npx bats tests/bats/init.bats --filter "devcontainer"` — both new tests pass
2. `npx bats tests/bats/init.bats` — all 70 tests pass (no regressions)
3. `just init --check` — devcontainer 0.81.1 detected as installed via `node_modules/.bin/devcontainer`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

The CI setup action (`.github/actions/setup-env/action.yml`) still uses `npm install -g` for the devcontainer CLI. This is intentional — GitHub Actions runners have appropriate permissions for global installs. Only the local development path (`just init`) is affected by this fix.

Refs: #111
