### PR TITLE
refactor(workspace): move alias definitions to source justfiles

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,6 +8,11 @@
       "source.fixAll": "explicit"
     }
   },
+  "files.associations": {
+    "justfile": "just",
+    "Justfile": "just",
+    "just.*": "just"
+  },
   "files.exclude": {
     "**/__pycache__": true,
     "**/*.pyc": true,

--- a/assets/workspace/.devcontainer/justfile.gh
+++ b/assets/workspace/.devcontainer/justfile.gh
@@ -2,6 +2,10 @@
 # GITHUB CLI RECIPES - Issue, PR, and Repository Management
 # ===============================================================================
 
+# ── Aliases — short prefixes for faster typing ──────────────────────────────
+
+alias gh-i := gh-issues
+
 _gh_scripts := source_directory() / "scripts"
 
 # List open issues and PRs grouped by milestone

--- a/assets/workspace/.devcontainer/justfile.worktree
+++ b/assets/workspace/.devcontainer/justfile.worktree
@@ -7,6 +7,14 @@
 # Tracked: https://forum.cursor.com/t/cursor-parallel-agents-in-wsl-devcontainers-misresolve-worktree-paths-and-context/145711
 # ===============================================================================
 
+# ── Aliases — short prefixes for faster typing ──────────────────────────────
+
+alias wt-start := worktree-start
+alias wt-list := worktree-list
+alias wt-attach := worktree-attach
+alias wt-stop := worktree-stop
+alias wt-clean := worktree-clean
+
 # Derive worktree base directory: ../<repo>-worktrees/
 _wt_repo := `basename "$(git rev-parse --show-toplevel)"`
 _wt_base := "../" + _wt_repo + "-worktrees"

--- a/justfile
+++ b/justfile
@@ -282,31 +282,3 @@ clean-test-containers:
 import 'justfile.podman'
 import 'justfile.gh'
 import 'justfile.worktree'
-
-# ===============================================================================
-# ALIASES — short prefixes for faster typing
-# ===============================================================================
-# podman -> pdm
-
-alias pdm-ps := podman-ps
-alias pdm-kill := podman-kill
-alias pdm-kill-all := podman-kill-all
-alias pdm-kill-project := podman-kill-project
-alias pdm-rmi := podman-rmi
-alias pdm-rmi-all := podman-rmi-all
-alias pdm-rmi-project := podman-rmi-project
-alias pdm-rmi-dangling := podman-rmi-dangling
-alias pdm-prune := podman-prune
-alias pdm-prune-all := podman-prune-all
-
-# worktree -> wt
-
-alias wt-start := worktree-start
-alias wt-list := worktree-list
-alias wt-attach := worktree-attach
-alias wt-stop := worktree-stop
-alias wt-clean := worktree-clean
-
-# github -> gh (already short, but single-char saves a hyphen)
-
-alias gh-i := gh-issues

--- a/justfile.gh
+++ b/justfile.gh
@@ -2,6 +2,10 @@
 # GITHUB CLI RECIPES - Issue, PR, and Repository Management
 # ===============================================================================
 
+# ── Aliases — short prefixes for faster typing ──────────────────────────────
+
+alias gh-i := gh-issues
+
 _gh_scripts := source_directory() / "scripts"
 
 # List open issues and PRs grouped by milestone

--- a/justfile.podman
+++ b/justfile.podman
@@ -2,6 +2,19 @@
 # PODMAN RECIPES - Container and Image Management
 # ===============================================================================
 
+# ── Aliases — short prefixes for faster typing ──────────────────────────────
+
+alias pdm-ps := podman-ps
+alias pdm-kill := podman-kill
+alias pdm-kill-all := podman-kill-all
+alias pdm-kill-project := podman-kill-project
+alias pdm-rmi := podman-rmi
+alias pdm-rmi-all := podman-rmi-all
+alias pdm-rmi-project := podman-rmi-project
+alias pdm-rmi-dangling := podman-rmi-dangling
+alias pdm-prune := podman-prune
+alias pdm-prune-all := podman-prune-all
+
 # List containers/images (--all for all podman resources)
 [group('podman')]
 podman-ps *args:

--- a/justfile.worktree
+++ b/justfile.worktree
@@ -7,6 +7,14 @@
 # Tracked: https://forum.cursor.com/t/cursor-parallel-agents-in-wsl-devcontainers-misresolve-worktree-paths-and-context/145711
 # ===============================================================================
 
+# ── Aliases — short prefixes for faster typing ──────────────────────────────
+
+alias wt-start := worktree-start
+alias wt-list := worktree-list
+alias wt-attach := worktree-attach
+alias wt-stop := worktree-stop
+alias wt-clean := worktree-clean
+
 # Derive worktree base directory: ../<repo>-worktrees/
 _wt_repo := `basename "$(git rev-parse --show-toplevel)"`
 _wt_base := "../" + _wt_repo + "-worktrees"

--- a/tests/bats/justfile-aliases.bats
+++ b/tests/bats/justfile-aliases.bats
@@ -1,0 +1,111 @@
+#!/usr/bin/env bats
+# BATS tests for justfile alias resolution
+#
+# Verifies that short aliases (pdm-*, wt-*, gh-*) resolve to their
+# target recipes regardless of which justfile defines them.
+
+setup() {
+    load test_helper
+}
+
+# ── podman aliases ───────────────────────────────────────────────────────────
+
+@test "pdm-ps alias resolves to podman-ps" {
+    command -v just >/dev/null 2>&1 || skip "just not installed"
+    run just --show pdm-ps 2>&1
+    assert_success
+}
+
+@test "pdm-kill alias resolves to podman-kill" {
+    command -v just >/dev/null 2>&1 || skip "just not installed"
+    run just --show pdm-kill 2>&1
+    assert_success
+}
+
+@test "pdm-kill-all alias resolves to podman-kill-all" {
+    command -v just >/dev/null 2>&1 || skip "just not installed"
+    run just --show pdm-kill-all 2>&1
+    assert_success
+}
+
+@test "pdm-kill-project alias resolves to podman-kill-project" {
+    command -v just >/dev/null 2>&1 || skip "just not installed"
+    run just --show pdm-kill-project 2>&1
+    assert_success
+}
+
+@test "pdm-rmi alias resolves to podman-rmi" {
+    command -v just >/dev/null 2>&1 || skip "just not installed"
+    run just --show pdm-rmi 2>&1
+    assert_success
+}
+
+@test "pdm-rmi-all alias resolves to podman-rmi-all" {
+    command -v just >/dev/null 2>&1 || skip "just not installed"
+    run just --show pdm-rmi-all 2>&1
+    assert_success
+}
+
+@test "pdm-rmi-project alias resolves to podman-rmi-project" {
+    command -v just >/dev/null 2>&1 || skip "just not installed"
+    run just --show pdm-rmi-project 2>&1
+    assert_success
+}
+
+@test "pdm-rmi-dangling alias resolves to podman-rmi-dangling" {
+    command -v just >/dev/null 2>&1 || skip "just not installed"
+    run just --show pdm-rmi-dangling 2>&1
+    assert_success
+}
+
+@test "pdm-prune alias resolves to podman-prune" {
+    command -v just >/dev/null 2>&1 || skip "just not installed"
+    run just --show pdm-prune 2>&1
+    assert_success
+}
+
+@test "pdm-prune-all alias resolves to podman-prune-all" {
+    command -v just >/dev/null 2>&1 || skip "just not installed"
+    run just --show pdm-prune-all 2>&1
+    assert_success
+}
+
+# ── worktree aliases ─────────────────────────────────────────────────────────
+
+@test "wt-start alias resolves to worktree-start" {
+    command -v just >/dev/null 2>&1 || skip "just not installed"
+    run just --show wt-start 2>&1
+    assert_success
+}
+
+@test "wt-list alias resolves to worktree-list" {
+    command -v just >/dev/null 2>&1 || skip "just not installed"
+    run just --show wt-list 2>&1
+    assert_success
+}
+
+@test "wt-attach alias resolves to worktree-attach" {
+    command -v just >/dev/null 2>&1 || skip "just not installed"
+    run just --show wt-attach 2>&1
+    assert_success
+}
+
+@test "wt-stop alias resolves to worktree-stop" {
+    command -v just >/dev/null 2>&1 || skip "just not installed"
+    run just --show wt-stop 2>&1
+    assert_success
+}
+
+@test "wt-clean alias resolves to worktree-clean" {
+    command -v just >/dev/null 2>&1 || skip "just not installed"
+    run just --show wt-clean 2>&1
+    assert_success
+}
+
+# ── github aliases ───────────────────────────────────────────────────────────
+
+@test "gh-i alias resolves to gh-issues" {
+    command -v just >/dev/null 2>&1 || skip "just not installed"
+    run just --show gh-i 2>&1
+    assert_success
+}


### PR DESCRIPTION
## Summary
- **Move alias ownership** from centralized top-level `justfile` to their respective source justfiles (`justfile.podman`, `justfile.worktree`, `justfile.gh`), improving modularity and reducing drift between imported files and alias declarations.
- **Add permanent file associations** in `.vscode/settings.json` so `just-lsp` recognizes `justfile`, `Justfile`, and `just.*` patterns.
- **Add regression test suite** (`tests/bats/justfile-aliases.bats`) verifying all 16 aliases resolve correctly after the move.

## Test plan
- [x] All 16 alias resolution tests pass (`npx bats tests/bats/justfile-aliases.bats`)
- [x] Existing `wt-clean` alias test passes (`worktree.bats:235`)
- [x] Full BATS suite passes (33/33)
- [x] All pre-commit hooks pass
- [x] `just --list` shows aliases inline on their source recipes
- [x] Workspace assets synced and verified

Closes #195

Made with [Cursor](https://cursor.com)