### PR TITLE
fix: skip TBD changelog entries in docs generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -437,6 +437,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Prepare-release uses scoped app tokens for protected branch writes** ([#268](https://github.com/vig-os/devcontainer/issues/268))
   - `prepare-release.yml` now uses `COMMIT_APP_*` for git/ref and `commit-action` operations that touch `dev` and release refs
   - Draft PR creation in prepare-release now uses `RELEASE_APP_*` token scope for pull-request operations
+- **generate-docs picks up unreleased TBD version on release branches** ([#271](https://github.com/vig-os/devcontainer/issues/271))
+  - `get_version_from_changelog()` and `get_release_date_from_changelog()` now skip entries without a concrete release date
 
 ### Security
 

--- a/docs/generate.py
+++ b/docs/generate.py
@@ -11,6 +11,7 @@ Single source of truth principle: All dependency information comes from requirem
 all skill metadata comes from SKILL.md frontmatter.
 """
 
+import re
 import subprocess
 import sys
 from datetime import datetime
@@ -41,8 +42,8 @@ def get_version_from_changelog() -> str:
     if changelog.exists():
         with changelog.open() as f:
             for line in f:
-                if line.startswith("## ["):
-                    # Extract version from "## [X.Y]" format
+                # Skip unreleased headings (e.g., "TBD") and use latest dated release.
+                if line.startswith("## [") and re.search(r"\d{4}-\d{2}-\d{2}", line):
                     version = line.split("[")[1].split("]")[0]
                     return version
     return "dev"
@@ -55,7 +56,9 @@ def get_release_date_from_changelog() -> str:
         with changelog.open() as f:
             for line in f:
                 if line.startswith("## ["):
-                    return line.split("]")[1].split(" - ")[1].strip()
+                    match = re.search(r"\d{4}-\d{2}-\d{2}", line)
+                    if match:
+                        return match.group()
     return datetime.now().isoformat(timespec="seconds")
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -26,6 +26,22 @@ generate = importlib.util.module_from_spec(generate_spec)
 generate_spec.loader.exec_module(generate)
 
 
+def _point_generate_to_temp_changelog(
+    monkeypatch, tmp_path: Path, content: str
+) -> Path:
+    """Point generate.py changelog lookup to a temp CHANGELOG.md file."""
+    docs_path = tmp_path / "docs"
+    docs_path.mkdir()
+    fake_generate = docs_path / "generate.py"
+    fake_generate.write_text("# test helper\n")
+
+    changelog = tmp_path / "CHANGELOG.md"
+    changelog.write_text(content)
+
+    monkeypatch.setattr(generate, "__file__", str(fake_generate))
+    return changelog
+
+
 # ═════════════════════════════════════════════════════════════════════════════
 # docs/generate.py — function-level unit tests
 # ═════════════════════════════════════════════════════════════════════════════
@@ -121,6 +137,18 @@ class TestGetVersionFromChangelog:
         )
         assert generate.get_version_from_changelog() == "2.0.0"
 
+    def test_skips_tbd_entry(self, tmp_path, monkeypatch):
+        """Should ignore unreleased headings and use latest released version."""
+        _point_generate_to_temp_changelog(
+            monkeypatch,
+            tmp_path,
+            "# Changelog\n\n"
+            "## [0.3.0] - TBD\n\n"
+            "## [0.2.1] - 2026-01-28\n\n"
+            "## [0.2.0] - 2025-12-10\n",
+        )
+        assert generate.get_version_from_changelog() == "0.2.1"
+
     def test_get_version_from_changelog_actual(self):
         """Test version extraction from actual CHANGELOG.md."""
         version = generate.get_version_from_changelog()
@@ -171,6 +199,18 @@ class TestGetReleaseDateFromChangelog:
                             break
 
         assert date_found is None
+
+    def test_skips_tbd_entry(self, tmp_path, monkeypatch):
+        """Should ignore unreleased headings and use latest released date."""
+        _point_generate_to_temp_changelog(
+            monkeypatch,
+            tmp_path,
+            "# Changelog\n\n"
+            "## [0.3.0] - TBD\n\n"
+            "## [0.2.1] - 2026-01-28\n\n"
+            "## [0.2.0] - 2025-12-10\n",
+        )
+        assert generate.get_release_date_from_changelog() == "2026-01-28"
 
     def test_get_release_date_from_changelog_actual(self):
         """Test date extraction from actual CHANGELOG.md."""


### PR DESCRIPTION
## Description

Fixes release-branch CI failures where `generate-docs` rewrote `README.md` to an unreleased `TBD` version after `prepare-release`.
The changelog parser in `docs/generate.py` now selects the latest dated release entry, and regression tests ensure `TBD` entries are skipped.

## Type of Change

- [x] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [ ] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- `docs/generate.py`
  - Added date-aware filtering for changelog headings so version/date extraction ignores `TBD` entries.
  - Updated `get_version_from_changelog()` and `get_release_date_from_changelog()` to pick the first heading containing a concrete `YYYY-MM-DD` date.
- `tests/test_utils.py`
  - Added regression tests in both changelog parser test classes to verify `## [x.y.z] - TBD` headings are skipped.
  - Added a test helper to point parser functions at a temporary changelog fixture.
- `CHANGELOG.md`
  - Added a `### Fixed` entry in `## [0.3.0] - TBD` for issue `#271`.

## Changelog Entry

### Fixed
- **generate-docs picks up unreleased TBD version on release branches** ([#271](https://github.com/vig-os/devcontainer/issues/271))
  - `get_version_from_changelog()` and `get_release_date_from_changelog()` now skip entries without a concrete release date

## Testing

- [ ] Tests pass locally (`just test`)
- [x] Manual testing performed (describe below)

### Manual Testing Details

- `uv run pytest tests/test_utils.py -k "skips_tbd_entry"` (RED before fix; two failures reproduced)
- `uv run pytest tests/test_utils.py -k "changelog"` (GREEN after fix; passing)
- `uv run pre-commit run generate-docs --all-files` (docs regenerated without remaining diffs)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [ ] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

This branch targets `release/0.3.0` to unblock the release pipeline affected by PR #270 checks.

Refs: #271
