### PR TITLE
fix(gh-issues): PR table Reviewer column distinguishes requested vs completed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **PR table Reviewer column distinguishes requested vs completed reviewers** ([#105](https://github.com/vig-os/devcontainer/issues/105))
+  - Requested reviewers (no review yet) display as `?login` with dim italic style
+  - Actual reviewers (submitted review) display as plain login with green/red
 - **worktree-attach restarts stopped tmux session when worktree dir exists** ([#132](https://github.com/vig-os/devcontainer/issues/132))
   - Detect when worktree directory exists but tmux session has terminated
   - Automatically restart session in existing worktree before attaching

--- a/scripts/gh_issues.py
+++ b/scripts/gh_issues.py
@@ -425,6 +425,8 @@ def _extract_reviewers(pr: dict) -> str:
             parts.append(_styled(login, "green"))
         elif state == "CHANGES_REQUESTED":
             parts.append(_styled(login, "red"))
+        elif state == "REQUESTED":
+            parts.append(_styled(f"?{login}", "dim italic"))
         else:
             parts.append(_styled(login, "yellow"))
     return " ".join(parts)

--- a/tests/test_gh_issues.py
+++ b/tests/test_gh_issues.py
@@ -318,14 +318,14 @@ class TestExtractReviewers:
         }
         result = _extract_reviewers(pr)
         assert "[green]alice[/]" in result
-        assert "[yellow]bob[/]" in result
+        assert "[dim italic]?bob[/]" in result
 
     def test_review_request_with_name_fallback(self):
         pr = {
             "latestReviews": [],
             "reviewRequests": [{"login": "", "name": "team-review"}],
         }
-        assert _extract_reviewers(pr) == "[yellow]team-review[/]"
+        assert _extract_reviewers(pr) == "[dim italic]?team-review[/]"
 
     def test_empty_pr_dict(self):
         assert _extract_reviewers({}) == "[dim]—[/]"

--- a/tests/test_gh_issues.py
+++ b/tests/test_gh_issues.py
@@ -309,7 +309,7 @@ class TestExtractReviewers:
             "latestReviews": [],
             "reviewRequests": [{"login": "carol"}],
         }
-        assert _extract_reviewers(pr) == "[yellow]carol[/]"
+        assert _extract_reviewers(pr) == "[dim italic]?carol[/]"
 
     def test_mixed_reviewers(self):
         pr = {


### PR DESCRIPTION
## Description

Fixes the Reviewer column in `just gh-issues` PR table to distinguish between requested reviewers (asked but not yet reviewed) and actual reviewers (submitted a review). Requested reviewers now display as `?login` with dim italic style; actual reviewers remain plain login with green/red for approved/changes requested.

## Type of Change

<!-- Mark the relevant option(s) with an 'x' -->

- [ ] `feat` -- New feature
- [x] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [ ] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- `scripts/gh_issues.py`: In `_extract_reviewers`, render REQUESTED state as `?login` with dim italic instead of yellow
- `tests/test_gh_issues.py`: Update assertions for requested reviewer format in test_requested_reviewer, test_mixed_reviewers, test_review_request_with_name_fallback
- `CHANGELOG.md`: Add Fixed entry for #105

## Changelog Entry

<!-- Paste the exact entry you added to CHANGELOG.md under ## Unreleased.
     If no changelog update is needed, write "No changelog needed" and explain why.
     Example:
     ### Added
     - **SSH agent forwarding** ([#42](https://github.com/vig-os/devcontainer/issues/42))
       - Forward host SSH agent into devcontainer for seamless git authentication
-->

### Fixed

- **PR table Reviewer column distinguishes requested vs completed reviewers** ([#105](https://github.com/vig-os/devcontainer/issues/105))
  - Requested reviewers (no review yet) display as `?login` with dim italic style
  - Actual reviewers (submitted review) display as plain login with green/red

## Testing

<!-- Describe the tests you ran and how to verify your changes -->
- [x] Tests pass locally (`just test`)
- [ ] Manual testing performed (describe below)

### Manual Testing Details

N/A — unit tests cover the change. Run `uv run pytest tests/test_gh_issues.py` to verify.

## Checklist

<!-- Mark completed items with an 'x' -->
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

Design and implementation plan posted on issue #105.

Refs: #105
