### PR TITLE
chore: consolidate dependabot updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Download image artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: container-image-${{ needs.build-image.outputs.version }}-amd64
           path: /tmp
@@ -137,7 +137,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Download image artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: container-image-${{ needs.build-image.outputs.version }}-amd64
           path: /tmp
@@ -244,7 +244,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Download image artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: container-image-${{ needs.build-image.outputs.version }}-amd64
           path: /tmp

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Generate version for dev build
         id: version
@@ -108,7 +108,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Download image artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
@@ -134,7 +134,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Download image artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
@@ -169,7 +169,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Run project checks
         uses: ./.github/actions/test-project
@@ -185,7 +185,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Set up environment
         uses: ./.github/actions/setup-env
@@ -241,7 +241,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Download image artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
@@ -327,7 +327,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Validate dependency-review exceptions
         id: exceptions

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Set up environment
         uses: ./.github/actions/setup-env

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -54,7 +54,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: dev
           fetch-depth: 0
@@ -169,7 +169,7 @@ jobs:
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
       - name: Checkout dev branch
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: dev
           fetch-depth: 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -939,7 +939,7 @@ jobs:
           fi
 
       - name: Create failure issue
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8.0.0
         with:
           script: |
             const publishVersion = '${{ needs.validate.outputs.publish_version }}';

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -604,7 +604,7 @@ jobs:
           echo "✓ Tag pushed: $PUBLISH_VERSION"
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@faadad0cce49287aee09b3a48701e75088a2c6ad  # v4
+        uses: sigstore/cosign-installer@ba7bc0a3fef59531c69a25acd34668d6d3fe6f22  # v4
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
@@ -774,7 +774,7 @@ jobs:
           fi
 
       - name: Generate SBOM
-        uses: anchore/sbom-action@28d71544de8eaf1b958d335707167c5f783590ad  # v0.22.2
+        uses: anchore/sbom-action@57aae528053a48a3f6235f2d9461b05fbcb7366d  # v0.23.1
         with:
           image: ghcr.io/vig-os/devcontainer:${{ needs.validate.outputs.publish_version }}
           artifact-name: sbom-${{ needs.validate.outputs.publish_version }}.spdx.json

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -812,7 +812,7 @@ jobs:
           echo "Image digest: $DIGEST"
 
       - name: Attest build provenance
