### PR TITLE
ci: remove workflow_call triggers and resolve container image from .vig-os

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -168,6 +168,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Replaced deprecated `APP_SYNC_ISSUES_*` secrets with `RELEASE_APP_*` for release and preparation workflows
   - `sync-issues.yml` now uses `COMMIT_APP_*`; `sync-main-to-dev.yml` uses both apps (commit app for refs, release app for PR operations)
   - Removed automatic `sync-issues` trigger from `sync-main-to-dev.yml` and documented the app permission model in `docs/RELEASE_CYCLE.md`
+- **Container CI defaults image tag from `.vig-os`** ([#264](https://github.com/vig-os/devcontainer/issues/264))
+  - `ci.yml` and `ci-container.yml` now run only on `pull_request` and `workflow_dispatch` after removing unused `workflow_call` triggers
+  - `ci-container.yml` now resolves `DEVCONTAINER_VERSION` from `.vig-os` before container jobs start
+  - Manual `workflow_dispatch` runs can still override the image via `image-tag`; fallback remains `latest` when no version is available
+  - Added an early manifest check in `resolve-image` so workflows fail fast if the resolved image tag is unavailable or inaccessible
 
 - **worktree-clean: add filter mode for stopped-only vs all** ([#158](https://github.com/vig-os/devcontainer/issues/158))
   - Default `just worktree-clean` (no args) now cleans only stopped worktrees, skips running tmux sessions
@@ -417,7 +422,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Update astral-sh/setup-uv, taiki-e/install-action, docker/build-push-action, github/codeql-action, actions/dependency-review-action, actions/attest-build-provenance
 - **Bump GitHub CLI to 2.88.x**
   - Update expected `gh` version in image tests from 2.87 to 2.88
-
 ### Deprecated
 
 ### Removed

--- a/assets/workspace/.github/workflows/ci-container.yml
+++ b/assets/workspace/.github/workflows/ci-container.yml
@@ -57,6 +57,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           sparse-checkout: .vig-os
+          sparse-checkout-cone-mode: false
 
       - name: Resolve image tag
         id: resolve
@@ -158,11 +159,17 @@ jobs:
           echo "CI (Container) Results Summary"
           echo "==============================="
           echo ""
+          echo "Resolve image: ${{ needs.resolve-image.result }}"
           echo "Lint: ${{ needs.lint.result }}"
           echo "Test: ${{ needs.test.result }}"
           echo ""
 
           FAILED=false
+
+          if [ "${{ needs.resolve-image.result }}" = "failure" ] || [ "${{ needs.resolve-image.result }}" = "cancelled" ]; then
+            echo "ERROR: Image resolution failed"
+            FAILED=true
+          fi
 
           if [ "${{ needs.lint.result }}" = "failure" ]; then
             echo "ERROR: Lint checks failed"

--- a/assets/workspace/.github/workflows/ci-container.yml
+++ b/assets/workspace/.github/workflows/ci-container.yml
@@ -36,8 +36,6 @@ on:  # yamllint disable-line rule:truthy
           - all
           - lint
           - test
-  workflow_call:
-    inputs:
       image-tag:
         description: 'Container image tag to use'
         required: false

--- a/assets/workspace/.github/workflows/ci-container.yml
+++ b/assets/workspace/.github/workflows/ci-container.yml
@@ -39,18 +39,60 @@ on:  # yamllint disable-line rule:truthy
       image-tag:
         description: 'Container image tag to use'
         required: false
-        default: 'latest'
         type: string
 
 permissions:
   contents: read
 
 jobs:
+  resolve-image:
+    name: Resolve image tag
+    runs-on: ubuntu-22.04
+    timeout-minutes: 2
+    outputs:
+      image-tag: ${{ steps.resolve.outputs.tag }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          sparse-checkout: .vig-os
+
+      - name: Resolve image tag
+        id: resolve
+        run: |
+          MANUAL="${{ inputs.image-tag }}"
+          if [[ -n "$MANUAL" ]]; then
+            echo "tag=$MANUAL" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [[ -f .vig-os ]]; then
+            VERSION="$(grep '^DEVCONTAINER_VERSION=' .vig-os | cut -d= -f2)"
+            if [[ -n "$VERSION" ]]; then
+              echo "tag=$VERSION" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          fi
+
+          echo "tag=latest" >> "$GITHUB_OUTPUT"
+
+      - name: Validate image accessibility
+        run: |
+          IMAGE="ghcr.io/vig-os/devcontainer:${{ steps.resolve.outputs.tag }}"
+          echo "Validating image availability: $IMAGE"
+          if ! docker manifest inspect "$IMAGE" > /dev/null 2>&1; then
+            echo "ERROR: Cannot access image manifest: $IMAGE"
+            echo "Check whether the tag exists and whether this workflow has access to GHCR."
+            exit 1
+          fi
+
   lint:
     name: Lint & Format (container)
+    needs: [resolve-image]
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/vig-os/devcontainer:${{ inputs.image-tag || 'latest' }}
+      image: ghcr.io/vig-os/devcontainer:${{ needs.resolve-image.outputs.image-tag }}
       env:
         # Image-baked cache; may miss if repo pins hooks by hash (see docs/container-ci-quirks.md)
         PRE_COMMIT_HOME: /opt/pre-commit-cache
@@ -77,9 +119,10 @@ jobs:
 
   test:
     name: Tests (container)
+    needs: [resolve-image]
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/vig-os/devcontainer:${{ inputs.image-tag || 'latest' }}
+      image: ghcr.io/vig-os/devcontainer:${{ needs.resolve-image.outputs.image-tag }}
       env:
         # Reuse the venv already present in the image instead of creating a new one
         UV_PROJECT_ENVIRONMENT: /root/assets/workspace/.venv
@@ -106,7 +149,7 @@ jobs:
     name: CI Summary (container)
     runs-on: ubuntu-22.04
     timeout-minutes: 5
-    needs: [lint, test]
+    needs: [resolve-image, lint, test]
     if: always()
 
     steps:

--- a/assets/workspace/.github/workflows/ci.yml
+++ b/assets/workspace/.github/workflows/ci.yml
@@ -35,13 +35,9 @@ on:  # yamllint disable-line rule:truthy
           - lint
           - test
           - security
-  workflow_call:
 
 permissions:
   contents: read
-  # workflow_call ceiling: dependency-review needs this; job-level perms cannot
-  # exceed workflow-level when called via workflow_call (see vig-os/devcontainer#173)
-  pull-requests: write
 
 jobs:
   lint:


### PR DESCRIPTION
## Description

Remove obsolete reusable-workflow triggers from workspace CI templates and make container CI resolve its default image tag from `.vig-os` (with manual override support). Add early validation and summary gating so CI fails fast when image resolution is invalid, inaccessible, or cancelled.

## Type of Change

- [ ] `feat` -- New feature
- [ ] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [x] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- `assets/workspace/.github/workflows/ci.yml`
  - Removed unused `workflow_call` trigger.
  - Removed workflow-call-specific permission rationale and `pull-requests: write` permission.
- `assets/workspace/.github/workflows/ci-container.yml`
  - Removed unused `workflow_call` trigger.
  - Added `resolve-image` job to resolve image tag priority: manual input > `.vig-os` > `latest`.
  - Wired `lint` and `test` container image to `${{ needs.resolve-image.outputs.image-tag }}` and updated job dependencies.
  - Added early image accessibility check via `docker manifest inspect`.
  - Added `sparse-checkout-cone-mode: false` to reliably include dotfile `.vig-os` during sparse checkout.
  - Updated summary output/failure logic to include `resolve-image` result and fail when it is `failure` or `cancelled`.
- `CHANGELOG.md`
  - Added Unreleased `Changed` entry for issue #264 covering trigger cleanup, `.vig-os`-based image resolution, and fail-fast image validation.

## Changelog Entry

### Changed

- **Container CI defaults image tag from `.vig-os`** ([#264](https://github.com/vig-os/devcontainer/issues/264))
  - `ci.yml` and `ci-container.yml` now run only on `pull_request` and `workflow_dispatch` after removing unused `workflow_call` triggers
  - `ci-container.yml` now resolves `DEVCONTAINER_VERSION` from `.vig-os` before container jobs start
  - Manual `workflow_dispatch` runs can still override the image via `image-tag`; fallback remains `latest` when no version is available
  - Added an early manifest check in `resolve-image` so workflows fail fast if the resolved image tag is unavailable or inaccessible
  - Added `sparse-checkout-cone-mode: false` so sparse checkout reliably includes dotfile `.vig-os`
  - Summary now reports `resolve-image` result and fails when image resolution is `failure` or `cancelled`

## Testing

- [x] Tests pass locally (`just test`)
- [x] Manual testing performed (describe below)

### Manual Testing Details

- Ran `uv run yamllint assets/workspace/.github/workflows/ci.yml assets/workspace/.github/workflows/ci-container.yml`
- Ran `uv run yamllint assets/workspace/.github/workflows/ci-container.yml`
- Ran `just test`
- Verified commit hooks and CI-related checks pass during local commits

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

N/A

Refs: #264
