### PR TITLE
chore: replace scripts/ wildcard with per-file CODEOWNERS rules

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,8 +13,21 @@ justfile.worktree               @gerchowl
 .github/workflows/              @c-vigo
 .github/actions/                @c-vigo
 
-# Build and release tooling
-scripts/                        @c-vigo
+# Build and release scripts
+scripts/build.sh                @c-vigo
+scripts/prepare-build.sh        @c-vigo
+scripts/clean.sh                @c-vigo
+scripts/sync_manifest.py        @c-vigo
+scripts/utils.py                @c-vigo
+
+# Developer tooling scripts
+scripts/gh_issues.py            @gerchowl
+scripts/setup-labels.sh         @gerchowl
+scripts/resolve-branch.sh       @gerchowl
+
+# Dev environment setup
+scripts/init.sh                 @c-vigo
+scripts/requirements.yaml       @c-vigo
 
 # Security-sensitive configuration
 .github/dependabot.yml          @c-vigo


### PR DESCRIPTION
## Description

Replace the blanket `scripts/` CODEOWNERS wildcard with per-file rules that assign ownership by concern — build/release, developer tooling, and dev environment setup. This removes unnecessary review friction when touching developer convenience scripts like `gh_issues.py`.

## Type of Change

- [x] `chore` -- Maintenance task (deps, config, etc.)

## Changes Made

- Removed `scripts/ @c-vigo` wildcard rule
- Added per-file rules grouped by concern:
  - **Build/release** (`build.sh`, `prepare-build.sh`, `clean.sh`, `sync_manifest.py`, `utils.py`) → `@c-vigo`
  - **Developer tooling** (`gh_issues.py`, `setup-labels.sh`, `resolve-branch.sh`) → `@gerchowl`
  - **Dev environment** (`init.sh`, `requirements.yaml`) → `@c-vigo`

## Changelog Entry

No changelog needed — internal review-routing config with no user-visible impact.

## Testing

- [x] Manual testing performed (describe below)

### Manual Testing Details

- Verified CODEOWNERS syntax is valid (no duplicate patterns, consistent formatting)
- Confirmed all 10 files in `scripts/` are covered by exactly one rule

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors

## Additional Notes

> **Future improvement:** If the per-file list grows unwieldy, consider splitting `scripts/` into subdirectories (`scripts/build/`, `scripts/github/`, `scripts/setup/`) and switching to wildcard rules per subfolder. This would make ownership automatic for new scripts added to a subfolder.

Refs: #134
