### PR TITLE
ci: add smoke dispatch source metadata contract

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -938,11 +938,24 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.smoke-app-token.outputs.token }}
           RC_TAG: ${{ needs.validate.outputs.publish_version }}
+          SOURCE_REPO: ${{ github.repository }}
+          SOURCE_WORKFLOW: ${{ github.workflow }}
+          SOURCE_RUN_ID: ${{ github.run_id }}
+          SOURCE_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          SOURCE_SHA: ${{ needs.finalize.outputs.finalize_sha }}
+          CORRELATION_ID: ${{ github.repository }}:${{ github.run_id }}:${{ needs.validate.outputs.publish_version }}
         run: |
           set -euo pipefail
           gh api repos/vig-os/devcontainer-smoke-test/dispatches \
             -f event_type=smoke-test-trigger \
-            -f "client_payload[tag]=$RC_TAG"
+            -f "client_payload[tag]=$RC_TAG" \
+            -f "client_payload[event_type]=smoke-test-trigger" \
+            -f "client_payload[source_repo]=$SOURCE_REPO" \
+            -f "client_payload[source_workflow]=$SOURCE_WORKFLOW" \
+            -f "client_payload[source_run_id]=$SOURCE_RUN_ID" \
+            -f "client_payload[source_run_url]=$SOURCE_RUN_URL" \
+            -f "client_payload[source_sha]=$SOURCE_SHA" \
+            -f "client_payload[correlation_id]=$CORRELATION_ID"
           echo "✓ Triggered smoke-test dispatch for RC tag: $RC_TAG"
 
       - name: Warn if smoke-test dispatch token generation failed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Update Docker build path pins in `build-image` (`docker/setup-buildx-action`, `docker/metadata-action`, `docker/build-push-action`) to Node24-compatible releases
   - Set `setup-env` default Node runtime to `24` and upgrade `actions/setup-node`
   - Align test composite actions with newer pins (`actions/checkout`, `actions/cache`, `actions/upload-artifact`)
