### PR TITLE
ci: use compliant title for release PRs

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -303,7 +303,7 @@ jobs:
           PR_URL=$(gh pr create \
             --base main \
             --head "$RELEASE_BRANCH" \
-            --title "Release $VERSION" \
+            --title "chore: release $VERSION" \
             --body "$PR_BODY" \
             --draft)
 


### PR DESCRIPTION
## Summary
- update `prepare-release` workflow to create release draft PRs with title format `chore: release X.Y.Z`
- align generated release PR titles with the repository commit-message/PR-title validation rules
- resolve issue #276 without expanding allowed commit types

## Test plan
- [x] Run `uv run validate-commit-msg` locally with `--subject-only` for `chore: release 0.3.0`
- [x] Retitle release PR #270 to `chore: release 0.3.0`
- [ ] Confirm `Validate PR Title` passes on PR #270 once unrelated blocker #274 is resolved

Refs: #276