### PR TITLE
fix: remove unsafe github.com substring assertions

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1366,8 +1366,11 @@ class TestDevContainerCLI:
             # Check if it's a permission denied (keys not authorized) vs connection error
             if "Permission denied" in result.stderr:
                 # Keys exist but aren't authorized - this is acceptable for testing
-                # The important thing is that SSH is configured
-                assert "github.com" in result.stderr, (
+                # Ensure this is an auth failure, not a connectivity/hostname failure.
+                assert (
+                    "Could not resolve hostname" not in result.stderr
+                    and "Name or service not known" not in result.stderr
+                ), (
                     f"SSH connection failed unexpectedly\n"
                     f"stdout: {result.stdout}\n"
                     f"stderr: {result.stderr}"
@@ -1381,7 +1384,12 @@ class TestDevContainerCLI:
                 )
         elif result.returncode == 1:
             # Success - GitHub responded (exit 1 is normal for test connections)
-            assert "Hi" in result.stdout or "github.com" in result.stderr, (
+            output = result.stdout + result.stderr
+            assert (
+                "successfully authenticated" in output
+                or "does not provide shell access" in output
+                or "Hi " in output
+            ), (
                 f"Unexpected SSH response from GitHub\n"
                 f"stdout: {result.stdout}\n"
                 f"stderr: {result.stderr}"
@@ -1632,15 +1640,11 @@ class TestDevContainerCLI:
 
         # Verify we got a successful authentication response
         output = result.stdout + result.stderr
-        assert (
-            "Logged in to github.com" in output
-            or "✓ Logged in" in output
-            or "github.com" in output
-        ), (
+        assert "Logged in to " in output or "✓ Logged in" in output, (
             f"GitHub CLI authentication status unclear\n"
             f"stdout: {result.stdout}\n"
             f"stderr: {result.stderr}\n"
-            f"Expected 'Logged in to github.com' or similar in output"
+            f"Expected a successful gh auth status message in output"
         )
 
     def test_valid_branch_names_commit_succeeds(self, devcontainer_up):


### PR DESCRIPTION
## Description

Fix CodeQL `py/incomplete-url-substring-sanitization` findings in integration tests by removing unsafe `github.com` substring checks and replacing them with deterministic SSH/GitHub auth output assertions.

## Type of Change

- [x] `fix` -- Bug fix
- [ ] `feat` -- New feature
- [ ] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [ ] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- `tests/test_integration.py`
  - Replace `github.com` substring assertions in SSH auth checks with safer output-based checks.
  - Ensure `Permission denied` path is validated as auth failure, not hostname/DNS failure.
  - Replace `gh auth status` assertion with generic success markers (`Logged in to`, `✓ Logged in`).

## Changelog Entry

No changelog needed: this change only adjusts integration-test assertions to satisfy static analysis and does not change shipped runtime behavior.

## Testing

- [ ] Tests pass locally (`just test`)
- [x] Manual testing performed (describe below)

### Manual Testing Details

- `uv run pytest tests/test_integration.py -k "ssh or gh_auth" -v` (3 selected tests passed)
- `uv run pre-commit run --all-files` (all hooks passed after formatter adjustment)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [ ] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

This PR targets `release/0.3.0` per issue requirements.

Refs: #272
