### PR TITLE
feat(gh-issues): make issue and PR numbers clickable links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Clickable issue and PR numbers in gh-issues table** ([#104](https://github.com/vig-os/devcontainer/issues/104))
+  - `#` column in issue and PR tables now uses Rich OSC 8 hyperlinks to GitHub URLs
+  - Clicking an issue or PR number opens it in the browser (or Cursor's integrated terminal)
 - **PR template aligned with canonical commit types** ([#115](https://github.com/vig-os/devcontainer/issues/115))
   - Replace ad-hoc Type of Change checkboxes with the 10 canonical commit types
   - Move breaking change from type to a separate modifier checkbox

--- a/scripts/gh_issues.py
+++ b/scripts/gh_issues.py
@@ -149,6 +149,11 @@ def _styled(value: str, style: str) -> str:
     return f"[{style}]{value}[/]"
 
 
+def _gh_link(owner_repo: str, num: int, kind: str) -> str:
+    """Return Rich hyperlink markup for issue or PR number."""
+    return f"[link=https://github.com/{owner_repo}/{kind}/{num}]{num}[/link]"
+
+
 def _extract_label(labels: list[dict], prefix: str) -> str:
     for lbl in labels:
         name = lbl["name"]
@@ -230,6 +235,7 @@ def _build_table(
     issue_to_pr: dict[int, int],
     child_to_parent: dict[int, int],
     parent_to_children: dict[int, list[int]],
+    owner_repo: str,
 ) -> Table:
     from rich.table import Table
 
@@ -287,7 +293,7 @@ def _build_table(
             title_text = _styled(f"▸ {title_text}", "bright_cyan")
 
         table.add_row(
-            str(num),
+            _gh_link(owner_repo, num, "issues"),
             _extract_type(labels),
             title_text,
             _format_assignees(issue["assignees"]),
@@ -350,6 +356,7 @@ def _build_pr_table(
     title: str,
     prs: list[dict],
     pr_to_issues: dict[int, list[int]],
+    owner_repo: str,
 ) -> Table:
     from rich.table import Table
 
@@ -390,7 +397,7 @@ def _build_pr_table(
         )
 
         table.add_row(
-            str(pr["number"]),
+            _gh_link(owner_repo, pr["number"], "pull"),
             _clean_title(pr["title"]) + draft_marker,
             f"[bright_white]{pr['author']['login']}[/]",
             issues_cell,
@@ -446,6 +453,7 @@ def main() -> int:
                 issue_to_pr,
                 child_to_parent,
                 parent_to_children,
+                owner_repo,
             )
             console.print()
             console.print(table)
@@ -458,6 +466,7 @@ def main() -> int:
                 issue_to_pr,
                 child_to_parent,
                 parent_to_children,
+                owner_repo,
             )
             console.print()
             console.print(table)
@@ -473,6 +482,7 @@ def main() -> int:
             f"[green]▸ Pull Requests[/]  [dim]({len(prs)} open)[/]",
             prs,
             pr_to_issues,
+            owner_repo,
         )
         console.print()
         console.print(table)

--- a/tests/test_gh_issues.py
+++ b/tests/test_gh_issues.py
@@ -1,0 +1,30 @@
+"""Unit tests for scripts/gh_issues.py."""
+
+import importlib.util
+from pathlib import Path
+
+scripts_dir = Path(__file__).parent.parent / "scripts"
+gh_issues_spec = importlib.util.spec_from_file_location(
+    "gh_issues", scripts_dir / "gh_issues.py"
+)
+gh_issues = importlib.util.module_from_spec(gh_issues_spec)
+gh_issues_spec.loader.exec_module(gh_issues)
+
+
+class TestGhLink:
+    """Test _gh_link helper for clickable issue/PR numbers."""
+
+    def test_issue_link_format(self):
+        """Issue number renders as Rich hyperlink to GitHub issues URL."""
+        result = gh_issues._gh_link("vig-os/devcontainer", 104, "issues")
+        assert (
+            result
+            == "[link=https://github.com/vig-os/devcontainer/issues/104]104[/link]"
+        )
+
+    def test_pr_link_format(self):
+        """PR number renders as Rich hyperlink to GitHub pull URL."""
+        result = gh_issues._gh_link("vig-os/devcontainer", 42, "pull")
+        assert (
+            result == "[link=https://github.com/vig-os/devcontainer/pull/42]42[/link]"
+        )


### PR DESCRIPTION
## Description

Enhance the `#` column in the `just gh-issues` overview table so that issue and PR numbers are clickable hyperlinks. Uses Rich's `[link=URL]text[/link]` markup for OSC 8 hyperlinks, which work in iTerm2, Windows Terminal, Cursor's integrated terminal, and other modern terminals.

Closes #104

## Type of Change

- [x] `feat` -- New feature

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- Added `_gh_link(owner_repo, num, kind)` helper in `scripts/gh_issues.py` to generate Rich hyperlink markup
- Thread `owner_repo` from `main()` to `_build_table` and `_build_pr_table`
- Issue `#` column: links to `https://github.com/{owner}/{repo}/issues/{num}`
- PR `#` column: links to `https://github.com/{owner}/{repo}/pull/{num}`
- Unit tests in `tests/test_gh_issues.py` for link formatting

## Changelog Entry

```
### Changed

- **Clickable issue and PR numbers in gh-issues table** ([#104](https://github.com/vig-os/devcontainer/issues/104))
  - `#` column in issue and PR tables now uses Rich OSC 8 hyperlinks to GitHub URLs
  - Clicking an issue or PR number opens it in the browser (or Cursor's integrated terminal)
```

## Testing

- [x] Tests pass locally (`uv run pytest tests/test_gh_issues.py tests/test_utils.py -v`)
- [x] Manual testing: `just gh-issues` displays tables with clickable numbers

### Manual Testing Details

Ran `uv run python scripts/gh_issues.py` — tables render correctly; issue and PR numbers are hyperlinked in terminals that support OSC 8.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Refs: #104