### PR TITLE
ci: fix scheduled security scan artifact handoff

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -66,6 +66,14 @@ jobs:
           output-type: tar
           output-file: /tmp/image.tar
 
+      - name: Upload image artifact
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
+        with:
+          name: container-image-${{ steps.version.outputs.version }}-amd64
+          path: /tmp/image.tar
+          retention-days: 1
+          compression-level: 0   # Image is already compressed; avoid double-compression overhead
+
   security-scan:
     name: Security Scan
     needs: build-image


### PR DESCRIPTION
## Description

Fix the scheduled security scan workflow by uploading the built container image artifact in `build-image` so `security-scan` can download it reliably.

## Type of Change

- [ ] `feat` -- New feature
- [ ] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [x] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- `.github/workflows/security-scan.yml`
  - Add `Upload image artifact` step after image build in `build-image`
  - Upload `/tmp/image.tar` as `container-image-${{ steps.version.outputs.version }}-amd64`
  - Keep artifact settings aligned with CI workflow (`retention-days: 1`, `compression-level: 0`)

## Changelog Entry

No changelog needed: issue `#320` specifies "No changelog needed" and this is an internal CI workflow reliability fix.

## Testing

- [ ] Tests pass locally (`just test`)
- [ ] Manual testing performed (describe below)

### Manual Testing Details

N/A (workflow change; validate via next scheduled or manual workflow run)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [ ] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

N/A

Refs: #320
