### PR TITLE
fix(ci): split prepare-release app tokens by scope

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -155,8 +155,15 @@ jobs:
       pull-requests: write    # create draft PR
 
     steps:
-      - name: Generate GitHub App Token
-        id: app-token
+      - name: Generate Commit App Token
+        id: commit-app-token
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf  # v2
+        with:
+          app-id: ${{ secrets.COMMIT_APP_ID }}
+          private-key: ${{ secrets.COMMIT_APP_PRIVATE_KEY }}
+
+      - name: Generate Release App Token
+        id: release-app-token
         uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf  # v2
         with:
           app-id: ${{ secrets.RELEASE_APP_ID }}
@@ -176,7 +183,7 @@ jobs:
       - name: Capture pre-prepare dev SHA
         id: pre-state
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ steps.commit-app-token.outputs.token }}
         run: |
           set -euo pipefail
           PREPARE_START_SHA=$(gh api "repos/${{ github.repository }}/git/ref/heads/dev" --jq '.object.sha')
@@ -208,7 +215,7 @@ jobs:
       - name: Commit prepared CHANGELOG to dev via API
         uses: vig-os/commit-action@b70c2d87acd0f146c40e8d88a9bda40b76c084b5  # v0.1.3
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ steps.commit-app-token.outputs.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           TARGET_BRANCH: refs/heads/dev
           COMMIT_MESSAGE: |-
@@ -221,7 +228,7 @@ jobs:
       - name: Create release branch from dev
         id: create-branch
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ steps.commit-app-token.outputs.token }}
           RELEASE_BRANCH: ${{ needs.validate.outputs.release_branch }}
         run: |
           set -euo pipefail
@@ -252,7 +259,7 @@ jobs:
       - name: Commit stripped CHANGELOG to release branch via API
         uses: vig-os/commit-action@b70c2d87acd0f146c40e8d88a9bda40b76c084b5  # v0.1.3
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ steps.commit-app-token.outputs.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           TARGET_BRANCH: refs/heads/${{ needs.validate.outputs.release_branch }}
           COMMIT_MESSAGE: |-
@@ -265,7 +272,7 @@ jobs:
       - name: Create draft PR to main
         id: pr
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ steps.release-app-token.outputs.token }}
           VERSION: ${{ needs.validate.outputs.version }}
           RELEASE_BRANCH: ${{ needs.validate.outputs.release_branch }}
           CHANGELOG_CONTENT: ${{ steps.changelog.outputs.changelog }}
@@ -310,7 +317,7 @@ jobs:
         if: ${{ failure() }}
         id: rollback-prepare
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ steps.commit-app-token.outputs.token }}
           VERSION: ${{ needs.validate.outputs.version }}
           RELEASE_BRANCH: ${{ needs.validate.outputs.release_branch }}
           PREPARE_START_SHA: ${{ steps.pre-state.outputs.prepare_start_sha }}
@@ -366,7 +373,7 @@ jobs:
         if: ${{ failure() && steps.rollback-prepare.outputs.changelog_rollback_needed == 'true' }}
         uses: vig-os/commit-action@b70c2d87acd0f146c40e8d88a9bda40b76c084b5  # v0.1.3
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GH_TOKEN: ${{ steps.commit-app-token.outputs.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           TARGET_BRANCH: refs/heads/dev
           COMMIT_MESSAGE: |-

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -152,7 +152,6 @@ jobs:
     if: ${{ github.event.inputs.dry-run != 'true' }}
     permissions:
       contents: read          # checkout dev branch
-      pull-requests: write    # create draft PR
 
     steps:
       - name: Generate Commit App Token

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -156,6 +156,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Smoke-test redeploy preserves synced docs directories** ([#262](https://github.com/vig-os/devcontainer/issues/262))
   - `init-workspace.sh --smoke-test` now excludes `docs/issues/` and `docs/pull-requests/` from `rsync --delete`
   - Re-deploying smoke assets no longer removes docs synced by `sync-issues`
+- **Prepare-release uses scoped app tokens for protected branch writes** ([#268](https://github.com/vig-os/devcontainer/issues/268))
+  - `prepare-release.yml` now uses `COMMIT_APP_*` for git/ref and `commit-action` operations that touch `dev` and release refs
+  - Draft PR creation in prepare-release now uses `RELEASE_APP_*` token scope for pull-request operations
 
 ### Changed
 


### PR DESCRIPTION
## Description

Split authentication in `prepare-release.yml` so protected branch git/ref operations use `COMMIT_APP_*`, while pull request operations use `RELEASE_APP_*`. This aligns token scope with repository rules and fixes the direct-write failure on `dev` during release preparation.

## Type of Change

- [ ] `feat` -- New feature
- [x] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [ ] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- `.github/workflows/prepare-release.yml`
  - Added two token-generation steps in `prepare`: `commit-app-token` (`COMMIT_APP_*`) and `release-app-token` (`RELEASE_APP_*`)
  - Switched git/ref and `commit-action` operations (dev SHA capture, changelog commits, release branch ref create, rollback operations) to `commit-app-token`
  - Switched draft PR creation to `release-app-token`
  - Removed unnecessary `pull-requests: write` job permission since PR operations use the release app token, keeping default `GITHUB_TOKEN` least-privileged
- `CHANGELOG.md`
  - Added an `Unreleased` `### Fixed` entry for issue `#268`

## Changelog Entry

### Fixed
- **Prepare-release uses scoped app tokens for protected branch writes** ([#268](https://github.com/vig-os/devcontainer/issues/268))
  - `prepare-release.yml` now uses `COMMIT_APP_*` for git/ref and `commit-action` operations that touch `dev` and release refs
  - Draft PR creation in prepare-release now uses `RELEASE_APP_*` token scope for pull-request operations

## Testing

- [ ] Tests pass locally (`just test`)
- [ ] Manual testing performed (describe below)

### Manual Testing Details

N/A

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

Fix targets the failure seen in prepare-release run 22999412063 where protected `dev` writes were rejected under repository rules.

Refs: #268
