### PR TITLE
feat(agent): add pr_solve skill and skill naming enforcement

### DIFF
--- a/.cursor/rules/tdd.mdc
+++ b/.cursor/rules/tdd.mdc
@@ -38,7 +38,9 @@ Before writing a test, evaluate which scenarios apply. Not every category applie
 | Edge cases | Empty input, single element, max values, boundary values |
 | Error paths | Invalid input, missing dependencies, network/IO failures |
 | Input validation | Null, undefined, wrong type, malformed data |
-| State & side effects | Does it modify state correctly? Idempotent? Cleanup? |
+| State & side effects | Does it modify state correctly? Cleanup? |
+| Idempotency | Does running the operation twice produce the same result as once? |
+| Concurrency | Do parallel or overlapping executions corrupt state or race? |
 | Regression | If fixing a bug, does the test prove the bug is fixed? |
 | Canary | Inject a known-bad state into the real environment, confirm the guard catches it, clean up |
 | Smoke | After integration, does the system start and key flows work? |

--- a/.cursor/rules/tdd.mdc
+++ b/.cursor/rules/tdd.mdc
@@ -40,6 +40,7 @@ Before writing a test, evaluate which scenarios apply. Not every category applie
 | Input validation | Null, undefined, wrong type, malformed data |
 | State & side effects | Does it modify state correctly? Idempotent? Cleanup? |
 | Regression | If fixing a bug, does the test prove the bug is fixed? |
+| Canary | Inject a known-bad state into the real environment, confirm the guard catches it, clean up |
 | Smoke | After integration, does the system start and key flows work? |
 
 ## Test types

