### PR TITLE
chore: add CC integration with project commands

### DIFF
--- a/.claude/commands/ci_check.md
+++ b/.claude/commands/ci_check.md
@@ -1,0 +1,3 @@
+Read and follow the workflow in `.cursor/skills/ci_check/SKILL.md`.
+
+Context: $ARGUMENTS

--- a/.claude/commands/ci_fix.md
+++ b/.claude/commands/ci_fix.md
@@ -1,0 +1,3 @@
+Read and follow the workflow in `.cursor/skills/ci_fix/SKILL.md`.
+
+Context: $ARGUMENTS

--- a/.claude/commands/code_debug.md
+++ b/.claude/commands/code_debug.md
@@ -1,0 +1,3 @@
+Read and follow the workflow in `.cursor/skills/code_debug/SKILL.md`.
+
+Context: $ARGUMENTS

--- a/.claude/commands/code_execute.md
+++ b/.claude/commands/code_execute.md
@@ -1,0 +1,3 @@
+Read and follow the workflow in `.cursor/skills/code_execute/SKILL.md`.
+
+Context: $ARGUMENTS

--- a/.claude/commands/code_review.md
+++ b/.claude/commands/code_review.md
@@ -1,0 +1,3 @@
+Read and follow the workflow in `.cursor/skills/code_review/SKILL.md`.
+
+Context: $ARGUMENTS

--- a/.claude/commands/code_tdd.md
+++ b/.claude/commands/code_tdd.md
@@ -1,0 +1,4 @@
+Read and follow the workflow in `.cursor/skills/code_tdd/SKILL.md`.
+Also read `.cursor/rules/tdd.mdc` for the scenario checklist and TDD rules.
+
+Context: $ARGUMENTS

--- a/.claude/commands/code_verify.md
+++ b/.claude/commands/code_verify.md
@@ -1,0 +1,3 @@
+Read and follow the workflow in `.cursor/skills/code_verify/SKILL.md`.
+
+Context: $ARGUMENTS

--- a/.claude/commands/design_brainstorm.md
+++ b/.claude/commands/design_brainstorm.md
@@ -1,0 +1,3 @@
+Read and follow the workflow in `.cursor/skills/design_brainstorm/SKILL.md`.
+
+Context: $ARGUMENTS

--- a/.claude/commands/design_plan.md
+++ b/.claude/commands/design_plan.md
@@ -1,0 +1,3 @@
+Read and follow the workflow in `.cursor/skills/design_plan/SKILL.md`.
+
+Context: $ARGUMENTS

--- a/.claude/commands/git_commit.md
+++ b/.claude/commands/git_commit.md
@@ -1,0 +1,4 @@
+Read and follow the workflow in `.cursor/skills/git_commit/SKILL.md`.
+Also read `.cursor/rules/commit-messages.mdc` for the commit message format.
+
+Context: $ARGUMENTS

--- a/.claude/commands/inception_architect.md
+++ b/.claude/commands/inception_architect.md
@@ -1,0 +1,3 @@
+Read and follow the workflow in `.cursor/skills/inception_architect/SKILL.md`.
+
+Context: $ARGUMENTS

--- a/.claude/commands/inception_explore.md
+++ b/.claude/commands/inception_explore.md
@@ -1,0 +1,3 @@
+Read and follow the workflow in `.cursor/skills/inception_explore/SKILL.md`.
+
+Context: $ARGUMENTS

--- a/.claude/commands/inception_plan.md
+++ b/.claude/commands/inception_plan.md
@@ -1,0 +1,3 @@
+Read and follow the workflow in `.cursor/skills/inception_plan/SKILL.md`.
+
+Context: $ARGUMENTS

--- a/.claude/commands/inception_scope.md
+++ b/.claude/commands/inception_scope.md
@@ -1,0 +1,3 @@
+Read and follow the workflow in `.cursor/skills/inception_scope/SKILL.md`.
+
+Context: $ARGUMENTS

