### PR TITLE
fix: make detect_editor_cli no-editor case deterministic

### DIFF
--- a/tests/bats/devc-remote.bats
+++ b/tests/bats/devc-remote.bats
@@ -136,10 +136,13 @@ setup() {
 }
 
 @test "detect_editor_cli fails when neither cursor nor code in PATH" {
-    # Use env -i for clean environment; minimal PATH has no cursor/code
-    run env -i PATH="/usr/bin:/bin" HOME="$HOME" "$DEVC_REMOTE" myserver 2>&1
+    local empty_path
+    empty_path="$(mktemp -d)"
+    # Run via /bin/bash so script execution does not depend on PATH/shebang lookup
+    run env -i PATH="$empty_path" HOME="$HOME" /bin/bash "$DEVC_REMOTE" myserver 2>&1
     assert_failure
     assert_output --partial "Neither cursor nor code"
+    rm -rf "$empty_path"
 }
 
 # ── check_ssh ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Description

Make the `detect_editor_cli` negative-path BATS test deterministic across host environments where `/usr/bin/code` may be present.

## Type of Change

- [ ] `feat` -- New feature
- [x] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [ ] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- `tests/bats/devc-remote.bats`
  - Replace `PATH="/usr/bin:/bin"` assumption with a temp empty PATH directory.
  - Execute via `/bin/bash "$DEVC_REMOTE"` under `env -i` to avoid shebang/PATH lookup side effects.
  - Clean up temporary directory at test end.

## Changelog Entry

No changelog needed: this is an internal test determinism fix with no user-facing behavior change.

## Testing

- [x] Tests pass locally (`just test`)
- [ ] Manual testing performed (describe below)

### Manual Testing Details

N/A

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [ ] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

Validated with:
- `npx bats tests/bats/devc-remote.bats -f "detect_editor_cli fails when neither cursor nor code in PATH"`
- `npx bats tests/bats/devc-remote.bats`

Refs: #202
