### PR TITLE
feat(scripts): devc_remote_uri.py — Cursor URI construction for remote devcontainers (#153)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **devc_remote_uri.py — Cursor URI construction for remote devcontainers** ([#153](https://github.com/vig-os/devcontainer/issues/153))
+  - Standalone Python module with `hex_encode()` and `build_uri()` for vscode-remote URIs
+  - CLI: `devc_remote_uri.py <workspace_path> <ssh_host> <container_workspace>` prints URI to stdout
+  - Stdlib only (json, argparse); called by devc-remote.sh (sibling sub-issue)
 - **CI status column in just gh-issues PR table** ([#143](https://github.com/vig-os/devcontainer/issues/143))
   - PR table shows CI column with pass/fail/pending summary (✓ 6/6, ⏳ 3/6, ✗ 5/6)
   - Failed check names visible when checks fail

--- a/scripts/devc_remote_uri.py
+++ b/scripts/devc_remote_uri.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python3
+"""Build Cursor/VS Code nested authority URI for remote devcontainers."""
+
+from __future__ import annotations
+
+
+def hex_encode(s: str) -> str:
+    """Hex-encode a string (UTF-8). Stub for TDD."""
+    raise NotImplementedError

--- a/scripts/devc_remote_uri.py
+++ b/scripts/devc_remote_uri.py
@@ -3,7 +3,29 @@
 
 from __future__ import annotations
 
+import json
+
 
 def hex_encode(s: str) -> str:
     """Hex-encode a string (UTF-8)."""
     return s.encode().hex()
+
+
+def build_uri(
+    workspace_path: str,
+    devcontainer_path: str,
+    ssh_host: str,
+    container_workspace: str,
+) -> str:
+    """Build vscode-remote URI for dev-container over SSH.
+
+    Format: vscode-remote://dev-container+{DC_HEX}@ssh-remote+{SSH_SPEC}/{container_workspace}
+    """
+    spec = {
+        "settingType": "config",
+        "workspacePath": workspace_path,
+        "devcontainerPath": devcontainer_path,
+    }
+    dc_hex = hex_encode(json.dumps(spec, separators=(",", ":")))
+    path = "/" + container_workspace.lstrip("/")
+    return f"vscode-remote://dev-container+{dc_hex}@ssh-remote+{ssh_host}{path}"

--- a/scripts/devc_remote_uri.py
+++ b/scripts/devc_remote_uri.py
@@ -5,5 +5,5 @@ from __future__ import annotations
 
 
 def hex_encode(s: str) -> str:
-    """Hex-encode a string (UTF-8). Stub for TDD."""
-    raise NotImplementedError
+    """Hex-encode a string (UTF-8)."""
+    return s.encode().hex()

--- a/tests/test_devc_remote_uri.py
+++ b/tests/test_devc_remote_uri.py
@@ -27,3 +27,33 @@ class TestHexEncode:
     def test_hex_encode_unicode(self):
         """Unicode string is UTF-8 encoded then hexed."""
         assert devc_remote_uri.hex_encode("é") == "c3a9"
+
+
+class TestBuildUri:
+    """Test build_uri function."""
+
+    def test_build_uri_matches_cursor_format(self):
+        """Known inputs produce exact URI matching Cursor docs."""
+        uri = devc_remote_uri.build_uri(
+            workspace_path="/home/user/repo",
+            devcontainer_path="/home/user/repo/.devcontainer/devcontainer.json",
+            ssh_host="loginnode",
+            container_workspace="/workspace",
+        )
+        expected = (
+            "vscode-remote://dev-container+"
+            "7b2273657474696e6754797065223a22636f6e666967222c22776f726b737061636550617468223a222f686f6d652f757365722f7265706f222c22646576636f6e7461696e657250617468223a222f686f6d652f757365722f7265706f2f2e646576636f6e7461696e65722f646576636f6e7461696e65722e6a736f6e227d"
+            "@ssh-remote+loginnode/workspace"
+        )
+        assert uri == expected
+
+    def test_build_uri_container_workspace_without_leading_slash(self):
+        """container_workspace without leading slash is normalized."""
+        uri = devc_remote_uri.build_uri(
+            workspace_path="/repo",
+            devcontainer_path="/repo/.devcontainer/devcontainer.json",
+            ssh_host="host",
+            container_workspace="workspace",
+        )
+        assert uri.endswith("/workspace")
+        assert "@ssh-remote+host" in uri

--- a/tests/test_devc_remote_uri.py
+++ b/tests/test_devc_remote_uri.py
@@ -1,0 +1,29 @@
+"""Tests for scripts/devc_remote_uri.py — Cursor URI construction for remote devcontainers."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+scripts_dir = Path(__file__).parent.parent / "scripts"
+devc_spec = importlib.util.spec_from_file_location(
+    "devc_remote_uri", scripts_dir / "devc_remote_uri.py"
+)
+devc_remote_uri = importlib.util.module_from_spec(devc_spec)
+devc_spec.loader.exec_module(devc_remote_uri)
+
+
+class TestHexEncode:
+    """Test hex_encode function."""
+
+    def test_hex_encode_simple_string(self):
+        """Known input produces exact hex output."""
+        assert devc_remote_uri.hex_encode("a") == "61"
+
+    def test_hex_encode_empty_string(self):
+        """Empty string produces empty hex."""
+        assert devc_remote_uri.hex_encode("") == ""
+
+    def test_hex_encode_unicode(self):
+        """Unicode string is UTF-8 encoded then hexed."""
+        assert devc_remote_uri.hex_encode("é") == "c3a9"


### PR DESCRIPTION
## Description

Adds `scripts/devc_remote_uri.py` — a standalone Python module/CLI that builds the Cursor/VS Code nested authority URI for remote devcontainers. Part of #70. Opening Cursor/VS Code into a remote devcontainer requires constructing a `vscode-remote://` URI with hex-encoded JSON specs; Python handles this cleanly with stdlib only.

## Type of Change

<!-- Mark the relevant option(s) with an 'x' -->

- [x] `feat` -- New feature
- [ ] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [ ] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- **scripts/devc_remote_uri.py** (new): `hex_encode()`, `build_uri()`, CLI with argparse
- **tests/test_devc_remote_uri.py** (new): 11 pytest unit tests (hex_encode, build_uri, CLI, edge cases)
- **CHANGELOG.md**: Added entry under ## Unreleased

## Changelog Entry

<!-- Paste the exact entry you added to CHANGELOG.md under ## Unreleased.
     If no changelog update is needed, write "No changelog needed" and explain why.
     Example:
     ### Added
     - **SSH agent forwarding** ([#42](https://github.com/vig-os/devcontainer/issues/42))
       - Forward host SSH agent into devcontainer for seamless git authentication
-->

### Added

- **devc_remote_uri.py — Cursor URI construction for remote devcontainers** ([#153](https://github.com/vig-os/devcontainer/issues/153))
  - Standalone Python module with `hex_encode()` and `build_uri()` for vscode-remote URIs
  - CLI: `devc_remote_uri.py <workspace_path> <ssh_host> <container_workspace>` prints URI to stdout
  - Stdlib only (json, argparse); called by devc-remote.sh (sibling sub-issue)

## Testing

<!-- Describe the tests you ran and how to verify your changes -->
- [x] Tests pass locally (`just test`)
- [ ] Manual testing performed (describe below)

### Manual Testing Details

<!-- If applicable, describe manual testing steps -->

N/A — `uv run pytest tests/test_devc_remote_uri.py -v` passes (11 tests). `just lint` passes.

## Checklist

<!-- Mark completed items with an 'x' -->
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

<!-- Any additional information, screenshots, or context that reviewers should know -->

Design and implementation plan posted on issue #153. Sub-issue of #70 (remote devcontainer orchestration).

Refs: #153
