### PR TITLE
fix(ci): pin release workflow refs and harden prepare-release rollback

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -173,6 +173,16 @@ jobs:
         with:
           sync-dependencies: 'true'
 
+      - name: Capture pre-prepare dev SHA
+        id: pre-state
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          PREPARE_START_SHA=$(gh api "repos/${{ github.repository }}/git/ref/heads/dev" --jq '.object.sha')
+          echo "prepare_start_sha=$PREPARE_START_SHA" >> "$GITHUB_OUTPUT"
+          echo "✓ Captured pre-prepare dev SHA: $PREPARE_START_SHA"
+
       - name: Prepare CHANGELOG (freeze + reset)
         env:
           VERSION: ${{ needs.validate.outputs.version }}
@@ -296,7 +306,69 @@ jobs:
           echo "pr_url=$PR_URL" >> $GITHUB_OUTPUT
           echo "✓ Draft PR created: $PR_URL (#$PR_NUMBER)"
 
+      - name: Roll back prepare-release side effects on failure
+        if: ${{ failure() }}
+        id: rollback-prepare
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          VERSION: ${{ needs.validate.outputs.version }}
+          RELEASE_BRANCH: ${{ needs.validate.outputs.release_branch }}
+          PREPARE_START_SHA: ${{ steps.pre-state.outputs.prepare_start_sha }}
+        run: |
+          set -euo pipefail
+
+          BRANCH_DELETED=false
+          CHANGELOG_ROLLBACK_NEEDED=false
+
+          if gh api "repos/${{ github.repository }}/git/ref/heads/$RELEASE_BRANCH" >/dev/null 2>&1; then
+            gh api -X DELETE "repos/${{ github.repository }}/git/refs/heads/$RELEASE_BRANCH"
+            BRANCH_DELETED=true
+            echo "✓ Deleted partially created release branch: $RELEASE_BRANCH"
+          else
+            echo "i Release branch not present; nothing to delete"
+          fi
+
+          gh api "repos/${{ github.repository }}/contents/CHANGELOG.md?ref=$PREPARE_START_SHA" --jq '.content' | tr -d '\n' | base64 -d > /tmp/changelog.pre-prepare.md
+          gh api "repos/${{ github.repository }}/contents/CHANGELOG.md?ref=dev" --jq '.content' | tr -d '\n' | base64 -d > /tmp/changelog.current-dev.md
+
+          if cmp -s /tmp/changelog.pre-prepare.md /tmp/changelog.current-dev.md; then
+            echo "i dev CHANGELOG already matches pre-prepare state"
+          else
+            cp /tmp/changelog.pre-prepare.md CHANGELOG.md
+            CHANGELOG_ROLLBACK_NEEDED=true
+            echo "✓ Prepared CHANGELOG rollback content for dev"
+          fi
+
+          echo "branch_deleted=$BRANCH_DELETED" >> "$GITHUB_OUTPUT"
+          echo "changelog_rollback_needed=$CHANGELOG_ROLLBACK_NEEDED" >> "$GITHUB_OUTPUT"
+
+      - name: Commit CHANGELOG rollback to dev via API
+        if: ${{ failure() && steps.rollback-prepare.outputs.changelog_rollback_needed == 'true' }}
+        uses: vig-os/commit-action@b70c2d87acd0f146c40e8d88a9bda40b76c084b5  # v0.1.3
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          TARGET_BRANCH: refs/heads/dev
+          COMMIT_MESSAGE: |-
+            chore: rollback failed prepare-release ${{ needs.validate.outputs.version }}
+
+            Restore CHANGELOG.md on dev to pre-prepare state after prepare-release failed.
+          FILE_PATHS: CHANGELOG.md
+
+      - name: Rollback summary
+        if: ${{ failure() }}
+        env:
+          RELEASE_BRANCH: ${{ needs.validate.outputs.release_branch }}
+          BRANCH_DELETED: ${{ steps.rollback-prepare.outputs.branch_deleted }}
+          CHANGELOG_ROLLBACK_NEEDED: ${{ steps.rollback-prepare.outputs.changelog_rollback_needed }}
+        run: |
+          echo "x Prepare release failed; rollback routine completed"
+          echo "  Release branch: $RELEASE_BRANCH"
+          echo "  Branch deleted: ${BRANCH_DELETED:-false}"
+          echo "  CHANGELOG rollback attempted: ${CHANGELOG_ROLLBACK_NEEDED:-false}"
+
       - name: Summary
