### PR TITLE
chore: add hadolint linting for Containerfiles (#122)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,6 +57,13 @@ repos:
         name: shellcheck
         args: ["-x"]
 
+  # Containerfile
+  - repo: https://github.com/hadolint/hadolint
+    rev: 346e4199e4baca7d6827f20ac078b6eee5b39327  # v2.9.3
+    hooks:
+      - id: hadolint-docker
+        name: hadolint
+
   # Markdown Linting (excludes auto-generated docs)
   - repo: https://github.com/jackdewinter/pymarkdown
     rev: f93643d339dfee2a1022e7b05e8b5a281bfac553  # v0.9.23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **hadolint pre-commit hook for Containerfile linting** ([#122](https://github.com/vig-os/devcontainer/issues/122))
+  - Add `hadolint` hook to `.pre-commit-config.yaml`, pinned by SHA (v2.9.3)
+  - Enforce Dockerfile best practices: pinned base image tags, consolidated `RUN` layers, shellcheck for inline scripts
+  - Fix `tests/fixtures/sidecar.Containerfile` to pass hadolint with no warnings
 - **Optional reviewer parameter for autonomous worktree pipeline** ([#102](https://github.com/vig-os/devcontainer/issues/102))
   - Support `reviewer` parameter in `just worktree-start`
   - Propagate `PR_REVIEWER` via tmux environment to the autonomous agent

--- a/tests/fixtures/sidecar.Containerfile
+++ b/tests/fixtures/sidecar.Containerfile
@@ -1,14 +1,13 @@
 # Test sidecar container for verifying multi-container devcontainer setups
 # This sidecar is used to test Approach 1: Direct command execution via podman exec
-FROM alpine:latest
+FROM alpine:3.21
 
-# Install minimal tools for testing build workflows
+# Install minimal tools for testing build workflows and create test build directory
+# hadolint ignore=DL3018
 RUN apk add --no-cache \
     bash \
-    coreutils
-
-# Create a test build directory
-RUN mkdir -p /workspace/build-output
+    coreutils \
+    && mkdir -p /workspace/build-output
 
 # Copy test script to demonstrate executing scripts in sidecar
 COPY test-build.sh /usr/local/bin/test-build.sh


### PR DESCRIPTION
## Description

Add [hadolint](https://github.com/hadolint/hadolint) static analysis for all Containerfiles in the repository. Hadolint enforces Dockerfile best practices (pinned base image tags, consolidated `RUN` layers, shellcheck for inline `RUN` scripts) and integrates seamlessly via pre-commit.

## Type of Change

- [ ] `feat` -- New feature
- [ ] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [x] `chore` -- Maintenance task (deps, config, etc.)
- [x] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [ ] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- **`.pre-commit-config.yaml`**: Add `hadolint-docker` hook pinned to SHA `346e4199e4baca7d6827f20ac078b6eee5b39327` (v2.9.3). Runs against `Containerfile` and `tests/fixtures/sidecar.Containerfile`.
- **`tests/fixtures/sidecar.Containerfile`**: Pin base image tag, consolidate `RUN` layers, add `# hadolint ignore=DL3018` for apk packages where pinning individual versions would be brittle.

## Changelog Entry

### Added

- **hadolint pre-commit hook for Containerfile linting** ([#122](https://github.com/vig-os/devcontainer/issues/122))
  - Add `hadolint` hook to `.pre-commit-config.yaml`, pinned by SHA (v2.9.3)
  - Enforce Dockerfile best practices: pinned base image tags, consolidated `RUN` layers, shellcheck for inline scripts
  - Fix `tests/fixtures/sidecar.Containerfile` to pass hadolint with no warnings

## Testing

- [x] Tests pass locally (`just test`)
- [x] Manual testing performed (describe below)

### Manual Testing Details

- Ran `uv run pre-commit run --all-files` — exits clean with no warnings.
- `just build no_cache && just test` passed locally.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

The `Containerfile` (main image) already passed hadolint without changes. Only the sidecar fixture required fixes.

Refs: #122
