### PR TITLE
fix(ci): use status-aware smoke-test release lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Smoke-test dispatch deploy now repairs workspace ownership before changelog copy** ([#352](https://github.com/vig-os/devcontainer/issues/352))
   - Add a write probe and conditional `sudo chown -R` in `assets/smoke-test/.github/workflows/repository-dispatch.yml` after installer execution
   - Prevent `Permission denied` failures when copying `.devcontainer/CHANGELOG.md` to repository root in GitHub-hosted runner jobs
+- **Smoke-test release lookup no longer treats missing tags as existing releases** ([#355](https://github.com/vig-os/devcontainer/issues/355))
+  - Change `assets/smoke-test/.github/workflows/repository-dispatch.yml` to branch on `gh api` exit status when querying `releases/tags/<tag>`
+  - Ensure missing release tags follow the create path instead of failing with `prerelease=null` mismatch
 
 ### Security
 

--- a/assets/smoke-test/.github/workflows/repository-dispatch.yml
+++ b/assets/smoke-test/.github/workflows/repository-dispatch.yml
@@ -316,8 +316,7 @@ jobs:
             EXPECTED_PRERELEASE=false
           fi
 
-          EXISTING_RELEASE=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}" 2>/dev/null || true)
-          if [ -n "$EXISTING_RELEASE" ]; then
+          if EXISTING_RELEASE=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}" 2>/dev/null); then
             EXISTING_PRERELEASE=$(echo "$EXISTING_RELEASE" | jq -r '.prerelease')
             if [ "$EXISTING_PRERELEASE" != "$EXPECTED_PRERELEASE" ]; then
               echo "ERROR: Existing release '$TAG' prerelease=$EXISTING_PRERELEASE (expected $EXPECTED_PRERELEASE)"
@@ -328,19 +327,23 @@ jobs:
               --title "$TAG" \
               --notes-file /tmp/smoke-test-release-notes.md
             echo "Release '$TAG' already exists with expected prerelease value."
+          else
+            if [ "$EXPECTED_PRERELEASE" = "true" ]; then
+              gh release create "$TAG" \
+                --title "$TAG" \
+                --notes-file /tmp/smoke-test-release-notes.md \
+                --prerelease
+            else
+              gh release create "$TAG" \
+                --title "$TAG" \
+                --notes-file /tmp/smoke-test-release-notes.md
+            fi
+            echo "Created release '$TAG' with prerelease=$EXPECTED_PRERELEASE."
             exit 0
           fi
 
-          if [ "$EXPECTED_PRERELEASE" = "true" ]; then
-            gh release create "$TAG" \
-              --title "$TAG" \
-              --notes-file /tmp/smoke-test-release-notes.md \
-              --prerelease
-          else
-            gh release create "$TAG" \
-              --title "$TAG" \
-              --notes-file /tmp/smoke-test-release-notes.md
-          fi
+          echo "Updated existing release '$TAG' with expected prerelease value."
+          exit 0
 
       - name: Summary
         env:

--- a/assets/smoke-test/.github/workflows/repository-dispatch.yml
+++ b/assets/smoke-test/.github/workflows/repository-dispatch.yml
@@ -316,8 +316,9 @@ jobs:
             EXPECTED_PRERELEASE=false
           fi
 
-          if EXISTING_RELEASE=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}" 2>/dev/null); then
-            EXISTING_PRERELEASE=$(echo "$EXISTING_RELEASE" | jq -r '.prerelease')
+          RELEASE_LOOKUP_OUTPUT=""
+          if RELEASE_LOOKUP_OUTPUT=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}" 2>&1); then
+            EXISTING_PRERELEASE=$(echo "$RELEASE_LOOKUP_OUTPUT" | jq -r '.prerelease')
             if [ "$EXISTING_PRERELEASE" != "$EXPECTED_PRERELEASE" ]; then
               echo "ERROR: Existing release '$TAG' prerelease=$EXISTING_PRERELEASE (expected $EXPECTED_PRERELEASE)"
               exit 1
@@ -326,24 +327,26 @@ jobs:
             gh release edit "$TAG" \
               --title "$TAG" \
               --notes-file /tmp/smoke-test-release-notes.md
-            echo "Release '$TAG' already exists with expected prerelease value."
+            echo "Updated existing release '$TAG' with expected prerelease=$EXPECTED_PRERELEASE."
           else
-            if [ "$EXPECTED_PRERELEASE" = "true" ]; then
-              gh release create "$TAG" \
-                --title "$TAG" \
-                --notes-file /tmp/smoke-test-release-notes.md \
-                --prerelease
+            if printf '%s' "$RELEASE_LOOKUP_OUTPUT" | grep -Eqi "404|not found"; then
+              if [ "$EXPECTED_PRERELEASE" = "true" ]; then
+                gh release create "$TAG" \
+                  --title "$TAG" \
+                  --notes-file /tmp/smoke-test-release-notes.md \
+                  --prerelease
+              else
+                gh release create "$TAG" \
+                  --title "$TAG" \
+                  --notes-file /tmp/smoke-test-release-notes.md
+              fi
+              echo "Created release '$TAG' with prerelease=$EXPECTED_PRERELEASE."
             else
-              gh release create "$TAG" \
-                --title "$TAG" \
-                --notes-file /tmp/smoke-test-release-notes.md
+              echo "ERROR: Failed to query release '$TAG'; refusing to create release."
+              echo "$RELEASE_LOOKUP_OUTPUT"
+              exit 1
             fi
