### PR TITLE
fix(setup): switch taplo pre-commit from source compilation to system binary

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -18,6 +18,7 @@
 #   node-version:             Node.js version (default: '20')
 #   install-devcontainer-cli: Install devcontainer CLI + docker-compose wrapper (default: false)
 #   install-hadolint:         Install hadolint binary (default: false)
+#   install-taplo:            Install taplo TOML linter/formatter (default: false)
 #   install-bats:             Install BATS + helper libraries (default: false)
 #
 # Outputs:
@@ -74,6 +75,10 @@ inputs:
     description: 'Install just command runner for Justfile support'
     required: false
     default: 'true'
+  install-taplo:
+    description: 'Install taplo TOML linter/formatter'
+    required: false
+    default: 'false'
   install-bats:
     description: 'Install BATS and helper libraries (support, assert, file) for shell testing'
     required: false
@@ -167,6 +172,33 @@ runs:
         rm -f "${BIN_FILE}" "${SHA_FILE}"
 
         hadolint --version
+
+    # ── taplo (TOML linter/formatter) ──────────────────────────────────
+    - name: Install taplo
+      if: inputs.install-taplo == 'true'
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        case "$(uname -m)" in
+          x86_64) ARCH="x86_64" ;;
+          aarch64|arm64) ARCH="aarch64" ;;
+          *)
+            echo "Unsupported architecture: $(uname -m)"
+            exit 1
+            ;;
+        esac
+
+        TAPLO_VERSION="$(curl -fsSL https://api.github.com/repos/tamasfe/taplo/releases/latest | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p')"
+        BASE_URL="https://github.com/tamasfe/taplo/releases/download/${TAPLO_VERSION}"
+        BIN_FILE="taplo-linux-${ARCH}.gz"
+
+        curl -fsSL "${BASE_URL}/${BIN_FILE}" -o "${BIN_FILE}"
+        gunzip "${BIN_FILE}"
+        sudo install -m 0755 "taplo-linux-${ARCH}" /usr/local/bin/taplo
+        rm -f "taplo-linux-${ARCH}"
+
+        taplo --version
 
     # ── Devcontainer CLI + docker-compose wrapper ───────────────────────
     # Requires Node.js (automatically installed above when this flag is set)

--- a/.github/actions/test-project/action.yml
+++ b/.github/actions/test-project/action.yml
@@ -46,6 +46,7 @@ runs:
       with:
         sync-dependencies: 'true'
         install-hadolint: 'true'
+        install-taplo: 'true'
         install-bats: 'true'
 
     - name: Cache pre-commit hooks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,13 +50,18 @@ repos:
         args: ["--format", "parsable", "--strict"]
 
   # TOML Linting (style + semantic checks)
-  - repo: https://github.com/ComPWA/taplo-pre-commit
-    rev: 23eab0f0eedcbedebff420f5fdfb284744adc7b3  # v0.9.3
+  - repo: local
     hooks:
       - id: taplo-format
-        args: ["--config", ".taplo.toml"]
+        name: taplo-format
+        entry: taplo format --config .taplo.toml
+        language: system
+        types: [toml]
       - id: taplo-lint
-        args: ["--config", ".taplo.toml", "--default-schema-catalogs"]
+        name: taplo-lint
+        entry: taplo lint --config .taplo.toml --default-schema-catalogs
+        language: system
+        types: [toml]
 
   # Shellcheck
   - repo: https://github.com/shellcheck-py/shellcheck-py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -490,6 +490,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Requirements parser and `just` install guidance in setup flow** ([#122](https://github.com/vig-os/devcontainer/issues/122))
   - `scripts/init.sh` now supports multiline `install_command` values in `scripts/requirements.yaml`
   - Update `just` install instructions to use `sudo` where required by apt-based installation steps
