### PR TITLE
refactor(skills): add pull-latest-base-before-pr to PR-creating skills (#192)

### DIFF
--- a/.cursor/skills/pr_create/SKILL.md
+++ b/.cursor/skills/pr_create/SKILL.md
@@ -17,6 +17,7 @@ Prepare and submit a pull request for **feature or bugfix work**.
 
 - Run `git status` and `git fetch origin`. If the current branch has a remote tracking branch, run `git pull --rebase origin <current-branch>` (or `git pull` if the user prefers merge) so the branch is up to date with the remote.
 - If there are uncommitted changes, list them and ask the user to commit or stash before submitting the PR. Do not prepare the PR until the working tree is clean (or the user explicitly says to proceed with uncommitted changes).
+- **Merge the base branch:** Once the base branch is confirmed (step 2), run `git merge origin/<base_branch>` to integrate the latest base before creating the PR. **Conflict handling:** If merge conflicts occur, list the conflicting files and ask the user to resolve them manually before proceeding.
 
 ### 2. Verify target branch
 

--- a/.cursor/skills/pr_solve/SKILL.md
+++ b/.cursor/skills/pr_solve/SKILL.md
@@ -108,6 +108,7 @@ Show the user a structured summary before any fixes:
 
 ### 5. Execute fixes
 
+- **Merge the base branch** before the first push: run `git fetch origin` and `git merge origin/<base_branch>` (use `baseRefName` from step 1's PR metadata). **Conflict handling:** If merge conflicts occur, list the conflicting files and ask the user to resolve them before proceeding.
 - Work through approved tasks one at a time.
 - Follow [code_tdd](../code_tdd/SKILL.md) discipline where applicable (write test first, then fix).
 - Commit each fix via [git_commit](../git_commit/SKILL.md).

--- a/assets/workspace/.cursor/skills/pr_create/SKILL.md
+++ b/assets/workspace/.cursor/skills/pr_create/SKILL.md
@@ -17,6 +17,7 @@ Prepare and submit a pull request for **feature or bugfix work**.
 
 - Run `git status` and `git fetch origin`. If the current branch has a remote tracking branch, run `git pull --rebase origin <current-branch>` (or `git pull` if the user prefers merge) so the branch is up to date with the remote.
 - If there are uncommitted changes, list them and ask the user to commit or stash before submitting the PR. Do not prepare the PR until the working tree is clean (or the user explicitly says to proceed with uncommitted changes).
+- **Merge the base branch:** Once the base branch is confirmed (step 2), run `git merge origin/<base_branch>` to integrate the latest base before creating the PR. **Conflict handling:** If merge conflicts occur, list the conflicting files and ask the user to resolve them manually before proceeding.
 
 ### 2. Verify target branch
 

--- a/assets/workspace/.cursor/skills/pr_solve/SKILL.md
+++ b/assets/workspace/.cursor/skills/pr_solve/SKILL.md
@@ -108,6 +108,7 @@ Show the user a structured summary before any fixes:
 
 ### 5. Execute fixes
 
+- **Merge the base branch** before the first push: run `git fetch origin` and `git merge origin/<base_branch>` (use `baseRefName` from step 1's PR metadata). **Conflict handling:** If merge conflicts occur, list the conflicting files and ask the user to resolve them before proceeding.
 - Work through approved tasks one at a time.
 - Follow [code_tdd](../code_tdd/SKILL.md) discipline where applicable (write test first, then fix).
 - Commit each fix via [git_commit](../git_commit/SKILL.md).


### PR DESCRIPTION
## Description

Adds a "pull latest base branch and merge" step to all PR-creating skills before creating or pushing a pull request. Ensures branches are up to date with `origin/dev` (or the target base) to avoid merge conflicts and stale code in PRs.

## Type of Change

<!-- Mark the relevant option(s) with an 'x' -->

- [x] `feat` -- New feature
- [x] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [ ] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- **pr_create**: Step 1 now merges `origin/<base_branch>` after base is confirmed. Conflict handling: ask user to resolve manually.
- **pr_solve**: Step 5 now merges `origin/<base_branch>` (from PR metadata) before first push. Conflict handling: ask user to resolve.
- **worktree_pr**: Reordered steps so base branch is determined first (step 1), then step 2 ensures clean state including merge of `origin/<base_branch>` before push. Conflict handling: invoke worktree_ask to post question on issue.
- **worktree_solve-and-pr**: Inherits merge step via worktree_pr (no direct changes).
- **solve-and-pr**: Delegates to worktree_solve-and-pr (no changes needed).

## Changelog Entry

No changelog needed — issue specifies "No changelog needed" for this refactor.

## Testing

<!-- Describe the tests you ran and how to verify your changes -->
- [x] Tests pass locally (`just test`)
- [x] Manual testing performed (describe below)

### Manual Testing Details

- Ran `just sync-workspace` to sync skills to assets/workspace
- Pre-commit hooks passed (branch-name, pymarkdown, trailing-whitespace, etc.)
- Merged latest `origin/dev` before PR per the new workflow

## Checklist

<!-- Mark completed items with an 'x' -->
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [ ] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

<!-- Any additional information, screenshots, or context that reviewers should know -->

Refs: #192