-            echo "Created release '$TAG' with prerelease=$EXPECTED_PRERELEASE."
-            exit 0
           fi
-
-          echo "Updated existing release '$TAG' with expected prerelease value."
-          exit 0
 
       - name: Summary
         env:

--- a/assets/smoke-test/.github/workflows/repository-dispatch.yml
+++ b/assets/smoke-test/.github/workflows/repository-dispatch.yml
@@ -317,8 +317,23 @@ jobs:
           fi
 
           RELEASE_LOOKUP_OUTPUT=""
-          if RELEASE_LOOKUP_OUTPUT=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}" 2>&1); then
-            EXISTING_PRERELEASE=$(echo "$RELEASE_LOOKUP_OUTPUT" | jq -r '.prerelease')
+          set +e
+          RELEASE_LOOKUP_OUTPUT=$(gh api -i "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}" 2>&1)
+          RELEASE_LOOKUP_EXIT=$?
+          set -e
+
+          RELEASE_LOOKUP_STATUS="$(
+            printf '%s\n' "$RELEASE_LOOKUP_OUTPUT" | awk '
+              toupper($1) ~ /^HTTP\// {
+                print $2
+                exit
+              }
+            '
+          )"
+
+          if [ "$RELEASE_LOOKUP_EXIT" -eq 0 ] && [ "$RELEASE_LOOKUP_STATUS" = "200" ]; then
+            EXISTING_RELEASE=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}")
+            EXISTING_PRERELEASE=$(echo "$EXISTING_RELEASE" | jq -r '.prerelease')
             if [ "$EXISTING_PRERELEASE" != "$EXPECTED_PRERELEASE" ]; then
               echo "ERROR: Existing release '$TAG' prerelease=$EXISTING_PRERELEASE (expected $EXPECTED_PRERELEASE)"
               exit 1
@@ -329,7 +344,7 @@ jobs:
               --notes-file /tmp/smoke-test-release-notes.md
             echo "Updated existing release '$TAG' with expected prerelease=$EXPECTED_PRERELEASE."
           else
-            if printf '%s' "$RELEASE_LOOKUP_OUTPUT" | grep -Eqi "404|not found"; then
+            if [ "$RELEASE_LOOKUP_STATUS" = "404" ]; then
               if [ "$EXPECTED_PRERELEASE" = "true" ]; then
                 gh release create "$TAG" \
                   --title "$TAG" \
@@ -342,7 +357,7 @@ jobs:
               fi
               echo "Created release '$TAG' with prerelease=$EXPECTED_PRERELEASE."
             else
-              echo "ERROR: Failed to query release '$TAG'; refusing to create release."
+              echo "ERROR: Failed to query release '$TAG' (status='${RELEASE_LOOKUP_STATUS:-unknown}', exit='${RELEASE_LOOKUP_EXIT}'); refusing to create release."
               echo "$RELEASE_LOOKUP_OUTPUT"
               exit 1
             fi

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -70,6 +70,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Smoke-test dispatch deploy now repairs workspace ownership before changelog copy** ([#352](https://github.com/vig-os/devcontainer/issues/352))
   - Add a write probe and conditional `sudo chown -R` in `assets/smoke-test/.github/workflows/repository-dispatch.yml` after installer execution
   - Prevent `Permission denied` failures when copying `.devcontainer/CHANGELOG.md` to repository root in GitHub-hosted runner jobs
+- **Smoke-test release lookup no longer treats missing tags as existing releases** ([#355](https://github.com/vig-os/devcontainer/issues/355))
+  - Change `assets/smoke-test/.github/workflows/repository-dispatch.yml` to branch on `gh api` exit status when querying `releases/tags/<tag>`
+  - Ensure missing release tags follow the create path instead of failing with `prerelease=null` mismatch
 
 ### Security
 


### PR DESCRIPTION
## Description

Fixes a false-positive release lookup in the smoke-test `repository_dispatch` workflow where a missing tag release (`404`) was treated as an existing release because the script relied on non-empty stdout instead of command status.

The workflow now branches on `gh api` exit status so missing tags correctly follow the release-create path, and existing releases still validate and update release notes.

## Type of Change

- [x] `fix` -- Bug fix
- [ ] `feat` -- New feature
- [ ] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [ ] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- `assets/smoke-test/.github/workflows/repository-dispatch.yml`
  - Replace `|| true` + stdout-emptiness release detection with status-aware `if EXISTING_RELEASE=$(gh api ...)`
  - Preserve existing release validation (`.prerelease` check) and `gh release edit` path
  - Ensure 404/missing tag falls into `gh release create` path instead of failing with `prerelease=null`
- `CHANGELOG.md`
  - Add `### Fixed` entry for issue `#355`
- `assets/workspace/.devcontainer/CHANGELOG.md`
  - Synced by pre-commit `sync-manifest` hook from root changelog update

## Changelog Entry

### Fixed
- **Smoke-test release lookup no longer treats missing tags as existing releases** ([#355](https://github.com/vig-os/devcontainer/issues/355))
  - Change `assets/smoke-test/.github/workflows/repository-dispatch.yml` to branch on `gh api` exit status when querying `releases/tags/<tag>`
  - Ensure missing release tags follow the create path instead of failing with `prerelease=null` mismatch

## Testing

- [ ] Tests pass locally (`just test`)
- [x] Manual testing performed (describe below)

### Manual Testing Details

- Ran `npx bats tests/bats/just.bats` (13/13 passing)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

N/A

Refs: #355