+- **Taplo pre-commit hook compiles from source instead of using system binary** ([#226](https://github.com/vig-os/devcontainer/issues/226))
+  - Switch taplo pre-commit hooks from `language: rust` (cargo compile) to `language: system` using the binary already installed in the container image
+  - Correct the taplo release URL and pin to the latest version in the Containerfile
+  - Add taplo to the CI `setup-env` action so pre-commit hooks work on bare runners
 
 ### Security
 

--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -60,19 +60,19 @@ rm -f "${BIN_FILE}" "${SHA_FILE}"
 
 # taplo
 case "$(dpkg --print-architecture)" in
-  amd64) ARCH="x86_64-unknown-linux-gnu" ;;
-  arm64) ARCH="aarch64-unknown-linux-gnu" ;;
+  amd64) ARCH="x86_64" ;;
+  arm64) ARCH="aarch64" ;;
   *)
     echo "Unsupported architecture: $(dpkg --print-architecture)"
     exit 1
     ;;
 esac
 BASE_URL="https://github.com/tamasfe/taplo/releases/latest/download"
-BIN_FILE="taplo-full-${ARCH}.gz"
+BIN_FILE="taplo-linux-${ARCH}.gz"
 curl -fsSL "${BASE_URL}/${BIN_FILE}" -o "${BIN_FILE}"
 gunzip "${BIN_FILE}"
-sudo install -m 0755 "taplo-full-${ARCH}" /usr/local/bin/taplo
-rm -f "taplo-full-${ARCH}"
+sudo install -m 0755 "taplo-linux-${ARCH}" /usr/local/bin/taplo
+rm -f "taplo-linux-${ARCH}"
 
 ```
 

--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -23,6 +23,7 @@ This guide explains how to develop, build, test, and release the vigOS developme
 | **bats** | 1.13.0 | Bash Automated Testing System for shell script tests |
 | **devcontainer** | 0.81.1 | DevContainer CLI for testing devcontainer functionality |
 | **hadolint** | latest | Containerfile/Dockerfile linter used by pre-commit |
+| **taplo** | latest | TOML formatter and linter used by pre-commit |
 | **parallel** | latest | Parallelizes BATS test execution for faster test runs |
 
 **Ubuntu/Debian:**
@@ -57,12 +58,28 @@ echo "${EXPECTED_SHA}  ${BIN_FILE}" | sha256sum -c -
 sudo install -m 0755 "${BIN_FILE}" /usr/local/bin/hadolint
 rm -f "${BIN_FILE}" "${SHA_FILE}"
 
+# taplo
+case "$(dpkg --print-architecture)" in
+  amd64) ARCH="x86_64-unknown-linux-gnu" ;;
+  arm64) ARCH="aarch64-unknown-linux-gnu" ;;
+  *)
+    echo "Unsupported architecture: $(dpkg --print-architecture)"
+    exit 1
+    ;;
+esac
+BASE_URL="https://github.com/tamasfe/taplo/releases/latest/download"
+BIN_FILE="taplo-full-${ARCH}.gz"
+curl -fsSL "${BASE_URL}/${BIN_FILE}" -o "${BIN_FILE}"
+gunzip "${BIN_FILE}"
+sudo install -m 0755 "taplo-full-${ARCH}" /usr/local/bin/taplo
+rm -f "taplo-full-${ARCH}"
+
 ```
 
 **macOS (Homebrew):**
 
 ```bash
-brew install podman just git openssh gh jq tmux node hadolint parallel
+brew install podman just git openssh gh jq tmux node hadolint taplo parallel
 ```
 
 - For other Linux distributions, use your package manager (e.g., `dnf`, `yum`, `zypper`, `apk`) to install these dependencies.

--- a/Containerfile
+++ b/Containerfile
@@ -133,17 +133,17 @@ RUN set -eux; \
 # Install taplo binary (TOML formatter/linter)
 RUN set -eux; \
     case "${TARGETARCH}" in \
-        amd64) ARCH=x86_64-unknown-linux-gnu ;; \
-        arm64) ARCH=aarch64-unknown-linux-gnu ;; \
+        amd64) ARCH=x86_64 ;; \
+        arm64) ARCH=aarch64 ;; \
         *) echo "Unsupported architecture: ${TARGETARCH}"; exit 1 ;; \
     esac; \
-    TAPLO_VERSION="0.9.3"; \
+    TAPLO_VERSION="$(curl -fsSL https://api.github.com/repos/tamasfe/taplo/releases/latest | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p')"; \
     URL="https://github.com/tamasfe/taplo/releases/download/${TAPLO_VERSION}"; \
-    FILE="taplo-full-${ARCH}.gz"; \
+    FILE="taplo-linux-${ARCH}.gz"; \
     curl -fsSL "${URL}/${FILE}" -o "$FILE"; \
     gunzip "$FILE"; \
