### PR TITLE
feat(skills): use PR template in pr_create and worktree_pr (#147)

### DIFF
--- a/.cursor/skills/pr_create/SKILL.md
+++ b/.cursor/skills/pr_create/SKILL.md
@@ -29,9 +29,19 @@ Prepare and submit a pull request for **feature or bugfix work**.
 
 ### 4. Prepare PR text following template
 
-- Use the structure of [.github/pull_request_template.md](.github/pull_request_template.md).
-- Populate **Description**, **Related Issue(s)** (e.g. Closes #NN), **Type of Change**, **Changes Made** (from `git log base..HEAD` and `git diff --stat base...HEAD`), **Testing**, and **Checklist** from the current branch and your knowledge of the changes.
-- Write the body to a file (e.g. `.github/pr-draft-<issue>-into-<base>.md` or similar) so the user can edit it if needed.
+1. **Read the template**: `cat .github/pull_request_template.md`
+2. **Use it as the literal skeleton** — keep every heading, every checkbox line, every sub-heading. Strip only the HTML comments (`<!-- ... -->`).
+3. **Section-by-section mapping**:
+   - **Description**: Summarize what the PR does from the issue body and commit messages.
+   - **Type of Change**: Check the single box matching the branch type / commit types. Check `Breaking change` modifier only if commits contain `!`.
+   - **Changes Made**: List changed files with bullet sub-details (from `git diff --stat base...HEAD` and `git log base..HEAD`).
+   - **Changelog Entry**: Paste the exact `## Unreleased` diff from CHANGELOG.md. If no changelog update, write "No changelog needed" and explain.
+   - **Testing**: Check `Tests pass locally` if tests were run. Check `Manual testing performed` only if actually done. Fill `Manual Testing Details` or write "N/A".
+   - **Checklist**: Check only items that are genuinely true. Leave unchecked items unchecked — do not remove them.
+   - **Additional Notes**: Add design links, context, or write "N/A".
+   - **Refs**: `Refs: #<issue_number>`
+4. **Explicit prohibitions**: Do not invent new sections. Do not rename headings. Do not omit sections. Do not remove unchecked boxes.
+5. Write the body to a file (e.g. `.github/pr-draft-<issue>-into-<base>.md` or similar) so the user can edit it if needed.
 
 ### 5. Ask user to review and choose assignee and reviewers
 

--- a/.cursor/skills/worktree_pr/SKILL.md
+++ b/.cursor/skills/worktree_pr/SKILL.md
@@ -68,9 +68,19 @@ gh issue view <issue_number> --json title,body
 
 ### 5. Generate PR text
 
-- Use the structure from [.github/pull_request_template.md](../../.github/pull_request_template.md).
-- Populate: Description, Related Issue(s) (`Closes #<issue_number>`), Type of Change, Changes Made, Testing, Checklist.
-- Write the body to `.github/pr-draft-<issue_number>.md`.
+1. **Read the template**: `cat .github/pull_request_template.md`
+2. **Use it as the literal skeleton** — keep every heading, every checkbox line, every sub-heading. Strip only the HTML comments (`<!-- ... -->`).
+3. **Section-by-section mapping**:
+   - **Description**: Summarize what the PR does from the issue body and commit messages.
+   - **Type of Change**: Check the single box matching the branch type / commit types. Check `Breaking change` modifier only if commits contain `!`.
+   - **Changes Made**: List changed files with bullet sub-details (from `git diff --stat` and `git log`).
+   - **Changelog Entry**: Paste the exact `## Unreleased` diff from CHANGELOG.md. If no changelog update, write "No changelog needed" and explain.
+   - **Testing**: Check `Tests pass locally` if tests were run. Check `Manual testing performed` only if actually done. Fill `Manual Testing Details` or write "N/A".
+   - **Checklist**: Check only items that are genuinely true. Leave unchecked items unchecked — do not remove them.
+   - **Additional Notes**: Add design links, context, or write "N/A".
+   - **Refs**: `Refs: #<issue_number>`
+4. **Explicit prohibitions**: Do not invent new sections. Do not rename headings. Do not omit sections. Do not remove unchecked boxes.
+5. Write the body to `.github/pr-draft-<issue_number>.md`.
 
 ### 6. Create PR
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Autonomous PR skills use pull request template** ([#147](https://github.com/vig-os/devcontainer/issues/147))
+  - `pr_create` and `worktree_pr` now read `.github/pull_request_template.md` and fill each section from available context
+  - Explicit read-then-fill procedure with section-by-section mapping (Description, Type of Change, Changelog Entry, Testing, Checklist, Refs)
+  - Ensures autonomous PRs match manual PR structure and include all checklist items
 - **Rename skill namespace separator from colon to underscore** ([#128](https://github.com/vig-os/devcontainer/issues/128))
   - All skill directories under `.cursor/skills/` and `assets/workspace/.cursor/skills/` renamed (e.g. `issue:create` → `issue_create`)
   - All internal cross-references, frontmatter, prose, `CLAUDE.md` command table, and label taxonomy updated

--- a/assets/workspace/.cursor/skills/pr_create/SKILL.md
+++ b/assets/workspace/.cursor/skills/pr_create/SKILL.md
@@ -29,9 +29,19 @@ Prepare and submit a pull request for **feature or bugfix work**.
 
 ### 4. Prepare PR text following template
 
-- Use the structure of [.github/pull_request_template.md](.github/pull_request_template.md).
-- Populate **Description**, **Related Issue(s)** (e.g. Closes #NN), **Type of Change**, **Changes Made** (from `git log base..HEAD` and `git diff --stat base...HEAD`), **Testing**, and **Checklist** from the current branch and your knowledge of the changes.
-- Write the body to a file (e.g. `.github/pr-draft-<issue>-into-<base>.md` or similar) so the user can edit it if needed.
+1. **Read the template**: `cat .github/pull_request_template.md`
+2. **Use it as the literal skeleton** — keep every heading, every checkbox line, every sub-heading. Strip only the HTML comments (`<!-- ... -->`).
+3. **Section-by-section mapping**:
+   - **Description**: Summarize what the PR does from the issue body and commit messages.
+   - **Type of Change**: Check the single box matching the branch type / commit types. Check `Breaking change` modifier only if commits contain `!`.
+   - **Changes Made**: List changed files with bullet sub-details (from `git diff --stat base...HEAD` and `git log base..HEAD`).
+   - **Changelog Entry**: Paste the exact `## Unreleased` diff from CHANGELOG.md. If no changelog update, write "No changelog needed" and explain.
+   - **Testing**: Check `Tests pass locally` if tests were run. Check `Manual testing performed` only if actually done. Fill `Manual Testing Details` or write "N/A".
+   - **Checklist**: Check only items that are genuinely true. Leave unchecked items unchecked — do not remove them.
+   - **Additional Notes**: Add design links, context, or write "N/A".
+   - **Refs**: `Refs: #<issue_number>`
+4. **Explicit prohibitions**: Do not invent new sections. Do not rename headings. Do not omit sections. Do not remove unchecked boxes.
+5. Write the body to a file (e.g. `.github/pr-draft-<issue>-into-<base>.md` or similar) so the user can edit it if needed.
 
 ### 5. Ask user to review and choose assignee and reviewers
 

--- a/assets/workspace/.cursor/skills/worktree_pr/SKILL.md
+++ b/assets/workspace/.cursor/skills/worktree_pr/SKILL.md
@@ -68,9 +68,19 @@ gh issue view <issue_number> --json title,body
 
 ### 5. Generate PR text
 
-- Use the structure from [.github/pull_request_template.md](../../.github/pull_request_template.md).
-- Populate: Description, Related Issue(s) (`Closes #<issue_number>`), Type of Change, Changes Made, Testing, Checklist.
-- Write the body to `.github/pr-draft-<issue_number>.md`.
+1. **Read the template**: `cat .github/pull_request_template.md`
+2. **Use it as the literal skeleton** — keep every heading, every checkbox line, every sub-heading. Strip only the HTML comments (`<!-- ... -->`).
+3. **Section-by-section mapping**:
+   - **Description**: Summarize what the PR does from the issue body and commit messages.
+   - **Type of Change**: Check the single box matching the branch type / commit types. Check `Breaking change` modifier only if commits contain `!`.
+   - **Changes Made**: List changed files with bullet sub-details (from `git diff --stat` and `git log`).
+   - **Changelog Entry**: Paste the exact `## Unreleased` diff from CHANGELOG.md. If no changelog update, write "No changelog needed" and explain.
+   - **Testing**: Check `Tests pass locally` if tests were run. Check `Manual testing performed` only if actually done. Fill `Manual Testing Details` or write "N/A".
+   - **Checklist**: Check only items that are genuinely true. Leave unchecked items unchecked — do not remove them.
+   - **Additional Notes**: Add design links, context, or write "N/A".
+   - **Refs**: `Refs: #<issue_number>`
+4. **Explicit prohibitions**: Do not invent new sections. Do not rename headings. Do not omit sections. Do not remove unchecked boxes.
+5. Write the body to `.github/pr-draft-<issue_number>.md`.
 
 ### 6. Create PR
 


### PR DESCRIPTION
## Description

Updates `pr_create` and `worktree_pr` skills to read `.github/pull_request_template.md` and fill each section from available context, instead of composing freeform PR bodies. Ensures autonomous PRs match manual PR structure and include all checklist items (Type of Change, Changelog Entry, Testing, Checklist, Refs).

## Type of Change

- [x] `feat` -- New feature
- [ ] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [ ] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- `.cursor/skills/pr_create/SKILL.md` — Step 4: replaced vague "use structure" with explicit read-then-fill procedure
- `.cursor/skills/worktree_pr/SKILL.md` — Step 5: same replacement
- `assets/workspace/.cursor/skills/pr_create/SKILL.md` — synced with primary
- `assets/workspace/.cursor/skills/worktree_pr/SKILL.md` — synced with primary
- `CHANGELOG.md` — added entry under Changed

## Changelog Entry

### Changed

- **Autonomous PR skills use pull request template** ([#147](https://github.com/vig-os/devcontainer/issues/147))
  - `pr_create` and `worktree_pr` now read `.github/pull_request_template.md` and fill each section from available context
  - Explicit read-then-fill procedure with section-by-section mapping (Description, Type of Change, Changelog Entry, Testing, Checklist, Refs)
  - Ensures autonomous PRs match manual PR structure and include all checklist items

## Testing

- [x] Tests pass locally (`just test`)
- [ ] Manual testing performed (describe below)

### Manual Testing Details

N/A — documentation/instruction-only change. Verification: next autonomous PR should match template structure.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

Design: see issue #147 Design comment. Documentation-only change per design — no testable code, TDD skipped.

Refs: #147
