### PR TITLE
ci: correct workflow bugs and hardcoded values (#123)

### DIFF
--- a/.github/actions/build-image/action.yml
+++ b/.github/actions/build-image/action.yml
@@ -118,7 +118,7 @@ runs:
           org.opencontainers.image.version=${{ inputs.version }}
           org.opencontainers.image.created=${{ inputs.build-timestamp }}
           org.opencontainers.image.revision=${{ inputs.vcs-ref }}
-          org.opencontainers.image.source=https://github.com/vig-os/devcontainer
+          org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
           org.opencontainers.image.vendor=vigOS
           org.opencontainers.image.licenses=MIT
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
           VERSION="dev-$(git rev-parse --short HEAD)"
           RELEASE_DATE=$(date -u +%Y-%m-%d)
           BUILD_TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-          RELEASE_URL="https://github.com/vig-os/devcontainer/commit/$(git rev-parse HEAD)"
+          RELEASE_URL="https://github.com/${GITHUB_REPOSITORY}/commit/$(git rev-parse HEAD)"
 
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "release_date=$RELEASE_DATE" >> $GITHUB_OUTPUT

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -120,9 +120,7 @@ jobs:
           else
             COMMIT_MSG="chore: sync dev with main after merge"
             if [ -n "$PR_NUMBER" ]; then
-              COMMIT_MSG="$COMMIT_MSG
-
-          Refs: #$PR_NUMBER"
+              COMMIT_MSG=$(printf '%s\n\nRefs: #%s' "$COMMIT_MSG" "$PR_NUMBER")
             fi
             git commit -m "$COMMIT_MSG" --no-verify
             git push origin dev

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -851,7 +851,7 @@ jobs:
               repo: context.repo.repo,
               title,
               body,
-              labels: ['bug', 'release']
+              labels: ['bug', 'area:ci']
             });
 
             console.log(`Created issue: ${title}`);

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -44,7 +44,7 @@ jobs:
           publish_results: true
 
       - name: Upload SARIF to GitHub Security
-        uses: github/codeql-action/upload-sarif@b5ebac6f4c00c8ccddb7cdcd45fdb248329f808a  # v3
+        uses: github/codeql-action/upload-sarif@45cbd0c69e560cd9e7cd7f8c32362050c9b7ded2  # v4
         with:
           sarif_file: results.sarif
           category: 'scorecard'

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -47,7 +47,11 @@ jobs:
           # Version format: scheduled-YYYY-MM-DD-<commit_short>
           COMMIT_SHORT=$(git rev-parse --short HEAD)
           VERSION="scheduled-$(date -u +'%Y-%m-%d')-${COMMIT_SHORT}"
+          RELEASE_DATE=$(date -u +%Y-%m-%d)
+          BUILD_TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "release_date=$RELEASE_DATE" >> $GITHUB_OUTPUT
+          echo "build_timestamp=$BUILD_TIMESTAMP" >> $GITHUB_OUTPUT
           echo "Generated version: ${VERSION}"
 
       - name: Build container image


### PR DESCRIPTION
## Description

Fix workflow bugs and hardcoded values identified during a thorough review of the `.github/` directory. Also applies repo setting improvements (deleteBranchOnMerge, wiki, sha_pinning_required) via the GitHub API.

## Type of Change

- [x] `ci` -- CI/CD pipeline changes

## Changes Made

**Workflow fixes (code):**

- `security-scan.yml`: Add missing `release_date` and `build_timestamp` outputs to the version step (were undefined, passing empty strings to the build-image action)
- `scorecard.yml`: Update `codeql-action/upload-sarif` from v3 to v4 SHA for consistency with all other workflows
- `post-release.yml`: Fix commit message `Refs:` line that inherited 10 spaces of YAML indentation (use `printf` instead of embedded newline)
- `ci.yml`: Replace hardcoded `vig-os/devcontainer` URL with `$GITHUB_REPOSITORY`
- `release.yml`: Replace undeclared `release` label in rollback issue with `area:ci` (from label taxonomy)
- `build-image/action.yml`: Replace hardcoded OCI `source` label URL with `${{ github.server_url }}/${{ github.repository }}`

**Repo settings (applied via API, not in diff):**

- Enable `deleteBranchOnMerge` -- head branches auto-delete after merge
- Disable wiki -- project uses docs-as-code
- Enable `sha_pinning_required` -- enforce SHA-pinned actions

## Changelog Entry

No changelog needed -- purely internal CI configuration fixes with no user-visible impact.

## Testing

- [x] Tests pass locally (`just test`)
- [x] Manual testing performed (describe below)

### Manual Testing Details

- All pre-commit hooks pass (yamllint, check-yaml, check-action-pins, typos, validate-commit-msg)
- Changes are YAML-only workflow config; runtime validation requires actual CI runs on the PR

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [ ] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

Repo settings (S1-S3) were applied via `gh api` during implementation and are not reflected in the diff. S4 (production environment for release publish) was deferred as it would require workflow changes to reference the environment.

W6 (ARM runner name verification) and W7 (prepare-release.yml Refs: line) were flagged as verify-only / by-design in the implementation plan and skipped.

Refs: #123
