### PR TITLE
ci: split downstream release workflow into reusable stages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Split downstream release workflow with project-owned extension hook** ([#326](https://github.com/vig-os/devcontainer/issues/326))
+  - Add local `workflow_call` release phases (`release-core.yml`, `release-publish.yml`) and a lightweight `release.yml` orchestrator in `assets/workspace/.github/workflows/`
+  - Add `release_kind` support with candidate mode (`X.Y.Z-rcN`) and final mode (`X.Y.Z`) in downstream release workflows
+  - Candidate mode now auto-computes the next RC tag, skips CHANGELOG finalization/sync-issues, and publishes a GitHub pre-release
+  - Add project-owned `release-extension.yml` stub and preserve it during `init-workspace.sh --force` upgrades
+  - Add `validate-contract` composite action for single-source contract version validation
+  - Add downstream release contract documentation and GHCR extension example in `docs/DOWNSTREAM_RELEASE.md`
+
 ### Changed
 
 - **Dependabot dependency update batch** ([#302](https://github.com/vig-os/devcontainer/pull/302), [#303](https://github.com/vig-os/devcontainer/pull/303), [#305](https://github.com/vig-os/devcontainer/pull/305), [#306](https://github.com/vig-os/devcontainer/pull/306), [#307](https://github.com/vig-os/devcontainer/pull/307), [#308](https://github.com/vig-os/devcontainer/pull/308), [#309](https://github.com/vig-os/devcontainer/pull/309))

--- a/assets/init-workspace.sh
+++ b/assets/init-workspace.sh
@@ -29,6 +29,7 @@ PRESERVE_FILES=(
     "CHANGELOG.md"
     "LICENSE"
     ".github/CODEOWNERS"
+    ".github/workflows/release-extension.yml"
     "justfile.project"
 )
 

--- a/assets/workspace/.github/actions/validate-contract/action.yml
+++ b/assets/workspace/.github/actions/validate-contract/action.yml
@@ -1,0 +1,27 @@
+name: Validate release contract version
+description: Validate that the caller's contract version matches the expected version
+
+inputs:
+  contract_version:
+    description: "Contract version received from caller"
+    required: true
+  expected_version:
+    description: "Expected contract version"
+    required: true
+    default: "1"
+
+runs:
+  using: composite
+  steps:
+    - name: Validate contract version
+      shell: bash
+      env:
+        CONTRACT_VERSION: ${{ inputs.contract_version }}
+        EXPECTED: ${{ inputs.expected_version }}
+      run: |
+        set -euo pipefail
+        if [ "$CONTRACT_VERSION" != "$EXPECTED" ]; then
+          echo "ERROR: Unsupported contract_version '$CONTRACT_VERSION' (expected '$EXPECTED')."
+          echo "Update your workflow template and set contract_version: \"$EXPECTED\"."
+          exit 1
+        fi

--- a/assets/workspace/.github/actions/validate-contract/action.yml
+++ b/assets/workspace/.github/actions/validate-contract/action.yml
@@ -7,7 +7,7 @@ inputs:
     required: true
   expected_version:
     description: "Expected contract version"
-    required: true
+    required: false
     default: "1"
 
 runs:

--- a/assets/workspace/.github/workflows/prepare-release.yml
+++ b/assets/workspace/.github/workflows/prepare-release.yml
@@ -111,11 +111,20 @@ jobs:
             exit 1
           fi
 
-      - name: Verify CHANGELOG has Unreleased section with content
+      - name: Verify CHANGELOG has Unreleased section entries
         run: |
           set -euo pipefail
           if ! grep -q "^## Unreleased" CHANGELOG.md; then
             echo "ERROR: CHANGELOG.md is missing '## Unreleased' section"
+            exit 1
+          fi
+          if ! awk '
+            /^## Unreleased$/ {in_unreleased=1; next}
+            /^## \[/ && in_unreleased {exit 1}
+            in_unreleased && /^[[:space:]]*-[[:space:]]/ {found_entry=1}
+            END {exit(found_entry ? 0 : 1)}
+          ' CHANGELOG.md; then
+            echo "ERROR: CHANGELOG.md Unreleased section has no entries"
             exit 1
           fi
 

--- a/assets/workspace/.github/workflows/prepare-release.yml
+++ b/assets/workspace/.github/workflows/prepare-release.yml
@@ -1,0 +1,309 @@
+name: Prepare Release
+
+on:  # yamllint disable-line rule:truthy
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Semantic version to prepare (e.g., 1.2.3)"
+        required: true
+        type: string
+      dry-run:
+        description: "Validate without making changes"
+        required: false
+        default: false
+        type: boolean
+      git-user-name:
+        description: "Git user name for commits"
+        required: false
+        default: "github-actions[bot]"
+        type: string
+      git-user-email:
+        description: "Git user email for commits"
+        required: false
+        default: "41898282+github-actions[bot]@users.noreply.github.com"
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Validate Release Preparation
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    outputs:
+      version: ${{ steps.vars.outputs.version }}
+      release_branch: ${{ steps.vars.outputs.release_branch }}
+      image_tag: ${{ steps.resolve_image.outputs.image_tag }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          ref: dev
+          fetch-depth: 0
+
+      - name: Validate and prepare variables
+        id: vars
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          VERSION="$INPUT_VERSION"
+          if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "ERROR: Invalid version format '$VERSION'"
+            echo "Version must follow semantic versioning format: MAJOR.MINOR.PATCH (e.g., 1.2.3)"
+            exit 1
+          fi
+          RELEASE_BRANCH="release/$VERSION"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "release_branch=$RELEASE_BRANCH" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve container image tag
+        id: resolve_image
+        run: |
+          set -euo pipefail
+          TAG=""
+          if [ -f ".vig-os" ]; then
+            TAG=$(awk -F= '/^DEVCONTAINER_VERSION=/{gsub(/^[ \t"]+|[ \t"]+$/, "", $2); print $2; exit}' .vig-os || true)
+          fi
+          if [ -z "${TAG:-}" ]; then
+            TAG="latest"
+          fi
+          echo "image_tag=$TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Validate image accessibility
+        env:
+          IMAGE_TAG: ${{ steps.resolve_image.outputs.image_tag }}
+        run: |
+          set -euo pipefail
+          IMAGE="ghcr.io/vig-os/devcontainer:${IMAGE_TAG}"
+          if ! docker manifest inspect "$IMAGE" > /dev/null 2>&1; then
+            echo "ERROR: Cannot access image manifest: $IMAGE"
+            exit 1
+          fi
+
+      - name: Verify release branch does not exist
+        env:
+          RELEASE_BRANCH: ${{ steps.vars.outputs.release_branch }}
+        run: |
+          set -euo pipefail
+          if git show-ref --verify --quiet "refs/heads/$RELEASE_BRANCH"; then
+            echo "ERROR: Release branch already exists locally: $RELEASE_BRANCH"
+            exit 1
+          fi
+          if git show-ref --verify --quiet "refs/remotes/origin/$RELEASE_BRANCH"; then
+            echo "ERROR: Release branch already exists on remote: $RELEASE_BRANCH"
+            exit 1
+          fi
+
+      - name: Verify tag does not exist
+        env:
+          VERSION: ${{ steps.vars.outputs.version }}
+        run: |
+          set -euo pipefail
+          if git tag -l | grep -q "^$VERSION$"; then
+            echo "ERROR: Tag $VERSION already exists"
+            exit 1
+          fi
+
+      - name: Verify CHANGELOG has Unreleased section with content
+        run: |
+          set -euo pipefail
+          if ! grep -q "^## Unreleased" CHANGELOG.md; then
+            echo "ERROR: CHANGELOG.md is missing '## Unreleased' section"
+            exit 1
+          fi
+
+      - name: Summary
+        env:
+          VERSION: ${{ steps.vars.outputs.version }}
+          RELEASE_BRANCH: ${{ steps.vars.outputs.release_branch }}
+          IMAGE_TAG: ${{ steps.resolve_image.outputs.image_tag }}
+          DRY_RUN: ${{ inputs.dry-run }}
+        run: |
+          echo "Validation passed"
+          echo "Version: $VERSION"
+          echo "Release branch: $RELEASE_BRANCH"
+          echo "Image tag: $IMAGE_TAG"
+          echo "Dry-run: $DRY_RUN"
+
+  prepare:
+    name: Prepare Release Branch
+    needs: validate
+    runs-on: ubuntu-22.04
+    container:
+      image: ghcr.io/vig-os/devcontainer:${{ needs.validate.outputs.image_tag }}
+      env:
+        UV_PROJECT_ENVIRONMENT: /root/assets/workspace/.venv
+    timeout-minutes: 15
+    if: ${{ inputs.dry-run != true }}
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout dev branch
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          ref: dev
+          fetch-depth: 0
+
+      - name: Fix git safe.directory
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      - name: Capture pre-prepare dev SHA
+        id: pre_state
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          PREPARE_START_SHA=$(gh api "repos/${{ github.repository }}/git/ref/heads/dev" --jq '.object.sha')
+          echo "prepare_start_sha=$PREPARE_START_SHA" >> "$GITHUB_OUTPUT"
+
+      - name: Prepare CHANGELOG (freeze + reset)
+        env:
+          VERSION: ${{ needs.validate.outputs.version }}
+        run: |
+          set -euo pipefail
+          prepare-changelog prepare "$VERSION" CHANGELOG.md
+
+      - name: Extract CHANGELOG content for PR body
+        id: changelog
+        env:
+          VERSION: ${{ needs.validate.outputs.version }}
+        run: |
+          set -euo pipefail
+          CHANGELOG_CONTENT=$(sed -n "/## \[$VERSION\]/,/## \[/p" CHANGELOG.md | sed '$d')
+          {
+            echo "changelog<<CHANGELOGEOF"
+            echo "$CHANGELOG_CONTENT"
+            echo "CHANGELOGEOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Commit prepared CHANGELOG to dev via API
+        uses: vig-os/commit-action@c0024cbad0e501764127cccab732c6cd465b4646  # v0.1.5
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          TARGET_BRANCH: refs/heads/dev
+          COMMIT_MESSAGE: |-
+            chore: freeze changelog for release ${{ needs.validate.outputs.version }}
+
+            Move Unreleased content to [${{ needs.validate.outputs.version }}] - TBD
+            and create fresh empty Unreleased section for continued development.
+          FILE_PATHS: CHANGELOG.md
+
+      - name: Create release branch from dev
+        id: create_branch
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_BRANCH: ${{ needs.validate.outputs.release_branch }}
+        run: |
+          set -euo pipefail
+          DEV_SHA=$(gh api "repos/${{ github.repository }}/git/ref/heads/dev" --jq '.object.sha')
+          gh api "repos/${{ github.repository }}/git/refs" \
+            -f ref="refs/heads/$RELEASE_BRANCH" \
+            -f sha="$DEV_SHA"
+          echo "dev_sha=$DEV_SHA" >> "$GITHUB_OUTPUT"
+
+      - name: Strip empty Unreleased section for release branch
+        run: |
+          set -euo pipefail
+          python3 -c "
+          import re
+          from pathlib import Path
+          content = Path('CHANGELOG.md').read_text()
+          content = re.sub(
+              r'## Unreleased\s*\n(?:### \w+\s*\n\s*)*\n*(?=## \[)',
+              '',
+              content,
+          )
+          Path('CHANGELOG.md').write_text(content)
+          "
+
+      - name: Commit stripped CHANGELOG to release branch via API
+        uses: vig-os/commit-action@c0024cbad0e501764127cccab732c6cd465b4646  # v0.1.5
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          TARGET_BRANCH: refs/heads/${{ needs.validate.outputs.release_branch }}
+          COMMIT_MESSAGE: |-
+            chore: prepare release ${{ needs.validate.outputs.version }}
+
+            Strip empty Unreleased section from release branch.
+            Release date TBD (set during finalization).
+          FILE_PATHS: CHANGELOG.md
+
+      - name: Create draft PR to main
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs.validate.outputs.version }}
+          RELEASE_BRANCH: ${{ needs.validate.outputs.release_branch }}
+          CHANGELOG_CONTENT: ${{ steps.changelog.outputs.changelog }}
+        run: |
+          set -euo pipefail
+          PR_BODY="## Release $VERSION
+
+          This PR prepares release $VERSION for merge to main.
+
+          ### Release Content
+
+          $CHANGELOG_CONTENT
+          "
+
+          PR_URL=$(gh pr create \
+            --base main \
+            --head "$RELEASE_BRANCH" \
+            --title "chore: release $VERSION" \
+            --body "$PR_BODY" \
+            --draft)
+
+          PR_NUMBER=$(echo "$PR_URL" | grep -oE '[0-9]+$')
+          echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+
+      - name: Roll back prepare-release side effects on failure
+        id: rollback_prepare
+        if: ${{ failure() }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_BRANCH: ${{ needs.validate.outputs.release_branch }}
+          PREPARE_START_SHA: ${{ steps.pre_state.outputs.prepare_start_sha }}
+          POST_FREEZE_DEV_SHA: ${{ steps.create_branch.outputs.dev_sha }}
+        run: |
+          set -euo pipefail
+          CHANGELOG_ROLLBACK_NEEDED=false
+          gh api -X DELETE "repos/${{ github.repository }}/git/refs/heads/$RELEASE_BRANCH" || true
+
+          if [ -z "${PREPARE_START_SHA:-}" ] || [ -z "${POST_FREEZE_DEV_SHA:-}" ]; then
+            echo "changelog_rollback_needed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          CURRENT_DEV_SHA=$(gh api "repos/${{ github.repository }}/git/ref/heads/dev" --jq '.object.sha')
+          if [ "$CURRENT_DEV_SHA" != "$POST_FREEZE_DEV_SHA" ]; then
+            echo "changelog_rollback_needed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          gh api "repos/${{ github.repository }}/contents/CHANGELOG.md?ref=$PREPARE_START_SHA" --jq '.content' | tr -d '\n' | base64 -d > /tmp/changelog.pre.md
+          gh api "repos/${{ github.repository }}/contents/CHANGELOG.md?ref=dev" --jq '.content' | tr -d '\n' | base64 -d > /tmp/changelog.current.md
+          if ! cmp -s /tmp/changelog.pre.md /tmp/changelog.current.md; then
+            cp /tmp/changelog.pre.md CHANGELOG.md
+            CHANGELOG_ROLLBACK_NEEDED=true
+          fi
+          echo "changelog_rollback_needed=$CHANGELOG_ROLLBACK_NEEDED" >> "$GITHUB_OUTPUT"
+
+      - name: Commit CHANGELOG rollback to dev via API
+        if: ${{ failure() && steps.rollback_prepare.outputs.changelog_rollback_needed == 'true' }}
+        uses: vig-os/commit-action@c0024cbad0e501764127cccab732c6cd465b4646  # v0.1.5
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          TARGET_BRANCH: refs/heads/dev
+          COMMIT_MESSAGE: |-
+            chore: rollback failed prepare-release ${{ needs.validate.outputs.version }}
+
+            Restore CHANGELOG.md on dev to pre-prepare state after prepare-release failed.
+          FILE_PATHS: CHANGELOG.md

--- a/assets/workspace/.github/workflows/prepare-release.yml
+++ b/assets/workspace/.github/workflows/prepare-release.yml
@@ -92,7 +92,7 @@ jobs:
             echo "ERROR: Release branch already exists locally: $RELEASE_BRANCH"
             exit 1
           fi
-          if git show-ref --verify --quiet "refs/remotes/origin/$RELEASE_BRANCH"; then
+          if git ls-remote --exit-code --heads origin "$RELEASE_BRANCH" > /dev/null 2>&1; then
             echo "ERROR: Release branch already exists on remote: $RELEASE_BRANCH"
             exit 1
           fi
@@ -102,8 +102,12 @@ jobs:
           VERSION: ${{ steps.vars.outputs.version }}
         run: |
           set -euo pipefail
-          if git tag -l | grep -q "^$VERSION$"; then
+          if git rev-parse -q --verify "refs/tags/$VERSION" > /dev/null; then
             echo "ERROR: Tag $VERSION already exists"
+            exit 1
+          fi
+          if git ls-remote --exit-code --tags --refs origin "refs/tags/$VERSION" > /dev/null 2>&1; then
+            echo "ERROR: Tag $VERSION already exists on remote"
             exit 1
           fi
 

--- a/assets/workspace/.github/workflows/release-core.yml
+++ b/assets/workspace/.github/workflows/release-core.yml
@@ -1,0 +1,454 @@
+name: Release Core
+
+on:  # yamllint disable-line rule:truthy
+  workflow_call:
+    inputs:
+      version:
+        description: "Semantic version to release (e.g., 1.2.3)"
+        required: true
+        type: string
+      release_kind:
+        description: "Release mode: candidate publishes X.Y.Z-rcN, final publishes X.Y.Z"
+        required: false
+        default: "candidate"
+        type: string
+      dry_run:
+        description: "Validate without making changes"
+        required: false
+        default: false
+        type: boolean
+      git_user_name:
+        description: "Git user name for release commits"
+        required: false
+        default: "github-actions[bot]"
+        type: string
+      git_user_email:
+        description: "Git user email for release commits"
+        required: false
+        default: "41898282+github-actions[bot]@users.noreply.github.com"
+        type: string
+      contract_version:
+        description: "Release workflow contract version"
+        required: true
+        type: string
+    secrets:
+      token:
+        required: false
+    outputs:
+      version:
+        description: "Resolved release version"
+        value: ${{ jobs.validate.outputs.version }}
+      pr_number:
+        description: "Release PR number"
+        value: ${{ jobs.validate.outputs.pr_number }}
+      release_date:
+        description: "UTC release date used for finalization"
+        value: ${{ jobs.validate.outputs.release_date }}
+      pre_finalize_sha:
+        description: "Release branch SHA before finalization"
+        value: ${{ jobs.validate.outputs.pre_finalize_sha }}
+      release_kind:
+        description: "Release kind (candidate or final)"
+        value: ${{ jobs.validate.outputs.release_kind }}
+      publish_version:
+        description: "Tag to publish (X.Y.Z or X.Y.Z-rcN)"
+        value: ${{ jobs.validate.outputs.publish_version }}
+      finalize_sha:
+        description: "Release branch SHA after finalization"
+        value: ${{ jobs.finalize.outputs.finalize_sha }}
+      image_tag:
+        description: "Resolved devcontainer image tag"
+        value: ${{ jobs.validate.outputs.image_tag }}
+
+concurrency:
+  group: release-core
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Validate Release Core
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    outputs:
+      version: ${{ steps.vars.outputs.version }}
+      pr_number: ${{ steps.pr.outputs.pr_number }}
+      release_date: ${{ steps.vars.outputs.release_date }}
+      pre_finalize_sha: ${{ steps.pre_sha.outputs.pre_finalize_sha }}
+      release_kind: ${{ steps.vars.outputs.release_kind }}
+      publish_version: ${{ steps.publish_meta.outputs.publish_version }}
+      image_tag: ${{ steps.resolve_image.outputs.image_tag }}
+
+    steps:
+      - name: Validate contract version
+        uses: ./.github/actions/validate-contract
+        with:
+          contract_version: ${{ inputs.contract_version }}
+
+      - name: Resolve auth token
+        id: auth
+        env:
+          PROVIDED_TOKEN: ${{ secrets.token }}
+          FALLBACK_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if [ -n "${PROVIDED_TOKEN:-}" ]; then
+            echo "token=$PROVIDED_TOKEN" >> "$GITHUB_OUTPUT"
+          else
+            echo "token=$FALLBACK_TOKEN" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Validate and prepare variables
+        id: vars
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+          INPUT_RELEASE_KIND: ${{ inputs.release_kind }}
+        run: |
+          set -euo pipefail
+          VERSION="$INPUT_VERSION"
+          RELEASE_KIND="$INPUT_RELEASE_KIND"
+
+          if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "ERROR: Invalid version format '$VERSION'"
+            echo "Version must follow semantic versioning: MAJOR.MINOR.PATCH (e.g., 1.2.3)"
+            exit 1
+          fi
+          if [ "$RELEASE_KIND" != "candidate" ] && [ "$RELEASE_KIND" != "final" ]; then
+            echo "ERROR: Invalid release-kind '$RELEASE_KIND'"
+            echo "release-kind must be one of: candidate, final"
+            exit 1
+          fi
+
+          RELEASE_DATE=$(date -u +%Y-%m-%d)
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "release_kind=$RELEASE_KIND" >> "$GITHUB_OUTPUT"
+          echo "release_date=$RELEASE_DATE" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout release branch
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          ref: release/${{ steps.vars.outputs.version }}
+          fetch-depth: 0
+          token: ${{ steps.auth.outputs.token }}
+
+      - name: Resolve container image tag
+        id: resolve_image
+        run: |
+          set -euo pipefail
+          TAG=""
+          if [ -f ".vig-os" ]; then
+            TAG=$(awk -F= '/^DEVCONTAINER_VERSION=/{gsub(/^[ \t"]+|[ \t"]+$/, "", $2); print $2; exit}' .vig-os || true)
+          fi
+          if [ -z "${TAG:-}" ]; then
+            TAG="latest"
+          fi
+          echo "image_tag=$TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Validate image accessibility
+        env:
+          IMAGE_TAG: ${{ steps.resolve_image.outputs.image_tag }}
+        run: |
+          set -euo pipefail
+          IMAGE="ghcr.io/vig-os/devcontainer:${IMAGE_TAG}"
+          echo "Validating image availability: $IMAGE"
+          if ! docker manifest inspect "$IMAGE" > /dev/null 2>&1; then
+            echo "ERROR: Cannot access image manifest: $IMAGE"
+            echo "Check whether the tag exists and whether this workflow has access to GHCR."
+            exit 1
+          fi
+
+      - name: Record pre-finalization SHA
+        id: pre_sha
+        run: |
+          PRE_FINALIZE_SHA=$(git rev-parse HEAD)
+          echo "pre_finalize_sha=$PRE_FINALIZE_SHA" >> "$GITHUB_OUTPUT"
+          echo "Pre-finalization SHA: $PRE_FINALIZE_SHA"
+
+      - name: Verify CHANGELOG has TBD entry
+        env:
+          VERSION: ${{ steps.vars.outputs.version }}
+        run: |
+          if ! grep -q "## \[$VERSION\] - TBD" CHANGELOG.md; then
+            echo "ERROR: CHANGELOG.md does not contain '## [$VERSION] - TBD'"
+            exit 1
+          fi
+
+      - name: Compute publish version
+        id: publish_meta
+        env:
+          VERSION: ${{ steps.vars.outputs.version }}
+          RELEASE_KIND: ${{ steps.vars.outputs.release_kind }}
+        run: |
+          set -euo pipefail
+          NEXT_RC=""
+          if [ "$RELEASE_KIND" = "candidate" ]; then
+            TAG_PATTERN="${VERSION}-rc*"
+            EXISTING_TAGS=$(git ls-remote --tags --refs origin "$TAG_PATTERN" | awk '{print $2}' | sed 's#refs/tags/##')
+
+            MAX_RC=0
+            if [ -n "$EXISTING_TAGS" ]; then
+              while IFS= read -r tag; do
+                [ -z "$tag" ] && continue
+                if ! echo "$tag" | grep -qE "^${VERSION}-rc[0-9]+$"; then
+                  echo "ERROR: Malformed candidate tag detected: $tag"
+                  echo "Expected format: ${VERSION}-rcN"
+                  exit 1
+                fi
+                rc_num="${tag##*-rc}"
+                if [ "$rc_num" -gt "$MAX_RC" ]; then
+                  MAX_RC="$rc_num"
+                fi
+              done <<< "$EXISTING_TAGS"
+            fi
+
+            NEXT_RC=$((MAX_RC + 1))
+            PUBLISH_VERSION="${VERSION}-rc${NEXT_RC}"
+          else
+            PUBLISH_VERSION="$VERSION"
+          fi
+          echo "publish_version=$PUBLISH_VERSION" >> "$GITHUB_OUTPUT"
+          echo "next_rc=$NEXT_RC" >> "$GITHUB_OUTPUT"
+
+      - name: Verify publish tag does not exist
+        env:
+          PUBLISH_VERSION: ${{ steps.publish_meta.outputs.publish_version }}
+        run: |
+          if git ls-remote --tags --refs origin "$PUBLISH_VERSION" | grep -q "refs/tags/$PUBLISH_VERSION$"; then
+            echo "ERROR: Tag $PUBLISH_VERSION already exists"
+            exit 1
+          fi
+          if git tag -l | grep -q "^${PUBLISH_VERSION}$"; then
+            echo "ERROR: Local tag $PUBLISH_VERSION already exists"
+            exit 1
+          fi
+
+      - name: Find and verify PR
+        id: pr
+        env:
+          VERSION: ${{ steps.vars.outputs.version }}
+          GH_TOKEN: ${{ steps.auth.outputs.token }}
+        run: |
+          set -euo pipefail
+
+          PR_JSON=$(gh pr list \
+            --head "release/$VERSION" \
+            --base main \
+            --json number,isDraft,reviewDecision,statusCheckRollup \
+            --limit 1)
+
+          PR_COUNT=$(echo "$PR_JSON" | jq 'length')
+          if [ "$PR_COUNT" != "1" ]; then
+            echo "ERROR: Expected exactly 1 PR from release/$VERSION to main, found $PR_COUNT"
+            exit 1
+          fi
+
+          PR_NUMBER=$(echo "$PR_JSON" | jq -r '.[0].number')
+          IS_DRAFT=$(echo "$PR_JSON" | jq -r '.[0].isDraft')
+          REVIEW_DECISION=$(echo "$PR_JSON" | jq -r '.[0].reviewDecision')
+          echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+
+          if [ "$IS_DRAFT" = "true" ]; then
+            echo "ERROR: PR #$PR_NUMBER is still in draft"
+            exit 1
+          fi
+          if [ "$REVIEW_DECISION" != "APPROVED" ]; then
+            echo "ERROR: PR #$PR_NUMBER is not approved (status: $REVIEW_DECISION)"
+            exit 1
+          fi
+
+          STATUS_ROLLUP=$(echo "$PR_JSON" | jq -r '.[0].statusCheckRollup // []')
+          CI_FAILED=$(echo "$STATUS_ROLLUP" | jq '[.[] | select(.conclusion == "FAILURE" or .conclusion == "ERROR")] | length')
+          if [ "$CI_FAILED" != "0" ]; then
+            echo "ERROR: PR #$PR_NUMBER has failed CI checks"
+            exit 1
+          fi
+
+      - name: Summary
+        env:
+          VERSION: ${{ steps.vars.outputs.version }}
+          RELEASE_KIND: ${{ steps.vars.outputs.release_kind }}
+          PUBLISH_VERSION: ${{ steps.publish_meta.outputs.publish_version }}
+          NEXT_RC: ${{ steps.publish_meta.outputs.next_rc }}
+          PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
+          RELEASE_DATE: ${{ steps.vars.outputs.release_date }}
+          DRY_RUN: ${{ inputs.dry_run }}
+          IMAGE_TAG: ${{ steps.resolve_image.outputs.image_tag }}
+        run: |
+          echo "Validation passed"
+          echo ""
+          echo "  Version:      $VERSION"
+          echo "  Release Kind: $RELEASE_KIND"
+          echo "  Publish Tag:  $PUBLISH_VERSION"
+          if [ -n "$NEXT_RC" ]; then
+            echo "  Next RC:      $NEXT_RC"
+          fi
+          echo "  Branch:       release/$VERSION"
+          echo "  PR:           #$PR_NUMBER"
+          echo "  Release Date: $RELEASE_DATE"
+          echo "  Image Tag:    $IMAGE_TAG"
+          echo "  Dry-run:      $DRY_RUN"
+
+  finalize:
+    name: Finalize Release Core
+    needs: validate
+    runs-on: ubuntu-22.04
+    container:
+      image: ghcr.io/vig-os/devcontainer:${{ needs.validate.outputs.image_tag }}
+      env:
+        UV_PROJECT_ENVIRONMENT: /root/assets/workspace/.venv
+    timeout-minutes: 15
+    if: ${{ inputs.dry_run != true }}
+    permissions:
+      contents: write
+    outputs:
+      finalize_sha: ${{ steps.finalize.outputs.finalize_sha }}
+
+    steps:
+      - name: Resolve auth token
+        id: auth
+        env:
+          PROVIDED_TOKEN: ${{ secrets.token }}
+          FALLBACK_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if [ -n "${PROVIDED_TOKEN:-}" ]; then
+            echo "token=$PROVIDED_TOKEN" >> "$GITHUB_OUTPUT"
+          else
+            echo "token=$FALLBACK_TOKEN" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout release branch
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          ref: release/${{ needs.validate.outputs.version }}
+          fetch-depth: 0
+          token: ${{ steps.auth.outputs.token }}
+
+      - name: Fix git safe.directory
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      - name: Finalize CHANGELOG date
+        if: ${{ inputs.release_kind == 'final' }}
+        env:
+          VERSION: ${{ needs.validate.outputs.version }}
+          RELEASE_DATE: ${{ needs.validate.outputs.release_date }}
+        run: |
+          set -euo pipefail
+          prepare-changelog finalize "$VERSION" "$RELEASE_DATE" CHANGELOG.md
+
+      - name: Commit and push finalization changes via API
+        if: ${{ inputs.release_kind == 'final' }}
+        uses: vig-os/commit-action@c0024cbad0e501764127cccab732c6cd465b4646  # v0.1.5
+        env:
+          GH_TOKEN: ${{ steps.auth.outputs.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          TARGET_BRANCH: refs/heads/release/${{ needs.validate.outputs.version }}
+          COMMIT_MESSAGE: |-
+            chore: finalize release ${{ needs.validate.outputs.version }}
+
+            Set release date to ${{ needs.validate.outputs.release_date }} in CHANGELOG.md
+
+            Refs: #${{ needs.validate.outputs.pr_number }}
+          FILE_PATHS: CHANGELOG.md
+
+      - name: Trigger sync-issues workflow
+        if: ${{ inputs.release_kind == 'final' }}
+        env:
+          GH_TOKEN: ${{ steps.auth.outputs.token }}
+          VERSION: ${{ needs.validate.outputs.version }}
+        run: |
+          set -euo pipefail
+          gh workflow run sync-issues.yml -f "target-branch=release/$VERSION"
+
+      - name: Wait for sync-issues completion
+        if: ${{ inputs.release_kind == 'final' }}
+        env:
+          GH_TOKEN: ${{ steps.auth.outputs.token }}
+        run: |
+          set -euo pipefail
+          TIMEOUT=120
+          ELAPSED=0
+          INTERVAL=10
+          sleep 5
+          ELAPSED=5
+
+          while [ $ELAPSED -lt $TIMEOUT ]; do
+            RUN_STATUS=$(gh run list \
+              --workflow sync-issues.yml \
+              --limit 1 \
+              --json status,conclusion \
+              --jq '.[0].status' 2>/dev/null || echo "unknown")
+
+            if [ "$RUN_STATUS" = "completed" ]; then
+              break
+            fi
+
+            sleep "$INTERVAL"
+            ELAPSED=$((ELAPSED + INTERVAL))
+          done
+
+      - name: Pull sync-issues changes
+        if: ${{ inputs.release_kind == 'final' }}
+        env:
+          VERSION: ${{ needs.validate.outputs.version }}
+        run: |
+          set -euo pipefail
+          git fetch origin "release/$VERSION"
+          git reset --hard "origin/release/$VERSION"
+
+      - name: Output finalize SHA
+        id: finalize
+        env:
+          VERSION: ${{ needs.validate.outputs.version }}
+          RELEASE_KIND: ${{ inputs.release_kind }}
+          GH_TOKEN: ${{ steps.auth.outputs.token }}
+        run: |
+          set -euo pipefail
+          if [ "$RELEASE_KIND" = "final" ]; then
+            FINALIZE_SHA=$(git rev-parse HEAD)
+          else
+            FINALIZE_SHA=$(gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/release/$VERSION" --jq '.object.sha')
+          fi
+          echo "finalize_sha=$FINALIZE_SHA" >> "$GITHUB_OUTPUT"
+
+  test:
+    name: Test Finalized Release
+    needs: [validate, finalize]
+    runs-on: ubuntu-22.04
+    container:
+      image: ghcr.io/vig-os/devcontainer:${{ needs.validate.outputs.image_tag }}
+      env:
+        UV_PROJECT_ENVIRONMENT: /root/assets/workspace/.venv
+    timeout-minutes: 20
+    if: ${{ inputs.dry_run != true }}
+
+    steps:
+      - name: Resolve auth token
+        id: auth
+        env:
+          PROVIDED_TOKEN: ${{ secrets.token }}
+          FALLBACK_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if [ -n "${PROVIDED_TOKEN:-}" ]; then
+            echo "token=$PROVIDED_TOKEN" >> "$GITHUB_OUTPUT"
+          else
+            echo "token=$FALLBACK_TOKEN" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout finalized commit
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          ref: ${{ needs.finalize.outputs.finalize_sha }}
+          token: ${{ steps.auth.outputs.token }}
+
+      - name: Fix git safe.directory
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      - name: Sync Python dependencies
+        run: just sync
+
+      - name: Run tests
+        run: just test

--- a/assets/workspace/.github/workflows/release-core.yml
+++ b/assets/workspace/.github/workflows/release-core.yml
@@ -369,6 +369,7 @@ jobs:
 
       - name: Wait for sync-issues completion
         if: ${{ inputs.release_kind == 'final' }}
+        id: wait_sync
         env:
           GH_TOKEN: ${{ steps.auth.outputs.token }}
         run: |
@@ -376,6 +377,7 @@ jobs:
           TIMEOUT=120
           ELAPSED=0
           INTERVAL=10
+          RUN_STATUS="unknown"
           sleep 5
           ELAPSED=5
 
@@ -393,6 +395,21 @@ jobs:
             sleep "$INTERVAL"
             ELAPSED=$((ELAPSED + INTERVAL))
           done
+
+          if [ "$RUN_STATUS" != "completed" ]; then
+            echo "ERROR: Timed out waiting for sync-issues workflow completion"
+            exit 1
+          fi
+
+          RUN_CONCLUSION=$(gh run list \
+            --workflow sync-issues.yml \
+            --limit 1 \
+            --json conclusion \
+            --jq '.[0].conclusion' 2>/dev/null || echo "unknown")
+          if [ "$RUN_CONCLUSION" != "success" ]; then
+            echo "ERROR: sync-issues workflow finished with conclusion '$RUN_CONCLUSION'"
+            exit 1
+          fi
 
       - name: Pull sync-issues changes
         if: ${{ inputs.release_kind == 'final' }}

--- a/assets/workspace/.github/workflows/release-core.yml
+++ b/assets/workspace/.github/workflows/release-core.yml
@@ -170,7 +170,7 @@ jobs:
         env:
           VERSION: ${{ steps.vars.outputs.version }}
         run: |
-          if ! grep -q "## \[$VERSION\] - TBD" CHANGELOG.md; then
+          if ! grep -Fq "## [$VERSION] - TBD" CHANGELOG.md; then
             echo "ERROR: CHANGELOG.md does not contain '## [$VERSION] - TBD'"
             exit 1
           fi
@@ -191,12 +191,17 @@ jobs:
             if [ -n "$EXISTING_TAGS" ]; then
               while IFS= read -r tag; do
                 [ -z "$tag" ] && continue
-                if ! echo "$tag" | grep -qE "^${VERSION}-rc[0-9]+$"; then
+                if [ "${tag#${VERSION}-rc}" = "$tag" ]; then
                   echo "ERROR: Malformed candidate tag detected: $tag"
                   echo "Expected format: ${VERSION}-rcN"
                   exit 1
                 fi
-                rc_num="${tag##*-rc}"
+                rc_num="${tag#${VERSION}-rc}"
+                if ! echo "$rc_num" | grep -qE '^[0-9]+$'; then
+                  echo "ERROR: Malformed candidate tag detected: $tag"
+                  echo "Expected format: ${VERSION}-rcN"
+                  exit 1
+                fi
                 if [ "$rc_num" -gt "$MAX_RC" ]; then
                   MAX_RC="$rc_num"
                 fi
@@ -215,11 +220,11 @@ jobs:
         env:
           PUBLISH_VERSION: ${{ steps.publish_meta.outputs.publish_version }}
         run: |
-          if git ls-remote --tags --refs origin "$PUBLISH_VERSION" | grep -q "refs/tags/$PUBLISH_VERSION$"; then
+          if git ls-remote --exit-code --tags --refs origin "refs/tags/$PUBLISH_VERSION" > /dev/null 2>&1; then
             echo "ERROR: Tag $PUBLISH_VERSION already exists"
             exit 1
           fi
-          if git tag -l | grep -q "^${PUBLISH_VERSION}$"; then
+          if git rev-parse -q --verify "refs/tags/$PUBLISH_VERSION" > /dev/null; then
             echo "ERROR: Local tag $PUBLISH_VERSION already exists"
             exit 1
           fi

--- a/assets/workspace/.github/workflows/release-extension.yml
+++ b/assets/workspace/.github/workflows/release-extension.yml
@@ -1,0 +1,54 @@
+name: Release Extension
+
+on:  # yamllint disable-line rule:truthy
+  workflow_call:
+    inputs:
+      version:
+        description: "Release version"
+        required: true
+        type: string
+      finalize_sha:
+        description: "Finalized commit SHA"
+        required: true
+        type: string
+      release_date:
+        description: "Release date"
+        required: true
+        type: string
+      release_kind:
+        description: "Release kind (candidate or final)"
+        required: true
+        type: string
+      publish_version:
+        description: "Version tag that will be published (X.Y.Z or X.Y.Z-rcN)"
+        required: true
+        type: string
+      contract_version:
+        description: "Release workflow contract version"
+        required: true
+        type: string
+
+jobs:
+  extension:
+    name: Extension Hook (Default No-op)
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Validate contract version
+        uses: ./.github/actions/validate-contract
+        with:
+          contract_version: ${{ inputs.contract_version }}
+
+      - name: Default extension summary
+        env:
+          VERSION: ${{ inputs.version }}
+          FINALIZE_SHA: ${{ inputs.finalize_sha }}
+          RELEASE_DATE: ${{ inputs.release_date }}
+          RELEASE_KIND: ${{ inputs.release_kind }}
+          PUBLISH_VERSION: ${{ inputs.publish_version }}
+        run: |
+          echo "No release extension configured."
+          echo "Version: $VERSION"
+          echo "Release kind: $RELEASE_KIND"
+          echo "Publish version: $PUBLISH_VERSION"
+          echo "Finalize SHA: $FINALIZE_SHA"
+          echo "Release date: $RELEASE_DATE"

--- a/assets/workspace/.github/workflows/release-publish.yml
+++ b/assets/workspace/.github/workflows/release-publish.yml
@@ -1,0 +1,145 @@
+name: Release Publish
+
+on:  # yamllint disable-line rule:truthy
+  workflow_call:
+    inputs:
+      version:
+        description: "Semantic version to release (e.g., 1.2.3)"
+        required: true
+        type: string
+      finalize_sha:
+        description: "Finalized commit SHA to publish"
+        required: true
+        type: string
+      release_date:
+        description: "Release date used for summary output"
+        required: true
+        type: string
+      publish_version:
+        description: "Version tag to publish (X.Y.Z or X.Y.Z-rcN)"
+        required: true
+        type: string
+      release_kind:
+        description: "Release kind (candidate or final)"
+        required: true
+        type: string
+      git_user_name:
+        description: "Git user name for release tag operations"
+        required: false
+        default: "github-actions[bot]"
+        type: string
+      git_user_email:
+        description: "Git user email for release tag operations"
+        required: false
+        default: "41898282+github-actions[bot]@users.noreply.github.com"
+        type: string
+      contract_version:
+        description: "Release workflow contract version"
+        required: true
+        type: string
+    secrets:
+      token:
+        required: false
+    outputs:
+      tag:
+        description: "Published tag"
+        value: ${{ jobs.publish.outputs.tag }}
+      release_url:
+        description: "Published release URL"
+        value: ${{ jobs.publish.outputs.release_url }}
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Publish Release
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    outputs:
+      tag: ${{ steps.out.outputs.tag }}
+      release_url: ${{ steps.out.outputs.release_url }}
+
+    steps:
+      - name: Validate contract version
+        uses: ./.github/actions/validate-contract
+        with:
+          contract_version: ${{ inputs.contract_version }}
+
+      - name: Resolve auth token
+        id: auth
+        env:
+          PROVIDED_TOKEN: ${{ secrets.token }}
+          FALLBACK_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          if [ -n "${PROVIDED_TOKEN:-}" ]; then
+            echo "token=$PROVIDED_TOKEN" >> "$GITHUB_OUTPUT"
+          else
+            echo "token=$FALLBACK_TOKEN" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout finalized commit
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          ref: ${{ inputs.finalize_sha }}
+          fetch-depth: 0
+          token: ${{ steps.auth.outputs.token }}
+
+      - name: Configure git
+        env:
+          GIT_USER_NAME: ${{ inputs.git_user_name }}
+          GIT_USER_EMAIL: ${{ inputs.git_user_email }}
+        run: |
+          git config user.name "$GIT_USER_NAME"
+          git config user.email "$GIT_USER_EMAIL"
+
+      - name: Create and push tag
+        env:
+          PUBLISH_VERSION: ${{ inputs.publish_version }}
+        run: |
+          set -euo pipefail
+          git tag -a "$PUBLISH_VERSION" -m "Release $PUBLISH_VERSION"
+          git push origin "$PUBLISH_VERSION"
+
+      - name: Extract release notes from CHANGELOG
+        env:
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          awk '/^## \['"$VERSION"'\]/{found=1; next} /^## \[/{found=0} found' \
+            CHANGELOG.md > /tmp/release-notes.md
+          if [ ! -s /tmp/release-notes.md ]; then
+            echo "No changelog notes found for $VERSION" > /tmp/release-notes.md
+          fi
+
+      - name: Create GitHub Release
+        env:
+          PUBLISH_VERSION: ${{ inputs.publish_version }}
+          RELEASE_KIND: ${{ inputs.release_kind }}
+          GH_TOKEN: ${{ steps.auth.outputs.token }}
+        run: |
+          set -euo pipefail
+          if [ "$RELEASE_KIND" = "candidate" ]; then
+            gh release create "$PUBLISH_VERSION" \
+              --title "$PUBLISH_VERSION" \
+              --notes-file /tmp/release-notes.md \
+              --verify-tag \
+              --prerelease
+          else
+            gh release create "$PUBLISH_VERSION" \
+              --title "$PUBLISH_VERSION" \
+              --notes-file /tmp/release-notes.md \
+              --verify-tag
+          fi
+
+      - name: Set outputs
+        id: out
+        env:
+          PUBLISH_VERSION: ${{ inputs.publish_version }}
+          RELEASE_URL: ${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ inputs.publish_version }}
+        run: |
+          echo "tag=$PUBLISH_VERSION" >> "$GITHUB_OUTPUT"
+          echo "release_url=$RELEASE_URL" >> "$GITHUB_OUTPUT"

--- a/assets/workspace/.github/workflows/release-publish.yml
+++ b/assets/workspace/.github/workflows/release-publish.yml
@@ -81,6 +81,17 @@ jobs:
             echo "token=$FALLBACK_TOKEN" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Validate release kind
+        env:
+          RELEASE_KIND: ${{ inputs.release_kind }}
+        run: |
+          set -euo pipefail
+          if [ "$RELEASE_KIND" != "candidate" ] && [ "$RELEASE_KIND" != "final" ]; then
+            echo "ERROR: Invalid release_kind '$RELEASE_KIND'"
+            echo "release_kind must be one of: candidate, final"
+            exit 1
+          fi
+
       - name: Checkout finalized commit
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:

--- a/assets/workspace/.github/workflows/release-publish.yml
+++ b/assets/workspace/.github/workflows/release-publish.yml
@@ -109,8 +109,11 @@ jobs:
           VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
-          awk '/^## \['"$VERSION"'\]/{found=1; next} /^## \[/{found=0} found' \
-            CHANGELOG.md > /tmp/release-notes.md
+          awk -v version="$VERSION" '
+            index($0, "## [" version "]") == 1 {found=1; next}
+            /^## \[/ && found {found=0}
+            found
+          ' CHANGELOG.md > /tmp/release-notes.md
           if [ ! -s /tmp/release-notes.md ]; then
             echo "No changelog notes found for $VERSION" > /tmp/release-notes.md
           fi

--- a/assets/workspace/.github/workflows/release.yml
+++ b/assets/workspace/.github/workflows/release.yml
@@ -1,51 +1,31 @@
-# Release Workflow
-#
-# Creates a versioned release from a release branch.
-# Default template for Python projects using the vigOS devcontainer.
-#
-# Prerequisites:
-#   - A release branch (release/X.Y.Z) exists
-#   - CHANGELOG.md contains "## [X.Y.Z] - TBD"
-#   - A PR from release/X.Y.Z to main is open, approved, and CI has passed
-#   - Tag X.Y.Z does not yet exist
-#
-# Steps:
-#   1. Validate  — Check all prerequisites
-#   2. Finalize  — Set release date in CHANGELOG, commit, push
-#   3. Test      — Run full test suite on finalized code
-#   4. Release   — Create tag and GitHub Release with changelog notes
-#   5. Rollback  — Revert changes and create issue on failure
-#
-# Trigger:
-#   - Manual workflow_dispatch with version input
-#
-# TODO: For branch-protected repos, replace GITHUB_TOKEN with a GitHub App token
-#       to allow pushing finalization commits. See:
-#       https://github.com/apps/settings → create app with contents:write permission.
-
 name: Release
 
 on:  # yamllint disable-line rule:truthy
   workflow_dispatch:
     inputs:
       version:
-        description: 'Semantic version to release (e.g., 1.2.3)'
+        description: "Semantic version to release (e.g., 1.2.3)"
         required: true
         type: string
+      release-kind:
+        description: "Release mode: candidate publishes X.Y.Z-rcN, final publishes X.Y.Z"
+        required: false
+        default: "candidate"
+        type: string
       dry-run:
-        description: 'Validate without making changes'
+        description: "Validate without making changes"
         required: false
         default: false
         type: boolean
       git-user-name:
-        description: 'Git user name for release commits'
+        description: "Git user name for release commits"
         required: false
-        default: 'github-actions[bot]'
+        default: "github-actions[bot]"
         type: string
       git-user-email:
-        description: 'Git user email for release commits'
+        description: "Git user email for release commits"
         required: false
-        default: '41898282+github-actions[bot]@users.noreply.github.com'
+        default: "41898282+github-actions[bot]@users.noreply.github.com"
         type: string
 
 concurrency:
@@ -56,437 +36,116 @@ permissions:
   contents: read
 
 jobs:
-  validate:
-    name: Validate Release
-    runs-on: ubuntu-22.04
-    timeout-minutes: 10
-    outputs:
-      version: ${{ steps.vars.outputs.version }}
-      pr_number: ${{ steps.pr.outputs.pr_number }}
-      release_date: ${{ steps.vars.outputs.release_date }}
-      pre_finalize_sha: ${{ steps.pre_sha.outputs.pre_finalize_sha }}
-      image_tag: ${{ steps.resolve_image.outputs.image-tag }}
+  core:
+    name: Release Core
+    uses: ./.github/workflows/release-core.yml
+    with:
+      version: ${{ inputs.version }}
+      release_kind: ${{ inputs.release-kind }}
+      dry_run: ${{ inputs.dry-run }}
+      git_user_name: ${{ inputs.git-user-name }}
+      git_user_email: ${{ inputs.git-user-email }}
+      contract_version: "1"
+    secrets: inherit
 
-    steps:
-      - name: Validate and prepare variables
-        id: vars
-        env:
-          INPUT_VERSION: ${{ github.event.inputs.version }}
-        run: |
-          set -euo pipefail
-          VERSION="$INPUT_VERSION"
+  extension:
+    name: Release Extension
+    needs: core
+    if: ${{ inputs.dry-run != true }}
+    uses: ./.github/workflows/release-extension.yml
+    with:
+      version: ${{ needs.core.outputs.version }}
+      finalize_sha: ${{ needs.core.outputs.finalize_sha }}
+      release_date: ${{ needs.core.outputs.release_date }}
+      release_kind: ${{ needs.core.outputs.release_kind }}
+      publish_version: ${{ needs.core.outputs.publish_version }}
+      contract_version: "1"
+    secrets: inherit
 
-          if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
-            echo "ERROR: Invalid version format '$VERSION'"
-            echo "Version must follow semantic versioning: MAJOR.MINOR.PATCH (e.g., 1.2.3)"
-            exit 1
-          fi
-
-          RELEASE_DATE=$(date -u +%Y-%m-%d)
-
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "release_date=$RELEASE_DATE" >> $GITHUB_OUTPUT
-
-      - name: Checkout release branch
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-
-        with:
-          ref: release/${{ steps.vars.outputs.version }}
-          fetch-depth: 0
-
-      - name: Resolve container image
-        id: resolve_image
-        uses: ./.github/actions/resolve-image
-
-      - name: Record pre-finalization SHA
-        id: pre_sha
-        run: |
-          PRE_FINALIZE_SHA=$(git rev-parse HEAD)
-          echo "pre_finalize_sha=$PRE_FINALIZE_SHA" >> $GITHUB_OUTPUT
-          echo "Pre-finalization SHA: $PRE_FINALIZE_SHA"
-
-      - name: Verify CHANGELOG has TBD entry
-        env:
-          VERSION: ${{ steps.vars.outputs.version }}
-        run: |
-          if ! grep -q "## \[$VERSION\] - TBD" CHANGELOG.md; then
-            echo "ERROR: CHANGELOG.md does not contain '## [$VERSION] - TBD'"
-            exit 1
-          fi
-
-      - name: Verify tag does not exist
-        env:
-          VERSION: ${{ steps.vars.outputs.version }}
-        run: |
-          if git tag -l | grep -q "^${VERSION}$"; then
-            echo "ERROR: Tag $VERSION already exists"
-            exit 1
-          fi
-
-      - name: Find and verify PR
-        id: pr
-        env:
-          VERSION: ${{ steps.vars.outputs.version }}
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-
-          PR_JSON=$(gh pr list \
-            --head "release/$VERSION" \
-            --base main \
-            --json number,isDraft,reviewDecision,statusCheckRollup \
-            --limit 1)
-
-          PR_COUNT=$(echo "$PR_JSON" | jq 'length')
-
-          if [ "$PR_COUNT" != "1" ]; then
-            echo "ERROR: Expected exactly 1 PR from release/$VERSION to main, found $PR_COUNT"
-            exit 1
-          fi
-
-          PR_NUMBER=$(echo "$PR_JSON" | jq -r '.[0].number')
-          IS_DRAFT=$(echo "$PR_JSON" | jq -r '.[0].isDraft')
-          REVIEW_DECISION=$(echo "$PR_JSON" | jq -r '.[0].reviewDecision')
-
-          echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
-
-          if [ "$IS_DRAFT" = "true" ]; then
-            echo "ERROR: PR #$PR_NUMBER is still in draft"
-            exit 1
-          fi
-
-          if [ "$REVIEW_DECISION" != "APPROVED" ]; then
-            echo "ERROR: PR #$PR_NUMBER is not approved (status: $REVIEW_DECISION)"
-            exit 1
-          fi
-
-          STATUS_ROLLUP=$(echo "$PR_JSON" | jq -r '.[0].statusCheckRollup // []')
-          CI_FAILED=$(echo "$STATUS_ROLLUP" | jq '[.[] | select(.conclusion == "FAILURE" or .conclusion == "ERROR")] | length')
-
-          if [ "$CI_FAILED" != "0" ]; then
-            echo "ERROR: PR #$PR_NUMBER has failed CI checks"
-            exit 1
-          fi
-
-          echo "PR #$PR_NUMBER verified: ready, approved, CI passed"
-
-      - name: Summary
-        env:
-          VERSION: ${{ steps.vars.outputs.version }}
-          PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
-          RELEASE_DATE: ${{ steps.vars.outputs.release_date }}
-          DRY_RUN: ${{ github.event.inputs.dry-run }}
-        run: |
-          echo "Validation passed"
-          echo ""
-          echo "  Version:      $VERSION"
-          echo "  Branch:       release/$VERSION"
-          echo "  PR:           #$PR_NUMBER"
-          echo "  Release Date: $RELEASE_DATE"
-          echo "  Dry-run:      $DRY_RUN"
-
-  finalize:
-    name: Finalize Release
-    needs: validate
-    runs-on: ubuntu-22.04
-    timeout-minutes: 10
-    if: ${{ github.event.inputs.dry-run != 'true' }}
-    permissions:
-      contents: write
-    outputs:
-      finalize_sha: ${{ steps.finalize.outputs.finalize_sha }}
-
-    steps:
-      - name: Checkout release branch
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          ref: release/${{ needs.validate.outputs.version }}
-          persist-credentials: true
-
-      - name: Set release date in CHANGELOG
-        env:
-          VERSION: ${{ needs.validate.outputs.version }}
-          RELEASE_DATE: ${{ needs.validate.outputs.release_date }}
-        run: |
-          set -euo pipefail
-          sed -i "s/## \[$VERSION\] - TBD/## [$VERSION] - $RELEASE_DATE/" CHANGELOG.md
-
-          if ! grep -q "## \[$VERSION\] - $RELEASE_DATE" CHANGELOG.md; then
-            echo "ERROR: Failed to set release date in CHANGELOG"
-            exit 1
-          fi
-          echo "Release date set in CHANGELOG.md"
-
-      - name: Commit and push finalization changes via API
-        uses: vig-os/commit-action@c0024cbad0e501764127cccab732c6cd465b4646  # v0.1.5
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
-          TARGET_BRANCH: refs/heads/release/${{ needs.validate.outputs.version }}
-          COMMIT_MESSAGE: |-
-            chore: finalize release ${{ needs.validate.outputs.version }}
-
-            Set release date to ${{ needs.validate.outputs.release_date }} in CHANGELOG.md
-
-            Refs: #${{ needs.validate.outputs.pr_number }}
-          FILE_PATHS: CHANGELOG.md
-
-      - name: Trigger sync-issues workflow
-        env:
-          GH_TOKEN: ${{ github.token }}
-          VERSION: ${{ needs.validate.outputs.version }}
-        run: |
-          set -euo pipefail
-          echo "Triggering sync-issues workflow..."
-          gh workflow run sync-issues.yml \
-            -f "target-branch=release/$VERSION"
-          echo "✓ sync-issues workflow triggered"
-
-      - name: Wait for sync-issues completion
-        run: |
-          set -euo pipefail
-          TIMEOUT=120
-          ELAPSED=0
-          INTERVAL=10
-
-          sleep 5
-          ELAPSED=5
-
-          while [ $ELAPSED -lt $TIMEOUT ]; do
-            RUN_STATUS=$(gh run list \
-              --workflow sync-issues.yml \
-              --limit 1 \
-              --json status,conclusion \
-              --jq '.[0].status' 2>/dev/null || echo "unknown")
-
-            if [ "$RUN_STATUS" = "completed" ]; then
-              RUN_CONCLUSION=$(gh run list \
-                --workflow sync-issues.yml \
-                --limit 1 \
-                --json conclusion \
-                --jq '.[0].conclusion' 2>/dev/null || echo "unknown")
-
-              if [ "$RUN_CONCLUSION" = "success" ]; then
-                echo "✓ sync-issues workflow completed successfully"
-              else
-                echo "⚠ sync-issues workflow completed with status: $RUN_CONCLUSION"
-              fi
-              break
-            fi
-
-            sleep "$INTERVAL"
-            ELAPSED=$((ELAPSED + INTERVAL))
-            echo "Waiting for sync-issues... (${ELAPSED}s / ${TIMEOUT}s)"
-          done
-
-          if [ $ELAPSED -ge $TIMEOUT ]; then
-            echo "⚠ Timed out waiting for sync-issues workflow"
-            echo "The release may continue, but PR documentation may not be synced"
-          fi
-
-        env:
-          GH_TOKEN: ${{ github.token }}
-
-      - name: Pull sync-issues changes
-        env:
-          VERSION: ${{ needs.validate.outputs.version }}
-        run: |
-          set -euo pipefail
-          git fetch origin "release/$VERSION"
-          git reset --hard "origin/release/$VERSION"
-          echo "✓ Synced with remote release branch"
-
-      - name: Output finalize SHA
-        id: finalize
-        run: |
-          FINALIZE_SHA=$(git rev-parse HEAD)
-          echo "finalize_sha=$FINALIZE_SHA" >> $GITHUB_OUTPUT
-          echo "Finalized at commit: $FINALIZE_SHA"
-
-  test:
-    name: Test (Finalized)
-    needs: [validate, finalize]
-    runs-on: ubuntu-22.04
-    container:
-      image: ghcr.io/vig-os/devcontainer:${{ needs.validate.outputs.image_tag }}
-      env:
-        UV_PROJECT_ENVIRONMENT: /root/assets/workspace/.venv
-    timeout-minutes: 15
-
-    steps:
-      - name: Checkout finalized commit
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          ref: ${{ needs.finalize.outputs.finalize_sha }}
-
-      - name: Fix git safe.directory
-        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
-
-      - name: Sync Python dependencies
-        run: just sync
-
-      - name: Run tests
-        run: just test
-
-  release:
-    name: Create Release
-    needs: [validate, finalize, test]
-    runs-on: ubuntu-22.04
-    timeout-minutes: 10
-    permissions:
-      contents: write
-
-    steps:
-      - name: Checkout finalized commit
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          ref: ${{ needs.finalize.outputs.finalize_sha }}
-          persist-credentials: true
-
-      - name: Configure git
-        env:
-          GIT_USER_NAME: ${{ github.event.inputs.git-user-name }}
-          GIT_USER_EMAIL: ${{ github.event.inputs.git-user-email }}
-        run: |
-          git config user.name "$GIT_USER_NAME"
-          git config user.email "$GIT_USER_EMAIL"
-
-      - name: Create and push tag
-        env:
-          VERSION: ${{ needs.validate.outputs.version }}
-        run: |
-          set -euo pipefail
-          git tag -a "$VERSION" -m "Release $VERSION"
-          git push origin "$VERSION"
-          echo "Tag $VERSION created and pushed"
-
-      - name: Extract release notes from CHANGELOG
-        id: notes
-        env:
-          VERSION: ${{ needs.validate.outputs.version }}
-        run: |
-          set -euo pipefail
-          # Extract content between this version header and the next version header
-          awk '/^## \['"$VERSION"'\]/{found=1; next} /^## \[/{found=0} found' \
-            CHANGELOG.md > /tmp/release-notes.md
-
-          if [ ! -s /tmp/release-notes.md ]; then
-            echo "No changelog notes found for $VERSION" > /tmp/release-notes.md
-          fi
-
-          echo "Release notes:"
-          cat /tmp/release-notes.md
-
-      - name: Create GitHub Release
-        env:
-          VERSION: ${{ needs.validate.outputs.version }}
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          gh release create "$VERSION" \
-            --title "$VERSION" \
-            --notes-file /tmp/release-notes.md \
-            --verify-tag
-          echo "GitHub Release $VERSION created"
-
-      - name: Summary
-        env:
-          VERSION: ${{ needs.validate.outputs.version }}
-        run: |
-          echo "Release published successfully"
-          echo ""
-          echo "  Version: $VERSION"
-          echo "  Tag:     $VERSION"
-          echo "  Release: https://github.com/${{ github.repository }}/releases/tag/$VERSION"
-          echo ""
-          echo "Next steps:"
-          echo "  1. Merge the release PR to main"
-          echo "  2. Merge main back into dev"
+  publish:
+    name: Publish Release
+    needs: [core, extension]
+    if: ${{ inputs.dry-run != true }}
+    uses: ./.github/workflows/release-publish.yml
+    with:
+      version: ${{ needs.core.outputs.version }}
+      finalize_sha: ${{ needs.core.outputs.finalize_sha }}
+      release_date: ${{ needs.core.outputs.release_date }}
+      publish_version: ${{ needs.core.outputs.publish_version }}
+      release_kind: ${{ needs.core.outputs.release_kind }}
+      git_user_name: ${{ inputs.git-user-name }}
+      git_user_email: ${{ inputs.git-user-email }}
+      contract_version: "1"
+    secrets: inherit
 
   rollback:
     name: Rollback on Failure
-    needs: [validate, finalize, test, release]
+    needs: [core, extension, publish]
     runs-on: ubuntu-22.04
     timeout-minutes: 10
-    if: failure()
+    if: ${{ failure() && inputs.dry-run != true }}
     permissions:
       contents: write
       issues: write
-
     steps:
       - name: Checkout repository
+        if: ${{ needs.core.outputs.pre_finalize_sha != '' }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
-          persist-credentials: true
+          fetch-depth: 0
 
       - name: Configure git
+        if: ${{ needs.core.outputs.pre_finalize_sha != '' }}
         env:
-          GIT_USER_NAME: ${{ github.event.inputs.git-user-name }}
-          GIT_USER_EMAIL: ${{ github.event.inputs.git-user-email }}
+          GIT_USER_NAME: ${{ inputs.git-user-name }}
+          GIT_USER_EMAIL: ${{ inputs.git-user-email }}
         run: |
           git config user.name "$GIT_USER_NAME"
           git config user.email "$GIT_USER_EMAIL"
 
       - name: Rollback release branch
+        if: ${{ needs.core.outputs.pre_finalize_sha != '' }}
         continue-on-error: true
         env:
-          VERSION: ${{ needs.validate.outputs.version }}
-          PRE_SHA: ${{ needs.validate.outputs.pre_finalize_sha }}
+          VERSION: ${{ needs.core.outputs.version }}
+          PRE_SHA: ${{ needs.core.outputs.pre_finalize_sha }}
         run: |
           set -euo pipefail
           git fetch origin "release/$VERSION"
           git checkout "release/$VERSION"
-
           if git reset --hard "$PRE_SHA" 2>/dev/null; then
             if git push --force-with-lease origin "release/$VERSION"; then
               echo "Release branch rolled back"
-            else
-              echo "Warning: Could not push rollback"
             fi
           fi
 
       - name: Delete tag if created
+        if: ${{ needs.core.outputs.publish_version != '' }}
         continue-on-error: true
         env:
-          VERSION: ${{ needs.validate.outputs.version }}
+          PUBLISH_VERSION: ${{ needs.core.outputs.publish_version }}
         run: |
-          if git ls-remote origin "refs/tags/$VERSION" | grep -q "$VERSION"; then
-            git push origin ":refs/tags/$VERSION" && echo "Tag deleted" || echo "Warning: Could not delete tag"
-          else
-            echo "Tag does not exist (not created yet)"
+          if git ls-remote origin "refs/tags/$PUBLISH_VERSION" | grep -q "$PUBLISH_VERSION"; then
+            git push origin ":refs/tags/$PUBLISH_VERSION" || true
           fi
 
       - name: Create failure issue
+        if: ${{ needs.core.outputs.version != '' }}
         env:
-          VERSION: ${{ needs.validate.outputs.version }}
-          PR_NUMBER: ${{ needs.validate.outputs.pr_number }}
+          VERSION: ${{ needs.core.outputs.version }}
+          PR_NUMBER: ${{ needs.core.outputs.pr_number }}
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           WORKFLOW_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-
           gh issue create \
             --title "Release $VERSION failed — automatic rollback" \
             --label "bug" \
-            --body "Release $VERSION encountered an error during the automated release workflow.
+            --body "Release $VERSION failed during the automated release workflow.
 
           **Workflow Run:** [View logs]($WORKFLOW_URL)
           **Release PR:** #$PR_NUMBER
 
           **Automatic rollback attempted:**
           - Release branch reset to pre-finalization state
-          - Release tag deleted (if created)
-
-          **Next steps:**
-          1. Review the workflow logs to identify the root cause
-          2. Verify rollback completed cleanly
-          3. Fix the issue on the release branch
-          4. Re-run the release workflow"
-
-      - name: Summary
-        run: |
-          echo "Release workflow failed"
-          echo ""
-          echo "Automatic rollback completed."
-          echo "A GitHub issue has been created for investigation."
-          echo "Check the workflow logs for details."
+          - Release tag deleted (if created)"

--- a/assets/workspace/justfile.project
+++ b/assets/workspace/justfile.project
@@ -105,3 +105,18 @@ branch:
 # [group('app')]
 # migrate:
 #     just sidecar postgres migrate
+#
+# # Prepare release branch (manual workflow dispatch helper)
+# [group('release')]
+# prepare-release version:
+#     gh workflow run prepare-release.yml --ref dev -f "version={{ version }}"
+#
+# # Finalize and publish release (manual workflow dispatch helper)
+# [group('release')]
+# finalize-release version:
+#     gh workflow run release.yml --ref release/{{ version }} -f "version={{ version }}" -f "release-kind=final" -f "dry-run=false"
+#
+# # Publish candidate release (manual workflow dispatch helper)
+# [group('release')]
+# publish-candidate version:
+#     gh workflow run release.yml --ref release/{{ version }} -f "version={{ version }}" -f "release-kind=candidate" -f "dry-run=false"

--- a/docs/DOWNSTREAM_RELEASE.md
+++ b/docs/DOWNSTREAM_RELEASE.md
@@ -1,0 +1,136 @@
+# Downstream Release Workflows
+
+This document describes the downstream release workflow contract shipped in `assets/workspace/.github/workflows/`.
+
+## Overview
+
+The downstream template uses a split release architecture:
+
+- `prepare-release.yml` (`workflow_dispatch`) prepares `release/X.Y.Z`
+- `release.yml` (`workflow_dispatch`) orchestrates:
+  - `release-core.yml` (`workflow_call`)
+  - `release-extension.yml` (`workflow_call`, project-owned)
+  - `release-publish.yml` (`workflow_call`)
+
+All files are deployed from `assets/workspace/` by `init-workspace.sh`.
+
+On failure, the orchestrator runs a single consolidated rollback that resets the release branch, removes any created tag, and opens a failure issue.
+
+## Release Modes
+
+`release.yml` supports two release modes via `release_kind`:
+
+- `candidate` (default): computes and publishes the next `X.Y.Z-rcN` tag as a GitHub pre-release
+- `final`: publishes `X.Y.Z`, finalizes `CHANGELOG.md` release date, and runs `sync-issues`
+
+Candidate mode keeps release branch content unchanged (no CHANGELOG date finalization). Final mode performs changelog finalization before publish.
+
+## Workflow Contract
+
+Current contract version: `"1"`.
+
+The following workflows require `contract_version: "1"`:
+
+- `.github/workflows/release-core.yml`
+- `.github/workflows/release-extension.yml`
+- `.github/workflows/release-publish.yml`
+
+Contract validation is performed by the shared composite action `.github/actions/validate-contract`. The expected version is defined once in that action's default input. When bumping the contract version, update the action default and the `contract_version` values in `release.yml`.
+
+If `contract_version` does not match, the workflow fails with an actionable error.
+
+## Input Naming Convention
+
+All `workflow_call` inputs use underscores (e.g. `release_kind`, `dry_run`, `git_user_name`). The orchestrator `release.yml` translates its own `workflow_dispatch` hyphenated inputs at each call site.
+
+## Extension Hook
+
+Project-specific release behavior belongs in `.github/workflows/release-extension.yml`.
+
+Default template behavior is no-op. Projects can customize this workflow for tasks such as:
+
+- package publishing
+- container publishing
+- signing and attestations
+- release artifact upload
+
+Extension contract inputs include both `release_kind` and `publish_version`, so custom logic can branch on candidate vs final behavior.
+
+`release.yml` requires extension success before publish, so extension failures block release publication.
+
+### Example: GHCR Publishing
+
+The following shows how a downstream project could customize `release-extension.yml` to build and push a container image to GHCR:
+
+```yaml
+name: Release Extension
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        type: string
+      finalize_sha:
+        required: true
+        type: string
+      release_date:
+        required: true
+        type: string
+      release_kind:
+        required: true
+        type: string
+      publish_version:
+        required: true
+        type: string
+      contract_version:
+        required: true
+        type: string
+
+jobs:
+  ghcr-publish:
+    name: Publish Container Image
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Validate contract version
+        uses: ./.github/actions/validate-contract
+        with:
+          contract_version: ${{ inputs.contract_version }}
+
+      - name: Checkout finalized commit
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.finalize_sha }}
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}:${{ inputs.publish_version }}
+            ${{ inputs.release_kind == 'final' && format('ghcr.io/{0}:latest', github.repository) || '' }}
+```
+
+## Upgrade Path
+
+1. Upgrade downstream devcontainer version (which redeploys `assets/workspace` templates).
+2. Keep project-owned `release-extension.yml` (preserved on force upgrades).
+3. Ensure orchestrator and called workflows use the expected `contract_version`.
+4. Run `prepare-release` / `release` in `--dry-run` mode to validate integration.
+
+## Pinning and Drift
+
+Release workflow logic is centralized in shipped local reusable workflows (`release-core.yml`, `release-publish.yml`) while extension logic remains project-owned (`release-extension.yml`).
+
+This reduces drift in release safety checks while preserving downstream customization boundaries.

--- a/docs/RELEASE_CYCLE.md
+++ b/docs/RELEASE_CYCLE.md
@@ -753,6 +753,20 @@ gh workflow run release.yml \
 
 ---
 
+## Downstream Integration
+
+Downstream repositories that use the workspace template consume release workflows from:
+
+- `assets/workspace/.github/workflows/prepare-release.yml`
+- `assets/workspace/.github/workflows/release.yml`
+- `assets/workspace/.github/workflows/release-core.yml`
+- `assets/workspace/.github/workflows/release-extension.yml`
+- `assets/workspace/.github/workflows/release-publish.yml`
+
+The orchestrator (`release.yml`) runs core -> extension -> publish and uses contract validation for local `workflow_call` interfaces.
+
+For contract details and extension ownership boundaries, see `docs/DOWNSTREAM_RELEASE.md`.
+
 ## QMS and Compliance
 
 ### Traceability
@@ -1030,6 +1044,7 @@ Follow [Semantic Versioning 2.0.0](https://semver.org/):
 
 - [CHANGELOG Format](../CHANGELOG.md) - Keep a Changelog standard
 - [Commit Message Standard](COMMIT_MESSAGE_STANDARD.md) - Commit format and validation
+- [Downstream Release Workflows](DOWNSTREAM_RELEASE.md) - Downstream release contract and extension model
 - [Branch Naming Rules](../.cursor/rules/branch-naming.mdc) - Topic branch conventions
 - [IEC 62304](https://www.iso.org/standard/38421.html) - Medical device software lifecycle
 - [Semantic Versioning](https://semver.org/) - Version numbering scheme


### PR DESCRIPTION
## Description

Split downstream release execution into reusable local workflows with a project-owned extension hook, add a release contract validator, and introduce a dedicated `prepare-release` workflow for branch preparation. This also documents the downstream contract and candidate/final release behavior.

## Type of Change

- [ ] `feat` -- New feature
- [ ] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [x] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- `assets/workspace/.github/workflows/release.yml`
  - Replaced monolithic release flow with orchestration over `release-core`, `release-extension`, and `release-publish`
  - Added `release-kind` dispatch input and propagated mapped inputs into reusable workflows
  - Kept rollback handling in the orchestrator with outputs from `core`
- `assets/workspace/.github/workflows/release-core.yml`
  - Added core validation/finalization/test stages behind `workflow_call`
  - Added `release_kind` support for candidate (`X.Y.Z-rcN`) and final (`X.Y.Z`) behavior
  - Added publish tag computation and candidate sequencing logic
- `assets/workspace/.github/workflows/release-extension.yml`
  - Added default no-op extension contract for downstream project-owned release steps
- `assets/workspace/.github/workflows/release-publish.yml`
  - Added isolated publish phase that tags and creates pre-release/final GitHub releases
- `assets/workspace/.github/actions/validate-contract/action.yml`
  - Added shared contract version validation to enforce compatible reusable workflow interfaces
- `assets/workspace/.github/workflows/prepare-release.yml`
  - Added standalone release preparation workflow (`workflow_dispatch`) for release branch setup and draft PR creation
- `assets/workspace/justfile.project`
  - Added commented release helper examples for dispatching prepare/finalize/candidate workflows
- `assets/init-workspace.sh`
  - Preserved downstream `release-extension.yml` on `--force` workspace upgrades
- `docs/DOWNSTREAM_RELEASE.md`, `docs/RELEASE_CYCLE.md`, `CHANGELOG.md`
  - Documented downstream release contract, extension model, and release mode behavior

## Changelog Entry

### Added

- **Split downstream release workflow with project-owned extension hook** ([#326](https://github.com/vig-os/devcontainer/issues/326))
  - Add local `workflow_call` release phases (`release-core.yml`, `release-publish.yml`) and a lightweight `release.yml` orchestrator in `assets/workspace/.github/workflows/`
  - Add `release_kind` support with candidate mode (`X.Y.Z-rcN`) and final mode (`X.Y.Z`) in downstream release workflows
  - Candidate mode now auto-computes the next RC tag, skips CHANGELOG finalization/sync-issues, and publishes a GitHub pre-release
  - Add project-owned `release-extension.yml` stub and preserve it during `init-workspace.sh --force` upgrades
  - Add `validate-contract` composite action for single-source contract version validation
  - Add downstream release contract documentation and GHCR extension example in `docs/DOWNSTREAM_RELEASE.md`

## Testing

- [x] Tests pass locally (`just test`)
- [ ] Manual testing performed (describe below)

### Manual Testing Details

N/A

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

The branch is split into three atomic commits to keep review boundaries clear (workflow architecture, prepare-release flow, docs/changelog).

Refs: #326
