### PR TITLE
feat: add hadolint support across image and CI

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -4,6 +4,7 @@
 # - Podman (for container operations)
 # - Node.js (for JS tooling)
 # - Devcontainer CLI + docker-compose wrapper (for integration tests)
+# - hadolint (for Containerfile linting in pre-commit)
 # - BATS + helper libraries (for shell script testing)
 #
 # IMPORTANT: The caller must checkout the repository before using this action.
@@ -16,6 +17,7 @@
 #   install-node:             Install Node.js (default: false)
 #   node-version:             Node.js version (default: '20')
 #   install-devcontainer-cli: Install devcontainer CLI + docker-compose wrapper (default: false)
+#   install-hadolint:         Install hadolint binary (default: false)
 #   install-bats:             Install BATS + helper libraries (default: false)
 #
 # Outputs:
@@ -41,7 +43,7 @@
 #       install-devcontainer-cli: 'true'
 
 name: 'Setup Environment'
-description: 'Set up CI environment with Python, uv, and optional tools (podman, Node.js, devcontainer CLI, BATS)'
+description: 'Set up CI environment with Python, uv, and optional tools (podman, Node.js, devcontainer CLI, hadolint, BATS)'
 
 inputs:
   sync-dependencies:
@@ -62,6 +64,10 @@ inputs:
     default: '20'
   install-devcontainer-cli:
     description: 'Install @devcontainers/cli and docker-compose wrapper (requires Node.js)'
+    required: false
+    default: 'false'
+  install-hadolint:
+    description: 'Install hadolint binary for Containerfile linting'
     required: false
     default: 'false'
   install-just:
@@ -129,6 +135,38 @@ runs:
       uses: taiki-e/install-action@3035223527de4d6eb6207d7b9f901df966359a8e  # just
       with:
         tool: just
+
+    # ── hadolint (Containerfile linter) ───────────────────────────────────
+    - name: Install hadolint
+      if: inputs.install-hadolint == 'true'
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        case "$(uname -m)" in
+          x86_64) ARCH="linux-x86_64" ;;
+          aarch64|arm64) ARCH="linux-arm64" ;;
+          *)
+            echo "Unsupported architecture: $(uname -m)"
+            exit 1
+            ;;
+        esac
+
+        HADOLINT_VERSION="v2.14.0"
+        BASE_URL="https://github.com/hadolint/hadolint/releases/download/${HADOLINT_VERSION}"
+        BIN_FILE="hadolint-${ARCH}"
+        SHA_FILE="${BIN_FILE}.sha256"
+
+        curl -fsSL "${BASE_URL}/${BIN_FILE}" -o "${BIN_FILE}"
+        curl -fsSL "${BASE_URL}/${SHA_FILE}" -o "${SHA_FILE}"
+
+        EXPECTED_SHA="$(awk '{print $1}' "${SHA_FILE}")"
+        echo "${EXPECTED_SHA}  ${BIN_FILE}" | sha256sum -c -
+
+        sudo install -m 0755 "${BIN_FILE}" /usr/local/bin/hadolint
+        rm -f "${BIN_FILE}" "${SHA_FILE}"
+
+        hadolint --version
 
     # ── Devcontainer CLI + docker-compose wrapper ───────────────────────
     # Requires Node.js (automatically installed above when this flag is set)

--- a/.github/actions/test-project/action.yml
+++ b/.github/actions/test-project/action.yml
@@ -45,6 +45,7 @@ runs:
       uses: ./.github/actions/setup-env
       with:
         sync-dependencies: 'true'
+        install-hadolint: 'true'
         install-bats: 'true'
 
     - name: Cache pre-commit hooks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,11 +58,13 @@ repos:
         args: ["-x"]
 
   # Containerfile
-  - repo: https://github.com/hadolint/hadolint
-    rev: 346e4199e4baca7d6827f20ac078b6eee5b39327  # v2.9.3
+  - repo: local
     hooks:
