### PR TITLE
fix(ci): preserve RC publish tag across release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -498,7 +498,7 @@ jobs:
         id: build
         uses: ./.github/actions/build-image
         with:
-          version: ${{ needs.validate.outputs.version }}
+          version: ${{ needs.validate.outputs.publish_version }}
           arch: ${{ matrix.arch }}
           release-date: ${{ needs.validate.outputs.release_date }}
           release-url: ${{ needs.validate.outputs.release_url }}
@@ -510,7 +510,7 @@ jobs:
       - name: Run image tests
         uses: ./.github/actions/test-image
         with:
-          image-tag: ${{ needs.validate.outputs.version }}-${{ matrix.arch }}
+          image-tag: ${{ needs.validate.outputs.publish_version }}-${{ matrix.arch }}
           image-source: tar
           tar-file: /tmp/image.tar
           ref: ${{ needs.finalize.outputs.finalize_sha }}
@@ -518,7 +518,7 @@ jobs:
       - name: Run integration tests
         uses: ./.github/actions/test-integration
         with:
-          image-tag: ${{ needs.validate.outputs.version }}-${{ matrix.arch }}
+          image-tag: ${{ needs.validate.outputs.publish_version }}-${{ matrix.arch }}
           ref: ${{ needs.finalize.outputs.finalize_sha }}
 
       - name: Scan image for vulnerabilities
@@ -535,7 +535,7 @@ jobs:
       - name: Upload tested image
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
-          name: container-image-${{ needs.validate.outputs.version }}-${{ matrix.arch }}
+          name: container-image-${{ needs.validate.outputs.publish_version }}-${{ matrix.arch }}
           path: /tmp/image.tar
           retention-days: 1
           compression-level: 0
@@ -617,11 +617,11 @@ jobs:
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
         with:
           path: /tmp/images
-          pattern: container-image-${{ needs.validate.outputs.version }}-*
+          pattern: container-image-${{ needs.validate.outputs.publish_version }}-*
 
       - name: Load and push images
         env:
-          BASE_VERSION: ${{ needs.validate.outputs.version }}
+          BUILD_VERSION: ${{ needs.validate.outputs.publish_version }}
           PUBLISH_VERSION: ${{ needs.validate.outputs.publish_version }}
           ARCHS: ${{ needs.validate.outputs.architectures }}
         run: |
@@ -631,7 +631,7 @@ jobs:
           IFS=' ' read -ra ARCH_ARRAY <<< "$ARCHS"
 
           for arch in "${ARCH_ARRAY[@]}"; do
-            ARTIFACT_PATH="/tmp/images/container-image-${BASE_VERSION}-${arch}"
+            ARTIFACT_PATH="/tmp/images/container-image-${BUILD_VERSION}-${arch}"
 
             if [ ! -f "$ARTIFACT_PATH/image.tar" ]; then
               echo "ERROR: Artifact not found: $ARTIFACT_PATH/image.tar"
@@ -642,7 +642,7 @@ jobs:
             echo "Loading $arch image..."
             docker load < "$ARTIFACT_PATH/image.tar"
 
-            SOURCE_IMAGE_TAG="$REPO:$BASE_VERSION-$arch"
+            SOURCE_IMAGE_TAG="$REPO:$BUILD_VERSION-$arch"
             IMAGE_TAG="$REPO:$PUBLISH_VERSION-$arch"
             docker tag "$SOURCE_IMAGE_TAG" "$IMAGE_TAG"
             echo "Pushing $arch image: $IMAGE_TAG"


### PR DESCRIPTION
## Summary
- Use `publish_version` (not base `version`) for build, test, and artifact naming in release candidate/final release image flow.
- Align downloaded artifact patterns and source image tags in publish step to the same `publish_version` value.
- Prevent RC smoke-test deploys from falling back to stable-only tags when validating container image availability.

## Test plan
- [x] Pre-commit hooks pass for the workflow change.
- [ ] Run release workflow in `candidate` mode for `0.3.0` and verify generated smoke-test PR writes `.vig-os` with `DEVCONTAINER_VERSION=<rc tag>`.
- [ ] Verify smoke-test `CI (Container)` resolves and validates `ghcr.io/vig-os/devcontainer:<rc tag>` successfully.
- [ ] Run final release workflow and verify stable release path remains unchanged.

Refs: #296