### PR TITLE
fix(ci): normalize smoke-test workspace ownership after installer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Release attestation warnings reduced by granting artifact metadata permission** ([#348](https://github.com/vig-os/devcontainer/issues/348))
   - Add `artifact-metadata: write` to the release publish job so attestation steps can persist metadata storage records
   - Keep `actions/attest`-based SBOM attestation path and remove missing-permission warnings from publish runs
+- **Smoke-test dispatch deploy now repairs workspace ownership before changelog copy** ([#352](https://github.com/vig-os/devcontainer/issues/352))
+  - Add a write probe and conditional `sudo chown -R` in `assets/smoke-test/.github/workflows/repository-dispatch.yml` after installer execution
+  - Prevent `Permission denied` failures when copying `.devcontainer/CHANGELOG.md` to repository root in GitHub-hosted runner jobs
 
 ### Security
 

--- a/assets/smoke-test/.github/workflows/repository-dispatch.yml
+++ b/assets/smoke-test/.github/workflows/repository-dispatch.yml
@@ -182,6 +182,13 @@ jobs:
           curl -sSf "https://raw.githubusercontent.com/vig-os/devcontainer/${TAG}/install.sh" \
             | bash -s -- --version "${TAG}" --smoke-test --force --docker .
 
+          # Docker-based initialization can leave bind-mounted files owned by root.
+          # Normalize ownership so subsequent host-side workflow steps can write.
+          if ! touch ".workflow-write-probe" >/dev/null 2>&1; then
+            sudo chown -R "$(id -u):$(id -g)" .
+          fi
+          rm -f ".workflow-write-probe"
+
           if [ ! -f ".devcontainer/CHANGELOG.md" ]; then
             echo "ERROR: expected .devcontainer/CHANGELOG.md after install"
             exit 1

--- a/assets/smoke-test/.github/workflows/repository-dispatch.yml
+++ b/assets/smoke-test/.github/workflows/repository-dispatch.yml
@@ -183,11 +183,21 @@ jobs:
             | bash -s -- --version "${TAG}" --smoke-test --force --docker .
 
           # Docker-based initialization can leave bind-mounted files owned by root.
-          # Normalize ownership so subsequent host-side workflow steps can write.
-          if ! touch ".workflow-write-probe" >/dev/null 2>&1; then
+          # Probe writability of actual copy source/destination paths before repair.
+          NEEDS_CHOWN=false
+          if [ ! -w ".devcontainer/CHANGELOG.md" ]; then
+            NEEDS_CHOWN=true
+          fi
+          if [ -e "CHANGELOG.md" ]; then
+            if [ ! -w "CHANGELOG.md" ]; then
+              NEEDS_CHOWN=true
+            fi
+          elif [ ! -w "." ]; then
+            NEEDS_CHOWN=true
+          fi
+          if [ "${NEEDS_CHOWN}" = "true" ]; then
             sudo chown -R "$(id -u):$(id -g)" .
           fi
-          rm -f ".workflow-write-probe"
 
           if [ ! -f ".devcontainer/CHANGELOG.md" ]; then
             echo "ERROR: expected .devcontainer/CHANGELOG.md after install"

--- a/assets/smoke-test/.github/workflows/repository-dispatch.yml
+++ b/assets/smoke-test/.github/workflows/repository-dispatch.yml
@@ -185,7 +185,7 @@ jobs:
           # Docker-based initialization can leave bind-mounted files owned by root.
           # Probe writability of actual copy source/destination paths before repair.
           NEEDS_CHOWN=false
-          if [ ! -w ".devcontainer/CHANGELOG.md" ]; then
+          if [ ! -r ".devcontainer/CHANGELOG.md" ]; then
             NEEDS_CHOWN=true
           fi
           if [ -e "CHANGELOG.md" ]; then

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -67,6 +67,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Release attestation warnings reduced by granting artifact metadata permission** ([#348](https://github.com/vig-os/devcontainer/issues/348))
   - Add `artifact-metadata: write` to the release publish job so attestation steps can persist metadata storage records
   - Keep `actions/attest`-based SBOM attestation path and remove missing-permission warnings from publish runs
+- **Smoke-test dispatch deploy now repairs workspace ownership before changelog copy** ([#352](https://github.com/vig-os/devcontainer/issues/352))
+  - Add a write probe and conditional `sudo chown -R` in `assets/smoke-test/.github/workflows/repository-dispatch.yml` after installer execution
+  - Prevent `Permission denied` failures when copying `.devcontainer/CHANGELOG.md` to repository root in GitHub-hosted runner jobs
 
 ### Security
 


### PR DESCRIPTION
## Summary
- add a post-install write probe in `assets/smoke-test/.github/workflows/repository-dispatch.yml` for repository dispatch deploy runs
- when the probe fails, normalize workspace ownership with `sudo chown -R "$(id -u):$(id -g)" .` before copying `.devcontainer/CHANGELOG.md` to root `CHANGELOG.md`
- document the fix in `CHANGELOG.md` (and synced `assets/workspace/.devcontainer/CHANGELOG.md`) under issue `#352`

## Test plan
- [x] run `uv run pre-commit run --files assets/smoke-test/.github/workflows/repository-dispatch.yml CHANGELOG.md assets/workspace/.devcontainer/CHANGELOG.md`
- [ ] trigger downstream `repository_dispatch` smoke-test run for an RC tag and confirm no `Permission denied` errors in `Run installer from dispatch tag`
- [ ] confirm deploy branch preparation and deploy PR creation steps execute after installer