### PR TITLE
chore: add Nix flake devShell for reproducible host tooling

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -152,7 +152,6 @@ activemq-data/
 
 # Environments
 .env
-.envrc
 .venv
 env/
 venv/

--- a/.gitignore
+++ b/.gitignore
@@ -150,6 +150,9 @@ activemq-data/
 # SageMath parsed files
 *.sage.py
 
+# Nix / direnv
+.direnv/
+
 # Environments
 .env
 .venv

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,6 +65,7 @@ repos:
       - id: shellcheck
         name: shellcheck
         args: ["-x"]
+        exclude: ^\.envrc$
 
   # Containerfile
   - repo: local

--- a/assets/workspace/.pre-commit-config.yaml
+++ b/assets/workspace/.pre-commit-config.yaml
@@ -65,6 +65,7 @@ repos:
       - id: shellcheck
         name: shellcheck
         args: ["-x"]
+        exclude: ^\.envrc$
 
   # Markdown Linting (excludes auto-generated docs)
   - repo: https://github.com/jackdewinter/pymarkdown

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1772736753,
+        "narHash": "sha256-au/m3+EuBLoSzWUCb64a/MZq6QUtOV8oC0D9tY2scPQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "917fec990948658ef1ccd07cef2a1ef060786846",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,49 @@
+{
+  description = "eXoma devcontainer – host development environment";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          packages = with pkgs; [
+            # Build automation
+            just
+
+            # Version control & GitHub
+            git
+            gh
+
+            # Python tooling
+            uv
+
+            # Node.js (bats, devcontainer CLI via npm)
+            nodejs
+
+            # Shell & JSON utilities
+            jq
+            tmux
+            shellcheck
+
+            # Linting
+            hadolint
+            taplo
+
+            # Container runtime
+            podman
+          ];
+
+          shellHook = ''
+            echo "devcontainer dev environment loaded (nix)"
+          '';
+        };
+      }
+    );
+}


### PR DESCRIPTION
## Summary

- Add `flake.nix` with devShell providing all host tools: just, uv, gh, hadolint, taplo, shellcheck, jq, tmux, nodejs, podman
- Add `.envrc` (`use flake`) for automatic direnv activation
- Exclude `.envrc` from shellcheck (direnv file, not a shell script)
- All pre-commit hooks pass inside `nix develop` with zero manual installs

## Test plan

- [x] `nix develop --command bash -c "which just uv gh hadolint taplo shellcheck"` — all found
- [x] Pre-commit hooks pass inside `nix develop`
- [ ] `direnv allow` auto-activates the environment

Refs: #227