### PR TITLE
feat(remote): add --bootstrap for one-time remote host setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -223,5 +223,8 @@ __marimo__/
 # Pre-commit cache
 .pre-commit-cache/
 
+# Worktrees
+.worktrees/
+
 # Bats
 node_modules/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`devc-remote --bootstrap`: one-time remote host setup** ([#235](https://github.com/vig-os/devcontainer/issues/235))
+  - Interactive first-run prompts for `projects_dir` with sensible defaults
+  - `--yes` flag skips prompts and uses defaults
+  - Creates `~/.config/devc-remote/config.yaml` on remote (human-editable)
+  - Forwards GHCR auth (podman/docker credentials or `GHCR_TOKEN`) to remote
+  - Clones devcontainer repo and builds image on remote
+  - Re-run reads existing config without re-prompting, pulls latest and rebuilds
 - **Opt-in Tailscale SSH support for devcontainer** ([#208](https://github.com/vig-os/devcontainer/issues/208))
   - New `setup-tailscale.sh` script with `install` and `start` subcommands
   - Hooks into `post-create.sh` (install) and `post-start.sh` (start)

--- a/assets/workspace/scripts/devc-remote.sh
+++ b/assets/workspace/scripts/devc-remote.sh
@@ -8,10 +8,12 @@
 #
 # USAGE:
 #   ./scripts/devc-remote.sh [options] <ssh-host>[:<remote-path>]
+#   ./scripts/devc-remote.sh --bootstrap [--yes] <ssh-host>
 #   ./scripts/devc-remote.sh --help
 #
 # Options:
-#   --yes, -y         Auto-accept prompts (reuse running containers)
+#   --bootstrap       One-time remote host setup (config, GHCR auth, image build)
+#   --yes, -y         Auto-accept prompts (use defaults without asking)
 #   --open <mode>     How to connect after compose up:
 #                       auto    - detect IDE from $TERM_PROGRAM or CLI availability (default)
 #                       cursor  - open Cursor via devcontainer protocol
@@ -79,11 +81,16 @@ parse_args() {
     REMOTE_PATH="~"
     YES_MODE=0
     OPEN_MODE="auto"
+    BOOTSTRAP_MODE=0
 
     while [[ $# -gt 0 ]]; do
         case "$1" in
             --help|-h)
                 show_help
+                ;;
+            --bootstrap)
+                BOOTSTRAP_MODE=1
+                shift
                 ;;
             --yes|-y)
                 # shellcheck disable=SC2034
@@ -483,11 +490,190 @@ for peer in (data.get('Peer') or {}).values():
 }
 
 # ═══════════════════════════════════════════════════════════════════════════════
+# BOOTSTRAP (one-time remote host setup)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+bootstrap_check_config() {
+    # Check if config exists on remote, read values if so
+    local config_output
+    # shellcheck disable=SC2029
+    config_output=$(ssh "$SSH_HOST" "bash -s" << 'CFGEOF'
+CONFIG_DIR="$HOME/.config/devc-remote"
+CONFIG_FILE="$CONFIG_DIR/config.yaml"
+if [ -f "$CONFIG_FILE" ]; then
+    echo "CONFIG_EXISTS=1"
+    # Parse simple flat YAML (key: value) using sed
+    sed -n 's/^projects_dir: *//p'      "$CONFIG_FILE" | while read -r v; do echo "PROJECTS_DIR=$v"; done
+    sed -n 's/^devcontainer_repo: *//p'  "$CONFIG_FILE" | while read -r v; do echo "DEVCONTAINER_REPO=$v"; done
+    sed -n 's/^devcontainer_path: *//p'  "$CONFIG_FILE" | while read -r v; do echo "DEVCONTAINER_PATH=$v"; done
+    sed -n 's/^image_tag: *//p'          "$CONFIG_FILE" | while read -r v; do echo "IMAGE_TAG=$v"; done
+    sed -n 's/^registry: *//p'           "$CONFIG_FILE" | while read -r v; do echo "REGISTRY=$v"; done
+else
+    echo "CONFIG_EXISTS=0"
+fi
+CFGEOF
+    )
+
+    CONFIG_EXISTS=0
+    while IFS= read -r line; do
+        [[ "$line" =~ ^([A-Z_]+)=(.*)$ ]] || continue
+        case "${BASH_REMATCH[1]}" in
+            CONFIG_EXISTS)      CONFIG_EXISTS="${BASH_REMATCH[2]}" ;;
+            PROJECTS_DIR)       BOOTSTRAP_PROJECTS_DIR="${BASH_REMATCH[2]}" ;;
+            DEVCONTAINER_REPO)  BOOTSTRAP_DEVC_REPO="${BASH_REMATCH[2]}" ;;
+            DEVCONTAINER_PATH)  BOOTSTRAP_DEVC_PATH="${BASH_REMATCH[2]}" ;;
+            IMAGE_TAG)          BOOTSTRAP_IMAGE_TAG="${BASH_REMATCH[2]}" ;;
+            REGISTRY)           BOOTSTRAP_REGISTRY="${BASH_REMATCH[2]}" ;;
+        esac
+    done <<< "$config_output"
+}
+
+bootstrap_prompt_config() {
+    # Set defaults
+    BOOTSTRAP_PROJECTS_DIR="${BOOTSTRAP_PROJECTS_DIR:-~/Projects}"
+    BOOTSTRAP_DEVC_REPO="${BOOTSTRAP_DEVC_REPO:-vig-os/devcontainer}"
+    BOOTSTRAP_IMAGE_TAG="${BOOTSTRAP_IMAGE_TAG:-dev}"
+    BOOTSTRAP_REGISTRY="${BOOTSTRAP_REGISTRY:-ghcr.io/vig-os/devcontainer}"
+
+    if [[ "$YES_MODE" == "0" ]]; then
+        log_info "No devc-remote config found on $SSH_HOST."
+        read -rp "Where should projects be cloned? [$BOOTSTRAP_PROJECTS_DIR]: " user_input
+        BOOTSTRAP_PROJECTS_DIR="${user_input:-$BOOTSTRAP_PROJECTS_DIR}"
+    fi
+
+    # Derive devcontainer_path from projects_dir
+    BOOTSTRAP_DEVC_PATH="${BOOTSTRAP_PROJECTS_DIR}/devcontainer"
+}
+
+bootstrap_write_config() {
+    # Write config file on remote
+    # shellcheck disable=SC2029
+    ssh "$SSH_HOST" "bash -s" "$BOOTSTRAP_PROJECTS_DIR" "$BOOTSTRAP_DEVC_REPO" "$BOOTSTRAP_DEVC_PATH" "$BOOTSTRAP_IMAGE_TAG" "$BOOTSTRAP_REGISTRY" << 'WRITEEOF'
+PROJECTS_DIR="$1"
+DEVC_REPO="$2"
+DEVC_PATH="$3"
+IMAGE_TAG="$4"
+REGISTRY="$5"
+CONFIG_DIR="$HOME/.config/devc-remote"
+CONFIG_FILE="$CONFIG_DIR/config.yaml"
+mkdir -p "$CONFIG_DIR"
+cat > "$CONFIG_FILE" << YAML
+projects_dir: ${PROJECTS_DIR}
+devcontainer_repo: ${DEVC_REPO}
+devcontainer_path: ${DEVC_PATH}
+image_tag: ${IMAGE_TAG}
+registry: ${REGISTRY}
+YAML
+WRITEEOF
+
+    log_success "Config written to ~/.config/devc-remote/config.yaml — edit to customize."
+}
+
+bootstrap_forward_ghcr_auth() {
+    # Forward container registry credentials to remote
+    local local_auth=""
+
+    # Check podman auth first, then docker
+    if [[ -f "${HOME}/.config/containers/auth.json" ]]; then
+        local_auth="${HOME}/.config/containers/auth.json"
+    elif [[ -f "${HOME}/.docker/config.json" ]]; then
+        local_auth="${HOME}/.docker/config.json"
+    elif [[ -n "${GHCR_TOKEN:-}" ]]; then
+        # Use token-based auth — create temp auth file
+        local tmp_auth
+        tmp_auth="$(mktemp)"
+        echo "{\"auths\":{\"ghcr.io\":{\"auth\":\"$(echo -n "token:${GHCR_TOKEN}" | base64)\"}}}" > "$tmp_auth"
+        local_auth="$tmp_auth"
+    fi
+
+    if [[ -z "$local_auth" ]]; then
+        log_warning "GHCR auth: no local credentials found, skipping"
+        return 0
+    fi
+
+    # Ensure remote directories exist and copy auth file
+    # shellcheck disable=SC2029
+    ssh "$SSH_HOST" "mkdir -p ~/.config/containers ~/.docker"
+    scp -q "$local_auth" "$SSH_HOST:~/.config/containers/auth.json"
+    scp -q "$local_auth" "$SSH_HOST:~/.docker/config.json"
+
+    # Clean up temp file if we created one
+    if [[ -n "${GHCR_TOKEN:-}" && -n "${tmp_auth:-}" ]]; then
+        rm -f "$tmp_auth"
+    fi
+
+    log_success "GHCR auth forwarded to $SSH_HOST"
+}
+
+bootstrap_clone_and_build() {
+    log_info "Building devcontainer image on $SSH_HOST..."
+    # shellcheck disable=SC2029
+    ssh "$SSH_HOST" "bash -s" "$BOOTSTRAP_DEVC_REPO" "$BOOTSTRAP_DEVC_PATH" "$BOOTSTRAP_IMAGE_TAG" "$BOOTSTRAP_REGISTRY" << 'BUILDEOF'
+DEVC_REPO="$1"
+DEVC_PATH="$2"
+IMAGE_TAG="$3"
+REGISTRY="$4"
+
+# Expand ~ in DEVC_PATH
+DEVC_PATH="${DEVC_PATH/#\~/$HOME}"
+
+if [ -d "$DEVC_PATH/.git" ]; then
+    echo "Repository exists, pulling latest..."
+    cd "$DEVC_PATH" && git pull
+else
+    echo "Cloning $DEVC_REPO..."
+    # Expand ~ in parent dir
+    PARENT_DIR="$(dirname "$DEVC_PATH")"
+    mkdir -p "$PARENT_DIR"
+    cd "$PARENT_DIR"
+    git clone "https://github.com/${DEVC_REPO}.git" "$(basename "$DEVC_PATH")"
+    cd "$DEVC_PATH"
+fi
+
+# Build the image
+if [ -f "scripts/build.sh" ]; then
+    echo "Running scripts/build.sh..."
+    bash scripts/build.sh
+else
+    echo "WARNING: scripts/build.sh not found in $DEVC_PATH"
+fi
+BUILDEOF
+
+    log_success "Devcontainer image built on $SSH_HOST"
+}
+
+bootstrap_remote() {
+    log_info "Bootstrap: checking remote config on $SSH_HOST..."
+    bootstrap_check_config
+
+    if [[ "$CONFIG_EXISTS" == "1" ]]; then
+        log_info "Config: ~/.config/devc-remote/config.yaml (existing, not modified)"
+    else
+        bootstrap_prompt_config
+        bootstrap_write_config
+    fi
+
+    bootstrap_forward_ghcr_auth
+    bootstrap_clone_and_build
+
+    log_success "Bootstrap complete for $SSH_HOST"
+}
+
+# ═══════════════════════════════════════════════════════════════════════════════
 # MAIN
 # ═══════════════════════════════════════════════════════════════════════════════
 
 main() {
     parse_args "$@"
+
+    # Bootstrap mode: one-time remote host setup
+    if [[ "$BOOTSTRAP_MODE" == "1" ]]; then
+        log_info "Checking SSH connectivity to $SSH_HOST..."
+        check_ssh
+        log_success "SSH connection OK"
+        bootstrap_remote
+        return
+    fi
 
     detect_editor_cli
     case "$OPEN_MODE" in

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
       "resolved": "https://registry.npmjs.org/bats/-/bats-1.13.0.tgz",
       "integrity": "sha512-giSYKGTOcPZyJDbfbTtzAedLcNWdjCLbXYU3/MwPnjyvDXzu6Dgw8d2M+8jHhZXSmsCMSQqCp+YBsJ603UO4vQ==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "bats": "bin/bats"
       }