-    install -m 0755 "taplo-full-${ARCH}" /usr/local/bin/taplo; \
-    rm -f "taplo-full-${ARCH}"; \
+    install -m 0755 "taplo-linux-${ARCH}" /usr/local/bin/taplo; \
+    rm -f "taplo-linux-${ARCH}"; \
     taplo --version;
 
 # Install cursor-agent CLI (installs to ~/.local/bin)

--- a/Containerfile
+++ b/Containerfile
@@ -130,6 +130,22 @@ RUN set -eux; \
     rm "$FILE" "$SHA_FILE"; \
     hadolint --version;
 
+# Install taplo binary (TOML formatter/linter)
+RUN set -eux; \
+    case "${TARGETARCH}" in \
+        amd64) ARCH=x86_64-unknown-linux-gnu ;; \
+        arm64) ARCH=aarch64-unknown-linux-gnu ;; \
+        *) echo "Unsupported architecture: ${TARGETARCH}"; exit 1 ;; \
+    esac; \
+    TAPLO_VERSION="0.9.3"; \
+    URL="https://github.com/tamasfe/taplo/releases/download/${TAPLO_VERSION}"; \
+    FILE="taplo-full-${ARCH}.gz"; \
+    curl -fsSL "${URL}/${FILE}" -o "$FILE"; \
+    gunzip "$FILE"; \
+    install -m 0755 "taplo-full-${ARCH}" /usr/local/bin/taplo; \
+    rm -f "taplo-full-${ARCH}"; \
+    taplo --version;
+
 # Install cursor-agent CLI (installs to ~/.local/bin)
 ENV PATH="/root/.local/bin:${PATH}"
 RUN set -eux; \

--- a/assets/workspace/.pre-commit-config.yaml
+++ b/assets/workspace/.pre-commit-config.yaml
@@ -50,13 +50,18 @@ repos:
         args: ["--format", "parsable", "--strict"]
 
   # TOML Linting (style + semantic checks)
-  - repo: https://github.com/ComPWA/taplo-pre-commit
-    rev: 23eab0f0eedcbedebff420f5fdfb284744adc7b3  # v0.9.3
+  - repo: local
     hooks:
       - id: taplo-format
-        args: ["--config", ".taplo.toml"]
+        name: taplo-format
+        entry: taplo format --config .taplo.toml
+        language: system
+        types: [toml]
       - id: taplo-lint
-        args: ["--config", ".taplo.toml", "--default-schema-catalogs"]
+        name: taplo-lint
+        entry: taplo lint --config .taplo.toml --default-schema-catalogs
+        language: system
+        types: [toml]
 
   # Shellcheck
   - repo: https://github.com/shellcheck-py/shellcheck-py

--- a/scripts/requirements.yaml
+++ b/scripts/requirements.yaml
@@ -228,6 +228,34 @@ dependencies:
         rm -f "${BIN_FILE}" "${SHA_FILE}"
       manual: https://github.com/hadolint/hadolint/releases
 
+  # TOML linting
+  - name: taplo
+    version: latest
+    purpose: TOML formatter and linter used by pre-commit
+    required: true
+    check:
+      command: command -v taplo
+      version_command: taplo --version
+      version_regex: 'taplo (\d+\.\d+)'
+    install:
+      macos: brew install taplo
+      debian: |
+        case "$(dpkg --print-architecture)" in
+          amd64) ARCH="x86_64-unknown-linux-gnu" ;;
+          arm64) ARCH="aarch64-unknown-linux-gnu" ;;
+          *)
+            echo "Unsupported architecture: $(dpkg --print-architecture)"
+            exit 1
+            ;;
+        esac
+        BASE_URL="https://github.com/tamasfe/taplo/releases/latest/download"
+        BIN_FILE="taplo-full-${ARCH}.gz"
+        curl -fsSL "${BASE_URL}/${BIN_FILE}" -o "${BIN_FILE}"
+        gunzip "${BIN_FILE}"
+        sudo install -m 0755 "taplo-full-${ARCH}" /usr/local/bin/taplo
+        rm -f "taplo-full-${ARCH}"
+      manual: https://github.com/tamasfe/taplo/releases
+
   # Parallel (auto-installed by npm install)
   - name: parallel
     version: latest

