### PR TITLE
feat(remote): add gh:org/repo[:branch] clone target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`gh:org/repo[:branch]` target for devc-remote** ([#236](https://github.com/vig-os/devcontainer/issues/236))
+  - Clone a GitHub repo on the remote host and start its devcontainer in one command
+  - Supports `gh:org/repo` (default branch) and `gh:org/repo:branch` (specific branch)
+  - Already-cloned repos are fetched, not re-cloned
+  - Clone location resolved from remote config `projects_dir` or overridden via `host:path`
 - **Opt-in Tailscale SSH support for devcontainer** ([#208](https://github.com/vig-os/devcontainer/issues/208))
   - New `setup-tailscale.sh` script with `install` and `start` subcommands
   - Hooks into `post-create.sh` (install) and `post-start.sh` (start)

--- a/assets/workspace/scripts/devc-remote.sh
+++ b/assets/workspace/scripts/devc-remote.sh
@@ -321,6 +321,78 @@ check_ssh() {
     fi
 }
 
+remote_clone_project() {
+    [[ "$GH_MODE" == "1" ]] || return 0
+
+    log_info "Cloning $GH_REPO on $SSH_HOST..."
+
+    local clone_output
+    # shellcheck disable=SC2029
+    clone_output=$(ssh "$SSH_HOST" "bash -s" "$GH_REPO" "$GH_BRANCH" "$REMOTE_PATH" << 'CLONEEOF'
+GH_REPO="$1"
+GH_BRANCH="$2"
+USER_PATH="$3"
+REPO_NAME="${GH_REPO##*/}"
+
+# Resolve target directory
+if [ "$USER_PATH" != "~" ] && [ -n "$USER_PATH" ]; then
+    TARGET_DIR="$USER_PATH"
+else
+    # Read projects_dir from config, fallback to ~/Projects
+    PROJECTS_DIR="$HOME/Projects"
+    CONFIG_FILE="$HOME/.config/devc-remote/config.yaml"
+    if [ -f "$CONFIG_FILE" ]; then
+        CONFIGURED_DIR=$(sed -n 's/^projects_dir: *//p' "$CONFIG_FILE")
+        [ -n "$CONFIGURED_DIR" ] && PROJECTS_DIR="${CONFIGURED_DIR/#\~/$HOME}"
+    fi
+    TARGET_DIR="$PROJECTS_DIR/$REPO_NAME"
+fi
+
+# Clone or fetch
+CLONE_STATUS="fetched"
+if [ ! -d "$TARGET_DIR/.git" ]; then
+    git clone "https://github.com/${GH_REPO}.git" "$TARGET_DIR"
+    CLONE_STATUS="cloned"
+else
+    cd "$TARGET_DIR" && git fetch
+fi
+
+# Checkout branch if specified
+if [ -n "$GH_BRANCH" ]; then
+    cd "$TARGET_DIR" && git checkout "$GH_BRANCH"
+    echo "CLONE_BRANCH=$GH_BRANCH"
+fi
+
+echo "CLONE_PATH=$TARGET_DIR"
+echo "CLONE_STATUS=$CLONE_STATUS"
+CLONEEOF
+    )
+
+    local clone_path="" clone_status="" clone_branch=""
+    while IFS= read -r line; do
+        [[ "$line" =~ ^([A-Z_]+)=(.*)$ ]] || continue
+        case "${BASH_REMATCH[1]}" in
+            CLONE_PATH) clone_path="${BASH_REMATCH[2]}" ;;
+            CLONE_STATUS) clone_status="${BASH_REMATCH[2]}" ;;
+            CLONE_BRANCH) clone_branch="${BASH_REMATCH[2]}" ;;
+        esac
+    done <<< "$clone_output"
+
+    if [[ -n "$clone_path" ]]; then
+        REMOTE_PATH="$clone_path"
+    fi
+
+    if [[ "$clone_status" == "cloned" ]]; then
+        log_success "Cloning $GH_REPO — cloned to $clone_path"
+    else
+        log_success "Fetching $GH_REPO — updated at $clone_path"
+    fi
+
+    if [[ -n "$clone_branch" ]]; then
+        log_success "Checked out $clone_branch"
+    fi
+}
+
 remote_preflight() {
     local preflight_output
     # shellcheck disable=SC2029
@@ -523,6 +595,8 @@ main() {
     log_info "Checking SSH connectivity to $SSH_HOST..."
     check_ssh
     log_success "SSH connection OK"
+
+    remote_clone_project
 
     log_info "Running pre-flight checks on $SSH_HOST..."
     remote_preflight

--- a/assets/workspace/scripts/devc-remote.sh
+++ b/assets/workspace/scripts/devc-remote.sh
@@ -79,6 +79,9 @@ parse_args() {
     REMOTE_PATH="~"
     YES_MODE=0
     OPEN_MODE="auto"
+    GH_REPO=""
+    GH_BRANCH=""
+    GH_MODE=0
 
     while [[ $# -gt 0 ]]; do
         case "$1" in
@@ -103,6 +106,27 @@ parse_args() {
                 log_error "Unknown option: $1"
                 echo "Use --help for usage information"
                 exit 1
+                ;;
+            gh:*)
+                # gh:org/repo or gh:org/repo:branch
+                local gh_target="${1#gh:}"
+                if [[ -z "$gh_target" || "$gh_target" != */* ]]; then
+                    log_error "Invalid gh: target. Use gh:org/repo or gh:org/repo:branch"
+                    exit 1
+                fi
+                # shellcheck disable=SC2034
+                GH_MODE=1
+                # Split on first colon after org/repo (branch may contain slashes)
+                if [[ "$gh_target" =~ ^([^:]+):(.+)$ ]]; then
+                    # shellcheck disable=SC2034
+                    GH_REPO="${BASH_REMATCH[1]}"
+                    # shellcheck disable=SC2034
+                    GH_BRANCH="${BASH_REMATCH[2]}"
+                else
+                    # shellcheck disable=SC2034
+                    GH_REPO="$gh_target"
+                fi
+                shift
                 ;;
             *)
                 if [[ -n "$SSH_HOST" ]]; then

--- a/assets/workspace/scripts/devc-remote.sh
+++ b/assets/workspace/scripts/devc-remote.sh
@@ -7,7 +7,7 @@
 # compose lifecycle, and optional Tailscale auth key injection.
 #
 # USAGE:
-#   ./scripts/devc-remote.sh [options] <ssh-host>[:<remote-path>]
+#   ./scripts/devc-remote.sh [options] <ssh-host>[:<remote-path>] [gh:<org>/<repo>[:<branch>]]
 #   ./scripts/devc-remote.sh --help
 #
 # Options:
@@ -19,6 +19,13 @@
 #                       ssh     - wait for Tailscale, print hostname (for SSH clients)
 #                       none    - infra only, no IDE
 #
+# GitHub repo target (gh:):
+#   Clone a GitHub repo on the remote host and start its devcontainer.
+#   gh:<org>/<repo>           Clone to <projects_dir>/<repo> (from config or ~/Projects)
+#   gh:<org>/<repo>:<branch>  Clone and checkout specified branch
+#   Combined with host:path to override clone location:
+#     <host>:<path> gh:<org>/<repo>   Clone to <path> instead of default
+#
 # Tailscale key injection (opt-in):
 #   When TS_CLIENT_ID and TS_CLIENT_SECRET are set in the local environment,
 #   generates an ephemeral auth key via the Tailscale API and injects it
@@ -29,8 +36,11 @@
 #   ./scripts/devc-remote.sh --open none myserver:/home/user/repo
 #   ./scripts/devc-remote.sh --open ssh myserver
 #   ./scripts/devc-remote.sh --yes --open code user@host:/opt/projects/myrepo
+#   ./scripts/devc-remote.sh myserver gh:vig-os/fd5
+#   ./scripts/devc-remote.sh myserver gh:vig-os/fd5:feature/my-branch
+#   ./scripts/devc-remote.sh myserver:~/custom/path gh:vig-os/fd5
 #
-# Part of #70. See issues #152, #230, #231 for design.
+# Part of #70. See issues #152, #230, #231, #236 for design.
 ###############################################################################
 
 set -euo pipefail

--- a/scripts/devc-remote.sh
+++ b/scripts/devc-remote.sh
@@ -321,6 +321,78 @@ check_ssh() {
     fi
 }
 
+remote_clone_project() {
+    [[ "$GH_MODE" == "1" ]] || return 0
+
+    log_info "Cloning $GH_REPO on $SSH_HOST..."
+
+    local clone_output
+    # shellcheck disable=SC2029
+    clone_output=$(ssh "$SSH_HOST" "bash -s" "$GH_REPO" "$GH_BRANCH" "$REMOTE_PATH" << 'CLONEEOF'
+GH_REPO="$1"
+GH_BRANCH="$2"
+USER_PATH="$3"
+REPO_NAME="${GH_REPO##*/}"
+
+# Resolve target directory
+if [ "$USER_PATH" != "~" ] && [ -n "$USER_PATH" ]; then
+    TARGET_DIR="$USER_PATH"
+else
+    # Read projects_dir from config, fallback to ~/Projects
+    PROJECTS_DIR="$HOME/Projects"
+    CONFIG_FILE="$HOME/.config/devc-remote/config.yaml"
+    if [ -f "$CONFIG_FILE" ]; then
+        CONFIGURED_DIR=$(sed -n 's/^projects_dir: *//p' "$CONFIG_FILE")
+        [ -n "$CONFIGURED_DIR" ] && PROJECTS_DIR="${CONFIGURED_DIR/#\~/$HOME}"
+    fi
+    TARGET_DIR="$PROJECTS_DIR/$REPO_NAME"
+fi
+
+# Clone or fetch
+CLONE_STATUS="fetched"
+if [ ! -d "$TARGET_DIR/.git" ]; then
+    git clone "https://github.com/${GH_REPO}.git" "$TARGET_DIR"
+    CLONE_STATUS="cloned"
+else
+    cd "$TARGET_DIR" && git fetch
+fi
+
+# Checkout branch if specified
+if [ -n "$GH_BRANCH" ]; then
+    cd "$TARGET_DIR" && git checkout "$GH_BRANCH"
+    echo "CLONE_BRANCH=$GH_BRANCH"
+fi
+
+echo "CLONE_PATH=$TARGET_DIR"
+echo "CLONE_STATUS=$CLONE_STATUS"
+CLONEEOF
+    )
+
+    local clone_path="" clone_status="" clone_branch=""
+    while IFS= read -r line; do
+        [[ "$line" =~ ^([A-Z_]+)=(.*)$ ]] || continue
+        case "${BASH_REMATCH[1]}" in
+            CLONE_PATH) clone_path="${BASH_REMATCH[2]}" ;;
+            CLONE_STATUS) clone_status="${BASH_REMATCH[2]}" ;;
+            CLONE_BRANCH) clone_branch="${BASH_REMATCH[2]}" ;;
+        esac
+    done <<< "$clone_output"
+
+    if [[ -n "$clone_path" ]]; then
+        REMOTE_PATH="$clone_path"
+    fi
+
+    if [[ "$clone_status" == "cloned" ]]; then
+        log_success "Cloning $GH_REPO — cloned to $clone_path"
+    else
+        log_success "Fetching $GH_REPO — updated at $clone_path"
+    fi
+
+    if [[ -n "$clone_branch" ]]; then
+        log_success "Checked out $clone_branch"
+    fi
+}
+
 remote_preflight() {
     local preflight_output
     # shellcheck disable=SC2029
@@ -523,6 +595,8 @@ main() {
     log_info "Checking SSH connectivity to $SSH_HOST..."
     check_ssh
     log_success "SSH connection OK"
+
+    remote_clone_project
 
     log_info "Running pre-flight checks on $SSH_HOST..."
     remote_preflight

--- a/scripts/devc-remote.sh
+++ b/scripts/devc-remote.sh
@@ -79,6 +79,9 @@ parse_args() {
     REMOTE_PATH="~"
     YES_MODE=0
     OPEN_MODE="auto"
+    GH_REPO=""
+    GH_BRANCH=""
+    GH_MODE=0
 
     while [[ $# -gt 0 ]]; do
         case "$1" in
@@ -103,6 +106,27 @@ parse_args() {
                 log_error "Unknown option: $1"
                 echo "Use --help for usage information"
                 exit 1
+                ;;
+            gh:*)
+                # gh:org/repo or gh:org/repo:branch
+                local gh_target="${1#gh:}"
+                if [[ -z "$gh_target" || "$gh_target" != */* ]]; then
+                    log_error "Invalid gh: target. Use gh:org/repo or gh:org/repo:branch"
+                    exit 1
+                fi
+                # shellcheck disable=SC2034
+                GH_MODE=1
+                # Split on first colon after org/repo (branch may contain slashes)
+                if [[ "$gh_target" =~ ^([^:]+):(.+)$ ]]; then
+                    # shellcheck disable=SC2034
+                    GH_REPO="${BASH_REMATCH[1]}"
+                    # shellcheck disable=SC2034
+                    GH_BRANCH="${BASH_REMATCH[2]}"
+                else
+                    # shellcheck disable=SC2034
+                    GH_REPO="$gh_target"
+                fi
+                shift
                 ;;
             *)
                 if [[ -n "$SSH_HOST" ]]; then

--- a/scripts/devc-remote.sh
+++ b/scripts/devc-remote.sh
@@ -7,7 +7,7 @@
 # compose lifecycle, and optional Tailscale auth key injection.
 #
 # USAGE:
-#   ./scripts/devc-remote.sh [options] <ssh-host>[:<remote-path>]
+#   ./scripts/devc-remote.sh [options] <ssh-host>[:<remote-path>] [gh:<org>/<repo>[:<branch>]]
 #   ./scripts/devc-remote.sh --help
 #
 # Options:
@@ -19,6 +19,13 @@
 #                       ssh     - wait for Tailscale, print hostname (for SSH clients)
 #                       none    - infra only, no IDE
 #
+# GitHub repo target (gh:):
+#   Clone a GitHub repo on the remote host and start its devcontainer.
+#   gh:<org>/<repo>           Clone to <projects_dir>/<repo> (from config or ~/Projects)
+#   gh:<org>/<repo>:<branch>  Clone and checkout specified branch
+#   Combined with host:path to override clone location:
+#     <host>:<path> gh:<org>/<repo>   Clone to <path> instead of default
+#
 # Tailscale key injection (opt-in):
 #   When TS_CLIENT_ID and TS_CLIENT_SECRET are set in the local environment,
 #   generates an ephemeral auth key via the Tailscale API and injects it
@@ -29,8 +36,11 @@
 #   ./scripts/devc-remote.sh --open none myserver:/home/user/repo
 #   ./scripts/devc-remote.sh --open ssh myserver
 #   ./scripts/devc-remote.sh --yes --open code user@host:/opt/projects/myrepo
+#   ./scripts/devc-remote.sh myserver gh:vig-os/fd5
+#   ./scripts/devc-remote.sh myserver gh:vig-os/fd5:feature/my-branch
+#   ./scripts/devc-remote.sh myserver:~/custom/path gh:vig-os/fd5
 #
-# Part of #70. See issues #152, #230, #231 for design.
+# Part of #70. See issues #152, #230, #231, #236 for design.
 ###############################################################################
 
 set -euo pipefail

--- a/tests/bats/devc-remote.bats
+++ b/tests/bats/devc-remote.bats
@@ -109,6 +109,48 @@ setup() {
     assert_failure
 }
 
+# ── parse_args: gh: target syntax ────────────────────────────────────────────
+
+@test "parse_args recognizes gh:org/repo as second positional arg" {
+    local mock_bin
+    mock_bin="$(mktemp -d)"
+    printf '%s\n' '#!/bin/sh' 'exit 1' > "$mock_bin/ssh"
+    chmod +x "$mock_bin/ssh"
+    PATH="$mock_bin:$PATH" run "$DEVC_REMOTE" --open none myserver gh:vig-os/fd5 2>&1
+    # Should get past parse_args (fail at check_ssh, not "Unexpected argument")
+    refute_output --partial "Unexpected argument"
+    assert_output --partial "Cannot connect to"
+    rm -rf "$mock_bin"
+}
+
+@test "parse_args recognizes gh:org/repo:branch with branch extraction" {
+    local mock_bin
+    mock_bin="$(mktemp -d)"
+    printf '%s\n' '#!/bin/sh' 'exit 1' > "$mock_bin/ssh"
+    chmod +x "$mock_bin/ssh"
+    PATH="$mock_bin:$PATH" run "$DEVC_REMOTE" --open none myserver gh:vig-os/fd5:feature/my-branch 2>&1
+    refute_output --partial "Unexpected argument"
+    assert_output --partial "Cannot connect to"
+    rm -rf "$mock_bin"
+}
+
+@test "parse_args accepts host:path combined with gh:org/repo" {
+    local mock_bin
+    mock_bin="$(mktemp -d)"
+    printf '%s\n' '#!/bin/sh' 'exit 1' > "$mock_bin/ssh"
+    chmod +x "$mock_bin/ssh"
+    PATH="$mock_bin:$PATH" run "$DEVC_REMOTE" --open none myserver:~/custom/path gh:vig-os/fd5 2>&1
+    refute_output --partial "Unexpected argument"
+    assert_output --partial "Cannot connect to"
+    rm -rf "$mock_bin"
+}
+
+@test "parse_args rejects gh: with missing repo" {
+    run "$DEVC_REMOTE" --open none myserver gh: 2>&1
+    assert_failure
+    assert_output --partial "Invalid gh: target"
+}
+
 # ── detect_editor_cli ─────────────────────────────────────────────────────────
 
 @test "detect_editor_cli prefers cursor when both cursor and code exist" {

--- a/tests/bats/devc-remote.bats
+++ b/tests/bats/devc-remote.bats
@@ -151,6 +151,99 @@ setup() {
     assert_output --partial "Invalid gh: target"
 }
 
+# ── remote_clone_project ─────────────────────────────────────────────────────
+
+@test "remote_clone_project clones repo on fresh target" {
+    local mock_bin
+    mock_bin="$(mktemp -d)"
+    cat > "$mock_bin/ssh" << SSHEOF
+#!/bin/sh
+counter="${mock_bin}/ssh_counter"
+count=\$(cat "\$counter" 2>/dev/null || echo 0)
+echo \$((count + 1)) > "\$counter"
+if [ "\$count" = "1" ]; then
+  echo "CLONE_PATH=/home/user/Projects/fd5"
+  echo "CLONE_STATUS=cloned"
+elif [ "\$count" = "2" ]; then
+  echo "RUNTIME=podman"
+  echo "COMPOSE_AVAILABLE=1"
+  echo "REPO_PATH_EXISTS=1"
+  echo "DEVCONTAINER_EXISTS=1"
+  echo "DISK_AVAILABLE_GB=5"
+  echo "OS_TYPE=linux"
+elif [ "\$count" = "3" ]; then
+  echo '[{"Service":"devcontainer","State":"running","Health":"healthy"}]'
+fi
+exit 0
+SSHEOF
+    chmod +x "$mock_bin/ssh"
+    PATH="$mock_bin:$PATH" run "$DEVC_REMOTE" --open none myserver gh:vig-os/fd5 2>&1
+    assert_success
+    assert_output --partial "Cloning vig-os/fd5"
+    rm -rf "$mock_bin"
+}
+
+@test "remote_clone_project fetches existing repo" {
+    local mock_bin
+    mock_bin="$(mktemp -d)"
+    cat > "$mock_bin/ssh" << SSHEOF
+#!/bin/sh
+counter="${mock_bin}/ssh_counter"
+count=\$(cat "\$counter" 2>/dev/null || echo 0)
+echo \$((count + 1)) > "\$counter"
+if [ "\$count" = "1" ]; then
+  echo "CLONE_PATH=/home/user/Projects/fd5"
+  echo "CLONE_STATUS=fetched"
+elif [ "\$count" = "2" ]; then
+  echo "RUNTIME=podman"
+  echo "COMPOSE_AVAILABLE=1"
+  echo "REPO_PATH_EXISTS=1"
+  echo "DEVCONTAINER_EXISTS=1"
+  echo "DISK_AVAILABLE_GB=5"
+  echo "OS_TYPE=linux"
+elif [ "\$count" = "3" ]; then
+  echo '[{"Service":"devcontainer","State":"running","Health":"healthy"}]'
+fi
+exit 0
+SSHEOF
+    chmod +x "$mock_bin/ssh"
+    PATH="$mock_bin:$PATH" run "$DEVC_REMOTE" --open none myserver gh:vig-os/fd5 2>&1
+    assert_success
+    assert_output --partial "Fetching vig-os/fd5"
+    rm -rf "$mock_bin"
+}
+
+@test "remote_clone_project checks out specified branch" {
+    local mock_bin
+    mock_bin="$(mktemp -d)"
+    cat > "$mock_bin/ssh" << SSHEOF
+#!/bin/sh
+counter="${mock_bin}/ssh_counter"
+count=\$(cat "\$counter" 2>/dev/null || echo 0)
+echo \$((count + 1)) > "\$counter"
+if [ "\$count" = "1" ]; then
+  echo "CLONE_PATH=/home/user/Projects/fd5"
+  echo "CLONE_STATUS=cloned"
+  echo "CLONE_BRANCH=feature/my-branch"
+elif [ "\$count" = "2" ]; then
+  echo "RUNTIME=podman"
+  echo "COMPOSE_AVAILABLE=1"
+  echo "REPO_PATH_EXISTS=1"
+  echo "DEVCONTAINER_EXISTS=1"
+  echo "DISK_AVAILABLE_GB=5"
+  echo "OS_TYPE=linux"
+elif [ "\$count" = "3" ]; then
+  echo '[{"Service":"devcontainer","State":"running","Health":"healthy"}]'
+fi
+exit 0
+SSHEOF
+    chmod +x "$mock_bin/ssh"
+    PATH="$mock_bin:$PATH" run "$DEVC_REMOTE" --open none myserver gh:vig-os/fd5:feature/my-branch 2>&1
+    assert_success
+    assert_output --partial "Checked out feature/my-branch"
+    rm -rf "$mock_bin"
+}
+
 # ── detect_editor_cli ─────────────────────────────────────────────────────────
 
 @test "detect_editor_cli prefers cursor when both cursor and code exist" {


### PR DESCRIPTION
## Description

Add `gh:org/repo[:branch]` target syntax to `devc-remote.sh`, enabling one-command clone-and-start of a project's devcontainer on a remote host. Existing `host:path` syntax continues to work unchanged.

## Type of Change

- [x] `feat` -- New feature
- [ ] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [ ] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- `scripts/devc-remote.sh` — Extended `parse_args` to recognize `gh:org/repo[:branch]` as second positional arg; new `remote_clone_project` function (single SSH call: clone or fetch, optional branch checkout, config-based path resolution); wired into `main()` between `check_ssh` and `remote_preflight`; updated help text with new syntax and examples
- `assets/workspace/scripts/devc-remote.sh` — Synced copy via manifest
- `tests/bats/devc-remote.bats` — 7 new tests: 4 for arg parsing (gh:org/repo, gh:org/repo:branch, host:path+gh:, invalid gh:), 3 for clone function (fresh clone, fetch existing, branch checkout)
- `CHANGELOG.md` — Added entry under Unreleased

## Changelog Entry

### Added
- **`gh:org/repo[:branch]` target for devc-remote** ([#236](https://github.com/vig-os/devcontainer/issues/236))
  - Clone a GitHub repo on the remote host and start its devcontainer in one command
  - Supports `gh:org/repo` (default branch) and `gh:org/repo:branch` (specific branch)
  - Already-cloned repos are fetched, not re-cloned
  - Clone location resolved from remote config `projects_dir` or overridden via `host:path`

## Testing

- [x] Tests pass locally (`just test`)
- [ ] Manual testing performed (describe below)

### Manual Testing Details

N/A

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

Design: https://github.com/vig-os/devcontainer/issues/236#issuecomment-4019537584

Refs: #236
