### PR TITLE
feat(devcontainer): install cursor-agent CLI in image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **GitHub issue and PR templates in workspace template** ([#63](https://github.com/vig-os/devcontainer/issues/63))
   - Pull request template, issue templates, Dependabot config, and `.gitmessage` synced to `assets/workspace/`
   - Ground truth lives in repo root; `assets/workspace/` is generated output
+- **cursor-agent CLI pre-installed in devcontainer image** ([#108](https://github.com/vig-os/devcontainer/issues/108))
+  - Enables `just worktree-start` to work out of the box without manual installation
 
 ### Changed
 

--- a/Containerfile
+++ b/Containerfile
@@ -109,13 +109,10 @@ RUN set -eux; \
     rm "$FILE"; \
     just --version;
 
-# Install cursor-agent CLI
+# Install cursor-agent CLI (installs to ~/.local/bin)
+ENV PATH="/root/.local/bin:${PATH}"
 RUN set -eux; \
     curl -fsSL https://cursor.com/install | bash; \
-    if ! command -v agent >/dev/null 2>&1; then \
-        echo "cursor-agent installation failed"; \
-        exit 1; \
-    fi; \
     agent --version;
 
 # Install latest cargo-binstall from release archive with minisign signature verification

--- a/Containerfile
+++ b/Containerfile
@@ -109,6 +109,15 @@ RUN set -eux; \
     rm "$FILE"; \
     just --version;
 
+# Install cursor-agent CLI
+RUN set -eux; \
+    curl -fsSL https://cursor.com/install | bash; \
+    if ! command -v agent >/dev/null 2>&1; then \
+        echo "cursor-agent installation failed"; \
+        exit 1; \
+    fi; \
+    agent --version;
+
 # Install latest cargo-binstall from release archive with minisign signature verification
 # cargo-binstall uses minisign for signing releases. Each release has an ephemeral key.
 ENV PATH="/root/.cargo/bin:${PATH}"

--- a/docs/issues/issue-101.md
+++ b/docs/issues/issue-101.md
@@ -1,0 +1,52 @@
+---
+type: issue
+state: open
+created: 2026-02-20T09:30:54Z
+updated: 2026-02-20T09:30:54Z
+author: gerchowl
+author_url: https://github.com/gerchowl
+url: https://github.com/vig-os/devcontainer/issues/101
+comments: 0
+labels: chore
+assignees: none
+milestone: none
+projects: none
+relationship: none
+synced: 2026-02-20T13:17:18.431Z
+---
+
+# [Issue 101]: [[CHORE] Remove manual sync-issues workflow triggers from skills](https://github.com/vig-os/devcontainer/issues/101)
+
+### Chore Type
+
+CI / Build change
+
+### Description
+
+Four skills currently trigger the `sync-issues` workflow via `gh workflow run sync-issues.yml` after posting comments to issues. Since the sync workflow has moved to a 24h schedule (`cron: '0 2 * * *'`), these fire-and-forget triggers are unnecessary and should be removed.
+
+Affected skills:
+- `.cursor/skills/worktree:plan/SKILL.md` (line 69-73)
+- `.cursor/skills/worktree:brainstorm/SKILL.md` (line 61-65)
+- `.cursor/skills/design:brainstorm/SKILL.md` (line 65-69)
+- `.cursor/skills/design:plan/SKILL.md` (line 77-81)
+
+### Acceptance Criteria
+
+- [ ] Remove the `gh workflow run sync-issues.yml` trigger step from `worktree:plan/SKILL.md`
+- [ ] Remove the `gh workflow run sync-issues.yml` trigger step from `worktree:brainstorm/SKILL.md`
+- [ ] Remove the `gh workflow run sync-issues.yml` trigger step from `design:brainstorm/SKILL.md`
+- [ ] Remove the `gh workflow run sync-issues.yml` trigger step from `design:plan/SKILL.md`
+- [ ] Step numbering in each skill remains correct after removal
+
+### Implementation Notes
+
+Each skill has a numbered step that triggers the workflow. Remove the entire step (description + code block) and renumber subsequent steps if necessary. The `design:brainstorm/SKILL.md` also mentions the sync-issues workflow in a comment about H2 headers (line 64) — that reference to header-level bumping is still valid context and can stay, but consider rewording since the sync is now on a schedule rather than triggered inline.
+
+### Priority
+
+Low
+
+### Changelog Category
+
+No changelog needed

--- a/docs/issues/issue-102.md
+++ b/docs/issues/issue-102.md
@@ -1,0 +1,63 @@
+---
+type: issue
+state: open
+created: 2026-02-20T09:40:30Z
+updated: 2026-02-20T10:00:52Z
+author: gerchowl
+author_url: https://github.com/gerchowl
+url: https://github.com/vig-os/devcontainer/issues/102
+comments: 1
+labels: feature, area:workflow, effort:small, semver:minor
+assignees: gerchowl
+milestone: none
+projects: none
+relationship: none
+synced: 2026-02-20T13:17:17.996Z
+---
+
+# [Issue 102]: [[FEATURE] Add optional reviewer parameter to worktree-start for autonomous PR creation](https://github.com/vig-os/devcontainer/issues/102)
+
+### Description
+
+Add an optional `reviewer` parameter to the `worktree-start` just recipe so the autonomous pipeline (`worktree:solve-and-pr`) can optionally assign a PR reviewer at creation time.
+
+### Problem Statement
+
+The autonomous `worktree:pr` skill creates PRs with `--assignee @me` but has no way to request a reviewer. The interactive `pr:create` skill asks the user, but the autonomous variant runs unattended. Currently there is no mechanism to control whether a reviewer gets tagged on the resulting PR.
+
+### Proposed Solution
+
+Thread an optional `reviewer` parameter through the justfile and tmux environment:
+
+1. **`justfile.worktree`** — add `reviewer=""` parameter to `worktree-start`. Assign to `REVIEWER` variable and pass into the tmux session via `-e "PR_REVIEWER=$REVIEWER"`.
+2. **`worktree:pr/SKILL.md`** — in step 6 (Create PR), if `$PR_REVIEWER` is set and non-empty, append `--reviewer "$PR_REVIEWER"` to the `gh pr create` command.
+3. **`assets/workspace/` copies** — mirror the same changes.
+
+Usage:
+```bash
+just worktree-start 99 "/worktree-solve-and-pr" "@c-vigo"   # with reviewer
+just worktree-start 99 "/worktree-solve-and-pr"              # no reviewer
+```
+
+### Alternatives Considered
+
+- **Agent-assessed reviewer at PR time**: Agent decides based on diff size/labels. Rejected — too subjective, and late in context window.
+- **Capture PR context upfront to a JSON file**: `worktree:solve-and-pr` writes `.github/pr-context-<issue>.json` at start when context is fresh. More elegant but heavier — overkill for a single setting right now. Could revisit if more PR preferences emerge.
+- **Prompt-based convention**: User includes "reviewer: @handle" in the prompt text. Less explicit, depends on agent parsing natural language reliably.
+
+### Impact
+
+- Backward compatible — `reviewer` defaults to empty string, existing invocations unchanged.
+- Benefits anyone using the autonomous worktree pipeline who wants PR review assignment.
+
+### Changelog Category
+
+Added
+---
+
+# [Comment #1]() by [gerchowl]()
+
+_Posted on February 20, 2026 at 10:00 AM_
+
+Parent issue: #103
+

--- a/docs/issues/issue-103.md
+++ b/docs/issues/issue-103.md
@@ -1,0 +1,75 @@
+---
+type: issue
+state: open
+created: 2026-02-20T10:00:14Z
+updated: 2026-02-20T13:08:16Z
+author: gerchowl
+author_url: https://github.com/gerchowl
+url: https://github.com/vig-os/devcontainer/issues/103
+comments: 1
+labels: feature, area:workflow, effort:large, semver:minor
+assignees: gerchowl
+milestone: none
+projects: none
+relationship: none
+synced: 2026-02-20T13:17:17.462Z
+---
+
+# [Issue 103]: [[FEATURE] Enhance worktree workflow and autonomous agent integration](https://github.com/vig-os/devcontainer/issues/103)
+
+### Description
+
+Improve the worktree-based autonomous development workflow by addressing configuration management, bug fixes, and PR automation enhancements. This is a parent issue tracking multiple related improvements to the `just worktree-*` recipes and autonomous agent integration.
+
+### Problem Statement
+
+The worktree workflow has evolved organically and now has several areas that need systematic improvement:
+
+1. **Configuration scattered across recipes** - Agent model selections were hardcoded in justfile recipes rather than being centrally configured
+2. **Branch resolution bugs** - `gh issue develop --list` now returns tab-separated output (`branch\tURL`), breaking the `grep -oE '[^ ]+$'` pattern that expects space-separated output
+3. **Limited PR automation** - The autonomous PR creation cannot specify reviewers, requiring manual follow-up
+
+These issues affect the reliability and maintainability of the autonomous agent workflow that powers parallel development via worktrees.
+
+### Proposed Solution
+
+Address these issues through focused sub-issues:
+
+1. **Config as SSoT** - Extract agent model assignments to `.cursor/agent-models.toml` with task tiers (lightweight, autonomous)
+2. **Fix branch resolution** - Update the parsing logic to handle tab-separated `gh` output correctly
+3. **Optional PR reviewer param** - Thread an optional `reviewer` parameter through `worktree-start` so autonomous PRs can assign reviewers
+
+Each improvement maintains backward compatibility and follows the repo's Single Source of Truth principle.
+
+### Alternatives Considered
+
+- **Monolithic refactor** - Rejected in favor of incremental, traceable improvements via sub-issues
+- **Wait for native Cursor worktree support in devcontainers** - Still broken as of Feb 2026, CLI workflow remains necessary
+
+### Additional Context
+
+The worktree workflow enables true parallel autonomous development where multiple agents can work on different issues simultaneously in isolated environments. Reliability and configuration management are critical for this workflow.
+
+Related:
+- Cursor forum issue: https://forum.cursor.com/t/cursor-parallel-agents-in-wsl-devcontainers-misresolve-worktree-paths-and-context/145711
+
+### Impact
+
+- Improves reliability and maintainability of autonomous agent workflows
+- Makes configuration explicit and centralized (SSoT)
+- Backward compatible - all changes are additive or fix existing bugs
+- Benefits anyone using `just worktree-start` for parallel development
+
+### Changelog Category
+
+Changed
+---
+
+# [Comment #1]() by [gerchowl]()
+
+_Posted on February 20, 2026 at 10:00 AM_
+
+## Sub-issues
+
+- #102 - Add optional reviewer parameter to worktree-start
+

--- a/docs/issues/issue-104.md
+++ b/docs/issues/issue-104.md
@@ -1,0 +1,59 @@
+---
+type: issue
+state: open
+created: 2026-02-20T10:03:02Z
+updated: 2026-02-20T10:03:02Z
+author: gerchowl
+author_url: https://github.com/gerchowl
+url: https://github.com/vig-os/devcontainer/issues/104
+comments: 0
+labels: feature
+assignees: none
+milestone: none
+projects: none
+relationship: none
+synced: 2026-02-20T13:17:16.911Z
+---
+
+# [Issue 104]: [[FEATURE] Make issue numbers in just gh-issues table clickable links](https://github.com/vig-os/devcontainer/issues/104)
+
+### Description
+
+Enhance the `#` column in the `just gh-issues` overview table so that issue numbers are clickable links. Ideally, clicking an issue number should open it directly in VS Code / Cursor (using a `vscode://` URI), with a fallback to the GitHub web URL for terminals that don't support custom URI schemes.
+
+### Problem Statement
+
+Currently the `#` column in the issue and PR tables rendered by `scripts/gh_issues.py` displays plain text numbers (e.g. `42`). Users who want to view an issue must manually copy the number and run `gh issue view` or navigate to GitHub. Adding clickable hyperlinks would eliminate this friction.
+
+### Proposed Solution
+
+Use Rich's built-in hyperlink support (`[link=URL]text[/link]`) to make the `#` column entries clickable in terminals that support OSC 8 hyperlinks (iTerm2, Windows Terminal, most modern terminal emulators, and Cursor's integrated terminal).
+
+**Two link targets to evaluate (in order of preference):**
+
+1. **Cursor/VS Code URI** — `vscode://file/...` or a `cursor://` URI that opens the issue in the editor's GitHub integration (if a reliable scheme exists)
+2. **GitHub web URL** — `https://github.com/{owner}/{repo}/issues/{number}` as a reliable fallback that works universally
+
+The `owner_repo` string is already fetched in `main()` and can be threaded to `_build_table` / `_build_pr_table`.
+
+### Alternatives Considered
+
+- **Keep plain numbers, add a separate "open issue" just recipe** — more keystrokes, doesn't leverage terminal hyperlink capabilities
+- **Use `gh issue view --web` shortcut hint** — informational but not interactive
+
+### Additional Context
+
+- Related: #99 (parent — test coverage for `gh_issues.py`)
+- Rich hyperlinks docs: `[link=https://...]text[/link]` markup
+- OSC 8 terminal hyperlink support is widespread in modern terminals
+- The PR table `#` column should also get the same treatment
+
+### Impact
+
+- Quality-of-life improvement for all developers using `just gh-issues`
+- Backward-compatible — terminals without OSC 8 support simply render plain text
+- Minor change (~5-10 lines in `_build_table` and `_build_pr_table`)
+
+### Changelog Category
+
+Changed

--- a/docs/issues/issue-105.md
+++ b/docs/issues/issue-105.md
@@ -1,0 +1,73 @@
+---
+type: issue
+state: open
+created: 2026-02-20T10:11:58Z
+updated: 2026-02-20T10:11:58Z
+author: gerchowl
+author_url: https://github.com/gerchowl
+url: https://github.com/vig-os/devcontainer/issues/105
+comments: 0
+labels: bug
+assignees: none
+milestone: none
+projects: none
+relationship: none
+synced: 2026-02-20T13:17:16.451Z
+---
+
+# [Issue 105]: [[BUG] PR table Reviewer column shows requested reviewers instead of actual reviewers](https://github.com/vig-os/devcontainer/issues/105)
+
+### Description
+
+The "Reviewer" column in the `just gh-issues` PR table displays users from `reviewRequests` (people who have been **asked** to review) rather than users from `reviews` (people who have **actually submitted** a review). This makes it appear as though a review has been submitted when none has.
+
+### Steps to Reproduce
+
+1. Create a PR and add a reviewer via `gh pr edit --add-reviewer <user>`
+2. Do **not** submit any review
+3. Run `just gh-issues`
+4. Observe the "Reviewer" column shows the requested reviewer's login with no distinction
+
+### Expected Behavior
+
+The Reviewer column should distinguish between requested and completed reviewers:
+
+- **Requested** (pending): `?gerchowl` — prefixed with `?` to indicate awaiting review
+- **Reviewed** (submitted): `gerchowl` — plain name, no prefix
+
+This way a single column conveys both states at a glance.
+
+### Actual Behavior
+
+The "Reviewer" column shows `gerchowl` for PR #100 with no distinction, even though `reviews` is empty (`[]`) — only `reviewRequests` contains that user.
+
+```json
+{
+  "reviewDecision": "REVIEW_REQUIRED",
+  "reviewRequests": [{"__typename": "User", "login": "gerchowl"}],
+  "reviews": []
+}
+```
+
+### Environment
+
+- **OS**: macOS (darwin 24.5.0)
+- **gh CLI**: current
+- **Script**: `scripts/gh_issues.py` (version with Reviewer/Assignee columns from #99 scope)
+
+### Additional Context
+
+- The Reviewer column is part of the uncommitted `gh_issues.py` enhancements tracked by #99
+- The `_fetch_prs` call currently doesn't include `reviewRequests` in its `--json` fields; the column implementation likely conflates the two data sources
+- Related: #99 (parent), #104 (clickable issue links)
+
+### Possible Solution
+
+Merge both data sources into the Reviewer column:
+1. Collect actual reviewers from `reviews` — display as plain login (e.g. `gerchowl`)
+2. Collect pending reviewers from `reviewRequests` that haven't submitted a review — display with `?` prefix (e.g. `?gerchowl`)
+3. Style `?`-prefixed names dimmed/italic to further distinguish visually
+
+### Changelog Category
+
+Fixed

--- a/docs/issues/issue-108.md
+++ b/docs/issues/issue-108.md
@@ -1,0 +1,76 @@
+---
+type: issue
+state: open
+created: 2026-02-20T10:23:44Z
+updated: 2026-02-20T13:16:50Z
+author: gerchowl
+author_url: https://github.com/gerchowl
+url: https://github.com/vig-os/devcontainer/issues/108
+comments: 1
+labels: feature, area:image, effort:small, semver:minor
+assignees: gerchowl
+milestone: none
+projects: none
+relationship: none
+synced: 2026-02-20T13:17:15.951Z
+---
+
+# [Issue 108]: [[FEATURE] Install cursor-agent CLI in devcontainer image](https://github.com/vig-os/devcontainer/issues/108)
+
+### Description
+
+Install the `cursor-agent` CLI (`agent` command) in the devcontainer image so that worktree recipes (`just worktree-start`, etc.) can run autonomously inside the container without manual installation.
+
+### Problem Statement
+
+The worktree workflow (`justfile.worktree`) depends on the `agent` CLI for launching autonomous cursor-agent sessions in tmux. Currently, `agent` is not installed in the container image nor in any lifecycle script. Running `just worktree-start` fails immediately with:
+
+```
+[ERROR] cursor-agent CLI is not installed.
+```
+
+Users must manually install it each time a container is created, which breaks the autonomous workflow.
+
+### Proposed Solution
+
+Add a `cursor-agent` installation step to the `Containerfile`, similar to how `gh`, `just`, and `uv` are installed — fetching the latest release with checksum verification:
+
+```bash
+RUN curl https://cursor.com/install -fsSL | bash
+```
+
+Verify with `agent --version` after install.
+
+### Alternatives Considered
+
+- **Install in `post-create.sh`**: Works but adds network dependency at container creation time and is slower than baking it into the image.
+- **Leave as manual step**: Current state — breaks the autonomous worktree workflow.
+
+### Impact
+
+- All users of the worktree workflow benefit — `just worktree-start` works out of the box.
+- Backward compatible — no existing functionality is changed.
+
+### Changelog Category
+
+Added
+---
+
+# [Comment #1]() by [gerchowl]()
+
+_Posted on February 20, 2026 at 01:16 PM_
+
+## Implementation Plan
+
+Issue: #108
+Branch: feature/108-install-cursor-agent-cli
+
+### Context
+
+The Containerfile change was contributed externally in PR #110 (by @nacholiya, commit preserved with original authorship). CHANGELOG entry and `Refs: #108` added by maintainer. TDD order is inverted because we adopted an external contribution — the test commit retroactively closes the gap.
+
+### Tasks
+
+- [ ] Task 1: Add failing test for `agent` CLI presence — `tests/test_image.py` — verify: `just test-image` (expect fail, image not yet rebuilt with change)
+- [ ] Task 2: Rebuild image and confirm test passes — verify: `just build && just test-image`
+

--- a/docs/issues/issue-109.md
+++ b/docs/issues/issue-109.md
@@ -1,0 +1,49 @@
+---
+type: issue
+state: open
+created: 2026-02-20T10:34:52Z
+updated: 2026-02-20T10:34:52Z
+author: gerchowl
+author_url: https://github.com/gerchowl
+url: https://github.com/vig-os/devcontainer/issues/109
+comments: 0
+labels: discussion, area:ci
+assignees: c-vigo
+milestone: none
+projects: none
+relationship: none
+synced: 2026-02-20T13:17:15.416Z
+---
+
+# [Issue 109]: [[DISCUSSION] Optimize CI pipeline for PRs to dev — full security scan on every PR?](https://github.com/vig-os/devcontainer/issues/109)
+
+### Description
+
+Should the full CI pipeline (including security scans and other long-running jobs) run on every PR to `dev`, or can we slim it down to "it builds & tests pass" for faster feedback?
+
+Currently, PRs to `dev` run the complete CI suite including security scanning, which adds significant time. With the goal of faster PR turnaround, we should discuss whether that's necessary or if a smarter approach exists.
+
+### Context / Motivation
+
+CI runs on PRs to `dev` take a long time, partly due to security scans and other heavyweight checks. For a branch that primarily serves as an integration target (not production), this slows down the development loop without a clear proportional benefit. The question is whether the full suite is justified for every PR to `dev` or only for PRs into `main`.
+
+### Options / Alternatives
+
+1. **Minimal CI on PRs to `dev`** — Only run build + test. Reserve security scans and other heavyweight checks for PRs into `main`.
+2. **Smart/conditional CI** — Detect what changed and skip security scans when no new packages or version updates are present. E.g., only trigger security scanning when `requirements.txt`, `Dockerfile`, lock files, or similar dependency files change.
+3. **Keep full CI everywhere** — Accept the longer times for maximum safety at every stage.
+
+### Open Questions
+
+- Is "it builds & tests pass" sufficient confidence for merging into `dev`?
+- Should security scanning only gate PRs into `main`?
+- Can we use path-based triggers (e.g., changes to dependency files) to conditionally run security scans on `dev` PRs?
+- Are there other long-running CI jobs besides security that could be deferred to the `main` gate?
+
+### Related Issues
+
+_None yet_
+
+### Changelog Category
+
+No changelog needed

--- a/docs/issues/issue-111.md
+++ b/docs/issues/issue-111.md
@@ -1,0 +1,132 @@
+---
+type: issue
+state: open
+created: 2026-02-20T10:59:01Z
+updated: 2026-02-20T10:59:20Z
+author: c-vigo
+author_url: https://github.com/c-vigo
+url: https://github.com/vig-os/devcontainer/issues/111
+comments: 1
+labels: bug
+assignees: none
+milestone: none
+projects: none
+relationship: none
+synced: 2026-02-20T13:17:14.953Z
+---
+
+# [Issue 111]: [[BUG] just init fails to install devcontainer CLI — npm global install permission denied](https://github.com/vig-os/devcontainer/issues/111)
+
+## Description
+
+`just init` fails to install the `devcontainer` CLI on Linux because `npm install -g` requires write access to `/usr/local/lib/node_modules`, which is owned by root.
+
+## Steps to Reproduce
+
+1. Run `just init` on a Linux machine where `devcontainer` CLI is not installed
+2. When prompted to install `devcontainer`, accept with `y`
+
+## Expected Behavior
+
+The `devcontainer` CLI should install successfully without requiring `sudo` or manual intervention.
+
+## Actual Behavior
+
+The installation fails with `EACCES: permission denied`:
+
+```
+  devcontainer (0.81.1)
+  Purpose: DevContainer CLI for testing devcontainer functionality
+  Command: npm install -g @devcontainers/cli@0.81.1
+?  Install devcontainer? [y/N]: y
+ℹ  Installing devcontainer...
+npm ERR! code EACCES
+npm ERR! syscall mkdir
+npm ERR! path /usr/local/lib/node_modules
+npm ERR! errno -13
+npm ERR! Error: EACCES: permission denied, mkdir '/usr/local/lib/node_modules'
+✗  Failed to install devcontainer
+```
+
+## Environment
+
+- **OS**: Ubuntu 24.04 (Linux 6.17.0-14-generic)
+- **npm**: system npm with default global prefix (`/usr/local/lib/node_modules`)
+- **Node**: system Node.js
+
+## Additional Context
+
+`@devcontainers/cli@0.81.1` is already declared as a local dependency in `package.json`. The `bats` dependency already uses the correct pattern — local `npm install` with a `node_modules/.bin/` check fallback. The `devcontainer` entry should follow the same approach instead of requiring a global install.
+
+## Possible Solution
+
+Change the `devcontainer` entry in `scripts/requirements.yaml` to:
+- Use `npm install` (local) instead of `npm install -g` (global)
+- Check `node_modules/.bin/devcontainer` in addition to `command -v devcontainer`
+- Use `npx devcontainer --version` for version checking
+
+This matches the existing `bats` pattern and avoids permission issues entirely.
+
+## Changelog Category
+
+Fixed
+---
+
+# [Comment #1]() by [c-vigo]()
+
+_Posted on February 20, 2026 at 10:59 AM_
+
+## Implementation Plan
+
+### Root Cause
+
+The `devcontainer` entry in `scripts/requirements.yaml` uses `npm install -g @devcontainers/cli@{{version}}` which requires root permissions on Linux. Meanwhile, `@devcontainers/cli@0.81.1` is already declared in `package.json` as a local dependency.
+
+### Fix
+
+Follow the same pattern already used by `bats` in `requirements.yaml`:
+
+**Before:**
+```yaml
+  # DevContainer CLI (auto-installed by setup.sh)
+  - name: devcontainer
+    version: "0.81.1"
+    check:
+      command: command -v devcontainer
+      version_command: devcontainer --version
+      version_regex: '(\d+\.\d+\.\d+)'
+    install:
+      all: npm install -g @devcontainers/cli@{{version}}
+      manual: https://github.com/devcontainers/cli
+```
+
+**After:**
+```yaml
+  # DevContainer CLI (auto-installed by npm install)
+  - name: devcontainer
+    version: "0.81.1"
+    check:
+      command: command -v devcontainer || test -x node_modules/.bin/devcontainer
+      version_command: npx devcontainer --version
+      version_regex: '(\d+\.\d+\.\d+)'
+    install:
+      all: npm install
+      manual: https://github.com/devcontainers/cli
+```
+
+### Files Changed
+
+- `scripts/requirements.yaml` — update devcontainer entry (check command, version command, install command, comment)
+
+### What Does NOT Change
+
+- `package.json` — already has the dependency at the correct version
+- `.github/actions/setup-env/action.yml` — CI runs with proper permissions, no change needed
+- `tests/bats/init.bats` — existing tests are structural grep checks, unaffected
+
+### TDD Steps
+
+1. **RED:** Add test asserting `requirements.yaml` uses `node_modules/.bin/devcontainer` check pattern → fails
+2. **GREEN:** Update `requirements.yaml` → test passes
+3. **Verify:** `just init --check` confirms devcontainer is detected via local path
+

--- a/docs/issues/issue-113.md
+++ b/docs/issues/issue-113.md
@@ -1,0 +1,86 @@
+---
+type: issue
+state: open
+created: 2026-02-20T13:03:35Z
+updated: 2026-02-20T13:05:29Z
+author: gerchowl
+author_url: https://github.com/gerchowl
+url: https://github.com/vig-os/devcontainer/issues/113
+comments: 1
+labels: feature, area:workflow, area:docs, effort:large, semver:minor
+assignees: gerchowl
+milestone: none
+projects: none
+relationship: none
+synced: 2026-02-20T13:17:14.457Z
+---
+
+# [Issue 113]: [[FEATURE] Declarative diagram-as-code tooling with model-renderer separation](https://github.com/vig-os/devcontainer/issues/113)
+
+### Description
+
+Adopt a declarative diagram-as-code tooling strategy for the project. The core idea is to separate the semantic model (components, relationships, properties) from the rendering backend, enabling reusable diagram components and tool-independent output.
+
+### Problem Statement
+
+Mermaid is used ad-hoc in a few docs but has no composability (no imports, variables, or reusable components). Its C4 and architecture-beta diagram types are experimental with open bugs. Layout is unpredictable. Diagrams live outside the Typst toolchain. There is no shared visual vocabulary or component library. Complex architecture diagrams are avoided because the tooling can't handle them.
+
+### Proposed Solution
+
+Evaluate and adopt a layered approach:
+
+1. **Semantic model (SSoT)** — Components and relationships defined in YAML/TOML, with views as filtered perspectives.
+2. **Pluggable renderers** — Generate output for multiple backends: Mermaid (GitHub inline), D2 (high-quality SVG), CeTZ/Fletcher (Typst docs), and optionally Excalidraw (round-trip editable PNGs).
+3. **Reusable components** — Define diagram building blocks once (e.g. "K8s cluster", "VPC"), compose them across diagrams.
+
+An RFC exploring the full design space has been drafted: `docs/rfcs/RFC-001-2026-02-20-diagram-as-code-tooling.md`.
+
+### Alternatives Considered
+
+Evaluated 10+ tools across Mermaid, D2, CeTZ/Fletcher, TikZ, PlantUML, Excalidraw, Graphviz, Pikchr, Structurizr, Ilograph, Bluefish, and Kroki. Also evaluated SQL (SQLite) as an alternative model store. Full analysis is in the RFC.
+
+### Additional Context
+
+- Typst is already active in the project — CeTZ/Fletcher are native Typst packages.
+- Mermaid's reuse feature request (#1396) has been open since 2020 with no implementation.
+- Structurizr provides model-view-renderer separation but is C4-only and Java-based.
+- RFC: `docs/rfcs/RFC-001-2026-02-20-diagram-as-code-tooling.md`
+
+### Impact
+
+- Documentation authors get composable, reusable diagrams.
+- Architecture reviewers get a consistent visual language.
+- Autonomous agents get a declared standard to generate against.
+- The Typst pipeline gets native diagram support.
+- No breaking changes — existing Mermaid diagrams stay as-is.
+
+### Changelog Category
+
+Added
+---
+
+# [Comment #1]() by [gerchowl]()
+
+_Posted on February 20, 2026 at 01:05 PM_
+
+## Exploration Complete — RFC Drafted
+
+The `inception:explore` phase is complete. An RFC has been committed to this branch:
+
+**[`docs/rfcs/RFC-001-2026-02-20-diagram-as-code-tooling.md`](https://github.com/vig-os/devcontainer/blob/feature/113-diagram-as-code-tooling/docs/rfcs/RFC-001-2026-02-20-diagram-as-code-tooling.md)**
+
+### What the RFC covers
+
+- **Problem statement:** No composability, unpredictable layouts, no Typst integration, no component reuse
+- **10+ tools evaluated:** Mermaid, D2, CeTZ/Fletcher, TikZ, PlantUML, Excalidraw, Graphviz, Pikchr, Structurizr, Ilograph, Bluefish, Kroki
+- **GitHub activity & maturity data** for all tools (collected 2026-02-20)
+- **Mermaid C4/architecture limitations** — neither supports component reuse; template request open since 2020
+- **Model-renderer separation architecture** — three-layer approach (semantic model → views → pluggable renderers)
+- **Three possible directions:** YAML/TOML model + Python renderers, SQL/SQLite model store, adopt Structurizr for C4
+- **Excalidraw's code layer** — JSON format, skeleton API, PNG/SVG metadata embedding for round-trip editing
+- **Open questions** for scoping phase
+
+### Next step
+
+Continue with `inception:scope` to define what to build and what not to build.
+

--- a/docs/issues/issue-37.md
+++ b/docs/issues/issue-37.md
@@ -1,0 +1,109 @@
+---
+type: issue
+state: closed
+created: 2026-01-29T09:44:01Z
+updated: 2026-02-17T15:34:34Z
+author: c-vigo
+author_url: https://github.com/c-vigo
+url: https://github.com/vig-os/devcontainer/issues/37
+comments: 0
+labels: feature
+assignees: c-vigo
+milestone: none
+projects: none
+relationship: none
+synced: 2026-02-20T13:17:39.056Z
+---
+
+# [Issue 37]: [[FEATURE] Automate and Standardize Repository Setup for Devcontainer Template](https://github.com/vig-os/devcontainer/issues/37)
+
+### Description
+
+Create a fully automated and standardized repository setup.
+This setup will serve as a reproducible starting point for all projects (software, QMS, others),
+enforcing best practices for medical-device compliance, code quality, and security.
+
+
+### Problem Statement
+
+Currently, each repository setup is manual, inconsistent, and may lack compliance and security best practices.
+This leads to:
+
+- Inconsistent commit and branch practices
+- Poor traceability and audit-readiness
+- Risk of non-compliance with IEC 62304 / ISO 13485 for QMS projects
+- Security exposure from unpinned actions or unreviewed workflows
+- Inconsistent code quality, CI/CD, and release processes
+
+We need a fully automated, reproducible repository template that embeds these standards,
+so all projects start compliant and maintainable from day one.
+
+### Proposed Solution
+
+Automatically configure new repositories with:
+
+1. **Commit Message Standardization** #36
+   - Conventional Commits–based, restricted types
+   - Mandatory references to issues, requirements, risks, or SOPs
+   - Git commit template included
+   - Cursor integration instructions
+   - Local commit-msg hook
+   - CI validation
+
+2. **Branching Strategy & Enforcement** #38
+   - Standard branches: `main`, `develop`, `release/*`, `hotfix/*`, `feature/*`, `bugfix/*`
+   - Branch protection rules programmatically applied
+   - Require signed commits
+   - Require PR reviews
+   - Enforce naming conventions via CI
+
+3. **Release Cycle** #48
+   - Automated release branch creation templates
+   - Recommended tagging conventions
+   - Integration with QMS baselining for audits
+
+4. **Default GitHub Actions / CI**
+   - Commit message enforcement
+   - Tests / linting
+   - Branch naming enforcement
+   - Code coverage #52
+   - Optional: semantic version checks
+   - Automatically pinned actions to specific SHA commits
+
+5. **Security Considerations** #50
+   - Pin all GitHub Actions to commit SHAs
+   - Require review/approval for workflows submitted by external contributors
+   - Enforce branch protection for critical branches
+   - Optional: dependabot for dependencies
+
+6. **Code Quality & Other Useful Features**
+   - Linters and formatters (ruff, black, clang-format, etc.)
+   - Optional pre-commit hooks for code style
+   - PR templates for traceability (linking to requirements/issues)
+   - Default issue templates for features, bugs, and QMS artifacts
+   - Optional GitHub discussion or projects enabled
+
+The goal is that any new repository created from this devcontainer template
+**installs itself and is audit-ready** with all enforced best practices.
+
+
+### Alternatives Considered
+
+- Manual repository setup per project → inconsistent, error-prone, not auditable  
+- Individual tooling setup for each project → high maintenance overhead  
+- Using separate templates for software vs QMS → complicates maintenance and consistency  
+
+
+### Additional Context
+
+- This is intended as the **base template** for all new projects.  
+- Sub-issues will be created for each component (commit standard, branch enforcement, CI, security, release cycle, etc.)  
+- Links / references for best practices: IEC 62304, ISO 13485, GitHub security guidelines, GitHub Actions best practices
+
+
+### Impact
+
+- **Beneficiaries:** All developers, QA, RA, auditors  
+- **Compatibility:** Backward-compatible with existing projects; all future repos standardized  
+- **Risks:** Minor; mostly tool adoption and learning curve for developers  
+- **Compliance:** Aligns repository setup with medical device QMS and software configuration requirements

--- a/docs/issues/issue-91.md
+++ b/docs/issues/issue-91.md
@@ -1,18 +1,18 @@
 ---
 type: issue
-state: open
+state: closed
 created: 2026-02-19T14:42:07Z
-updated: 2026-02-19T15:28:37Z
+updated: 2026-02-20T10:37:41Z
 author: c-vigo
 author_url: https://github.com/c-vigo
 url: https://github.com/vig-os/devcontainer/issues/91
-comments: 0
-labels: chore
+comments: 3
+labels: chore, priority:blocking
 assignees: c-vigo
-milestone: none
+milestone: 0.3
 projects: none
 relationship: none
-synced: 2026-02-19T15:36:54.394Z
+synced: 2026-02-20T13:17:20.320Z
 ---
 
 # [Issue 91]: [Reduce sync-issues workflow frequency to daily schedule only](https://github.com/vig-os/devcontainer/issues/91)
@@ -41,8 +41,128 @@ This also allows simplifying the target branch decision logic. Currently the wor
 
 ## Acceptance Criteria
 
-- [ ] Remove `issues` and `pull_request` triggers from `sync-issues.yml`
-- [ ] Keep `schedule` and `workflow_dispatch` triggers
-- [ ] Simplify target branch logic (remove PR-merged-into-main branch)
-- [ ] Optionally adjust cron time if needed
-- [ ] Verify `release.yml` and `post-release.yml` dispatch calls still work (no changes needed there)
+- [x] Remove `issues` and `pull_request` triggers from `sync-issues.yml`
+- [x] Keep `schedule` and `workflow_dispatch` triggers
+- [x] Simplify target branch logic (remove PR-merged-into-main branch)
+- [x] Optionally adjust cron time if needed
+- [x] Verify `release.yml` and `post-release.yml` dispatch calls still work (no changes needed there)
+---
+
+# [Comment #1]() by [gerchowl]()
+
+_Posted on February 20, 2026 at 08:38 AM_
+
+Closed by merged PR #95 (chore/91-reduce-sync-issues-frequency, merged 2026-02-19). Workflow frequency reduced to daily schedule only.
+
+---
+
+# [Comment #2]() by [c-vigo]()
+
+_Posted on February 20, 2026 at 08:57 AM_
+
+@gerchowl the [2am sync](https://github.com/vig-os/devcontainer/actions/runs/22211151138/job/64245460160) failed, leave open until I fix it
+
+---
+
+# [Comment #3]() by [c-vigo]()
+
+_Posted on February 20, 2026 at 09:19 AM_
+
+## Implementation plan: fix sync-issues schedule trigger and align main/dev
+
+### Root Cause
+
+PR #95 partially implemented issue #91 on `main` (removed `issues`/`pull_request` triggers, adjusted cron) but left a gap in the target branch logic. On schedule events, `github.event.inputs` does not exist, so:
+
+- Line 53: `ref: ${{ github.event.inputs.target-branch }}` resolves to empty — checkout defaults to `main` (harmless but wrong: issue #91 says schedule should target `dev`)
+- Line 106: `TARGET_BRANCH: refs/heads/${{ github.event.inputs.target-branch }}` resolves to `refs/heads/` — commit-action gets a 404 "Not Found"
+
+The fix: add `|| 'dev'` fallbacks everywhere `github.event.inputs.*` is referenced, so schedule triggers default to `dev`.
+
+### State Differences (main vs dev)
+
+`dev` already has several improvements over `main` for this file:
+
+- Pinned SHA action references (e.g. `actions/checkout@34e11...  # v4`)
+- `output-dir: 'docs'` instead of `.github_data`
+- `runs-on: ubuntu-22.04` instead of `ubuntu-latest`
+- `timeout-minutes: 10`
+- Top-level `permissions: {}`
+- Removed stale cache restore-key prefix `sync-issues-state-`
+
+The plan is to use dev's version as the base and add the fix + new inputs on top, so both branches converge.
+
+### File Inventory
+
+- `.github_data/` on `main`: 31 files (stale, will never be written to again since output-dir changed to `docs`)
+- `.github_data/` on `dev`: 95 files (also stale, same reason)
+- `docs/` on `dev`: 104 files (active sync target)
+
+### Phase 1: Bugfix PR to main
+
+#### 1. Create and link branch
+
+Branch name `bugfix/91-fix-sync-issues-schedule` from `main`, linked to issue #91 via `gh issue develop`.
+
+#### 2. Replace workflow file with dev version + fix + enhancements
+
+Take `.github/workflows/sync-issues.yml` from `dev` as the base (it already has all the improvements above). Then apply these changes:
+
+**a) Add `output-dir` and `commit-msg` workflow_dispatch inputs** (with defaults `docs` and `chore: sync issues and PRs`):
+
+```yaml
+workflow_dispatch:
+  inputs:
+    force-update:
+      description: 'Force update all issues and PRs (ignores last sync timestamp)'
+      required: false
+      default: false
+      type: boolean
+    target-branch:
+      description: 'Target branch to commit changes to (e.g., dev, release/x.y.z).'
+      required: false
+      default: 'dev'
+      type: string
+    output-dir:
+      description: 'Directory to write synced issue/PR files to.'
+      required: false
+      default: 'docs'
+      type: string
+    commit-msg:
+      description: 'Commit message for the sync commit.'
+      required: false
+      default: 'chore: sync issues and PRs'
+      type: string
+```
+
+**b) Add `|| 'default'` fallback for all input references** (schedule events have no inputs):
+
+- Checkout ref: `ref: ${{ github.event.inputs.target-branch || 'dev' }}`
+- Sync action output-dir: `output-dir: ${{ github.event.inputs.output-dir || 'docs' }}`
+- Commit TARGET_BRANCH: `TARGET_BRANCH: refs/heads/${{ github.event.inputs.target-branch || 'dev' }}`
+- Commit COMMIT_MESSAGE: `COMMIT_MESSAGE: ${{ github.event.inputs.commit-msg || 'chore: sync issues and PRs' }}`
+- Force-update: `updated-since: ${{ (github.event.inputs.force-update == 'true' && '1970-01-01T00:00:00Z') || '' }}`
+
+**c) Callers are unaffected**: `release.yml` dispatches with `-f "target-branch=release/$VERSION"` and `post-release.yml` with `-f "target-branch=dev"` — neither passes `output-dir` or `commit-msg`, so they get defaults automatically.
+
+#### 3. Delete `.github_data/` on this branch
+
+Remove the 31 stale files in `.github_data/` (issues + pull-requests subdirectories). These were the old sync target and will never be updated again.
+
+#### 4. Commit, push, and create PR to main
+
+Can be multiple commits (e.g., one for the workflow fix, one for the `.github_data` deletion). PR references issue #91.
+
+### Phase 2: Sync to dev (after main PR merges)
+
+1. Create a branch from `dev` (e.g. `chore/sync-main-to-dev`)
+2. Merge `main` into it — this brings the workflow fix and `.github_data` deletion
+3. Additionally delete the 95 stale `.github_data/` files on dev (they were added independently on dev and won't be removed by the merge)
+4. Update CHANGELOG under `## Unreleased` if warranted (likely a one-liner noting the schedule fix)
+5. PR to `dev` for review
+
+### Risks / Notes
+
+- The `force-update` input reference already uses `&&`/`||` but still depends on `github.event.inputs.force-update` which is empty on schedule. Current behavior: empty evaluates to falsy, so `||` returns `''` — the sync action treats empty `updated-since` as "use last-sync state". This is correct; no change needed to the logic, but the parenthesization should be verified.
+- After merge, the next scheduled run (2:00 AM UTC) will checkout `dev`, sync to `docs/`, and commit to `dev` — the desired behavior per issue #91.
+

--- a/docs/issues/issue-99.md
+++ b/docs/issues/issue-99.md
@@ -1,0 +1,130 @@
+---
+type: issue
+state: open
+created: 2026-02-20T09:25:33Z
+updated: 2026-02-20T09:25:49Z
+author: gerchowl
+author_url: https://github.com/gerchowl
+url: https://github.com/vig-os/devcontainer/issues/99
+comments: 1
+labels: feature
+assignees: gerchowl
+milestone: 0.3
+projects: none
+relationship: none
+synced: 2026-02-20T13:17:18.889Z
+---
+
+# [Issue 99]: [[FEATURE] Add unit and container integration tests for scripts/gh_issues.py](https://github.com/vig-os/devcontainer/issues/99)
+
+### Description
+
+Add unit tests and container integration tests for `scripts/gh_issues.py`, which currently has ~540 lines, ~15 functions, and zero test coverage. The script is deployed to downstream workspaces via the sync manifest and needs verification at both the logic and deployment layers.
+
+### Problem Statement
+
+`scripts/gh_issues.py` was originally skipped for TDD with the rationale "no unit-testable logic beyond subprocess calls and rich rendering" (see #84). The script has since grown to include multiple pure-logic functions that are fully testable without mocking `gh` CLI calls or Rich rendering. Additionally, there is no verification that the deployed copy works inside the container or that runtime dependencies are available.
+
+### Proposed Solution
+
+**Two test layers:**
+
+#### 1. Unit tests (`tests/test_gh_issues.py`)
+
+Test all pure-logic functions — no subprocess mocking, no Rich rendering tests:
+
+| Function | What it does |
+|---|---|
+| `_styled(value, style)` | Wraps text in Rich markup |
+| `_extract_label(labels, prefix)` | Finds label by prefix, applies style |
+| `_extract_type(labels)` | Finds type label, applies style |
+| `_extract_scope(labels)` | Collects `area:*` labels |
+| `_clean_title(title)` | Strips `[FEATURE]` etc. prefix |
+| `_format_assignees(assignees)` | Formats assignee list |
+| `_infer_review(pr)` | Derives review state from PR dict |
+| `_extract_reviewers(pr)` | Builds reviewer string from PR dict |
+| `_build_cross_refs(branches, prs)` | Builds issue↔PR mappings |
+
+#### 2. Container integration tests (in `tests/test_image.py`)
+
+Add to existing test structure:
+- Verify `.devcontainer/scripts/gh_issues.py` exists in the image
+- Verify `.devcontainer/justfile.gh` exists in the image
+- Verify `rich` is importable: `python -c "from rich.table import Table"`
+- Verify `gh_issues.py` is importable in the container (catches syntax errors, missing imports)
+
+### Prerequisite
+
+The uncommitted `gh_issues.py` changes from the #67 branch (reviewer/assignee columns, `_infer_review`, `_extract_reviewers`, `_fetch_sub_issue_tree`, `_build_cross_refs` with closing-keyword parsing) should be moved to this issue's branch. These are the functions that need test coverage.
+
+### Alternatives Considered
+
+- **Test Rich rendering output** — fragile, visual, not worth the maintenance cost
+- **Mock subprocess/gh CLI calls** — adds complexity without testing real behavior; save for a future refactoring issue that separates I/O from logic
+- **Refactor to extract I/O boundaries first** — worthwhile but separate scope; test the current pure functions first
+
+### Additional Context
+
+- Related: #84 (original script creation), #67 (declarative sync manifest)
+- The existing `test_manifest_files` in `test_image.py` already partially covers the deployed copy via SHA-256 checksum verification, but doesn't verify importability or runtime deps
+- `scripts/gh_issues.py` depends on `rich` (installed via `uv pip install --system` in the Containerfile) and `gh` CLI
+
+### Impact
+
+- Tests-only change — no user-visible impact, no changelog entry needed
+- Establishes test coverage for a growing utility script
+- Container integration tests catch deployment regressions early
+
+### Changelog Category
+
+No changelog needed
+---
+
+# [Comment #1]() by [gerchowl]()
+
+_Posted on February 20, 2026 at 09:25 AM_
+
+## Design
+
+### Problem
+
+`scripts/gh_issues.py` has ~540 lines, ~15 functions, and zero test coverage. The original TDD-skip rationale ("no unit-testable logic beyond subprocess calls and rich rendering") no longer holds — the script now contains multiple pure-logic functions fully testable without mocking.
+
+The script is deployed via the sync manifest to `.devcontainer/scripts/gh_issues.py`, but there is no verification that the deployed copy works inside the container or that runtime dependencies are available.
+
+### Approach: Two Test Layers
+
+#### Layer 1: Unit tests (`tests/test_gh_issues.py`)
+
+Pure-logic functions tested with plain data in, data out — no mocking needed:
+
+| Function | Signature | Test strategy |
+|---|---|---|
+| `_styled(value, style)` | `str, str -> str` | Assert Rich markup wrapping |
+| `_extract_label(labels, prefix)` | `list[dict], str -> str` | Label dicts with matching/missing prefixes |
+| `_extract_type(labels)` | `list[dict] -> str` | Label dicts with/without type labels |
+| `_extract_scope(labels)` | `list[dict] -> str` | Single and multiple `area:*` labels |
+| `_clean_title(title)` | `str -> str` | Titles with/without `[FEATURE]` etc. prefix |
+| `_format_assignees(assignees)` | `list[dict] -> str` | Empty list, single, multiple assignees |
+| `_infer_review(pr)` | `dict -> tuple[str, str]` | Various combinations of `reviewDecision`, `latestReviews`, `reviewRequests` |
+| `_extract_reviewers(pr)` | `dict -> str` | Approved, changes requested, requested states |
+| `_build_cross_refs(branches, prs)` | `dict, list[dict] -> tuple[dict, dict]` | Branch matching, closing keywords, both |
+
+#### Layer 2: Container integration tests (in `tests/test_image.py`)
+
+Added to existing `TestWorkspaceStructure`:
+
+1. **Deployed files exist**: `.devcontainer/scripts/gh_issues.py` and `.devcontainer/justfile.gh` present in image
+2. **`rich` importable**: `python -c "from rich.table import Table"` succeeds
+3. **Script importable**: `python -c "import sys; sys.path.insert(0, '/root/assets/workspace/.devcontainer/scripts'); import gh_issues"` succeeds
+
+### Prerequisite
+
+Move the uncommitted `gh_issues.py` changes from the #67 branch to this issue's branch. These contain the functions (`_infer_review`, `_extract_reviewers`, enhanced `_build_cross_refs`) that need test coverage.
+
+### Out of scope
+
+- Testing actual `gh` CLI calls (requires GitHub auth)
+- Testing Rich table rendering output (visual, fragile)
+- Refactoring to extract I/O boundaries (separate issue)
+

--- a/docs/pull-requests/pr-100.md
+++ b/docs/pull-requests/pr-100.md
@@ -1,0 +1,48 @@
+---
+type: pull_request
+state: closed (merged)
+branch: bugfix/91-fix-sync-issues-schedule → main
+created: 2026-02-20T09:28:32Z
+updated: 2026-02-20T10:36:16Z
+author: c-vigo
+author_url: https://github.com/c-vigo
+url: https://github.com/vig-os/devcontainer/pull/100
+comments: 0
+labels: none
+assignees: c-vigo
+milestone: none
+projects: none
+relationship: none
+merged: 2026-02-20T10:08:55Z
+synced: 2026-02-20T13:17:58.804Z
+---
+
+# [PR 100](https://github.com/vig-os/devcontainer/pull/100) fix(ci): fix sync-issues schedule trigger and align with dev
+
+## Summary
+
+- Fix broken schedule trigger: `github.event.inputs.target-branch` is null on schedule events, causing `TARGET_BRANCH` to resolve to `refs/heads/` (404 in commit-action). Added `|| 'dev'` fallbacks for all input references.
+- Align workflow with `dev` branch improvements: pinned action SHAs, `ubuntu-22.04`, `timeout-minutes: 10`, top-level `permissions: {}`, removed stale cache restore-key prefix.
+- Add `output-dir` and `commit-msg` as parameterized `workflow_dispatch` inputs (defaults: `docs` and `chore: sync issues and PRs`). Existing callers (`release.yml`, `post-release.yml`) are unaffected since they only pass `target-branch`.
+- Remove stale `.github_data/` directory (31 files) superseded by `docs/` output directory.
+
+Closes #91
+
+## Test plan
+
+- [x] Trigger workflow manually via `workflow_dispatch` with default inputs -- verify it checks out `dev`, syncs to `docs/`, and commits to `dev`
+- [x] Trigger with explicit `target-branch` (e.g. a test branch) -- verify it respects the override
+- [x] Verify `release.yml` and `post-release.yml` dispatch calls still work (no input changes needed)
+- [ ] Wait for next scheduled run (2:00 AM UTC) to confirm automatic fallback to `dev`
+
+
+---
+---
+
+## Commits
+
+### Commit 1: [8d78c8f](https://github.com/vig-os/devcontainer/commit/8d78c8f6263be1fc340fd84c3b1379fa5d185090) by [c-vigo](https://github.com/c-vigo) on February 20, 2026 at 09:23 AM
+fix(ci): add fallback defaults for schedule trigger inputs, 39 files modified (.github/workflows/sync-issues.yml)
+
+### Commit 2: [c4e42df](https://github.com/vig-os/devcontainer/commit/c4e42df800928f9ddeb6ecf14c0e9c07db0d37c4) by [c-vigo](https://github.com/c-vigo) on February 20, 2026 at 09:23 AM
+chore: remove stale .github_data directory, 3813 files modified

--- a/docs/pull-requests/pr-106.md
+++ b/docs/pull-requests/pr-106.md
@@ -1,0 +1,45 @@
+---
+type: pull_request
+state: open
+branch: feature/102-worktree-reviewer-parameter → dev
+created: 2026-02-20T10:15:28Z
+updated: 2026-02-20T10:35:27Z
+author: gerchowl
+author_url: https://github.com/gerchowl
+url: https://github.com/vig-os/devcontainer/pull/106
+comments: 0
+labels: none
+assignees: gerchowl
+milestone: none
+projects: none
+relationship: none
+synced: 2026-02-20T13:17:57.410Z
+---
+
+# [PR 106](https://github.com/vig-os/devcontainer/pull/106) feat(worktree): add optional reviewer parameter to worktree-start
+
+## Summary
+
+This PR adds an optional `reviewer` parameter to the `worktree-start` just recipe, explicitly forbids agents from adding the Cursor co-author trailer, and fixes trust-related stalls in autonomous worktree pipelines.
+
+## Changes Made
+
+### Reviewer Parameter
+- **`justfile.worktree`**: Added `reviewer=""` parameter to `worktree-start`. Passed into the tmux session via `-e "PR_REVIEWER=$REVIEWER"`.
+- **`.cursor/skills/worktree:pr/SKILL.md`**: Updated to append `--reviewer "$PR_REVIEWER"` to `gh pr create` if set.
+
+### Co-author Prohibition
+- Updated all relevant skill files to explicitly state: **NEVER add 'Co-authored-by: Cursor <cursoragent@cursor.com>'** to commit messages.
+
+### Trust and Autonomous Reliability
+- **`justfile.worktree`**: Added `--trust` and `--approve-mcps` flags to `agent chat` invocations within tmux sessions. This ensures autonomous pipelines do not stall on trust or MCP approval prompts.
+- Mirrored all changes to `assets/workspace/`.
+
+### Documentation
+- **`CHANGELOG.md`**: Added entry for the new feature.
+
+## Test Plan
+
+Verified by running `just --show worktree-start` to ensure flags and environment variables are correctly propagated.
+
+Refs: #102

--- a/docs/pull-requests/pr-107.md
+++ b/docs/pull-requests/pr-107.md
@@ -1,0 +1,60 @@
+---
+type: pull_request
+state: closed (merged)
+branch: chore/91-sync-main-to-dev → dev
+created: 2026-02-20T10:18:04Z
+updated: 2026-02-20T10:28:15Z
+author: c-vigo
+author_url: https://github.com/c-vigo
+url: https://github.com/vig-os/devcontainer/pull/107
+comments: 0
+labels: none
+assignees: none
+milestone: none
+projects: none
+relationship: none
+merged: 2026-02-20T10:26:18Z
+synced: 2026-02-20T13:17:56.275Z
+---
+
+# [PR 107](https://github.com/vig-os/devcontainer/pull/107) chore: merge main into dev after sync-issues fix (#91)
+
+## Summary
+
+- Merge `main` into `dev` to bring in the sync-issues schedule trigger fix from PR #100
+- Remove stale `.github_data/` directory (67 files on dev that were superseded by `docs/issues/` and `docs/pull-requests/`)
+- Update CHANGELOG with the schedule fix and `.github_data` removal entries under `## Unreleased`
+
+Refs: #91
+
+## Test plan
+
+- [x] Verify `.github_data/` directory no longer exists on dev after merge
+- [x] Verify `sync-issues.yml` on dev matches the canonical version from main (with `|| 'dev'` fallbacks and parameterized inputs)
+- [x] Verify CHANGELOG entries are correctly placed under `### Fixed` and `### Removed`
+
+Refs: #91
+
+
+---
+---
+
+## Commits
+
+### Commit 1: [8d78c8f](https://github.com/vig-os/devcontainer/commit/8d78c8f6263be1fc340fd84c3b1379fa5d185090) by [c-vigo](https://github.com/c-vigo) on February 20, 2026 at 09:23 AM
+fix(ci): add fallback defaults for schedule trigger inputs, 39 files modified (.github/workflows/sync-issues.yml)
+
+### Commit 2: [c4e42df](https://github.com/vig-os/devcontainer/commit/c4e42df800928f9ddeb6ecf14c0e9c07db0d37c4) by [c-vigo](https://github.com/c-vigo) on February 20, 2026 at 09:23 AM
+chore: remove stale .github_data directory, 3813 files modified
+
+### Commit 3: [039a752](https://github.com/vig-os/devcontainer/commit/039a752641fc012459e036324db02ccc934db3d1) by [gerchowl](https://github.com/gerchowl) on February 20, 2026 at 10:08 AM
+fix(ci): fix sync-issues schedule trigger and align with dev (#100), 3852 files modified
+
+### Commit 4: [074fd59](https://github.com/vig-os/devcontainer/commit/074fd59bffb632f20c705de901173dd2566b8719) by [c-vigo](https://github.com/c-vigo) on February 20, 2026 at 10:12 AM
+chore: merge main into dev to apply sync-issues fix from #91, 3863 files modified
+
+### Commit 5: [b757417](https://github.com/vig-os/devcontainer/commit/b757417bf35cbc601d48b2b78420298be3fa198e) by [c-vigo](https://github.com/c-vigo) on February 20, 2026 at 10:12 AM
+chore: remove stale .github_data directory from dev, 9379 files modified
+
+### Commit 6: [88d786e](https://github.com/vig-os/devcontainer/commit/88d786e2b73455bb0e589213affca07563f88cf5) by [c-vigo](https://github.com/c-vigo) on February 20, 2026 at 10:13 AM
+docs: add sync-issues schedule fix to CHANGELOG, 5 files modified (CHANGELOG.md)

--- a/docs/pull-requests/pr-110.md
+++ b/docs/pull-requests/pr-110.md
@@ -1,0 +1,60 @@
+---
+type: pull_request
+state: closed
+branch: feature/install-cursor-agent → dev
+created: 2026-02-20T10:41:08Z
+updated: 2026-02-20T13:14:31Z
+author: nacholiya
+author_url: https://github.com/nacholiya
+url: https://github.com/vig-os/devcontainer/pull/110
+comments: 1
+labels: none
+assignees: none
+milestone: none
+projects: none
+relationship: none
+synced: 2026-02-20T13:17:54.336Z
+---
+
+# [PR 110](https://github.com/vig-os/devcontainer/pull/110) feat: install cursor-agent CLI in devcontainer image
+
+## Summary
+
+Installs the `cursor-agent` CLI inside the devcontainer image so that
+`just worktree-start` works without requiring manual installation.
+
+## Changes
+
+- Added cursor-agent installation step to Containerfile
+- Verified installation with `agent --version`
+- Fails build if installation fails
+
+## Impact
+
+- Fixes: `[ERROR] cursor-agent CLI is not installed.`
+- Enables autonomous worktree workflow out of the box
+- No breaking changes
+
+
+---
+---
+
+## Comments (1)
+
+### [Comment #1](https://github.com/vig-os/devcontainer/pull/110#issuecomment-3934449550) by [@gerchowl](https://github.com/gerchowl)
+
+_Posted on February 20, 2026 at 01:14 PM_
+
+Thanks for the contribution, @nacholiya! The Containerfile change is exactly right.
+
+I've adopted your commit (preserving your authorship) onto the branch `feature/108-install-cursor-agent-cli` which follows our branch naming convention (`<type>/<issue>-<summary>`) and targets `dev` instead of `main` per our [branching strategy](docs/RELEASE_CYCLE.md#branching-strategy). I also added the CHANGELOG entry and `Refs: #108` reference.
+
+Closing this in favor of the new PR — your commit and authorship are fully preserved there. Thanks again!
+
+---
+---
+
+## Commits
+
+### Commit 1: [15f7efd](https://github.com/vig-os/devcontainer/commit/15f7efdb5856d0d70510145adcdd158497ccc217) by [nacholiya](https://github.com/nacholiya) on February 20, 2026 at 10:39 AM
+feat(devcontainer): install cursor-agent CLI in image to enable autonomous woktree workflow, 9 files modified (Containerfile)

--- a/docs/pull-requests/pr-112.md
+++ b/docs/pull-requests/pr-112.md
@@ -1,0 +1,81 @@
+---
+type: pull_request
+state: open
+branch: bugfix/111-fix-devcontainer-npm-permissions → dev
+created: 2026-02-20T11:06:38Z
+updated: 2026-02-20T12:33:23Z
+author: c-vigo
+author_url: https://github.com/c-vigo
+url: https://github.com/vig-os/devcontainer/pull/112
+comments: 0
+labels: none
+assignees: c-vigo
+milestone: none
+projects: none
+relationship: none
+synced: 2026-02-20T13:17:52.780Z
+---
+
+# [PR 112](https://github.com/vig-os/devcontainer/pull/112) fix(setup): use local npm install for devcontainer CLI
+
+## Description
+
+Fix `just init` failing to install the `devcontainer` CLI on Linux due to npm global install permission error (`EACCES: permission denied` on `/usr/local/lib/node_modules`). The `@devcontainers/cli` package is already declared in `package.json`, so this switches from `npm install -g` to a local `npm install`, matching the existing `bats` dependency pattern.
+
+## Related Issue(s)
+
+Closes #111
+
+## Type of Change
+
+- [x] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation update
+- [ ] Refactoring (no functional changes)
+- [ ] CI / Build change
+- [x] Test updates
+
+## Changes Made
+
+- `scripts/requirements.yaml`: Changed devcontainer entry to use local `npm install` instead of `npm install -g`, added `node_modules/.bin/devcontainer` fallback to check command, switched version command to `npx devcontainer --version`
+- `tests/bats/init.bats`: Added 2 tests asserting the local install pattern and absence of global install
+- `CHANGELOG.md`: Added Fixed entry under Unreleased
+
+## Changelog Entry
+
+### Fixed
+
+- **`just init` fails to install devcontainer CLI on Linux** ([#111](https://github.com/vig-os/devcontainer/issues/111))
+  - `npm install -g` requires root access to `/usr/local/lib/node_modules`, causing EACCES permission denied
+  - Switched to local `npm install` (package already declared in `package.json`), matching the existing `bats` pattern
+
+## Testing
+
+- [x] Tests pass locally (`just test`)
+- [x] Manual testing performed (describe below)
+
+### Manual Testing Details
+
+1. `npx bats tests/bats/init.bats --filter "devcontainer"` — both new tests pass
+2. `npx bats tests/bats/init.bats` — all 70 tests pass (no regressions)
+3. `just init --check` — devcontainer 0.81.1 detected as installed via `node_modules/.bin/devcontainer`
+
+## Checklist
+
+- [x] My code follows the project's style guidelines
+- [x] I have performed a self-review of my code
+- [x] I have commented my code, particularly in hard-to-understand areas
+- [x] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
+- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
+- [x] My changes generate no new warnings or errors
+- [x] I have added tests that prove my fix is effective or that my feature works
+- [x] New and existing unit tests pass locally with my changes
+- [x] Any dependent changes have been merged and published
+
+## Additional Notes
+
+The CI setup action (`.github/actions/setup-env/action.yml`) still uses `npm install -g` for the devcontainer CLI. This is intentional — GitHub Actions runners have appropriate permissions for global installs. Only the local development path (`just init`) is affected by this fix.
+
+Refs: #111
+

--- a/docs/pull-requests/pr-54.md
+++ b/docs/pull-requests/pr-54.md
@@ -14,7 +14,7 @@ milestone: none
 projects: none
 relationship: none
 merged: 2026-02-17T15:32:55Z
-synced: 2026-02-17T15:33:19.522Z
+synced: 2026-02-20T13:18:27.531Z
 ---
 
 # [PR 54](https://github.com/vig-os/devcontainer/pull/54) feat: automate and standardize repository setup
@@ -148,7 +148,7 @@ This is a large feature branch (70 files changed, ~10,300 insertions, ~1,800 del
 
 _Posted on February 13, 2026 at 07:42 AM_
 
-This pull request sets up GitHub code scanning for this repository. Once the scans have completed and the checks have passed, the analysis results for this pull request branch will appear on [this overview](/vig-os/devcontainer/security/code-scanning?query=pr%3A54+is%3Aopen). Once you merge this pull request, the 'Security' tab will show more code scanning analysis results (for example, for the default branch). Depending on your configuration and choice of analysis tool, future pull requests will be annotated with code scanning analysis results. For more information about GitHub code scanning, check out [the documentation](https://docs.github.com/code-security/code-scanning/introduction-to-code-scanning/about-code-scanning).
+This pull request sets up GitHub code scanning for this repository. Once the scans have completed and the checks have passed, the analysis results for this pull request branch will appear on [this overview](/vig-os/devcontainer/security/code-scanning?query=pr%3A54+is%3Aopen). Once you merge this pull request, the 'Security' tab will show more code scanning analysis results (for example, for the default branch). Depending on your configuration and choice of analysis tool, future pull requests will be annotated with code scanning analysis results. For more information about GitHub code scanning, check out [the documentation](https://docs.github.com/code-security/code-scanning/introduction-to-code-scanning/about-code-scanning). 
 
 ---
 ---
@@ -170,16 +170,16 @@ _File: [`justfile (line 14 RIGHT)`](https://github.com/vig-os/devcontainer/pull/
 -# ═══════════════════════════════════════════════════════════════════════════════
 +# ===============================================================================
  # Import standard dev recipes
-
+ 
  import 'justfile.base'
-
+ 
 -# ═══════════════════════════════════════════════════════════════════════════════
 +# ===============================================================================
  # VARIABLES
 -# ═══════════════════════════════════════════════════════════════════════════════
 +# ===============================================================================
  # Allow TEST_REGISTRY to override REPO for testing (e.g., localhost:5000/test/)
-
+ 
 -repo := env_var_or_default("TEST_REGISTRY", "ghcr.io/vig-os/devcontainer")
 +repo := env("TEST_REGISTRY", "ghcr.io/vig-os/devcontainer")
 ```
@@ -216,7 +216,7 @@ _File: [`justfile.podman`](https://github.com/vig-os/devcontainer/pull/54#discus
 +        echo "[ERROR] Container '{{ name }}' not found"
          exit 1
      fi
-
+ 
  # Stop and remove all containers (with confirmation)
  [group('podman')]
 -[confirm("⚠️  This will remove ALL containers. Continue? [y/N]")]
@@ -253,7 +253,7 @@ _File: [`justfile.podman`](https://github.com/vig-os/devcontainer/pull/54#discus
 +        echo "[ERROR] Container '{{ name }}' not found"
          exit 1
      fi
-
+ 
  # Stop and remove all containers (with confirmation)
  [group('podman')]
 -[confirm("⚠️  This will remove ALL containers. Continue? [y/N]")]
@@ -271,7 +271,7 @@ _File: [`justfile.podman`](https://github.com/vig-os/devcontainer/pull/54#discus
 -        echo "✨ No containers to remove"
 +        echo "[*] No containers to remove"
      fi
-
+ 
  # Stop and remove project-related containers
  [group('podman')]
  podman-kill-project:
@@ -294,7 +294,7 @@ _File: [`install.sh`](https://github.com/vig-os/devcontainer/pull/54#discussion_
 @@ -321,8 +354,20 @@ info "Using $RUNTIME with image $IMAGE"
  info "Target directory: $PROJECT_PATH"
  info "Project name: $PROJECT_NAME"
-
+ 
 +# Build the command
 +# Use --rm to cleanup container after run; no -it since we use --no-prompts (non-interactive)
 +# Pass SHORT_NAME and ORG_NAME as environment variables to the container
@@ -360,7 +360,7 @@ refactor: remove trailing newline requirement from commit message rules, 39 file
 ### Commit 17: [8ec802f](https://github.com/vig-os/devcontainer/commit/8ec802fc87e577946e546e6f0d66808bb7b2c443) by [c-vigo](https://github.com/c-vigo) on February 2, 2026 at 05:05 PM
 feat: add commit message validation hook to pre-commit configuration, 161 files modified (assets/validate_commit_msg.py, assets/workspace/.pre-commit-config.yaml)
 
-### Commit 18: [calf172d](https://github.com/vig-os/devcontainer/commit/caf172da13f4c0b04db643d23e72fd9843e76939) by [c-vigo](https://github.com/c-vigo) on February 2, 2026 at 05:09 PM
+### Commit 18: [caf172d](https://github.com/vig-os/devcontainer/commit/caf172da13f4c0b04db643d23e72fd9843e76939) by [c-vigo](https://github.com/c-vigo) on February 2, 2026 at 05:09 PM
 Merge pull request #41 from vig-os:feature/36-standardize-commit-messages, 877 files modified
 
 ### Commit 19: [0ab7dba](https://github.com/vig-os/devcontainer/commit/0ab7dba5517a62264e17e27d3160b80cf5c8ebd2) by [c-vigo](https://github.com/c-vigo) on February 3, 2026 at 10:44 AM
@@ -441,7 +441,7 @@ feat: add script to prepare CHANGELOG for releases, 192 files modified (scripts/
 ### Commit 44: [1c2558d](https://github.com/vig-os/devcontainer/commit/1c2558dd3d34b31d35b8089c252fd68b9f74b1fe) by [c-vigo](https://github.com/c-vigo) on February 6, 2026 at 04:51 PM
 test: add tests for release management scripts, 341 files modified (tests/test_release_scripts.py)
 
-### Commit 45: [af5safe1](https://github.com/vig-os/devcontainer/commit/af5afe13d316f9557024447267383348b8d0a385) by [c-vigo](https://github.com/c-vigo) on February 6, 2026 at 04:52 PM
+### Commit 45: [af5afe1](https://github.com/vig-os/devcontainer/commit/af5afe13d316f9557024447267383348b8d0a385) by [c-vigo](https://github.com/c-vigo) on February 6, 2026 at 04:52 PM
 feat: add script to prepare release branches, 319 files modified (scripts/prepare-release.sh)
 
 ### Commit 46: [530eb64](https://github.com/vig-os/devcontainer/commit/530eb640d62bd002b914b39dd2f37a87dfc1a9ea) by [c-vigo](https://github.com/c-vigo) on February 6, 2026 at 04:52 PM

--- a/docs/pull-requests/pr-62.md
+++ b/docs/pull-requests/pr-62.md
@@ -13,7 +13,7 @@ assignees: gerchowl
 milestone: none
 projects: none
 relationship: none
-synced: 2026-02-18T01:07:34.650Z
+synced: 2026-02-20T13:18:22.710Z
 ---
 
 # [PR 62](https://github.com/vig-os/devcontainer/pull/62) feat: add agent-friendly issue templates, changelog rule, and PR template enhancements (#61)
@@ -95,3 +95,26 @@ Closes #61
 - The `feature_request.yml` template currently uses `labels: ['enhancement']` but the repo label is `feature`. This mismatch predates this PR and is not addressed here — consider a follow-up to align template labels with repo labels.
 - No test changes are needed since this is purely templates and Cursor rules (no executable code).
 
+
+
+---
+---
+
+## Comments (1)
+
+### [Comment #1](https://github.com/vig-os/devcontainer/pull/62#issuecomment-3917902907) by [@gerchowl](https://github.com/gerchowl)
+
+_Posted on February 18, 2026 at 01:07 AM_
+
+Superseded by #68 which consolidates the work from #61, #63, and #67 into a single PR.
+
+---
+---
+
+## Commits
+
+### Commit 1: [8b91124](https://github.com/vig-os/devcontainer/commit/8b911249be72bd4e4bb38358b0b2a82bb6e144b0) by [gerchowl](https://github.com/gerchowl) on February 17, 2026 at 10:01 PM
+feat: add agent-friendly issue templates, changelog rule, and PR template enhancements, 410 files modified
+
+### Commit 2: [049502b](https://github.com/vig-os/devcontainer/commit/049502b2cfa5707e6ee6fec7042e142bfd3126aa) by [gerchowl](https://github.com/gerchowl) on February 17, 2026 at 10:46 PM
+docs: add smaller commits guidance to commit-msg command, 1 file modified (.cursor/commands/commit-msg.md)

--- a/docs/pull-requests/pr-65.md
+++ b/docs/pull-requests/pr-65.md
@@ -1,15 +1,5 @@
 ---
 type: pull_request
-<<<<<<< HEAD
-state: open
-branch: feature/63-agent-driven-development-workflows → dev
-created: 2026-02-17T23:10:02Z
-updated: 2026-02-17T23:10:04Z
-author: gerchowl
-author_url: https://github.com/gerchowl
-url: https://github.com/vig-os/devcontainer/pull/65
-comments: 0
-=======
 state: closed
 branch: feature/63-agent-driven-development-workflows → dev
 created: 2026-02-17T23:10:02Z
@@ -18,17 +8,12 @@ author: gerchowl
 author_url: https://github.com/gerchowl
 url: https://github.com/vig-os/devcontainer/pull/65
 comments: 1
->>>>>>> origin/dev
 labels: none
 assignees: gerchowl
 milestone: none
 projects: none
 relationship: none
-<<<<<<< HEAD
-synced: 2026-02-17T23:10:20.801Z
-=======
-synced: 2026-02-18T08:56:48.919Z
->>>>>>> origin/dev
+synced: 2026-02-20T13:18:21.083Z
 ---
 
 # [PR 65](https://github.com/vig-os/devcontainer/pull/65) feat: add Cursor commands and rules for agent-driven development workflows (#63)
@@ -119,8 +104,6 @@ Closes #63
 - No executable code is added — all files are Cursor commands (`.md`) and rules (`.mdc`), which are agent instructions only.
 - Worktree/parallel agent support was explored during this work and scoped as a separate issue: #64
 - Inspired by [obra/superpowers](https://github.com/obra/superpowers) agentic skills framework.
-<<<<<<< HEAD
-=======
 
 
 
@@ -163,4 +146,3 @@ chore: update sync-manifest and fix pre-commit formatting issues, 90 files modif
 
 ### Commit 8: [1ba52b6](https://github.com/vig-os/devcontainer/commit/1ba52b6fcabe2ae8cc0c11beba05d572a100323a) by [gerchowl](https://github.com/gerchowl) on February 18, 2026 at 12:40 AM
 fix: add COMMIT_MESSAGE_STANDARD.md to workspace sync, 100 files modified (assets/workspace/docs/COMMIT_MESSAGE_STANDARD.md, scripts/sync-workspace.sh)
->>>>>>> origin/dev

--- a/docs/pull-requests/pr-68.md
+++ b/docs/pull-requests/pr-68.md
@@ -1,19 +1,20 @@
 ---
 type: pull_request
-state: open
+state: closed (merged)
 branch: feature/67-declarative-sync-manifest → dev
 created: 2026-02-18T00:58:00Z
-updated: 2026-02-19T17:35:23Z
+updated: 2026-02-20T10:30:18Z
 author: gerchowl
 author_url: https://github.com/gerchowl
 url: https://github.com/vig-os/devcontainer/pull/68
-comments: 27
+comments: 28
 labels: none
 assignees: none
 milestone: none
 projects: none
 relationship: none
-synced: 2026-02-19T17:40:54.548Z
+merged: 2026-02-20T09:28:26Z
+synced: 2026-02-20T13:18:19.423Z
 ---
 
 # [PR 68](https://github.com/vig-os/devcontainer/pull/68) feat: agent-driven development workflows, templates, and declarative sync manifest
@@ -35,13 +36,23 @@ synced: 2026-02-19T17:40:54.548Z
   - `justfile.worktree` with tmux + cursor-agent CLI recipes for devcontainer environments
   - 7 autonomous worktree skills (`worktree:brainstorm`, `worktree:plan`, `worktree:execute`, `worktree:verify`, `worktree:pr`, `worktree:ask`, `worktree:solve-and-pr`)
   - Sync manifest updated to propagate worktree config and recipes to downstream projects
+- Wire version-check notification into post-attach lifecycle and add host-side devcontainer-upgrade recipe (#73)
+  - `just check` recipe for version-check subcommands
+  - `just devcontainer-upgrade` host-side recipe
+  - Fixed notification message with correct upgrade instructions
+  - Comprehensive BATS tests for version-check recipes
+- Add inception:* skill family for pre-development product thinking (#90)
+  - 4 skills: `inception:explore`, `inception:scope`, `inception:architect`, `inception:plan`
+  - RFC and DESIGN document templates
 
 Closes #61
 Closes #63
 Closes #64
 Closes #67
+Closes #73
 Closes #80
 Closes #84
+Closes #90
 
 ### Key files
 
@@ -51,11 +62,15 @@ Closes #84
 | `.cursor/commands/*.md` | 14 new agent workflow commands |
 | `.cursor/rules/*.mdc` | 3 new always-on rules (coding-principles, tdd, changelog) |
 | `.cursor/skills/worktree:*/SKILL.md` | 7 autonomous worktree skills |
+| `.cursor/skills/inception:*/SKILL.md` | 4 inception phase skills |
 | `.cursor/worktrees.json` | Native Cursor worktree initialization |
 | `justfile.worktree` | tmux + cursor-agent CLI worktree recipes |
 | `.github/ISSUE_TEMPLATE/*.yml` | 6 issue templates + config.yml |
 | `.github/pull_request_template.md` | Enhanced PR template |
 | `scripts/prepare-build.sh` | Now calls `sync_manifest.py` instead of bash function |
+| `assets/workspace/.devcontainer/scripts/version-check.sh` | Version-check notification + upgrade instructions |
+| `assets/workspace/.devcontainer/scripts/post-attach.sh` | Wired version-check into lifecycle |
+| `assets/workspace/.devcontainer/justfile.base` | Added `check` and `devcontainer-upgrade` recipes |
 
 ### Transforms applied to workspace template
 
@@ -73,6 +88,7 @@ Closes #84
 - [ ] New issue templates render correctly on GitHub
 - [ ] `just worktree-list` runs without error
 - [ ] `.cursor/worktrees.json` is valid JSON
+
 
 
 ---
@@ -398,7 +414,7 @@ All tasks complete.
 ---
 ---
 
-## Review Threads (9)
+## Review Threads (10)
 
 ### Review by [@c-vigo](https://github.com/c-vigo)
 
@@ -847,3 +863,271 @@ this has changed to `docs/issues` in a recent PR
 
 ---
 
+### Review by [@c-vigo](https://github.com/c-vigo)
+
+_Posted on February 19, 2026 at 08:07 AM_
+
+_File: [`scripts/gh_issues.py (line 1 RIGHT)`](https://github.com/vig-os/devcontainer/pull/68#discussion_r2826236680)_
+
+tests for this file? and for its deployment with the container image?
+
+
+---
+---
+
+## Commits
+
+### Commit 1: [8b91124](https://github.com/vig-os/devcontainer/commit/8b911249be72bd4e4bb38358b0b2a82bb6e144b0) by [gerchowl](https://github.com/gerchowl) on February 17, 2026 at 10:01 PM
+feat: add agent-friendly issue templates, changelog rule, and PR template enhancements, 410 files modified
+
+### Commit 2: [049502b](https://github.com/vig-os/devcontainer/commit/049502b2cfa5707e6ee6fec7042e142bfd3126aa) by [gerchowl](https://github.com/gerchowl) on February 17, 2026 at 10:46 PM
+docs: add smaller commits guidance to commit-msg command, 1 file modified (.cursor/commands/commit-msg.md)
+
+### Commit 3: [514f15d](https://github.com/vig-os/devcontainer/commit/514f15df979964054b7b04008b62074c91094339) by [gerchowl](https://github.com/gerchowl) on February 17, 2026 at 10:48 PM
+feat: add always-on coding principles rule, 21 files modified (.cursor/rules/coding-principles.mdc)
+
+### Commit 4: [47d0e8c](https://github.com/vig-os/devcontainer/commit/47d0e8cd237edfd2bc2b467c1b7dfd8b27c74408) by [gerchowl](https://github.com/gerchowl) on February 17, 2026 at 10:52 PM
+feat: add agent-driven development commands and TDD rule, 496 files modified
+
+### Commit 5: [d64020c](https://github.com/vig-os/devcontainer/commit/d64020c942075cf22f0c7163cf695208f5b4c2a5) by [gerchowl](https://github.com/gerchowl) on February 17, 2026 at 10:52 PM
+feat: add agent-driven development commands and TDD rule, 1972 files modified
+
+### Commit 6: [18ddeb7](https://github.com/vig-os/devcontainer/commit/18ddeb75381ef3d9aaeb8f6ab130bde7ae8f6191) by [gerchowl](https://github.com/gerchowl) on February 18, 2026 at 12:04 AM
+chore: resolve merge conflict in CHANGELOG.md
+
+### Commit 7: [1544198](https://github.com/vig-os/devcontainer/commit/1544198d2144385df957809f73c87fb01ff83e01) by [gerchowl](https://github.com/gerchowl) on February 18, 2026 at 12:11 AM
+fix: remove sync-workspace hook from workspace template, 8 files modified (scripts/sync-workspace.sh)
+
+### Commit 8: [f6f99a2](https://github.com/vig-os/devcontainer/commit/f6f99a25926cb391dc1019dabf751f6426239a97) by [gerchowl](https://github.com/gerchowl) on February 18, 2026 at 12:20 AM
+fix: use sed/awk for hook removal to preserve YAML structure, 117 files modified (assets/workspace/.pre-commit-config.yaml, scripts/remove-precommit-hooks.py, scripts/sync-workspace.sh)
+
+### Commit 9: [345a8dc](https://github.com/vig-os/devcontainer/commit/345a8dc2672b5c1c209dacc54275ffbdde1773cd) by [gerchowl](https://github.com/gerchowl) on February 18, 2026 at 12:27 AM
+chore: update sync-manifest and fix pre-commit formatting issues, 90 files modified (CONTRIBUTE.md, README.md, docs/issues/issue-37.md, docs/pull-requests/pr-54.md, docs/pull-requests/pr-62.md, justfile, scripts/sync-manifest.txt)
+
+### Commit 10: [1ba52b6](https://github.com/vig-os/devcontainer/commit/1ba52b6fcabe2ae8cc0c11beba05d572a100323a) by [gerchowl](https://github.com/gerchowl) on February 18, 2026 at 12:40 AM
+fix: add COMMIT_MESSAGE_STANDARD.md to workspace sync, 100 files modified (assets/workspace/docs/COMMIT_MESSAGE_STANDARD.md, scripts/sync-workspace.sh)
+
+### Commit 11: [01ee2c8](https://github.com/vig-os/devcontainer/commit/01ee2c810d13d4db2e714f5a0a5909f29d07321c) by [commit-action-bot[bot]](https://github.com/apps/commit-action-bot) on February 17, 2026 at 11:09 PM
+chore: sync issues and PRs, 65 files modified (.github_data/issues/issue-64.md)
+
+### Commit 12: [8736726](https://github.com/vig-os/devcontainer/commit/87367269e22da8bc5b5b892755992a23b34e057f) by [commit-action-bot[bot]](https://github.com/apps/commit-action-bot) on February 17, 2026 at 11:10 PM
+chore: sync issues and PRs, 107 files modified (docs/pull-requests/pr-65.md)
+
+### Commit 13: [596d50c](https://github.com/vig-os/devcontainer/commit/596d50c079b68737837617ca6b38daef739c3a7f) by [commit-action-bot[bot]](https://github.com/apps/commit-action-bot) on February 18, 2026 at 12:33 AM
+chore: sync issues and PRs, 168 files modified (.github_data/issues/issue-66.md, .github_data/pull-requests/pr-65.md)
+
+### Commit 14: [3c329c1](https://github.com/vig-os/devcontainer/commit/3c329c151144c1d61463ba2c83b3fd67e1f32eba) by [commit-action-bot[bot]](https://github.com/apps/commit-action-bot) on February 18, 2026 at 12:45 AM
+chore: sync issues and PRs, 85 files modified (.github_data/issues/issue-67.md)
+
+### Commit 15: [36ace4c](https://github.com/vig-os/devcontainer/commit/36ace4c6c55cf9bc47d1b84b53072ffeff4919a0) by [gerchowl](https://github.com/gerchowl) on February 18, 2026 at 12:53 AM
+refactor: replace sync-manifest.txt with declarative Python manifest, 1596 files modified
+
+### Commit 16: [7580bfc](https://github.com/vig-os/devcontainer/commit/7580bfc33991a065247dbbaeefaacce5d5a852f5) by [gerchowl](https://github.com/gerchowl) on February 18, 2026 at 01:01 AM
+chore: fix trailing blank line in pr-65.md, 1 file modified (docs/pull-requests/pr-65.md)
+
+### Commit 17: [d69def9](https://github.com/vig-os/devcontainer/commit/d69def92afbd5d8ba96b104b32b0ab154e4e9704) by [gerchowl](https://github.com/gerchowl) on February 18, 2026 at 01:06 AM
+chore: merge feature/61 (agent-friendly templates and changelog rule), 835 files modified
+
+### Commit 18: [fee3454](https://github.com/vig-os/devcontainer/commit/fee3454e5be681aca69a7ab2052ab3009cc6973b) by [gerchowl](https://github.com/gerchowl) on February 18, 2026 at 01:48 PM
+refactor: rename start-issue command to claim-issue with assignment check, 25 files modified (.cursor/commands/claim-issue.md)
+
+### Commit 19: [f8cc359](https://github.com/vig-os/devcontainer/commit/f8cc3594c44a8421dce915c84d513797cdbdae53) by [gerchowl](https://github.com/gerchowl) on February 18, 2026 at 02:21 PM
+refactor: move plan and design storage to GitHub issue comments, 310 files modified
+
+### Commit 20: [2ea1add](https://github.com/vig-os/devcontainer/commit/2ea1add1ce4ab145eb83abe033bcd8efe4be4e9a) by [gerchowl](https://github.com/gerchowl) on February 18, 2026 at 02:22 PM
+refactor: enforce per-phase TDD commits for audit compliance, 36 files modified (.cursor/commands/tdd.md, .cursor/rules/tdd.mdc, assets/workspace/.cursor/commands/tdd.md, assets/workspace/.cursor/rules/tdd.mdc)
+
+### Commit 21: [f06cd55](https://github.com/vig-os/devcontainer/commit/f06cd55d92ec50077c9405858d05d291ef831771) by [gerchowl](https://github.com/gerchowl) on February 18, 2026 at 02:22 PM
+refactor: sync claim-issue rename to workspace template, 25 files modified (assets/workspace/.cursor/commands/claim-issue.md)
+
+### Commit 22: [bc65a91](https://github.com/vig-os/devcontainer/commit/bc65a91afaabf0fd430f47279339964036692ed2) by [gerchowl](https://github.com/gerchowl) on February 18, 2026 at 02:22 PM
+chore: add plan.md transform to sync manifest, 6 files modified (scripts/sync_manifest.py)
+
+### Commit 23: [2fbce7b](https://github.com/vig-os/devcontainer/commit/2fbce7bcd462075ec57e310b313d32d8f6a2d888) by [gerchowl](https://github.com/gerchowl) on February 18, 2026 at 02:22 PM
+chore: remove stale synced issue-37 from docs/, 109 files modified (docs/issues/issue-37.md)
+
+### Commit 24: [0d16570](https://github.com/vig-os/devcontainer/commit/0d16570bbf32a1960d3418d7bec4de85dd38cdf9) by [gerchowl](https://github.com/gerchowl) on February 18, 2026 at 02:46 PM
+feat: reconcile issue template labels with repository labels, 562 files modified
+
+### Commit 25: [479adc5](https://github.com/vig-os/devcontainer/commit/479adc50686316d54d7a64d45ff30e41f8449724) by [gerchowl](https://github.com/gerchowl) on February 18, 2026 at 02:47 PM
+feat: add Single Source of Truth guidelines, 54 files modified (.cursor/rules/single-source-of-truth.mdc, assets/workspace/.cursor/rules/single-source-of-truth.mdc)
+
+### Commit 26: [2c592db](https://github.com/vig-os/devcontainer/commit/2c592dbe8240972b7fb7333d7bf60658565484e8) by [gerchowl](https://github.com/gerchowl) on February 18, 2026 at 03:04 PM
+feat: add issue triage agent skill with label taxonomy, 253 files modified (.cursor/skills/issue-triage/SKILL.md, .cursor/skills/issue-triage/label-taxonomy.md)
+
+### Commit 27: [8ec63d6](https://github.com/vig-os/devcontainer/commit/8ec63d629d1c5c3b632f738fc7be71665cea1289) by [gerchowl](https://github.com/gerchowl) on February 18, 2026 at 03:04 PM
+chore: add .cursor/skills/ to sync manifest, 2 files modified (scripts/sync_manifest.py)
+
+### Commit 28: [9294c75](https://github.com/vig-os/devcontainer/commit/9294c75fe0aeff43f6c717db415b4ebd39a5287e) by [gerchowl](https://github.com/gerchowl) on February 18, 2026 at 03:04 PM
+chore: sync issue-triage skill to workspace template, 253 files modified (assets/workspace/.cursor/skills/issue-triage/SKILL.md, assets/workspace/.cursor/skills/issue-triage/label-taxonomy.md)
+
+### Commit 29: [754a21b](https://github.com/vig-os/devcontainer/commit/754a21bd696dc80af2b777199c1544315c5a2c20) by [gerchowl](https://github.com/gerchowl) on February 18, 2026 at 03:05 PM
+docs: add issue triage skill to CHANGELOG, 5 files modified (CHANGELOG.md)
+
+### Commit 30: [44fd32e](https://github.com/vig-os/devcontainer/commit/44fd32e69cf7f2d1c9818f3970ecf3eff1912194) by [gerchowl](https://github.com/gerchowl) on February 18, 2026 at 03:34 PM
+refactor: migrate cursor commands to skills and fix stale links, 280 files modified
+
+### Commit 31: [a10aca9](https://github.com/vig-os/devcontainer/commit/a10aca915cfa8650e625281060fbe45eb07d0347) by [gerchowl](https://github.com/gerchowl) on February 18, 2026 at 03:35 PM
+test: add BATS tests for init-workspace non-empty detection, 83 files modified (tests/bats/init-workspace.bats)
+
+### Commit 32: [5f4a10c](https://github.com/vig-os/devcontainer/commit/5f4a10c439b4f38efda40c4d5b71ae372884b174) by [gerchowl](https://github.com/gerchowl) on February 18, 2026 at 04:04 PM
+feat: add PR analysis, file-based matrix, and parent milestone convention to triage skill, 116 files modified (.cursor/skills/issue-triage/SKILL.md)
+
+### Commit 33: [925fe8c](https://github.com/vig-os/devcontainer/commit/925fe8cba858e49d657bba955a9cbec9496a6108) by [gerchowl](https://github.com/gerchowl) on February 18, 2026 at 04:04 PM
+feat: add discussion issue template, 70 files modified (.github/ISSUE_TEMPLATE/discussion.yml)
+
+### Commit 34: [cb30d30](https://github.com/vig-os/devcontainer/commit/cb30d30f9c8c00a20f1501e0276d369bcb66434e) by [gerchowl](https://github.com/gerchowl) on February 18, 2026 at 04:06 PM
+chore: add 'agent' to allowed commit message scopes, 2 files modified (.pre-commit-config.yaml)
+
+### Commit 35: [016f9ee](https://github.com/vig-os/devcontainer/commit/016f9ee089503959e1c7f161086debce84793493) by [gerchowl](https://github.com/gerchowl) on February 18, 2026 at 04:34 PM
+chore: add 'agent' to allowed commit message scopes, 2 files modified (tests/conftest.py)
+
+### Commit 36: [ad3266c](https://github.com/vig-os/devcontainer/commit/ad3266cc7de0d45ceb9e12ec36ebb6dfd7e47cc2) by [commit-action-bot[bot]](https://github.com/apps/commit-action-bot) on February 18, 2026 at 04:40 PM
+chore: sync issues and PRs, 68 files modified (.github_data/issues/issue-67.md)
+
+### Commit 37: [7e14942](https://github.com/vig-os/devcontainer/commit/7e14942e1751aaa8109b364519b3fd85a8b1e0fd) by [gerchowl](https://github.com/gerchowl) on February 18, 2026 at 04:45 PM
+refactor: namespace-prefix all Cursor skill names with colon separator, 265 files modified
+
+### Commit 38: [0905c21](https://github.com/vig-os/devcontainer/commit/0905c214ee07c2976bd7030068641810c7becd56) by [gerchowl](https://github.com/gerchowl) on February 18, 2026 at 04:47 PM
+chore: sync workspace for devc asset, 70 files modified (assets/workspace/.github/ISSUE_TEMPLATE/discussion.yml)
+
+### Commit 39: [ac8b32f](https://github.com/vig-os/devcontainer/commit/ac8b32f16e04ecf25588d823e5e5facd7aa40a26) by [gerchowl](https://github.com/gerchowl) on February 18, 2026 at 05:05 PM
+feat: add GitHub issue and PR dashboard recipe, 782 files modified
+
+### Commit 40: [d5ee578](https://github.com/vig-os/devcontainer/commit/d5ee578c42c020a378386b9485085c520e2aa91a) by [gerchowl](https://github.com/gerchowl) on February 18, 2026 at 06:30 PM
+chore: merge feature/67-declarative-sync-manifest into dev
+
+### Commit 41: [18f008f](https://github.com/vig-os/devcontainer/commit/18f008f62102721fcc0c489d7e338cac0819bcc3) by [commit-action-bot[bot]](https://github.com/apps/commit-action-bot) on February 18, 2026 at 08:39 PM
+chore: sync issues and PRs, 180 files modified (.github_data/issues/issue-64.md)
+
+### Commit 42: [60ffa95](https://github.com/vig-os/devcontainer/commit/60ffa9530c0741f01053e84ce8f064acdc72cbef) by [gerchowl](https://github.com/gerchowl) on February 18, 2026 at 11:13 PM
+feat: add worktree support for parallel agent development, 888 files modified
+
+### Commit 43: [f8c3644](https://github.com/vig-os/devcontainer/commit/f8c364407d598d6e8720c72aa9c7898e086aaa26) by [gerchowl](https://github.com/gerchowl) on February 18, 2026 at 11:21 PM
+chore: merge branch 'dev' into feature/67-declarative-sync-manifest, 10256 files modified
+
+### Commit 44: [7083c13](https://github.com/vig-os/devcontainer/commit/7083c132658a999b84c14fe5a0d09abc28bee694) by [gerchowl](https://github.com/gerchowl) on February 18, 2026 at 11:35 PM
+chore: merge feature/64-cursor-worktree-support into feature/67-declarative-sync-manifest, 1058 files modified
+
+### Commit 45: [bda828f](https://github.com/vig-os/devcontainer/commit/bda828f4d65d09e61ca27ad907d6d27c87aa9094) by [gerchowl](https://github.com/gerchowl) on February 18, 2026 at 11:39 PM
+fix: check existing cursor-agent login before requiring API key, 19 files modified (justfile.worktree)
+
+### Commit 46: [a85957b](https://github.com/vig-os/devcontainer/commit/a85957bbdb850a8e4b3d8eeae2e3f82f38dac9bb) by [gerchowl](https://github.com/gerchowl) on February 18, 2026 at 11:40 PM
+fix: unset core.hooksPath in worktree before pre-commit install, 1 file modified (justfile.worktree)
+
+### Commit 47: [1bd764a](https://github.com/vig-os/devcontainer/commit/1bd764a1ae220ac5eed5a282b7e02fe93f2f85e1) by [gerchowl](https://github.com/gerchowl) on February 18, 2026 at 11:42 PM
+fix: drop --install-hooks from worktree setup, 2 files modified (justfile.worktree)
+
+### Commit 48: [21e9ee0](https://github.com/vig-os/devcontainer/commit/21e9ee0e0c858ecb38c0a03c42eaff47849be25e) by [gerchowl](https://github.com/gerchowl) on February 18, 2026 at 11:45 PM
+fix: auto-trust worktree directory and pass --yes to cursor-agent, 21 files modified (justfile.worktree)
+
+### Commit 49: [9302313](https://github.com/vig-os/devcontainer/commit/9302313c24a419f3b552d54fb5cda2dffe67b252) by [gerchowl](https://github.com/gerchowl) on February 18, 2026 at 11:46 PM
+fix: use trustedDirectories config instead of nonexistent --yes flag, 8 files modified (justfile.worktree)
+
+### Commit 50: [87e8d12](https://github.com/vig-os/devcontainer/commit/87e8d1290b6fd95a0b33d1d61bf38cfc165af411) by [gerchowl](https://github.com/gerchowl) on February 18, 2026 at 11:51 PM
+fix: ensure trust for pre-existing worktrees on restart, 34 files modified (justfile.worktree)
+
+### Commit 51: [6a6a3f0](https://github.com/vig-os/devcontainer/commit/6a6a3f0bbd2aedd1d4f38d8c3c01586e48f70cd0) by [gerchowl](https://github.com/gerchowl) on February 18, 2026 at 11:53 PM
+feat: pass --yolo to cursor-agent for autonomous command execution, 7 files modified (justfile.worktree)
+
+### Commit 52: [717b257](https://github.com/vig-os/devcontainer/commit/717b257ec65f4784da376c70a8ed7bde0bea7e34) by [gerchowl](https://github.com/gerchowl) on February 19, 2026 at 12:04 AM
+test: add comprehensive tests for version-check just recipes, 936 files modified (.github_data/issues/issue-73-plan.md, tests/test_integration.py)
+
+### Commit 53: [f1d36e2](https://github.com/vig-os/devcontainer/commit/f1d36e25237bb06f25ad8fc04010e1e395c9c825) by [gerchowl](https://github.com/gerchowl) on February 19, 2026 at 12:05 AM
+feat(devcontainer): add just check recipe to justfile.base, 28 files modified (assets/workspace/.devcontainer/justfile.base)
+
+### Commit 54: [d8dc12b](https://github.com/vig-os/devcontainer/commit/d8dc12b93c2b16c3fccc70ceef10478fbdffe387) by [gerchowl](https://github.com/gerchowl) on February 19, 2026 at 12:05 AM
+feat(devcontainer): wire version-check into post-attach.sh, 3 files modified (assets/workspace/.devcontainer/scripts/post-attach.sh)
+
+### Commit 55: [58f900e](https://github.com/vig-os/devcontainer/commit/58f900e2bb0ba42f259eb5232f157262324f5fc2) by [gerchowl](https://github.com/gerchowl) on February 19, 2026 at 12:05 AM
+fix(devcontainer): correct update instructions in version-check notification, 13 files modified (assets/workspace/.devcontainer/scripts/version-check.sh)
+
+### Commit 56: [bbf47f3](https://github.com/vig-os/devcontainer/commit/bbf47f3019ee54d07bf627897a48951111699b5b) by [gerchowl](https://github.com/gerchowl) on February 19, 2026 at 12:06 AM
+feat(devcontainer): add host-side devcontainer-upgrade recipe, 47 files modified (assets/workspace/.devcontainer/justfile.base)
+
+### Commit 57: [5114cfc](https://github.com/vig-os/devcontainer/commit/5114cfc65e3ab259af92de5be30488f965e8866b) by [gerchowl](https://github.com/gerchowl) on February 19, 2026 at 12:06 AM
+docs: update CHANGELOG for version-check wiring and upgrade recipe, 16 files modified (CHANGELOG.md)
+
+### Commit 58: [202c79d](https://github.com/vig-os/devcontainer/commit/202c79dbe23f39aa0ea2a78e93e11f6db679adeb) by [gerchowl](https://github.com/gerchowl) on February 19, 2026 at 06:45 AM
+test: update expected gh CLI version to 2.87, 2 files modified (tests/test_image.py)
+
+### Commit 59: [bb1bc2c](https://github.com/vig-os/devcontainer/commit/bb1bc2c9bdad011f51426af5797c5a2dda2eab65) by [gerchowl](https://github.com/gerchowl) on February 19, 2026 at 06:54 AM
+refactor: consolidate label taxonomy as single source of truth, 201 files modified
+
+### Commit 60: [84b19a9](https://github.com/vig-os/devcontainer/commit/84b19a986e78173310b6b0cfeab5bd601a3766d7) by [gerchowl](https://github.com/gerchowl) on February 19, 2026 at 06:58 AM
+chore: add short aliases for podman, worktree, and github recipes, 92 files modified (CONTRIBUTE.md, README.md, justfile)
+
+### Commit 61: [175b4c9](https://github.com/vig-os/devcontainer/commit/175b4c9ef92fe7f89824fe226536e71dd06300ee) by [gerchowl](https://github.com/gerchowl) on February 19, 2026 at 12:36 PM
+feat: add autonomous CI check and fix capabilities, 237 files modified
+
+### Commit 62: [1d6ff4d](https://github.com/vig-os/devcontainer/commit/1d6ff4d3173ad792f588fe354da3ba2174e876f1) by [gerchowl](https://github.com/gerchowl) on February 19, 2026 at 02:19 PM
+Merge remote-tracking branch 'origin/worktree/73' into feature/67-declarative-sync-manifest, 1045 files modified
+
+### Commit 63: [489233a](https://github.com/vig-os/devcontainer/commit/489233a573cbae469f71aada4c5c29d84790bc82) by [c-vigo](https://github.com/c-vigo) on February 19, 2026 at 02:59 PM
+Merge branch 'dev' into feature/67-declarative-sync-manifest, 4163 files modified
+
+### Commit 64: [7a86a74](https://github.com/vig-os/devcontainer/commit/7a86a7452066369f7ab0beb7e3040691610f08e5) by [gerchowl](https://github.com/gerchowl) on February 19, 2026 at 05:04 PM
+fix(agent): allow worktree branches in pre-commit hook, 3 files modified (.pre-commit-config.yaml, docs/designs/.gitkeep, docs/rfcs/.gitkeep)
+
+### Commit 65: [2be1dab](https://github.com/vig-os/devcontainer/commit/2be1dab26b73896f5caac3e8903f414a0daf22e2) by [gerchowl](https://github.com/gerchowl) on February 19, 2026 at 05:05 PM
+docs: add RFC template for inception phase, 82 files modified (docs/templates/RFC.md)
+
+### Commit 66: [494e81a](https://github.com/vig-os/devcontainer/commit/494e81a92d6368a9116f1aed07a682a970b46ef0) by [gerchowl](https://github.com/gerchowl) on February 19, 2026 at 05:06 PM
+docs: add DESIGN template for inception phase, 153 files modified (docs/templates/DESIGN.md)
+
+### Commit 67: [a7ca111](https://github.com/vig-os/devcontainer/commit/a7ca111de1de1445ef56ddd2b0ea8d99cc27318d) by [gerchowl](https://github.com/gerchowl) on February 19, 2026 at 05:06 PM
+feat(agent): add inception:explore skill, 171 files modified (.cursor/skills/inception:explore/SKILL.md)
+
+### Commit 68: [7d711d8](https://github.com/vig-os/devcontainer/commit/7d711d89ca62c689d2bda58ba85e35cc0a9e06f1) by [gerchowl](https://github.com/gerchowl) on February 19, 2026 at 05:07 PM
+feat(agent): add inception:scope skill, 203 files modified (.cursor/skills/inception:scope/SKILL.md)
+
+### Commit 69: [a25a4b9](https://github.com/vig-os/devcontainer/commit/a25a4b9849f1bccce3731cbca0fb0020172baafa) by [gerchowl](https://github.com/gerchowl) on February 19, 2026 at 05:08 PM
+feat(agent): add inception:architect skill, 240 files modified (.cursor/skills/inception:architect/SKILL.md)
+
+### Commit 70: [be1a972](https://github.com/vig-os/devcontainer/commit/be1a9721ffba4cbe14648e688df03753a21f604e) by [gerchowl](https://github.com/gerchowl) on February 19, 2026 at 05:09 PM
+feat(agent): add inception:plan skill, 253 files modified (.cursor/skills/inception:plan/SKILL.md)
+
+### Commit 71: [c635e4b](https://github.com/vig-os/devcontainer/commit/c635e4ba6f23700adb7a6062dfd88e0dc8125676) by [gerchowl](https://github.com/gerchowl) on February 19, 2026 at 05:09 PM
+docs: add inception skills to CLAUDE.md command table, 4 files modified (CLAUDE.md)
+
+### Commit 72: [2493878](https://github.com/vig-os/devcontainer/commit/2493878ceec7b4b46db689565452403c5fb266d6) by [gerchowl](https://github.com/gerchowl) on February 19, 2026 at 05:10 PM
+docs: add inception skills to CHANGELOG, 6 files modified (CHANGELOG.md)
+
+### Commit 73: [188e6a1](https://github.com/vig-os/devcontainer/commit/188e6a1d98bdd2f24498c1eff292ae39d285455d) by [gerchowl](https://github.com/gerchowl) on February 19, 2026 at 05:11 PM
+docs: add inception skills README, 183 files modified (.cursor/skills/inception:explore/README.md)
+
+### Commit 74: [fe2e0e6](https://github.com/vig-os/devcontainer/commit/fe2e0e6e297439eeec706152bed26c2f17521dd7) by [gerchowl](https://github.com/gerchowl) on February 19, 2026 at 05:13 PM
+fix(agent): never add cursor-agent as co-author in commits, 2 files modified (.cursor/skills/worktree:execute/SKILL.md, .cursor/skills/worktree:pr/SKILL.md)
+
+### Commit 75: [afd1ab1](https://github.com/vig-os/devcontainer/commit/afd1ab14080e8b69d283505d2de08fb5c24544bb) by [gerchowl](https://github.com/gerchowl) on February 19, 2026 at 05:15 PM
+Merge worktree/90 into feature/67-declarative-sync-manifest, 1300 files modified
+
+### Commit 76: [519533c](https://github.com/vig-os/devcontainer/commit/519533ca86551ee9c2b7fa7354150d65f25fee7f) by [gerchowl](https://github.com/gerchowl) on February 19, 2026 at 05:33 PM
+fix(agent): address PR #68 review comments, 2397 files modified
+
+### Commit 77: [1d3243c](https://github.com/vig-os/devcontainer/commit/1d3243c3ad10e83a6dd2f6383b69914d07ea876e) by [c-vigo](https://github.com/c-vigo) on February 20, 2026 at 07:01 AM
+chore: merge branch 'dev' into feature/67-declarative-sync-manifest, 2842 files modified
+
+### Commit 78: [197fce8](https://github.com/vig-os/devcontainer/commit/197fce87e455dd208d77f45358ba281220cdcb8e) by [c-vigo](https://github.com/c-vigo) on February 20, 2026 at 07:51 AM
+feat: wire version-check.sh into post-attach lifecycle, 5 files modified (assets/workspace/.devcontainer/scripts/post-attach.sh, tests/test_integration.py)
+
+### Commit 79: [17c71b3](https://github.com/vig-os/devcontainer/commit/17c71b3310ff573f04547121463896b8c8ab397e) by [c-vigo](https://github.com/c-vigo) on February 20, 2026 at 07:56 AM
+fix: bump bats-assert to v2.2.0 to eliminate vulnerable verbose dependency, 1039 files modified (.github/dependency-review-allow.txt, CHANGELOG.md, package-lock.json, package.json)
+
+### Commit 80: [97d0627](https://github.com/vig-os/devcontainer/commit/97d0627b416663718f2d081c5a2a6949b3601167) by [c-vigo](https://github.com/c-vigo) on February 20, 2026 at 08:00 AM
+fix: correct BATS test failures in init-workspace and prepare-build suites, 64 files modified (CHANGELOG.md, tests/bats/init-workspace.bats, tests/bats/prepare-build.bats)
+
+### Commit 81: [9bbfa2f](https://github.com/vig-os/devcontainer/commit/9bbfa2fa1cbcb65377709424061d78653d43921a) by [gerchowl](https://github.com/gerchowl) on February 20, 2026 at 08:22 AM
+chore: delegate code:review to readonly subagent for fresh context, 158 files modified (.cursor/skills/code:review/SKILL.md, assets/workspace/.cursor/skills/code:review/SKILL.md)
+
+### Commit 82: [3d1666c](https://github.com/vig-os/devcontainer/commit/3d1666ce4700773ffb36f1340bb960b97c4660a3) by [gerchowl](https://github.com/gerchowl) on February 20, 2026 at 09:06 AM
+chore: enforce branch naming convention in worktree workflow, 96 files modified
+
+### Commit 83: [d7981e1](https://github.com/vig-os/devcontainer/commit/d7981e1acd6e6646e178d700c639dcf9e01c73a3) by [gerchowl](https://github.com/gerchowl) on February 20, 2026 at 09:09 AM
+feat(gh-issues): parse PR body for closing refs and show sub-issue tree, 141 files modified (scripts/gh_issues.py)
+
+### Commit 84: [ebde4b8](https://github.com/vig-os/devcontainer/commit/ebde4b894706dc87a29a8d05a451e52cf9a0b059) by [gerchowl](https://github.com/gerchowl) on February 20, 2026 at 09:09 AM
+Merge branch 'feature/67-declarative-sync-manifest' of github.com:vig-os/devcontainer into feature/67-declarative-sync-manifest, 3946 files modified
+
+### Commit 85: [a9b741d](https://github.com/vig-os/devcontainer/commit/a9b741d6bec2179e3efb594efdb906ea96e17cb1) by [commit-action-bot[bot]](https://github.com/apps/commit-action-bot) on February 20, 2026 at 09:26 AM
+chore: sync issues and PRs, 409 files modified (.github_data/issues/issue-90.md, .github_data/issues/issue-91.md, .github_data/issues/issue-96.md, .github_data/issues/issue-99.md, .github_data/pull-requests/pr-68.md)

--- a/docs/pull-requests/pr-95.md
+++ b/docs/pull-requests/pr-95.md
@@ -3,7 +3,7 @@ type: pull_request
 state: closed (merged)
 branch: chore/91-reduce-sync-issues-frequency → main
 created: 2026-02-19T15:39:22Z
-updated: 2026-02-19T17:04:55Z
+updated: 2026-02-19T18:00:53Z
 author: c-vigo
 author_url: https://github.com/c-vigo
 url: https://github.com/vig-os/devcontainer/pull/95
@@ -14,7 +14,7 @@ milestone: none
 projects: none
 relationship: none
 merged: 2026-02-19T17:04:47Z
-synced: 2026-02-19T17:40:55.582Z
+synced: 2026-02-20T13:18:03.089Z
 ---
 
 # [PR 95](https://github.com/vig-os/devcontainer/pull/95) chore: reduce sync-issues workflow frequency and simplify triggers
@@ -31,8 +31,8 @@ Closes #91
 ## Test plan (only possible after merge)
 
 - [ ] Verify workflow runs correctly on the daily schedule at 2:00 AM UTC
-- [ ] Trigger manually via `workflow_dispatch` without specifying a branch — confirm it checks out `dev`
-- [ ] Trigger manually via `workflow_dispatch` with a specific branch — confirm it checks out the specified branch
+- [x] Trigger manually via `workflow_dispatch` without specifying a branch — confirm it checks out `dev`
+- [x] Trigger manually via `workflow_dispatch` with a specific branch — confirm it checks out the specified branch
 
 
 ---

--- a/docs/pull-requests/pr-97.md
+++ b/docs/pull-requests/pr-97.md
@@ -1,0 +1,59 @@
+---
+type: pull_request
+state: closed
+branch: main → dev
+created: 2026-02-19T18:00:17Z
+updated: 2026-02-19T18:07:57Z
+author: c-vigo
+author_url: https://github.com/c-vigo
+url: https://github.com/vig-os/devcontainer/pull/97
+comments: 1
+labels: none
+assignees: none
+milestone: none
+projects: none
+relationship: none
+synced: 2026-02-20T13:18:01.787Z
+---
+
+# [PR 97](https://github.com/vig-os/devcontainer/pull/97) chore: merge main into dev to apply changes from #91
+
+## Summary
+
+Merge `main` back into `dev` to synchronize changes that landed on `main` via #91:
+
+- **Reduce sync-issues workflow frequency** — removed `issues` and `pull_request` event triggers from `sync-issues.yml`, keeping only the daily schedule (`0 2 * * *`) and `workflow_dispatch`. Simplifies target branch logic by removing the now-dead PR-merged-into-main code path.
+
+## Context
+
+After PR #91 was merged into `main`, the `dev` branch is missing the workflow schedule update (`adafdc5`). This PR brings `dev` in sync with `main` to prevent the sync-issues workflow from continuing to fire on every issue/PR state change on `dev`-based branches.
+
+## Tests
+
+- [x] Verify the `sync-issues.yml` workflow no longer triggers on issue/PR events
+- [x] Verify `workflow_dispatch` with `target-branch` input still works (used by `release.yml` and `post-release.yml`)
+
+Refs: #91
+
+
+---
+---
+
+## Comments (1)
+
+### [Comment #1](https://github.com/vig-os/devcontainer/pull/97#issuecomment-3928966940) by [@c-vigo](https://github.com/c-vigo)
+
+_Posted on February 19, 2026 at 06:07 PM_
+
+Superseded by a new PR from `chore/91-sync-main-to-dev` which resolves the merge conflict.
+
+---
+---
+
+## Commits
+
+### Commit 1: [adafdc5](https://github.com/vig-os/devcontainer/commit/adafdc533a0be82d5b014fa2cec7a1397863a861) by [c-vigo](https://github.com/c-vigo) on February 19, 2026 at 03:38 PM
+chore: update sync issues workflow schedule, 45 files modified (.github/workflows/sync-issues.yml)
+
+### Commit 2: [ca04f8f](https://github.com/vig-os/devcontainer/commit/ca04f8ff8a0b8cf978e48471086df2eada0c8f29) by [c-vigo](https://github.com/c-vigo) on February 19, 2026 at 05:04 PM
+chore: reduce sync-issues workflow frequency and simplify triggers (#95), 45 files modified (.github/workflows/sync-issues.yml)

--- a/docs/pull-requests/pr-98.md
+++ b/docs/pull-requests/pr-98.md
@@ -1,0 +1,55 @@
+---
+type: pull_request
+state: closed (merged)
+branch: chore/91-sync-main-to-dev → dev
+created: 2026-02-19T18:08:12Z
+updated: 2026-02-19T21:34:34Z
+author: c-vigo
+author_url: https://github.com/c-vigo
+url: https://github.com/vig-os/devcontainer/pull/98
+comments: 0
+labels: none
+assignees: none
+milestone: none
+projects: none
+relationship: none
+merged: 2026-02-19T21:34:14Z
+synced: 2026-02-20T13:18:00.140Z
+---
+
+# [PR 98](https://github.com/vig-os/devcontainer/pull/98) chore: merge main into dev to apply changes from #91
+
+## Summary
+
+Merge `main` back into `dev` to synchronize changes that landed on `main` via #91:
+
+- **Reduce sync-issues workflow frequency** — removed `issues` and `pull_request` event triggers from `sync-issues.yml`, keeping only the daily schedule (`0 2 * * *`) and `workflow_dispatch`. Simplifies target branch logic by removing the now-unnecessary "Determine target branch" step.
+
+## Conflict Resolution
+
+The `dev` branch had additional hardening changes to `sync-issues.yml` (pinned action SHAs, `ubuntu-22.04`, `timeout-minutes`, restrictive top-level `permissions`, `output-dir: 'docs'`). The merge conflict was resolved by keeping all of `dev`'s security hardening while applying `main`'s trigger simplification.
+
+Supersedes #97 (which had an unresolvable conflict due to head being `main` itself).
+
+## Tests
+
+- [x] Verify the `sync-issues.yml` workflow no longer triggers on issue/PR events
+- [x] Verify `workflow_dispatch` with `target-branch` input still works (used by `release.yml` and `post-release.yml`)
+- [x] All pre-commit hooks pass (yamllint, check-action-pins, etc.)
+
+Refs: #91
+
+
+---
+---
+
+## Commits
+
+### Commit 1: [adafdc5](https://github.com/vig-os/devcontainer/commit/adafdc533a0be82d5b014fa2cec7a1397863a861) by [c-vigo](https://github.com/c-vigo) on February 19, 2026 at 03:38 PM
+chore: update sync issues workflow schedule, 45 files modified (.github/workflows/sync-issues.yml)
+
+### Commit 2: [ca04f8f](https://github.com/vig-os/devcontainer/commit/ca04f8ff8a0b8cf978e48471086df2eada0c8f29) by [c-vigo](https://github.com/c-vigo) on February 19, 2026 at 05:04 PM
+chore: reduce sync-issues workflow frequency and simplify triggers (#95), 45 files modified (.github/workflows/sync-issues.yml)
+
+### Commit 3: [bab27ee](https://github.com/vig-os/devcontainer/commit/bab27eede20ef12c3543a78d74e41d0ec7cbe348) by [c-vigo](https://github.com/c-vigo) on February 19, 2026 at 06:07 PM
+chore: merge main into dev to sync workflow changes from #91, 54 files modified (.github/workflows/sync-issues.yml)

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -140,6 +140,11 @@ class TestSystemTools:
             f"Expected just {expected}, got: {result.stdout}"
         )
 
+    def test_cursor_agent_installed(self, host):
+        """Test that cursor-agent CLI (agent) is installed."""
+        result = host.run("agent --version")
+        assert result.rc == 0, "agent --version failed"
+
     def test_cargo_binstall(self, host):
         """Test that cargo-binstall is installed and right version."""
         result = host.run("cargo-binstall -V")


### PR DESCRIPTION
# Pull Request

## Description

Install the `cursor-agent` CLI (`agent` command) in the devcontainer image so that worktree recipes (`just worktree-start`, etc.) work out of the box without manual installation.

Original Containerfile change contributed by @nacholiya in PR #110 (commit authorship preserved). Maintainer added PATH fix, image test, and CHANGELOG entry.

## Related Issue(s)

Closes #108

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI / Build change
- [x] Test updates

## Changes Made

- **Containerfile**: Added `cursor-agent` installation step via `curl -fsSL https://cursor.com/install | bash`, with `ENV PATH` for `~/.local/bin` and `agent --version` verification
- **tests/test_image.py**: Added `test_cursor_agent_installed` to verify `agent --version` succeeds in the built image
- **CHANGELOG.md**: Added entry under `### Added` in `## Unreleased`

## Changelog Entry

### Added
- **cursor-agent CLI pre-installed in devcontainer image** ([#108](https://github.com/vig-os/devcontainer/issues/108))
  - Enables `just worktree-start` to work out of the box without manual installation

## Testing

- [x] Tests pass locally (`just test`)
- [x] Manual testing performed (describe below)

### Manual Testing Details

1. `just build` — image builds successfully with cursor-agent installed
2. `just test-image` — `test_cursor_agent_installed` passes (agent --version returns rc 0)
3. `just test` — full suite passes (234 pytest + 209 BATS, 0 failures)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

- The cursor-agent installer places the binary in `~/.local/bin`. The original PR #110 didn't include this in PATH, causing the build to fail. Fixed by adding `ENV PATH="/root/.local/bin:${PATH}"` before the install step, matching the pattern used for cargo-binstall.
- No version pinning — cursor-agent uses a rolling install script per the issue's proposed solution.
