### PR TITLE
fix(gh-issues): detect Refs: #N in PR bodies for cross-refs (#121)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **gh-issues cross-ref detects Refs: #N in PR bodies** ([#121](https://github.com/vig-os/devcontainer/issues/121))
+  - `_build_cross_refs` now parses `Refs: #102` and comma-separated variants (`Refs: #102, #103`) alongside Closes/Fixes/Resolves
 - **worktree-attach restarts stopped tmux session when worktree dir exists** ([#132](https://github.com/vig-os/devcontainer/issues/132))
   - Detect when worktree directory exists but tmux session has terminated
   - Automatically restart session in existing worktree before attaching

--- a/scripts/gh_issues.py
+++ b/scripts/gh_issues.py
@@ -195,6 +195,7 @@ def _format_assignees(assignees: list[dict]) -> str:
 
 
 _CLOSING_RE = re.compile(r"(?:closes|fixes|resolves)\s+#(\d+)", re.IGNORECASE)
+_REFS_RE = re.compile(r"Refs:\s*((?:#\d+(?:\s*,\s*)?)+)", re.IGNORECASE)
 
 
 def _build_cross_refs(
@@ -220,6 +221,10 @@ def _build_cross_refs(
         body = pr.get("body") or ""
         for match in _CLOSING_RE.finditer(body):
             linked.add(int(match.group(1)))
+        refs_match = _REFS_RE.search(body)
+        if refs_match:
+            for m in re.finditer(r"#(\d+)", refs_match.group(1)):
+                linked.add(int(m.group(1)))
 
         for inum in linked:
             issue_to_pr[inum] = pr_num

--- a/tests/test_gh_issues.py
+++ b/tests/test_gh_issues.py
@@ -413,3 +413,17 @@ class TestBuildCrossRefs:
         issue_to_pr, pr_to_issues = _build_cross_refs(branches, prs)
         assert issue_to_pr == {42: 100, 43: 101}
         assert pr_to_issues == {100: [42], 101: [43]}
+
+    def test_refs_keyword_match(self):
+        branches = {}
+        prs = [{"number": 100, "headRefName": "some-branch", "body": "Refs: #102"}]
+        issue_to_pr, pr_to_issues = _build_cross_refs(branches, prs)
+        assert issue_to_pr == {102: 100}
+        assert pr_to_issues == {100: [102]}
+
+    def test_refs_comma_separated(self):
+        branches = {}
+        prs = [{"number": 100, "headRefName": "x", "body": "Refs: #102, #103"}]
+        issue_to_pr, pr_to_issues = _build_cross_refs(branches, prs)
+        assert issue_to_pr == {102: 100, 103: 100}
+        assert pr_to_issues == {100: [102, 103]}


### PR DESCRIPTION
## Description

Fixes the `gh_issues` cross-reference logic so PRs linked via `Refs: #N` (the project's standard format per CLAUDE.md) are detected. Previously only `Closes`/`Fixes`/`Resolves` and branch-name matching were supported. GitHub does not auto-link `Refs:`, so the gh-issues table showed empty PR columns for such PRs.

## Type of Change

<!-- Mark the relevant option(s) with an 'x' -->

- [ ] `feat` -- New feature
- [x] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [ ] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- `scripts/gh_issues.py`: Added `_REFS_RE` regex and parsing logic in `_build_cross_refs` to detect `Refs: #102` and comma-separated variants (`Refs: #102, #103`)
- `tests/test_gh_issues.py`: Added `test_refs_keyword_match` and `test_refs_comma_separated` unit tests
- `CHANGELOG.md`: Added Fixed entry for #121

## Changelog Entry

<!-- Paste the exact entry you added to CHANGELOG.md under ## Unreleased.
     If no changelog update is needed, write "No changelog needed" and explain why.
     Example:
     ### Added
     - **SSH agent forwarding** ([#42](https://github.com/vig-os/devcontainer/issues/42))
       - Forward host SSH agent into devcontainer for seamless git authentication
-->

### Fixed

- **gh-issues cross-ref detects Refs: #N in PR bodies** ([#121](https://github.com/vig-os/devcontainer/issues/121))
  - `_build_cross_refs` now parses `Refs: #102` and comma-separated variants (`Refs: #102, #103`) alongside Closes/Fixes/Resolves

## Testing

<!-- Describe the tests you ran and how to verify your changes -->
- [x] Tests pass locally (`just test`)
- [ ] Manual testing performed (describe below)

### Manual Testing Details

N/A — unit tests cover the new behavior. Run `just gh-issues` after merge to verify PR↔issue links appear for PRs with `Refs:` in body.

## Checklist

<!-- Mark completed items with an 'x' -->
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

N/A

Refs: #121
