### PR TITLE
ci: publish final GitHub Release with notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,12 +4,12 @@
 # 1. Validate: Check all prerequisites (PR status, CI passed, CHANGELOG ready)
 # 2. Finalize: For final releases only, set release date in CHANGELOG
 # 3. Build & Test: Build and test images for all architectures
-# 4. Publish: Create tag and publish images only if all tests pass
+# 4. Publish: Create tag, publish images, and publish final GitHub Release
 # 5. Rollback (on failure): Revert changes and create issue
 #
 # Release kinds:
 #   candidate: Publishes X.Y.Z-rcN. No CHANGELOG changes, no sync-issues.
-#   final:     Publishes X.Y.Z. Sets release date in CHANGELOG, triggers sync-issues.
+#   final:     Publishes X.Y.Z. Sets release date in CHANGELOG, triggers sync-issues, publishes GitHub Release.
 #
 # Design: Everything happens in one workflow dispatch before creating the tag.
 # This ensures no broken releases are tagged.
@@ -760,6 +760,43 @@ jobs:
 
           git push origin "$PUBLISH_VERSION"
           echo "✓ Tag pushed: $PUBLISH_VERSION"
+
+      - name: Generate final release notes from CHANGELOG
+        if: needs.validate.outputs.release_kind == 'final'
+        env:
+          VERSION: ${{ needs.validate.outputs.version }}
+        run: |
+          set -euo pipefail
+          awk -v version="$VERSION" '
+            index($0, "## [" version "] - ") == 1 {found=1; next}
+            /^## \[/ && found {found=0}
+            found {print}
+          ' CHANGELOG.md > /tmp/github-release-notes.md
+
+          if [ ! -s /tmp/github-release-notes.md ]; then
+            echo "ERROR: Failed to generate GitHub Release notes for $VERSION from CHANGELOG.md"
+            echo "Expected section heading: ## [$VERSION] - YYYY-MM-DD"
+            exit 1
+          fi
+
+      - name: Publish final GitHub Release
+        if: needs.validate.outputs.release_kind == 'final'
+        env:
+          PUBLISH_VERSION: ${{ needs.validate.outputs.publish_version }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          if gh release view "$PUBLISH_VERSION" >/dev/null 2>&1; then
+            echo "ERROR: GitHub Release already exists for tag $PUBLISH_VERSION"
+            exit 1
+          fi
+
+          gh release create "$PUBLISH_VERSION" \
+            --title "$PUBLISH_VERSION" \
+            --notes-file /tmp/github-release-notes.md \
+            --verify-tag
+
+          echo "✓ GitHub Release published: $PUBLISH_VERSION"
 
       - name: Install cosign
         uses: sigstore/cosign-installer@ba7bc0a3fef59531c69a25acd34668d6d3fe6f22  # v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Ship changelog into workspace payload and smoke-test deploy root** ([#333](https://github.com/vig-os/devcontainer/issues/333))
   - Sync canonical `CHANGELOG.md` into both workspace root and `.devcontainer/` template paths
   - Smoke-test dispatch now copies `.devcontainer/CHANGELOG.md` to repository root so deploy output keeps a root changelog
+- **Final release now publishes a GitHub Release with finalized notes** ([#310](https://github.com/vig-os/devcontainer/issues/310))
+  - Add a final-only publish step in `.github/workflows/release.yml` that creates a GitHub Release for `X.Y.Z`
+  - Source GitHub Release notes from the finalized `CHANGELOG.md` section and fail the run if notes extraction or release publishing fails
 
 ### Deprecated
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -49,6 +49,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Ship changelog into workspace payload and smoke-test deploy root** ([#333](https://github.com/vig-os/devcontainer/issues/333))
   - Sync canonical `CHANGELOG.md` into both workspace root and `.devcontainer/` template paths
   - Smoke-test dispatch now copies `.devcontainer/CHANGELOG.md` to repository root so deploy output keeps a root changelog
+- **Final release now publishes a GitHub Release with finalized notes** ([#310](https://github.com/vig-os/devcontainer/issues/310))
+  - Add a final-only publish step in `.github/workflows/release.yml` that creates a GitHub Release for `X.Y.Z`
+  - Source GitHub Release notes from the finalized `CHANGELOG.md` section and fail the run if notes extraction or release publishing fails
 
 ### Deprecated
 

--- a/assets/workspace/CHANGELOG.md
+++ b/assets/workspace/CHANGELOG.md
@@ -49,6 +49,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Ship changelog into workspace payload and smoke-test deploy root** ([#333](https://github.com/vig-os/devcontainer/issues/333))
   - Sync canonical `CHANGELOG.md` into both workspace root and `.devcontainer/` template paths
   - Smoke-test dispatch now copies `.devcontainer/CHANGELOG.md` to repository root so deploy output keeps a root changelog
+- **Final release now publishes a GitHub Release with finalized notes** ([#310](https://github.com/vig-os/devcontainer/issues/310))
+  - Add a final-only publish step in `.github/workflows/release.yml` that creates a GitHub Release for `X.Y.Z`
+  - Source GitHub Release notes from the finalized `CHANGELOG.md` section and fail the run if notes extraction or release publishing fails
 
 ### Deprecated
 

--- a/docs/RELEASE_CYCLE.md
+++ b/docs/RELEASE_CYCLE.md
@@ -124,7 +124,7 @@ graph TB
     N --> O["Workflow: set release date<br/>build & test"]
     O --> P{Tests pass?}
     P -->|No| Q["Automatic rollback<br/>+ issue creation"]
-    P -->|Yes| R["Workflow: create tag<br/>publish images"]
+    P -->|Yes| R["Workflow: create tag<br/>publish images<br/>publish GitHub Release (final only)"]
     R --> S["Merge PR to main"]
     S --> T["Workflow: sync-main-to-dev<br/>PR-based sync"]
 ```
@@ -361,6 +361,7 @@ The `release.yml` workflow performs the entire remaining release process. Behavi
    - Candidate mode: infers next `rcN`, creates annotated tag `X.Y.Z-rcN`, publishes candidate manifests
    - Final mode: creates annotated tag `X.Y.Z`, publishes final manifests
    - Pushes tag to origin
+   - Final mode only: extracts release notes from finalized `CHANGELOG.md` and publishes GitHub Release for `X.Y.Z`
    - Downloads tested images from artifacts
    - Logs in to GitHub Container Registry
    - Pushes images to GHCR with architecture-specific tags
@@ -605,6 +606,7 @@ gh workflow run prepare-release.yml --ref dev -f "version=1.0.0" -f "dry-run=tru
    - Candidate mode creates and pushes `X.Y.Z-rcN` (next available `N`)
    - Final mode creates and pushes `X.Y.Z`
    - Pushes tag
+   - Final mode only: publishes GitHub Release `X.Y.Z` with notes sourced from finalized `CHANGELOG.md`
    - Downloads tested images from artifacts
    - Pushes images to GHCR
    - Creates multi-architecture manifest for computed publish tag


### PR DESCRIPTION
## Description

Implements issue #310 by extending the release publish stage so final releases automatically create a GitHub Release with notes generated from finalized `CHANGELOG.md`, while RC releases keep current behavior.

Adds explicit failure paths when release-note extraction fails or when GitHub Release publication cannot proceed, and updates release-cycle documentation to reflect the final-only GitHub Release step.

## Type of Change

- [ ] `feat` -- New feature
- [ ] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [x] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- `.github/workflows/release.yml`
  - Add final-only step to extract release notes from the finalized `CHANGELOG.md` section (`## [X.Y.Z] - YYYY-MM-DD`)
  - Add final-only step to create GitHub Release for `X.Y.Z` using `gh release create --notes-file`
  - Fail fast when notes extraction yields no content or when a release already exists for the final tag
- `docs/RELEASE_CYCLE.md`
  - Document final-only GitHub Release publication in release flow diagram and publish phase details
- `CHANGELOG.md`
  - Add Unreleased entry for issue #310
- `assets/workspace/CHANGELOG.md`
  - Synced by pre-commit `sync-manifest` hook from root changelog update
- `assets/workspace/.devcontainer/CHANGELOG.md`
  - Synced by pre-commit `sync-manifest` hook from root changelog update

## Changelog Entry

### Changed

- **Final release now publishes a GitHub Release with finalized notes** ([#310](https://github.com/vig-os/devcontainer/issues/310))
  - Add a final-only publish step in `.github/workflows/release.yml` that creates a GitHub Release for `X.Y.Z`
  - Source GitHub Release notes from the finalized `CHANGELOG.md` section and fail the run if notes extraction or release publishing fails

## Testing

- [ ] Tests pass locally (`just test`)
- [ ] Manual testing performed (describe below)

### Manual Testing Details

N/A

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

Pre-commit hooks required syncing changelog mirrors in `assets/workspace/` and `.devcontainer/` via `sync-manifest`.

Refs: #310