--- a/.claude/commands/issue_claim.md
+++ b/.claude/commands/issue_claim.md
@@ -1,0 +1,3 @@
+Read and follow the workflow in `.cursor/skills/issue_claim/SKILL.md`.
+
+Context: $ARGUMENTS

--- a/.claude/commands/issue_create.md
+++ b/.claude/commands/issue_create.md
@@ -1,0 +1,4 @@
+Read and follow the workflow in `.cursor/skills/issue_create/SKILL.md`.
+Also read `.github/ISSUE_TEMPLATE/` and `.github/label-taxonomy.toml` for templates and labels.
+
+Context: $ARGUMENTS

--- a/.claude/commands/issue_triage.md
+++ b/.claude/commands/issue_triage.md
@@ -1,0 +1,4 @@
+Read and follow the workflow in `.cursor/skills/issue_triage/SKILL.md`.
+Also read `.github/label-taxonomy.toml` for canonical labels.
+
+Context: $ARGUMENTS

--- a/.claude/commands/pr_create.md
+++ b/.claude/commands/pr_create.md
@@ -1,0 +1,4 @@
+Read and follow the workflow in `.cursor/skills/pr_create/SKILL.md`.
+Also read `.github/pull_request_template.md` for the PR template.
+
+Context: $ARGUMENTS

--- a/.claude/commands/pr_post-merge.md
+++ b/.claude/commands/pr_post-merge.md
@@ -1,0 +1,3 @@
+Read and follow the workflow in `.cursor/skills/pr_post-merge/SKILL.md`.
+
+Context: $ARGUMENTS

--- a/.claude/commands/pr_solve.md
+++ b/.claude/commands/pr_solve.md
@@ -1,0 +1,3 @@
+Read and follow the workflow in `.cursor/skills/pr_solve/SKILL.md`.
+
+Context: $ARGUMENTS

--- a/.claude/commands/worktree_ask.md
+++ b/.claude/commands/worktree_ask.md
@@ -1,0 +1,3 @@
+Read and follow the workflow in `.cursor/skills/worktree_ask/SKILL.md`.
+
+Context: $ARGUMENTS

--- a/.claude/commands/worktree_brainstorm.md
+++ b/.claude/commands/worktree_brainstorm.md
@@ -1,0 +1,3 @@
+Read and follow the workflow in `.cursor/skills/worktree_brainstorm/SKILL.md`.
+
+Context: $ARGUMENTS

--- a/.claude/commands/worktree_ci-check.md
+++ b/.claude/commands/worktree_ci-check.md
@@ -1,0 +1,3 @@
+Read and follow the workflow in `.cursor/skills/worktree_ci-check/SKILL.md`.
+
+Context: $ARGUMENTS

--- a/.claude/commands/worktree_ci-fix.md
+++ b/.claude/commands/worktree_ci-fix.md
@@ -1,0 +1,3 @@
+Read and follow the workflow in `.cursor/skills/worktree_ci-fix/SKILL.md`.
+
+Context: $ARGUMENTS

--- a/.claude/commands/worktree_execute.md
+++ b/.claude/commands/worktree_execute.md
@@ -1,0 +1,4 @@
+Read and follow the workflow in `.cursor/skills/worktree_execute/SKILL.md`.
+Also read `.cursor/rules/tdd.mdc` for TDD rules.
+
+Context: $ARGUMENTS

--- a/.claude/commands/worktree_plan.md
+++ b/.claude/commands/worktree_plan.md
@@ -1,0 +1,3 @@
+Read and follow the workflow in `.cursor/skills/worktree_plan/SKILL.md`.
+
+Context: $ARGUMENTS

--- a/.claude/commands/worktree_pr.md
+++ b/.claude/commands/worktree_pr.md
@@ -1,0 +1,3 @@
+Read and follow the workflow in `.cursor/skills/worktree_pr/SKILL.md`.
+
+Context: $ARGUMENTS