--- a/.cursor/skills/pr_solve/SKILL.md
+++ b/.cursor/skills/pr_solve/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: pr_solve
+description: Diagnoses all PR failures (CI, reviews, merge state), plans fixes, executes them.
+disable-model-invocation: true
+---
+
+# Solve PR Failures
+
+Diagnose all failures on a pull request — CI failures, review feedback, merge conflicts — produce a consolidated fix plan, and execute it.
+
+**Rule: no fixes without presenting the diagnosis first. No guessing — cite actual output.**
+
+## When to Use
+
+- A PR has failing CI checks, requested changes from reviewers, or merge conflicts.
+- You want a single entry point that gathers all problems, plans fixes, and executes them — instead of manually orchestrating [ci_check](../ci_check/SKILL.md), review reading, and [ci_fix](../ci_fix/SKILL.md) individually.
+
+## Workflow Steps
+
+### 1. Identify the PR
+
+- The user provides a PR number (e.g. `/pr_solve 42`).
+- Fetch PR metadata:
+
+  ```bash
+  gh pr view <number> --json number,title,body,headRefName,baseRefName,mergeable,mergeStateStatus,reviewDecision,state
+  ```
+
+- Derive the linked issue number from the PR body (`Closes #N`, `Refs: #N`, or `Fixes #N`). If no issue is linked, ask the user.
+- Confirm the PR is open. If merged or closed, stop and tell the user.
+
+### 2. Gather all problems
+
+Collect problems from three independent sources. Keep them separated — they are different concerns that require different fixes.
+
+#### 2a. CI failures
+
+```bash
+gh pr checks <number>
+```
+
+- For each failing check, fetch the failure log:
+
+  ```bash
+  gh run view <run-id> --log-failed
+  ```
+
+- Extract: workflow name, job, step, key error lines.
+- If all checks pass or are pending, note it and move on.
+
+#### 2b. Review feedback
+
+```bash
+gh api repos/{owner}/{repo}/pulls/<number>/reviews \
+  --jq '[.[] | select(.state == "CHANGES_REQUESTED" or .state == "COMMENTED") | {author: .user.login, state: .state, body: .body}]'
+```
+
+```bash
+gh api repos/{owner}/{repo}/pulls/<number>/comments \
+  --jq '[.[] | {author: .user.login, path: .path, line: .line, body: .body, url: .html_url}]'
+```
+
+- Include only unresolved review threads (comments without a resolution).
+- Group by reviewer, then by file.
+- If no pending reviews or comments, note it and move on.
+
+#### 2c. Merge state
+
+- From step 1's metadata, check `mergeable` and `mergeStateStatus`.
+- If there are merge conflicts, list the conflicting status but **do not attempt an automatic rebase** — report it as requiring manual resolution.
+
+### 3. Present diagnosis
+
+Show the user a structured summary before any fixes:
+
+```
+## PR Diagnosis: #<number>
+
+### CI Failures
+- <workflow> / <job> / <step>: <key error line> (run <run-id>)
+- ...
+(or: All CI checks passing ✓)
+
+### Review Feedback
+- @<reviewer> (changes requested):
+  - `<file>:<line>`: <comment summary> ([link](<url>))
+  - ...
+(or: No pending review feedback ✓)
+
+### Merge State
+- <mergeable status>
+(or: Clean — no conflicts ✓)
+```
+
+**If no problems are found in any category**, report a clean bill of health and stop. Do not proceed to planning.
+
+**Wait for the user to acknowledge the diagnosis before proceeding.**
+
+### 4. Plan fixes
+
+- For each problem, create an ordered fix task following [design_plan](../design_plan/SKILL.md) conventions:
+  - **What**: one sentence describing the fix
+  - **Files**: exact file paths to modify
+  - **Verification**: how to confirm the fix works
+- Order: CI failures first (they block merge), then review feedback (by file to minimize context switching), then merge conflicts last (manual).
+- Merge conflicts are listed as "manual action required" — the skill does not rebase.
+- Present the plan to the user for approval. Do not start fixing until approved.
+
+### 5. Execute fixes
+
+- Work through approved tasks one at a time.
+- Follow [code_tdd](../code_tdd/SKILL.md) discipline where applicable (write test first, then fix).
+- Commit each fix via [git_commit](../git_commit/SKILL.md).
+- Push after each fix: `git push`
+
+### 6. Verify
+
+- After all fixes are pushed, run [ci_check](../ci_check/SKILL.md) to confirm CI passes.
+- If new failures appear, loop back to step 2 to re-diagnose.
+- **Maximum 2 loops.** After the second re-diagnosis, escalate to the user — do not keep cycling.
+
+## Delegation
+
+Step 2 (gather all problems) is entirely data-gathering and CLI commands, making it ideal for lightweight delegation:
+
+Spawn a Task subagent with `model: "fast"` that:
+1. Runs `gh pr checks` and fetches `--log-failed` for any failing runs
+2. Fetches reviews and inline comments via `gh api`
+3. Extracts merge state from the PR metadata
+
+Returns: structured data for each category (CI failures with error logs, review comments grouped by reviewer/file, merge state).
+
+Steps 3-6 (diagnosis presentation, planning, execution, verification) remain in the main agent as they require user interaction and code changes.
+
+Reference: [subagent-delegation rule](../../rules/subagent-delegation.mdc)
+
+## Stop If
+
+- You are about to fix something without presenting the diagnosis (step 3) first.
+- You are guessing at the cause of a CI failure — fetch the log.
+- You are attempting a rebase or merge conflict resolution automatically.
+- You are stacking a second fix on top of a failed first fix — re-diagnose instead.
+- You have looped through steps 2-6 more than twice — escalate to the user.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -129,6 +129,16 @@ repos:
         types: [python]
         pass_filenames: false
 