+        if: ${{ success() }}
         env:
           VERSION: ${{ needs.validate.outputs.version }}
           RELEASE_BRANCH: ${{ needs.validate.outputs.release_branch }}

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -314,11 +314,21 @@ jobs:
           VERSION: ${{ needs.validate.outputs.version }}
           RELEASE_BRANCH: ${{ needs.validate.outputs.release_branch }}
           PREPARE_START_SHA: ${{ steps.pre-state.outputs.prepare_start_sha }}
+          POST_FREEZE_DEV_SHA: ${{ steps.create-branch.outputs.dev_sha }}
         run: |
           set -euo pipefail
 
           BRANCH_DELETED=false
           CHANGELOG_ROLLBACK_NEEDED=false
+
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "w Skipping rollback: GH_TOKEN is not set; cannot safely call GitHub API"
+            exit 0
+          fi
+          if [ -z "${PREPARE_START_SHA:-}" ]; then
+            echo "w Skipping rollback: PREPARE_START_SHA is not set; cannot restore pre-prepare CHANGELOG"
+            exit 0
+          fi
 
           if gh api "repos/${{ github.repository }}/git/ref/heads/$RELEASE_BRANCH" >/dev/null 2>&1; then
             gh api -X DELETE "repos/${{ github.repository }}/git/refs/heads/$RELEASE_BRANCH"
@@ -326,6 +336,16 @@ jobs:
             echo "✓ Deleted partially created release branch: $RELEASE_BRANCH"
           else
             echo "i Release branch not present; nothing to delete"
