### PR TITLE
fix(image): run lifecycle commands inside the container via bash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Add manifest entries for resolve-branch.sh, derive-branch-summary.sh, check-skill-names.sh → `.devcontainer/scripts/`
   - Update justfile.worktree to use `source_directory() / "scripts"` for portable path resolution
   - Add Sed transform for check-skill-names.sh path in synced `.pre-commit-config.yaml`
+- **Devcontainer lifecycle commands fail in mock-up folders with crun getcwd error** ([#204](https://github.com/vig-os/devcontainer/issues/204))
+  - Run post-create, post-start, and post-attach commands via `/bin/bash` in `devcontainer.json` for stable command resolution on attach
+  - Prevent attach-time failure where OCI runtime reports `getcwd: No such file or directory`
+  - Update tests in `test-integration.py`
 
 ### Changed
 

--- a/assets/workspace/.devcontainer/devcontainer.json
+++ b/assets/workspace/.devcontainer/devcontainer.json
@@ -50,7 +50,7 @@
         "--group-add=0"
     ],
     "initializeCommand": ".devcontainer/scripts/initialize.sh",
-    "postStartCommand": "/workspace/{{SHORT_NAME}}/.devcontainer/scripts/post-start.sh",
-    "postAttachCommand": "/workspace/{{SHORT_NAME}}/.devcontainer/scripts/post-attach.sh",
-    "postCreateCommand": "/workspace/{{SHORT_NAME}}/.devcontainer/scripts/post-create.sh"
+    "postStartCommand": "/bin/bash /workspace/{{SHORT_NAME}}/.devcontainer/scripts/post-start.sh",
+    "postAttachCommand": "/bin/bash /workspace/{{SHORT_NAME}}/.devcontainer/scripts/post-attach.sh",
+    "postCreateCommand": "/bin/bash /workspace/{{SHORT_NAME}}/.devcontainer/scripts/post-create.sh"
 }

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -443,7 +443,7 @@ class TestDevContainerJson:
         )
         # postAttachCommand should reference .devcontainer inside project subdirectory
         expected_command = (
-            "/workspace/test_project/.devcontainer/scripts/post-attach.sh"
+            "/bin/bash /workspace/test_project/.devcontainer/scripts/post-attach.sh"
         )
         assert config["postAttachCommand"] == expected_command, (
             f"Expected postAttachCommand='{expected_command}', "
@@ -464,11 +464,32 @@ class TestDevContainerJson:
         )
         # postCreateCommand should reference .devcontainer inside project subdirectory
         expected_command = (
-            "/workspace/test_project/.devcontainer/scripts/post-create.sh"
+            "/bin/bash /workspace/test_project/.devcontainer/scripts/post-create.sh"
         )
         assert config["postCreateCommand"] == expected_command, (
             f"Expected postCreateCommand='{expected_command}', "
             f"got: {config['postCreateCommand']}"
+        )
+
+    def test_devcontainer_json_post_start_command(self, initialized_workspace):
+        """Test that postStartCommand is configured correctly."""
+        devcontainer_json = (
+            initialized_workspace / ".devcontainer" / "devcontainer.json"
+        )
+
+        with devcontainer_json.open() as f:
+            config = json.load(f)
+
+        assert "postStartCommand" in config, (
+            "devcontainer.json missing 'postStartCommand' field"
+        )
+        # postStartCommand should reference .devcontainer inside project subdirectory
+        expected_command = (
+            "/bin/bash /workspace/test_project/.devcontainer/scripts/post-start.sh"
+        )
+        assert config["postStartCommand"] == expected_command, (
+            f"Expected postStartCommand='{expected_command}', "
+            f"got: {config['postStartCommand']}"
         )
 
     def test_devcontainer_json_no_redundant_container_env(self, initialized_workspace):


### PR DESCRIPTION
## Description

Ensure devcontainer lifecycle hooks execute reliably in downstream workspaces by invoking hook scripts through `/bin/bash` in `devcontainer.json`. Add integration coverage for all three lifecycle commands (`postCreate`, `postStart`, `postAttach`) so command format regressions are caught by tests.

## Type of Change

- [ ] `feat` -- New feature
- [x] `fix` -- Bug fix
- [x] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [x] `test` -- Adding or updating tests
- [ ] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- `assets/workspace/.devcontainer/devcontainer.json`
  - Update `postCreateCommand`, `postStartCommand`, and `postAttachCommand` to run scripts via `/bin/bash`.
  - Keep existing script paths unchanged while making command execution more robust.
- `tests/test_integration.py`
  - Update expectations for `postAttachCommand` and `postCreateCommand` to include `/bin/bash`.
  - Add `test_devcontainer_json_post_start_command` to validate `postStartCommand` uses the same bash-wrapped format.
- `CHANGELOG.md`
  - Add an Unreleased `### Fixed` entry for issue `#204` describing the lifecycle-command fix and user-visible error resolved.

## Changelog Entry

### Fixed
- **Devcontainer lifecycle commands fail in mock-up folders with crun getcwd error** ([#204](https://github.com/vig-os/devcontainer/issues/204))
  - Run post-create, post-start, and post-attach commands via `/bin/bash` in `devcontainer.json` for stable command resolution on attach
  - Prevent attach-time failure where OCI runtime reports `getcwd: No such file or directory`
  - Update tests in `test-integration.py`

## Testing

- [ ] Tests pass locally (`just test`)
- [ ] Manual testing performed (describe below)

### Manual Testing Details

Added/updated integration assertions in `tests/test_integration.py`:
- `postAttachCommand` expected value includes `/bin/bash`
- `postCreateCommand` expected value includes `/bin/bash`
- new `postStartCommand` assertion

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

Closes #204

Refs: #204
