### PR TITLE
fix(gh-issues): make issue numbers in PR table clickable hyperlinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Automatically restart session in existing worktree before attaching
   - Guard `worktree-start` against branches already checked out elsewhere with an informative error
   - BATS integration tests for restart, error paths, and checkout detection
+- **Issue numbers in PR table are now clickable hyperlinks** ([#174](https://github.com/vig-os/devcontainer/issues/174))
+  - Replace plain styled text with Rich hyperlink markup in the Issues column of the PR table
 
 ### Changed
 

--- a/scripts/gh_issues.py
+++ b/scripts/gh_issues.py
@@ -485,7 +485,9 @@ def _build_pr_table(
 
         linked = pr_to_issues.get(pr["number"], [])
         issues_cell = (
-            " ".join(_styled(f"#{n}", "cyan") for n in sorted(linked)) if linked else ""
+            " ".join(_gh_link(owner_repo, n, "issues") for n in sorted(linked))
+            if linked
+            else ""
         )
 
         ci_cell = _format_ci_status(pr, owner_repo)

--- a/tests/test_gh_issues.py
+++ b/tests/test_gh_issues.py
@@ -22,6 +22,7 @@ _format_assignees = gh_issues._format_assignees
 _infer_review = gh_issues._infer_review
 _extract_reviewers = gh_issues._extract_reviewers
 _build_cross_refs = gh_issues._build_cross_refs
+_build_pr_table = gh_issues._build_pr_table
 
 
 class TestFormatCiStatus:
@@ -427,3 +428,54 @@ class TestBuildCrossRefs:
         issue_to_pr, pr_to_issues = _build_cross_refs(branches, prs)
         assert issue_to_pr == {102: 100, 103: 100}
         assert pr_to_issues == {100: [102, 103]}
+
+
+def _minimal_pr(number=42, linked_issues=None):
+    """Build a minimal PR dict sufficient for _build_pr_table."""
+    return {
+        "number": number,
+        "title": "Test PR",
+        "author": {"login": "alice"},
+        "assignees": [],
+        "headRefName": "feature/42",
+        "baseRefName": "dev",
+        "isDraft": False,
+        "additions": 10,
+        "deletions": 2,
+        "changedFiles": 1,
+        "reviewDecision": "",
+        "latestReviews": [],
+        "reviewRequests": [],
+        "statusCheckRollup": [],
+    }
+
+
+class TestBuildPrTableIssueLinks:
+    """Regression: issue numbers in PR table Issues column must be clickable links.
+
+    Ref: #174
+    """
+
+    def _issues_cell(self, table):
+        """Extract the raw Issues column cell string from the first row."""
+        issues_col_idx = 4
+        return table.columns[issues_col_idx]._cells[0]
+
+    def test_linked_issues_are_hyperlinks(self):
+        """Issue numbers in the Issues column render as Rich hyperlinks, not plain styled text."""
+        pr = _minimal_pr(number=42)
+        pr_to_issues = {42: [100, 101]}
+        table = _build_pr_table("Test", [pr], pr_to_issues, "owner/repo")
+
+        cell = self._issues_cell(table)
+        assert "link=https://github.com/owner/repo/issues/100" in cell
+        assert "link=https://github.com/owner/repo/issues/101" in cell
+
+    def test_linked_issues_contain_github_url(self):
+        """Each linked issue number should have a GitHub issues URL in link markup."""
+        pr = _minimal_pr(number=10)
+        pr_to_issues = {10: [55]}
+        table = _build_pr_table("PRs", [pr], pr_to_issues, "vig-os/devcontainer")
+
+        cell = self._issues_cell(table)
+        assert "link=https://github.com/vig-os/devcontainer/issues/55" in cell


### PR DESCRIPTION
## Summary

- Replace `_styled(f"#{n}", "cyan")` with `_gh_link(owner_repo, n, "issues")` in `_build_pr_table`
- Issue numbers in the PR table's "Issues" column are now clickable hyperlinks (consistent with PR numbers and issue table)
- Minor display change: numbers no longer have `#` prefix (matches `_gh_link` convention used elsewhere)

## Test plan

- [x] Failing regression test added (`TestBuildPrTableIssueLinks`)
- [x] Test passes after fix
- [x] All 68 existing tests pass
- [ ] Manual verification: `just gh-issues` shows clickable issue links in PR table

Refs: #174