### PR TITLE
feat(ci): automate deploy-and-test via PR in smoke-test workflow

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -105,5 +105,15 @@ CVE-2025-61730
 Expiration: 2026-04-15
 CVE-2025-15558
 
+# CVE-2026-31812: quinn-proto unauthenticated remote DoS via QUIC transport parameter panic
+# Risk Assessment: LOW (devcontainer context)
+# - HIGH severity in quinn-proto v0.11.12 embedded in uv/uvx Rust binaries
+# - Affects QUIC transport parameter handling and may panic on malformed unauthenticated input
+# - uv/uvx in this image is used for package downloads from trusted registries, not as a QUIC server
+# - No user-facing QUIC endpoint is exposed by devcontainer workflows
+# - Fixed in quinn-proto v0.11.14; awaiting upstream uv release with patched dependency
+Expiration: 2026-05-15
+CVE-2026-31812
+
 # Tracking: https://github.com/vig-os/devcontainer
 # Upstream: https://github.com/aquasecurity/trivy/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - CI workflows (`ci.yml`, `ci-container.yml`) trigger on the deploy PR, and auto-merge is enabled when checks pass
   - Stale deploy PRs are closed before each new deployment
   - The smoke-test repo keeps audit trail through deploy PRs and merge history instead of a local changelog
