### PR TITLE
fix: remove CodeQL PR path filter to satisfy merge protection

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -18,8 +18,6 @@ on:  # yamllint disable-line rule:truthy
       - dev
       - 'release/**'
       - main
-    paths:
-      - '**.py'
   push:
     branches:
       - main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -526,6 +526,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Sidecar recipes now support both podman and docker runtimes for listing, starting, and executing sidecar commands
   - Worktree and GitHub helper recipes now fail fast with actionable guidance when helper CLIs are unavailable
   - Label taxonomy guidance clarifies that `setup-labels` is provided by devcontainer bootstrap tooling
+- **CodeQL PR trigger no longer blocks merge protection on non-Python changes** ([#247](https://github.com/vig-os/devcontainer/issues/247))
+  - Removed `pull_request` `paths` filter from `codeql.yml` in both root and workspace template so CodeQL always runs for PRs targeting protected branches and uploads SARIF results
 
 ### Security
 

--- a/assets/workspace/.github/workflows/codeql.yml
+++ b/assets/workspace/.github/workflows/codeql.yml
@@ -18,8 +18,6 @@ on:  # yamllint disable-line rule:truthy
       - dev
       - 'release/**'
       - main
-    paths:
-      - '**.py'
   push:
     branches:
       - main


### PR DESCRIPTION
## Description

Remove the `pull_request` `paths` filter from CodeQL workflows so PRs with non-Python changes still run CodeQL and upload SARIF results, preventing merge protection from getting stuck waiting for missing results.

## Type of Change

- [ ] `feat` -- New feature
- [x] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [ ] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- `.github/workflows/codeql.yml`
  - Removed `pull_request.paths` (`'**.py'`) so CodeQL always runs for PRs to `dev`, `release/**`, and `main`
- `assets/workspace/.github/workflows/codeql.yml`
  - Mirrored the same trigger change in the workspace template copy
- `CHANGELOG.md`
  - Added an Unreleased `### Fixed` entry for issue `#247`

## Changelog Entry

### Fixed

- **CodeQL PR trigger no longer blocks merge protection on non-Python changes** ([#247](https://github.com/vig-os/devcontainer/issues/247))
  - Removed `pull_request` `paths` filter from `codeql.yml` in both root and workspace template so CodeQL always runs for PRs targeting protected branches and uploads SARIF results

## Testing

- [ ] Tests pass locally (`just test`)
- [ ] Manual testing performed (describe below)

### Manual Testing Details

N/A

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

This branch is based on `feature/173-wire-cross-repo-dispatch-release-gate`.

Refs: #247
## Description

Remove the `pull_request` `paths` filter from CodeQL workflows so PRs with non-Python changes still run CodeQL and upload SARIF results, preventing merge protection from getting stuck waiting for missing results.

## Type of Change

- [ ] `feat` -- New feature
- [x] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [ ] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- `.github/workflows/codeql.yml`
  - Removed `pull_request.paths` (`'**.py'`) so CodeQL always runs for PRs to `dev`, `release/**`, and `main`
- `assets/workspace/.github/workflows/codeql.yml`
  - Mirrored the same trigger change in the workspace template copy
- `CHANGELOG.md`
  - Added an Unreleased `### Fixed` entry for issue `#247`

## Changelog Entry

### Fixed

- **CodeQL PR trigger no longer blocks merge protection on non-Python changes** ([#247](https://github.com/vig-os/devcontainer/issues/247))
  - Removed `pull_request` `paths` filter from `codeql.yml` in both root and workspace template so CodeQL always runs for PRs targeting protected branches and uploads SARIF results

## Testing

- [ ] Tests pass locally (`just test`)
- [ ] Manual testing performed (describe below)

### Manual Testing Details

N/A

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

This branch is based on `feature/173-wire-cross-repo-dispatch-release-gate`.

Refs: #247
