### PR TITLE
feat(setup): add .vig-os as devcontainer version source of truth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,6 +154,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `install.sh` forwards `--smoke-test` flag to `init-workspace.sh`
   - Smoke mode implies `--force --no-prompts` for unattended use
   - Refactor `initialized_workspace` fixture into reusable `_init_workspace()` with `smoke_test` parameter
+- **Root `.vig-os` config file as devcontainer version SSoT** ([#257](https://github.com/vig-os/devcontainer/issues/257))
+  - Add committed `assets/workspace/.vig-os` key/value config with `DEVCONTAINER_VERSION` as the canonical version source
+  - Update `docker-compose.yml`, `initialize.sh`, and `version-check.sh` to consume `.vig-os`-driven version flow
+  - Extend integration/image tests for `.vig-os` presence and graceful handling when `.vig-os` is missing
 
 ### Changed
 

--- a/assets/workspace/.devcontainer/docker-compose.yml
+++ b/assets/workspace/.devcontainer/docker-compose.yml
@@ -1,7 +1,7 @@
 ---
 services:
   devcontainer:
-    image: ghcr.io/vig-os/devcontainer:{{IMAGE_TAG}}
+    image: ghcr.io/vig-os/devcontainer:${DEVCONTAINER_VERSION:-latest}
     volumes:
       # Mount the project folder to a subdirectory of workspace
       - ..:/workspace/{{SHORT_NAME}}:cached

--- a/assets/workspace/.devcontainer/scripts/initialize.sh
+++ b/assets/workspace/.devcontainer/scripts/initialize.sh
@@ -13,6 +13,33 @@ DEVCONTAINER_DIR="$(dirname "$SCRIPT_DIR")"
 # Copy host user configuration (git, ssh, gh)
 "$SCRIPT_DIR/copy-host-user-conf.sh"
 
+# Load devcontainer version from root .vig-os config
+load_vig_os_config() {
+    local config_file="$DEVCONTAINER_DIR/../.vig-os"
+    local env_file="$DEVCONTAINER_DIR/.env"
+
+    if [[ ! -f "$config_file" ]]; then
+        return 0
+    fi
+
+    # shellcheck source=/dev/null
+    source "$config_file"
+
+    if [[ -z "${DEVCONTAINER_VERSION:-}" ]]; then
+        return 0
+    fi
+
+    if [[ -f "$env_file" ]] && grep -q "^DEVCONTAINER_VERSION=" "$env_file" 2>/dev/null; then
+        if [[ "$(uname -s)" == "Darwin" ]]; then
+            sed -i '' "s|^DEVCONTAINER_VERSION=.*|DEVCONTAINER_VERSION=${DEVCONTAINER_VERSION}|" "$env_file"
+        else
+            sed -i "s|^DEVCONTAINER_VERSION=.*|DEVCONTAINER_VERSION=${DEVCONTAINER_VERSION}|" "$env_file"
+        fi
+    else
+        echo "DEVCONTAINER_VERSION=${DEVCONTAINER_VERSION}" >> "$env_file"
+    fi
+}
+
 # Configure container socket path based on host OS
 configure_socket_path() {
     local env_file="$DEVCONTAINER_DIR/.env"
@@ -89,6 +116,7 @@ configure_socket_path() {
     echo "Socket configuration complete (written to .env)"
 }
 
+load_vig_os_config
 configure_socket_path
 
 echo "Initialization complete"

--- a/assets/workspace/.devcontainer/scripts/version-check.sh
+++ b/assets/workspace/.devcontainer/scripts/version-check.sh
@@ -190,17 +190,18 @@ record_check() {
 # VERSION DETECTION
 # ═══════════════════════════════════════════════════════════════════════════════
 
-# Get current installed version from docker-compose.yml
+# Get current installed version from root .vig-os config
 get_current_version() {
-    local compose_file="$DEVCONTAINER_DIR/docker-compose.yml"
+    local config_file="$DEVCONTAINER_DIR/../.vig-os"
 
-    if [[ ! -f "$compose_file" ]]; then
+    if [[ ! -f "$config_file" ]]; then
         return 1
     fi
 
-    # Extract version from image tag (e.g., ghcr.io/vig-os/devcontainer:1.0.0)
-    local version
-    version=$(grep -o 'ghcr\.io/vig-os/devcontainer:[^"]*' "$compose_file" 2>/dev/null | head -1 | cut -d: -f2)
+    # shellcheck source=/dev/null
+    source "$config_file"
+
+    local version="${DEVCONTAINER_VERSION:-}"
 
     if [[ -z "$version" || "$version" == "dev" || "$version" == "latest" ]]; then
         return 1  # Not a pinned version

--- a/assets/workspace/.vig-os
+++ b/assets/workspace/.vig-os
@@ -1,0 +1,2 @@
+# vig-os devcontainer configuration
+DEVCONTAINER_VERSION={{IMAGE_TAG}}

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -553,6 +553,7 @@ class TestFileStructure:
             "/root/assets/workspace/CHANGELOG.md",
             "/root/assets/workspace/README.md",
             "/root/assets/workspace/LICENSE",
+            "/root/assets/workspace/.vig-os",
             # .devcontainer files
             "/root/assets/workspace/.devcontainer/.gitignore",
             "/root/assets/workspace/.devcontainer/README.md",

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -528,7 +528,7 @@ class TestDevContainerDockerCompose:
             "docker-compose.yml missing 'devcontainer' service"
         )
 
-    def test_docker_compose_yml_image(self, initialized_workspace, container_image):
+    def test_docker_compose_yml_image(self, initialized_workspace):
         """Test that docker-compose.yml has correct image reference."""
         docker_compose_yml = (
             initialized_workspace / ".devcontainer" / "docker-compose.yml"
@@ -540,17 +540,10 @@ class TestDevContainerDockerCompose:
         service = config["services"]["devcontainer"]
         assert "image" in service, "devcontainer service missing 'image' field"
 
-        # Verify the docker-compose.yml image matches the container_image fixture
-        # Normalize arch suffix if present (e.g., :X.Y or :X.Y-amd64 -> :X.Y)
-        # Only remove known architecture suffixes (-amd64, -arm64) at the very end
-        expected_image = re.sub(r"-(amd64|arm64)$", "", container_image)
+        # docker-compose now references version from .env / .vig-os
+        expected_image = "ghcr.io/vig-os/devcontainer:${DEVCONTAINER_VERSION:-latest}"
         assert service["image"] == expected_image, (
             f"Expected image to be {expected_image}, got: {service['image']}"
-        )
-
-        # {{IMAGE_TAG}} should be replaced (or at least not present)
-        assert "{{IMAGE_TAG}}" not in service["image"], (
-            f"Image tag placeholder not replaced: {service['image']}"
         )
 
     def test_docker_compose_yml_volumes(self, initialized_workspace):
@@ -660,6 +653,54 @@ class TestDevContainerDockerCompose:
         )
         assert "tty" in service, "devcontainer service missing 'tty' field"
         assert service["tty"] is True, f"Expected tty=True, got: {service['tty']}"
+
+
+class TestVigOsConfig:
+    """Test .vig-os configuration as version source of truth."""
+
+    def test_vig_os_exists(self, initialized_workspace):
+        """Test that .vig-os exists at workspace root."""
+        vig_os_file = initialized_workspace / ".vig-os"
+        assert vig_os_file.exists(), ".vig-os not found in workspace root"
+        assert vig_os_file.is_file(), ".vig-os is not a regular file"
+
+    def test_vig_os_contains_devcontainer_version(self, initialized_workspace):
+        """Test that .vig-os contains DEVCONTAINER_VERSION key."""
+        vig_os_file = initialized_workspace / ".vig-os"
+        content = vig_os_file.read_text(encoding="utf-8")
+        assert "DEVCONTAINER_VERSION=" in content, (
+            "DEVCONTAINER_VERSION key not found in .vig-os"
+        )
+        assert "{{IMAGE_TAG}}" not in content, (
+            "IMAGE_TAG placeholder should be replaced in .vig-os"
+        )
+
+    def test_initialize_writes_devcontainer_version_to_env(self, initialized_workspace):
+        """Test initialize.sh writes DEVCONTAINER_VERSION to .devcontainer/.env."""
+        init_script = (
+            initialized_workspace / ".devcontainer" / "scripts" / "initialize.sh"
+        )
+        env_file = initialized_workspace / ".devcontainer" / ".env"
+
+        if env_file.exists():
+            env_file.unlink()
+
+        result = subprocess.run(
+            [str(init_script)],
+            capture_output=True,
+            text=True,
+            cwd=str(initialized_workspace),
+            timeout=10,
+        )
+        assert result.returncode == 0, (
+            f"initialize.sh failed\nstdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+        assert env_file.exists(), ".devcontainer/.env was not created by initialize.sh"
+
+        env_content = env_file.read_text(encoding="utf-8")
+        assert "DEVCONTAINER_VERSION=" in env_content, (
+            "initialize.sh did not write DEVCONTAINER_VERSION to .env"
+        )
 
 
 class TestPlaceholders:
@@ -2575,6 +2616,14 @@ class TestVersionCheckScript:
         assert "on|enable" in result.stdout
         assert "off|disable" in result.stdout
 
+    def test_reads_version_from_vig_os_config(self, version_check_script):
+        """Test that version-check reads version from .vig-os config."""
+        content = version_check_script.read_text(encoding="utf-8")
+        assert ".vig-os" in content, "version-check.sh should reference .vig-os"
+        assert "DEVCONTAINER_VERSION" in content, (
+            "version-check.sh should read DEVCONTAINER_VERSION"
+        )
+
     def test_config_creation(self, version_check_script, local_dir):
         """Test that config file is created with defaults on first run."""
         config_file = local_dir / "version-check.conf"
@@ -3566,3 +3615,28 @@ class TestVersionCheckGracefulFailure:
             # Restore file
             if backup_path.exists():
                 backup_path.rename(compose_file)
+
+    def test_missing_vig_os_silent_failure(
+        self, version_check_script, initialized_workspace
+    ):
+        """Test that missing .vig-os doesn't break silent mode."""
+        vig_os_file = initialized_workspace / ".vig-os"
+        backup_path = initialized_workspace / ".vig-os.backup"
+
+        if vig_os_file.exists():
+            vig_os_file.rename(backup_path)
+
+        try:
+            result = subprocess.run(
+                [str(version_check_script)],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+
+            # Should succeed silently
+            assert result.returncode == 0
+            assert len(result.stderr) == 0
+        finally:
+            if backup_path.exists():
+                backup_path.rename(vig_os_file)


### PR DESCRIPTION
## Description

Introduce a committed root `.vig-os` config file as the single source of truth for devcontainer versioning in workspace assets. This removes version discovery via `docker-compose.yml` parsing and routes version flow through `DEVCONTAINER_VERSION`.

## Type of Change

- [x] `feat` -- New feature
- [ ] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [x] `test` -- Adding or updating tests
- [ ] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- Add `assets/workspace/.vig-os` with `DEVCONTAINER_VERSION={{IMAGE_TAG}}`
- Update `assets/workspace/.devcontainer/docker-compose.yml`
  - switch image tag from `{{IMAGE_TAG}}` to `${DEVCONTAINER_VERSION:-latest}`
- Update `assets/workspace/.devcontainer/scripts/initialize.sh`
  - source root `.vig-os`
  - write/update `DEVCONTAINER_VERSION` in `.devcontainer/.env`
- Update `assets/workspace/.devcontainer/scripts/version-check.sh`
  - replace `docker-compose.yml` grep parsing with `.vig-os` sourcing
- Update tests
  - `tests/test_integration.py`: add `.vig-os` coverage, update image assertion, add missing `.vig-os` graceful-failure test
  - `tests/test_image.py`: include `.vig-os` in expected workspace files
- Update `CHANGELOG.md` (`## Unreleased > Added`) with issue #257 entry

## Changelog Entry

### Added
- **Root `.vig-os` config file as devcontainer version SSoT** ([#257](https://github.com/vig-os/devcontainer/issues/257))
  - Add committed `assets/workspace/.vig-os` key/value config with `DEVCONTAINER_VERSION` as the canonical version source
  - Update `docker-compose.yml`, `initialize.sh`, and `version-check.sh` to consume `.vig-os`-driven version flow
  - Extend integration/image tests for `.vig-os` presence and graceful handling when `.vig-os` is missing

## Testing

- [x] Tests pass locally (`just test`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

- This PR is intentionally based on `feature/173-wire-cross-repo-dispatch-release-gate` (issue #173 branch), not `dev`.

Refs: #257