@@ -52,7 +53,8 @@
     },
     "node_modules/bats-support": {
       "version": "0.3.0",
-      "resolved": "git+ssh://git@github.com/bats-core/bats-support.git#24a72e14349690bcbf7c151b9d2d1cdd32d36eb1"
+      "resolved": "git+ssh://git@github.com/bats-core/bats-support.git#24a72e14349690bcbf7c151b9d2d1cdd32d36eb1",
+      "peer": true
     }
   }
 }

--- a/scripts/devc-remote.sh
+++ b/scripts/devc-remote.sh
@@ -8,10 +8,12 @@
 #
 # USAGE:
 #   ./scripts/devc-remote.sh [options] <ssh-host>[:<remote-path>]
+#   ./scripts/devc-remote.sh --bootstrap [--yes] <ssh-host>
 #   ./scripts/devc-remote.sh --help
 #
 # Options:
-#   --yes, -y         Auto-accept prompts (reuse running containers)
+#   --bootstrap       One-time remote host setup (config, GHCR auth, image build)
+#   --yes, -y         Auto-accept prompts (use defaults without asking)
 #   --open <mode>     How to connect after compose up:
 #                       auto    - detect IDE from $TERM_PROGRAM or CLI availability (default)
 #                       cursor  - open Cursor via devcontainer protocol
