### PR TITLE
fix(setup): normalize short name boundaries for package validity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -454,6 +454,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Smoke-test deploy commit no longer references non-local issue IDs** ([#284](https://github.com/vig-os/devcontainer/issues/284))
   - `assets/smoke-test/.github/workflows/repository-dispatch.yml` no longer injects `Refs: #258` into automated `chore: deploy <tag>` commits in the smoke-test repository
   - Added maintainer note that workflow-template changes require manual redeploy to `vig-os/devcontainer-smoke-test` and promotion through PRs to `main`
+- **Install name sanitization trims invalid package boundaries** ([#291](https://github.com/vig-os/devcontainer/issues/291))
+  - `install.sh` now normalizes sanitized project names to ensure they start/end with alphanumeric characters before passing `SHORT_NAME`
+  - `init-workspace.sh` mirrors the same normalization so generated `pyproject.toml` names cannot end with separators like `_`
 
 ### Security
 

--- a/assets/init-workspace.sh
+++ b/assets/init-workspace.sh
@@ -119,6 +119,8 @@ fi
 
 # Sanitize: replace hyphens and spaces with underscore; lowercase; remove other special chars
 SHORT_NAME=$(echo "$SHORT_NAME" | tr '[:upper:]' '[:lower:]' | sed 's/[ -]/_/g' | sed 's/[^a-z0-9_]/_/g')
+SHORT_NAME=$(echo "$SHORT_NAME" | sed 's/__*/_/g' | sed 's/^[^a-z0-9]*//; s/[^a-z0-9]*$//')
+SHORT_NAME="${SHORT_NAME:-project}"
 echo "Project short name set to: $SHORT_NAME"
 
 # Get ORG_NAME - from env var, default, or prompt

--- a/install.sh
+++ b/install.sh
@@ -209,7 +209,11 @@ show_install_instructions() {
 
 # Sanitize project name: replace hyphens and spaces with underscore; lowercase; remove other special chars
 sanitize_name() {
-    echo "$1" | tr '[:upper:]' '[:lower:]' | sed 's/[ -]/_/g' | sed 's/[^a-z0-9_]/_/g'
+    local sanitized
+    sanitized=$(echo "$1" | tr '[:upper:]' '[:lower:]' | sed 's/[ -]/_/g' | sed 's/[^a-z0-9_]/_/g')
+    # Ensure generated package names start/end with alphanumeric characters.
+    sanitized=$(echo "$sanitized" | sed 's/__*/_/g' | sed 's/^[^a-z0-9]*//; s/[^a-z0-9]*$//')
+    echo "${sanitized:-project}"
 }
 
 # Sanitize for security only: remove shell metacharacters but preserve capitalization

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -119,6 +119,30 @@ class TestInstallScriptIntegration:
             "Expected --smoke-test to be forwarded in dry-run command output"
         )
 
+    def test_dry_run_name_sanitization_trims_trailing_separator(self):
+        """Test --name sanitization trims trailing separators for valid package name."""
+        project_root = Path(__file__).resolve().parents[1]
+        install_script = project_root / "install.sh"
+
+        result = subprocess.run(
+            [str(install_script), "--dry-run", "--name", "Install-Test-Project-", "."],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            cwd=str(project_root),
+        )
+
+        assert result.returncode == 0, (
+            f"install.sh --dry-run --name failed:\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+        assert 'SHORT_NAME="install_test_project"' in result.stdout, (
+            "Expected sanitized name without trailing underscore in dry-run output"
+        )
+        assert 'SHORT_NAME="install_test_project_"' not in result.stdout, (
+            "Sanitized name should not end with an underscore"
+        )
+
     def test_install_creates_devcontainer_json(self, install_workspace):
         """Test install.sh creates devcontainer.json."""
         devcontainer_json = install_workspace / ".devcontainer" / "devcontainer.json"


### PR DESCRIPTION
## Description

Fixes a release-blocking edge case where sanitized project names could end with `_`, producing an invalid `pyproject.toml` package name during install/integration flows. Adds a regression test, applies boundary-safe normalization in both install paths, and records the fix in the changelog.

## Type of Change

- [ ] `feat` -- New feature
- [x] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [ ] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- `tests/test_install_script.py`
  - Added `test_dry_run_name_sanitization_trims_trailing_separator`.
  - Verifies `--name "Install-Test-Project-"` becomes `install_test_project` (no trailing underscore).
- `install.sh`
  - Updated `sanitize_name()` to collapse duplicate underscores, trim non-alphanumeric boundaries, and fallback to `project` when empty.
- `assets/init-workspace.sh`
  - Mirrored the same short-name normalization to keep runtime initialization behavior consistent with install-time behavior.
- `CHANGELOG.md`
  - Added a `### Fixed` entry for issue `#291` under the active `0.3.0` section.

## Changelog Entry

### Fixed
- **Install name sanitization trims invalid package boundaries** ([#291](https://github.com/vig-os/devcontainer/issues/291))
  - `install.sh` now normalizes sanitized project names to ensure they start/end with alphanumeric characters before passing `SHORT_NAME`
  - `init-workspace.sh` mirrors the same normalization so generated `pyproject.toml` names cannot end with separators like `_`

## Testing

- [x] Tests pass locally (`just test`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

- Release failure reference: [run 23049118093](https://github.com/vig-os/devcontainer/actions/runs/23049118093), [job 66945611261](https://github.com/vig-os/devcontainer/actions/runs/23049118093/job/66945611261)
- Intended base branch for this fix PR: `release/0.3.0`

Refs: #291
