### PR TITLE
fix: add artifact-metadata permission for release attestations

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -754,6 +754,7 @@ jobs:
       packages: write       # push images to GHCR
       id-token: write       # keyless cosign signing via OIDC
       attestations: write   # build provenance attestations
+      artifact-metadata: write  # persist attestation storage records
 
     steps:
       - name: Generate GitHub App Token

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Release finalization now commits generated docs and refreshes PR content** ([#300](https://github.com/vig-os/devcontainer/issues/300))
   - Final release automation regenerates docs before committing so pre-commit `generate-docs` does not fail CI with tracked file diffs
   - Release PR body is refreshed from finalized `CHANGELOG.md`
+- **Release attestation warnings reduced by granting artifact metadata permission** ([#348](https://github.com/vig-os/devcontainer/issues/348))
+  - Add `artifact-metadata: write` to the release publish job so attestation steps can persist metadata storage records
+  - Keep `actions/attest`-based SBOM attestation path and remove missing-permission warnings from publish runs
 
 ### Security
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -64,6 +64,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Release finalization now commits generated docs and refreshes PR content** ([#300](https://github.com/vig-os/devcontainer/issues/300))
   - Final release automation regenerates docs before committing so pre-commit `generate-docs` does not fail CI with tracked file diffs
   - Release PR body is refreshed from finalized `CHANGELOG.md`
+- **Release attestation warnings reduced by granting artifact metadata permission** ([#348](https://github.com/vig-os/devcontainer/issues/348))
+  - Add `artifact-metadata: write` to the release publish job so attestation steps can persist metadata storage records
+  - Keep `actions/attest`-based SBOM attestation path and remove missing-permission warnings from publish runs
 
 ### Security
 


### PR DESCRIPTION
## Description

Adds the missing `artifact-metadata: write` permission to the release publish job so attestation metadata storage records can be persisted and related warnings are removed during release publish runs.

## Type of Change

- [ ] `feat` -- New feature
- [x] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [ ] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- `.github/workflows/release.yml`
  - Add `artifact-metadata: write` under `publish` job permissions for attestation metadata persistence.
- `CHANGELOG.md`
  - Add `0.3.1` Fixed entry for issue `#348`.
- `assets/workspace/.devcontainer/CHANGELOG.md`
  - Sync mirrored changelog entry via repository manifest hook.

## Changelog Entry

### Fixed
- **Release attestation warnings reduced by granting artifact metadata permission** ([#348](https://github.com/vig-os/devcontainer/issues/348))
  - Add `artifact-metadata: write` to the release publish job so attestation steps can persist metadata storage records
  - Keep `actions/attest`-based SBOM attestation path and remove missing-permission warnings from publish runs

## Testing

- [ ] Tests pass locally (`just test`)
- [x] Manual testing performed (describe below)

### Manual Testing Details

- Verified workflow diff includes only the permission addition in `publish` job.
- Verified attestation steps use `actions/attest` and no `actions/attest-sbom` remains in `.github/workflows/release.yml`.
- Verified pre-commit hooks passed on both commits.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

This PR targets `release/0.3.1` because the warning was observed in that release workflow run path.

Refs: #348
