### PR TITLE
chore: install tmux in Containerfile for worktree session persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Add `hadolint` hook to `.pre-commit-config.yaml`, pinned by SHA (v2.9.3)
   - Enforce Dockerfile best practices: pinned base image tags, consolidated `RUN` layers, shellcheck for inline scripts
   - Fix `tests/fixtures/sidecar.Containerfile` to pass hadolint with no warnings
+- **tmux installed in container image for worktree session persistence** ([#130](https://github.com/vig-os/devcontainer/issues/130))
+  - Add `tmux` to the Containerfile `apt-get install` block
+  - Enables autonomous worktree agents to survive Cursor session disconnects
 - **Optional reviewer parameter for autonomous worktree pipeline** ([#102](https://github.com/vig-os/devcontainer/issues/102))
   - Support `reviewer` parameter in `just worktree-start`
   - Propagate `PR_REVIEWER` via tmux environment to the autonomous agent

--- a/Containerfile
+++ b/Containerfile
@@ -59,6 +59,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     nano \
     minisign \
     podman \
+    tmux \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Generate en_US.UTF-8 locale

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -27,6 +27,7 @@ EXPECTED_VERSIONS = {
     "cargo-binstall": "1.17.",  # Minor version check (installed from latest release),
     "typstyle": "0.14.",  # Minor version check (installed from latest release)
     "vig_utils": "0.1.",  # Minor version check (installed via uv pip)
+    "tmux": "3.5",  # Major.minor version check (from apt package)
 }
 
 
@@ -170,6 +171,42 @@ class TestSystemTools:
         assert "just-lsp" in result.stdout.lower(), (
             f"Expected just-lsp version output, got: {result.stdout}"
         )
+
+    def test_tmux_installed(self, host):
+        """Test that tmux is installed."""
+        assert host.package("tmux").is_installed, "tmux is not installed"
+
+    def test_tmux_version(self, host):
+        """Test that tmux version is correct."""
+        result = host.run("tmux -V")
+        assert result.rc == 0, "tmux -V failed"
+        expected = EXPECTED_VERSIONS["tmux"]
+        assert expected in result.stdout, (
+            f"Expected tmux {expected}, got: {result.stdout}"
+        )
+
+    def test_tmux_detached_session_survives(self, host):
+        """Test that tmux can create a detached session with a background process."""
+        session = "test-session"
+        host.run(f"tmux kill-session -t {session} 2>/dev/null")
+        try:
+            result = host.run(f"tmux new-session -d -s {session} 'sleep 60'")
+            assert result.rc == 0, f"Failed to create tmux session: {result.stderr}"
+
+            result = host.run("tmux list-sessions")
+            assert result.rc == 0, "tmux list-sessions failed"
+            assert session in result.stdout, (
+                f"Session '{session}' not found in: {result.stdout}"
+            )
+
+            result = host.run(f"tmux list-panes -t {session} -F '#{{pane_pid}}'")
+            assert result.rc == 0, "Failed to get pane PID"
+            pid = result.stdout.strip()
+            assert pid, "No PID returned for tmux pane"
+            result = host.run(f"kill -0 {pid}")
+            assert result.rc == 0, f"Process {pid} is not running"
+        finally:
+            host.run(f"tmux kill-session -t {session} 2>/dev/null")
 
 
 class TestPythonEnvironment:

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -27,7 +27,7 @@ EXPECTED_VERSIONS = {
     "cargo-binstall": "1.17.",  # Minor version check (installed from latest release),
     "typstyle": "0.14.",  # Minor version check (installed from latest release)
     "vig_utils": "0.1.",  # Minor version check (installed via uv pip)
-    "tmux": "3.5",  # Major.minor version check (from apt package)
+    "tmux": "3.3",  # Major.minor version check (from apt package)
 }
 
 


### PR DESCRIPTION
## Description

Install tmux in the container image so that autonomous worktree agents can run in detached tmux sessions that survive Cursor session disconnects. Without tmux, `just worktree-start` fails the prerequisite check and autonomous TDD workflows cannot complete.

## Type of Change

- [ ] `feat` -- New feature
- [ ] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [x] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [x] `test` -- Adding or updating tests
- [ ] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- **Containerfile**: Add `tmux` to the `apt-get install` block alongside existing system dependencies
- **tests/test_image.py**: Add `"tmux": "3.3"` to `EXPECTED_VERSIONS` dict
- **tests/test_image.py**: Add `test_tmux_installed` — verifies tmux apt package is installed
- **tests/test_image.py**: Add `test_tmux_version` — verifies `tmux -V` returns expected version
- **tests/test_image.py**: Add `test_tmux_detached_session_survives` — creates a detached session, verifies it in `tmux list-sessions`, confirms the background process is running via PID check
- **CHANGELOG.md**: Add entry under `## Unreleased` → `### Added`

## Changelog Entry

### Added

- **tmux installed in container image for worktree session persistence** ([#130](https://github.com/vig-os/devcontainer/issues/130))
  - Add `tmux` to the Containerfile `apt-get install` block
  - Enables autonomous worktree agents to survive Cursor session disconnects

## Testing

- [x] Tests pass locally (`just test-image`) — 35 passed, 0 failed
- [x] Manual testing performed (describe below)

### Manual Testing Details

```
$ just test-image
======================== 35 passed in 77.95s (0:01:17) =========================
```

All 3 new tmux tests pass:
- `test_tmux_installed` — confirms `host.package("tmux").is_installed`
- `test_tmux_version` — confirms `tmux -V` contains `3.3`
- `test_tmux_detached_session_survives` — creates detached session, verifies via `tmux list-sessions` and PID liveness check

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

- The `hadolint-docker` pre-commit hook (added in #122/#124) was skipped locally via `SKIP=hadolint-docker` because it requires a Docker daemon and the project uses Podman. Issue #122 has been reopened with a comment describing the problem. CI will run hadolint independently.
- TDD compliance: failing tests committed first (`9cfceed`), then implementation (`5358f40`), then changelog (`caebb7b`).

Refs: #130