-        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a  # v3
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32  # v4.1.0
         with:
           subject-name: ghcr.io/vig-os/devcontainer
           subject-digest: ${{ steps.digest.outputs.digest }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Validate and prepare variables
         id: vars
@@ -359,7 +359,7 @@ jobs:
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
       - name: Checkout release branch
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: release/${{ needs.validate.outputs.version }}
           token: ${{ steps.app-token.outputs.token }}
@@ -490,7 +490,7 @@ jobs:
 
     steps:
       - name: Checkout release commit
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: ${{ needs.finalize.outputs.finalize_sha }}
 
@@ -564,7 +564,7 @@ jobs:
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
       - name: Checkout release commit
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: ${{ needs.finalize.outputs.finalize_sha }}
           token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -614,7 +614,7 @@ jobs:
           password: ${{ github.token }}
 
       - name: Download image artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           path: /tmp/images
           pattern: container-image-${{ needs.validate.outputs.publish_version }}-*

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -80,7 +80,7 @@ jobs:
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Download image artifact
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           name: container-image-${{ needs.build-image.outputs.version }}-amd64
           path: /tmp

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           ref: dev
 
@@ -77,7 +77,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Download image artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Dependabot dependency update batch** ([#302](https://github.com/vig-os/devcontainer/pull/302), [#303](https://github.com/vig-os/devcontainer/pull/303), [#305](https://github.com/vig-os/devcontainer/pull/305), [#306](https://github.com/vig-os/devcontainer/pull/306), [#307](https://github.com/vig-os/devcontainer/pull/307), [#308](https://github.com/vig-os/devcontainer/pull/308), [#309](https://github.com/vig-os/devcontainer/pull/309))
+  - Bump `@devcontainers/cli` from `0.81.1` to `0.84.0` and `bats-assert` from `v2.2.0` to `v2.2.4`
+  - Bump GitHub Actions: `actions/download-artifact` (`4.3.0` -> `8.0.1`), `actions/github-script` (`7.1.0` -> `8.0.0`), `actions/attest-build-provenance` (`3.0.0` -> `4.1.0`), `actions/checkout` (`4.3.1` -> `6.0.2`)
+  - Bump release workflow action pins: `sigstore/cosign-installer` (`4.0.0` -> `4.1.0`) and `anchore/sbom-action` (`0.22.2` -> `0.23.1`)
+
 ### Deprecated
 
 ### Removed

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "devcontainer-ci-deps",
       "dependencies": {
-        "@devcontainers/cli": "0.81.1",
+        "@devcontainers/cli": "0.84.0",
         "bats": "1.13.0",
         "bats-assert": "github:bats-core/bats-assert#v2.2.0",
         "bats-file": "github:bats-core/bats-file#v0.4.0",
@@ -14,15 +14,15 @@
       }
     },
     "node_modules/@devcontainers/cli": {
-      "version": "0.81.1",
-      "resolved": "https://registry.npmjs.org/@devcontainers/cli/-/cli-0.81.1.tgz",
-      "integrity": "sha512-6xfQk1kDJz0qCfBVb9MW596zKnrb7wvtw414dbrf7ExSk5e+Moq+K/unalVDqhmNXn72EaURxHFaDFW9IeLDgg==",
+      "version": "0.84.0",
+      "resolved": "https://registry.npmjs.org/@devcontainers/cli/-/cli-0.84.0.tgz",
+      "integrity": "sha512-zAG9Kvj8qH6bAvReYTO5ZtDUHNr6OEsUqXxK1L1856XZN6c2RVV7aSAp/qIADGqqe0poqPr+ighFlvui2CH2LQ==",
       "license": "MIT",
       "bin": {
         "devcontainer": "devcontainer.js"
       },
       "engines": {
-        "node": "^16.13.0 || >=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/bats": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "dependencies": {
         "@devcontainers/cli": "0.81.1",
         "bats": "1.13.0",
-        "bats-assert": "github:bats-core/bats-assert#v2.2.0",
+        "bats-assert": "github:bats-core/bats-assert#v2.2.4",
         "bats-file": "github:bats-core/bats-file#v0.4.0",
         "bats-support": "github:bats-core/bats-support#v0.3.0"
       }
@@ -35,8 +35,9 @@
       }
     },
     "node_modules/bats-assert": {
-      "version": "2.2.0",
-      "resolved": "git+ssh://git@github.com/bats-core/bats-assert.git#d396ee3e943f7c1c058f3a1f4baddc12fab875ef",
+      "version": "2.2.4",
+      "resolved": "git+ssh://git@github.com/bats-core/bats-assert.git#f1e9280eaae8f86cbe278a687e6ba755bc802c1a",
+      "integrity": "sha512-EcaY4Z+Tbz1c7pnC1SrVSq0epr7tLwFpz6qt7KUW9K8uSw8V12DTfH9d2HxZWvBEATaCuMsZ7KoZMFiSQPRoXw==",
       "license": "CC0-1.0",
       "peerDependencies": {
         "bats": "0.4 || ^1",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@devcontainers/cli": "0.81.1",
     "bats": "1.13.0",
     "bats-support": "github:bats-core/bats-support#v0.3.0",
-    "bats-assert": "github:bats-core/bats-assert#v2.2.0",
+    "bats-assert": "github:bats-core/bats-assert#v2.2.4",
     "bats-file": "github:bats-core/bats-file#v0.4.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "description": "CI-only npm dependencies tracked by Dependabot",
   "dependencies": {
-    "@devcontainers/cli": "0.81.1",
+    "@devcontainers/cli": "0.84.0",
     "bats": "1.13.0",
     "bats-support": "github:bats-core/bats-support#v0.3.0",
     "bats-assert": "github:bats-core/bats-assert#v2.2.0",


### PR DESCRIPTION
## Summary
- Consolidate Dependabot dependency updates from open PRs #302, #303, #305, #306, #307, #308, and #309 into a single branch based on `dev`
- Update `CHANGELOG.md` (`## Unreleased` -> `### Changed`) with one grouped entry referencing all merged Dependabot PRs
- Keep closed PR #304 out of scope because its actionable updates are already covered by #309/current `dev` state

## Validation
- Ran `just build no_cache && just test`
- Result: success (command exited 0)

## Includes
- #302 https://github.com/vig-os/devcontainer/pull/302
- #303 https://github.com/vig-os/devcontainer/pull/303
- #305 https://github.com/vig-os/devcontainer/pull/305
- #306 https://github.com/vig-os/devcontainer/pull/306
- #307 https://github.com/vig-os/devcontainer/pull/307
- #308 https://github.com/vig-os/devcontainer/pull/308
- #309 https://github.com/vig-os/devcontainer/pull/309