### PR TITLE
feat: add smoke-test asset deployment workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Taplo TOML linting in pre-commit** ([#181](https://github.com/vig-os/devcontainer/issues/181))
   - Add SHA-pinned `taplo-format` and `taplo-lint` hooks to enforce TOML formatting and schema-aware validation
   - Add `.taplo.toml` configuration (local to this repository, not synced downstream)
+- **Add `--smoke-test` flag to deploy smoke-test-specific assets** ([#250](https://github.com/vig-os/devcontainer/issues/250))
+  - `init-workspace.sh --smoke-test` deploys files from `assets/smoke-test/` (currently `repository-dispatch.yml` and `README.md`)
+  - `install.sh` forwards `--smoke-test` flag to `init-workspace.sh`
+  - Smoke mode implies `--force --no-prompts` for unattended use
+  - Refactor `initialized_workspace` fixture into reusable `_init_workspace()` with `smoke_test` parameter
 
 ### Changed
 

--- a/assets/init-workspace.sh
+++ b/assets/init-workspace.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 # Initialize workspace by copying template files
 #
-# Usage: init-workspace [--force] [--no-prompts]
+# Usage: init-workspace [--force] [--no-prompts] [--smoke-test]
 #
 # Options:
 #   --force       Overwrite existing files (for upgrades)
 #   --no-prompts  Run non-interactively (requires SHORT_NAME env var)
+#   --smoke-test  Deploy smoke-test-specific assets
 #
 # Environment variables (used with --no-prompts):
 #   SHORT_NAME  - Project short name (required)
@@ -17,6 +18,7 @@ TEMPLATE_DIR="/root/assets/workspace"
 WORKSPACE_DIR="/workspace"
 FORCE=false
 NO_PROMPTS=false
+SMOKE_TEST=false
 
 # Files to preserve during --force upgrades (never overwrite if they exist)
 # These are user/project customization files that should survive upgrades
@@ -43,13 +45,22 @@ for arg in "$@"; do
         --no-prompts)
             NO_PROMPTS=true
             ;;
+        --smoke-test)
+            SMOKE_TEST=true
+            ;;
         *)
             echo "Unknown option: $arg" >&2
-            echo "Usage: init-workspace [--force] [--no-prompts]" >&2
+            echo "Usage: init-workspace [--force] [--no-prompts] [--smoke-test]" >&2
             exit 1
             ;;
     esac
 done
+
+# Smoke mode must run unattended and allow overwriting existing content.
+if [[ "$SMOKE_TEST" == "true" ]]; then
+    NO_PROMPTS=true
+    FORCE=true
+fi
 
 # Check if running in interactive mode (only if prompts are needed)
 if [[ "$NO_PROMPTS" != "true" ]] && [[ ! -t 0 ]]; then
@@ -212,6 +223,16 @@ done
 # via UV_PROJECT_ENVIRONMENT environment variable (set in docker-compose.yml)
 # Pre-commit cache is now at /opt/pre-commit-cache (not in assets/workspace)
 rsync -av --exclude='.git' --exclude='.venv' "${EXCLUDE_ARGS[@]}" "$TEMPLATE_DIR/" "$WORKSPACE_DIR/"
+
+if [[ "$SMOKE_TEST" == "true" ]]; then
+    SMOKE_TEST_DIR="$SCRIPT_DIR/smoke-test"
+    if [[ -d "$SMOKE_TEST_DIR" ]]; then
+        echo "Deploying smoke-test-specific files..."
+        rsync -av "$SMOKE_TEST_DIR/" "$WORKSPACE_DIR/"
+    else
+        echo "Warning: Smoke-test directory not found at $SMOKE_TEST_DIR" >&2
+    fi
+fi
 
 # Replace placeholders in files (using pre-built manifest from image)
 echo "Replacing placeholders in files..."

--- a/assets/init-workspace.sh
+++ b/assets/init-workspace.sh
@@ -211,20 +211,13 @@ fi
 echo "Initializing workspace from template..."
 echo "Copying files from $TEMPLATE_DIR to $WORKSPACE_DIR..."
 
-# Build exclude list for preserved files that already exist
-EXCLUDE_ARGS=()
-for preserved in "${PRESERVE_FILES[@]}"; do
-    if [[ -e "$WORKSPACE_DIR/$preserved" ]]; then
-        EXCLUDE_ARGS+=("--exclude=$preserved")
-    fi
-done
-
 # Note: Excluding .venv - it is used directly from the container image
 # via UV_PROJECT_ENVIRONMENT environment variable (set in docker-compose.yml)
 # Pre-commit cache is now at /opt/pre-commit-cache (not in assets/workspace)
-rsync -av --exclude='.git' --exclude='.venv' "${EXCLUDE_ARGS[@]}" "$TEMPLATE_DIR/" "$WORKSPACE_DIR/"
-
 if [[ "$SMOKE_TEST" == "true" ]]; then
+    # Smoke mode: clean deploy (--delete removes stale files), then overlay smoke-test assets
+    rsync -av --delete --exclude='.git' --exclude='.venv' "$TEMPLATE_DIR/" "$WORKSPACE_DIR/"
+
     SMOKE_TEST_DIR="$SCRIPT_DIR/smoke-test"
     if [[ -d "$SMOKE_TEST_DIR" ]]; then
         echo "Deploying smoke-test-specific files..."
@@ -232,6 +225,16 @@ if [[ "$SMOKE_TEST" == "true" ]]; then
     else
         echo "Warning: Smoke-test directory not found at $SMOKE_TEST_DIR" >&2
     fi
+else
+    # Build exclude list for preserved files that already exist
+    EXCLUDE_ARGS=()
+    for preserved in "${PRESERVE_FILES[@]}"; do
+        if [[ -e "$WORKSPACE_DIR/$preserved" ]]; then
+            EXCLUDE_ARGS+=("--exclude=$preserved")
+        fi
+    done
+
+    rsync -av --exclude='.git' --exclude='.venv' "${EXCLUDE_ARGS[@]}" "$TEMPLATE_DIR/" "$WORKSPACE_DIR/"
 fi
 
 # Replace placeholders in files (using pre-built manifest from image)

--- a/assets/smoke-test/.github/workflows/repository-dispatch.yml
+++ b/assets/smoke-test/.github/workflows/repository-dispatch.yml
@@ -1,0 +1,94 @@
+name: Repository Dispatch Listener
+
+on:  # yamllint disable-line rule:truthy
+  repository_dispatch:
+    types:
+      - smoke-test-trigger
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  validate:
+    name: Validate dispatch payload
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    outputs:
+      rc_tag: ${{ steps.extract.outputs.rc_tag }}
+    steps:
+      - name: Extract and validate rc_tag
+        id: extract
+        env:
+          EVENT_ACTION: ${{ github.event.action }}
+          EVENT_TYPE: ${{ github.event.client_payload.event_type || '' }}
+          RC_TAG: ${{ github.event.client_payload.rc_tag || '' }}
+          SOURCE_REPO: ${{ github.event.client_payload.source_repo || '' }}
+        run: |
+          echo "repository_dispatch received"
+          echo "action=${EVENT_ACTION}"
+          echo "event_type=${EVENT_TYPE}"
+          echo "rc_tag=${RC_TAG}"
+          echo "source_repo=${SOURCE_REPO}"
+
+          if [ -z "${RC_TAG}" ]; then
+            echo "ERROR: rc_tag is required in github.event.client_payload"
+            exit 1
+          fi
+
+          echo "rc_tag=${RC_TAG}" >> "${GITHUB_OUTPUT}"
+
+  ci-bare:
+    name: Run bare-runner CI
+    needs: validate
+    uses: ./.github/workflows/ci.yml
+
+  ci-container:
+    name: Run container CI
+    needs: validate
+    uses: ./.github/workflows/ci-container.yml
+    with:
+      image-tag: ${{ needs.validate.outputs.rc_tag }}
+
+  summary:
+    name: Dispatch summary
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    needs: [validate, ci-bare, ci-container]
+    if: always()
+    steps:
+      - name: Check orchestration results
+        run: |
+          echo "Repository Dispatch Results Summary"
+          echo "==================================="
+          echo ""
+          echo "Validate:     ${{ needs.validate.result }}"
+          echo "CI (bare):    ${{ needs.ci-bare.result }}"
+          echo "CI (container): ${{ needs.ci-container.result }}"
+          echo ""
+
+          FAILED=false
+
+          if [ "${{ needs.validate.result }}" != "success" ]; then
+            echo "ERROR: Dispatch payload validation failed"
+            FAILED=true
+          fi
+
+          if [ "${{ needs.ci-bare.result }}" != "success" ]; then
+            echo "ERROR: Bare-runner CI failed"
+            FAILED=true
+          fi
+
+          if [ "${{ needs.ci-container.result }}" != "success" ]; then
+            echo "ERROR: Container CI failed"
+            FAILED=true
+          fi
+
+          if [ "${FAILED}" = "true" ]; then
+            echo ""
+            echo "Dispatch orchestration failed"
+            exit 1
+          fi
+
+          echo ""
+          echo "Dispatch orchestration passed"

--- a/assets/smoke-test/README.md
+++ b/assets/smoke-test/README.md
@@ -1,0 +1,58 @@
+# devcontainer Smoke Test
+
+This repository is a smoke-test workspace for the
+[vig-os/devcontainer](https://github.com/vig-os/devcontainer) project.
+
+Its purpose is to verify that the devcontainer template and the shipped CI
+workflow run successfully on real GitHub-hosted runners, not only in local or
+synthetic test environments.
+
+## Why this repo exists
+
+The main `vig-os/devcontainer` repository publishes template files under
+`assets/workspace/`, including a CI workflow
+(`assets/workspace/.github/workflows/ci.yml`).
+
+This repository provides a real target where that template can be bootstrapped
+and executed end-to-end so regressions are caught early, for example:
+
+- broken GitHub Action pins
+- runner environment changes
+- dependency/tooling incompatibilities (for example `uv` changes)
+
+## Scope
+
+This repository is intentionally minimal. It is used to:
+
+1. bootstrap a fresh workspace from the current devcontainer template
+2. run the shipped CI workflow on pull requests
+3. validate that expected jobs pass in GitHub Actions
+4. host CI wiring experiments such as `repository_dispatch` listeners
+
+## Relationship to `vig-os/devcontainer`
+
+- **Source of truth for template**: `vig-os/devcontainer`
+- **Execution/verification target**: this repository
+
+Template or workflow changes should be made in
+[`vig-os/devcontainer`](https://github.com/vig-os/devcontainer), then validated
+here through a normal PR run.
+
+## Recreate this smoke-test repo
+
+If this repository is lost or needs to be rebuilt, recreate it from the
+`vig-os/devcontainer` image/template:
+
+1. Create a new empty repository (for example `vig-os/devcontainer-smoke-test`).
+2. Clone it locally and run the installer with smoke-test assets enabled:
+
+   ```bash
+   curl -sSf https://vig-os.github.io/devcontainer/install.sh | sh -s -- --smoke-test .
+   ```
+
+3. Commit the generated files and push to `main`.
+4. Open a PR and confirm both shipped workflows pass:
+   - `.github/workflows/ci.yml`
+   - `.github/workflows/ci-container.yml`
+5. Verify `.github/workflows/repository-dispatch.yml` exists and listens for
+   `repository_dispatch` events.

--- a/install.sh
+++ b/install.sh
@@ -391,7 +391,7 @@ fi
 
 if [ "$DRY_RUN" = true ]; then
     info "Would execute:"
-    printf "  %s" "$RUNTIME run --rm -e SHORT_NAME=\"$PROJECT_NAME\" -e ORG_NAME=\"$ORG_NAME\" -v $PROJECT_PATH:/workspace $IMAGE /root/assets/init-workspace.sh --no-prompts"
+    printf "  %s" "$RUNTIME run --rm -e SHORT_NAME=\"$PROJECT_NAME\" -e ORG_NAME=\"$ORG_NAME\" -v \"$PROJECT_PATH\":/workspace \"$IMAGE\" /root/assets/init-workspace.sh --no-prompts"
     if [ -n "$FORCE" ]; then
         printf " %s" "--force"
     fi

--- a/install.sh
+++ b/install.sh
@@ -12,6 +12,7 @@
 #   --podman          Force podman
 #   --name NAME       Override project name (SHORT_NAME)
 #   --org ORG         Override organization name (default: vigOS)
+#   --smoke-test      Deploy smoke-test-specific assets
 #   --dry-run         Show what would be done without executing
 #   -h, --help        Show this help message
 #
@@ -33,6 +34,7 @@ SKIP_PULL=false
 PROJECT_PATH=""
 PROJECT_NAME=""
 ORG_NAME="vigOS"
+SMOKE_TEST=""
 
 # Colors (disabled if not a tty)
 if [ -t 1 ]; then
@@ -65,6 +67,7 @@ OPTIONS:
     --podman          Force podman runtime
     --name NAME       Override project name (SHORT_NAME, used for module name)
     --org ORG         Override organization name (default: vigOS)
+    --smoke-test      Deploy smoke-test-specific assets
     --dry-run         Show what would be done
     -h, --help        Show this help
 
@@ -267,6 +270,10 @@ while [ $# -gt 0 ]; do
             DRY_RUN=true
             shift
             ;;
+        --smoke-test)
+            SMOKE_TEST="--smoke-test"
+            shift
+            ;;
         --skip-pull)
             SKIP_PULL=true
             shift
@@ -378,11 +385,18 @@ if [ -n "$FORCE" ]; then
     CMD+=(--force)
 fi
 
+if [ -n "$SMOKE_TEST" ]; then
+    CMD+=(--smoke-test)
+fi
+
 if [ "$DRY_RUN" = true ]; then
     info "Would execute:"
     printf "  %s" "$RUNTIME run --rm -e SHORT_NAME=\"$PROJECT_NAME\" -e ORG_NAME=\"$ORG_NAME\" -v $PROJECT_PATH:/workspace $IMAGE /root/assets/init-workspace.sh --no-prompts"
     if [ -n "$FORCE" ]; then
         printf " %s" "--force"
+    fi
+    if [ -n "$SMOKE_TEST" ]; then
+        printf " %s" "--smoke-test"
     fi
     printf "\n"
     exit 0

--- a/tests/bats/init-workspace.bats
+++ b/tests/bats/init-workspace.bats
@@ -79,3 +79,8 @@ setup() {
     # shellcheck disable=SC2016
     assert_output --partial 'FORCE=true'
 }
+
+@test "init-workspace.sh smoke mode uses rsync --delete for clean deploy" {
+    run grep 'rsync -av --delete' "$INIT_WORKSPACE_SH"
+    assert_success
+}

--- a/tests/bats/init-workspace.bats
+++ b/tests/bats/init-workspace.bats
@@ -52,3 +52,30 @@ setup() {
     # shellcheck disable=SC2016
     assert_output --partial 'EXCLUDE_ARGS+=("--exclude=$preserved")'
 }
+
+@test "init-workspace.sh accepts --smoke-test flag" {
+    run grep -- '--smoke-test' "$INIT_WORKSPACE_SH"
+    assert_success
+}
+
+@test "init-workspace.sh uses SCRIPT_DIR smoke-test assets path" {
+    # shellcheck disable=SC2016
+    run grep 'SMOKE_TEST_DIR="$SCRIPT_DIR/smoke-test"' "$INIT_WORKSPACE_SH"
+    assert_success
+}
+
+@test "init-workspace.sh smoke mode implies --no-prompts" {
+    # shellcheck disable=SC2016
+    run grep -A4 'if \[\[ "\$SMOKE_TEST" == "true" \]\]' "$INIT_WORKSPACE_SH"
+    assert_success
+    # shellcheck disable=SC2016
+    assert_output --partial 'NO_PROMPTS=true'
+}
+
+@test "init-workspace.sh smoke mode implies --force" {
+    # shellcheck disable=SC2016
+    run grep -A4 'if \[\[ "\$SMOKE_TEST" == "true" \]\]' "$INIT_WORKSPACE_SH"
+    assert_success
+    # shellcheck disable=SC2016
+    assert_output --partial 'FORCE=true'
+}

--- a/tests/bats/install.bats
+++ b/tests/bats/install.bats
@@ -49,6 +49,7 @@ setup() {
     assert_output --partial "--name"
     assert_output --partial "--org"
     assert_output --partial "--dry-run"
+    assert_output --partial "--smoke-test"
 }
 
 # ── unknown option ────────────────────────────────────────────────────────────
@@ -95,6 +96,12 @@ setup() {
     run bash "$INSTALL_SH" --dry-run --force .
     assert_success
     assert_output --partial "--force"
+}
+
+@test "smoke-test flag is forwarded to init-workspace.sh" {
+    run bash "$INSTALL_SH" --dry-run --smoke-test .
+    assert_success
+    assert_output --partial "--smoke-test"
 }
 
 # ── org flag ──────────────────────────────────────────────────────────────────

--- a/tests/bats/install.bats
+++ b/tests/bats/install.bats
@@ -76,6 +76,13 @@ setup() {
     assert_output --partial "ghcr.io/vig-os/devcontainer"
 }
 
+@test "dry-run output quotes project path and image for safe copy-paste" {
+    run bash "$INSTALL_SH" --dry-run .
+    assert_success
+    assert_output --regexp '"[^"]+":/workspace'
+    assert_output --regexp '"ghcr.io/vig-os/devcontainer:[^"]+"'
+}
+
 # ── version flag ──────────────────────────────────────────────────────────────
 
 @test "version flag appears in dry-run command" {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -289,51 +289,184 @@ def host(test_container):
     return host
 
 
-@pytest.fixture(scope="session")
-def initialized_workspace(container_image):
+# --- Helpers and fixtures for init-workspace.sh ---
+
+
+def _build_podman_cmd(container_image, workspace_mount, smoke_test):
+    """Build podman command for init-workspace script."""
+    cmd = ["podman", "run", "--rm", "-v", workspace_mount]
+    if smoke_test:
+        cmd.extend(["-e", "SHORT_NAME=test_project", "-e", "ORG_NAME=Test Org"])
+    else:
+        cmd.append("-it")
+    cmd.extend([container_image, "/root/assets/init-workspace.sh"])
+    if smoke_test:
+        cmd.append("--smoke-test")
+    return cmd
+
+
+def _run_noninteractive_init(cmd):
+    """Run init-workspace in non-interactive mode."""
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=180)
+    if result.returncode != 0:
+        pytest.fail(
+            "Failed to initialize workspace with init-workspace.sh (non-interactive)\n"
+            f"Command: {' '.join(cmd)}\n"
+            f"stdout: {result.stdout}\n"
+            f"stderr: {result.stderr}"
+        )
+
+
+def _run_interactive_init(cmd, container_image):
+    """Run init-workspace in interactive mode with pexpect progress tracking."""
+    project_name = "test_project"
+    organization_name = "Test Org"
+    stages = {
+        "started": None,
+        "short_name_prompt": None,
+        "org_name_prompt": None,
+        "copying_files": None,
+        "replacing_placeholders": None,
+        "setting_permissions": None,
+        "syncing_deps": None,
+        "completed": None,
+    }
+    current_stage = "started"
+    stages["started"] = time.time()
+    stage_patterns = [
+        ("Copying files from", "copying_files", 30),
+        ("Replacing placeholders", "replacing_placeholders", 60),
+        ("Setting executable permissions", "setting_permissions", 30),
+        ("Syncing dependencies", "syncing_deps", 60),
+        ("Workspace initialized successfully", "completed", 30),
+    ]
+
+    try:
+        child = pexpect.spawn(" ".join(cmd), encoding="utf-8", timeout=60)
+        child.expect("Enter a short name", timeout=30)
+        stages["short_name_prompt"] = time.time()
+        current_stage = "short_name_prompt"
+        child.sendline(project_name)
+
+        child.expect("Enter the name of your organization", timeout=30)
+        stages["org_name_prompt"] = time.time()
+        current_stage = "org_name_prompt"
+        child.sendline(organization_name)
+
+        for pattern, stage_name, timeout in stage_patterns:
+            try:
+                child.expect(pattern, timeout=timeout)
+                stages[stage_name] = time.time()
+                current_stage = stage_name
+            except pexpect.TIMEOUT:
+                stage_start = stages.get(current_stage) or stages["started"]
+                time_in_stage = time.time() - stage_start
+                pytest.fail(
+                    f"⏱️  Timeout waiting for: '{pattern}'\n"
+                    f"\n"
+                    f"📊 Progress tracking:\n"
+                    f"   Current stage: {current_stage}\n"
+                    f"   Time in stage: {time_in_stage:.1f}s (timeout: {timeout}s)\n"
+                    f"\n"
+                    f"📈 Stage timings:\n"
+                    + "\n".join(
+                        f"   {'✓' if stages[s] else '✗'} {s}: "
+                        + (
+                            f"{stages[s] - stages['started']:.1f}s"
+                            if stages[s]
+                            else "not reached"
+                        )
+                        for s in stages
+                    )
+                    + "\n\n"
+                    "💡 If stuck on 'copying_files':\n"
+                    "   - Check if .pre-commit-cache is being copied (should be excluded)\n"
+                    "   - Volume mounts can be slow\n"
+                    f"   - Check: podman run --rm {container_image} du -sh /root/assets/workspace/\n"
+                    "\n"
+                    f"📤 Last output:\n{child.before}"
+                )
+
+        child.expect(pexpect.EOF, timeout=30)
+        child.close()
+        if child.exitstatus != 0:
+            pytest.fail(
+                "Failed to initialize workspace with init-workspace.sh\n"
+                f"Return code: {child.exitstatus}\n"
+                f"Output: {child.before}"
+            )
+
+        total_time = time.time() - stages["started"]
+        print(f"[DEBUG] Workspace initialized in {total_time:.1f}s")
+    except pexpect.TIMEOUT:
+        output = child.before if "child" in locals() else "N/A"
+        stage_start = stages.get(current_stage) or stages.get("started") or time.time()
+        time_in_stage = time.time() - stage_start
+        pytest.fail(
+            "⏱️  Timeout while initializing workspace\n"
+            "\n"
+            "📊 Progress tracking:\n"
+            f"   Current stage: {current_stage}\n"
+            f"   Time in stage: {time_in_stage:.1f}s\n"
+            "\n"
+            "📈 Stage timings:\n"
+            + "\n".join(
+                f"   {'✓' if stages[s] else '✗'} {s}: "
+                + (
+                    f"{stages[s] - stages['started']:.1f}s"
+                    if stages[s]
+                    else "not reached"
+                )
+                for s in stages
+            )
+            + "\n\n"
+            f"Command: {' '.join(cmd)}\n"
+            "\n"
+            f"📤 Last output:\n{output}"
+        )
+    except pexpect.EOF:
+        output = child.before if "child" in locals() else "N/A"
+        pytest.fail(
+            "Error while initializing workspace with init-workspace.sh: EOF\n"
+            f"Command: {' '.join(cmd)}\n"
+            f"Output so far: {output}\n"
+            "This usually means the container exited before responding.\n"
+            "Check that the image exists and the command is correct."
+        )
+    except pexpect.ExceptionPexpect as e:
+        output = child.before if "child" in locals() else "N/A"
+        pytest.fail(
+            f"Error while initializing workspace with init-workspace.sh: {e}\n"
+            f"Command: {' '.join(cmd)}\n"
+            f"Output: {output}"
+        )
+
+
+def _init_workspace(container_image, *, smoke_test=False):
     """
     Create a temporary workspace directory and initialize it with init-workspace.
 
-    This fixture supports running from both:
-    1. Host machine - uses direct bind mounts
-    2. Inside a devcontainer - uses podman compose with named volumes
-
-    When running inside a container (Docker-out-of-Docker), we use compose
-    to handle volume management, avoiding the host path translation issue.
-
-    The workspace will be cleaned up when the test session ends.
+    Supports running from host and from inside a container.
     """
-    # Get the project root (assuming conftest.py is in tests/)
     project_root = Path(__file__).resolve().parents[1]
     tests_dir = project_root / "tests"
-
-    # Check if we're running inside a container
     in_container = is_running_in_container()
 
-    # Always use tests/tmp - it's in the shared workspace which is mounted
-    # both on host and in container, so both can access it
     tests_tmp_dir = tests_dir / "tmp"
     tests_tmp_dir.mkdir(parents=True, exist_ok=True)
     workspace_dir = tempfile.mkdtemp(
         dir=str(tests_tmp_dir), prefix="workspace-devcontainer-"
     )
-
     workspace_path = Path(workspace_dir)
 
-    # Generate unique names for compose project and volume
     unique_id = workspace_path.name.replace("workspace-devcontainer-", "")
-    compose_project = f"test-{unique_id}"
     volume_name = f"test-workspace-{unique_id}"
+    using_compose = in_container
 
-    # Track whether we're using compose (for cleanup)
-    using_compose = False
-
-    # Register cleanup function
     def cleanup():
         if workspace_path.exists():
             shutil.rmtree(workspace_path, ignore_errors=True)
         if using_compose:
-            # Clean up the named volume
             subprocess.run(
                 ["podman", "volume", "rm", "-f", volume_name],
                 capture_output=True,
@@ -342,379 +475,81 @@ def initialized_workspace(container_image):
 
     atexit.register(cleanup)
 
-    # Run init-workspace in the container
-    # The script requires an interactive terminal (-it) and expects input
-    project_name = "test_project"
-    organization_name = "Test Org"
-
-    if in_container:
-        # Use podman with named volumes to avoid path translation issues
-        # Named volumes work everywhere without needing compose
-        using_compose = True  # We still track this for volume cleanup
-
-        # Create the named volume
-        create_volume_cmd = ["podman", "volume", "create", volume_name]
-        create_result = subprocess.run(
-            create_volume_cmd, capture_output=True, text=True, timeout=30
-        )
-
-        if create_result.returncode != 0:
-            cleanup()
-            pytest.fail(
-                f"Failed to create volume {volume_name}\n"
-                f"stdout: {create_result.stdout}\n"
-                f"stderr: {create_result.stderr}"
+    try:
+        if in_container:
+            create_result = subprocess.run(
+                ["podman", "volume", "create", volume_name],
+                capture_output=True,
+                text=True,
+                timeout=30,
             )
-
-        print(f"[DEBUG] Created volume: {volume_name}")
-
-        # Run init-workspace with the named volume
-        cmd = [
-            "podman",
-            "run",
-            "-it",
-            "--rm",
-            "-v",
-            f"{volume_name}:/workspace",
-            container_image,
-            "/root/assets/init-workspace.sh",
-        ]
-
-        # Track progress through stages for better timeout diagnostics
-        stages = {
-            "started": None,
-            "short_name_prompt": None,
-            "org_name_prompt": None,
-            "copying_files": None,
-            "replacing_placeholders": None,
-            "setting_permissions": None,
-            "syncing_deps": None,
-            "completed": None,
-        }
-        current_stage = "started"
-        stages["started"] = time.time()
-
-        try:
-            # Spawn the process with pexpect
-            print(f"[DEBUG] Running podman command: {' '.join(cmd)}")
-            print(f"[DEBUG] Volume: {volume_name}, Image: {container_image}")
-
-            child = pexpect.spawn(" ".join(cmd), encoding="utf-8", timeout=60)
-
-            # Stage 1: Wait for short name prompt
-            child.expect("Enter a short name", timeout=30)
-            stages["short_name_prompt"] = time.time()
-            current_stage = "short_name_prompt"
-            child.sendline(project_name)
-
-            # Stage 2: Wait for org name prompt
-            child.expect("Enter the name of your organization", timeout=30)
-            stages["org_name_prompt"] = time.time()
-            current_stage = "org_name_prompt"
-            child.sendline(organization_name)
-
-            # Stage 3: Monitor progress through remaining stages
-            stage_patterns = [
-                ("Copying files from", "copying_files", 30),
-                ("Replacing placeholders", "replacing_placeholders", 60),
-                ("Setting executable permissions", "setting_permissions", 30),
-                ("Syncing dependencies", "syncing_deps", 60),
-                ("Workspace initialized successfully", "completed", 30),
-            ]
-
-            for pattern, stage_name, timeout in stage_patterns:
-                try:
-                    child.expect(pattern, timeout=timeout)
-                    stages[stage_name] = time.time()
-                    current_stage = stage_name
-                except pexpect.TIMEOUT:
-                    stage_start = stages.get(current_stage) or stages["started"]
-                    time_in_stage = time.time() - stage_start
-
-                    cleanup()
-                    pytest.fail(
-                        f"⏱️  Timeout waiting for: '{pattern}'\n"
-                        f"\n"
-                        f"📊 Progress tracking:\n"
-                        f"   Current stage: {current_stage}\n"
-                        f"   Time in stage: {time_in_stage:.1f}s (timeout: {timeout}s)\n"
-                        f"\n"
-                        f"📈 Stage timings:\n"
-                        + "\n".join(
-                            f"   {'✓' if stages[s] else '✗'} {s}: "
-                            + (
-                                f"{stages[s] - stages['started']:.1f}s"
-                                if stages[s]
-                                else "not reached"
-                            )
-                            for s in stages
-                        )
-                        + f"\n\n"
-                        f"💡 If stuck on 'copying_files':\n"
-                        f"   - Check if .pre-commit-cache is being copied (should be excluded)\n"
-                        f"   - Volume mounts can be slow\n"
-                        f"\n"
-                        f"📤 Last output:\n{child.before}"
-                    )
-
-            # Wait for EOF
-            child.expect(pexpect.EOF, timeout=30)
-            child.close()
-
-            # Check return code
-            if child.exitstatus != 0:
-                cleanup()
+            if create_result.returncode != 0:
                 pytest.fail(
-                    f"Failed to initialize workspace with init-workspace.sh\n"
-                    f"Return code: {child.exitstatus}\n"
-                    f"Output: {child.before}"
+                    f"Failed to create volume {volume_name}\n"
+                    f"stdout: {create_result.stdout}\n"
+                    f"stderr: {create_result.stderr}"
                 )
+            print(f"[DEBUG] Created volume: {volume_name}")
+            workspace_mount = f"{volume_name}:/workspace"
+        else:
+            workspace_mount = f"{workspace_path}:/workspace"
 
-            # Log successful timing
-            total_time = time.time() - stages["started"]
-            print(f"[DEBUG] Workspace initialized in {total_time:.1f}s")
+        cmd = _build_podman_cmd(container_image, workspace_mount, smoke_test)
+        if smoke_test:
+            _run_noninteractive_init(cmd)
+        else:
+            _run_interactive_init(cmd, container_image)
 
-        except pexpect.TIMEOUT:
-            cleanup()
-            output = child.before if "child" in locals() else "N/A"
-            stage_start = (
-                stages.get(current_stage) or stages.get("started") or time.time()
-            )
-            time_in_stage = time.time() - stage_start
-
-            pytest.fail(
-                f"⏱️  Timeout while initializing workspace\n"
-                f"\n"
-                f"📊 Progress tracking:\n"
-                f"   Current stage: {current_stage}\n"
-                f"   Time in stage: {time_in_stage:.1f}s\n"
-                f"\n"
-                f"📈 Stage timings:\n"
-                + "\n".join(
-                    f"   {'✓' if stages[s] else '✗'} {s}: "
-                    + (
-                        f"{stages[s] - stages['started']:.1f}s"
-                        if stages[s]
-                        else "not reached"
-                    )
-                    for s in stages
-                )
-                + f"\n\n"
-                f"Command: {' '.join(cmd)}\n"
-                f"\n"
-                f"📤 Last output:\n{output}"
-            )
-        except pexpect.EOF:
-            cleanup()
-            output = child.before if "child" in locals() else "N/A"
-            pytest.fail(
-                f"Error while initializing workspace with init-workspace.sh: EOF\n"
-                f"Command: {' '.join(cmd)}\n"
-                f"Output so far: {output}\n"
-                f"This usually means the container exited before responding.\n"
-                f"Check that the image exists and the compose file is correct."
-            )
-        except pexpect.ExceptionPexpect as e:
-            cleanup()
-            output = child.before if "child" in locals() else "N/A"
-            pytest.fail(
-                f"Error while initializing workspace with init-workspace.sh: {e}\n"
-                f"Command: {' '.join(cmd)}\n"
-                f"Output: {output}"
-            )
-
-        # Copy files from the named volume to the local temp directory
-        # The temp directory is in /workspace/devcontainer/tests/tmp which is
-        # shared between host and container, so we use host path for the mount
-        workspace_path_host = get_host_path(workspace_path)
-
-        copy_cmd = [
-            "podman",
-            "run",
-            "--rm",
-            "-v",
-            f"{volume_name}:/source:ro",
-            "-v",
-            f"{workspace_path_host}:/dest",  # Use host path!
-            "alpine",
-            "sh",
-            "-c",
-            "cp -a /source/. /dest/",
-        ]
-
-        print(
-            f"[DEBUG] Copying files from volume {volume_name} to {workspace_path_host}"
-        )
-        copy_result = subprocess.run(
-            copy_cmd, capture_output=True, text=True, timeout=30
-        )
-
-        if copy_result.returncode != 0:
-            cleanup()
-            pytest.fail(
-                f"Failed to copy files from volume to workspace\n"
-                f"Command: {' '.join(copy_cmd)}\n"
-                f"stdout: {copy_result.stdout}\n"
-                f"stderr: {copy_result.stderr}"
-            )
-    else:
-        # Running on host - use direct bind mount (original behavior)
-        cmd = [
-            "podman",
-            "run",
-            "-it",
-            "--rm",
-            "-v",
-            f"{workspace_path}:/workspace",
-            container_image,
-            "/root/assets/init-workspace.sh",
-        ]
-
-        # Track progress through stages for better timeout diagnostics
-        stages = {
-            "started": None,
-            "short_name_prompt": None,
-            "org_name_prompt": None,
-            "copying_files": None,
-            "replacing_placeholders": None,
-            "setting_permissions": None,
-            "syncing_deps": None,
-            "completed": None,
-        }
-        current_stage = "started"
-        stages["started"] = time.time()
-
-        try:
-            # Spawn the process with pexpect
-            child = pexpect.spawn(" ".join(cmd), encoding="utf-8", timeout=60)
-
-            # Stage 1: Wait for short name prompt
-            child.expect("Enter a short name", timeout=30)
-            stages["short_name_prompt"] = time.time()
-            current_stage = "short_name_prompt"
-            child.sendline(project_name)
-
-            # Stage 2: Wait for org name prompt
-            child.expect("Enter the name of your organization", timeout=30)
-            stages["org_name_prompt"] = time.time()
-            current_stage = "org_name_prompt"
-            child.sendline(organization_name)
-
-            # Stage 3: Monitor progress through remaining stages
-            # Use shorter timeouts to detect slow operations
-            stage_patterns = [
-                ("Copying files from", "copying_files", 30),
-                ("Replacing placeholders", "replacing_placeholders", 60),
-                ("Setting executable permissions", "setting_permissions", 30),
-                ("Syncing dependencies", "syncing_deps", 60),
-                ("Workspace initialized successfully", "completed", 30),
+        if in_container:
+            workspace_path_host = get_host_path(workspace_path)
+            copy_cmd = [
+                "podman",
+                "run",
+                "--rm",
+                "-v",
+                f"{volume_name}:/source:ro",
+                "-v",
+                f"{workspace_path_host}:/dest",
+                "alpine",
+                "sh",
+                "-c",
+                "cp -a /source/. /dest/",
             ]
-
-            for pattern, stage_name, timeout in stage_patterns:
-                try:
-                    child.expect(pattern, timeout=timeout)
-                    stages[stage_name] = time.time()
-                    current_stage = stage_name
-                except pexpect.TIMEOUT:
-                    # Calculate time spent in current stage
-                    stage_start = stages.get(current_stage) or stages["started"]
-                    time_in_stage = time.time() - stage_start
-
-                    cleanup()
-                    pytest.fail(
-                        f"⏱️  Timeout waiting for: '{pattern}'\n"
-                        f"\n"
-                        f"📊 Progress tracking:\n"
-                        f"   Current stage: {current_stage}\n"
-                        f"   Time in stage: {time_in_stage:.1f}s (timeout: {timeout}s)\n"
-                        f"\n"
-                        f"📈 Stage timings:\n"
-                        + "\n".join(
-                            f"   {'✓' if stages[s] else '✗'} {s}: "
-                            + (
-                                f"{stages[s] - stages['started']:.1f}s"
-                                if stages[s]
-                                else "not reached"
-                            )
-                            for s in stages
-                        )
-                        + f"\n\n"
-                        f"💡 If stuck on 'copying_files':\n"
-                        f"   - Check if .pre-commit-cache is being copied (should be excluded)\n"
-                        f"   - Volume mounts on macOS are slow (Podman VM overhead)\n"
-                        f"   - Check: podman run --rm {container_image} du -sh /root/assets/workspace/\n"
-                        f"\n"
-                        f"📤 Last output:\n{child.before}"
-                    )
-
-            # Wait for EOF
-            child.expect(pexpect.EOF, timeout=30)
-            child.close()
-
-            # Check return code
-            if child.exitstatus != 0:
-                cleanup()
+            print(
+                f"[DEBUG] Copying files from volume {volume_name} to {workspace_path_host}"
+            )
+            copy_result = subprocess.run(
+                copy_cmd, capture_output=True, text=True, timeout=30
+            )
+            if copy_result.returncode != 0:
                 pytest.fail(
-                    f"Failed to initialize workspace with init-workspace.sh\n"
-                    f"Return code: {child.exitstatus}\n"
-                    f"Output: {child.before}"
+                    "Failed to copy files from volume to workspace\n"
+                    f"Command: {' '.join(copy_cmd)}\n"
+                    f"stdout: {copy_result.stdout}\n"
+                    f"stderr: {copy_result.stderr}"
                 )
 
-            # Log successful timing
-            total_time = time.time() - stages["started"]
-            print(f"[DEBUG] Workspace initialized in {total_time:.1f}s")
-
-        except pexpect.TIMEOUT:
-            cleanup()
-            output = child.before if "child" in locals() else "N/A"
-            stage_start = (
-                stages.get(current_stage) or stages.get("started") or time.time()
-            )
-            time_in_stage = time.time() - stage_start
-
+        if not (workspace_path / "README.md").exists():
             pytest.fail(
-                f"⏱️  Timeout while initializing workspace\n"
-                f"\n"
-                f"📊 Progress tracking:\n"
-                f"   Current stage: {current_stage}\n"
-                f"   Time in stage: {time_in_stage:.1f}s\n"
-                f"\n"
-                f"📈 Stage timings:\n"
-                + "\n".join(
-                    f"   {'✓' if stages[s] else '✗'} {s}: "
-                    + (
-                        f"{stages[s] - stages['started']:.1f}s"
-                        if stages[s]
-                        else "not reached"
-                    )
-                    for s in stages
-                )
-                + f"\n\n"
-                f"💡 Common causes:\n"
-                f"   - Large .pre-commit-cache being copied (should be excluded now)\n"
-                f"   - Slow volume mount (macOS Podman runs through VM)\n"
-                f"   - Script hanging on a prompt or I/O operation\n"
-                f"\n"
-                f"📤 Last output:\n{output}"
-            )
-        except pexpect.ExceptionPexpect as e:
-            cleanup()
-            pytest.fail(
-                f"Error while initializing workspace with init-workspace.sh: {e}"
+                f"Workspace initialization failed - README.md not found in {workspace_path}\n"
+                f"Workspace contents: {list(workspace_path.iterdir()) if workspace_path.exists() else 'N/A'}"
             )
 
-    # Verify the workspace was initialized
-    if not (workspace_path / "README.md").exists():
+        yield workspace_path
+    finally:
         cleanup()
-        pytest.fail(
-            f"Workspace initialization failed - README.md not found in {workspace_path}\n"
-            f"Workspace contents: {list(workspace_path.iterdir()) if workspace_path.exists() else 'N/A'}"
-        )
 
-    yield workspace_path
 
-    # Cleanup
-    cleanup()
+@pytest.fixture(scope="session")
+def initialized_workspace(container_image):
+    """Default workspace initialization fixture."""
+    yield from _init_workspace(container_image, smoke_test=False)
+
+
+@pytest.fixture(scope="session")
+def initialized_smoke_workspace(container_image):
+    """Smoke-test workspace initialization fixture."""
+    yield from _init_workspace(container_image, smoke_test=True)
 
 
 # --- Shared helpers for devcontainer_up and devcontainer_with_sidecar ---

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -98,6 +98,27 @@ class TestInstallScriptIntegration:
         assert devcontainer_dir.exists(), ".devcontainer directory not created"
         assert devcontainer_dir.is_dir(), ".devcontainer is not a directory"
 
+    def test_dry_run_smoke_test_flag_forwarded(self):
+        """Test install.sh forwards --smoke-test to init-workspace.sh in dry-run."""
+        project_root = Path(__file__).resolve().parents[1]
+        install_script = project_root / "install.sh"
+
+        result = subprocess.run(
+            [str(install_script), "--dry-run", "--smoke-test", "."],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            cwd=str(project_root),
+        )
+
+        assert result.returncode == 0, (
+            f"install.sh --dry-run --smoke-test failed:\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+        assert "--smoke-test" in result.stdout, (
+            "Expected --smoke-test to be forwarded in dry-run command output"
+        )
+
     def test_install_creates_devcontainer_json(self, install_workspace):
         """Test install.sh creates devcontainer.json."""
         devcontainer_json = install_workspace / ".devcontainer" / "devcontainer.json"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -729,6 +729,35 @@ class TestPlaceholders:
             assert "test_project" in content, f"Short name not replaced in {file}"
 
 
+class TestSmokeRepo:
+    """Tests for smoke-test-specific asset deployment."""
+
+    def test_smoke_test_flag_deploys_assets(self, initialized_smoke_workspace):
+        """Test --smoke-test deploys specific assets."""
+        project_root = Path(__file__).resolve().parents[1]
+        smoke_test_assets_dir = project_root / "assets" / "smoke-test"
+        smoke_test_files = [
+            path for path in smoke_test_assets_dir.rglob("*") if path.is_file()
+        ]
+
+        assert smoke_test_files, "No smoke-test assets found in assets/smoke-test"
+        for source_file in smoke_test_files:
+            relative_path = source_file.relative_to(smoke_test_assets_dir)
+            deployed_path = initialized_smoke_workspace / relative_path
+            assert deployed_path.exists(), f"{relative_path} not deployed"
+
+    def test_default_init_does_not_deploy_repository_dispatch(
+        self, initialized_workspace
+    ):
+        """Test default init does not deploy repository-dispatch workflow."""
+        dispatch_workflow = (
+            initialized_workspace / ".github" / "workflows" / "repository-dispatch.yml"
+        )
+        assert not dispatch_workflow.exists(), (
+            "repository-dispatch.yml should not be deployed without --smoke-test"
+        )
+
+
 class TestDevContainerGit:
     """Test that git configuration files are set up."""
 


### PR DESCRIPTION
## Description

Add opt-in smoke-test deployment support so the smoke-test repository can be fully bootstrapped from the shipped image without manual workflow file sync.

## Type of Change

- [x] `feat` -- New feature
- [ ] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [x] `test` -- Adding or updating tests
- [ ] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- `assets/smoke-test/.github/workflows/repository-dispatch.yml`
  - Bundle smoke-test-specific repository dispatch listener in image assets
- `assets/smoke-test/README.md`
  - Document smoke-test repository purpose and recreation flow
- `assets/init-workspace.sh`
  - Add `--smoke-test` flag
  - In smoke mode, force unattended behavior (`--force --no-prompts`)
  - Deploy smoke-test assets from `$SCRIPT_DIR/smoke-test/`
- `install.sh`
  - Add and document `--smoke-test` option
  - Forward the flag to `init-workspace.sh` including dry-run output
- `tests/bats/init-workspace.bats`
  - Cover smoke-test flag parsing and behavior toggles
- `tests/bats/install.bats`
  - Cover forwarding of `--smoke-test`
- `tests/conftest.py`
  - Refactor workspace init fixture into reusable `_init_workspace()`
  - Add dedicated `initialized_smoke_workspace` fixture
- `tests/test_integration.py`
  - Add `TestSmokeRepo` coverage for smoke/non-smoke deployment behavior
- `tests/test_install_script.py`
  - Add dry-run forwarding assertion for `--smoke-test`
- `CHANGELOG.md`
  - Add Unreleased Added entry for #250

## Changelog Entry

### Added
- **Add `--smoke-test` flag to deploy smoke-test-specific assets** ([#250](https://github.com/vig-os/devcontainer/issues/250))
  - `init-workspace.sh --smoke-test` deploys files from `assets/smoke-test/` (currently `repository-dispatch.yml` and `README.md`)
  - `install.sh` forwards `--smoke-test` flag to `init-workspace.sh`
  - Smoke mode implies `--force --no-prompts` for unattended use
  - Refactor `initialized_workspace` fixture into reusable `_init_workspace()` with `smoke_test` parameter

## Testing

- [x] Tests pass locally (`just test`)
- [x] Manual testing performed (describe below)

### Manual Testing Details

- Verified `--smoke-test` flag manually by deploying to the smoke-test repo and confirming smoke-test-specific files are present

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

N/A

Refs: #250
