### PR TITLE
fix(setup): preserve docs sync directories in smoke redeploy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,6 +153,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Broken `gh-issues --help` guard in justfile recipe** ([#173](https://github.com/vig-os/devcontainer/issues/173))
   - `gh-issues` CLI has no `--help` flag, so the availability check always failed even when the binary was installed
   - Removed the broken guard; binary availability is now verified by the image test suite
+- **Smoke-test redeploy preserves synced docs directories** ([#262](https://github.com/vig-os/devcontainer/issues/262))
+  - `init-workspace.sh --smoke-test` now excludes `docs/issues/` and `docs/pull-requests/` from `rsync --delete`
+  - Re-deploying smoke assets no longer removes docs synced by `sync-issues`
 
 ### Changed
 

--- a/assets/init-workspace.sh
+++ b/assets/init-workspace.sh
@@ -216,7 +216,7 @@ echo "Copying files from $TEMPLATE_DIR to $WORKSPACE_DIR..."
 # Pre-commit cache is now at /opt/pre-commit-cache (not in assets/workspace)
 if [[ "$SMOKE_TEST" == "true" ]]; then
     # Smoke mode: clean deploy (--delete removes stale files), then overlay smoke-test assets
-    rsync -av --delete --exclude='.git' --exclude='.venv' "$TEMPLATE_DIR/" "$WORKSPACE_DIR/"
+    rsync -av --delete --exclude='.git' --exclude='.venv' --exclude='docs/issues/' --exclude='docs/pull-requests/' "$TEMPLATE_DIR/" "$WORKSPACE_DIR/"
 
     SMOKE_TEST_DIR="$SCRIPT_DIR/smoke-test"
     if [[ -d "$SMOKE_TEST_DIR" ]]; then

--- a/tests/bats/init-workspace.bats
+++ b/tests/bats/init-workspace.bats
@@ -84,3 +84,10 @@ setup() {
     run grep 'rsync -av --delete' "$INIT_WORKSPACE_SH"
     assert_success
 }
+
+@test "init-workspace.sh smoke mode excludes synced docs directories from delete" {
+    run grep -A1 'rsync -av --delete' "$INIT_WORKSPACE_SH"
+    assert_success
+    assert_output --partial "--exclude='docs/issues/'"
+    assert_output --partial "--exclude='docs/pull-requests/'"
+}

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -19,6 +19,8 @@ from pathlib import Path
 import pytest
 import yaml
 
+from .conftest import _build_podman_cmd, _run_noninteractive_init
+
 
 class TestHostGitSignatureSetup:
     """Test that git commit signing is properly configured on the host.
@@ -786,6 +788,40 @@ class TestSmokeRepo:
             relative_path = source_file.relative_to(smoke_test_assets_dir)
             deployed_path = initialized_smoke_workspace / relative_path
             assert deployed_path.exists(), f"{relative_path} not deployed"
+
+    def test_smoke_redeploy_preserves_synced_docs_directories(
+        self, initialized_smoke_workspace, container_image
+    ):
+        """Regression: smoke re-deploy must not delete docs synced by sync-issues."""
+        docs_issues = initialized_smoke_workspace / "docs" / "issues"
+        docs_pull_requests = initialized_smoke_workspace / "docs" / "pull-requests"
+        docs_issues.mkdir(parents=True, exist_ok=True)
+        docs_pull_requests.mkdir(parents=True, exist_ok=True)
+
+        issues_sentinel = docs_issues / "keep.md"
+        prs_sentinel = docs_pull_requests / "keep.md"
+        issues_sentinel.write_text("keep issue docs", encoding="utf-8")
+        prs_sentinel.write_text("keep PR docs", encoding="utf-8")
+
+        cmd = _build_podman_cmd(
+            container_image,
+            f"{initialized_smoke_workspace}:/workspace",
+            smoke_test=True,
+        )
+        _run_noninteractive_init(cmd)
+
+        assert docs_issues.exists(), (
+            "docs/issues directory was deleted by smoke re-deploy"
+        )
+        assert docs_pull_requests.exists(), (
+            "docs/pull-requests directory was deleted by smoke re-deploy"
+        )
+        assert issues_sentinel.exists(), (
+            "docs/issues sentinel was deleted by smoke re-deploy"
+        )
+        assert prs_sentinel.exists(), (
+            "docs/pull-requests sentinel was deleted by smoke re-deploy"
+        )
 
     def test_default_init_does_not_deploy_repository_dispatch(
         self, initialized_workspace


### PR DESCRIPTION
## Summary
- preserve `docs/issues/` and `docs/pull-requests/` during `init-workspace.sh --smoke-test` by excluding both from smoke `rsync --delete`
- add a regression integration test that reproduces smoke re-deploy and verifies both synced docs directories survive
- add a BATS assertion to guard smoke-mode rsync flags and update `CHANGELOG.md` under `Unreleased -> Fixed`

## Test plan
- [x] `uv run pytest tests/test_integration.py -k smoke_redeploy_preserves_synced_docs_directories`
- [x] `./node_modules/.bin/bats tests/bats/init-workspace.bats`