@@ -79,11 +81,16 @@ parse_args() {
     REMOTE_PATH="~"
     YES_MODE=0
     OPEN_MODE="auto"
+    BOOTSTRAP_MODE=0
 
     while [[ $# -gt 0 ]]; do
         case "$1" in
             --help|-h)
                 show_help
+                ;;
+            --bootstrap)
+                BOOTSTRAP_MODE=1
+                shift
                 ;;
             --yes|-y)
                 # shellcheck disable=SC2034
@@ -483,11 +490,190 @@ for peer in (data.get('Peer') or {}).values():
 }
 
 # ═══════════════════════════════════════════════════════════════════════════════
+# BOOTSTRAP (one-time remote host setup)
+# ═══════════════════════════════════════════════════════════════════════════════
+
+bootstrap_check_config() {
+    # Check if config exists on remote, read values if so
+    local config_output
+    # shellcheck disable=SC2029
+    config_output=$(ssh "$SSH_HOST" "bash -s" << 'CFGEOF'
+CONFIG_DIR="$HOME/.config/devc-remote"
+CONFIG_FILE="$CONFIG_DIR/config.yaml"
+if [ -f "$CONFIG_FILE" ]; then
+    echo "CONFIG_EXISTS=1"
+    # Parse simple flat YAML (key: value) using sed
+    sed -n 's/^projects_dir: *//p'      "$CONFIG_FILE" | while read -r v; do echo "PROJECTS_DIR=$v"; done
+    sed -n 's/^devcontainer_repo: *//p'  "$CONFIG_FILE" | while read -r v; do echo "DEVCONTAINER_REPO=$v"; done
+    sed -n 's/^devcontainer_path: *//p'  "$CONFIG_FILE" | while read -r v; do echo "DEVCONTAINER_PATH=$v"; done
+    sed -n 's/^image_tag: *//p'          "$CONFIG_FILE" | while read -r v; do echo "IMAGE_TAG=$v"; done
+    sed -n 's/^registry: *//p'           "$CONFIG_FILE" | while read -r v; do echo "REGISTRY=$v"; done
+else
+    echo "CONFIG_EXISTS=0"
+fi
+CFGEOF
+    )
+
+    CONFIG_EXISTS=0
+    while IFS= read -r line; do
+        [[ "$line" =~ ^([A-Z_]+)=(.*)$ ]] || continue
+        case "${BASH_REMATCH[1]}" in
+            CONFIG_EXISTS)      CONFIG_EXISTS="${BASH_REMATCH[2]}" ;;
+            PROJECTS_DIR)       BOOTSTRAP_PROJECTS_DIR="${BASH_REMATCH[2]}" ;;
+            DEVCONTAINER_REPO)  BOOTSTRAP_DEVC_REPO="${BASH_REMATCH[2]}" ;;
+            DEVCONTAINER_PATH)  BOOTSTRAP_DEVC_PATH="${BASH_REMATCH[2]}" ;;
+            IMAGE_TAG)          BOOTSTRAP_IMAGE_TAG="${BASH_REMATCH[2]}" ;;
+            REGISTRY)           BOOTSTRAP_REGISTRY="${BASH_REMATCH[2]}" ;;
+        esac
+    done <<< "$config_output"
+}
+
+bootstrap_prompt_config() {
+    # Set defaults
+    BOOTSTRAP_PROJECTS_DIR="${BOOTSTRAP_PROJECTS_DIR:-~/Projects}"
+    BOOTSTRAP_DEVC_REPO="${BOOTSTRAP_DEVC_REPO:-vig-os/devcontainer}"
+    BOOTSTRAP_IMAGE_TAG="${BOOTSTRAP_IMAGE_TAG:-dev}"
+    BOOTSTRAP_REGISTRY="${BOOTSTRAP_REGISTRY:-ghcr.io/vig-os/devcontainer}"
+
+    if [[ "$YES_MODE" == "0" ]]; then
+        log_info "No devc-remote config found on $SSH_HOST."
+        read -rp "Where should projects be cloned? [$BOOTSTRAP_PROJECTS_DIR]: " user_input
+        BOOTSTRAP_PROJECTS_DIR="${user_input:-$BOOTSTRAP_PROJECTS_DIR}"
+    fi
+
+    # Derive devcontainer_path from projects_dir
+    BOOTSTRAP_DEVC_PATH="${BOOTSTRAP_PROJECTS_DIR}/devcontainer"
+}
+
+bootstrap_write_config() {
+    # Write config file on remote
+    # shellcheck disable=SC2029
+    ssh "$SSH_HOST" "bash -s" "$BOOTSTRAP_PROJECTS_DIR" "$BOOTSTRAP_DEVC_REPO" "$BOOTSTRAP_DEVC_PATH" "$BOOTSTRAP_IMAGE_TAG" "$BOOTSTRAP_REGISTRY" << 'WRITEEOF'
+PROJECTS_DIR="$1"
+DEVC_REPO="$2"
+DEVC_PATH="$3"
+IMAGE_TAG="$4"
+REGISTRY="$5"
+CONFIG_DIR="$HOME/.config/devc-remote"
+CONFIG_FILE="$CONFIG_DIR/config.yaml"
+mkdir -p "$CONFIG_DIR"
+cat > "$CONFIG_FILE" << YAML
+projects_dir: ${PROJECTS_DIR}
+devcontainer_repo: ${DEVC_REPO}
+devcontainer_path: ${DEVC_PATH}
+image_tag: ${IMAGE_TAG}
+registry: ${REGISTRY}
+YAML
+WRITEEOF
+
+    log_success "Config written to ~/.config/devc-remote/config.yaml — edit to customize."
+}
+
+bootstrap_forward_ghcr_auth() {
+    # Forward container registry credentials to remote
+    local local_auth=""
+
+    # Check podman auth first, then docker
+    if [[ -f "${HOME}/.config/containers/auth.json" ]]; then
+        local_auth="${HOME}/.config/containers/auth.json"
+    elif [[ -f "${HOME}/.docker/config.json" ]]; then
+        local_auth="${HOME}/.docker/config.json"
+    elif [[ -n "${GHCR_TOKEN:-}" ]]; then
+        # Use token-based auth — create temp auth file
+        local tmp_auth
+        tmp_auth="$(mktemp)"
+        echo "{\"auths\":{\"ghcr.io\":{\"auth\":\"$(echo -n "token:${GHCR_TOKEN}" | base64)\"}}}" > "$tmp_auth"
+        local_auth="$tmp_auth"
+    fi
+
+    if [[ -z "$local_auth" ]]; then
+        log_warning "GHCR auth: no local credentials found, skipping"
+        return 0
+    fi
+
+    # Ensure remote directories exist and copy auth file
+    # shellcheck disable=SC2029
+    ssh "$SSH_HOST" "mkdir -p ~/.config/containers ~/.docker"
+    scp -q "$local_auth" "$SSH_HOST:~/.config/containers/auth.json"
+    scp -q "$local_auth" "$SSH_HOST:~/.docker/config.json"
+
+    # Clean up temp file if we created one
+    if [[ -n "${GHCR_TOKEN:-}" && -n "${tmp_auth:-}" ]]; then
+        rm -f "$tmp_auth"
+    fi
+
+    log_success "GHCR auth forwarded to $SSH_HOST"
+}
+
+bootstrap_clone_and_build() {
+    log_info "Building devcontainer image on $SSH_HOST..."
+    # shellcheck disable=SC2029
+    ssh "$SSH_HOST" "bash -s" "$BOOTSTRAP_DEVC_REPO" "$BOOTSTRAP_DEVC_PATH" "$BOOTSTRAP_IMAGE_TAG" "$BOOTSTRAP_REGISTRY" << 'BUILDEOF'
+DEVC_REPO="$1"
+DEVC_PATH="$2"
+IMAGE_TAG="$3"
+REGISTRY="$4"
+
+# Expand ~ in DEVC_PATH
+DEVC_PATH="${DEVC_PATH/#\~/$HOME}"
+
+if [ -d "$DEVC_PATH/.git" ]; then
+    echo "Repository exists, pulling latest..."
+    cd "$DEVC_PATH" && git pull
+else
+    echo "Cloning $DEVC_REPO..."
+    # Expand ~ in parent dir
+    PARENT_DIR="$(dirname "$DEVC_PATH")"
+    mkdir -p "$PARENT_DIR"
+    cd "$PARENT_DIR"
+    git clone "https://github.com/${DEVC_REPO}.git" "$(basename "$DEVC_PATH")"
+    cd "$DEVC_PATH"
+fi
+
+# Build the image
+if [ -f "scripts/build.sh" ]; then
+    echo "Running scripts/build.sh..."
+    bash scripts/build.sh
+else
+    echo "WARNING: scripts/build.sh not found in $DEVC_PATH"
+fi
+BUILDEOF
+
+    log_success "Devcontainer image built on $SSH_HOST"
+}
+
+bootstrap_remote() {
+    log_info "Bootstrap: checking remote config on $SSH_HOST..."
+    bootstrap_check_config
+
+    if [[ "$CONFIG_EXISTS" == "1" ]]; then
+        log_info "Config: ~/.config/devc-remote/config.yaml (existing, not modified)"
+    else
+        bootstrap_prompt_config
+        bootstrap_write_config
+    fi
+
+    bootstrap_forward_ghcr_auth
+    bootstrap_clone_and_build
+
+    log_success "Bootstrap complete for $SSH_HOST"
+}
+
+# ═══════════════════════════════════════════════════════════════════════════════
 # MAIN
 # ═══════════════════════════════════════════════════════════════════════════════
 
 main() {
     parse_args "$@"
+
+    # Bootstrap mode: one-time remote host setup
+    if [[ "$BOOTSTRAP_MODE" == "1" ]]; then
+        log_info "Checking SSH connectivity to $SSH_HOST..."
+        check_ssh
+        log_success "SSH connection OK"
+        bootstrap_remote
+        return
+    fi
 
     detect_editor_cli
     case "$OPEN_MODE" in

--- a/tests/bats/devc-remote.bats
+++ b/tests/bats/devc-remote.bats
@@ -443,6 +443,186 @@ SSHEOF
 
 # ── remote_compose_up ────────────────────────────────────────────────────────
 
+# ── --bootstrap flag parsing ──────────────────────────────────────────────
+
+@test "--bootstrap requires ssh-host argument" {
+    run "$DEVC_REMOTE" --bootstrap
+    assert_failure
+    assert_output --partial "Missing required argument"
+}
+
+@test "--bootstrap sets BOOTSTRAP_MODE" {
+    run grep 'BOOTSTRAP_MODE=' "$DEVC_REMOTE"
+    assert_success
+}
+
+@test "--bootstrap defines bootstrap_remote function" {
+    run grep 'bootstrap_remote()' "$DEVC_REMOTE"
+    assert_success
+}
+
+@test "--bootstrap with host runs bootstrap flow" {
+    local mock_bin
+    mock_bin="$(mktemp -d)"
+    cat > "$mock_bin/ssh" << SSHEOF
+#!/bin/sh
+counter="${mock_bin}/ssh_counter"
+count=\$(cat "\$counter" 2>/dev/null || echo 0)
+echo \$((count + 1)) > "\$counter"
+# check_ssh
+if [ "\$count" = "0" ]; then
+  exit 0
+fi
+# bootstrap_check_config: config does not exist
+if [ "\$count" = "1" ]; then
+  echo "CONFIG_EXISTS=0"
+  exit 0
+fi
+# bootstrap_write_config
+if [ "\$count" = "2" ]; then
+  exit 0
+fi
+# bootstrap_forward_ghcr_auth
+if [ "\$count" = "3" ]; then
+  exit 0
+fi
+# bootstrap_clone_and_build
+if [ "\$count" = "4" ]; then
+  exit 0
+fi
+exit 0
+SSHEOF
+    chmod +x "$mock_bin/ssh"
+    # Provide scp mock (for GHCR auth forwarding)
+    printf '%s\n' '#!/bin/sh' 'exit 0' > "$mock_bin/scp"
+    chmod +x "$mock_bin/scp"
+    PATH="$mock_bin:$PATH" run "$DEVC_REMOTE" --bootstrap --yes myserver 2>&1
+    assert_success
+    assert_output --partial "Bootstrap"
+    rm -rf "$mock_bin"
+}
+
+@test "--bootstrap first-run creates config on remote" {
+    local mock_bin
+    mock_bin="$(mktemp -d)"
+    cat > "$mock_bin/ssh" << SSHEOF
+#!/bin/sh
+counter="${mock_bin}/ssh_counter"
+count=\$(cat "\$counter" 2>/dev/null || echo 0)
+echo \$((count + 1)) > "\$counter"
+# check_ssh
+if [ "\$count" = "0" ]; then exit 0; fi
+# bootstrap_check_config: no config
+if [ "\$count" = "1" ]; then
+  echo "CONFIG_EXISTS=0"
+  exit 0
+fi
+# write config
+if [ "\$count" = "2" ]; then exit 0; fi
+# clone/build
+exit 0
+SSHEOF
+    chmod +x "$mock_bin/ssh"
+    printf '%s\n' '#!/bin/sh' 'exit 0' > "$mock_bin/scp"
+    chmod +x "$mock_bin/scp"
+    PATH="$mock_bin:$PATH" run "$DEVC_REMOTE" --bootstrap --yes myserver 2>&1
+    assert_success
+    assert_output --partial "Config written"
+    rm -rf "$mock_bin"
+}
+
+@test "--bootstrap re-run reads existing config without re-prompting" {
+    local mock_bin
+    mock_bin="$(mktemp -d)"
+    cat > "$mock_bin/ssh" << SSHEOF
+#!/bin/sh
+counter="${mock_bin}/ssh_counter"
+count=\$(cat "\$counter" 2>/dev/null || echo 0)
+echo \$((count + 1)) > "\$counter"
+# check_ssh
+if [ "\$count" = "0" ]; then exit 0; fi
+# bootstrap_check_config: config exists
+if [ "\$count" = "1" ]; then
+  echo "CONFIG_EXISTS=1"
+  echo "PROJECTS_DIR=~/Projects"
+  echo "DEVCONTAINER_REPO=vig-os/devcontainer"
+  echo "DEVCONTAINER_PATH=~/Projects/devcontainer"
+  echo "IMAGE_TAG=dev"
+  echo "REGISTRY=ghcr.io/vig-os/devcontainer"
+  exit 0
+fi
+# pull + rebuild
+exit 0
+SSHEOF
+    chmod +x "$mock_bin/ssh"
+    printf '%s\n' '#!/bin/sh' 'exit 0' > "$mock_bin/scp"
+    chmod +x "$mock_bin/scp"
+    PATH="$mock_bin:$PATH" run "$DEVC_REMOTE" --bootstrap myserver 2>&1
+    assert_success
+    assert_output --partial "existing, not modified"
+    rm -rf "$mock_bin"
+}
+
+@test "--bootstrap forwards GHCR auth to remote" {
+    local mock_bin
+    mock_bin="$(mktemp -d)"
+    # Create fake local auth file
+    local fake_home
+    fake_home="$(mktemp -d)"
+    mkdir -p "$fake_home/.config/containers"
+    echo '{"auths":{}}' > "$fake_home/.config/containers/auth.json"
+    cat > "$mock_bin/ssh" << SSHEOF
+#!/bin/sh
+counter="${mock_bin}/ssh_counter"
+count=\$(cat "\$counter" 2>/dev/null || echo 0)
+echo \$((count + 1)) > "\$counter"
+if [ "\$count" = "0" ]; then exit 0; fi
+if [ "\$count" = "1" ]; then
+  echo "CONFIG_EXISTS=0"
+  exit 0
+fi
+exit 0
+SSHEOF
+    chmod +x "$mock_bin/ssh"
+    # scp mock that records what was copied
+    cat > "$mock_bin/scp" << SCPEOF
+#!/bin/sh
+echo "SCP_CALLED: \$@" >> "${mock_bin}/scp_log"
+exit 0
+SCPEOF
+    chmod +x "$mock_bin/scp"
+    HOME="$fake_home" PATH="$mock_bin:$PATH" run "$DEVC_REMOTE" --bootstrap --yes myserver 2>&1
+    assert_success
+    assert_output --partial "GHCR auth"
+    rm -rf "$mock_bin" "$fake_home"
+}
+
+@test "--bootstrap builds devcontainer image on remote" {
+    local mock_bin
+    mock_bin="$(mktemp -d)"
+    cat > "$mock_bin/ssh" << SSHEOF
+#!/bin/sh
+counter="${mock_bin}/ssh_counter"
+count=\$(cat "\$counter" 2>/dev/null || echo 0)
+echo \$((count + 1)) > "\$counter"
+if [ "\$count" = "0" ]; then exit 0; fi
+if [ "\$count" = "1" ]; then
+  echo "CONFIG_EXISTS=0"
+  exit 0
+fi
+exit 0
+SSHEOF
+    chmod +x "$mock_bin/ssh"
+    printf '%s\n' '#!/bin/sh' 'exit 0' > "$mock_bin/scp"
+    chmod +x "$mock_bin/scp"
+    PATH="$mock_bin:$PATH" run "$DEVC_REMOTE" --bootstrap --yes myserver 2>&1
+    assert_success
+    assert_output --partial "Building devcontainer image"
+    rm -rf "$mock_bin"
+}
+
+# ── remote_compose_up ────────────────────────────────────────────────────────
+
 @test "remote_compose_up skips when container running and healthy" {
     local mock_bin
     mock_bin="$(mktemp -d)"


### PR DESCRIPTION
## Summary

- Add `devc-remote.sh --bootstrap <ssh-host>` for one-time remote host setup
- Interactive config creation at `~/.config/devc-remote/config.yaml` on remote (`--yes` skips prompts)
- Forward GHCR auth (podman/docker credentials or `GHCR_TOKEN` env var) to remote
- Clone devcontainer repo and build image on remote
- Re-runs read existing config without re-prompting, pull latest and rebuild

## Test plan

- [x] 8 new BATS tests covering flag parsing, config creation, re-run idempotency, GHCR auth forwarding, image build
- [x] All 47 existing tests still pass
- [ ] Manual test on real remote host (first run + re-run)

Refs: #235