+- **Smoke-test dispatch payload now carries source run traceability metadata** ([#289](https://github.com/vig-os/devcontainer/issues/289))
+  - Candidate release dispatches now include source repo/workflow/run/SHA metadata plus a deterministic `correlation_id`
+  - Smoke-test dispatch receiver logs normalized source context, derives source run URL when possible, and writes it to workflow summary output
+  - Release-cycle docs now define required vs optional dispatch payload keys and the future callback contract path for `publish-candidate`
 
 ### Deprecated
 

--- a/assets/smoke-test/.github/workflows/repository-dispatch.yml
+++ b/assets/smoke-test/.github/workflows/repository-dispatch.yml
@@ -235,7 +235,7 @@ jobs:
           {
             echo "## Source Dispatch Context"
             echo ""
-            echo "- Tag: ${TAG}"
+            echo "- Tag: ${TAG:-n/a}"
             echo "- Source Repo: ${SOURCE_REPO:-n/a}"
             echo "- Source Workflow: ${SOURCE_WORKFLOW:-n/a}"
             echo "- Source Run ID: ${SOURCE_RUN_ID:-n/a}"

--- a/assets/smoke-test/.github/workflows/repository-dispatch.yml
+++ b/assets/smoke-test/.github/workflows/repository-dispatch.yml
@@ -9,7 +9,10 @@ name: Repository Dispatch Listener
 #
 # Dispatch payload:
 # - Preferred:   client_payload.tag
-# - Optional:    client_payload.event_type, client_payload.source_repo
+# - Optional:    client_payload.event_type, client_payload.source_repo,
+#                client_payload.source_workflow, client_payload.source_run_id,
+#                client_payload.source_run_url, client_payload.source_sha,
+#                client_payload.correlation_id
 #
 # NOTE: Changes to this template may require manual redeploy to
 # vig-os/devcontainer-smoke-test and promotion through PRs until merged to main.
@@ -29,6 +32,12 @@ jobs:
     timeout-minutes: 5
     outputs:
       tag: ${{ steps.extract.outputs.tag }}
+      source_repo: ${{ steps.extract.outputs.source_repo }}
+      source_workflow: ${{ steps.extract.outputs.source_workflow }}
+      source_run_id: ${{ steps.extract.outputs.source_run_id }}
+      source_run_url: ${{ steps.extract.outputs.source_run_url }}
+      source_sha: ${{ steps.extract.outputs.source_sha }}
+      correlation_id: ${{ steps.extract.outputs.correlation_id }}
     steps:
       - name: Extract and validate tag
         id: extract
@@ -37,12 +46,23 @@ jobs:
           EVENT_TYPE: ${{ github.event.client_payload.event_type || '' }}
           TAG: ${{ github.event.client_payload.tag || '' }}
           SOURCE_REPO: ${{ github.event.client_payload.source_repo || '' }}
+          SOURCE_WORKFLOW: ${{ github.event.client_payload.source_workflow || '' }}
+          SOURCE_RUN_ID: ${{ github.event.client_payload.source_run_id || '' }}
+          SOURCE_RUN_URL: ${{ github.event.client_payload.source_run_url || '' }}
+          SOURCE_SHA: ${{ github.event.client_payload.source_sha || '' }}
+          CORRELATION_ID: ${{ github.event.client_payload.correlation_id || '' }}
+          GITHUB_SERVER_URL: ${{ github.server_url }}
         run: |
           echo "repository_dispatch received"
           echo "action=${EVENT_ACTION}"
           echo "event_type=${EVENT_TYPE}"
           echo "tag=${TAG}"
           echo "source_repo=${SOURCE_REPO}"
+          echo "source_workflow=${SOURCE_WORKFLOW}"
+          echo "source_run_id=${SOURCE_RUN_ID}"
+          echo "source_run_url=${SOURCE_RUN_URL}"
+          echo "source_sha=${SOURCE_SHA}"
+          echo "correlation_id=${CORRELATION_ID}"
 
           if [ -z "${TAG}" ]; then
             echo "ERROR: tag is required in github.event.client_payload"
@@ -54,7 +74,18 @@ jobs:
             exit 1
           fi
 
+          EFFECTIVE_SOURCE_RUN_URL="${SOURCE_RUN_URL}"
+          if [ -z "${EFFECTIVE_SOURCE_RUN_URL}" ] && [ -n "${SOURCE_REPO}" ] && [ -n "${SOURCE_RUN_ID}" ]; then
+            EFFECTIVE_SOURCE_RUN_URL="${GITHUB_SERVER_URL}/${SOURCE_REPO}/actions/runs/${SOURCE_RUN_ID}"
+          fi
+
           echo "tag=${TAG}" >> "${GITHUB_OUTPUT}"
+          echo "source_repo=${SOURCE_REPO}" >> "${GITHUB_OUTPUT}"
+          echo "source_workflow=${SOURCE_WORKFLOW}" >> "${GITHUB_OUTPUT}"
+          echo "source_run_id=${SOURCE_RUN_ID}" >> "${GITHUB_OUTPUT}"
+          echo "source_run_url=${EFFECTIVE_SOURCE_RUN_URL}" >> "${GITHUB_OUTPUT}"
+          echo "source_sha=${SOURCE_SHA}" >> "${GITHUB_OUTPUT}"
+          echo "correlation_id=${CORRELATION_ID}" >> "${GITHUB_OUTPUT}"
 
   deploy:
     name: Deploy tag and open PR to dev
@@ -191,6 +222,28 @@ jobs:
     needs: [validate, deploy]
     if: always()
     steps:
+      - name: Write source context summary
+        env:
+          TAG: ${{ needs.validate.outputs.tag }}
+          SOURCE_REPO: ${{ needs.validate.outputs.source_repo }}
+          SOURCE_WORKFLOW: ${{ needs.validate.outputs.source_workflow }}
+          SOURCE_RUN_ID: ${{ needs.validate.outputs.source_run_id }}
+          SOURCE_RUN_URL: ${{ needs.validate.outputs.source_run_url }}
+          SOURCE_SHA: ${{ needs.validate.outputs.source_sha }}
+          CORRELATION_ID: ${{ needs.validate.outputs.correlation_id }}
+        run: |
+          {
+            echo "## Source Dispatch Context"
+            echo ""
+            echo "- Tag: ${TAG}"
+            echo "- Source Repo: ${SOURCE_REPO:-n/a}"
+            echo "- Source Workflow: ${SOURCE_WORKFLOW:-n/a}"
+            echo "- Source Run ID: ${SOURCE_RUN_ID:-n/a}"
+            echo "- Source Run URL: ${SOURCE_RUN_URL:-n/a}"
+            echo "- Source SHA: ${SOURCE_SHA:-n/a}"
+            echo "- Correlation ID: ${CORRELATION_ID:-n/a}"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
       - name: Check orchestration results
         run: |
           echo "Repository Dispatch Results Summary"

--- a/docs/RELEASE_CYCLE.md
+++ b/docs/RELEASE_CYCLE.md
@@ -359,7 +359,7 @@ The `release.yml` workflow performs the entire remaining release process. Behavi
 
 4. ✅ **Publish** job (runs only if all builds/tests pass)
    - Candidate mode: infers next `rcN`, creates annotated tag `X.Y.Z-rcN`, publishes candidate manifests
-   - Candidate mode: triggers `repository_dispatch` to `vig-os/devcontainer-smoke-test` with `client_payload.tag`
+   - Candidate mode: triggers `repository_dispatch` to `vig-os/devcontainer-smoke-test` with `client_payload[tag]` plus source metadata (`source_repo`, `source_workflow`, `source_run_id`, `source_run_url`, `source_sha`, `correlation_id`)
    - Final mode: creates annotated tag `X.Y.Z`, publishes final manifests
    - Pushes tag to origin
    - Downloads tested images from artifacts
@@ -405,6 +405,22 @@ Release Summary:
 
 After `just publish-candidate X.Y.Z` succeeds, verify smoke tests before running final release.
 
+Dispatch payload contract for the smoke-test repository:
+
+- Required key:
+  - `client_payload[tag]`
+- Optional source-context keys:
+  - `client_payload[event_type]`
+  - `client_payload[source_repo]`
+  - `client_payload[source_workflow]`
+  - `client_payload[source_run_id]`
+  - `client_payload[source_run_url]`
+  - `client_payload[source_sha]`
+  - `client_payload[correlation_id]`
+- Backward compatibility:
+  - Receiver validation requires only `tag`.
+  - If `source_run_url` is absent, the receiver derives a deterministic link from `source_repo + source_run_id` when both are present.
+
 1. Confirm dispatch-triggered smoke-test run in the smoke-test repo:
 
    ```bash
@@ -432,6 +448,12 @@ After `just publish-candidate X.Y.Z` succeeds, verify smoke tests before running
    ```bash
    just finalize-release X.Y.Z
    ```
+
+Future automation path (not enabled as a gate in this issue):
+
+- The smoke-test workflow can emit a completion callback keyed by `correlation_id`.
+- The callback can later be consumed by the release orchestration path behind `publish-candidate` to post result context and eventually support automated gating.
+- Until that callback flow is implemented, this phase remains a manual operator gate.
 
 ### Phase 5: Post-Release Cleanup
 

--- a/tests/bats/just.bats
+++ b/tests/bats/just.bats
@@ -59,3 +59,13 @@ setup() {
     run bash -lc 'grep -Fq -- "name: Refresh release PR body from finalized changelog" .github/workflows/release.yml && grep -Fq -- "CHANGELOG_CONTENT=\$(sed -n" .github/workflows/release.yml && grep -Fq -- "gh pr edit \"\$PR_NUMBER\" --body-file /tmp/release-pr-body.md" .github/workflows/release.yml'
     assert_success
 }
+
+@test "candidate dispatch includes smoke-test source metadata payload fields" {
+    run bash -lc "grep -Fq -- 'event_type=smoke-test-trigger' .github/workflows/release.yml && grep -Fq -- 'client_payload[source_repo]' .github/workflows/release.yml && grep -Fq -- 'client_payload[source_workflow]' .github/workflows/release.yml && grep -Fq -- 'client_payload[source_run_id]' .github/workflows/release.yml && grep -Fq -- 'client_payload[source_run_url]' .github/workflows/release.yml && grep -Fq -- 'client_payload[source_sha]' .github/workflows/release.yml && grep -Fq -- 'client_payload[correlation_id]' .github/workflows/release.yml"
+    assert_success
+}
+
+@test "smoke-test dispatch template logs source metadata and writes summary" {
+    run bash -lc "grep -Fq -- 'EFFECTIVE_SOURCE_RUN_URL=' assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- 'source_run_url=' assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- 'correlation_id=' assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- 'GITHUB_STEP_SUMMARY' assets/smoke-test/.github/workflows/repository-dispatch.yml"
+    assert_success
+}


### PR DESCRIPTION
## Description

Add traceability metadata to candidate `repository_dispatch` events sent to `vig-os/devcontainer-smoke-test`, and make the smoke-test receiver summarize source context with backward-compatible parsing. This also documents the dispatch payload contract and future callback direction for `publish-candidate`.

## Type of Change

- [ ] `feat` -- New feature
- [ ] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [x] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- `.github/workflows/release.yml`
  - Extend candidate dispatch payload with `event_type`, `source_repo`, `source_workflow`, `source_run_id`, `source_run_url`, `source_sha`, and deterministic `correlation_id`
  - Keep `client_payload[tag]` as required contract key
- `assets/smoke-test/.github/workflows/repository-dispatch.yml`
  - Parse optional source metadata fields and expose them as validate job outputs
  - Derive `source_run_url` when absent but `source_repo` and `source_run_id` are present
  - Write normalized source context to `$GITHUB_STEP_SUMMARY`
- `tests/bats/just.bats`
  - Add regression guards for sender payload keys and receiver summary/fallback behavior
- `docs/RELEASE_CYCLE.md`
  - Document required/optional dispatch payload schema, compatibility behavior, and future callback path
- `CHANGELOG.md`
  - Add Unreleased entry for issue #289

## Changelog Entry

### Changed

- **Smoke-test dispatch payload now carries source run traceability metadata** ([#289](https://github.com/vig-os/devcontainer/issues/289))
  - Candidate release dispatches now include source repo/workflow/run/SHA metadata plus a deterministic `correlation_id`
  - Smoke-test dispatch receiver logs normalized source context, derives source run URL when possible, and writes it to workflow summary output
  - Release-cycle docs now define required vs optional dispatch payload keys and the future callback contract path for `publish-candidate`

## Testing

- [ ] Tests pass locally (`just test`)
- [x] Manual testing performed (describe below)

### Manual Testing Details

- `npx bats tests/bats/just.bats`
- Verified all 12 BATS tests pass, including new dispatch metadata regression guards

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

No gating callback is implemented in this PR; callback wiring is intentionally documented-only for a follow-up that can report smoke-test completion back to `publish-candidate`.

Refs: #289