### PR TITLE
feat: add opt-in Tailscale SSH support to devcontainer (#208)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Added
+
+- **Opt-in Tailscale SSH support for devcontainer** ([#208](https://github.com/vig-os/devcontainer/issues/208))
+  - New `setup-tailscale.sh` script with `install` and `start` subcommands
+  - Hooks into `post-create.sh` (install) and `post-start.sh` (start)
+  - Silent no-op when `TAILSCALE_AUTHKEY` is unset — zero impact on existing users
+  - Commented example in `docker-compose.local.yaml` for quick setup
+  - Documentation in `.devcontainer/README.md` with quick-start and ACL instructions
+
 ### Fixed
 
 - **CI Project Checks coverage includes devc_remote_uri tests** ([#70](https://github.com/vig-os/devcontainer/issues/70))

--- a/assets/workspace/.devcontainer/docker-compose.local.yaml
+++ b/assets/workspace/.devcontainer/docker-compose.local.yaml
@@ -22,4 +22,14 @@
 #       environment:
 #         - MY_API_KEY=secret123
 
+# Optional: Tailscale SSH for direct mesh access (e.g. Cursor GUI workaround)
+# Generate an auth key at https://login.tailscale.com/admin/settings/keys
+# Use an ephemeral + reusable key so stale containers auto-expire.
+#
+#   services:
+#     devcontainer:
+#       environment:
+#         - TAILSCALE_AUTHKEY=tskey-auth-XXXX
+#         - TAILSCALE_HOSTNAME=myproject-devc-mybox  # optional override
+
 services: {}

--- a/assets/workspace/.devcontainer/scripts/post-create.sh
+++ b/assets/workspace/.devcontainer/scripts/post-create.sh
@@ -35,6 +35,9 @@ sed -i 's/template-project/{{SHORT_NAME}}/g' /root/assets/workspace/.venv/bin/ac
 echo "Syncing dependencies..."
 just --justfile "$PROJECT_ROOT/justfile" --working-directory "$PROJECT_ROOT" sync
 
+# Tailscale SSH (opt-in: no-op when TAILSCALE_AUTHKEY is unset)
+"$SCRIPT_DIR/setup-tailscale.sh" install
+
 # User specific setup
 # Add your custom setup commands here to install any dependencies or tools needed for your project
 

--- a/assets/workspace/.devcontainer/scripts/post-start.sh
+++ b/assets/workspace/.devcontainer/scripts/post-start.sh
@@ -11,6 +11,7 @@ set -euo pipefail
 
 echo "Running post-start setup..."
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="/workspace/{{SHORT_NAME}}"
 
 # Ensure Docker socket is accessible
@@ -19,5 +20,8 @@ sudo chmod 666 /var/run/docker.sock 2>/dev/null || true
 # Sync dependencies (fast no-op if nothing changed)
 echo "Syncing dependencies..."
 just --justfile "$PROJECT_ROOT/justfile" --working-directory "$PROJECT_ROOT" sync
+
+# Tailscale SSH (opt-in: no-op when TAILSCALE_AUTHKEY is unset)
+"$SCRIPT_DIR/setup-tailscale.sh" start
 
 echo "Post-start setup complete"

--- a/assets/workspace/.devcontainer/scripts/setup-tailscale.sh
+++ b/assets/workspace/.devcontainer/scripts/setup-tailscale.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+
+# Tailscale SSH setup for devcontainer — opt-in via TAILSCALE_AUTHKEY env var.
+#
+# Subcommands:
+#   install  — install Tailscale (called from post-create.sh, runs once)
+#   start    — start tailscaled + tailscale up --ssh (called from post-start.sh, runs every start)
+#
+# Both subcommands are silent no-ops when TAILSCALE_AUTHKEY is unset or empty.
+
+set -euo pipefail
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+require_authkey() {
+    if [ -z "${TAILSCALE_AUTHKEY:-}" ]; then
+        echo "Tailscale: TAILSCALE_AUTHKEY not set, skipping."
+        return 1
+    fi
+    return 0
+}
+
+resolve_hostname() {
+    if [ -n "${TAILSCALE_HOSTNAME:-}" ]; then
+        echo "$TAILSCALE_HOSTNAME"
+        return
+    fi
+
+    local project="devc"
+    local devc_json
+    devc_json="$(dirname "${BASH_SOURCE[0]}")/../devcontainer.json"
+    if [ -f "$devc_json" ]; then
+        local name
+        name=$(python3 -c "import json,sys; print(json.load(sys.stdin).get('name',''))" < "$devc_json" 2>/dev/null || true)
+        if [ -n "$name" ]; then
+            project="${name%-devc}"
+        fi
+    fi
+
+    echo "${project}-devc-$(hostname -s)"
+}
+
+# ── subcommands ──────────────────────────────────────────────────────────────
+
+cmd_install() {
+    require_authkey || return 0
+
+    if command -v tailscale &>/dev/null; then
+        echo "Tailscale: already installed, skipping install."
+        return 0
+    fi
+
+    echo "Tailscale: installing..."
+    curl -fsSL https://tailscale.com/install.sh | sh
+    echo "Tailscale: install complete."
+}
+
+cmd_start() {
+    require_authkey || return 0
+
+    local hostname
+    hostname=$(resolve_hostname)
+
+    echo "Tailscale: starting (hostname=$hostname)..."
+
+    if ! pgrep -x tailscaled &>/dev/null; then
+        tailscaled --tun=userspace-networking --state=/var/lib/tailscale/tailscaled.state &
+        sleep 2
+    fi
+
+    if tailscale up --ssh --authkey="$TAILSCALE_AUTHKEY" --hostname="$hostname"; then
+        echo "Tailscale: connected as $hostname"
+    else
+        echo "Tailscale: WARNING — failed to connect. Container still usable via devcontainer protocol." >&2
+    fi
+}
+
+# ── main ─────────────────────────────────────────────────────────────────────
+
+case "${1:-}" in
+    install) cmd_install ;;
+    start)   cmd_start ;;
+    *)
+        echo "Usage: $(basename "$0") {install|start}" >&2
+        exit 1
+        ;;
+esac

--- a/assets/workspace/.devcontainer/scripts/setup-tailscale.sh
+++ b/assets/workspace/.devcontainer/scripts/setup-tailscale.sh
@@ -64,7 +64,7 @@ cmd_start() {
     echo "Tailscale: starting (hostname=$hostname)..."
 
     if ! pgrep -x tailscaled &>/dev/null; then
-        tailscaled --tun=userspace-networking --state=/var/lib/tailscale/tailscaled.state &
+        setsid tailscaled --tun=userspace-networking --state=/var/lib/tailscale/tailscaled.state &>/dev/null &
         sleep 2
     fi
 

--- a/docs/designs/tailscale-ssh.md
+++ b/docs/designs/tailscale-ssh.md
@@ -1,0 +1,220 @@
+# Tailscale SSH for Devcontainers
+
+Design document for opt-in Tailscale SSH access to vigOS devcontainers.
+Prototyped in `vig-os/fd5`, upstreamed here.
+
+Refs: #208
+
+## Problem
+
+Cursor GUI connected to a devcontainer via the devcontainer protocol cannot
+execute shell commands through the AI agent. The agent's shell tool fails to
+route commands into the container's remote execution context. This is a Cursor
+IDE limitation, not a container or project issue.
+
+VS Code's devcontainer protocol works fine. Cursor's CLI/terminal mode also
+works. Only Cursor GUI + devcontainer protocol is broken.
+
+## Solution
+
+Run Tailscale inside the devcontainer with SSH enabled. Connect Cursor via
+SSH remote (`ssh root@<hostname>`) instead of the devcontainer protocol.
+No jump hosts, no port forwarding — direct mesh access over the tailnet.
+
+## Architecture decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Networking mode | `--tun=userspace-networking` | No `/dev/net/tun` device needed. Tailscale SSH is handled by the daemon directly, not through the TUN interface. Works in any container runtime without extra device mounts. |
+| SSH server | Tailscale SSH (`--ssh`) | No need to install/configure openssh-server. Auth is handled by Tailscale ACLs. |
+| Auth mechanism | `TAILSCALE_AUTHKEY` env var | Passed via `docker-compose.local.yaml` (git-ignored). Recommended: reusable + ephemeral keys so stale containers auto-expire. |
+| Opt-in strategy | No-op when `TAILSCALE_AUTHKEY` is unset | Install is skipped in post-create, start is skipped in post-start. Zero impact on users who don't set the key. |
+| Install method | `curl -fsSL https://tailscale.com/install.sh \| sh` | Official installer, idempotent. Runs once in post-create. |
+| Daemon lifecycle | `setsid tailscaled ... &` in `postStartCommand` | `setsid` detaches the daemon from the shell process group so it survives when `postStartCommand` exits. Without `setsid`, the daemon dies with the parent shell. |
+| State persistence | `/var/lib/tailscale/tailscaled.state` | Inside the container volume. Lost on container recreate, which is fine with ephemeral auth keys (re-registers automatically). |
+| Hostname | `TAILSCALE_HOSTNAME` env var, default `<project>-devc-<server>` | Disambiguates same repo on different machines. Project name is parsed from `devcontainer.json`'s `name` field. Override via env var. |
+
+## Lifecycle hook placement
+
+| Hook | Script | Tailscale action |
+|------|--------|-----------------|
+| `postCreateCommand` | `post-create.sh` | `setup-tailscale.sh install` — installs binary once |
+| `postStartCommand` | `post-start.sh` | `setup-tailscale.sh start` — starts daemon + connects |
+
+`postStartCommand` runs on every container start (create + restart), **before**
+the IDE attaches. This is critical — `postAttachCommand` runs in a transient
+shell tied to the IDE session, and background processes started there die when
+the shell exits.
+
+## Files
+
+| File | Role |
+|------|------|
+| `assets/workspace/.devcontainer/scripts/setup-tailscale.sh` | Single script with `install` and `start` subcommands |
+| `assets/workspace/.devcontainer/scripts/post-create.sh` | Calls `setup-tailscale.sh install` |
+| `assets/workspace/.devcontainer/scripts/post-start.sh` | Calls `setup-tailscale.sh start` |
+| `assets/workspace/.devcontainer/docker-compose.local.yaml` | Commented example for `TAILSCALE_AUTHKEY` |
+| `assets/workspace/.devcontainer/README.md` | User-facing setup instructions |
+
+## User setup
+
+### 1. Configure Tailscale SSH ACLs
+
+The tailnet's ACL policy must allow SSH access. In the
+[Tailscale admin console](https://login.tailscale.com/admin/acls/file), add:
+
+```jsonc
+"ssh": [
+  {
+    "action": "accept",
+    "src":    ["autogroup:member"],
+    "dst":    ["autogroup:self"],
+    "users":  ["root", "autogroup:nonroot"]
+  }
+]
+```
+
+### 2. Generate a Tailscale auth key
+
+Generate at https://login.tailscale.com/admin/settings/keys
+(Reusable + Ephemeral recommended).
+
+### 3. Configure the devcontainer
+
+Edit `.devcontainer/docker-compose.local.yaml`:
+
+```yaml
+services:
+  devcontainer:
+    environment:
+      - TAILSCALE_AUTHKEY=tskey-auth-XXXX
+      - TAILSCALE_HOSTNAME=myproject-devc-mybox  # optional
+```
+
+### 4. Rebuild
+
+Rebuild the devcontainer. Post-create installs Tailscale (~10s on first build).
+Post-start connects to the tailnet on every start.
+
+### 5. Connect
+
+```bash
+ssh root@<tailscale-hostname>
+```
+
+For Cursor, use "Remote - SSH" to connect to `root@<hostname>`. On first
+connection, authenticate the Cursor remote server:
+
+```bash
+cursor tunnel --accept-server-license-terms --name <hostname>
+```
+
+## Programmatic auth key generation
+
+Instead of manual key creation in the admin console, auth keys can be generated
+via the Tailscale API using an OAuth client. This enables fully automated setup.
+
+### Setup
+
+1. Create an OAuth client in the [admin console](https://login.tailscale.com/admin/settings/oauth)
+   with scope `auth_keys` (write) and tag(s) like `tag:devcontainer`.
+2. Store `TS_CLIENT_ID` and `TS_CLIENT_SECRET` per-user (keychain, vault, `.env.local`).
+
+### Key generation flow
+
+```bash
+# 1. Get an OAuth access token
+TOKEN=$(curl -s -d "client_id=$TS_CLIENT_ID" \
+  -d "client_secret=$TS_CLIENT_SECRET" \
+  "https://api.tailscale.com/api/v2/oauth/token" | jq -r .access_token)
+
+# 2. Create an ephemeral + reusable auth key
+AUTH_KEY=$(curl -s -X POST \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "capabilities": {
+      "devices": {
+        "create": {
+          "reusable": true,
+          "ephemeral": true,
+          "tags": ["tag:devcontainer"]
+        }
+      }
+    }
+  }' \
+  "https://api.tailscale.com/api/v2/tailnet/-/keys" | jq -r .key)
+```
+
+### Integration point
+
+`initialize.sh` (host-side, before container build) could:
+1. Check if `TAILSCALE_AUTHKEY` is already set in `docker-compose.local.yaml`
+2. If not, check for `TS_CLIENT_ID` + `TS_CLIENT_SECRET` in environment
+3. Generate an ephemeral key via the API
+4. Inject it into `docker-compose.local.yaml`
+
+This is a future enhancement — the current implementation requires manual key
+configuration, which is sufficient for the initial release.
+
+## Known gap: git commit signing over Tailscale SSH
+
+When connecting via Tailscale SSH (instead of the devcontainer protocol),
+**git commit signing does not work out of the box**.
+
+The devcontainer image sets `user.signingkey` to an SSH public key
+(`/root/.ssh/id_ed25519_github.pub`), but two things are missing:
+
+1. **The private key is not present.** Only the `.pub` file exists inside the
+   container. The private key lives on the host and is normally forwarded via
+   SSH agent forwarding — but Tailscale SSH doesn't forward the host's SSH
+   agent into the container session.
+
+2. **Git signing config is incomplete.** The following settings are not set:
+
+   ```gitconfig
+   [commit]
+       gpgsign = true
+   [gpg]
+       format = ssh
+   [gpg "ssh"]
+       allowedSignersFile = <path>   # needed for verification only
+   ```
+
+### Workarounds
+
+- **Forward the SSH agent manually.** SSH into the container with `ssh -A root@<hostname>`
+  so the agent is available. Then set the missing git config:
+
+  ```bash
+  git config --global commit.gpgsign true
+  git config --global gpg.format ssh
+  ```
+
+- **Copy the private key into the container.** Mount or copy the signing key
+  via `docker-compose.local.yaml` volume mount. Less secure (key at rest in
+  container).
+
+- **Use a container-local signing key.** Generate a key inside the container,
+  register it with GitHub, and configure git to use it.
+
+### Future fix
+
+The `setup-tailscale.sh start` script should detect whether an SSH agent is
+available and, if not, print a warning that commit signing will not work. The
+git signing config (`commit.gpgsign`, `gpg.format`) should be set alongside
+`user.signingkey` in the devcontainer image or init script so that signing
+works automatically when the key is available.
+
+## Future considerations
+
+- **Bake Tailscale into the container image** to avoid the ~10s install latency
+  on first create. Trade-off: image size (~30MB) vs. cold-start time.
+- **Hostname templating** via `init-workspace.sh` — the `{{SHORT_NAME}}`
+  placeholder could feed the default hostname.
+- **`docker-compose.local.yaml` template** — include commented Tailscale
+  example in the template that `init-workspace.sh` generates.
+- **Tailscale ACL documentation** — ship a recommended ACL snippet in the
+  devcontainer README or docs.
+- **Programmatic key generation** — integrate OAuth-based key generation into
+  `initialize.sh` for zero-touch setup (see section above).

--- a/tests/bats/setup-tailscale.bats
+++ b/tests/bats/setup-tailscale.bats
@@ -1,0 +1,71 @@
+#!/usr/bin/env bats
+# BATS tests for setup-tailscale.sh
+#
+# Tests script structure, opt-in behavior, and subcommand handling.
+# No live Tailscale tests — we only verify the opt-in gate logic.
+
+setup() {
+    load test_helper
+    SETUP_TAILSCALE="$PROJECT_ROOT/assets/workspace/.devcontainer/scripts/setup-tailscale.sh"
+}
+
+# ── script structure ──────────────────────────────────────────────────────────
+
+@test "setup-tailscale.sh is executable" {
+    run test -x "$SETUP_TAILSCALE"
+    assert_success
+}
+
+@test "setup-tailscale.sh has shebang" {
+    run head -1 "$SETUP_TAILSCALE"
+    assert_output "#!/bin/bash"
+}
+
+@test "setup-tailscale.sh uses strict error handling (set -euo pipefail)" {
+    run grep 'set -euo pipefail' "$SETUP_TAILSCALE"
+    assert_success
+}
+
+# ── no subcommand / invalid subcommand ────────────────────────────────────────
+
+@test "setup-tailscale.sh with no arguments exits with error" {
+    run "$SETUP_TAILSCALE"
+    assert_failure
+    assert_output --partial "Usage:"
+}
+
+@test "setup-tailscale.sh with invalid subcommand exits with error" {
+    run "$SETUP_TAILSCALE" bogus
+    assert_failure
+    assert_output --partial "Usage:"
+}
+
+# ── install subcommand: opt-in gate ──────────────────────────────────────────
+
+@test "install is a no-op when TAILSCALE_AUTHKEY is unset" {
+    unset TAILSCALE_AUTHKEY
+    run "$SETUP_TAILSCALE" install
+    assert_success
+    assert_output --partial "TAILSCALE_AUTHKEY not set"
+}
+
+@test "install is a no-op when TAILSCALE_AUTHKEY is empty" {
+    TAILSCALE_AUTHKEY="" run "$SETUP_TAILSCALE" install
+    assert_success
+    assert_output --partial "TAILSCALE_AUTHKEY not set"
+}
+
+# ── start subcommand: opt-in gate ────────────────────────────────────────────
+
+@test "start is a no-op when TAILSCALE_AUTHKEY is unset" {
+    unset TAILSCALE_AUTHKEY
+    run "$SETUP_TAILSCALE" start
+    assert_success
+    assert_output --partial "TAILSCALE_AUTHKEY not set"
+}
+
+@test "start is a no-op when TAILSCALE_AUTHKEY is empty" {
+    TAILSCALE_AUTHKEY="" run "$SETUP_TAILSCALE" start
+    assert_success
+    assert_output --partial "TAILSCALE_AUTHKEY not set"
+}


### PR DESCRIPTION
## Description

Add opt-in Tailscale SSH support to the devcontainer workspace template. When `TAILSCALE_AUTHKEY` is set via `docker-compose.local.yaml`, Tailscale is installed at container creation and started on every container start, enabling direct SSH access over the tailnet. When unset, all hooks are silent no-ops — zero impact on existing users.

This enables tools like Cur*or GUI to execute shell commands inside the container via SSH remote, working around the known devcontainer protocol limitation.

## Type of Change

- [x] `feat` -- New feature
- [ ] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [ ] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- **`assets/workspace/.devcontainer/scripts/setup-tailscale.sh`** (new) — Single script with `install` and `start` subcommands. Uses userspace networking (`--tun=userspace-networking`), Tailscale SSH (`--ssh`), and auto-generates hostname from `devcontainer.json` name field.
- **`assets/workspace/.devcontainer/scripts/post-create.sh`** — Added hook to `setup-tailscale.sh install` after dependency sync.
- **`assets/workspace/.devcontainer/scripts/post-start.sh`** — Added `SCRIPT_DIR` resolution and hook to `setup-tailscale.sh start` after dependency sync.
- **`assets/workspace/.devcontainer/docker-compose.local.yaml`** — Added commented example for `TAILSCALE_AUTHKEY` and `TAILSCALE_HOSTNAME` env vars.
- **`assets/workspace/.devcontainer/README.md`** — Added "Tailscale SSH" section with prerequisites, setup, ACL configuration, and how-it-works documentation.
- **`tests/bats/setup-tailscale.bats`** (new) — 9 BATS tests covering script structure, opt-in gate (no-op when authkey unset/empty), and invalid subcommand handling.
- **`CHANGELOG.md`** — Added entry under `## Unreleased` → `### Added`.

## Changelog Entry

### Added

- **Opt-in Tailscale SSH support for devcontainer** ([#208](https://github.com/vig-os/devcontainer/issues/208))
  - New `setup-tailscale.sh` script with `install` and `start` subcommands
  - Hooks into `post-create.sh` (install) and `post-start.sh` (start)
  - Silent no-op when `TAILSCALE_AUTHKEY` is unset — zero impact on existing users
  - Commented example in `docker-compose.local.yaml` for quick setup
  - Documentation in `.devcontainer/README.md` with quick-start and ACL instructions

## Testing

- [x] Tests pass locally (`just test`)
- [ ] Manual testing performed (describe below)

### Manual Testing Details

N/A — Live Tailscale testing requires network access and a valid authkey. BATS tests cover the opt-in gate logic (the critical behavior).

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

- Design: [#208 Design comment](https://github.com/vig-os/devcontainer/issues/208#issuecomment-3968551685)
- Implementation Plan: [#208 Plan comment](https://github.com/vig-os/devcontainer/issues/208#issuecomment-3968553610)
- Prototype: `vig-os/fd5` commit `13797db`

Refs: #208