+  # Skill directory naming convention
+  - repo: local
+    hooks:
+      - id: check-skill-names
+        name: check-skill-names (enforce naming convention)
+        entry: scripts/check-skill-names.sh .cursor/skills
+        language: script
+        files: ^\.cursor/skills/
+        pass_filenames: false
+
   # Commit message validation (commit-msg stage)
   - repo: local
     hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **pr_solve skill — diagnose PR failures, plan fixes, execute** ([#133](https://github.com/vig-os/devcontainer/issues/133))
   - Single entry point that gathers CI failures, review feedback, and merge state into a consolidated diagnosis
   - Presents diagnosis for approval before any fixes, plans fixes using design_plan conventions, executes with TDD discipline
+  - Pre-commit hook `check-skill-names` enforces `[a-z0-9][a-z0-9_-]*` naming for skill directories
+  - BATS test suite with canary test that injects a bad name into the real repo
+  - TDD scenario checklist expanded with canary, idempotency, and concurrency categories
 - **Optional reviewer parameter for autonomous worktree pipeline** ([#102](https://github.com/vig-os/devcontainer/issues/102))
   - Support `reviewer` parameter in `just worktree-start`
   - Propagate `PR_REVIEWER` via tmux environment to the autonomous agent

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **tmux installed in container image for worktree session persistence** ([#130](https://github.com/vig-os/devcontainer/issues/130))
   - Add `tmux` to the Containerfile `apt-get install` block
   - Enables autonomous worktree agents to survive Cursor session disconnects
+- **pr_solve skill — diagnose PR failures, plan fixes, execute** ([#133](https://github.com/vig-os/devcontainer/issues/133))
+  - Single entry point that gathers CI failures, review feedback, and merge state into a consolidated diagnosis
+  - Presents diagnosis for approval before any fixes, plans fixes using design_plan conventions, executes with TDD discipline
 - **Optional reviewer parameter for autonomous worktree pipeline** ([#102](https://github.com/vig-os/devcontainer/issues/102))
   - Support `reviewer` parameter in `just worktree-start`
   - Propagate `PR_REVIEWER` via tmux environment to the autonomous agent

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,7 @@ Available slash commands (symlinked from `.cursor/skills/`):
 | `/issue_triage` | Triage and label GitHub issues |
 | `/pr_create` | Prepare and submit a pull request |
 | `/pr_post-merge` | Cleanup after PR merge |
+| `/pr_solve` | Diagnose PR failures, plan fixes, execute them |
 | `/worktree_ci-check` | Autonomous CI check — polls until completion, triggers fix on failure |
 | `/worktree_ci-fix` | Autonomous CI fix — diagnose, post diagnosis, fix, push, re-check |
 | `/worktree_brainstorm` | Autonomous design — reads issue, posts design, never blocks |

--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -180,7 +180,7 @@ Available recipes:
     test-vig-utils                             # Run check action pins tests only
 
     [worktree]
-    worktree-attach issue                      # Attach to a worktree's tmux session [alias: wt-attach]
+    worktree-attach issue                      # before attaching. See tests/bats/worktree.bats for integration tests. [alias: wt-attach]
     worktree-clean                             # Remove all cursor-managed worktrees and tmux sessions [alias: wt-clean]
     worktree-list                              # List active worktrees and their tmux sessions [alias: wt-list]
     worktree-start issue prompt="" reviewer="" # Create a worktree for an issue, open tmux session, launch cursor-agent [alias: wt-start]

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Available recipes:
     test-vig-utils                             # Run check action pins tests only
 
     [worktree]
-    worktree-attach issue                      # Attach to a worktree's tmux session [alias: wt-attach]
+    worktree-attach issue                      # before attaching. See tests/bats/worktree.bats for integration tests. [alias: wt-attach]
     worktree-clean                             # Remove all cursor-managed worktrees and tmux sessions [alias: wt-clean]
     worktree-list                              # List active worktrees and their tmux sessions [alias: wt-list]
     worktree-start issue prompt="" reviewer="" # Create a worktree for an issue, open tmux session, launch cursor-agent [alias: wt-start]

--- a/assets/workspace/.cursor/rules/tdd.mdc
+++ b/assets/workspace/.cursor/rules/tdd.mdc
@@ -38,7 +38,9 @@ Before writing a test, evaluate which scenarios apply. Not every category applie
 | Edge cases | Empty input, single element, max values, boundary values |
 | Error paths | Invalid input, missing dependencies, network/IO failures |
 | Input validation | Null, undefined, wrong type, malformed data |
-| State & side effects | Does it modify state correctly? Idempotent? Cleanup? |
+| State & side effects | Does it modify state correctly? Cleanup? |
+| Idempotency | Does running the operation twice produce the same result as once? |
+| Concurrency | Do parallel or overlapping executions corrupt state or race? |
 | Regression | If fixing a bug, does the test prove the bug is fixed? |
 | Canary | Inject a known-bad state into the real environment, confirm the guard catches it, clean up |
 | Smoke | After integration, does the system start and key flows work? |

--- a/assets/workspace/.cursor/rules/tdd.mdc
+++ b/assets/workspace/.cursor/rules/tdd.mdc
@@ -40,6 +40,7 @@ Before writing a test, evaluate which scenarios apply. Not every category applie
 | Input validation | Null, undefined, wrong type, malformed data |
 | State & side effects | Does it modify state correctly? Idempotent? Cleanup? |
 | Regression | If fixing a bug, does the test prove the bug is fixed? |
+| Canary | Inject a known-bad state into the real environment, confirm the guard catches it, clean up |
 | Smoke | After integration, does the system start and key flows work? |
 
 ## Test types

--- a/assets/workspace/.cursor/skills/pr_solve/SKILL.md
+++ b/assets/workspace/.cursor/skills/pr_solve/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: pr_solve
+description: Diagnoses all PR failures (CI, reviews, merge state), plans fixes, executes them.
+disable-model-invocation: true
+---
+
+# Solve PR Failures
+
+Diagnose all failures on a pull request — CI failures, review feedback, merge conflicts — produce a consolidated fix plan, and execute it.
+
+**Rule: no fixes without presenting the diagnosis first. No guessing — cite actual output.**
+
+## When to Use
+
+- A PR has failing CI checks, requested changes from reviewers, or merge conflicts.
+- You want a single entry point that gathers all problems, plans fixes, and executes them — instead of manually orchestrating [ci_check](../ci_check/SKILL.md), review reading, and [ci_fix](../ci_fix/SKILL.md) individually.
+
+## Workflow Steps
+
+### 1. Identify the PR
+
+- The user provides a PR number (e.g. `/pr_solve 42`).
+- Fetch PR metadata:
+
+  ```bash
+  gh pr view <number> --json number,title,body,headRefName,baseRefName,mergeable,mergeStateStatus,reviewDecision,state
+  ```
+
+- Derive the linked issue number from the PR body (`Closes #N`, `Refs: #N`, or `Fixes #N`). If no issue is linked, ask the user.
+- Confirm the PR is open. If merged or closed, stop and tell the user.
+
+### 2. Gather all problems
+
+Collect problems from three independent sources. Keep them separated — they are different concerns that require different fixes.
+
+#### 2a. CI failures
+
+```bash
+gh pr checks <number>
+```
+
+- For each failing check, fetch the failure log:
+
+  ```bash
+  gh run view <run-id> --log-failed
+  ```
+
+- Extract: workflow name, job, step, key error lines.
+- If all checks pass or are pending, note it and move on.
+
+#### 2b. Review feedback
+
+```bash
+gh api repos/{owner}/{repo}/pulls/<number>/reviews \
+  --jq '[.[] | select(.state == "CHANGES_REQUESTED" or .state == "COMMENTED") | {author: .user.login, state: .state, body: .body}]'
+```
+
+```bash
+gh api repos/{owner}/{repo}/pulls/<number>/comments \
+  --jq '[.[] | {author: .user.login, path: .path, line: .line, body: .body, url: .html_url}]'
+```
+
+- Include only unresolved review threads (comments without a resolution).
+- Group by reviewer, then by file.
+- If no pending reviews or comments, note it and move on.
+
+#### 2c. Merge state
+
+- From step 1's metadata, check `mergeable` and `mergeStateStatus`.
+- If there are merge conflicts, list the conflicting status but **do not attempt an automatic rebase** — report it as requiring manual resolution.
+
+### 3. Present diagnosis
+
+Show the user a structured summary before any fixes:
+
+```
+## PR Diagnosis: #<number>
+
+### CI Failures
+- <workflow> / <job> / <step>: <key error line> (run <run-id>)
+- ...
+(or: All CI checks passing ✓)
+
+### Review Feedback
+- @<reviewer> (changes requested):
+  - `<file>:<line>`: <comment summary> ([link](<url>))
+  - ...
+(or: No pending review feedback ✓)
+
+### Merge State
+- <mergeable status>
+(or: Clean — no conflicts ✓)
+```
+
+**If no problems are found in any category**, report a clean bill of health and stop. Do not proceed to planning.
+
+**Wait for the user to acknowledge the diagnosis before proceeding.**
+
+### 4. Plan fixes
+
+- For each problem, create an ordered fix task following [design_plan](../design_plan/SKILL.md) conventions:
+  - **What**: one sentence describing the fix
+  - **Files**: exact file paths to modify
+  - **Verification**: how to confirm the fix works
+- Order: CI failures first (they block merge), then review feedback (by file to minimize context switching), then merge conflicts last (manual).
+- Merge conflicts are listed as "manual action required" — the skill does not rebase.
+- Present the plan to the user for approval. Do not start fixing until approved.
+
+### 5. Execute fixes
+
+- Work through approved tasks one at a time.
+- Follow [code_tdd](../code_tdd/SKILL.md) discipline where applicable (write test first, then fix).
+- Commit each fix via [git_commit](../git_commit/SKILL.md).
+- Push after each fix: `git push`
+
+### 6. Verify
+
+- After all fixes are pushed, run [ci_check](../ci_check/SKILL.md) to confirm CI passes.
+- If new failures appear, loop back to step 2 to re-diagnose.
+- **Maximum 2 loops.** After the second re-diagnosis, escalate to the user — do not keep cycling.
+
+## Delegation
+
+Step 2 (gather all problems) is entirely data-gathering and CLI commands, making it ideal for lightweight delegation:
+
+Spawn a Task subagent with `model: "fast"` that:
+1. Runs `gh pr checks` and fetches `--log-failed` for any failing runs
+2. Fetches reviews and inline comments via `gh api`
+3. Extracts merge state from the PR metadata
+
+Returns: structured data for each category (CI failures with error logs, review comments grouped by reviewer/file, merge state).
+
+Steps 3-6 (diagnosis presentation, planning, execution, verification) remain in the main agent as they require user interaction and code changes.
+
+Reference: [subagent-delegation rule](../../rules/subagent-delegation.mdc)
+
+## Stop If
+
+- You are about to fix something without presenting the diagnosis (step 3) first.
+- You are guessing at the cause of a CI failure — fetch the log.
+- You are attempting a rebase or merge conflict resolution automatically.
+- You are stacking a second fix on top of a failed first fix — re-diagnose instead.
+- You have looped through steps 2-6 more than twice — escalate to the user.

--- a/assets/workspace/.pre-commit-config.yaml
+++ b/assets/workspace/.pre-commit-config.yaml
@@ -118,6 +118,16 @@ repos:
         types: [python]
         pass_filenames: false
 
+  # Skill directory naming convention
+  - repo: local
+    hooks:
+      - id: check-skill-names
+        name: check-skill-names (enforce naming convention)
+        entry: scripts/check-skill-names.sh .cursor/skills
+        language: script
+        files: ^\.cursor/skills/
+        pass_filenames: false
+
   # Commit message validation (commit-msg stage)
   - repo: local
     hooks:

--- a/docs/SKILL_PIPELINE.md
+++ b/docs/SKILL_PIPELINE.md
@@ -106,6 +106,7 @@ Run when starting a new repo or major initiative. Explores the problem space, sc
 | `git_commit` | `/git-commit` | Executes the commit workflow following the project's commit message conventions. |
 | `pr_create` | `/pr-create` | Prepares and submits a pull request for feature or bugfix work. |
 | `pr_post-merge` | `/pr-post-merge` | Performs cleanup and branch switching after a PR merge. |
+| `pr_solve` | `/pr-solve` | Diagnoses all PR failures (CI, reviews, merge state), plans fixes, executes them. |
 
 
 ### CI

--- a/docs/SKILL_PIPELINE.md
+++ b/docs/SKILL_PIPELINE.md
@@ -38,7 +38,7 @@ Skills are markdown playbooks that live in `.cursor/skills/`. Each one defines a
   │  git_commit              │                              │            ├─ worktree_execute              │
   │  pr_create               │                              │            ├─ worktree_verify               │
   │  ci_check / ci_fix       │                              │            ├─ worktree_pr                   │
-  │                          │                              │            └─ worktree_ci-check / ci-fix    │
+  │  pr_solve                │                              │            └─ worktree_ci-check / ci-fix    │
   └─────────────▼────────────┘                              │                                             │
                 |                                           │  worktree_ask  (escape hatch: post          │
                 |                                           │                 question on issue)          │
@@ -50,8 +50,8 @@ Skills are markdown playbooks that live in `.cursor/skills/`. Each one defines a
                                                   |
                              ┌────────────────────▼──────────────────────┐
                              │            RELEASE MANAGEMENT             │
-              │             pr_create                     │
-              │             pr_post-merge                 │
+                             │             pr_create                     │
+                             │             pr_post-merge                 │
                              └───────────────────────────────────────────┘
 
 

--- a/docs/templates/SKILL_PIPELINE.md.j2
+++ b/docs/templates/SKILL_PIPELINE.md.j2
@@ -38,7 +38,7 @@ Skills are markdown playbooks that live in `.cursor/skills/`. Each one defines a
   │  git_commit              │                              │            ├─ worktree_execute              │
   │  pr_create               │                              │            ├─ worktree_verify               │
   │  ci_check / ci_fix       │                              │            ├─ worktree_pr                   │
-  │                          │                              │            └─ worktree_ci-check / ci-fix    │
+  │  pr_solve                │                              │            └─ worktree_ci-check / ci-fix    │
   └─────────────▼────────────┘                              │                                             │
                 |                                           │  worktree_ask  (escape hatch: post          │
                 |                                           │                 question on issue)          │
@@ -50,8 +50,8 @@ Skills are markdown playbooks that live in `.cursor/skills/`. Each one defines a
                                                   |
                              ┌────────────────────▼──────────────────────┐
                              │            RELEASE MANAGEMENT             │
-              │             pr_create                     │
-              │             pr_post-merge                 │
+                             │             pr_create                     │
+                             │             pr_post-merge                 │
                              └───────────────────────────────────────────┘
 
 

--- a/scripts/check-skill-names.sh
+++ b/scripts/check-skill-names.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Check that all skill directory names under a given path use only
+# lowercase letters, digits, hyphens, and underscores.
+#
+# Usage: check-skill-names.sh [skills_dir]
+#   skills_dir  Path to scan (default: .cursor/skills)
+#
+# Exit 0 if all names are valid, 1 if any are invalid.
+
+set -euo pipefail
+
+skills_dir="${1:-.cursor/skills}"
+
+if [[ ! -d "$skills_dir" ]]; then
+    echo "Error: directory not found: $skills_dir" >&2
+    exit 1
+fi
+
+invalid=()
+
+for dir in "$skills_dir"/*/; do
+    [[ -d "$dir" ]] || continue
+    name="$(basename "$dir")"
+    if [[ ! "$name" =~ ^[a-z0-9][a-z0-9_-]*$ ]]; then
+        invalid+=("$name")
+    fi
+done
+
+if [[ ${#invalid[@]} -gt 0 ]]; then
+    echo "Invalid skill directory name(s) — must match [a-z0-9][a-z0-9_-]*:" >&2
+    for name in "${invalid[@]}"; do
+        echo "  $name" >&2
+    done
+    exit 1
+fi

--- a/tests/bats/skill-naming.bats
+++ b/tests/bats/skill-naming.bats
@@ -122,3 +122,15 @@ setup() {
     run "$CHECK_SCRIPT" "$PROJECT_ROOT/.cursor/skills"
     assert_success
 }
+
+@test "canary: injecting a bad name into real skills dir is caught and cleaned up" {
+    local canary="$PROJECT_ROOT/.cursor/skills/bad:canary"
+    mkdir -p "$canary"
+    touch "$canary/SKILL.md"
+
+    run "$CHECK_SCRIPT" "$PROJECT_ROOT/.cursor/skills"
+    rm -rf "$canary"
+
+    assert_failure
+    assert_output --partial "bad:canary"
+}

--- a/tests/bats/skill-naming.bats
+++ b/tests/bats/skill-naming.bats
@@ -1,0 +1,124 @@
+#!/usr/bin/env bats
+# BATS tests for scripts/check-skill-names.sh
+#
+# Validates that the skill naming checker correctly accepts valid names
+# (lowercase letters, digits, hyphens, underscores) and rejects invalid
+# names (colons, dots, uppercase, spaces, etc.).
+
+setup() {
+    load test_helper
+    CHECK_SCRIPT="$PROJECT_ROOT/scripts/check-skill-names.sh"
+}
+
+# ── script basics ─────────────────────────────────────────────────────────────
+
+@test "check-skill-names.sh exists and is executable" {
+    assert_file_exists "$CHECK_SCRIPT"
+    run test -x "$CHECK_SCRIPT"
+    assert_success
+}
+
+# ── valid names ───────────────────────────────────────────────────────────────
+
+@test "accepts underscore-separated names (ci_check)" {
+    local dir
+    dir="$(mktemp -d)"
+    mkdir -p "$dir/ci_check"
+    touch "$dir/ci_check/SKILL.md"
+    run "$CHECK_SCRIPT" "$dir"
+    assert_success
+    rm -rf "$dir"
+}
+
+@test "accepts hyphenated names (pr_post-merge)" {
+    local dir
+    dir="$(mktemp -d)"
+    mkdir -p "$dir/pr_post-merge"
+    touch "$dir/pr_post-merge/SKILL.md"
+    run "$CHECK_SCRIPT" "$dir"
+    assert_success
+    rm -rf "$dir"
+}
+
+@test "accepts multiple valid skill directories" {
+    local dir
+    dir="$(mktemp -d)"
+    mkdir -p "$dir/ci_check" "$dir/code_tdd" "$dir/worktree_solve-and-pr"
+    touch "$dir/ci_check/SKILL.md" "$dir/code_tdd/SKILL.md" "$dir/worktree_solve-and-pr/SKILL.md"
+    run "$CHECK_SCRIPT" "$dir"
+    assert_success
+    rm -rf "$dir"
+}
+
+@test "accepts empty skills directory (no subdirs)" {
+    local dir
+    dir="$(mktemp -d)"
+    run "$CHECK_SCRIPT" "$dir"
+    assert_success
+    rm -rf "$dir"
+}
+
+# ── invalid names ─────────────────────────────────────────────────────────────
+
+@test "rejects colon-separated names (ci:check)" {
+    local dir
+    dir="$(mktemp -d)"
+    mkdir -p "$dir/ci:check"
+    touch "$dir/ci:check/SKILL.md"
+    run "$CHECK_SCRIPT" "$dir"
+    assert_failure
+    assert_output --partial "ci:check"
+    rm -rf "$dir"
+}
+
+@test "rejects names with dots (ci.check)" {
+    local dir
+    dir="$(mktemp -d)"
+    mkdir -p "$dir/ci.check"
+    touch "$dir/ci.check/SKILL.md"
+    run "$CHECK_SCRIPT" "$dir"
+    assert_failure
+    assert_output --partial "ci.check"
+    rm -rf "$dir"
+}
+
+@test "rejects names with uppercase (CI_Check)" {
+    local dir
+    dir="$(mktemp -d)"
+    mkdir -p "$dir/CI_Check"
+    touch "$dir/CI_Check/SKILL.md"
+    run "$CHECK_SCRIPT" "$dir"
+    assert_failure
+    assert_output --partial "CI_Check"
+    rm -rf "$dir"
+}
+
+@test "rejects names with spaces" {
+    local dir
+    dir="$(mktemp -d)"
+    mkdir -p "$dir/ci check"
+    touch "$dir/ci check/SKILL.md"
+    run "$CHECK_SCRIPT" "$dir"
+    assert_failure
+    assert_output --partial "ci check"
+    rm -rf "$dir"
+}
+
+@test "reports all invalid names when multiple exist" {
+    local dir
+    dir="$(mktemp -d)"
+    mkdir -p "$dir/ci:check" "$dir/code_tdd" "$dir/Design:Plan"
+    touch "$dir/ci:check/SKILL.md" "$dir/code_tdd/SKILL.md" "$dir/Design:Plan/SKILL.md"
+    run "$CHECK_SCRIPT" "$dir"
+    assert_failure
+    assert_output --partial "ci:check"
+    assert_output --partial "Design:Plan"
+    rm -rf "$dir"
+}
+
+# ── real repo validation ──────────────────────────────────────────────────────
+
+@test "all skills in .cursor/skills/ have valid names" {
+    run "$CHECK_SCRIPT" "$PROJECT_ROOT/.cursor/skills"
+    assert_success
+}


### PR DESCRIPTION
## Description

Add the `pr_solve` skill — a single entry point that diagnoses all PR failures (CI, review feedback, merge conflicts), presents a structured diagnosis, plans fixes with user approval, and executes them with TDD discipline.

Also introduces a pre-commit hook and BATS test suite to enforce the new underscore-based skill directory naming convention, and expands the TDD scenario checklist with three new categories.

Closes #133

## Type of Change

- [x] `feat` -- New feature
- [x] `test` -- Adding or updating tests
- [x] `docs` -- Documentation only

## Changes Made

### pr_solve skill
- `.cursor/skills/pr_solve/SKILL.md` — 6-step workflow: identify PR, gather problems (CI/reviews/merge state), present diagnosis, plan fixes, execute with TDD, verify via ci_check
- Registered in `CLAUDE.md` command table
- Workspace copy synced via `sync_manifest.py`

### Skill naming enforcement
- `scripts/check-skill-names.sh` — validates skill directory names match `[a-z0-9][a-z0-9_-]*`
- Pre-commit hook `check-skill-names` in `.pre-commit-config.yaml` — triggers on changes under `.cursor/skills/`
- `tests/bats/skill-naming.bats` — 12 BATS tests covering valid names, invalid names (colons, dots, uppercase, spaces), multiple violations, empty dirs, real repo validation, and a canary test that injects a bad name into the real `.cursor/skills/` to prove the guard catches it

### TDD checklist expansion
- `.cursor/rules/tdd.mdc` — added canary, idempotency, and concurrency to the test scenario checklist

## Changelog Entry

### Added

- **pr_solve skill — diagnose PR failures, plan fixes, execute** ([#133](https://github.com/vig-os/devcontainer/issues/133))
  - Single entry point that gathers CI failures, review feedback, and merge state into a consolidated diagnosis
  - Presents diagnosis for approval before any fixes, plans fixes using design_plan conventions, executes with TDD discipline
  - Pre-commit hook `check-skill-names` enforces `[a-z0-9][a-z0-9_-]*` naming for skill directories
  - BATS test suite with canary test that injects a bad name into the real repo
  - TDD scenario checklist expanded with canary, idempotency, and concurrency categories

## Testing

- [x] Tests pass locally (`just test-bats`)
- [x] All 12 BATS tests pass including canary test
- [x] Pre-commit hook `check-skill-names` passes on real repo
- [x] All pre-commit hooks pass on every commit

### Manual Testing Details

- Ran `npx bats tests/bats/skill-naming.bats` — 12/12 pass
- Ran `scripts/check-skill-names.sh .cursor/skills` — exits 0
- Verified canary test creates `bad:canary` dir, checker rejects it, dir is cleaned up

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

Refs: #133