-      - id: hadolint-docker
+      - id: hadolint
         name: hadolint
+        entry: hadolint
+        language: system
+        files: ^(.*/)?(Containerfile|Dockerfile)$
 
   # Markdown Linting (excludes auto-generated docs)
   - repo: https://github.com/jackdewinter/pymarkdown

--- a/.trivyignore
+++ b/.trivyignore
@@ -95,5 +95,15 @@ CVE-2025-61728
 Expiration: 2026-05-15
 CVE-2025-61730
 
-# Tracking: https://github.com/vig-os/devcontainer/issues/37
+# CVE-2025-15558: docker/cli plugin search path privilege escalation
+# Risk Assessment: LOW (devcontainer context)
+# - Reported against github.com/docker/cli v29.0.3 embedded in gh v2.87.3
+# - Fix is in github.com/docker/cli >= 29.2.0 and requires upstream gh rebuild
+# - gh in this image is used for trusted GitHub workflows, not privileged plugin execution
+# - Temporary exception to unblock CI until upstream gh release includes the patched dependency
+# - Tracking: https://github.com/vig-os/devcontainer/issues/162
+Expiration: 2026-04-15
+CVE-2025-15558
+
+# Tracking: https://github.com/vig-os/devcontainer
 # Upstream: https://github.com/aquasecurity/trivy/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `sync-main-to-dev.yml` replaces `post-release.yml` — syncs main into dev via PR instead of direct push, satisfying branch protection rules
   - Detects merge conflicts, labels `merge-conflict` with resolution instructions
   - Auto-merge enabled for conflict-free PRs; stale sync branches cleaned up automatically
