### PR TITLE
refactor: move alias definitions to source justfiles and add file associations (#195)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,9 @@
 {
+  "files.associations": {
+    "justfile": "just",
+    "Justfile": "just",
+    "just.*": "just"
+  },
   "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python3",
   "[python]": {
     "editor.defaultFormatter": "charliermarsh.ruff",

--- a/justfile
+++ b/justfile
@@ -282,31 +282,3 @@ clean-test-containers:
 import 'justfile.podman'
 import 'justfile.gh'
 import 'justfile.worktree'
-
-# ===============================================================================
-# ALIASES — short prefixes for faster typing
-# ===============================================================================
-# podman -> pdm
-
-alias pdm-ps := podman-ps
-alias pdm-kill := podman-kill
-alias pdm-kill-all := podman-kill-all
-alias pdm-kill-project := podman-kill-project
-alias pdm-rmi := podman-rmi
-alias pdm-rmi-all := podman-rmi-all
-alias pdm-rmi-project := podman-rmi-project
-alias pdm-rmi-dangling := podman-rmi-dangling
-alias pdm-prune := podman-prune
-alias pdm-prune-all := podman-prune-all
-
-# worktree -> wt
-
-alias wt-start := worktree-start
-alias wt-list := worktree-list
-alias wt-attach := worktree-attach
-alias wt-stop := worktree-stop
-alias wt-clean := worktree-clean
-
-# github -> gh (already short, but single-char saves a hyphen)
-
-alias gh-i := gh-issues

--- a/justfile.gh
+++ b/justfile.gh
@@ -2,6 +2,12 @@
 # GITHUB CLI RECIPES - Issue, PR, and Repository Management
 # ===============================================================================
 
+# -------------------------------------------------------------------------------
+# ALIASES
+# -------------------------------------------------------------------------------
+
+alias gh-i := gh-issues
+
 _gh_scripts := source_directory() / "scripts"
 
 # List open issues and PRs grouped by milestone

--- a/justfile.podman
+++ b/justfile.podman
@@ -2,6 +2,21 @@
 # PODMAN RECIPES - Container and Image Management
 # ===============================================================================
 
+# -------------------------------------------------------------------------------
+# ALIASES — short prefixes for faster typing (podman -> pdm)
+# -------------------------------------------------------------------------------
+
+alias pdm-ps := podman-ps
+alias pdm-kill := podman-kill
+alias pdm-kill-all := podman-kill-all
+alias pdm-kill-project := podman-kill-project
+alias pdm-rmi := podman-rmi
+alias pdm-rmi-all := podman-rmi-all
+alias pdm-rmi-project := podman-rmi-project
+alias pdm-rmi-dangling := podman-rmi-dangling
+alias pdm-prune := podman-prune
+alias pdm-prune-all := podman-prune-all
+
 # List containers/images (--all for all podman resources)
 [group('podman')]
 podman-ps *args:

--- a/justfile.worktree
+++ b/justfile.worktree
@@ -1,6 +1,16 @@
 # ===============================================================================
 # WORKTREE RECIPES — CLI-based parallel agent development
 # ===============================================================================
+
+# -------------------------------------------------------------------------------
+# ALIASES — short prefixes for faster typing (worktree -> wt)
+# -------------------------------------------------------------------------------
+
+alias wt-start := worktree-start
+alias wt-list := worktree-list
+alias wt-attach := worktree-attach
+alias wt-stop := worktree-stop
+alias wt-clean := worktree-clean
 # NOTE: Cursor's native worktree UI does NOT work inside devcontainers (Feb 2026).
 # These recipes provide a CLI-based alternative using tmux + cursor-agent.
 # Native worktree support (.cursor/worktrees.json) works on macOS/Linux local only.


### PR DESCRIPTION
## Description

Move alias definitions from the centralized top-level `justfile` to their respective source justfiles (`justfile.podman`, `justfile.worktree`, `justfile.gh`), improving modularity and reducing drift between imported files and alias declarations. Also add permanent editor file associations so `just-lsp` recognizes `justfile`, `Justfile`, and `just.*` files.

## Type of Change

- [ ] `feat` -- New feature
- [ ] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [x] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [ ] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- **justfile**: Removed the centralized alias section (28 lines). All 16 aliases moved to their source modules.
- **justfile.podman**: Added 10 `pdm-*` aliases for podman recipes.
- **justfile.worktree**: Added 5 `wt-*` aliases for worktree recipes.
- **justfile.gh**: Added 1 `gh-i` alias for the github issues recipe.
- **.vscode/settings.json**: Added `files.associations` for `justfile`, `Justfile`, and `just.*` so `just-lsp` recognizes all justfile variants.

## Changelog Entry

No changelog needed. This is an internal refactor with no observable behavior change -- all aliases remain available and the `just --list` output is identical before and after.

## Testing

- [x] Tests pass locally (`just test`)
- [x] Manual testing performed (describe below)

### Manual Testing Details

- Ran `just --list` before and after, diffed outputs: identical (zero differences).
- Ran `just --evaluate` to confirm all justfiles parse correctly.
- Ran `just lint`: all checks passed.
- Ran `just precommit`: all hooks pass except pre-existing `branch-name` hook (branch naming convention).
- Ran `just test-utils`: 76 tests passed.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [ ] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

N/A

Refs: #195
