### PR TITLE
test: fix bats warnings in githooks and tmux crash in worktree tests

### DIFF
--- a/tests/bats/githooks.bats
+++ b/tests/bats/githooks.bats
@@ -5,6 +5,8 @@
 # commits when IN_CONTAINER is not "true" (i.e. outside the devcontainer).
 # Refs: #238
 
+bats_require_minimum_version 1.5.0
+
 setup() {
     load test_helper
     HOOKS_DIR="$PROJECT_ROOT/assets/workspace/.githooks"
@@ -31,7 +33,7 @@ setup() {
 }
 
 @test "pre-commit does not show guard message when IN_CONTAINER is true" {
-    run env IN_CONTAINER="true" bash "$HOOKS_DIR/pre-commit"
+    run -127 env IN_CONTAINER="true" bash "$HOOKS_DIR/pre-commit"
     refute_output --partial "Please commit your changes within the dev container"
 }
 
@@ -56,7 +58,7 @@ setup() {
 }
 
 @test "prepare-commit-msg does not show guard message when IN_CONTAINER is true" {
-    run env IN_CONTAINER="true" bash "$HOOKS_DIR/prepare-commit-msg" /dev/null
+    run -127 env IN_CONTAINER="true" bash "$HOOKS_DIR/prepare-commit-msg" /dev/null
     refute_output --partial "Please commit your changes within the dev container"
 }
 
@@ -81,6 +83,6 @@ setup() {
 }
 
 @test "commit-msg does not show guard message when IN_CONTAINER is true" {
-    run env IN_CONTAINER="true" bash "$HOOKS_DIR/commit-msg" /dev/null
+    run -127 env IN_CONTAINER="true" bash "$HOOKS_DIR/commit-msg" /dev/null
     refute_output --partial "Please commit your changes within the dev container"
 }

--- a/tests/bats/worktree.bats
+++ b/tests/bats/worktree.bats
@@ -50,8 +50,9 @@ setup() {
     TESTDIR="/tmp/bats-trust-$$"
     mkdir -p "$TESTDIR"
 
-    tmux new-session -d -s "$SESSION" -c "$TESTDIR" \
-        "agent chat --yolo --approve-mcps 'say hello'"
+    tmux new-session -d -s "$SESSION" -c "$TESTDIR"
+    tmux set-option -t "$SESSION" remain-on-exit on
+    tmux send-keys -t "$SESSION" "agent chat --yolo --approve-mcps 'say hello'" Enter
     sleep 5
     tmux send-keys -t "$SESSION" "a" 2>/dev/null || true
     sleep 5


### PR DESCRIPTION
## Description

Fix bats test warnings and a tmux session crash in the test suite.

- **githooks.bats**: BW01 warnings fired because `run` saw exit code 127 on the IN_CONTAINER=true guard tests (hooks call downstream tooling unavailable on the host). Added `run -127` with `bats_require_minimum_version 1.5.0` to acknowledge the expected exit code.
- **worktree.bats**: The `send-keys` trust-prompt test crashed with `server exited unexpectedly` because the `agent` command exited immediately, killing the only tmux session and the server with it. Changed to start a persistent shell first with `remain-on-exit on`, then send the command.

## Type of Change

- [ ] `feat` -- New feature
- [ ] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [x] `test` -- Adding or updating tests
- [ ] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- **tests/bats/githooks.bats** — Added `bats_require_minimum_version 1.5.0`; changed three `run` calls to `run -127` for IN_CONTAINER=true tests
- **tests/bats/worktree.bats** — Replaced inline tmux command with persistent shell + `remain-on-exit on` + `send-keys` for the agent trust-prompt test

## Changelog Entry

No changelog needed — test-only fix with no user-visible impact.

## Testing

- [x] Tests pass locally (`just test`)
- [x] Manual testing performed (describe below)

### Manual Testing Details

- Ran `npx bats tests/bats/githooks.bats` — 12/12 pass, zero warnings
- Ran `npx bats tests/bats/worktree.bats` — 8/8 pass, zero warnings

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [ ] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

N/A

Refs: #252