+- **hadolint installed and wired into CI tooling** ([#122](https://github.com/vig-os/devcontainer/issues/122))
+  - Install `hadolint` in the devcontainer image with SHA-256 checksum verification
+  - Add image test coverage to verify `hadolint` is available in the built image
+  - Configure pre-commit to use the local `hadolint` binary and install it in `setup-env`/`test-project` workflows
 
 ### Changed
 
@@ -475,6 +479,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Add an explicit empty-version guard so the build fails with a clear error message if version resolution fails
 - **CI python security scan fails on unsatisfiable safety pin** ([#213](https://github.com/vig-os/devcontainer/issues/213))
   - Bump workflow `safety` install pin from `3.2.11` to `3.7.0` in both root and workspace-template CI workflows so `uv pip install` resolves successfully again
+- **Requirements parser and `just` install guidance in setup flow** ([#122](https://github.com/vig-os/devcontainer/issues/122))
+  - `scripts/init.sh` now supports multiline `install_command` values in `scripts/requirements.yaml`
+  - Update `just` install instructions to use `sudo` where required by apt-based installation steps
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -506,6 +506,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Update vulnerable Python dependencies** ([#88](https://github.com/vig-os/devcontainer/issues/88))
   - Add uv constraints for transitive dependencies: `urllib3>=2.6.3`, `filelock>=3.20.3`, and `virtualenv>=20.36.1`
   - Regenerate `uv.lock` with patched resolutions (`urllib3 2.6.3`, `filelock 3.25.0`, `virtualenv 21.1.0`)
+- **Temporary Trivy exception for CVE-2025-15558 in gh binary** ([#122](https://github.com/vig-os/devcontainer/issues/122))
+  - Added `CVE-2025-15558` to `.trivyignore` with risk assessment, upstream dependency context, and an expiration date
+  - Keeps CI vulnerability scan unblocked while waiting for an upstream `gh` release that includes the patched `github.com/docker/cli` dependency
 
 ## [0.2.1](https://github.com/vig-os/devcontainer/releases/tag/0.2.1) - 2026-01-28
 

--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -30,7 +30,7 @@ This guide explains how to develop, build, test, and release the vigOS developme
 sudo apt update
 sudo apt install -y podman git openssh-client jq tmux nodejs npm parallel
 # just
-curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/local/bin
+curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | sudo bash -s -- --to /usr/local/bin
 
 # gh
 curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg

--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -22,6 +22,7 @@ This guide explains how to develop, build, test, and release the vigOS developme
 | **uv** | >=0.8 | Python package and project manager |
 | **bats** | 1.13.0 | Bash Automated Testing System for shell script tests |
 | **devcontainer** | 0.81.1 | DevContainer CLI for testing devcontainer functionality |
+| **hadolint** | latest | Containerfile/Dockerfile linter used by pre-commit |
 | **parallel** | latest | Parallelizes BATS test execution for faster test runs |
 
 **Ubuntu/Debian:**
@@ -37,12 +38,31 @@ curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo 
 echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
 sudo apt update && sudo apt install -y gh
 
+# hadolint
+case "$(dpkg --print-architecture)" in
+  amd64) ARCH="linux-x86_64" ;;
+  arm64) ARCH="linux-arm64" ;;
+  *)
+    echo "Unsupported architecture: $(dpkg --print-architecture)"
+    exit 1
+    ;;
+esac
+BASE_URL="https://github.com/hadolint/hadolint/releases/latest/download"
+BIN_FILE="hadolint-${ARCH}"
+SHA_FILE="${BIN_FILE}.sha256"
+curl -fsSL "${BASE_URL}/${BIN_FILE}" -o "${BIN_FILE}"
+curl -fsSL "${BASE_URL}/${SHA_FILE}" -o "${SHA_FILE}"
+EXPECTED_SHA="$(awk '{print $1}' "${SHA_FILE}")"
+echo "${EXPECTED_SHA}  ${BIN_FILE}" | sha256sum -c -
+sudo install -m 0755 "${BIN_FILE}" /usr/local/bin/hadolint
+rm -f "${BIN_FILE}" "${SHA_FILE}"
+
 ```
 
 **macOS (Homebrew):**
 
 ```bash
-brew install podman just git openssh gh jq tmux node parallel
+brew install podman just git openssh gh jq tmux node hadolint parallel
 ```
 
 - For other Linux distributions, use your package manager (e.g., `dnf`, `yum`, `zypper`, `apk`) to install these dependencies.

--- a/Containerfile
+++ b/Containerfile
@@ -111,6 +111,25 @@ RUN set -eux; \
     rm "$FILE"; \
     just --version;
 
+# Install hadolint binary with checksum verification
+RUN set -eux; \
+    case "${TARGETARCH}" in \
+        amd64) ARCH=linux-x86_64 ;; \
+        arm64) ARCH=linux-arm64 ;; \
+        *) echo "Unsupported architecture: ${TARGETARCH}"; exit 1 ;; \
+    esac; \
+    HADOLINT_VERSION="v2.14.0"; \
+    URL="https://github.com/hadolint/hadolint/releases/download/${HADOLINT_VERSION}"; \
+    FILE="hadolint-${ARCH}"; \
+    SHA_FILE="${FILE}.sha256"; \
+    curl -fsSL "${URL}/${FILE}" -o "$FILE"; \
+    curl -fsSL "${URL}/${SHA_FILE}" -o "$SHA_FILE"; \
+    EXPECTED_SHA="$(awk '{print $1}' "$SHA_FILE")"; \
+    echo "${EXPECTED_SHA}  ${FILE}" | sha256sum -c -; \
+    install -m 0755 "$FILE" /usr/local/bin/hadolint; \
+    rm "$FILE" "$SHA_FILE"; \
+    hadolint --version;
+
 # Install cursor-agent CLI (installs to ~/.local/bin)
 ENV PATH="/root/.local/bin:${PATH}"
 RUN set -eux; \

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -181,6 +181,7 @@ parse_requirements() {
     local in_dependencies=false
     local in_optional=false
     local current_section=""
+    local multiline_install_field=""
 
     # Reset global arrays
     DEPS_NAMES=()
@@ -208,6 +209,19 @@ parse_requirements() {
     local current_install_manual=""
 
     while IFS= read -r line || [ -n "$line" ]; do
+        # Handle multiline install commands (YAML block scalar, e.g. "debian: |")
+        if [ -n "$multiline_install_field" ]; then
+            if [[ "$line" =~ ^[[:space:]]{8}(.*)$ ]]; then
+                if [ -n "${!multiline_install_field}" ]; then
+                    printf -v "$multiline_install_field" '%s\n%s' "${!multiline_install_field}" "${BASH_REMATCH[1]}"
+                else
+                    printf -v "$multiline_install_field" '%s' "${BASH_REMATCH[1]}"
+                fi
+                continue
+            fi
+            multiline_install_field=""
+        fi
+
         # Skip comments and empty lines
         [[ "$line" =~ ^[[:space:]]*# ]] && continue
         [[ -z "${line// /}" ]] && continue
@@ -271,16 +285,27 @@ parse_requirements() {
                 current_section="install"
             elif [[ "$line" =~ ^[[:space:]]{6}command:[[:space:]]*(.+) ]] && [ "$current_section" = "check" ]; then
                 current_check_cmd="${BASH_REMATCH[1]}"
-            elif [[ "$line" =~ ^[[:space:]]{6}macos:[[:space:]]*(.+) ]] && [ "$current_section" = "install" ]; then
-                current_install_macos="${BASH_REMATCH[1]}"
-            elif [[ "$line" =~ ^[[:space:]]{6}debian:[[:space:]]*(.+) ]] && [ "$current_section" = "install" ]; then
-                current_install_debian="${BASH_REMATCH[1]}"
-            elif [[ "$line" =~ ^[[:space:]]{6}fedora:[[:space:]]*(.+) ]] && [ "$current_section" = "install" ]; then
-                current_install_fedora="${BASH_REMATCH[1]}"
-            elif [[ "$line" =~ ^[[:space:]]{6}alpine:[[:space:]]*(.+) ]] && [ "$current_section" = "install" ]; then
-                current_install_alpine="${BASH_REMATCH[1]}"
-            elif [[ "$line" =~ ^[[:space:]]{6}all:[[:space:]]*(.+) ]] && [ "$current_section" = "install" ]; then
-                current_install_all="${BASH_REMATCH[1]}"
+            elif [[ "$line" =~ ^[[:space:]]{6}(macos|debian|fedora|alpine|all):[[:space:]]*(.*)$ ]] && [ "$current_section" = "install" ]; then
+                local install_key="${BASH_REMATCH[1]}"
+                local install_value="${BASH_REMATCH[2]}"
+                local target_var=""
+
+                case "$install_key" in
+                    macos) target_var="current_install_macos" ;;
+                    debian) target_var="current_install_debian" ;;
+                    fedora) target_var="current_install_fedora" ;;
+                    alpine) target_var="current_install_alpine" ;;
+                    all) target_var="current_install_all" ;;
+                esac
+
+                local scalar_marker
+                scalar_marker="$(echo "$install_value" | tr -d '[:space:]')"
+                if [ "$scalar_marker" = "|" ] || [ "$scalar_marker" = "|-" ] || [ "$scalar_marker" = "|+" ] || [ "$scalar_marker" = ">" ] || [ "$scalar_marker" = ">-" ] || [ "$scalar_marker" = ">+" ]; then
+                    printf -v "$target_var" '%s' ""
+                    multiline_install_field="$target_var"
+                else
+                    printf -v "$target_var" '%s' "$install_value"
+                fi
             elif [[ "$line" =~ ^[[:space:]]{6}manual:[[:space:]]*(.+) ]] && [ "$current_section" = "install" ]; then
                 current_install_manual="${BASH_REMATCH[1]}"
             fi

--- a/scripts/manifest.toml
+++ b/scripts/manifest.toml
@@ -107,7 +107,7 @@ dest = ".devcontainer/justfile.worktree"
 src = ".pre-commit-config.yaml"
 transforms = [
   { type = "RemovePrecommitHooks", hook_ids = [
-    "hadolint-docker",
+    "hadolint",
     "generate-docs",
     "sync-manifest",
     "pip-licenses",

--- a/scripts/requirements.yaml
+++ b/scripts/requirements.yaml
@@ -197,6 +197,37 @@ dependencies:
       all: npm install
       manual: https://github.com/devcontainers/cli
 
+  # Containerfile linting
+  - name: hadolint
+    version: latest
+    purpose: Containerfile/Dockerfile linter used by pre-commit
+    required: true
+    check:
+      command: command -v hadolint
+      version_command: hadolint --version
+      version_regex: 'Haskell Dockerfile Linter (\d+\.\d+)'
+    install:
+      macos: brew install hadolint
+      debian: |
+        case "$(dpkg --print-architecture)" in
+          amd64) ARCH="linux-x86_64" ;;
+          arm64) ARCH="linux-arm64" ;;
+          *)
+            echo "Unsupported architecture: $(dpkg --print-architecture)"
+            exit 1
+            ;;
+        esac
+        BASE_URL="https://github.com/hadolint/hadolint/releases/latest/download"
+        BIN_FILE="hadolint-${ARCH}"
+        SHA_FILE="${BIN_FILE}.sha256"
+        curl -fsSL "${BASE_URL}/${BIN_FILE}" -o "${BIN_FILE}"
+        curl -fsSL "${BASE_URL}/${SHA_FILE}" -o "${SHA_FILE}"
+        EXPECTED_SHA="$(awk '{print $1}' "${SHA_FILE}")"
+        echo "${EXPECTED_SHA}  ${BIN_FILE}" | sha256sum -c -
+        sudo install -m 0755 "${BIN_FILE}" /usr/local/bin/hadolint
+        rm -f "${BIN_FILE}" "${SHA_FILE}"
+      manual: https://github.com/hadolint/hadolint/releases
+
   # Parallel (auto-installed by npm install)
   - name: parallel
     version: latest

--- a/scripts/requirements.yaml
+++ b/scripts/requirements.yaml
@@ -46,7 +46,7 @@ dependencies:
     install:
       macos: brew install just
       debian: |
-        curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/local/bin
+        curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | sudo bash -s -- --to /usr/local/bin
       fedora: sudo dnf install -y just
       manual: https://github.com/casey/just#installation
 

--- a/tests/bats/init.bats
+++ b/tests/bats/init.bats
@@ -208,27 +208,27 @@ setup() {
 }
 
 @test "init.sh supports macOS-specific install" {
-    run grep 'macos:' "$INIT_SH"
+    run grep 'macos) target_var="current_install_macos"' "$INIT_SH"
     assert_success
 }
 
 @test "init.sh supports Debian-specific install" {
-    run grep 'debian:' "$INIT_SH"
+    run grep 'debian) target_var="current_install_debian"' "$INIT_SH"
     assert_success
 }
 
 @test "init.sh supports Fedora-specific install" {
-    run grep 'fedora:' "$INIT_SH"
+    run grep 'fedora) target_var="current_install_fedora"' "$INIT_SH"
     assert_success
 }
 
 @test "init.sh supports Alpine-specific install" {
-    run grep 'alpine:' "$INIT_SH"
+    run grep 'alpine) target_var="current_install_alpine"' "$INIT_SH"
     assert_success
 }
 
 @test "init.sh supports platform-agnostic install" {
-    run grep 'all:' "$INIT_SH"
+    run grep 'all) target_var="current_install_all"' "$INIT_SH"
     assert_success
 }
 

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -25,6 +25,7 @@ EXPECTED_VERSIONS = {
     "bandit": "1.9.",  # Minor version check (installed via uv pip)
     "pip_licenses": "5.",  # Major version check (installed via uv pip)
     "just": "1.46.",  # Minor version check (manually installed from latest release)
+    "hadolint": "2.14.",  # Minor version check (manually installed from pinned release)
     "cargo-binstall": "1.17.",  # Minor version check (installed from latest release),
     "typstyle": "0.14.",  # Minor version check (installed from latest release)
     "vig_utils": "0.1.",  # Minor version check (installed via uv pip)
@@ -141,6 +142,21 @@ class TestSystemTools:
         expected = EXPECTED_VERSIONS["just"]
         assert expected in result.stdout, (
             f"Expected just {expected}, got: {result.stdout}"
+        )
+
+    def test_hadolint_installed(self, host):
+        """Test that hadolint is installed."""
+        # hadolint is manually installed, so check for the binary file
+        assert host.file("/usr/local/bin/hadolint").exists, "hadolint binary not found"
+        assert host.file("/usr/local/bin/hadolint").is_file, "hadolint is not a file"
+
+    def test_hadolint_version(self, host):
+        """Test that hadolint version is correct."""
+        result = host.run("hadolint --version")
+        assert result.rc == 0, "hadolint --version failed"
+        expected = EXPECTED_VERSIONS["hadolint"]
+        assert expected in result.stdout, (
+            f"Expected hadolint {expected}, got: {result.stdout}"
         )
 
     def test_cursor_agent_installed(self, host):


### PR DESCRIPTION
## Description

Adds hadolint end-to-end for this repository: image installation with checksum verification, local pre-commit integration, and CI setup updates so linting works consistently in local and runner contexts. Also includes setup script improvements for multiline requirement install commands, updated `just` install guidance, and follow-up security/changelog updates from the latest commits.

## Type of Change

- [x] `feat` -- New feature
- [ ] `fix` -- Bug fix
- [x] `docs` -- Documentation only
- [x] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [ ] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- `Containerfile`
  - Installs `hadolint` in the image and verifies download integrity via SHA-256 checksum.
- `.pre-commit-config.yaml`
  - Switches hadolint hook execution to the local binary path.
- `.github/actions/setup-env/action.yml` and `.github/actions/test-project/action.yml`
  - Ensures hadolint availability in CI setup/test flows.
- `tests/test_image.py`
  - Adds assertions for hadolint presence and version in image validation.
- `scripts/init.sh`, `scripts/requirements.yaml`, `scripts/manifest.toml`, `CONTRIBUTE.md`
  - Improves setup requirement parsing for multiline install commands and updates `just` install guidance.
- `.trivyignore`
  - Adds a tracked temporary exception for `CVE-2025-15558` with risk context and expiration metadata.
- `CHANGELOG.md`
  - Updates Unreleased entries for issue #122, including follow-up documentation from the latest commits.

## Changelog Entry

### Added

- **hadolint installed and wired into CI tooling** ([#122](https://github.com/vig-os/devcontainer/issues/122))
  - Install `hadolint` in the devcontainer image with SHA-256 checksum verification
  - Add image test coverage to verify `hadolint` is available in the built image
  - Configure pre-commit to use the local `hadolint` binary and install it in `setup-env`/`test-project` workflows

### Changed

- **Requirements parser and `just` install guidance in setup flow** ([#122](https://github.com/vig-os/devcontainer/issues/122))
  - `scripts/init.sh` now supports multiline `install_command` values in `scripts/requirements.yaml`
  - Update `just` install instructions to use `sudo` where required by apt-based installation steps

### Security

- **Temporary ignore entry for docker/cli CVE with tracked follow-up** ([#122](https://github.com/vig-os/devcontainer/issues/122))
  - Add `.trivyignore` exception for `CVE-2025-15558` including risk assessment and expiry date

## Testing

- [x] Tests pass locally (`just test`)

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [ ] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

N/A

Refs: #122