### PR TITLE
refactor: parse .vig-os config as data

### DIFF
--- a/assets/workspace/.devcontainer/scripts/initialize.sh
+++ b/assets/workspace/.devcontainer/scripts/initialize.sh
@@ -17,26 +17,44 @@ DEVCONTAINER_DIR="$(dirname "$SCRIPT_DIR")"
 load_vig_os_config() {
     local config_file="$DEVCONTAINER_DIR/../.vig-os"
     local env_file="$DEVCONTAINER_DIR/.env"
+    local devcontainer_version=""
 
     if [[ ! -f "$config_file" ]]; then
         return 0
     fi
 
-    # shellcheck source=/dev/null
-    source "$config_file"
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        [[ -z "${line//[[:space:]]/}" ]] && continue
+        [[ "$line" =~ ^[[:space:]]*# ]] && continue
 
-    if [[ -z "${DEVCONTAINER_VERSION:-}" ]]; then
+        case "$line" in
+            DEVCONTAINER_VERSION=*)
+                devcontainer_version="${line#*=}"
+                devcontainer_version="${devcontainer_version#"${devcontainer_version%%[![:space:]]*}"}"
+                devcontainer_version="${devcontainer_version%"${devcontainer_version##*[![:space:]]}"}"
+
+                if [[ "$devcontainer_version" =~ ^\".*\"$ ]]; then
+                    devcontainer_version="${devcontainer_version:1:-1}"
+                elif [[ "$devcontainer_version" =~ ^\'.*\'$ ]]; then
+                    devcontainer_version="${devcontainer_version:1:-1}"
+                fi
+                break
+                ;;
+        esac
+    done < "$config_file"
+
+    if [[ -z "$devcontainer_version" ]]; then
         return 0
     fi
 
     if [[ -f "$env_file" ]] && grep -q "^DEVCONTAINER_VERSION=" "$env_file" 2>/dev/null; then
         if [[ "$(uname -s)" == "Darwin" ]]; then
-            sed -i '' "s|^DEVCONTAINER_VERSION=.*|DEVCONTAINER_VERSION=${DEVCONTAINER_VERSION}|" "$env_file"
+            sed -i '' "s|^DEVCONTAINER_VERSION=.*|DEVCONTAINER_VERSION=${devcontainer_version}|" "$env_file"
         else
-            sed -i "s|^DEVCONTAINER_VERSION=.*|DEVCONTAINER_VERSION=${DEVCONTAINER_VERSION}|" "$env_file"
+            sed -i "s|^DEVCONTAINER_VERSION=.*|DEVCONTAINER_VERSION=${devcontainer_version}|" "$env_file"
         fi
     else
-        echo "DEVCONTAINER_VERSION=${DEVCONTAINER_VERSION}" >> "$env_file"
+        echo "DEVCONTAINER_VERSION=${devcontainer_version}" >> "$env_file"
     fi
 }
 

--- a/assets/workspace/.devcontainer/scripts/initialize.sh
+++ b/assets/workspace/.devcontainer/scripts/initialize.sh
@@ -23,7 +23,7 @@ load_vig_os_config() {
         return 0
     fi
 
-    while IFS= read -r line || [[ -n "$line" ]]; do
+    while IFS= read -r line || [[ -n "${line:-}" ]]; do
         [[ -z "${line//[[:space:]]/}" ]] && continue
         [[ "$line" =~ ^[[:space:]]*# ]] && continue
 

--- a/assets/workspace/.devcontainer/scripts/version-check.sh
+++ b/assets/workspace/.devcontainer/scripts/version-check.sh
@@ -193,15 +193,32 @@ record_check() {
 # Get current installed version from root .vig-os config
 get_current_version() {
     local config_file="$DEVCONTAINER_DIR/../.vig-os"
+    local line
+    local version=""
 
     if [[ ! -f "$config_file" ]]; then
         return 1
     fi
 
-    # shellcheck source=/dev/null
-    source "$config_file"
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        [[ -z "${line//[[:space:]]/}" ]] && continue
+        [[ "$line" =~ ^[[:space:]]*# ]] && continue
 
-    local version="${DEVCONTAINER_VERSION:-}"
+        case "$line" in
+            DEVCONTAINER_VERSION=*)
+                version="${line#*=}"
+                version="${version#"${version%%[![:space:]]*}"}"
+                version="${version%"${version##*[![:space:]]}"}"
+
+                if [[ "$version" =~ ^\".*\"$ ]]; then
+                    version="${version:1:-1}"
+                elif [[ "$version" =~ ^\'.*\'$ ]]; then
+                    version="${version:1:-1}"
+                fi
+                break
+                ;;
+        esac
+    done < "$config_file"
 
     if [[ -z "$version" || "$version" == "dev" || "$version" == "latest" ]]; then
         return 1  # Not a pinned version

--- a/tests/bats/githooks.bats
+++ b/tests/bats/githooks.bats
@@ -33,7 +33,7 @@ setup() {
 }
 
 @test "pre-commit does not show guard message when IN_CONTAINER is true" {
-    run -127 env IN_CONTAINER="true" bash "$HOOKS_DIR/pre-commit"
+    run -127 env PATH="/nonexistent" IN_CONTAINER="true" /bin/bash "$HOOKS_DIR/pre-commit"
     refute_output --partial "Please commit your changes within the dev container"
 }
 
@@ -58,7 +58,7 @@ setup() {
 }
 
 @test "prepare-commit-msg does not show guard message when IN_CONTAINER is true" {
-    run -127 env IN_CONTAINER="true" bash "$HOOKS_DIR/prepare-commit-msg" /dev/null
+    run -127 env PATH="/nonexistent" IN_CONTAINER="true" /bin/bash "$HOOKS_DIR/prepare-commit-msg" /dev/null
     refute_output --partial "Please commit your changes within the dev container"
 }
 
@@ -83,6 +83,6 @@ setup() {
 }
 
 @test "commit-msg does not show guard message when IN_CONTAINER is true" {
-    run -127 env IN_CONTAINER="true" bash "$HOOKS_DIR/commit-msg" /dev/null
+    run -127 env PATH="/nonexistent" IN_CONTAINER="true" /bin/bash "$HOOKS_DIR/commit-msg" /dev/null
     refute_output --partial "Please commit your changes within the dev container"
 }

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -704,6 +704,52 @@ class TestVigOsConfig:
             "initialize.sh did not write DEVCONTAINER_VERSION to .env"
         )
 
+    def test_initialize_does_not_execute_vig_os_shell_content(
+        self, initialized_workspace
+    ):
+        """Test initialize.sh parses .vig-os as data, not executable shell."""
+        init_script = (
+            initialized_workspace / ".devcontainer" / "scripts" / "initialize.sh"
+        )
+        vig_os_file = initialized_workspace / ".vig-os"
+        env_file = initialized_workspace / ".devcontainer" / ".env"
+        marker_file = initialized_workspace / ".issue285_init_marker"
+
+        if env_file.exists():
+            env_file.unlink()
+        if marker_file.exists():
+            marker_file.unlink()
+
+        vig_os_file.write_text(
+            "\n".join(
+                [
+                    "DEVCONTAINER_VERSION=1.2.3",
+                    f'EVIL=$(touch "{marker_file}")',
+                    "UNRELATED_KEY=ignored",
+                ]
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        result = subprocess.run(
+            [str(init_script)],
+            capture_output=True,
+            text=True,
+            cwd=str(initialized_workspace),
+            timeout=10,
+        )
+
+        assert result.returncode == 0, (
+            f"initialize.sh failed\nstdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+        assert marker_file.exists() is False, (
+            "initialize.sh executed shell content from .vig-os"
+        )
+        assert env_file.exists(), ".devcontainer/.env was not created by initialize.sh"
+        env_content = env_file.read_text(encoding="utf-8")
+        assert "DEVCONTAINER_VERSION=1.2.3" in env_content
+
 
 class TestPlaceholders:
     """Test that placeholders are replaced correctly."""
@@ -2663,6 +2709,44 @@ class TestVersionCheckScript:
         assert "DEVCONTAINER_VERSION" in content, (
             "version-check.sh should read DEVCONTAINER_VERSION"
         )
+
+    def test_config_does_not_execute_vig_os_shell_content(
+        self, version_check_script, initialized_workspace
+    ):
+        """Test config command does not execute shell code from .vig-os."""
+        vig_os_file = initialized_workspace / ".vig-os"
+        marker_file = initialized_workspace / ".issue285_version_marker"
+
+        if marker_file.exists():
+            marker_file.unlink()
+
+        vig_os_file.write_text(
+            "\n".join(
+                [
+                    "DEVCONTAINER_VERSION=1.2.3",
+                    f'EVIL=$(touch "{marker_file}")',
+                    "NOT_RELEVANT=ok",
+                ]
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        result = subprocess.run(
+            [str(version_check_script), "config"],
+            capture_output=True,
+            text=True,
+            cwd=str(initialized_workspace),
+            timeout=10,
+        )
+
+        assert result.returncode == 0, (
+            f"version-check.sh config failed\nstdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+        assert marker_file.exists() is False, (
+            "version-check.sh executed shell content from .vig-os"
+        )
+        assert "Current ver:    1.2.3" in result.stdout
 
     def test_config_creation(self, version_check_script, local_dir):
         """Test that config file is created with defaults on first run."""

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -714,41 +714,53 @@ class TestVigOsConfig:
         vig_os_file = initialized_workspace / ".vig-os"
         env_file = initialized_workspace / ".devcontainer" / ".env"
         marker_file = initialized_workspace / ".issue285_init_marker"
+        original_vig_os = (
+            vig_os_file.read_text(encoding="utf-8") if vig_os_file.exists() else None
+        )
 
-        if env_file.exists():
-            env_file.unlink()
-        if marker_file.exists():
-            marker_file.unlink()
+        try:
+            if env_file.exists():
+                env_file.unlink()
+            if marker_file.exists():
+                marker_file.unlink()
 
-        vig_os_file.write_text(
-            "\n".join(
-                [
-                    "DEVCONTAINER_VERSION=1.2.3",
-                    f'EVIL=$(touch "{marker_file}")',
-                    "UNRELATED_KEY=ignored",
-                ]
+            vig_os_file.write_text(
+                "\n".join(
+                    [
+                        "DEVCONTAINER_VERSION=1.2.3",
+                        f'EVIL=$(touch "{marker_file}")',
+                        "UNRELATED_KEY=ignored",
+                    ]
+                )
+                + "\n",
+                encoding="utf-8",
             )
-            + "\n",
-            encoding="utf-8",
-        )
 
-        result = subprocess.run(
-            [str(init_script)],
-            capture_output=True,
-            text=True,
-            cwd=str(initialized_workspace),
-            timeout=10,
-        )
+            result = subprocess.run(
+                [str(init_script)],
+                capture_output=True,
+                text=True,
+                cwd=str(initialized_workspace),
+                timeout=10,
+            )
 
-        assert result.returncode == 0, (
-            f"initialize.sh failed\nstdout: {result.stdout}\nstderr: {result.stderr}"
-        )
-        assert marker_file.exists() is False, (
-            "initialize.sh executed shell content from .vig-os"
-        )
-        assert env_file.exists(), ".devcontainer/.env was not created by initialize.sh"
-        env_content = env_file.read_text(encoding="utf-8")
-        assert "DEVCONTAINER_VERSION=1.2.3" in env_content
+            assert result.returncode == 0, (
+                f"initialize.sh failed\nstdout: {result.stdout}\nstderr: {result.stderr}"
+            )
+            assert marker_file.exists() is False, (
+                "initialize.sh executed shell content from .vig-os"
+            )
+            assert env_file.exists(), (
+                ".devcontainer/.env was not created by initialize.sh"
+            )
+            env_content = env_file.read_text(encoding="utf-8")
+            assert "DEVCONTAINER_VERSION=1.2.3" in env_content
+        finally:
+            if original_vig_os is None:
+                if vig_os_file.exists():
+                    vig_os_file.unlink()
+            else:
+                vig_os_file.write_text(original_vig_os, encoding="utf-8")
 
 
 class TestPlaceholders:
@@ -2716,37 +2728,47 @@ class TestVersionCheckScript:
         """Test config command does not execute shell code from .vig-os."""
         vig_os_file = initialized_workspace / ".vig-os"
         marker_file = initialized_workspace / ".issue285_version_marker"
+        original_vig_os = (
+            vig_os_file.read_text(encoding="utf-8") if vig_os_file.exists() else None
+        )
 
-        if marker_file.exists():
-            marker_file.unlink()
+        try:
+            if marker_file.exists():
+                marker_file.unlink()
 
-        vig_os_file.write_text(
-            "\n".join(
-                [
-                    "DEVCONTAINER_VERSION=1.2.3",
-                    f'EVIL=$(touch "{marker_file}")',
-                    "NOT_RELEVANT=ok",
-                ]
+            vig_os_file.write_text(
+                "\n".join(
+                    [
+                        "DEVCONTAINER_VERSION=1.2.3",
+                        f'EVIL=$(touch "{marker_file}")',
+                        "NOT_RELEVANT=ok",
+                    ]
+                )
+                + "\n",
+                encoding="utf-8",
             )
-            + "\n",
-            encoding="utf-8",
-        )
 
-        result = subprocess.run(
-            [str(version_check_script), "config"],
-            capture_output=True,
-            text=True,
-            cwd=str(initialized_workspace),
-            timeout=10,
-        )
+            result = subprocess.run(
+                [str(version_check_script), "config"],
+                capture_output=True,
+                text=True,
+                cwd=str(initialized_workspace),
+                timeout=10,
+            )
 
-        assert result.returncode == 0, (
-            f"version-check.sh config failed\nstdout: {result.stdout}\nstderr: {result.stderr}"
-        )
-        assert marker_file.exists() is False, (
-            "version-check.sh executed shell content from .vig-os"
-        )
-        assert "Current ver:    1.2.3" in result.stdout
+            assert result.returncode == 0, (
+                f"version-check.sh config failed\nstdout: {result.stdout}\nstderr: {result.stderr}"
+            )
+            assert marker_file.exists() is False, (
+                "version-check.sh executed shell content from .vig-os"
+            )
+            assert "Current ver:    1.2.3" in result.stdout
+        finally:
+            if original_vig_os is None:
+                if vig_os_file.exists():
+                    vig_os_file.unlink()
+            else:
+                vig_os_file.write_text(original_vig_os, encoding="utf-8")
 
     def test_config_creation(self, version_check_script, local_dir):
         """Test that config file is created with defaults on first run."""


### PR DESCRIPTION
## Description

Replaces executable `.vig-os` loading with data-only parsing in `initialize.sh` and `version-check.sh` so unexpected shell content cannot execute.

Adds regression integration coverage proving shell payloads in `.vig-os` are not executed while `DEVCONTAINER_VERSION` is still read and used.

Includes a follow-up test hardening commit to restore `.vig-os` after mutation-based tests so later integration tests are not impacted by test-side config changes.

Adds a final test stabilization commit so `IN_CONTAINER=true` hook-path BATS checks are deterministic and no longer depend on host hook return behavior.

## Type of Change

- [ ] `feat` -- New feature
- [ ] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [x] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [ ] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- `assets/workspace/.devcontainer/scripts/initialize.sh`
  - Replaced `source "$config_file"` in `load_vig_os_config` with line-by-line key/value parsing for `DEVCONTAINER_VERSION`
  - Preserved existing `.env` update behavior and Darwin/Linux `sed` handling
- `assets/workspace/.devcontainer/scripts/version-check.sh`
  - Replaced `source "$config_file"` in `get_current_version` with data-only parsing for `DEVCONTAINER_VERSION`
  - Preserved existing pinned-version filtering (`dev`, `latest`, empty)
- `tests/test_integration.py`
  - Added regression test for `initialize.sh` to ensure shell payloads in `.vig-os` are not executed
  - Added regression test for `version-check.sh config` to ensure shell payloads in `.vig-os` are not executed
  - Added restoration of `.vig-os` after mutation tests to prevent side effects on later tests
- `tests/bats/githooks.bats`
  - Made `IN_CONTAINER=true` guard tests deterministic for `pre-commit`, `prepare-commit-msg`, and `commit-msg`
  - Adjusted expectations so tests validate guard behavior without flaky exit-code assumptions

## Changelog Entry

No changelog needed. Issue `#285` explicitly marks changelog category as "No changelog needed", and this PR keeps behavior intact while hardening implementation details.

## Testing

- [x] Tests pass locally (`just test`)
- [ ] Manual testing performed (describe below)

### Manual Testing Details

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [ ] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

Issue references a security hardening concern flagged during smoke-test review; this PR keeps scope limited to the two script functions and corresponding tests.

Refs: #285
