### PR TITLE
fix(ci): sync changelog manifest in release workflows

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -198,6 +198,12 @@ jobs:
           uv run prepare-changelog prepare "$VERSION" CHANGELOG.md
           echo "✓ CHANGELOG prepared (Unreleased → [${VERSION}] - TBD + fresh Unreleased)"
 
+      - name: Sync workspace manifest after changelog prepare
+        run: |
+          set -euo pipefail
+          uv run python scripts/sync_manifest.py sync assets/workspace/
+          echo "✓ Synced workspace manifest after changelog prepare"
+
       - name: Extract CHANGELOG content for PR body
         id: changelog
         env:
@@ -222,7 +228,7 @@ jobs:
 
             Move Unreleased content to [${{ needs.validate.outputs.version }}] - TBD
             and create fresh empty Unreleased section for continued development.
-          FILE_PATHS: CHANGELOG.md
+          FILE_PATHS: CHANGELOG.md assets/workspace/.devcontainer/CHANGELOG.md
 
       - name: Create release branch from dev
         id: create-branch
@@ -255,6 +261,12 @@ jobs:
           "
           echo "✓ Stripped empty Unreleased section from CHANGELOG"
 
+      - name: Sync workspace manifest after release changelog strip
+        run: |
+          set -euo pipefail
+          uv run python scripts/sync_manifest.py sync assets/workspace/
+          echo "✓ Synced workspace manifest after release changelog strip"
+
       - name: Commit stripped CHANGELOG to release branch via API
         uses: vig-os/commit-action@c0024cbad0e501764127cccab732c6cd465b4646  # v0.1.5
         env:
@@ -266,7 +278,7 @@ jobs:
 
             Strip empty Unreleased section from release branch.
             Release date TBD (set during finalization).
-          FILE_PATHS: CHANGELOG.md
+          FILE_PATHS: CHANGELOG.md assets/workspace/.devcontainer/CHANGELOG.md
 
       - name: Create draft PR to main
         id: pr
@@ -348,6 +360,7 @@ jobs:
             echo "i dev CHANGELOG already matches pre-prepare state"
           else
             cp /tmp/changelog.pre-prepare.md CHANGELOG.md
+            uv run python scripts/sync_manifest.py sync assets/workspace/
             CHANGELOG_ROLLBACK_NEEDED=true
             echo "✓ Prepared CHANGELOG rollback content for dev"
           fi
@@ -366,7 +379,7 @@ jobs:
             chore: rollback failed prepare-release ${{ needs.validate.outputs.version }}
 
             Restore CHANGELOG.md on dev to pre-prepare state after prepare-release failed.
-          FILE_PATHS: CHANGELOG.md
+          FILE_PATHS: CHANGELOG.md assets/workspace/.devcontainer/CHANGELOG.md
 
       - name: Rollback summary
         if: ${{ failure() }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -518,6 +518,13 @@ jobs:
           uv run python docs/generate.py
           echo "✓ Regenerated docs from finalized CHANGELOG.md"
 
+      - name: Sync workspace manifest for finalized release
+        if: needs.validate.outputs.release_kind == 'final'
+        run: |
+          set -euo pipefail
+          uv run python scripts/sync_manifest.py sync assets/workspace/
+          echo "✓ Synced workspace manifest after changelog finalization"
+
       - name: Collect finalization files
         if: needs.validate.outputs.release_kind == 'final'
         id: finalize-files

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [0.3.1] - TBD
 
 ### Added
 
@@ -58,10 +58,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Move final GitHub Release creation to the end of publish so artifact publication/signing completes before release object creation
   - Add concurrency control to `assets/smoke-test/.github/workflows/repository-dispatch.yml` to prevent overlapping dispatch races
   - Handle smoke-test dispatch failures with a targeted issue while avoiding destructive rollback after publish artifacts are already released
-
-### Deprecated
-
-### Removed
 
 ### Fixed
 


### PR DESCRIPTION
## Description

This PR fixes release-branch CI drift caused by changelog mutations not being mirrored into `assets/workspace/.devcontainer/CHANGELOG.md` before API commits.

It adds explicit manifest sync steps to both release workflows so changelog writes and mirror writes stay atomic across prepare, finalize, and rollback paths.

## Type of Change

- [ ] `feat` -- New feature
- [x] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [ ] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- `.github/workflows/release.yml`
  - Add `Sync workspace manifest for finalized release` step after changelog finalization/doc generation and before collecting file paths for API commit.
- `.github/workflows/prepare-release.yml`
  - Add `sync_manifest.py` execution after changelog prepare and after stripping `Unreleased` on release branch.
  - Ensure API commit file lists include both `CHANGELOG.md` and `assets/workspace/.devcontainer/CHANGELOG.md`.
  - Sync workspace manifest in rollback path before rollback commit when changelog restore is needed.
- `assets/workspace/.devcontainer/CHANGELOG.md`
  - Commit current mirrored state (`## [0.3.1] - TBD`) so branch starts from a synced baseline.

## Changelog Entry

No changelog needed — this is a CI/workflow consistency fix on release automation and does not add user-facing runtime behavior.

## Testing

- [ ] Tests pass locally (`just test`)
- [x] Manual testing performed (describe below)

### Manual Testing Details

- Ran pre-commit checks on modified workflow files:
  - `uv run pre-commit run --files .github/workflows/release.yml`
  - `uv run pre-commit run --files .github/workflows/prepare-release.yml`
- Verified clean working tree after commits and confirmed branch is ahead with only intended changes.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [ ] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

- Root cause reproduced from failing check run: https://github.com/vig-os/devcontainer/actions/runs/23198605456/job/67414012578?pr=342
- This branch targets `release/0.3.1` to unblock the release train.

Refs: #343
