### PR TITLE
feat: automatic commit message for pull request merge (#79)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -62,3 +62,6 @@ Closes #
 ## Additional Notes
 
 <!-- Any additional information, screenshots, or context that reviewers should know -->
+
+<!-- Refs line below becomes part of the merge commit message (do not remove) -->
+Refs: #

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -1,0 +1,39 @@
+# PR Title Check
+#
+# Validates that PR titles follow the commit message standard (type(scope): description).
+# Merge commits use PR_TITLE as the commit subject, so enforcing the standard here
+# ensures compliant merge commit messages.
+#
+# Triggers: pull_request opened, edited, synchronize (title may change on edit)
+
+name: PR Title Check
+
+on:  # yamllint disable-line rule:truthy
+  pull_request:
+    types: [opened, edited, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  check-title:
+    name: Validate PR Title
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+
+      - name: Set up environment
+        uses: ./.github/actions/setup-env
+        with:
+          sync-dependencies: 'true'
+
+      - name: Validate PR title
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          TITLE_FILE=$(mktemp)
+          printf '%s' "$PR_TITLE" > "$TITLE_FILE"
+          uv run validate-commit-msg "$TITLE_FILE" --subject-only

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Ground truth lives in repo root; `assets/workspace/` is generated output
 - **cursor-agent CLI pre-installed in devcontainer image** ([#108](https://github.com/vig-os/devcontainer/issues/108))
   - Enables `just worktree-start` to work out of the box without manual installation
+- **Automatic merge commit message compliance** ([#79](https://github.com/vig-os/devcontainer/issues/79))
+  - `setup-gh-repo.sh` configures repo merge settings via `gh api` (`merge_commit_title=PR_TITLE`, `merge_commit_message=PR_BODY`, `allow_auto_merge=true`)
+  - Wired into `post-create.sh` so downstream devcontainer projects get compliant merge commits automatically
+  - `--subject-only` flag for `validate-commit-msg` to validate PR titles without requiring body or Refs
+  - `pr-title-check.yml` CI workflow enforces commit message standard on PR titles
+  - PR body template includes `Refs: #` placeholder for merge commit traceability
 
 ### Changed
 

--- a/assets/workspace/.devcontainer/scripts/post-create.sh
+++ b/assets/workspace/.devcontainer/scripts/post-create.sh
@@ -28,6 +28,7 @@ sed -i 's/template-project/{{SHORT_NAME}}/g' /root/assets/workspace/.venv/bin/ac
 # One-time setup: git repo, config, hooks, gh auth
 "$SCRIPT_DIR/init-git.sh"
 "$SCRIPT_DIR/setup-git-conf.sh"
+"$SCRIPT_DIR/setup-gh-repo.sh"
 "$SCRIPT_DIR/init-precommit.sh"
 
 # Sync dependencies (fast if nothing changed from pre-built venv)

--- a/assets/workspace/.devcontainer/scripts/setup-gh-repo.sh
+++ b/assets/workspace/.devcontainer/scripts/setup-gh-repo.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -euo pipefail
+
+# Configure GitHub repository settings for merge commit compliance.
+# Sets merge commit format to use PR title/body and enables auto-merge.
+# Called from post-create.sh (postCreateCommand) — runs once per container.
+#
+# Requires: gh CLI authenticated with repo admin permissions.
+# Fails gracefully if gh is not authenticated or lacks permissions.
+
+REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner' 2>/dev/null || echo "")
+
+if [ -z "$REPO" ]; then
+	echo "Skipping repo merge settings (not in a GitHub repo or gh not authenticated)"
+	exit 0
+fi
+
+echo "Configuring merge commit settings for $REPO..."
+
+if gh api "repos/$REPO" -X PATCH \
+	-f merge_commit_title=PR_TITLE \
+	-f merge_commit_message=PR_BODY \
+	-F allow_auto_merge=true \
+	>/dev/null 2>&1; then
+	echo "✓ Merge commit format: PR title + body"
+	echo "✓ Auto-merge: enabled"
+else
+	echo "✗ Could not update repo settings (insufficient permissions?)"
+	echo "  Manual setup: gh api repos/$REPO -X PATCH -f merge_commit_title=PR_TITLE -f merge_commit_message=PR_BODY -F allow_auto_merge=true"
+fi


### PR DESCRIPTION
# Pull Request

## Description

Ensure merge commits follow the project's commit message standard automatically. PR titles are validated in CI, GitHub repo settings are configured to use PR title as merge commit subject and PR body as merge commit body, and the PR template includes a `Refs:` placeholder for traceability.

## Related Issue(s)

Closes #79

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI / Build change
- [ ] Test updates

## Changes Made

- **`validate-commit-msg --subject-only` flag** — validates only the subject line (type, scope, description), skipping body and Refs. Enables PR title validation without requiring a full commit message. 12 new tests added.
- **`setup-gh-repo.sh`** — new devcontainer lifecycle script that configures GitHub repo merge settings via `gh api` (`merge_commit_title=PR_TITLE`, `merge_commit_message=PR_BODY`, `allow_auto_merge=true`). Wired into `post-create.sh` so downstream projects get compliant merge commits on first container creation.
- **`pr-title-check.yml`** — new CI workflow that validates PR titles on `opened/edited/synchronize` using `validate-commit-msg --subject-only`.
- **PR template `Refs:` placeholder** — added at the end of the PR body template so the merge commit body includes issue traceability.

## Changelog Entry

### Added

- **Automatic merge commit message compliance** ([#79](https://github.com/vig-os/devcontainer/issues/79))
  - `setup-gh-repo.sh` configures repo merge settings via `gh api` (`merge_commit_title=PR_TITLE`, `merge_commit_message=PR_BODY`, `allow_auto_merge=true`)
  - Wired into `post-create.sh` so downstream devcontainer projects get compliant merge commits automatically
  - `--subject-only` flag for `validate-commit-msg` to validate PR titles without requiring body or Refs
  - `pr-title-check.yml` CI workflow enforces commit message standard on PR titles
  - PR body template includes `Refs: #` placeholder for merge commit traceability

## Testing

- [x] Tests pass locally (`just test`)
- [x] Manual testing performed (describe below)

### Manual Testing Details

- 115/115 `validate_commit_msg` tests pass (12 new `TestSubjectOnly` tests + 103 existing)
- `bash -n` syntax check on `setup-gh-repo.sh` and `post-create.sh`
- YAML syntax validation on `pr-title-check.yml`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

**Post-merge action:** Run `setup-gh-repo.sh` manually against `vig-os/devcontainer` to apply the merge settings to this repo (since the container won't be recreated just for this change).

<!-- Refs line below becomes part of the merge commit message (do not remove) -->
Refs: #79
