### PR TITLE
fix: remove issue number from PR title to prevent duplicate refs in merge commits

### DIFF
--- a/.cursor/skills/pr:create/SKILL.md
+++ b/.cursor/skills/pr:create/SKILL.md
@@ -35,7 +35,7 @@ Prepare and submit a pull request for **feature or bugfix work**.
 
 ### 5. Ask user to review and choose assignee and reviewers
 
-- Show the user the **title** you will use (e.g. `feat: short description (#NN)`) and the **PR body** (full markdown).
+- Show the user the **title** you will use (e.g. `feat: short description`) and the **PR body** (full markdown). Do **not** include the issue number in the title — GitHub automatically appends `(#PR)` to the merge commit subject, and the issue is traceable via `Refs:` in the body.
 - Ask the user to confirm or edit the text.
 - Ask the user to specify **assignee** and **reviewers** (e.g. "assign to me, no reviewers" or "assign @c-vigo, reviewers @foo"). Do not run `gh pr create` until the user approves and provides assignee/reviewers.
 

--- a/assets/workspace/.cursor/skills/pr:create/SKILL.md
+++ b/assets/workspace/.cursor/skills/pr:create/SKILL.md
@@ -35,7 +35,7 @@ Prepare and submit a pull request for **feature or bugfix work**.
 
 ### 5. Ask user to review and choose assignee and reviewers
 
-- Show the user the **title** you will use (e.g. `feat: short description (#NN)`) and the **PR body** (full markdown).
+- Show the user the **title** you will use (e.g. `feat: short description`) and the **PR body** (full markdown). Do **not** include the issue number in the title — GitHub automatically appends `(#PR)` to the merge commit subject, and the issue is traceable via `Refs:` in the body.
 - Ask the user to confirm or edit the text.
 - Ask the user to specify **assignee** and **reviewers** (e.g. "assign to me, no reviewers" or "assign @c-vigo, reviewers @foo"). Do not run `gh pr create` until the user approves and provides assignee/reviewers.
 


### PR DESCRIPTION
## Description

Ensure merge commits follow the project's commit message standard automatically. PR titles are validated in CI, GitHub repo settings are configured to use PR title as merge commit subject and PR body as merge commit body, and the PR template includes a `Refs:` placeholder for traceability.

## Related Issue(s)

Closes #79

## Type of Change

- [x] `feat` -- New feature
- [x] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [x] `test` -- Adding or updating tests
- [x] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- **`validate-commit-msg --subject-only` flag** — validates only the subject line (type, scope, description), skipping body and Refs. Enables PR title validation without requiring a full commit message. 12 new tests added.
- **`setup-gh-repo.sh`** — new devcontainer lifecycle script that configures GitHub repo merge settings via `gh api` (`merge_commit_title=PR_TITLE`, `merge_commit_message=PR_BODY`, `allow_auto_merge=true`). Wired into `post-create.sh` so downstream projects get compliant merge commits on first container creation.
- **`pr-title-check.yml`** — new CI workflow that validates PR titles on `opened/edited/synchronize` using `validate-commit-msg --subject-only`.
- **PR template `Refs:` placeholder** — added at the end of the PR body template so the merge commit body includes issue traceability.
- **PR title format fix** — removed issue number `(#NN)` from `pr:create` skill's title example to prevent duplicate refs in merge commits (GitHub auto-appends `(#PR)`).

## Changelog Entry

### Added

- **Automatic merge commit message compliance** ([#79](https://github.com/vig-os/devcontainer/issues/79))
  - `setup-gh-repo.sh` configures repo merge settings via `gh api` (`merge_commit_title=PR_TITLE`, `merge_commit_message=PR_BODY`, `allow_auto_merge=true`)
  - Wired into `post-create.sh` so downstream devcontainer projects get compliant merge commits automatically
  - `--subject-only` flag for `validate-commit-msg` to validate PR titles without requiring body or Refs
  - `pr-title-check.yml` CI workflow enforces commit message standard on PR titles
  - PR body template includes `Refs: #` placeholder for merge commit traceability

## Testing

- [x] Tests pass locally (`just test`)
- [x] Manual testing performed (describe below)

### Manual Testing Details

- 115/115 `validate_commit_msg` tests pass (12 new `TestSubjectOnly` tests + 103 existing)
- `bash -n` syntax check on `setup-gh-repo.sh` and `post-create.sh`
- YAML syntax validation on `pr-title-check.yml`

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

**Post-merge action:** Run `setup-gh-repo.sh` manually against `vig-os/devcontainer` to apply the merge settings to this repo (since the container won't be recreated just for this change).

Refs: #79
