### PR TITLE
fix(workspace): make install.sh idempotent for template_project rename (#197)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **install.sh is not idempotent — creates nested src/template_project on second run** ([#197](https://github.com/vig-os/devcontainer/issues/197))
+  - Guard template_project rename: if `src/${SHORT_NAME}` already exists, remove the redundant copy instead of moving it inside
 - **just check uses wrong path — justfile_directory() resolves incorrectly in imported justfile.base** ([#187](https://github.com/vig-os/devcontainer/issues/187))
   - Replace `dirname(justfile_directory())` with `source_directory()/scripts` to correctly locate version-check.sh in deployed workspaces and devcontainer repo
   - Regression test: `just check config` runs successfully from workspace

--- a/assets/init-workspace.sh
+++ b/assets/init-workspace.sh
@@ -254,8 +254,13 @@ fi
 
 # Rename template_project directory to match project short name
 if [[ -d "$WORKSPACE_DIR/src/template_project" ]]; then
-    echo "Renaming src/template_project to src/${SHORT_NAME}..."
-    mv "$WORKSPACE_DIR/src/template_project" "$WORKSPACE_DIR/src/${SHORT_NAME}"
+    if [[ -d "$WORKSPACE_DIR/src/${SHORT_NAME}" ]] && [[ "$SHORT_NAME" != "template_project" ]]; then
+        echo "Removing duplicate src/template_project (src/${SHORT_NAME} already exists)..."
+        rm -rf "$WORKSPACE_DIR/src/template_project"
+    else
+        echo "Renaming src/template_project to src/${SHORT_NAME}..."
+        mv "$WORKSPACE_DIR/src/template_project" "$WORKSPACE_DIR/src/${SHORT_NAME}"
+    fi
 fi
 
 # Update test imports to use actual project name (template_project -> $SHORT_NAME)

--- a/tests/bats/init-workspace.bats
+++ b/tests/bats/init-workspace.bats
@@ -28,7 +28,7 @@ setup() {
 # ── idempotent rename guard (#197) ───────────────────────────────────────────
 
 @test "init-workspace.sh guards against nested template_project on re-run" {
-    run grep -A2 'if \[\[ -d.*src/template_project' "$INIT_WORKSPACE_SH"
+    run grep -A4 'if \[\[ -d.*src/template_project' "$INIT_WORKSPACE_SH"
     assert_success
     assert_output --partial 'src/${SHORT_NAME}'
     assert_output --partial 'rm -rf'

--- a/tests/bats/init-workspace.bats
+++ b/tests/bats/init-workspace.bats
@@ -24,3 +24,12 @@ setup() {
     run grep 'set -euo pipefail' "$INIT_WORKSPACE_SH"
     assert_success
 }
+
+# ── idempotent rename guard (#197) ───────────────────────────────────────────
+
+@test "init-workspace.sh guards against nested template_project on re-run" {
+    run grep -A2 'if \[\[ -d.*src/template_project' "$INIT_WORKSPACE_SH"
+    assert_success
+    assert_output --partial 'src/${SHORT_NAME}'
+    assert_output --partial 'rm -rf'
+}

--- a/tests/bats/init-workspace.bats
+++ b/tests/bats/init-workspace.bats
@@ -30,6 +30,7 @@ setup() {
 @test "init-workspace.sh guards against nested template_project on re-run" {
     run grep -A4 'if \[\[ -d.*src/template_project' "$INIT_WORKSPACE_SH"
     assert_success
+    # shellcheck disable=SC2016
     assert_output --partial 'src/${SHORT_NAME}'
     assert_output --partial 'rm -rf'
 }


### PR DESCRIPTION
## Description

Fix `install.sh` (via `init-workspace.sh`) to be idempotent when run with `--force` on an already-initialized workspace. On second run, rsync re-copies `src/template_project/` and the `mv` command moves it inside the existing `src/${SHORT_NAME}/` directory, creating a nested `src/${SHORT_NAME}/template_project/`. The fix guards the rename: if the destination already exists, the redundant copy is removed instead.

## Type of Change

- [ ] `feat` -- New feature
- [x] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [ ] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- `assets/init-workspace.sh` — Guard the `mv src/template_project src/${SHORT_NAME}` block: if the destination directory already exists (and SHORT_NAME is not "template_project"), remove the redundant rsync-copied `src/template_project` instead of moving it inside the existing directory.
- `tests/bats/init-workspace.bats` — BATS test verifying the idempotent guard clause exists in the script (checks for the `rm -rf` branch alongside `src/${SHORT_NAME}`).
- `CHANGELOG.md` — Entry under `## Unreleased` / `### Fixed`.

## Changelog Entry

### Fixed

- **install.sh is not idempotent — creates nested src/template_project on second run** ([#197](https://github.com/vig-os/devcontainer/issues/197))
  - Guard template_project rename: if `src/${SHORT_NAME}` already exists, remove the redundant copy instead of moving it inside

## Testing

- [x] Tests pass locally (`just test`)
- [ ] Manual testing performed (describe below)

### Manual Testing Details

N/A — functional testing of init-workspace.sh requires a container environment (covered by integration tests in CI).

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

N/A

Refs: #197
