### PR TITLE
fix(gh-issues): make PR table Issues column clickable links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Issue numbers in PR table Issues column are not clickable links** ([#174](https://github.com/vig-os/devcontainer/issues/174))
+  - Replace `_styled` with `_gh_link` in `_build_pr_table` so issue numbers render as clickable terminal hyperlinks
 - **just gh-issues fails locally — rich not in .venv dependencies** ([#159](https://github.com/vig-os/devcontainer/issues/159))
   - Add `rich>=13.0.0` to dev dependency group in `pyproject.toml` so `uv sync` installs it into `.venv`
 - **gh-issues cross-ref detects Refs: #N in PR bodies** ([#121](https://github.com/vig-os/devcontainer/issues/121))

--- a/scripts/gh_issues.py
+++ b/scripts/gh_issues.py
@@ -175,6 +175,16 @@ def _gh_link(owner_repo: str, num: int, kind: str) -> str:
     return f"[link=https://github.com/{owner_repo}/{kind}/{num}]{num}[/link]"
 
 
+def _format_pr_issues_cell(owner_repo: str, linked: list[int]) -> str:
+    """Return Rich markup for PR table Issues column — clickable links.
+
+    Ref: #174
+    """
+    if not linked:
+        return ""
+    return " ".join(_gh_link(owner_repo, n, "issues") for n in sorted(linked))
+
+
 def _extract_label(labels: list[dict], prefix: str) -> str:
     for lbl in labels:
         name = lbl["name"]
@@ -632,9 +642,7 @@ def _build_pr_table(
         branch = f"[dim]{pr['headRefName']}[/] → [dim]{pr['baseRefName']}[/]"
 
         linked = pr_to_issues.get(pr["number"], [])
-        issues_cell = (
-            " ".join(_styled(f"#{n}", "cyan") for n in sorted(linked)) if linked else ""
-        )
+        issues_cell = _format_pr_issues_cell(owner_repo, linked)
 
         ci_cell = _format_ci_status(pr, owner_repo)
 

--- a/tests/test_gh_issues.py
+++ b/tests/test_gh_issues.py
@@ -96,6 +96,24 @@ class TestFormatCiStatus:
         assert "dim" in result
 
 
+class TestFormatPrIssuesCell:
+    """Test issues cell in PR table uses clickable links.
+
+    Ref: #174
+    """
+
+    def test_linked_issues_render_as_clickable_links(self):
+        """Issue numbers in PR table Issues column use _gh_link markup."""
+        result = gh_issues._format_pr_issues_cell("vig-os/devcontainer", [143, 42])
+        assert "link=https://github.com/vig-os/devcontainer/issues/143" in result
+        assert "link=https://github.com/vig-os/devcontainer/issues/42" in result
+        assert "[/link]" in result
+
+    def test_empty_linked_returns_empty_string(self):
+        """No linked issues returns empty string."""
+        assert gh_issues._format_pr_issues_cell("owner/repo", []) == ""
+
+
 class TestGhLink:
     """Test _gh_link helper for clickable issue/PR numbers."""
 


### PR DESCRIPTION
## Description

Makes issue numbers in the PR table "Issues" column clickable terminal hyperlinks. Previously they were styled with cyan but not clickable. The fix replaces `_styled` with `_gh_link` for consistency with how PR numbers and issue numbers elsewhere in the dashboard are rendered.

## Type of Change

<!-- Mark the relevant option(s) with an 'x' -->

- [ ] `feat` -- New feature
- [x] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [ ] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- `scripts/gh_issues.py` — Add `_format_pr_issues_cell` helper, use `_gh_link` instead of `_styled` for issues cell in `_build_pr_table`
- `tests/test_gh_issues.py` — Add `TestFormatPrIssuesCell` tests for clickable link markup

## Changelog Entry

<!-- Paste the exact entry you added to CHANGELOG.md under ## Unreleased.
     If no changelog update is needed, write "No changelog needed" and explain why.
     Example:
     ### Added
     - **SSH agent forwarding** ([#42](https://github.com/vig-os/devcontainer/issues/42))
       - Forward host SSH agent into devcontainer for seamless git authentication
-->

### Fixed

- **Issue numbers in PR table Issues column are not clickable links** ([#174](https://github.com/vig-os/devcontainer/issues/174))
  - Replace `_styled` with `_gh_link` in `_build_pr_table` so issue numbers render as clickable terminal hyperlinks

## Testing

<!-- Describe the tests you ran and how to verify your changes -->
- [x] Tests pass locally (`just test`)
- [ ] Manual testing performed (describe below)

### Manual Testing Details

N/A — Run `just gh-issues` and visually verify issue numbers in the PR table Issues column are clickable.

## Checklist

<!-- Mark completed items with an 'x' -->
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

N/A

Refs: #174
