### PR TITLE
ci: migrate shared GitHub Action pins for Node24 readiness

### DIFF
--- a/.github/actions/build-image/action.yml
+++ b/.github/actions/build-image/action.yml
@@ -82,7 +82,7 @@ runs:
   using: composite
   steps:
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3.12.0
+      uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4.0.0
 
     - name: Set up environment
       uses: ./.github/actions/setup-env
@@ -107,7 +107,7 @@ runs:
 
     - name: Extract metadata
       id: meta
-      uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051  # v5.10.0
+      uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf  # v6.0.0
       with:
         images: ${{ inputs.registry }}
         tags: |
@@ -124,7 +124,7 @@ runs:
 
     - name: Build image (tar output)
       if: inputs.output-type == 'tar'
-      uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
+      uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294  # v7.0.0
       with:
         context: ./build
         file: ./build/Containerfile
@@ -174,7 +174,7 @@ runs:
 
     - name: Build image (registry output)
       if: inputs.output-type == 'registry'
-      uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8  # v6
+      uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294  # v7.0.0
       with:
         context: ./build
         file: ./build/Containerfile

--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -15,7 +15,7 @@
 #   sync-dependencies:        Run uv sync to install project deps (default: false)
 #   install-podman:           Install podman (default: false)
 #   install-node:             Install Node.js (default: false)
-#   node-version:             Node.js version (default: '20')
+#   node-version:             Node.js version (default: '24')
 #   install-devcontainer-cli: Install devcontainer CLI + docker-compose wrapper (default: false)
 #   install-hadolint:         Install hadolint binary (default: false)
 #   install-taplo:            Install taplo TOML linter/formatter (default: false)
@@ -62,7 +62,7 @@ inputs:
   node-version:
     description: 'Node.js version (when install-node is true)'
     required: false
-    default: '20'
+    default: '24'
   install-devcontainer-cli:
     description: 'Install @devcontainers/cli and docker-compose wrapper (requires Node.js)'
     required: false
@@ -130,7 +130,7 @@ runs:
     # Also installed when install-devcontainer-cli is true (npm is required)
     - name: Install Node.js
       if: inputs.install-node == 'true' || inputs.install-devcontainer-cli == 'true'
-      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
+      uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
       with:
         node-version: ${{ inputs.node-version }}
 

--- a/.github/actions/test-image/action.yml
+++ b/.github/actions/test-image/action.yml
@@ -68,7 +68,7 @@ runs:
   using: composite
   steps:
     - name: Checkout code
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       with:
         ref: ${{ inputs.ref || github.ref }}
 

--- a/.github/actions/test-integration/action.yml
+++ b/.github/actions/test-integration/action.yml
@@ -46,7 +46,7 @@ runs:
   using: composite
   steps:
     - name: Checkout code
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       with:
         ref: ${{ inputs.ref || github.ref }}
 

--- a/.github/actions/test-project/action.yml
+++ b/.github/actions/test-project/action.yml
@@ -39,7 +39,7 @@ runs:
   using: composite
   steps:
     - name: Checkout code
-      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
     - name: Set up test environment
       uses: ./.github/actions/setup-env
@@ -51,7 +51,7 @@ runs:
 
     - name: Cache pre-commit hooks
       if: inputs.suite == 'all' || inputs.suite == 'lint'
-      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830  # v4
+      uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306  # v5.0.3
       with:
         path: ~/.cache/pre-commit
         key: pre-commit-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}
@@ -147,7 +147,7 @@ runs:
 
     - name: Upload coverage report
       if: always() && inputs.suite == 'all'
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
       with:
         name: coverage-report
         path: coverage.xml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Bump GitHub Actions: `actions/attest-sbom` (`3.0.0` -> `4.0.0`), `actions/upload-artifact` (`4.6.2` -> `7.0.0`), `actions/create-github-app-token` (`2.2.1` -> `3.0.0`)
   - Bump `docker/login-action` from `3.7.0` to `4.0.0`
   - Bump `just` minor version from `1.46` to `1.47`
+- **Node24-ready GitHub Actions pin refresh for shared composite actions** ([#321](https://github.com/vig-os/devcontainer/issues/321))
+  - Update Docker build path pins in `build-image` (`docker/setup-buildx-action`, `docker/metadata-action`, `docker/build-push-action`) to Node24-compatible releases
+  - Set `setup-env` default Node runtime to `24` and upgrade `actions/setup-node`
+  - Align test composite actions with newer pins (`actions/checkout`, `actions/cache`, `actions/upload-artifact`)
 
 ### Deprecated
 


### PR DESCRIPTION
## Description

Migrate shared composite GitHub Action pins to Node24-ready releases and update the default Node runtime in `setup-env` from `20` to `24` to reduce risk from GitHub's Node 20 deprecation timeline.

## Type of Change

- [ ] `feat` -- New feature
- [ ] `fix` -- Bug fix
- [x] `docs` -- Documentation only
- [x] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [x] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- `.github/actions/build-image/action.yml`
  - Upgraded `docker/setup-buildx-action` to `v4.0.0`
  - Upgraded `docker/metadata-action` to `v6.0.0`
  - Upgraded `docker/build-push-action` to `v7.0.0` for both tar and registry builds
- `.github/actions/setup-env/action.yml`
  - Updated default `node-version` from `20` to `24`
  - Upgraded `actions/setup-node` to `v6.3.0`
- `.github/actions/test-image/action.yml`
  - Upgraded `actions/checkout` to `v6.0.2`
- `.github/actions/test-integration/action.yml`
  - Upgraded `actions/checkout` to `v6.0.2`
- `.github/actions/test-project/action.yml`
  - Upgraded `actions/checkout` to `v6.0.2`
  - Upgraded `actions/cache` to `v5.0.3`
  - Upgraded `actions/upload-artifact` to `v7.0.0`
- `CHANGELOG.md`
  - Added `Unreleased > Changed` entry for issue `#321`

## Changelog Entry

### Changed
- **Node24-ready GitHub Actions pin refresh for shared composite actions** ([#321](https://github.com/vig-os/devcontainer/issues/321))
  - Update Docker build path pins in `build-image` (`docker/setup-buildx-action`, `docker/metadata-action`, `docker/build-push-action`) to Node24-compatible releases
  - Set `setup-env` default Node runtime to `24` and upgrade `actions/setup-node`
  - Align test composite actions with newer pins (`actions/checkout`, `actions/cache`, `actions/upload-artifact`)

## Testing

- [ ] Tests pass locally (`just test`)
- [ ] Manual testing performed (describe below)

### Manual Testing Details

N/A

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

- Related issue: https://github.com/vig-os/sync-issues-action/issues/77
- Validation completed with pre-commit checks on modified files, including `check-action-pins`, `check yaml`, and `yamllint`.

Refs: #321
