### PR TITLE
fix: correct IN_CONTAINER guard in workspace githooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -391,6 +391,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **IN_CONTAINER guard never triggers on host** ([#238](https://github.com/vig-os/devcontainer/issues/238))
+  - Workspace githooks used `= "false"` but `IN_CONTAINER` is unset (not `"false"`) outside the devcontainer
+  - Changed to `!= "true"` in `pre-commit`, `prepare-commit-msg`, and `commit-msg` hooks to fail closed
 - **CHANGELOG extraction truncated on inline `##` markers** ([#172](https://github.com/vig-os/devcontainer/issues/172))
   - `extract_unreleased_content` regex used mid-line lookahead for `##`/`###` which treated inline hash markers (e.g. `` `##` `` in backticks) as heading boundaries
   - Anchored regex to line starts with `re.MULTILINE` so only actual heading lines terminate section capture

--- a/assets/workspace/.githooks/commit-msg
+++ b/assets/workspace/.githooks/commit-msg
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 # Check if we're running inside the dev container
-if [ "${IN_CONTAINER:-}" = "false" ]; then
+if [ "${IN_CONTAINER:-}" != "true" ]; then
 	# Outside dev container
 	echo "Please commit your changes within the dev container."
 	exit 1

--- a/assets/workspace/.githooks/pre-commit
+++ b/assets/workspace/.githooks/pre-commit
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 # Check if we're running inside the dev container
-if [ "${IN_CONTAINER:-}" = "false" ]; then
+if [ "${IN_CONTAINER:-}" != "true" ]; then
 	# Outside dev container
 	echo "Please commit your changes within the dev container."
 	exit 1

--- a/assets/workspace/.githooks/prepare-commit-msg
+++ b/assets/workspace/.githooks/prepare-commit-msg
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 # Check if we're running inside the dev container
-if [ "${IN_CONTAINER:-}" = "false" ]; then
+if [ "${IN_CONTAINER:-}" != "true" ]; then
 	# Outside dev container
 	echo "Please commit your changes within the dev container."
 	exit 1

--- a/tests/bats/githooks.bats
+++ b/tests/bats/githooks.bats
@@ -1,0 +1,86 @@
+#!/usr/bin/env bats
+# BATS tests for workspace githook IN_CONTAINER guard
+#
+# Verifies that .githooks/{pre-commit,prepare-commit-msg,commit-msg} block
+# commits when IN_CONTAINER is not "true" (i.e. outside the devcontainer).
+# Refs: #238
+
+setup() {
+    load test_helper
+    HOOKS_DIR="$PROJECT_ROOT/assets/workspace/.githooks"
+}
+
+# ── pre-commit ────────────────────────────────────────────────────────────────
+
+@test "pre-commit blocks when IN_CONTAINER is unset" {
+    run env -u IN_CONTAINER bash "$HOOKS_DIR/pre-commit"
+    assert_failure
+    assert_output --partial "Please commit your changes within the dev container"
+}
+
+@test "pre-commit blocks when IN_CONTAINER is empty" {
+    run env IN_CONTAINER="" bash "$HOOKS_DIR/pre-commit"
+    assert_failure
+    assert_output --partial "Please commit your changes within the dev container"
+}
+
+@test "pre-commit blocks when IN_CONTAINER is false" {
+    run env IN_CONTAINER="false" bash "$HOOKS_DIR/pre-commit"
+    assert_failure
+    assert_output --partial "Please commit your changes within the dev container"
+}
+
+@test "pre-commit does not show guard message when IN_CONTAINER is true" {
+    run env IN_CONTAINER="true" bash "$HOOKS_DIR/pre-commit"
+    refute_output --partial "Please commit your changes within the dev container"
+}
+
+# ── prepare-commit-msg ────────────────────────────────────────────────────────
+
+@test "prepare-commit-msg blocks when IN_CONTAINER is unset" {
+    run env -u IN_CONTAINER bash "$HOOKS_DIR/prepare-commit-msg" /dev/null
+    assert_failure
+    assert_output --partial "Please commit your changes within the dev container"
+}
+
+@test "prepare-commit-msg blocks when IN_CONTAINER is empty" {
+    run env IN_CONTAINER="" bash "$HOOKS_DIR/prepare-commit-msg" /dev/null
+    assert_failure
+    assert_output --partial "Please commit your changes within the dev container"
+}
+
+@test "prepare-commit-msg blocks when IN_CONTAINER is false" {
+    run env IN_CONTAINER="false" bash "$HOOKS_DIR/prepare-commit-msg" /dev/null
+    assert_failure
+    assert_output --partial "Please commit your changes within the dev container"
+}
+
+@test "prepare-commit-msg does not show guard message when IN_CONTAINER is true" {
+    run env IN_CONTAINER="true" bash "$HOOKS_DIR/prepare-commit-msg" /dev/null
+    refute_output --partial "Please commit your changes within the dev container"
+}
+
+# ── commit-msg ────────────────────────────────────────────────────────────────
+
+@test "commit-msg blocks when IN_CONTAINER is unset" {
+    run env -u IN_CONTAINER bash "$HOOKS_DIR/commit-msg" /dev/null
+    assert_failure
+    assert_output --partial "Please commit your changes within the dev container"
+}
+
+@test "commit-msg blocks when IN_CONTAINER is empty" {
+    run env IN_CONTAINER="" bash "$HOOKS_DIR/commit-msg" /dev/null
+    assert_failure
+    assert_output --partial "Please commit your changes within the dev container"
+}
+
+@test "commit-msg blocks when IN_CONTAINER is false" {
+    run env IN_CONTAINER="false" bash "$HOOKS_DIR/commit-msg" /dev/null
+    assert_failure
+    assert_output --partial "Please commit your changes within the dev container"
+}
+
+@test "commit-msg does not show guard message when IN_CONTAINER is true" {
+    run env IN_CONTAINER="true" bash "$HOOKS_DIR/commit-msg" /dev/null
+    refute_output --partial "Please commit your changes within the dev container"
+}


### PR DESCRIPTION
## Description

Fix the inverted `IN_CONTAINER` guard in workspace githooks that silently allowed host commits through.

Issue #238 describes three defects (A, B, C) from #163. After analysing the current codebase, **defects A and B were already resolved** by the `vig-utils` migration (#218):

- **A (wrong `project_root`):** The old `Path(__file__).resolve().parent.parent` was replaced by `find_repo_root()` which traverses up from `cwd` looking for `.github/`.
- **B (missing `vig_utils` dependency):** The scripts now live inside `vig-utils` and are invoked as entry points — no external import needed.

**Defect C** was the only remaining bug: all three workspace githooks used `= "false"` to check `IN_CONTAINER`, but outside the devcontainer the variable is typically **unset** (empty string), not the literal `"false"`. The guard never triggered, so host commits were not blocked. Changed to `!= "true"` to fail closed.

## Type of Change

- [ ] `feat` -- New feature
- [x] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [ ] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- `assets/workspace/.githooks/pre-commit` — changed `= "false"` to `!= "true"`
- `assets/workspace/.githooks/prepare-commit-msg` — changed `= "false"` to `!= "true"`
- `assets/workspace/.githooks/commit-msg` — changed `= "false"` to `!= "true"`
- `tests/bats/githooks.bats` — new BATS test suite (12 tests: 3 hooks × 4 scenarios: unset, empty, "false", "true")
- `CHANGELOG.md` — added entry under `### Fixed`

## Changelog Entry

### Fixed

- **IN_CONTAINER guard never triggers on host** ([#238](https://github.com/vig-os/devcontainer/issues/238))
  - Workspace githooks used `= "false"` but `IN_CONTAINER` is unset (not `"false"`) outside the devcontainer
  - Changed to `!= "true"` in `pre-commit`, `prepare-commit-msg`, and `commit-msg` hooks to fail closed

## Testing

- [ ] Tests pass locally (`just test`)
- [x] Manual testing performed (describe below)

### Manual Testing Details

BATS test suite `tests/bats/githooks.bats` — 12 tests, all pass:

```
ok 1 pre-commit blocks when IN_CONTAINER is unset
ok 2 pre-commit blocks when IN_CONTAINER is empty
ok 3 pre-commit blocks when IN_CONTAINER is false
ok 4 pre-commit does not show guard message when IN_CONTAINER is true
ok 5 prepare-commit-msg blocks when IN_CONTAINER is unset
ok 6 prepare-commit-msg blocks when IN_CONTAINER is empty
ok 7 prepare-commit-msg blocks when IN_CONTAINER is false
ok 8 prepare-commit-msg does not show guard message when IN_CONTAINER is true
ok 9 commit-msg blocks when IN_CONTAINER is unset
ok 10 commit-msg blocks when IN_CONTAINER is empty
ok 11 commit-msg blocks when IN_CONTAINER is false
ok 12 commit-msg does not show guard message when IN_CONTAINER is true
```

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

The implementation plan with full triage analysis is posted as a [comment on issue #238](https://github.com/vig-os/devcontainer/issues/238#issuecomment-4021876408).

Refs: #238
