### PR TITLE
chore: declare worktree prerequisites in setup requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Add manifest entries for resolve-branch.sh, derive-branch-summary.sh, check-skill-names.sh → `.devcontainer/scripts/`
   - Update justfile.worktree to use `source_directory() / "scripts"` for portable path resolution
   - Add Sed transform for check-skill-names.sh path in synced `.pre-commit-config.yaml`
+- **Worktree prerequisites are declared in setup requirements** ([#196](https://github.com/vig-os/devcontainer/issues/196))
+  - Add `tmux`, `agent`, and `jq` to `scripts/requirements.yaml` as required host dependencies with install guidance
+  - `scripts/init.sh --check` now surfaces missing worktree prerequisites before running worktree commands
 
 ### Changed
 

--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -15,6 +15,9 @@ This guide explains how to develop, build, test, and release the vigOS developme
 | **git** | >=2.34 | Version control and pre-commit hooks |
 | **ssh** | latest | GitHub authentication and commit signing |
 | **gh** | latest | GitHub CLI for repository and PR/issue management |
+| **jq** | latest | JSON parsing for worktree commands and issue metadata |
+| **tmux** | latest | Session manager required by worktree-start and worktree-attach |
+| **agent** | latest | Cursor Agent CLI required by worktree-start/worktree-attach flows |
 | **npm** | latest | Node.js package manager (for DevContainer CLI) |
 | **uv** | >=0.8 | Python package and project manager |
 | **bats** | 1.13.0 | Bash Automated Testing System for shell script tests |
@@ -25,7 +28,7 @@ This guide explains how to develop, build, test, and release the vigOS developme
 
 ```bash
 sudo apt update
-sudo apt install -y podman git openssh-client nodejs npm parallel
+sudo apt install -y podman git openssh-client jq tmux nodejs npm parallel
 # just
 curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/local/bin
 
@@ -39,7 +42,7 @@ sudo apt update && sudo apt install -y gh
 **macOS (Homebrew):**
 
 ```bash
-brew install podman just git openssh gh node parallel
+brew install podman just git openssh gh jq tmux node parallel
 ```
 
 - For other Linux distributions, use your package manager (e.g., `dnf`, `yum`, `zypper`, `apk`) to install these dependencies.
@@ -125,14 +128,29 @@ Available recipes:
     clean-test-containers                      # Clean up lingering test containers
 
     [deps]
-    sync                                       # Sync dependencies from pyproject.toml
+    sync                                       # Sync all dependencies (idempotent, fast if nothing changed)
     update                                     # Update all dependencies
+
+    [devcontainer]
+    down                                       # Stop and remove containers
+    logs *args                                 # Tail container logs
+    open                                       # Open Cursor/VS Code attached to the running container
+    restart *args                              # Restart service(s)
+    shell                                      # Open bash in running devcontainer
+    status                                     # Show container status
+    up                                         # Start devcontainer + sidecars via compose
+
+    [git]
+    branch                                     # Show current branch + list recent branches
+    log                                        # Pretty one-line git log (last 20 commits)
 
     [github]
     gh-issues                                  # List open issues and PRs grouped by milestone [alias: gh-i]
 
     [info]
+    check *args                                # Examples: just check, just check config, just check off, just check 7d
     default                                    # Show available commands (default)
+    devcontainer-upgrade                       # This recipe MUST be run from a host terminal, not inside the container
     docs                                       # Generate documentation from templates
     help                                       # Show available commands
     info                                       # Show image information
@@ -164,7 +182,7 @@ Available recipes:
     reset-changelog                            # Reset CHANGELOG Unreleased section (after merging release to dev)
 
     [sidecar]
-    sidecar name *args                         # just sidecar redis flush
+    sidecar name *args                         # Example: just sidecar postgres migrate / just sidecar redis flush
     sidecars                                   # List available sidecar containers
 
     [test]
@@ -181,7 +199,7 @@ Available recipes:
 
     [worktree]
     worktree-attach issue                      # before attaching. See tests/bats/worktree.bats for integration tests. [alias: wt-attach]
-    worktree-clean                             # Remove all cursor-managed worktrees and tmux sessions [alias: wt-clean]
+    worktree-clean mode=""                     # Default (no args): clean only stopped worktrees. Use 'all' to clean everything. [alias: wt-clean]
     worktree-list                              # List active worktrees and their tmux sessions [alias: wt-list]
     worktree-start issue prompt="" reviewer="" # Create a worktree for an issue, open tmux session, launch cursor-agent [alias: wt-start]
     worktree-stop issue                        # Stop a worktree's tmux session and remove the worktree [alias: wt-stop]

--- a/README.md
+++ b/README.md
@@ -116,14 +116,29 @@ Available recipes:
     clean-test-containers                      # Clean up lingering test containers
 
     [deps]
-    sync                                       # Sync dependencies from pyproject.toml
+    sync                                       # Sync all dependencies (idempotent, fast if nothing changed)
     update                                     # Update all dependencies
+
+    [devcontainer]
+    down                                       # Stop and remove containers
+    logs *args                                 # Tail container logs
+    open                                       # Open Cursor/VS Code attached to the running container
+    restart *args                              # Restart service(s)
+    shell                                      # Open bash in running devcontainer
+    status                                     # Show container status
+    up                                         # Start devcontainer + sidecars via compose
+
+    [git]
+    branch                                     # Show current branch + list recent branches
+    log                                        # Pretty one-line git log (last 20 commits)
 
     [github]
     gh-issues                                  # List open issues and PRs grouped by milestone [alias: gh-i]
 
     [info]
+    check *args                                # Examples: just check, just check config, just check off, just check 7d
     default                                    # Show available commands (default)
+    devcontainer-upgrade                       # This recipe MUST be run from a host terminal, not inside the container
     docs                                       # Generate documentation from templates
     help                                       # Show available commands
     info                                       # Show image information
@@ -155,7 +170,7 @@ Available recipes:
     reset-changelog                            # Reset CHANGELOG Unreleased section (after merging release to dev)
 
     [sidecar]
-    sidecar name *args                         # just sidecar redis flush
+    sidecar name *args                         # Example: just sidecar postgres migrate / just sidecar redis flush
     sidecars                                   # List available sidecar containers
 
     [test]
@@ -172,7 +187,7 @@ Available recipes:
 
     [worktree]
     worktree-attach issue                      # before attaching. See tests/bats/worktree.bats for integration tests. [alias: wt-attach]
-    worktree-clean                             # Remove all cursor-managed worktrees and tmux sessions [alias: wt-clean]
+    worktree-clean mode=""                     # Default (no args): clean only stopped worktrees. Use 'all' to clean everything. [alias: wt-clean]
     worktree-list                              # List active worktrees and their tmux sessions [alias: wt-list]
     worktree-start issue prompt="" reviewer="" # Create a worktree for an issue, open tmux session, launch cursor-agent [alias: wt-start]
     worktree-stop issue                        # Stop a worktree's tmux session and remove the worktree [alias: wt-stop]

--- a/scripts/requirements.yaml
+++ b/scripts/requirements.yaml
@@ -98,6 +98,51 @@ dependencies:
       fedora: sudo dnf install -y gh
       manual: https://cli.github.com/
 
+  # JSON processor (required by worktree trust/config commands)
+  - name: jq
+    version: latest
+    purpose: JSON parsing for worktree commands and issue metadata
+    required: true
+    check:
+      command: command -v jq
+      version_command: jq --version
+      version_regex: 'jq-(\d+\.\d+)'
+    install:
+      macos: brew install jq
+      debian: sudo apt install -y jq
+      fedora: sudo dnf install -y jq
+      alpine: sudo apk add jq
+      manual: https://jqlang.github.io/jq/download/
+
+  # Terminal multiplexer (required by worktree tmux sessions)
+  - name: tmux
+    version: latest
+    purpose: Session manager required by worktree-start and worktree-attach
+    required: true
+    check:
+      command: command -v tmux
+      version_command: tmux -V
+      version_regex: 'tmux (\d+\.\d+)'
+    install:
+      macos: brew install tmux
+      debian: sudo apt install -y tmux
+      fedora: sudo dnf install -y tmux
+      alpine: sudo apk add tmux
+      manual: https://github.com/tmux/tmux/wiki/Installing
+
+  # Cursor agent CLI (required by worktree autonomous flows)
+  - name: agent
+    version: latest
+    purpose: Cursor Agent CLI required by worktree-start/worktree-attach flows
+    required: true
+    check:
+      command: command -v agent
+      version_command: agent --version
+      version_regex: '([0-9]+\.[0-9]+\.[0-9]+)'
+    install:
+      all: curl https://cursor.com/install -fsSL | bash
+      manual: https://cursor.com/install
+
   # Node.js (for devcontainer CLI)
   - name: npm
     version: latest


### PR DESCRIPTION
## Description

This PR declares missing host-level worktree prerequisites in setup requirements so `scripts/init.sh --check` catches them before `just worktree-start` or `just worktree-attach` fail at runtime.

It also updates generated contributor/user docs to reflect the new dependency requirements and the current command listing output.

## Type of Change

- [ ] `feat` -- New feature
- [ ] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [x] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [ ] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- `scripts/requirements.yaml`
  - Add required host dependencies for worktree workflow: `jq`, `tmux`, and `agent`
  - Add check/install metadata so `scripts/init.sh --check` validates these tools
- `CHANGELOG.md`
  - Add `## Unreleased` `### Fixed` entry for issue `#196`
- `CONTRIBUTE.md`
  - Sync dependency table and install examples to include `jq`, `tmux`, and `agent`
  - Sync command listing snippets to current output
- `README.md`
  - Sync command listing snippets to current output

## Changelog Entry

### Fixed
- **Worktree prerequisites are declared in setup requirements** ([#196](https://github.com/vig-os/devcontainer/issues/196))
  - Add `tmux`, `agent`, and `jq` to `scripts/requirements.yaml` as required host dependencies with install guidance
  - `scripts/init.sh --check` now surfaces missing worktree prerequisites before running worktree commands

## Testing

- [ ] Tests pass locally (`just test`)
- [x] Manual testing performed (describe below)

### Manual Testing Details

- Ran `./scripts/init.sh --check`
- Verified preflight now reports missing `tmux` and `agent` in this host environment before running worktree commands
- Verified `jq` is recognized as installed in this host environment

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

N/A

Refs: #196