--- a/scripts/requirements.yaml
+++ b/scripts/requirements.yaml
@@ -241,19 +241,19 @@ dependencies:
       macos: brew install taplo
       debian: |
         case "$(dpkg --print-architecture)" in
-          amd64) ARCH="x86_64-unknown-linux-gnu" ;;
-          arm64) ARCH="aarch64-unknown-linux-gnu" ;;
+          amd64) ARCH="x86_64" ;;
+          arm64) ARCH="aarch64" ;;
           *)
             echo "Unsupported architecture: $(dpkg --print-architecture)"
             exit 1
             ;;
         esac
         BASE_URL="https://github.com/tamasfe/taplo/releases/latest/download"
-        BIN_FILE="taplo-full-${ARCH}.gz"
+        BIN_FILE="taplo-linux-${ARCH}.gz"
         curl -fsSL "${BASE_URL}/${BIN_FILE}" -o "${BIN_FILE}"
         gunzip "${BIN_FILE}"
-        sudo install -m 0755 "taplo-full-${ARCH}" /usr/local/bin/taplo
-        rm -f "taplo-full-${ARCH}"
+        sudo install -m 0755 "taplo-linux-${ARCH}" /usr/local/bin/taplo
+        rm -f "taplo-linux-${ARCH}"
       manual: https://github.com/tamasfe/taplo/releases
 
   # Parallel (auto-installed by npm install)

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -26,6 +26,7 @@ EXPECTED_VERSIONS = {
     "pip_licenses": "5.",  # Major version check (installed via uv pip)
     "just": "1.46.",  # Minor version check (manually installed from latest release)
     "hadolint": "2.14.",  # Minor version check (manually installed from pinned release)
+    "taplo": "0.10.",  # Minor version check (manually installed from latest release)
     "cargo-binstall": "1.17.",  # Minor version check (installed from latest release),
     "typstyle": "0.14.",  # Minor version check (installed from latest release)
     "vig_utils": "0.1.",  # Minor version check (installed via uv pip)
@@ -157,6 +158,20 @@ class TestSystemTools:
         expected = EXPECTED_VERSIONS["hadolint"]
         assert expected in result.stdout, (
             f"Expected hadolint {expected}, got: {result.stdout}"
+        )
+
+    def test_taplo_installed(self, host):
+        """Test that taplo (TOML formatter/linter) is installed."""
+        assert host.file("/usr/local/bin/taplo").exists, "taplo binary not found"
+        assert host.file("/usr/local/bin/taplo").is_file, "taplo is not a file"
+
+    def test_taplo_version(self, host):
+        """Test that taplo version is correct."""
+        result = host.run("taplo --version")
+        assert result.rc == 0, "taplo --version failed"
+        expected = EXPECTED_VERSIONS["taplo"]
+        assert expected in result.stdout, (
+            f"Expected taplo {expected}, got: {result.stdout}"
         )
 
     def test_cursor_agent_installed(self, host):


### PR DESCRIPTION
## Summary

Switch taplo pre-commit hooks from `language: rust` (cargo compile from source) to `language: system` using a pre-installed binary — same pattern used for hadolint. This unblocks the image build which was failing due to taplo Rust compilation issues.

### What changed

- **Pre-commit configs** (`.pre-commit-config.yaml`, `assets/workspace/.pre-commit-config.yaml`): replace `ComPWA/taplo-pre-commit` repo with local `language: system` hooks for both `taplo-format` and `taplo-lint`
- **Containerfile**: add taplo binary installation from GitHub releases (multi-arch: amd64/arm64)
- **CI setup-env action**: add `install-taplo` input and installation step; enable it in `test-project` action
- **`scripts/requirements.yaml`**: add taplo entry with brew (macOS) and GitHub release binary (Linux) install methods
- **`CONTRIBUTE.md`**: document taplo as a host dependency with installation instructions
- **Tests**: add `test_taplo_installed` and `test_taplo_version` to image test suite
- **CHANGELOG**: document the fix under the existing `## [0.7.0]` Fixed section

## Test plan

- [x] Pre-commit hooks pass with taplo as system binary
- [x] `just init` installs taplo on host
- [x] `just build` succeeds with taplo available in image
- [x] CI passes with taplo installed via `setup-env` action

Refs: #226