### PR TITLE
fix(ci): send typed force flag for smoke-test ref reset

### DIFF
--- a/assets/smoke-test/.github/workflows/repository-dispatch.yml
+++ b/assets/smoke-test/.github/workflows/repository-dispatch.yml
@@ -132,7 +132,7 @@ jobs:
           if gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/${BRANCH_NAME}" >/dev/null 2>&1; then
             gh api -X PATCH "repos/${GITHUB_REPOSITORY}/git/refs/heads/${BRANCH_NAME}" \
               -f sha="${DEV_SHA}" \
-              -f force=true >/dev/null
+              -F force=true >/dev/null
           else
             gh api -X POST "repos/${GITHUB_REPOSITORY}/git/refs" \
               -f ref="refs/heads/${BRANCH_NAME}" \


### PR DESCRIPTION
## Description

Fixes the smoke-test dispatch redeploy failure when resetting an existing `chore/deploy-<tag>` branch.

The GitHub API PATCH request in `repository-dispatch.yml` previously sent `force` as a string (`-f force=true`), which returns `HTTP 422` in the smoke-test repository. This updates the call to use a typed boolean flag.

## Type of Change

- [ ] `feat` -- New feature
- [x] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [x] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- `assets/smoke-test/.github/workflows/repository-dispatch.yml`
  - Changed `gh api` PATCH argument from `-f force=true` to `-F force=true`
  - Ensures `force` is sent as a boolean, matching GitHub API schema for ref updates

## Changelog Entry

No changelog needed. This is an internal CI workflow fix on a release bugfix branch, and issue `#293` explicitly sets changelog category to "No changelog needed".

## Testing

- [ ] Tests pass locally (`just test`)
- [ ] Manual testing performed (describe below)

### Manual Testing Details

N/A

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [ ] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

Repro/error reference: https://github.com/vig-os/devcontainer-smoke-test/actions/runs/23051686417/job/66954252175

Refs: #293
