### PR TITLE
fix(vigutils): AI agent identity enforcement (#163)

### DIFF
--- a/.cursor/skills/git_commit/SKILL.md
+++ b/.cursor/skills/git_commit/SKILL.md
@@ -59,5 +59,4 @@ git status && echo "=== STAGED CHANGES ===" && git diff --cached
 - Do not read/summarize git command output after execution unless asked
 - Your shell is already at the project root so you do not need `cd` or 'bash', just use `git ...`
 - Do not use `--no-verify` to cheat
-- Do not add any trailer (e.g. `Co-authored-by: ...`)
-- **NEVER add 'Co-authored-by: Cursor <cursoragent@cursor.com>'** to commit messages.
+- Never add Co-authored-by trailers. Never set git author/committer to an AI agent identity. Never mention AI agent names in commit messages or PR descriptions. The pre-commit hooks will reject violations.

--- a/.cursor/skills/worktree_execute/SKILL.md
+++ b/.cursor/skills/worktree_execute/SKILL.md
@@ -91,4 +91,4 @@ Reference: [subagent-delegation rule](../../rules/subagent-delegation.mdc)
 - Each task should leave the codebase in a working, testable state.
 - Skip TDD for non-testable changes (config, templates, docs) — note why in the commit.
 - The plan comment is the single source of truth for progress.
-- **NEVER add 'Co-authored-by: Cursor <cursoragent@cursor.com>'** to commit messages.
+- Never add Co-authored-by trailers. Never set git author/committer to an AI agent identity. Never mention AI agent names in commit messages or PR descriptions. The pre-commit hooks will reject violations.

--- a/.cursor/skills/worktree_pr/SKILL.md
+++ b/.cursor/skills/worktree_pr/SKILL.md
@@ -136,4 +136,4 @@ Reference: [subagent-delegation rule](../../rules/subagent-delegation.mdc)
 - Never block for user review of the PR text. Generate the best text from available context.
 - Base branch is auto-detected: parent issue's branch for sub-issues, `dev` otherwise.
 - The PR title should follow commit message conventions: `type(scope): description (#issue)`.
-- **NEVER add 'Co-authored-by: Cursor <cursoragent@cursor.com>'** to commit messages.
+- Never add Co-authored-by trailers. Never set git author/committer to an AI agent identity. Never mention AI agent names in commit messages or PR descriptions. The pre-commit hooks will reject violations.

--- a/.githooks/prepare-commit-msg
+++ b/.githooks/prepare-commit-msg
@@ -1,0 +1,6 @@
+#!/bin/bash
+# Strip AI agent trailers from commit message before validation.
+# Refs: #163
+set -euo pipefail
+
+uv run pre-commit run --hook-stage prepare-commit-msg --commit-msg-filename "$1"

--- a/.github/agent-blocklist.toml
+++ b/.github/agent-blocklist.toml
@@ -1,0 +1,29 @@
+# Canonical blocklist for AI agent identity fingerprints.
+# Referenced by: validate-commit-msg, pre-commit hooks, pr-title-check CI.
+# Refs: #163
+
+[patterns]
+# Trailer patterns (regex, matched against full lines)
+trailers = [
+  "^Co-authored-by:.*$",
+  "^Signed-off-by:.*cursor.*$",
+]
+
+# Agent names/identifiers (substring match, case-insensitive)
+names = [
+  "cursor",
+  "claude",
+  "codex",
+  "chatgpt",
+  "copilot",
+  "openai",
+  "anthropic",
+  "devin",
+]
+
+# Agent email patterns (substring match, case-insensitive)
+emails = [
+  "cursoragent@cursor.com",
+  "noreply@cursor.com",
+  "github-actions[bot]",
+]

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -37,3 +37,9 @@ jobs:
           TITLE_FILE=$(mktemp)
           printf '%s' "$PR_TITLE" > "$TITLE_FILE"
           uv run validate-commit-msg "$TITLE_FILE" --subject-only
+
+      - name: Check PR for agent fingerprints
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: uv run python scripts/check-pr-agent-fingerprints.py

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -139,6 +139,25 @@ repos:
         files: ^\.cursor/skills/
         pass_filenames: false
 
+  # AI agent identity: strip trailers before commit-msg (Refs: #163)
+  - repo: local
+    hooks:
+      - id: prepare-commit-msg-strip-trailers
+        name: strip agent trailers from commit message
+        entry: uv run python scripts/prepare-commit-msg-strip-trailers.py
+        language: system
+        stages: [prepare-commit-msg]
+        pass_filenames: true
+
+  # AI agent identity: reject author/committer matching blocklist (Refs: #163)
+  - repo: local
+    hooks:
+      - id: check-agent-identity
+        name: check agent identity
+        entry: uv run python scripts/check-agent-identity.py
+        language: system
+        pass_filenames: false
+
   # Commit message validation (commit-msg stage)
   - repo: local
     hooks:
@@ -151,4 +170,5 @@ repos:
           "--types", "feat,fix,docs,chore,refactor,test,ci,build,revert,style",
           "--scopes", "agent,setup,image,vigutils",
           "--refs-optional-types", "chore",
+          "--blocked-patterns", ".github/agent-blocklist.toml",
         ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,10 +19,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Remove stderr suppression so error messages from derive-branch-summary.sh are visible
   - Retry with standard model when lightweight model fails; print manual workaround hint if both fail
   - Add optional MODEL_TIER parameter to derive-branch-summary.sh; BATS test for retry path
-- **validate-commit-msg rejects AI agent identity fingerprints** ([#163](https://github.com/vig-os/devcontainer/issues/163))
-  - Commit-msg hook now rejects commits containing Co-authored-by, cursoragent, cursor.com, claude, codex, chatgpt, copilot
-  - Blocks "Made with [Cursor](https://cursor.com)" and similar branding
-  - Enforced before other validation; applies to full message including subject-only mode
+- **AI agent identity enforcement: blocklist, prepare-commit-msg, author check, PR body scan** ([#163](https://github.com/vig-os/devcontainer/issues/163))
+  - Canonical blocklist `.github/agent-blocklist.toml` (trailers, names, emails) — single source of truth
+  - prepare-commit-msg hook strips Co-authored-by trailers before validation
+  - Pre-commit hook rejects commits when author/committer matches blocklist (skips in CI)
+  - validate-commit-msg accepts `--blocked-patterns` for TOML blocklist; rejects remaining fingerprints
+  - pr-title-check CI scans PR title and body for agent fingerprints
+  - Skill rules strengthened (git_commit, worktree_execute, worktree_pr)
 - **worktree-start preflight gaps — agent hang and gh repo set-default** ([#154](https://github.com/vig-os/devcontainer/issues/154))
   - Add timeout (30s) to agent-based branch summary derivation; failure produces clear error with manual workaround
   - Add gh repo set-default preflight before any gh API calls; auto-resolve from origin or fail with instructions

--- a/assets/workspace/.cursor/skills/git_commit/SKILL.md
+++ b/assets/workspace/.cursor/skills/git_commit/SKILL.md
@@ -59,5 +59,4 @@ git status && echo "=== STAGED CHANGES ===" && git diff --cached
 - Do not read/summarize git command output after execution unless asked
 - Your shell is already at the project root so you do not need `cd` or 'bash', just use `git ...`
 - Do not use `--no-verify` to cheat
-- Do not add any trailer (e.g. `Co-authored-by: ...`)
-- **NEVER add 'Co-authored-by: Cursor <cursoragent@cursor.com>'** to commit messages.
+- Never add Co-authored-by trailers. Never set git author/committer to an AI agent identity. Never mention AI agent names in commit messages or PR descriptions. The pre-commit hooks will reject violations.

--- a/assets/workspace/.cursor/skills/worktree_execute/SKILL.md
+++ b/assets/workspace/.cursor/skills/worktree_execute/SKILL.md
@@ -85,22 +85,10 @@ Steps 2 and 4 (execute tasks, handle failures) should remain in the main agent a
 
 Reference: [subagent-delegation rule](../../rules/subagent-delegation.mdc)
 
-## Delegation
-
-The following steps SHOULD be delegated to reduce token consumption:
-
-- **Step 1** (precondition check, load plan): Spawn a Task subagent with `model: "fast"` that validates the branch name, fetches the `## Implementation Plan` comment via `gh api`, parses the task list, and returns: issue number, comment ID, list of pending/completed tasks.
-- **Step 3** (update progress): Spawn a Task subagent with `model: "fast"` that re-fetches the comment, performs the checkbox replacement, and updates the comment via `gh api`. Returns: success confirmation.
-- **Step 5** (invoke next skill): Can remain in main agent (simple skill invocation).
-
-Steps 2 and 4 (execute tasks, handle failures) should remain in the main agent as they require code generation, TDD discipline, and debugging.
-
-Reference: [subagent-delegation rule](../../rules/subagent-delegation.mdc)
-
 ## Important Notes
 
 - Never block waiting for user input. Execute tasks continuously.
 - Each task should leave the codebase in a working, testable state.
 - Skip TDD for non-testable changes (config, templates, docs) — note why in the commit.
 - The plan comment is the single source of truth for progress.
-- **NEVER add 'Co-authored-by: Cursor <cursoragent@cursor.com>'** to commit messages.
+- Never add Co-authored-by trailers. Never set git author/committer to an AI agent identity. Never mention AI agent names in commit messages or PR descriptions. The pre-commit hooks will reject violations.

--- a/assets/workspace/.cursor/skills/worktree_pr/SKILL.md
+++ b/assets/workspace/.cursor/skills/worktree_pr/SKILL.md
@@ -136,4 +136,4 @@ Reference: [subagent-delegation rule](../../rules/subagent-delegation.mdc)
 - Never block for user review of the PR text. Generate the best text from available context.
 - Base branch is auto-detected: parent issue's branch for sub-issues, `dev` otherwise.
 - The PR title should follow commit message conventions: `type(scope): description (#issue)`.
-- **NEVER add 'Co-authored-by: Cursor <cursoragent@cursor.com>'** to commit messages.
+- Never add Co-authored-by trailers. Never set git author/committer to an AI agent identity. Never mention AI agent names in commit messages or PR descriptions. The pre-commit hooks will reject violations.

--- a/assets/workspace/.devcontainer/scripts/check-agent-identity.py
+++ b/assets/workspace/.devcontainer/scripts/check-agent-identity.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Reject commits when git author/committer matches AI agent identity blocklist.
+
+Runs in pre-commit stage. Checks GIT_AUTHOR_NAME, GIT_AUTHOR_EMAIL,
+GIT_COMMITTER_NAME, GIT_COMMITTER_EMAIL (from env) and git config user.name/email.
+Skips when running in CI (GITHUB_ACTIONS=true or CI=true).
+
+Refs: #163
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _get_git_config(cwd: Path, key: str) -> str:
+    """Get git config value, empty string if not set."""
+    try:
+        result = subprocess.run(
+            ["git", "config", key],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        return (result.stdout or "").strip()
+    except Exception:
+        return ""
+
+
+def _check_value(value: str, blocklist: dict) -> str | None:
+    """Return matching pattern if value matches blocklist, else None."""
+    if not value:
+        return None
+    value_lower = value.lower()
+    for name in blocklist.get("names", []):
+        if name in value_lower:
+            return name
+    for email in blocklist.get("emails", []):
+        if email in value_lower:
+            return email
+    return None
+
+
+def main() -> int:
+    """Entry point. Exits 1 if author/committer matches blocklist."""
+    if os.environ.get("GITHUB_ACTIONS") == "true" or os.environ.get("CI") == "true":
+        return 0  # Skip in CI; Dependabot etc. use bot identities
+
+    project_root = Path(__file__).resolve().parent.parent
+    blocklist_path = project_root / ".github" / "agent-blocklist.toml"
+    if not blocklist_path.exists():
+        return 0
+
+    from vig_utils.agent_blocklist import load_blocklist
+
+    blocklist = load_blocklist(blocklist_path)
+
+    values_to_check: list[tuple[str, str]] = [
+        ("GIT_AUTHOR_NAME", os.environ.get("GIT_AUTHOR_NAME", "")),
+        ("GIT_AUTHOR_EMAIL", os.environ.get("GIT_AUTHOR_EMAIL", "")),
+        ("GIT_COMMITTER_NAME", os.environ.get("GIT_COMMITTER_NAME", "")),
+        ("GIT_COMMITTER_EMAIL", os.environ.get("GIT_COMMITTER_EMAIL", "")),
+    ]
+    # git config user.name/email when not in env (e.g. user-initiated commit)
+    if not values_to_check[0][1]:
+        values_to_check.append(
+            ("user.name", _get_git_config(project_root, "user.name"))
+        )
+    if not values_to_check[1][1]:
+        values_to_check.append(
+            ("user.email", _get_git_config(project_root, "user.email"))
+        )
+
+    for label, value in values_to_check:
+        match = _check_value(value, blocklist)
+        if match:
+            print(
+                f"Git {label} matches blocklisted AI agent identity: '{match}'. "
+                "Set author/committer to your own identity.",
+                file=sys.stderr,
+            )
+            return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/assets/workspace/.devcontainer/scripts/check-pr-agent-fingerprints.py
+++ b/assets/workspace/.devcontainer/scripts/check-pr-agent-fingerprints.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Check PR title and body for AI agent identity fingerprints.
+
+Exits 1 if any blocklisted pattern is found. Used by pr-title-check CI.
+Refs: #163
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+
+def main() -> int:
+    """Entry point. Reads PR_TITLE and PR_BODY from env."""
+    title = os.environ.get("PR_TITLE", "")
+    body = os.environ.get("PR_BODY", "")
+
+    project_root = Path(__file__).resolve().parent.parent
+    blocklist_path = project_root / ".github" / "agent-blocklist.toml"
+    if not blocklist_path.exists():
+        return 0
+
+    from vig_utils.agent_blocklist import contains_agent_fingerprint, load_blocklist
+
+    blocklist = load_blocklist(blocklist_path)
+    content = f"{title}\n{body}"
+    match = contains_agent_fingerprint(content, blocklist)
+    if match:
+        print(
+            f"PR title or body contains blocked AI agent fingerprint: '{match}'. "
+            "Remove agent identity from the PR.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/assets/workspace/.devcontainer/scripts/prepare-commit-msg-strip-trailers.py
+++ b/assets/workspace/.devcontainer/scripts/prepare-commit-msg-strip-trailers.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Strip AI agent identity trailers from commit message before validation.
+
+Runs in prepare-commit-msg stage. Reads COMMIT_EDITMSG, removes lines matching
+trailer patterns from .github/agent-blocklist.toml, writes back.
+
+Refs: #163
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+def _load_trailer_patterns(blocklist_path: Path) -> list[re.Pattern[str]]:
+    """Load trailer regex patterns from blocklist TOML."""
+    import tomllib
+
+    with blocklist_path.open("rb") as f:
+        data = tomllib.load(f)
+    patterns = data.get("patterns", {}).get("trailers", [])
+    return [re.compile(p) for p in patterns]
+
+
+def strip_trailers(msg_path: Path, blocklist_path: Path) -> bool:
+    """Remove lines matching trailer patterns. Returns True if any line was removed."""
+    patterns = _load_trailer_patterns(blocklist_path)
+    content = msg_path.read_text(encoding="utf-8", errors="replace")
+    lines = content.splitlines(keepends=True)
+    new_lines: list[str] = []
+    changed = False
+    for line in lines:
+        stripped = line.rstrip("\n\r")
+        if any(p.match(stripped) for p in patterns):
+            changed = True
+            continue
+        new_lines.append(line)
+    if changed:
+        msg_path.write_text("".join(new_lines), encoding="utf-8")
+    return changed
+
+
+def main() -> int:
+    """Entry point. Expects COMMIT_EDITMSG path as first arg."""
+    if len(sys.argv) < 2:
+        print(
+            "Usage: prepare-commit-msg-strip-trailers <path-to-COMMIT_EDITMSG>",
+            file=sys.stderr,
+        )
+        return 2
+    msg_path = Path(sys.argv[1])
+    project_root = Path(__file__).resolve().parent.parent
+    blocklist_path = project_root / ".github" / "agent-blocklist.toml"
+    if not blocklist_path.exists():
+        return 0  # No blocklist, nothing to strip
+    if not msg_path.exists():
+        print(f"File not found: {msg_path}", file=sys.stderr)
+        return 2
+    strip_trailers(msg_path, blocklist_path)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/assets/workspace/.githooks/prepare-commit-msg
+++ b/assets/workspace/.githooks/prepare-commit-msg
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Strip AI agent trailers from commit message before validation.
+# Refs: #163
+set -euo pipefail
+
+# Check if we're running inside the dev container
+if [ "${IN_CONTAINER:-}" = "false" ]; then
+	# Outside dev container
+	echo "Please commit your changes within the dev container."
+	exit 1
+fi
+
+# Run pre-commit prepare-commit-msg hooks
+pre-commit run --hook-stage prepare-commit-msg --commit-msg-filename "$1"

--- a/assets/workspace/.github/agent-blocklist.toml
+++ b/assets/workspace/.github/agent-blocklist.toml
@@ -1,0 +1,29 @@
+# Canonical blocklist for AI agent identity fingerprints.
+# Referenced by: validate-commit-msg, pre-commit hooks, pr-title-check CI.
+# Refs: #163
+
+[patterns]
+# Trailer patterns (regex, matched against full lines)
+trailers = [
+  "^Co-authored-by:.*$",
+  "^Signed-off-by:.*cursor.*$",
+]
+
+# Agent names/identifiers (substring match, case-insensitive)
+names = [
+  "cursor",
+  "claude",
+  "codex",
+  "chatgpt",
+  "copilot",
+  "openai",
+  "anthropic",
+  "devin",
+]
+
+# Agent email patterns (substring match, case-insensitive)
+emails = [
+  "cursoragent@cursor.com",
+  "noreply@cursor.com",
+  "github-actions[bot]",
+]

--- a/assets/workspace/.pre-commit-config.yaml
+++ b/assets/workspace/.pre-commit-config.yaml
@@ -128,6 +128,25 @@ repos:
         files: ^\.cursor/skills/
         pass_filenames: false
 
+  # AI agent identity: strip trailers before commit-msg (Refs: #163)
+  - repo: local
+    hooks:
+      - id: prepare-commit-msg-strip-trailers
+        name: strip agent trailers from commit message
+        entry: uv run python .devcontainer/scripts/prepare-commit-msg-strip-trailers.py
+        language: system
+        stages: [prepare-commit-msg]
+        pass_filenames: true
+
+  # AI agent identity: reject author/committer matching blocklist (Refs: #163)
+  - repo: local
+    hooks:
+      - id: check-agent-identity
+        name: check agent identity
+        entry: uv run python .devcontainer/scripts/check-agent-identity.py
+        language: system
+        pass_filenames: false
+
   # Commit message validation (commit-msg stage)
   - repo: local
     hooks:

--- a/packages/vig-utils/src/vig_utils/agent_blocklist.py
+++ b/packages/vig-utils/src/vig_utils/agent_blocklist.py
@@ -1,0 +1,49 @@
+"""Load and check content against AI agent identity blocklist.
+
+Single source of truth: .github/agent-blocklist.toml
+Refs: #163
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path  # noqa: TC003 - Path used at runtime in path.open()
+
+
+def load_blocklist(path: Path) -> dict:
+    """Load blocklist from TOML file. Returns dict with keys: trailers, names, emails."""
+    import tomllib
+
+    with path.open("rb") as f:
+        data = tomllib.load(f)
+    patterns = data.get("patterns", {})
+    return {
+        "trailers": [re.compile(p) for p in patterns.get("trailers", [])],
+        "names": [s.lower() for s in patterns.get("names", [])],
+        "emails": [s.lower() for s in patterns.get("emails", [])],
+    }
+
+
+def contains_agent_fingerprint(
+    content: str,
+    blocklist: dict,
+    *,
+    check_trailers: bool = True,
+) -> str | None:
+    """Check if content contains any blocklisted pattern.
+
+    Returns the first matching pattern string if found, else None.
+    """
+    content_lower = content.lower()
+    for name in blocklist.get("names", []):
+        if name in content_lower:
+            return name
+    for email in blocklist.get("emails", []):
+        if email in content_lower:
+            return email
+    if check_trailers:
+        for line in content.splitlines():
+            for pattern_re in blocklist.get("trailers", []):
+                if pattern_re.match(line.strip()):
+                    return line.strip()
+    return None

--- a/packages/vig-utils/src/vig_utils/validate_commit_msg.py
+++ b/packages/vig-utils/src/vig_utils/validate_commit_msg.py
@@ -16,6 +16,7 @@ Examples:
     validate-commit-msg .git/COMMIT_EDITMSG --refs-optional-types chore,build
     validate-commit-msg .git/COMMIT_EDITMSG --types feat,fix --scopes api,cli --refs-optional-types chore
     validate-commit-msg .git/COMMIT_EDITMSG --scopes api,cli,utils --require-scope
+    validate-commit-msg .git/COMMIT_EDITMSG --blocked-patterns .github/agent-blocklist.toml
 """
 
 from __future__ import annotations
@@ -24,6 +25,9 @@ import argparse
 import re
 import sys
 from pathlib import Path
+
+from vig_utils.agent_blocklist import contains_agent_fingerprint as check_blocklist
+from vig_utils.agent_blocklist import load_blocklist
 
 # Default approved commit types (single source of truth; keep in sync with COMMIT_MESSAGE_STANDARD.md)
 DEFAULT_APPROVED_TYPES = frozenset[str](
@@ -44,12 +48,11 @@ DEFAULT_APPROVED_TYPES = frozenset[str](
 # Default types where the Refs line is optional (maintenance commits that may not relate to an issue)
 DEFAULT_REFS_OPTIONAL_TYPES = frozenset[str]({"chore"})
 
-# Agent identity fingerprints (case-insensitive). Commit messages containing these are rejected.
-# Refs: #163
+# Fallback agent fingerprints when --blocked-patterns not provided (Refs: #163)
 _AGENT_FINGERPRINT_PATTERNS: list[tuple[str, int]] = [
     (r"Co-authored-by", re.IGNORECASE),
     (r"cursoragent", re.IGNORECASE),
-    (r"cursor\.com", re.IGNORECASE),  # "Made with [Cursor](https://cursor.com)" etc.
+    (r"cursor\.com", re.IGNORECASE),
     (r"\bclaude\b", re.IGNORECASE),
     (r"\bcodex\b", re.IGNORECASE),
     (r"\bchatgpt\b", re.IGNORECASE),
@@ -60,8 +63,8 @@ _AGENT_FINGERPRINT_PATTERNS_COMPILED = [
 ]
 
 
-def _contains_agent_fingerprint(content: str) -> bool:
-    """Check if content contains AI agent identity fingerprints."""
+def _contains_agent_fingerprint_fallback(content: str) -> bool:
+    """Check if content contains AI agent identity fingerprints (hardcoded fallback)."""
     for pattern_re in _AGENT_FINGERPRINT_PATTERNS_COMPILED:
         if pattern_re.search(content):
             return True
@@ -106,6 +109,7 @@ def validate_commit_message(
     refs_optional_types: frozenset[str] | None = None,
     require_scope: bool = False,
     subject_only: bool = False,
+    blocked_patterns: dict | None = None,
 ) -> tuple[bool, str | None]:
     """Validate a commit message string.
 
@@ -117,6 +121,7 @@ def validate_commit_message(
         require_scope: If True, at least one scope is mandatory. Defaults to False.
         subject_only: If True, validate only the subject line (type, scope, description).
             Skips blank-line, body, and Refs validation. Useful for PR title checks.
+        blocked_patterns: Blocklist dict from agent_blocklist.load_blocklist(). If None, uses hardcoded fallback.
 
     Returns:
         (True, None) if valid.
@@ -138,7 +143,14 @@ def validate_commit_message(
         )
 
     # Reject agent identity fingerprints (Refs: #163)
-    if _contains_agent_fingerprint(content):
+    if blocked_patterns:
+        match = check_blocklist(content, blocked_patterns)
+        if match:
+            return (
+                False,
+                f"Commit message contains blocked AI agent fingerprint: '{match}'. Remove agent identity from commit.",
+            )
+    elif _contains_agent_fingerprint_fallback(content):
         return (
             False,
             "Commit message contains AI agent fingerprint (e.g. Co-authored-by, "
@@ -289,6 +301,12 @@ def main() -> int:
         action="store_true",
         help="Validate only the subject line (skip body and Refs). Useful for PR title validation.",
     )
+    parser.add_argument(
+        "--blocked-patterns",
+        type=Path,
+        default=None,
+        help="Path to agent blocklist TOML (e.g. .github/agent-blocklist.toml). If not provided, uses built-in fallback.",
+    )
 
     args = parser.parse_args()
 
@@ -318,6 +336,10 @@ def main() -> int:
         print(f"File not found: {path}", file=sys.stderr)
         return 2
 
+    blocked_patterns = None
+    if args.blocked_patterns and args.blocked_patterns.exists():
+        blocked_patterns = load_blocklist(args.blocked_patterns)
+
     content = path.read_text(encoding="utf-8", errors="replace")
     valid, error = validate_commit_message(
         content,
@@ -326,6 +348,7 @@ def main() -> int:
         refs_optional_types=refs_optional_types,
         require_scope=args.require_scope,
         subject_only=args.subject_only,
+        blocked_patterns=blocked_patterns,
     )
     if valid:
         return 0

--- a/scripts/check-agent-identity.py
+++ b/scripts/check-agent-identity.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Reject commits when git author/committer matches AI agent identity blocklist.
+
+Runs in pre-commit stage. Checks GIT_AUTHOR_NAME, GIT_AUTHOR_EMAIL,
+GIT_COMMITTER_NAME, GIT_COMMITTER_EMAIL (from env) and git config user.name/email.
+Skips when running in CI (GITHUB_ACTIONS=true or CI=true).
+
+Refs: #163
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _get_git_config(cwd: Path, key: str) -> str:
+    """Get git config value, empty string if not set."""
+    try:
+        result = subprocess.run(
+            ["git", "config", key],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        return (result.stdout or "").strip()
+    except Exception:
+        return ""
+
+
+def _check_value(value: str, blocklist: dict) -> str | None:
+    """Return matching pattern if value matches blocklist, else None."""
+    if not value:
+        return None
+    value_lower = value.lower()
+    for name in blocklist.get("names", []):
+        if name in value_lower:
+            return name
+    for email in blocklist.get("emails", []):
+        if email in value_lower:
+            return email
+    return None
+
+
+def main() -> int:
+    """Entry point. Exits 1 if author/committer matches blocklist."""
+    if os.environ.get("GITHUB_ACTIONS") == "true" or os.environ.get("CI") == "true":
+        return 0  # Skip in CI; Dependabot etc. use bot identities
+
+    project_root = Path(__file__).resolve().parent.parent
+    blocklist_path = project_root / ".github" / "agent-blocklist.toml"
+    if not blocklist_path.exists():
+        return 0
+
+    from vig_utils.agent_blocklist import load_blocklist
+
+    blocklist = load_blocklist(blocklist_path)
+
+    values_to_check: list[tuple[str, str]] = [
+        ("GIT_AUTHOR_NAME", os.environ.get("GIT_AUTHOR_NAME", "")),
+        ("GIT_AUTHOR_EMAIL", os.environ.get("GIT_AUTHOR_EMAIL", "")),
+        ("GIT_COMMITTER_NAME", os.environ.get("GIT_COMMITTER_NAME", "")),
+        ("GIT_COMMITTER_EMAIL", os.environ.get("GIT_COMMITTER_EMAIL", "")),
+    ]
+    # git config user.name/email when not in env (e.g. user-initiated commit)
+    if not values_to_check[0][1]:
+        values_to_check.append(
+            ("user.name", _get_git_config(project_root, "user.name"))
+        )
+    if not values_to_check[1][1]:
+        values_to_check.append(
+            ("user.email", _get_git_config(project_root, "user.email"))
+        )
+
+    for label, value in values_to_check:
+        match = _check_value(value, blocklist)
+        if match:
+            print(
+                f"Git {label} matches blocklisted AI agent identity: '{match}'. "
+                "Set author/committer to your own identity.",
+                file=sys.stderr,
+            )
+            return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check-pr-agent-fingerprints.py
+++ b/scripts/check-pr-agent-fingerprints.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Check PR title and body for AI agent identity fingerprints.
+
+Exits 1 if any blocklisted pattern is found. Used by pr-title-check CI.
+Refs: #163
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+
+def main() -> int:
+    """Entry point. Reads PR_TITLE and PR_BODY from env."""
+    title = os.environ.get("PR_TITLE", "")
+    body = os.environ.get("PR_BODY", "")
+
+    project_root = Path(__file__).resolve().parent.parent
+    blocklist_path = project_root / ".github" / "agent-blocklist.toml"
+    if not blocklist_path.exists():
+        return 0
+
+    from vig_utils.agent_blocklist import contains_agent_fingerprint, load_blocklist
+
+    blocklist = load_blocklist(blocklist_path)
+    content = f"{title}\n{body}"
+    match = contains_agent_fingerprint(content, blocklist)
+    if match:
+        print(
+            f"PR title or body contains blocked AI agent fingerprint: '{match}'. "
+            "Remove agent identity from the PR.",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -580,7 +580,7 @@ main() {
 
     # Setup hooks
     log_info "Setting up hooks..."
-    if git config core.hooksPath .githooks && chmod +x .githooks/pre-commit .githooks/commit-msg 2>/dev/null; then
+    if git config core.hooksPath .githooks && chmod +x .githooks/pre-commit .githooks/prepare-commit-msg .githooks/commit-msg 2>/dev/null; then
         log_success "Git hooks path configured"
     else
         log_warning "Could not configure Git hooks path (may not exist yet)"

--- a/scripts/manifest.toml
+++ b/scripts/manifest.toml
@@ -36,6 +36,9 @@ src = ".pymarkdown.config.md"
 src = ".hadolint.yaml"
 
 [[entries]]
+src = ".github/agent-blocklist.toml"
+
+[[entries]]
 src = ".github/label-taxonomy.toml"
 
 [[entries]]
@@ -88,6 +91,18 @@ src = "scripts/check-skill-names.sh"
 dest = ".devcontainer/scripts/check-skill-names.sh"
 
 [[entries]]
+src = "scripts/prepare-commit-msg-strip-trailers.py"
+dest = ".devcontainer/scripts/prepare-commit-msg-strip-trailers.py"
+
+[[entries]]
+src = "scripts/check-agent-identity.py"
+dest = ".devcontainer/scripts/check-agent-identity.py"
+
+[[entries]]
+src = "scripts/check-pr-agent-fingerprints.py"
+dest = ".devcontainer/scripts/check-pr-agent-fingerprints.py"
+
+[[entries]]
 src = "justfile.worktree"
 dest = ".devcontainer/justfile.worktree"
 
@@ -97,6 +112,8 @@ transforms = [
   { type = "RemovePrecommitHooks", hook_ids = ["generate-docs"] },
   { type = "Sed", pattern = "bandit -r packages/vig-utils/src/ scripts/ assets/workspace/", replace = "bandit -r src/" },
   { type = "Sed", pattern = "scripts/check-skill-names.sh", replace = ".devcontainer/scripts/check-skill-names.sh" },
+  { type = "Sed", pattern = "scripts/prepare-commit-msg-strip-trailers.py", replace = ".devcontainer/scripts/prepare-commit-msg-strip-trailers.py" },
+  { type = "Sed", pattern = "scripts/check-agent-identity.py", replace = ".devcontainer/scripts/check-agent-identity.py" },
   { type = "ReplaceBlock", start_pattern = "^\\s+args: \\[$", end_pattern = "^\\s+\\]$", replacement = """
         # Optional: customize commit types, scopes, or refs-optional types via CLI arguments.
         # By default, scopes are not enforced. Set --scopes to require specific scopes.

--- a/scripts/prepare-commit-msg-strip-trailers.py
+++ b/scripts/prepare-commit-msg-strip-trailers.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Strip AI agent identity trailers from commit message before validation.
+
+Runs in prepare-commit-msg stage. Reads COMMIT_EDITMSG, removes lines matching
+trailer patterns from .github/agent-blocklist.toml, writes back.
+
+Refs: #163
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+
+def _load_trailer_patterns(blocklist_path: Path) -> list[re.Pattern[str]]:
+    """Load trailer regex patterns from blocklist TOML."""
+    import tomllib
+
+    with blocklist_path.open("rb") as f:
+        data = tomllib.load(f)
+    patterns = data.get("patterns", {}).get("trailers", [])
+    return [re.compile(p) for p in patterns]
+
+
+def strip_trailers(msg_path: Path, blocklist_path: Path) -> bool:
+    """Remove lines matching trailer patterns. Returns True if any line was removed."""
+    patterns = _load_trailer_patterns(blocklist_path)
+    content = msg_path.read_text(encoding="utf-8", errors="replace")
+    lines = content.splitlines(keepends=True)
+    new_lines: list[str] = []
+    changed = False
+    for line in lines:
+        stripped = line.rstrip("\n\r")
+        if any(p.match(stripped) for p in patterns):
+            changed = True
+            continue
+        new_lines.append(line)
+    if changed:
+        msg_path.write_text("".join(new_lines), encoding="utf-8")
+    return changed
+
+
+def main() -> int:
+    """Entry point. Expects COMMIT_EDITMSG path as first arg."""
+    if len(sys.argv) < 2:
+        print(
+            "Usage: prepare-commit-msg-strip-trailers <path-to-COMMIT_EDITMSG>",
+            file=sys.stderr,
+        )
+        return 2
+    msg_path = Path(sys.argv[1])
+    project_root = Path(__file__).resolve().parent.parent
+    blocklist_path = project_root / ".github" / "agent-blocklist.toml"
+    if not blocklist_path.exists():
+        return 0  # No blocklist, nothing to strip
+    if not msg_path.exists():
+        print(f"File not found: {msg_path}", file=sys.stderr)
+        return 2
+    strip_trailers(msg_path, blocklist_path)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Description

Implements the full design from issue #163: five enforcement layers to strip AI agent identity from commits and PRs.

- **Canonical blocklist** `.github/agent-blocklist.toml` — single source of truth for trailers, names, emails
- **prepare-commit-msg hook** — strips Co-authored-by trailers before commit-msg validation
- **Pre-commit hook** — rejects commits when author/committer matches blocklist (skips in CI)
- **validate-commit-msg** — `--blocked-patterns` for TOML blocklist; shared `agent_blocklist` module
- **pr-title-check CI** — scans PR title and body for agent fingerprints
- **Skill rules** — strengthened in git_commit, worktree_execute, worktree_pr

Closes #163

## Type of Change

- [x] `fix` -- Bug fix

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- `.github/agent-blocklist.toml` — canonical blocklist (trailers, names, emails)
- `scripts/prepare-commit-msg-strip-trailers.py` — strips trailer patterns from COMMIT_EDITMSG
- `scripts/check-agent-identity.py` — rejects author/committer matching blocklist
- `scripts/check-pr-agent-fingerprints.py` — CI script for PR body scan
- `packages/vig-utils/src/vig_utils/agent_blocklist.py` — shared load_blocklist, contains_agent_fingerprint
- `packages/vig-utils` — validate_commit_msg extended with `--blocked-patterns`
- `.pre-commit-config.yaml` — prepare-commit-msg, check-agent-identity, validate-commit-msg --blocked-patterns
- `.githooks/prepare-commit-msg` — runs pre-commit prepare-commit-msg stage
- `.github/workflows/pr-title-check.yml` — new step to check PR body
- `scripts/manifest.toml` — agent-blocklist.toml + new scripts synced to workspace
- Skill rules updated in git_commit, worktree_execute, worktree_pr

## Changelog Entry

### Fixed

- **AI agent identity enforcement: blocklist, prepare-commit-msg, author check, PR body scan** ([#163](https://github.com/vig-os/devcontainer/issues/163))
  - Canonical blocklist `.github/agent-blocklist.toml` (trailers, names, emails) — single source of truth
  - prepare-commit-msg hook strips Co-authored-by trailers before validation
  - Pre-commit hook rejects commits when author/committer matches blocklist (skips in CI)
  - validate-commit-msg accepts `--blocked-patterns` for TOML blocklist; rejects remaining fingerprints
  - pr-title-check CI scans PR title and body for agent fingerprints
  - Skill rules strengthened (git_commit, worktree_execute, worktree_pr)

## Testing

- [x] Tests pass locally (`uv run pytest packages/vig-utils/tests/` — 271 passed)
- [x] Manual testing performed (prepare-commit-msg strip, check-agent-identity, check-pr-agent-fingerprints)
- [x] Lint passes (`just lint`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

N/A

Refs: #163
