### PR TITLE
chore: remove manual sync-issues workflow triggers from skills

### DIFF
--- a/.cursor/skills/design:brainstorm/SKILL.md
+++ b/.cursor/skills/design:brainstorm/SKILL.md
@@ -61,12 +61,7 @@ After user approval, post the design as a **comment on the issue**. This is the 
      -f body="<design_content>"
    ```
 
-3. The comment must start with `## Design` (H2) to avoid header-level bumping when synced by the `sync-issues` workflow.
-4. Trigger the `sync-issues` workflow (fire-and-forget):
-
-   ```bash
-   gh workflow run sync-issues.yml -f target-branch=<current_branch>
-   ```
+3. The comment must start with `## Design` (H2) so other skills can detect the design phase is complete.
 
 ### 6. Transition to planning
 

--- a/.cursor/skills/design:plan/SKILL.md
+++ b/.cursor/skills/design:plan/SKILL.md
@@ -58,7 +58,7 @@ After user approval, post the full detailed plan as a **comment on the issue**. 
      -f body="<plan_content>"
    ```
 
-3. The comment must start with `##` (H2) to avoid header-level bumping when synced by the `sync-issues` workflow.
+3. The comment must start with `##` (H2) so other skills can detect that the planning phase is complete.
 4. Use this format:
 
    ```markdown
@@ -72,12 +72,6 @@ After user approval, post the full detailed plan as a **comment on the issue**. 
    - [ ] Task 1: description — `files` — verify: `command`
    - [ ] Task 2: description — `files` — verify: `command`
    ...
-   ```
-
-5. Trigger the `sync-issues` workflow (fire-and-forget) so the plan is eventually available locally:
-
-   ```bash
-   gh workflow run sync-issues.yml -f target-branch=<current_branch>
    ```
 
 ## Important Notes

--- a/.cursor/skills/worktree:brainstorm/SKILL.md
+++ b/.cursor/skills/worktree:brainstorm/SKILL.md
@@ -58,11 +58,6 @@ gh issue view <issue_number> --json title,body,labels,comments
    ```
 
 3. The comment **must** start with `## Design` (H2) — this is how other skills detect that the design phase is complete.
-4. Trigger the `sync-issues` workflow (fire-and-forget):
-
-   ```bash
-   gh workflow run sync-issues.yml -f target-branch=<current_branch>
-   ```
 
 ### 6. Proceed to planning
 

--- a/.cursor/skills/worktree:plan/SKILL.md
+++ b/.cursor/skills/worktree:plan/SKILL.md
@@ -66,12 +66,6 @@ gh issue view <issue_number> --json title,body,labels,comments
    ...
    ```
 
-5. Trigger the `sync-issues` workflow (fire-and-forget):
-
-   ```bash
-   gh workflow run sync-issues.yml -f target-branch=<current_branch>
-   ```
-
 ### 4. Proceed to execution
 
 - Invoke [worktree:execute](../worktree:execute/SKILL.md) to start implementing.


### PR DESCRIPTION
# Pull Request

## Description

Remove fire-and-forget `gh workflow run sync-issues.yml` trigger steps from four skills. The sync-issues workflow now runs on a 24h cron schedule, making these inline triggers unnecessary.

## Related Issue(s)

Closes #101

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI / Build change
- [ ] Test updates

## Changes Made

- **`worktree:plan/SKILL.md`** — Removed step 5 (sync-issues trigger). Steps renumbered 1–4.
- **`worktree:brainstorm/SKILL.md`** — Removed substep 4 under "Publish design as a GitHub issue comment".
- **`design:brainstorm/SKILL.md`** — Removed substep 4 under "Publish design". Reworded H2-header rationale comment (was referencing sync workflow, now explains purpose for skill detection).
- **`design:plan/SKILL.md`** — Removed step 5 (sync-issues trigger). Reworded H2-header rationale comment to match.

## Changelog Entry

No changelog needed — internal skill maintenance with no user-visible impact (issue is labeled `chore` with "No changelog needed" category).

## Testing

- [x] Tests pass locally (`just test`) — N/A, markdown-only changes
- [x] Manual testing performed (describe below)

### Manual Testing Details

- Verified `grep -c 'sync-issues'` returns 0 for all four files
- Verified step numbering is sequential and correct in each file
- Pre-commit hooks (including pymarkdown linter) passed

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

Pure documentation/skill maintenance. No functional code changes. No tests needed — these are markdown workflow instructions.