### PR TITLE
fix(workspace): sync scripts referenced by justfiles into manifest (#190)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - BATS integration tests for restart, error paths, and checkout detection
 - **Issue numbers in PR table are now clickable hyperlinks** ([#174](https://github.com/vig-os/devcontainer/issues/174))
   - Replace plain styled text with Rich hyperlink markup in the Issues column of the PR table
+- **Synced justfiles reference scripts not included in workspace manifest** ([#190](https://github.com/vig-os/devcontainer/issues/190))
+  - Add manifest entries for resolve-branch.sh, derive-branch-summary.sh, check-skill-names.sh → `.devcontainer/scripts/`
+  - Update justfile.worktree to use `source_directory() / "scripts"` for portable path resolution
+  - Add Sed transform for check-skill-names.sh path in synced `.pre-commit-config.yaml`
 
 ### Changed
 

--- a/assets/workspace/.devcontainer/justfile.worktree
+++ b/assets/workspace/.devcontainer/justfile.worktree
@@ -11,6 +11,9 @@
 _wt_repo := `basename "$(git rev-parse --show-toplevel)"`
 _wt_base := "../" + _wt_repo + "-worktrees"
 
+# Scripts path: resolves to scripts/ in devcontainer repo, .devcontainer/scripts/ in workspace
+_scripts := source_directory() / "scripts"
+
 # -------------------------------------------------------------------------------
 # START
 # -------------------------------------------------------------------------------
@@ -126,7 +129,7 @@ worktree-start issue prompt="" reviewer="":
     fi
 
     # Resolve the issue's linked branch (may already exist from issue:claim)
-    BRANCH=$(gh issue develop --list "$ISSUE" 2>/dev/null | "$(pwd)/scripts/resolve-branch.sh")
+    BRANCH=$(gh issue develop --list "$ISSUE" 2>/dev/null | "{{ _scripts }}/resolve-branch.sh")
 
     if [ -z "$BRANCH" ]; then
         echo "[*] No linked branch for issue #${ISSUE}. Creating one..."
@@ -146,11 +149,11 @@ worktree-start issue prompt="" reviewer="":
         # Use agent ONLY for the intelligent part: deriving the short summary
         # Try lightweight first; on failure retry with standard model (#183)
         NAMING_RULE="$(pwd)/.cursor/rules/branch-naming.mdc"
-        SUMMARY=$("$(pwd)/scripts/derive-branch-summary.sh" "$TITLE" "$NAMING_RULE" "lightweight") || true
+        SUMMARY=$("{{ _scripts }}/derive-branch-summary.sh" "$TITLE" "$NAMING_RULE" "lightweight") || true
 
         if [ -z "$SUMMARY" ]; then
             echo "[!] Lightweight model failed. Retrying with standard model..."
-            SUMMARY=$("$(pwd)/scripts/derive-branch-summary.sh" "$TITLE" "$NAMING_RULE" "standard") || true
+            SUMMARY=$("{{ _scripts }}/derive-branch-summary.sh" "$TITLE" "$NAMING_RULE" "standard") || true
         fi
 
         if [ -z "$SUMMARY" ]; then
@@ -162,7 +165,7 @@ worktree-start issue prompt="" reviewer="":
         OWNER_REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
         PARENT=$(gh api "repos/${OWNER_REPO}/issues/${ISSUE}/parent" --jq '.number' 2>/dev/null || true)
         if [ -n "$PARENT" ]; then
-            BASE=$(gh issue develop --list "$PARENT" 2>/dev/null | "$(pwd)/scripts/resolve-branch.sh")
+            BASE=$(gh issue develop --list "$PARENT" 2>/dev/null | "{{ _scripts }}/resolve-branch.sh")
             BASE="${BASE:-dev}"
         else
             BASE="dev"

--- a/assets/workspace/.devcontainer/scripts/check-skill-names.sh
+++ b/assets/workspace/.devcontainer/scripts/check-skill-names.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Check that all skill directory names under a given path use only
+# lowercase letters, digits, hyphens, and underscores.
+#
+# Usage: check-skill-names.sh [skills_dir]
+#   skills_dir  Path to scan (default: .cursor/skills)
+#
+# Exit 0 if all names are valid, 1 if any are invalid.
+
+set -euo pipefail
+
+skills_dir="${1:-.cursor/skills}"
+
+if [[ ! -d "$skills_dir" ]]; then
+    echo "Error: directory not found: $skills_dir" >&2
+    exit 1
+fi
+
+invalid=()
+
+for dir in "$skills_dir"/*/; do
+    [[ -d "$dir" ]] || continue
+    name="$(basename "$dir")"
+    if [[ ! "$name" =~ ^[a-z0-9][a-z0-9_-]*$ ]]; then
+        invalid+=("$name")
+    fi
+done
+
+if [[ ${#invalid[@]} -gt 0 ]]; then
+    echo "Invalid skill directory name(s) — must match [a-z0-9][a-z0-9_-]*:" >&2
+    for name in "${invalid[@]}"; do
+        echo "  $name" >&2
+    done
+    exit 1
+fi

--- a/assets/workspace/.devcontainer/scripts/derive-branch-summary.sh
+++ b/assets/workspace/.devcontainer/scripts/derive-branch-summary.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Derive a kebab-case branch summary from an issue title.
+# Used by worktree-start when no linked branch exists.
+#
+# Usage: derive-branch-summary.sh <TITLE> [NAMING_RULE] [MODEL_TIER]
+#   TITLE: issue title
+#   NAMING_RULE: path to branch-naming.mdc (default: .cursor/rules/branch-naming.mdc)
+#   MODEL_TIER: agent-models.toml tier (default: lightweight). Use standard for retry.
+#
+# Env: BRANCH_SUMMARY_CMD — override for tests (e.g. "echo test-summary")
+#      When set, runs instead of agent. Must output summary to stdout.
+#      BRANCH_SUMMARY_MODEL — override model tier (e.g. "standard"). Ignored if BRANCH_SUMMARY_CMD set.
+#      DERIVE_BRANCH_TIMEOUT — timeout in seconds (default: 30). Use 2 for tests.
+set -euo pipefail
+
+TITLE="${1:?Usage: derive-branch-summary.sh <TITLE> [NAMING_RULE] [MODEL_TIER]}"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+NAMING_RULE="${2:-${REPO_ROOT}/.cursor/rules/branch-naming.mdc}"
+MODEL_TIER="${3:-${BRANCH_SUMMARY_MODEL:-lightweight}}"
+TIMEOUT="${DERIVE_BRANCH_TIMEOUT:-30}"
+
+if [ -n "${BRANCH_SUMMARY_CMD:-}" ]; then
+    SUMMARY=$(timeout "$TIMEOUT" sh -c "$BRANCH_SUMMARY_CMD" 2>/dev/null | tail -1 | tr -d '[:space:]') || true
+else
+    MODEL=$(grep "^${MODEL_TIER}" "${REPO_ROOT}/.cursor/agent-models.toml" | sed 's/.*= *"//' | sed 's/".*//')
+    SUMMARY=$(timeout "$TIMEOUT" agent --print --yolo --trust --model "$MODEL" \
+        "Read the branch naming rules in ${NAMING_RULE}. " \
+        "The issue title is: ${TITLE} " \
+        "Output ONLY a kebab-case short summary suitable for a branch name (a few words). " \
+        "Omit prefixes like FEATURE, BUG, Add, Implement, Support. " \
+        "Example: 'Standardize and Enforce Commit Message Format' -> 'standardize-commit-messages'. " \
+        "No explanation. No quotes. Just the summary." 2>/dev/null | tail -1 | tr -d '[:space:]') || true
+fi
+
+if [ -z "$SUMMARY" ]; then
+    echo "[ERROR] Failed to derive branch summary from title: ${TITLE}" >&2
+    echo "        Create one manually: gh issue develop <ISSUE> --base dev --name <type>/<issue>-<summary>" >&2
+    exit 1
+fi
+
+echo "$SUMMARY"

--- a/assets/workspace/.devcontainer/scripts/resolve-branch.sh
+++ b/assets/workspace/.devcontainer/scripts/resolve-branch.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Extract the branch name from `gh issue develop --list` output.
+# Input:  tab-separated lines on stdin (branch<TAB>URL)
+# Output: first branch name (first field of first line)
+head -1 | cut -f1

--- a/assets/workspace/.pre-commit-config.yaml
+++ b/assets/workspace/.pre-commit-config.yaml
@@ -123,7 +123,7 @@ repos:
     hooks:
       - id: check-skill-names
         name: check-skill-names (enforce naming convention)
-        entry: scripts/check-skill-names.sh .cursor/skills
+        entry: .devcontainer/scripts/check-skill-names.sh .cursor/skills
         language: script
         files: ^\.cursor/skills/
         pass_filenames: false

--- a/justfile.worktree
+++ b/justfile.worktree
@@ -11,6 +11,9 @@
 _wt_repo := `basename "$(git rev-parse --show-toplevel)"`
 _wt_base := "../" + _wt_repo + "-worktrees"
 
+# Scripts path: resolves to scripts/ in devcontainer repo, .devcontainer/scripts/ in workspace
+_scripts := source_directory() / "scripts"
+
 # -------------------------------------------------------------------------------
 # START
 # -------------------------------------------------------------------------------
@@ -126,7 +129,7 @@ worktree-start issue prompt="" reviewer="":
     fi
 
     # Resolve the issue's linked branch (may already exist from issue:claim)
-    BRANCH=$(gh issue develop --list "$ISSUE" 2>/dev/null | "$(pwd)/scripts/resolve-branch.sh")
+    BRANCH=$(gh issue develop --list "$ISSUE" 2>/dev/null | "{{ _scripts }}/resolve-branch.sh")
 
     if [ -z "$BRANCH" ]; then
         echo "[*] No linked branch for issue #${ISSUE}. Creating one..."
@@ -146,11 +149,11 @@ worktree-start issue prompt="" reviewer="":
         # Use agent ONLY for the intelligent part: deriving the short summary
         # Try lightweight first; on failure retry with standard model (#183)
         NAMING_RULE="$(pwd)/.cursor/rules/branch-naming.mdc"
-        SUMMARY=$("$(pwd)/scripts/derive-branch-summary.sh" "$TITLE" "$NAMING_RULE" "lightweight") || true
+        SUMMARY=$("{{ _scripts }}/derive-branch-summary.sh" "$TITLE" "$NAMING_RULE" "lightweight") || true
 
         if [ -z "$SUMMARY" ]; then
             echo "[!] Lightweight model failed. Retrying with standard model..."
-            SUMMARY=$("$(pwd)/scripts/derive-branch-summary.sh" "$TITLE" "$NAMING_RULE" "standard") || true
+            SUMMARY=$("{{ _scripts }}/derive-branch-summary.sh" "$TITLE" "$NAMING_RULE" "standard") || true
         fi
 
         if [ -z "$SUMMARY" ]; then
@@ -162,7 +165,7 @@ worktree-start issue prompt="" reviewer="":
         OWNER_REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
         PARENT=$(gh api "repos/${OWNER_REPO}/issues/${ISSUE}/parent" --jq '.number' 2>/dev/null || true)
         if [ -n "$PARENT" ]; then
-            BASE=$(gh issue develop --list "$PARENT" 2>/dev/null | "$(pwd)/scripts/resolve-branch.sh")
+            BASE=$(gh issue develop --list "$PARENT" 2>/dev/null | "{{ _scripts }}/resolve-branch.sh")
             BASE="${BASE:-dev}"
         else
             BASE="dev"

--- a/scripts/manifest.toml
+++ b/scripts/manifest.toml
@@ -76,6 +76,18 @@ src = "scripts/gh_issues.py"
 dest = ".devcontainer/scripts/gh_issues.py"
 
 [[entries]]
+src = "scripts/resolve-branch.sh"
+dest = ".devcontainer/scripts/resolve-branch.sh"
+
+[[entries]]
+src = "scripts/derive-branch-summary.sh"
+dest = ".devcontainer/scripts/derive-branch-summary.sh"
+
+[[entries]]
+src = "scripts/check-skill-names.sh"
+dest = ".devcontainer/scripts/check-skill-names.sh"
+
+[[entries]]
 src = "justfile.worktree"
 dest = ".devcontainer/justfile.worktree"
 
@@ -84,6 +96,7 @@ src = ".pre-commit-config.yaml"
 transforms = [
   { type = "RemovePrecommitHooks", hook_ids = ["generate-docs"] },
   { type = "Sed", pattern = "bandit -r packages/vig-utils/src/ scripts/ assets/workspace/", replace = "bandit -r src/" },
+  { type = "Sed", pattern = "scripts/check-skill-names.sh", replace = ".devcontainer/scripts/check-skill-names.sh" },
   { type = "ReplaceBlock", start_pattern = "^\\s+args: \\[$", end_pattern = "^\\s+\\]$", replacement = """
         # Optional: customize commit types, scopes, or refs-optional types via CLI arguments.
         # By default, scopes are not enforced. Set --scopes to require specific scopes.


### PR DESCRIPTION
## Summary

Fixes #190 — scripts referenced by synced justfiles and pre-commit were not deployed to workspaces.

## Changes

1. **Manifest entries** — Add resolve-branch.sh, derive-branch-summary.sh, check-skill-names.sh to `scripts/manifest.toml` with dest `.devcontainer/scripts/`

2. **Path resolution** — Update justfile.worktree to use `source_directory() / "scripts"` instead of `$(pwd)/scripts/`:
   - Devcontainer repo: `source_directory()` = repo root → `scripts/` ✓
   - Deployed workspace: `source_directory()` = `.devcontainer/` → `.devcontainer/scripts/` ✓

3. **Pre-commit transform** — Add Sed transform to update check-skill-names.sh path from `scripts/` to `.devcontainer/scripts/` in synced `.pre-commit-config.yaml`

## Note

Issue #190 lists devc-remote.sh as a fourth script; it does not exist in the current codebase. The three scripts that exist are now synced. If devc-remote.sh is added later, a manifest entry can be added in a follow-up.

## Verification

- `uv run python scripts/sync_manifest.py sync assets/workspace/` — all entries sync successfully
- `just -f justfile.worktree --list` — parses correctly
- `uv run pytest tests/test_transforms.py tests/test_utils.py` — 78 passed