+  - Dispatch payload tag validation now enforces semver format `X.Y.Z` or `X.Y.Z-rc.N` before using the tag in refs/URLs
+  - CI security scan now includes a time-bounded exception for `CVE-2026-31812` in `uv`/`uvx` pending upstream dependency patch release
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Cross-repo smoke-test dispatch on RC publish** ([#173](https://github.com/vig-os/devcontainer/issues/173))
   - RC candidate publishes now trigger `repository_dispatch` in `vig-os/devcontainer-smoke-test` with the RC tag payload
   - Release process now includes a documented manual smoke gate before running final publish
+- **Automated RC deploy-and-test via PR in smoke-test repo** ([#258](https://github.com/vig-os/devcontainer/issues/258))
+  - Dispatch workflow now deploys the tag, creates a signed commit on `chore/deploy-<tag>`, and opens a PR to `dev`
+  - CI workflows (`ci.yml`, `ci-container.yml`) trigger on the deploy PR, and auto-merge is enabled when checks pass
+  - Stale deploy PRs are closed before each new deployment
+  - The smoke-test repo keeps audit trail through deploy PRs and merge history instead of a local changelog
 
 ### Fixed
 

--- a/assets/smoke-test/.github/workflows/repository-dispatch.yml
+++ b/assets/smoke-test/.github/workflows/repository-dispatch.yml
@@ -46,6 +46,11 @@ jobs:
             exit 1
           fi
 
+          if ! printf '%s' "${TAG}" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$'; then
+            echo "ERROR: tag '${TAG}' does not match required format (expected X.Y.Z or X.Y.Z-rc.N)"
+            exit 1
+          fi
+
           echo "tag=${TAG}" >> "${GITHUB_OUTPUT}"
 
   deploy:
@@ -75,7 +80,7 @@ jobs:
           repositories: ${{ github.event.repository.name }}
 
       - name: Checkout dev branch
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: dev
           fetch-depth: 0

--- a/assets/smoke-test/.github/workflows/repository-dispatch.yml
+++ b/assets/smoke-test/.github/workflows/repository-dispatch.yml
@@ -1,4 +1,15 @@
 name: Repository Dispatch Listener
+#
+# Purpose:
+# - Handle cross-repo `repository_dispatch` events from vig-os/devcontainer.
+# - Deploy the requested tag into the smoke-test repo.
+# - Always create a `chore/deploy-<tag>` branch and PR to `dev`.
+# - Create signed deploy commits via `vig-os/commit-action`.
+# - CI (ci.yml + ci-container.yml) triggers on the deploy PR.
+#
+# Dispatch payload:
+# - Preferred:   client_payload.tag
+# - Optional:    client_payload.event_type, client_payload.source_repo
 
 on:  # yamllint disable-line rule:truthy
   repository_dispatch:
@@ -7,7 +18,6 @@ on:  # yamllint disable-line rule:truthy
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   validate:
@@ -15,46 +25,164 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 5
     outputs:
-      rc_tag: ${{ steps.extract.outputs.rc_tag }}
+      tag: ${{ steps.extract.outputs.tag }}
     steps:
-      - name: Extract and validate rc_tag
+      - name: Extract and validate tag
         id: extract
         env:
           EVENT_ACTION: ${{ github.event.action }}
           EVENT_TYPE: ${{ github.event.client_payload.event_type || '' }}
-          RC_TAG: ${{ github.event.client_payload.rc_tag || '' }}
+          TAG: ${{ github.event.client_payload.tag || '' }}
           SOURCE_REPO: ${{ github.event.client_payload.source_repo || '' }}
         run: |
           echo "repository_dispatch received"
           echo "action=${EVENT_ACTION}"
           echo "event_type=${EVENT_TYPE}"
-          echo "rc_tag=${RC_TAG}"
+          echo "tag=${TAG}"
           echo "source_repo=${SOURCE_REPO}"
 
-          if [ -z "${RC_TAG}" ]; then
-            echo "ERROR: rc_tag is required in github.event.client_payload"
+          if [ -z "${TAG}" ]; then
+            echo "ERROR: tag is required in github.event.client_payload"
             exit 1
           fi
 
-          echo "rc_tag=${RC_TAG}" >> "${GITHUB_OUTPUT}"
+          echo "tag=${TAG}" >> "${GITHUB_OUTPUT}"
 
-  ci-bare:
-    name: Run bare-runner CI
+  deploy:
+    name: Deploy tag and open PR to dev
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15
     needs: validate
-    uses: ./.github/workflows/ci.yml
+    outputs:
+      pr_url: ${{ steps.create_pr.outputs.pr_url }}
+    steps:
+      - name: Generate release app token for PR/issue operations
+        id: generate_release_token
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf  # v2
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
 
-  ci-container:
-    name: Run container CI
-    needs: validate
-    uses: ./.github/workflows/ci-container.yml
-    with:
-      image-tag: ${{ needs.validate.outputs.rc_tag }}
+      - name: Generate commit app token for signed commits
+        id: generate_commit_token
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf  # v2
+        with:
+          app-id: ${{ secrets.COMMIT_APP_ID }}
+          private-key: ${{ secrets.COMMIT_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+
+      - name: Checkout dev branch
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          ref: dev
+          fetch-depth: 0
+
+      - name: Close stale deploy PRs
+        env:
+          GH_TOKEN: ${{ steps.generate_release_token.outputs.token }}
+        run: |
+          gh label create deploy --color 0E8A16 \
+            --description "Automated smoke-test deploy PRs" \
+            --force
+
+          mapfile -t OPEN_DEPLOY_PRS < <(
+            gh pr list --base dev --state open --label deploy \
+              --json number --jq '.[].number'
+          )
+
+          if [ "${#OPEN_DEPLOY_PRS[@]}" -eq 0 ]; then
+            echo "No stale deploy PRs found."
+            exit 0
+          fi
+
+          for pr_number in "${OPEN_DEPLOY_PRS[@]}"; do
+            echo "Closing stale deploy PR #${pr_number}"
+            gh pr close "${pr_number}" --delete-branch
+          done
+
+      - name: Run installer from dispatch tag
+        env:
+          TAG: ${{ needs.validate.outputs.tag }}
+        run: |
+          curl -sSf "https://raw.githubusercontent.com/vig-os/devcontainer/${TAG}/install.sh" \
+            | bash -s -- --version "${TAG}" --smoke-test --force --docker .
+
+      - name: Prepare deploy branch and metadata
+        id: prepare_branch
+        env:
+          GH_TOKEN: ${{ steps.generate_release_token.outputs.token }}
+          TAG: ${{ needs.validate.outputs.tag }}
+        run: |
+          BRANCH_NAME="chore/deploy-${TAG}"
+          echo "branch_name=${BRANCH_NAME}" >> "${GITHUB_OUTPUT}"
+
+          DEV_SHA="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/dev" --jq '.object.sha')"
+
+          if gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/${BRANCH_NAME}" >/dev/null 2>&1; then
+            gh api -X PATCH "repos/${GITHUB_REPOSITORY}/git/refs/heads/${BRANCH_NAME}" \
+              -f sha="${DEV_SHA}" \
+              -f force=true >/dev/null
+          else
+            gh api -X POST "repos/${GITHUB_REPOSITORY}/git/refs" \
+              -f ref="refs/heads/${BRANCH_NAME}" \
+              -f sha="${DEV_SHA}" >/dev/null
+          fi
+
+      - name: Commit and push deploy changes via signed commit-action
+        uses: vig-os/commit-action@e7dc876fbb73df9099831fed9bfc402108fd04c3  # v0.1.4
+        env:
+          GH_TOKEN: ${{ steps.generate_commit_token.outputs.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          TARGET_BRANCH: refs/heads/${{ steps.prepare_branch.outputs.branch_name }}
+          ALLOW_EMPTY: "true"
+          COMMIT_MESSAGE: |-
+            chore: deploy ${{ needs.validate.outputs.tag }}
+
+            Refs: #258
+          FILE_PATHS: .
+
+      - name: Create deploy PR
+        id: create_pr
+        env:
+          GH_TOKEN: ${{ steps.generate_release_token.outputs.token }}
+          TAG: ${{ needs.validate.outputs.tag }}
+          BRANCH_NAME: ${{ steps.prepare_branch.outputs.branch_name }}
+        run: |
+          PR_BODY="$(
+            printf '%s\n' \
+              "Automated smoke-test deployment commit created by repository_dispatch." \
+              "" \
+              "- Dispatch tag: ${TAG}" \
+              "- Branch: ${BRANCH_NAME}" \
+              "- Target: dev"
+          )"
+          PR_URL="$(
+            gh pr create \
+              --base dev \
+              --head "${BRANCH_NAME}" \
+              --title "chore: deploy ${TAG}" \
+              --body "${PR_BODY}" \
+              --label deploy
+          )"
+          echo "pr_url=${PR_URL}" >> "${GITHUB_OUTPUT}"
+          echo "Created PR: ${PR_URL}"
+
+      - name: Enable auto-merge
+        env:
+          GH_TOKEN: ${{ steps.generate_release_token.outputs.token }}
+          PR_URL: ${{ steps.create_pr.outputs.pr_url }}
+        run: |
+          gh pr merge "${PR_URL}" --auto --merge || \
+            echo "Warning: could not enable auto-merge"
 
   summary:
     name: Dispatch summary
     runs-on: ubuntu-22.04
     timeout-minutes: 5
-    needs: [validate, ci-bare, ci-container]
+    needs: [validate, deploy]
     if: always()
     steps:
       - name: Check orchestration results
@@ -63,8 +191,8 @@ jobs:
           echo "==================================="
           echo ""
           echo "Validate:     ${{ needs.validate.result }}"
-          echo "CI (bare):    ${{ needs.ci-bare.result }}"
-          echo "CI (container): ${{ needs.ci-container.result }}"
+          echo "Deploy:       ${{ needs.deploy.result }}"
+          echo "Deploy PR:    ${{ needs.deploy.outputs.pr_url }}"
           echo ""
 
           FAILED=false
@@ -74,13 +202,8 @@ jobs:
             FAILED=true
           fi
 
-          if [ "${{ needs.ci-bare.result }}" != "success" ]; then
-            echo "ERROR: Bare-runner CI failed"
-            FAILED=true
-          fi
-
-          if [ "${{ needs.ci-container.result }}" != "success" ]; then
-            echo "ERROR: Container CI failed"
+          if [ "${{ needs.deploy.result }}" != "success" ]; then
+            echo "ERROR: Deploy job failed"
             FAILED=true
           fi
 

--- a/assets/smoke-test/README.md
+++ b/assets/smoke-test/README.md
@@ -38,6 +38,29 @@ Template or workflow changes should be made in
 [`vig-os/devcontainer`](https://github.com/vig-os/devcontainer), then validated
 here through a normal PR run.
 
+## Automated deploy-and-test flow
+
+For release validation, this repository receives `repository_dispatch` events
+from `vig-os/devcontainer` and runs an automated deploy-and-test cycle:
+
+1. validate the dispatch payload and extract the tag
+2. deploy that tag with the online installer
+3. create branch `chore/deploy-<tag>`, commit (always), and open a PR to `dev`
+4. CI workflows (`ci.yml`, `ci-container.yml`) trigger on the PR
+5. enable auto-merge once checks pass
+
+This flow applies to both RC tags and final tags.
+
+## Audit trail and status
+
+There is no CHANGELOG in this repository.
+
+Deployment history is tracked through:
+
+- deploy PRs labeled `deploy`
+- merge history on `dev`
+- GitHub Actions runs attached to each deploy PR
+
 ## Recreate this smoke-test repo
 
 If this repository is lost or needs to be rebuilt, recreate it from the


### PR DESCRIPTION
## Description

Implements issue #258 by refurbishing the smoke-test `repository_dispatch` workflow into a deploy-and-test orchestration that deploys the dispatched tag, opens a deploy PR to `dev`, and enables auto-merge after checks pass.

## Type of Change

- [ ] `feat` -- New feature
- [ ] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [x] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- `assets/smoke-test/.github/workflows/repository-dispatch.yml`
  - Replaces the old dispatch validation + inline workflow-call shape with deploy orchestration
  - Validates `client_payload.tag`, deploys via installer, prepares `chore/deploy-<tag>` branch, commits through signed commit action, opens labeled deploy PR, and enables auto-merge
  - Adds strict semver validation for tags using project convention: `X.Y.Z` or `X.Y.Z-rc.N` (no `v` prefix)
  - Adds inline pinned action version annotation for `actions/checkout` (`# v6.0.2`)
- `assets/smoke-test/README.md`
  - Adds automated deploy-and-test flow section
  - Clarifies that `ci.yml` and `ci-container.yml` are PR-triggered
  - Documents audit trail expectations (deploy PRs + merge history)
- `.trivyignore`
  - Adds temporary, time-bounded exception for `CVE-2026-31812` (`quinn-proto` in `uv`/`uvx`) pending upstream patched release
- `CHANGELOG.md`
  - Adds `## Unreleased` / `### Added` entry for #258
  - Extends the #258 entry with follow-up notes for tag validation and security-scan exception

## Changelog Entry

### Added
- **Automated RC deploy-and-test via PR in smoke-test repo** ([#258](https://github.com/vig-os/devcontainer/issues/258))
  - Dispatch workflow now deploys the tag, creates a signed commit on `chore/deploy-<tag>`, and opens a PR to `dev`
  - CI workflows (`ci.yml`, `ci-container.yml`) trigger on the deploy PR, and auto-merge is enabled when checks pass
  - Stale deploy PRs are closed before each new deployment
  - The smoke-test repo keeps audit trail through deploy PRs and merge history instead of a local changelog
  - Dispatch payload tag validation now enforces semver format `X.Y.Z` or `X.Y.Z-rc.N` before using the tag in refs/URLs
  - CI security scan now includes a time-bounded exception for `CVE-2026-31812` in `uv`/`uvx` pending upstream dependency patch release

## Testing

- [ ] Tests pass locally (`just test`)
- [ ] Manual testing performed (describe below)

### Manual Testing Details

N/A

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

Includes one merge commit (`chore(setup): merge origin/dev into issue 258 branch`) created while synchronizing with current `dev` prior to PR preparation.

Follow-up commits on this PR branch:
- `c33ba60` -- `ci: harden dispatch tag validation`
- `99d70f0` -- `chore: add CVE-2026-31812 to trivyignore`
- `b8fdc4f` -- `docs(ci): update unreleased notes for PR 260 follow-ups`

Refs: #258