--- a/.claude/commands/worktree_solve-and-pr.md
+++ b/.claude/commands/worktree_solve-and-pr.md
@@ -1,0 +1,4 @@
+Read and follow the workflow in `.cursor/skills/worktree_solve-and-pr/SKILL.md`.
+Also read `.cursor/rules/subagent-delegation.mdc` for delegation patterns.
+
+Context: $ARGUMENTS

--- a/.claude/commands/worktree_verify.md
+++ b/.claude/commands/worktree_verify.md
@@ -1,0 +1,3 @@
+Read and follow the workflow in `.cursor/skills/worktree_verify/SKILL.md`.
+
+Context: $ARGUMENTS

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,24 @@
+{
+  "permissions": {
+    "allow": [
+      "Read",
+      "Glob",
+      "Grep",
+      "Bash(git status*)",
+      "Bash(git diff*)",
+      "Bash(git log*)",
+      "Bash(git branch*)",
+      "Bash(git fetch*)",
+      "Bash(gh issue*)",
+      "Bash(gh pr*)",
+      "Bash(gh api*)",
+      "Bash(just --list*)",
+      "Bash(just test*)",
+      "Bash(just lint*)",
+      "Bash(just format*)",
+      "Bash(just info*)",
+      "Bash(just check*)"
+    ],
+    "deny": []
+  }
+}

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(gh pr:*)"
+    ]
+  }
+}