+          fi
+
+          if [ -n "${POST_FREEZE_DEV_SHA:-}" ]; then
+            CURRENT_DEV_SHA="$(gh api "repos/${{ github.repository }}/git/ref/heads/dev" --jq '.object.sha')"
+            if [ "$CURRENT_DEV_SHA" != "$POST_FREEZE_DEV_SHA" ]; then
+              echo "w dev advanced after freeze commit; skipping CHANGELOG rollback to avoid clobbering concurrent updates"
+              echo "branch_deleted=$BRANCH_DELETED" >> "$GITHUB_OUTPUT"
+              echo "changelog_rollback_needed=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
           fi
 
           gh api "repos/${{ github.repository }}/contents/CHANGELOG.md?ref=$PREPARE_START_SHA" --jq '.content' | tr -d '\n' | base64 -d > /tmp/changelog.pre-prepare.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -559,6 +559,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Label taxonomy guidance clarifies that `setup-labels` is provided by devcontainer bootstrap tooling
 - **CodeQL PR trigger no longer blocks merge protection on non-Python changes** ([#247](https://github.com/vig-os/devcontainer/issues/247))
   - Removed `pull_request` `paths` filter from `codeql.yml` in both root and workspace template so CodeQL always runs for PRs targeting protected branches and uploads SARIF results
+- **Release workflow dispatch refs and prepare rollback safeguards** ([#266](https://github.com/vig-os/devcontainer/issues/266))
+  - `just prepare-release` dispatches `prepare-release.yml` from `dev` via `--ref dev`
+  - `just publish-candidate` and `just finalize-release` dispatch `release.yml` from `release/X.Y.Z` via `--ref release/{{ version }}`
+  - `prepare-release.yml` now rolls back partial side effects on failure by deleting a created `release/X.Y.Z` branch and restoring `CHANGELOG.md` on `dev`
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -561,7 +561,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Removed `pull_request` `paths` filter from `codeql.yml` in both root and workspace template so CodeQL always runs for PRs targeting protected branches and uploads SARIF results
 - **Release workflow dispatch refs and prepare rollback safeguards** ([#266](https://github.com/vig-os/devcontainer/issues/266))
   - `just prepare-release` dispatches `prepare-release.yml` from `dev` via `--ref dev`
-  - `just publish-candidate` and `just finalize-release` dispatch `release.yml` from `release/X.Y.Z` via `--ref release/{{ version }}`
+  - `just publish-candidate` and `just finalize-release` dispatch `release.yml` from `release/X.Y.Z` via `--ref release/X.Y.Z`
   - `prepare-release.yml` now rolls back partial side effects on failure by deleting a created `release/X.Y.Z` branch and restoring `CHANGELOG.md` on `dev`
 
 ### Security

--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -193,9 +193,9 @@ Available recipes:
     precommit                                  # Run pre-commit hooks on all files
 
     [release]
-    finalize-release version *flags            # Finalize and publish release via GitHub Actions workflow (step 3, after testing)
-    prepare-release version *flags             # Prepare release branch for testing (step 1)
-    publish-candidate version *flags           # Publish release candidate via GitHub Actions workflow
+    finalize-release version ref="" *flags     # Finalize and publish release via GitHub Actions workflow (step 3, after testing)
+    prepare-release version ref="" *flags      # Prepare release branch for testing (step 1)
+    publish-candidate version ref="" *flags    # Publish release candidate via GitHub Actions workflow
     pull version="latest"                      # Pull image from registry (default: latest)
     reset-changelog                            # Reset CHANGELOG Unreleased section (after merging release to dev)
 

--- a/README.md
+++ b/README.md
@@ -144,9 +144,9 @@ Available recipes:
     precommit                                  # Run pre-commit hooks on all files
 
     [release]
-    finalize-release version *flags            # Finalize and publish release via GitHub Actions workflow (step 3, after testing)
-    prepare-release version *flags             # Prepare release branch for testing (step 1)
-    publish-candidate version *flags           # Publish release candidate via GitHub Actions workflow
+    finalize-release version ref="" *flags     # Finalize and publish release via GitHub Actions workflow (step 3, after testing)
+    prepare-release version ref="" *flags      # Prepare release branch for testing (step 1)
+    publish-candidate version ref="" *flags    # Publish release candidate via GitHub Actions workflow
     pull version="latest"                      # Pull image from registry (default: latest)
     reset-changelog                            # Reset CHANGELOG Unreleased section (after merging release to dev)
 

--- a/docs/RELEASE_CYCLE.md
+++ b/docs/RELEASE_CYCLE.md
@@ -156,7 +156,7 @@ graph TB
 just prepare-release X.Y.Z
 
 # Or directly via GitHub CLI:
-gh workflow run prepare-release.yml -f "version=X.Y.Z"
+gh workflow run prepare-release.yml --ref dev -f "version=X.Y.Z"
 ```
 
 **What the workflow does (automatically):**
@@ -585,10 +585,10 @@ Additional requirement:
 **Manual trigger (for testing):**
 
 ```bash
-gh workflow run prepare-release.yml -f "version=1.0.0" -f "dry-run=false"
+gh workflow run prepare-release.yml --ref dev -f "version=1.0.0" -f "dry-run=false"
 
 # Dry-run mode (validates without making changes)
-gh workflow run prepare-release.yml -f "version=1.0.0" -f "dry-run=true"
+gh workflow run prepare-release.yml --ref dev -f "version=1.0.0" -f "dry-run=true"
 ```
 
 **Key characteristics:**
@@ -596,6 +596,8 @@ gh workflow run prepare-release.yml -f "version=1.0.0" -f "dry-run=true"
 - Push via GitHub App token ensures CI runs on new release branch
 - Audit trail in GitHub Actions logs
 - No dependency on local developer environment
+- Dispatch is pinned to `dev` (`--ref dev`) so workflow behavior matches the development branch
+- On failure, rollback removes partial release branch state and restores `CHANGELOG.md` on `dev`
 
 #### release.yml (Unified Release Workflow)
 
@@ -646,6 +648,7 @@ gh workflow run prepare-release.yml -f "version=1.0.0" -f "dry-run=true"
 
 ```bash
 gh workflow run release.yml \
+  --ref release/X.Y.Z \
   -f "version=1.0.0" \
   -f "release-kind=final" \
   -f "architectures=amd64,arm64" \
@@ -653,6 +656,7 @@ gh workflow run release.yml \
 
 # Dry-run mode (validates without making changes)
 gh workflow run release.yml \
+  --ref release/X.Y.Z \
   -f "version=1.0.0" \
   -f "release-kind=candidate" \
   -f "dry-run=true"
@@ -663,6 +667,7 @@ gh workflow run release.yml \
 - Automatic rollback on failure
 - All in one workflow for atomic operation
 - Audit trail in GitHub Actions logs
+- Dispatch is pinned to `release/X.Y.Z` so candidate/final runs use the release branch workflow definition
 
 #### sync-issues.yml
 

--- a/justfile
+++ b/justfile
@@ -209,35 +209,47 @@ test version="dev":
 
 # Prepare release branch for testing (step 1)
 [group('release')]
-prepare-release version *flags:
+prepare-release version ref="" *flags:
     #!/usr/bin/env bash
     set -euo pipefail
     # Trigger the prepare-release workflow via GitHub Actions
     # The workflow handles: validate inputs, create release branch, prepare CHANGELOG, create draft PR
-    gh workflow run prepare-release.yml -f "version={{ version }}" {{ flags }}
+    REF="{{ ref }}"
+    if [ -z "$REF" ]; then
+        REF="dev"
+    fi
+    gh workflow run prepare-release.yml --ref "$REF" -f "version={{ version }}" {{ flags }}
     echo ""
     echo "✓ Release preparation workflow triggered for version {{ version }}"
     echo "Monitor progress: gh run list --workflow prepare-release.yml"
 
 # Finalize and publish release via GitHub Actions workflow (step 3, after testing)
 [group('release')]
-finalize-release version *flags:
+finalize-release version ref="" *flags:
     #!/usr/bin/env bash
     set -euo pipefail
     # Trigger the release workflow via GitHub Actions
     # The workflow handles: finalize CHANGELOG, build/test images, create final tag, publish
-    gh workflow run release.yml -f "version={{ version }}" -f "release-kind=final" {{ flags }}
+    REF="{{ ref }}"
+    if [ -z "$REF" ]; then
+        REF="release/{{ version }}"
+    fi
+    gh workflow run release.yml --ref "$REF" -f "version={{ version }}" -f "release-kind=final" {{ flags }}
     echo ""
     echo "✓ Release workflow triggered for version {{ version }}"
     echo "Monitor progress: gh run list --workflow release.yml"
 
 # Publish release candidate via GitHub Actions workflow
 [group('release')]
-publish-candidate version *flags:
+publish-candidate version ref="" *flags:
     #!/usr/bin/env bash
     set -euo pipefail
     # Trigger release workflow in candidate mode (default mode in workflow)
-    gh workflow run release.yml -f "version={{ version }}" -f "release-kind=candidate" {{ flags }}
+    REF="{{ ref }}"
+    if [ -z "$REF" ]; then
+        REF="release/{{ version }}"
+    fi
+    gh workflow run release.yml --ref "$REF" -f "version={{ version }}" -f "release-kind=candidate" {{ flags }}
     echo ""
     echo "✓ Candidate release workflow triggered for version {{ version }}"
     echo "Monitor progress: gh run list --workflow release.yml"

--- a/tests/bats/just.bats
+++ b/tests/bats/just.bats
@@ -14,3 +14,18 @@ setup() {
     assert_success
     assert_output --partial "Available recipes"
 }
+
+@test "prepare-release dispatches workflow from dev ref" {
+    run bash -lc "awk '/^prepare-release version ref=\"\" \\*flags:/{flag=1; next} /^$/{if(flag){exit}} flag' justfile | grep -Fq -- 'REF=\"dev\"'"
+    assert_success
+}
+
+@test "finalize-release dispatches workflow from release branch ref" {
+    run bash -lc "awk '/^finalize-release version ref=\"\" \\*flags:/{flag=1; next} /^$/{if(flag){exit}} flag' justfile | grep -Fq -- 'REF=\"release/{{ version }}\"'"
+    assert_success
+}
+
+@test "publish-candidate dispatches workflow from release branch ref" {
+    run bash -lc "awk '/^publish-candidate version ref=\"\" \\*flags:/{flag=1; next} /^$/{if(flag){exit}} flag' justfile | grep -Fq -- 'REF=\"release/{{ version }}\"'"
+    assert_success
+}

--- a/tests/bats/just.bats
+++ b/tests/bats/just.bats
@@ -29,3 +29,13 @@ setup() {
     run bash -lc "awk '/^publish-candidate version ref=\"\" \\*flags:/{flag=1; next} /^$/{if(flag){exit}} flag' justfile | grep -Fq -- 'REF=\"release/{{ version }}\"'"
     assert_success
 }
+
+@test "prepare-release workflow defines rollback step on failure" {
+    run bash -lc "grep -Fq -- 'name: Roll back prepare-release side effects on failure' .github/workflows/prepare-release.yml"
+    assert_success
+}
+
+@test "prepare-release workflow rollback deletes release branch ref" {
+    run bash -lc "grep -Fq -- 'git/refs/heads/$RELEASE_BRANCH' .github/workflows/prepare-release.yml"
+    assert_success
+}


### PR DESCRIPTION
## Description

Pins release workflow dispatches to explicit branch refs and hardens `prepare-release` failure rollback so partial side effects are reverted safely without clobbering concurrent `dev` updates.

## Type of Change

- [ ] `feat` -- New feature
- [x] `fix` -- Bug fix
- [x] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [x] `test` -- Adding or updating tests
- [x] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- `justfile`
  - `prepare-release`, `publish-candidate`, and `finalize-release` accept optional `ref`
  - workflow dispatches use `gh workflow run ... --ref "$REF"`
  - default refs: `dev` (prepare) and `release/{{ version }}` (candidate/finalize)
- `tests/bats/just.bats`
  - regression tests for dispatch ref defaults
  - assertions for rollback step presence in `prepare-release.yml`
- `.github/workflows/prepare-release.yml`
  - captures pre-prepare `dev` SHA
  - adds rollback routine on failure
  - adds rollback safety guards for missing `GH_TOKEN` / `PREPARE_START_SHA`
  - skips CHANGELOG rollback when `dev` has advanced past freeze SHA
- `docs/RELEASE_CYCLE.md`
  - documents explicit ref usage and rollback behavior
- `CHANGELOG.md`
  - adds/updates unreleased fixed entry for #266 with consistent `release/X.Y.Z` notation
- generated docs updated by hooks
  - `README.md`
  - `CONTRIBUTE.md`

## Changelog Entry

### Fixed

- **Release workflow dispatch refs and prepare rollback safeguards** ([#266](https://github.com/vig-os/devcontainer/issues/266))
  - `just prepare-release` dispatches `prepare-release.yml` from `dev` via `--ref dev`
  - `just publish-candidate` and `just finalize-release` dispatch `release.yml` from `release/X.Y.Z` via `--ref release/X.Y.Z`
  - `prepare-release.yml` now rolls back partial side effects on failure by deleting a created `release/X.Y.Z` branch and restoring `CHANGELOG.md` on `dev`

## Testing

- [x] Tests pass locally (`just test`)
- [ ] Manual testing performed (describe below)

### Manual Testing Details

N/A

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

- Addressed Co*ilot review feedback: accepted rollback guard improvements and changelog notation consistency; rejected false-positive escaping comments on BATS tests after runtime verification.

Refs: #266