### PR TITLE
fix(ci): finalize release docs and refresh release PR body

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -285,19 +285,6 @@ jobs:
           ### Release Content
 
           $CHANGELOG_CONTENT
-
-          ### Testing Checklist
-          - [ ] All tests pass (\`just test\`)
-          - [ ] Manual testing complete
-          - [ ] No critical bugs found
-          - [ ] Ready for release
-
-          ### When Ready to Release
-          - Publish candidate: \`just publish-candidate $VERSION\`
-          - Publish final release: \`just finalize-release $VERSION\`
-
-          ### Related
-          - Release automation: #48, #172
           "
 
           PR_URL=$(gh pr create \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -381,6 +381,40 @@ jobs:
           uv run prepare-changelog finalize "$VERSION" "$RELEASE_DATE"
           echo "✓ Release date set in CHANGELOG.md"
 
+      - name: Regenerate docs for finalized release
+        if: needs.validate.outputs.release_kind == 'final'
+        run: |
+          set -euo pipefail
+          uv run python docs/generate.py
+          echo "✓ Regenerated docs from finalized CHANGELOG.md"
+
+      - name: Collect finalization files
+        if: needs.validate.outputs.release_kind == 'final'
+        id: finalize-files
+        run: |
+          set -euo pipefail
+
+          CHANGED_FILES="$(git diff --name-only)"
+          if [ -z "$CHANGED_FILES" ]; then
+            echo "ERROR: Finalization produced no tracked file changes."
+            echo "Expected CHANGELOG.md and possibly generated docs to change."
+            exit 1
+          fi
+
+          FILE_PATHS="$(echo "$CHANGED_FILES" | tr '\n' ' ' | sed 's/[[:space:]]*$//')"
+          echo "file_paths=$FILE_PATHS" >> "$GITHUB_OUTPUT"
+          echo "Finalization files: $FILE_PATHS"
+
+          for expected_doc in README.md CONTRIBUTE.md TESTING.md docs/SKILL_PIPELINE.md; do
+            if git diff --quiet -- "$expected_doc"; then
+              continue
+            fi
+            if ! echo "$FILE_PATHS" | grep -Eq "(^|[[:space:]])$expected_doc([[:space:]]|$)"; then
+              echo "ERROR: Expected modified doc '$expected_doc' missing from commit file list."
+              exit 1
+            fi
+          done
+
       - name: Commit finalization changes via API
         if: needs.validate.outputs.release_kind == 'final'
         uses: vig-os/commit-action@c0024cbad0e501764127cccab732c6cd465b4646  # v0.1.5
@@ -391,10 +425,10 @@ jobs:
           COMMIT_MESSAGE: |-
             chore: finalize release ${{ needs.validate.outputs.version }}
 
-            Set release date to ${{ needs.validate.outputs.release_date }} in CHANGELOG.md
+            Set release date to ${{ needs.validate.outputs.release_date }} and regenerate release docs.
 
             Refs: #${{ needs.validate.outputs.pr_number }}
-          FILE_PATHS: CHANGELOG.md
+          FILE_PATHS: ${{ steps.finalize-files.outputs.file_paths }}
 
       - name: Trigger sync-issues workflow
         if: needs.validate.outputs.release_kind == 'final'
@@ -462,6 +496,35 @@ jobs:
           git fetch origin "release/$VERSION"
           git reset --hard "origin/release/$VERSION"
           echo "✓ Synced with remote release branch"
+
+      - name: Refresh release PR body from finalized changelog
+        if: needs.validate.outputs.release_kind == 'final'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          VERSION: ${{ needs.validate.outputs.version }}
+          RELEASE_DATE: ${{ needs.validate.outputs.release_date }}
+          PR_NUMBER: ${{ needs.validate.outputs.pr_number }}
+        run: |
+          set -euo pipefail
+          CHANGELOG_CONTENT=$(sed -n "/## \[$VERSION\]/,/^## \[/p" CHANGELOG.md | sed '$d')
+
+          if [ -z "$CHANGELOG_CONTENT" ]; then
+            echo "ERROR: Could not extract release section for version $VERSION from CHANGELOG.md"
+            exit 1
+          fi
+
+          cat > /tmp/release-pr-body.md <<EOF
+          # [Release $VERSION](https://github.com/${GITHUB_REPOSITORY}/releases/tag/$VERSION) - $RELEASE_DATE
+
+          This PR prepares release $VERSION for merge to main.
+
+          ### Release Content
+
+          $CHANGELOG_CONTENT
+          EOF
+
+          gh pr edit "$PR_NUMBER" --body-file /tmp/release-pr-body.md
+          echo "✓ Refreshed PR #$PR_NUMBER body from finalized CHANGELOG.md"
 
       - name: Output finalize SHA
         id: finalize

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -409,7 +409,7 @@ jobs:
             if git diff --quiet -- "$expected_doc"; then
               continue
             fi
-            if ! echo "$FILE_PATHS" | grep -Eq "(^|[[:space:]])$expected_doc([[:space:]]|$)"; then
+            if ! printf '%s\n' "$CHANGED_FILES" | grep -Fxq -- "$expected_doc"; then
               echo "ERROR: Expected modified doc '$expected_doc' missing from commit file list."
               exit 1
             fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Release finalization now commits generated docs and refreshes PR content** ([#300](https://github.com/vig-os/devcontainer/issues/300))
+  - Final release automation regenerates docs before committing so pre-commit `generate-docs` does not fail CI with tracked file diffs
+  - Release PR body is refreshed from finalized `CHANGELOG.md`
+
 ### Security
 
 ## [0.3.0](https://github.com/vig-os/devcontainer/releases/tag/0.3.0) - 2026-03-13

--- a/docs/RELEASE_CYCLE.md
+++ b/docs/RELEASE_CYCLE.md
@@ -348,7 +348,7 @@ The `release.yml` workflow performs the entire remaining release process. Behavi
 
 2. ✅ **Finalize** job (skipped if --dry-run)
    - **Candidate**: No CHANGELOG changes. Outputs current release branch HEAD SHA.
-   - **Final**: Sets actual release date in CHANGELOG (TBD → YYYY-MM-DD), commits, triggers sync-issues workflow, outputs finalized SHA.
+   - **Final**: Sets actual release date in CHANGELOG (TBD → YYYY-MM-DD), regenerates docs from templates, commits all tracked finalization changes (dynamic file list), refreshes release PR body from finalized CHANGELOG, triggers sync-issues workflow, outputs finalized SHA.
 
 3. ✅ **Build & Test** jobs (per-architecture, runs in parallel)
    - Builds container image as tar file
@@ -620,7 +620,7 @@ gh workflow run prepare-release.yml --ref dev -f "version=1.0.0" -f "dry-run=tru
 
 2. **finalize** (skipped if dry-run) - Conditionally updates release branch
    - **Candidate**: No CHANGELOG changes, no sync-issues. Outputs current release branch HEAD SHA.
-   - **Final**: Sets release date in CHANGELOG (TBD → YYYY-MM-DD), commits, triggers sync-issues, outputs finalized SHA.
+   - **Final**: Sets release date in CHANGELOG (TBD → YYYY-MM-DD), regenerates docs, commits all tracked finalization changes via dynamic file list, refreshes release PR body from finalized changelog content, triggers sync-issues, outputs finalized SHA.
 
 3. **build-and-test** (matrix: amd64, arm64) - Builds and validates images
    - Builds container image for architecture

--- a/tests/bats/just.bats
+++ b/tests/bats/just.bats
@@ -39,3 +39,18 @@ setup() {
     run bash -lc "grep -Fq -- 'git/refs/heads/$RELEASE_BRANCH' .github/workflows/prepare-release.yml"
     assert_success
 }
+
+@test "release workflow regenerates docs during finalization" {
+    run bash -lc "grep -Fq -- 'name: Regenerate docs for finalized release' .github/workflows/release.yml"
+    assert_success
+}
+
+@test "release workflow commits dynamic finalization file paths" {
+    run bash -lc "grep -Fq -- 'id: finalize-files' .github/workflows/release.yml && grep -Fq -- 'steps.finalize-files.outputs.file_paths' .github/workflows/release.yml"
+    assert_success
+}
+
+@test "prepare-release PR body omits persistent checklist and related sections" {
+    run bash -lc "! awk '/^      - name: Create draft PR to main/{flag=1} /^      - name: Roll back prepare-release side effects on failure/{flag=0} flag {print}' .github/workflows/prepare-release.yml | grep -Fq -- '### Testing Checklist' && ! awk '/^      - name: Create draft PR to main/{flag=1} /^      - name: Roll back prepare-release side effects on failure/{flag=0} flag {print}' .github/workflows/prepare-release.yml | grep -Fq -- '### When Ready to Release' && ! awk '/^      - name: Create draft PR to main/{flag=1} /^      - name: Roll back prepare-release side effects on failure/{flag=0} flag {print}' .github/workflows/prepare-release.yml | grep -Fq -- '### Related'"
+    assert_success
+}

--- a/tests/bats/just.bats
+++ b/tests/bats/just.bats
@@ -54,3 +54,8 @@ setup() {
     run bash -lc "! awk '/^      - name: Create draft PR to main/{flag=1} /^      - name: Roll back prepare-release side effects on failure/{flag=0} flag {print}' .github/workflows/prepare-release.yml | grep -Fq -- '### Testing Checklist' && ! awk '/^      - name: Create draft PR to main/{flag=1} /^      - name: Roll back prepare-release side effects on failure/{flag=0} flag {print}' .github/workflows/prepare-release.yml | grep -Fq -- '### When Ready to Release' && ! awk '/^      - name: Create draft PR to main/{flag=1} /^      - name: Roll back prepare-release side effects on failure/{flag=0} flag {print}' .github/workflows/prepare-release.yml | grep -Fq -- '### Related'"
     assert_success
 }
+
+@test "release workflow refreshes release PR body from changelog" {
+    run bash -lc 'grep -Fq -- "name: Refresh release PR body from finalized changelog" .github/workflows/release.yml && grep -Fq -- "CHANGELOG_CONTENT=\$(sed -n" .github/workflows/release.yml && grep -Fq -- "gh pr edit \"\$PR_NUMBER\" --body-file /tmp/release-pr-body.md" .github/workflows/release.yml'
+    assert_success
+}


### PR DESCRIPTION
## Description

Fixes release finalization regressions from issue #300 by ensuring final releases commit all generated docs required by pre-commit and by refreshing release PR body content from finalized `CHANGELOG.md`.

The release PR body now follows the established release format (linked release heading with date and release-content section), while checklist/related sections are removed from persistent release PR body text.

## Type of Change

- [ ] `feat` -- New feature
- [x] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [x] `test` -- Adding or updating tests
- [x] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- `.github/workflows/release.yml`
  - Regenerate docs during final release finalization (`docs/generate.py`)
  - Collect dynamic tracked changed files and pass them to `commit-action` instead of hardcoding `CHANGELOG.md`
  - Add guardrails to fail if finalization produces no tracked changes or misses expected generated docs
  - Refresh release PR body from finalized `CHANGELOG.md` with the release heading format used in previous release PRs
- `.github/workflows/prepare-release.yml`
  - Remove persistent `Testing Checklist`, `When Ready to Release`, and `Related` sections from draft release PR body
- `tests/bats/just.bats`
  - Add regressions for docs regeneration and dynamic finalization file-path commit behavior
  - Add regression asserting release PR body section cleanup in prepare workflow
- `CHANGELOG.md`
  - Add `Unreleased` `### Fixed` entry documenting issue #300 behavior change

## Changelog Entry

### Fixed

- **Release finalization now commits generated docs and refreshes PR content** ([#300](https://github.com/vig-os/devcontainer/issues/300))
  - Final release automation regenerates docs before committing so pre-commit `generate-docs` does not fail CI with tracked file diffs
  - Release PR body is refreshed from finalized `CHANGELOG.md`

## Testing

- [ ] Tests pass locally (`just test`)
- [x] Manual testing performed (describe below)

### Manual Testing Details

- Ran `npx bats tests/bats/just.bats`
- Result: all tests passed (`9/9`)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

The release PR heading/body format aligns with prior release PR style for consistency (release link + date heading, then `## Release Content`).

Refs: #300