--- a/.github/agent-blocklist.toml
+++ b/.github/agent-blocklist.toml
@@ -20,3 +20,10 @@ names = [
 
 # Agent email patterns (substring match, case-insensitive)
 emails = ["cursoragent@cursor.com", "noreply@cursor.com", "github-actions[bot]"]
+
+# Patterns that legitimately contain blocked names (regex, stripped before checking)
+# These are removed from content before name/email matching runs.
+allow_patterns = [
+  "\\.[a-zA-Z][\\w-]*/[\\w./-]*", # dotfile paths: .cursor/skills/, .claude/commands/
+  "[A-Z]+\\.md",                  # doc files: CLAUDE.md
+]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,43 +2,49 @@
 
 ## Custom Commands
 
-Available slash commands (symlinked from `.cursor/skills/`):
+Available slash commands (SSoT: `.cursor/skills/`, mapped via `.claude/commands/`):
+
 | Command | Description |
 |---------|-------------|
-| `/ci_check` | Check CI pipeline status for current branch/PR |
-| `/ci_fix` | Diagnose and fix failing CI runs |
-| `/code_debug` | Systematic debugging: root cause first, fix second |
-| `/code_execute` | Work through implementation plan in batches with checkpoints |
-| `/code_review` | Structured self-review before submitting a PR |
-| `/code_tdd` | Strict RED-GREEN-REFACTOR discipline |
-| `/code_verify` | Run verification and provide evidence before claiming done |
-| `/design_brainstorm` | Explore requirements and design before writing code |
-| `/design_plan` | Break approved design into implementation tasks |
-| `/git_commit` | Commit workflow following project conventions |
-| `/inception_explore` | Divergent exploration — understand the problem space |
-| `/inception_scope` | Convergent scoping — define what to build and what not to build |
-| `/inception_architect` | Architecture evaluation — validate design against established patterns |
-| `/inception_plan` | Decomposition — turn scoped design into actionable GitHub issues |
-| `/issue_claim` | Set up local environment to work on a GitHub issue |
-| `/issue_create` | Create a new GitHub issue using templates |
-| `/issue_triage` | Triage and label GitHub issues |
-| `/pr_create` | Prepare and submit a pull request |
-| `/pr_post-merge` | Cleanup after PR merge |
-| `/pr_solve` | Diagnose PR failures, plan fixes, execute them |
-| `/worktree_ci-check` | Autonomous CI check — polls until completion, triggers fix on failure |
-| `/worktree_ci-fix` | Autonomous CI fix — diagnose, post diagnosis, fix, push, re-check |
-| `/worktree_brainstorm` | Autonomous design — reads issue, posts design, never blocks |
-| `/worktree_plan` | Autonomous planning — posts implementation plan, never blocks |
-| `/worktree_execute` | Autonomous TDD implementation — no user checkpoints |
-| `/worktree_verify` | Autonomous verification — evidence only, loops on failure |
-| `/worktree_pr` | Autonomous PR creation from worktree branch |
-| `/worktree_ask` | Post question to issue when autonomous agent is stuck |
-| `/worktree_solve-and-pr` | Full autonomous pipeline: detect state → design → plan → execute → verify → PR |
+| `/project:ci_check` | Check CI pipeline status for current branch/PR |
+| `/project:ci_fix` | Diagnose and fix failing CI runs |
+| `/project:code_debug` | Systematic debugging: root cause first, fix second |
+| `/project:code_execute` | Work through implementation plan in batches with checkpoints |
+| `/project:code_review` | Structured self-review before submitting a PR |
+| `/project:code_tdd` | Strict RED-GREEN-REFACTOR discipline |
+| `/project:code_verify` | Run verification and provide evidence before claiming done |
+| `/project:design_brainstorm` | Explore requirements and design before writing code |
+| `/project:design_plan` | Break approved design into implementation tasks |
+| `/project:git_commit` | Commit workflow following project conventions |
+| `/project:inception_explore` | Divergent exploration -- understand the problem space |
+| `/project:inception_scope` | Convergent scoping -- define what to build and what not to build |
+| `/project:inception_architect` | Architecture evaluation -- validate design against established patterns |
+| `/project:inception_plan` | Decomposition -- turn scoped design into actionable GitHub issues |
+| `/project:issue_claim` | Set up local environment to work on a GitHub issue |
+| `/project:issue_create` | Create a new GitHub issue using templates |
+| `/project:issue_triage` | Triage and label GitHub issues |
+| `/project:pr_create` | Prepare and submit a pull request |
+| `/project:pr_post-merge` | Cleanup after PR merge |
+| `/project:pr_solve` | Diagnose PR failures, plan fixes, execute them |
+| `/project:worktree_ci-check` | Autonomous CI check -- polls until completion, triggers fix on failure |
+| `/project:worktree_ci-fix` | Autonomous CI fix -- diagnose, post diagnosis, fix, push, re-check |
+| `/project:worktree_brainstorm` | Autonomous design -- reads issue, posts design, never blocks |
+| `/project:worktree_plan` | Autonomous planning -- posts implementation plan, never blocks |
+| `/project:worktree_execute` | Autonomous TDD implementation -- no user checkpoints |
+| `/project:worktree_verify` | Autonomous verification -- evidence only, loops on failure |
+| `/project:worktree_pr` | Autonomous PR creation from worktree branch |
+| `/project:worktree_ask` | Post question to issue when autonomous agent is stuck |
+| `/project:worktree_solve-and-pr` | Full autonomous pipeline: detect state, design, plan, execute, verify, PR |
+
 ---
 
 ## Always-Apply Rules
 
+Rules SSoT: `.cursor/rules/` (read these files for full detail).
+
 ### Coding Principles
+
+See `.cursor/rules/coding-principles.mdc` for full detail.
 
 1. **YAGNI** -- Implement only what the issue or user explicitly requests. No speculative features. Ask before adding anything unasked.
 2. **Minimal diff** -- Touch only files and lines required for the task. No drive-by refactors, renames, or reformats. Mention improvements separately; don't silently change them.
@@ -50,6 +56,8 @@ Available slash commands (symlinked from `.cursor/skills/`):
 **Stop if:** Adding code the issue didn't ask for, editing files outside scope, hardcoding secrets, making untraceable changes, or growing a function beyond one purpose.
 
 ### Commit Message Standard
+
+See `.cursor/rules/commit-messages.mdc` and `docs/COMMIT_MESSAGE_STANDARD.md` for full detail.
 
 Format:
 
@@ -65,6 +73,7 @@ Refs: #<issue>
 - **Refs line mandatory** (at least one GitHub issue, e.g. `Refs: #36`). Exception: `chore` commits may omit `Refs:` when no issue is related.
 - Exactly one `Refs:` line, always last line
 - No emojis, no semantic-release style, no types outside the list
+- Never add Co-authored-by trailers. Never set git author/committer to an AI agent identity. Never mention AI agent names in commit messages or PR descriptions. The pre-commit hooks will reject violations.
 
 ### Changelog Rules
 
@@ -76,6 +85,8 @@ Refs: #<issue>
 
 ### Branch Naming
 
+See `.cursor/rules/branch-naming.mdc` for full detail.
+
 Format: `<type>/<issue_number>-<short_summary>`
 
 Types: `feature` | `bugfix` | `release`
@@ -86,7 +97,9 @@ Use `gh issue develop` to create and link branches. Always confirm branch name w
 
 Every piece of knowledge lives in exactly one place. Reference it everywhere else. Don't copy -- link. Applies to docs, config, infra, rules, and comments.
 
-### TDD (glob-triggered on source/test files, see `.cursor/rules/tdd.mdc`)
+### TDD
+
+See `.cursor/rules/tdd.mdc` for the scenario checklist and full detail.
 
 1. Write the failing test first. Run it. Confirm it fails.
 2. **Commit** the failing test (`test: ...`) following the Commit Message Standard above. Do not proceed before committing.
@@ -96,5 +109,3 @@ Every piece of knowledge lives in exactly one place. Reference it everywhere els
 All commits must follow the Commit Message Standard. Never use `--no-verify`.
 
 Each phase gets its own commit. Do not write implementation before its test. Skip TDD only for non-testable changes (config, templates, docs) -- note why.
-
-Before writing tests, use the **scenario checklist** in `tdd.mdc`: happy path, edge cases, error paths, input validation, state/side effects, regression, smoke. Use the narrowest test type (unit > integration > smoke > E2E) that covers the behavior.

--- a/assets/workspace/.github/agent-blocklist.toml
+++ b/assets/workspace/.github/agent-blocklist.toml
@@ -20,3 +20,10 @@ names = [
 
 # Agent email patterns (substring match, case-insensitive)
 emails = ["cursoragent@cursor.com", "noreply@cursor.com", "github-actions[bot]"]
+
+# Patterns that legitimately contain blocked names (regex, stripped before checking)
+# These are removed from content before name/email matching runs.
+allow_patterns = [
+  "\\.[a-zA-Z][\\w-]*/[\\w./-]*", # dotfile paths: .cursor/skills/, .claude/commands/
+  "[A-Z]+\\.md",                  # doc files: CLAUDE.md
+]

--- a/packages/vig-utils/src/vig_utils/agent_blocklist.py
+++ b/packages/vig-utils/src/vig_utils/agent_blocklist.py
@@ -21,6 +21,7 @@ def load_blocklist(path: Path) -> dict:
         "trailers": [re.compile(p) for p in patterns.get("trailers", [])],
         "names": [s.lower() for s in patterns.get("names", [])],
         "emails": [s.lower() for s in patterns.get("emails", [])],
+        "allow_patterns": [re.compile(p) for p in patterns.get("allow_patterns", [])],
     }
 
 
@@ -34,7 +35,10 @@ def contains_agent_fingerprint(
 
     Returns the first matching pattern string if found, else None.
     """
-    content_lower = content.lower()
+    stripped = content
+    for pattern in blocklist.get("allow_patterns", []):
+        stripped = pattern.sub("", stripped)
+    content_lower = stripped.lower()
     for name in blocklist.get("names", []):
         if name in content_lower:
             return name


### PR DESCRIPTION
## Summary

- Add `.claude/commands/` with 29 slash commands that reference `.cursor/skills/` as SSoT (no duplication)
- Add `.claude/settings.json` with safe read-only default permissions
- Update `CLAUDE.md` to use `/project:` command format and reference `.cursor/rules/`

## Test plan

- [ ] Verify `/project:git_commit` reads and follows the SKILL.md workflow
- [ ] Verify `/project:issue_create` reads templates and label taxonomy
- [ ] Verify `CLAUDE.md` rules are picked up in a fresh CC session

Refs: #224
