### PR TITLE
fix(workspace): add terminal.integrated.defaultProfile.linux override to devcontainer.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Run post-create, post-start, and post-attach commands via `/bin/bash` in `devcontainer.json` for stable command resolution on attach
   - Prevent attach-time failure where OCI runtime reports `getcwd: No such file or directory`
   - Update tests in `test-integration.py`
+- **Cursor Agent shell fails with forkpty(3) when host sets zsh as default terminal profile** ([#206](https://github.com/vig-os/devcontainer/issues/206))
+  - Add `terminal.integrated.defaultProfile.linux: "bash"` to devcontainer.json template settings
+  - Prevents user's host-side shell preference from leaking into the container
 
 ### Changed
 

--- a/assets/workspace/.devcontainer/devcontainer.json
+++ b/assets/workspace/.devcontainer/devcontainer.json
@@ -18,6 +18,7 @@
                 "nefrob.vscode-just-syntax"
             ],
             "settings": {
+                "terminal.integrated.defaultProfile.linux": "bash",
                 "python.defaultInterpreterPath": "/root/assets/workspace/.venv/bin/python",
                 "[python]": {
                     "editor.defaultFormatter": "charliermarsh.ruff",

--- a/tests/bats/init-workspace.bats
+++ b/tests/bats/init-workspace.bats
@@ -24,3 +24,24 @@ setup() {
     run grep 'set -euo pipefail' "$INIT_WORKSPACE_SH"
     assert_success
 }
+
+# ── devcontainer.json template ───────────────────────────────────────────────
+
+@test "devcontainer.json template sets terminal.integrated.defaultProfile.linux to bash" {
+    DEVCONTAINER_JSON="$PROJECT_ROOT/assets/workspace/.devcontainer/devcontainer.json"
+    run python3 -c "
+import json, sys
+with open('$DEVCONTAINER_JSON') as f:
+    data = json.load(f)
+settings = data.get('customizations', {}).get('vscode', {}).get('settings', {})
+profile = settings.get('terminal.integrated.defaultProfile.linux')
+if profile == 'bash':
+    print('bash')
+    sys.exit(0)
+else:
+    print(f'expected bash, got {profile!r}')
+    sys.exit(1)
+"
+    assert_success
+    assert_output "bash"
+}


### PR DESCRIPTION
## Description

When a user's Cursor/VS Code settings configure `terminal.integrated.defaultProfile.linux` to a shell not present in the container image (e.g. `zsh`), the Agent chat shell fails with `forkpty(3) failed` and the extension host times out. This adds a `"terminal.integrated.defaultProfile.linux": "bash"` setting to the devcontainer.json template so the container always overrides the user's host-side preference.

## Type of Change

- [x] `fix` -- Bug fix

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- Add `"terminal.integrated.defaultProfile.linux": "bash"` to `assets/workspace/.devcontainer/devcontainer.json` settings
- Add BATS test verifying the setting is present in the template
- Update CHANGELOG.md

## Changelog Entry

### Fixed

- **Cursor Agent shell fails with forkpty(3) when host sets zsh as default terminal profile** ([#206](https://github.com/vig-os/devcontainer/issues/206))
  - Add `terminal.integrated.defaultProfile.linux: "bash"` to devcontainer.json template settings
  - Prevents user's host-side shell preference from leaking into the container

## Testing

- [x] Tests pass locally (`npx bats tests/bats/init-workspace.bats`)
- [x] Manual testing performed (describe below)

### Manual Testing Details

- Verified the devcontainer.json template is valid JSON after the change
- Confirmed the new BATS test fails before the fix (RED) and passes after (GREEN)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

The container image ships `bash` but not `zsh`. Users with `"terminal.integrated.defaultProfile.linux": "zsh"` in their global Cursor settings hit this silently. The devcontainer.json `customizations.vscode.settings` override ensures the container always uses `bash` regardless of the host-side preference.

Refs: #206