### PR TITLE
fix: harden network retries in CI and release workflows

### DIFF
--- a/.github/actions/resolve-image/action.yml
+++ b/.github/actions/resolve-image/action.yml
@@ -1,0 +1,74 @@
+name: Resolve devcontainer image
+description: Resolve and validate the devcontainer image tag for CI jobs
+
+inputs:
+  image-tag:
+    description: Optional image tag override
+    required: false
+    default: ''
+
+outputs:
+  image-tag:
+    description: Resolved image tag
+    value: ${{ steps.resolve.outputs.tag }}
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve image tag
+      id: resolve
+      shell: bash
+      env:
+        INPUT_IMAGE_TAG: ${{ inputs.image-tag }}
+      run: |
+        set -euo pipefail
+
+        if [[ -n "$INPUT_IMAGE_TAG" ]]; then
+          echo "tag=$INPUT_IMAGE_TAG" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        if [[ -f .vig-os ]]; then
+          VERSION=""
+          while IFS= read -r line || [[ -n "${line:-}" ]]; do
+            [[ -z "${line//[[:space:]]/}" ]] && continue
+            [[ "$line" =~ ^[[:space:]]*# ]] && continue
+
+            case "$line" in
+              DEVCONTAINER_VERSION=*)
+                VERSION="${line#*=}"
+                VERSION="${VERSION#"${VERSION%%[![:space:]]*}"}"
+                VERSION="${VERSION%"${VERSION##*[![:space:]]}"}"
+
+                if [[ "$VERSION" =~ ^\".*\"$ ]]; then
+                  VERSION="${VERSION:1:-1}"
+                elif [[ "$VERSION" =~ ^\'.*\'$ ]]; then
+                  VERSION="${VERSION:1:-1}"
+                fi
+                break
+                ;;
+            esac
+          done < .vig-os
+
+          if [[ -n "$VERSION" ]]; then
+            echo "tag=$VERSION" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+        fi
+
+        echo "ERROR: Could not resolve DEVCONTAINER_VERSION from .vig-os and no image-tag override was provided."
+        exit 1
+
+    - name: Validate image accessibility
+      shell: bash
+      env:
+        IMAGE_TAG: ${{ steps.resolve.outputs.tag }}
+      run: |
+        set -euo pipefail
+        IMAGE="ghcr.io/vig-os/devcontainer:${IMAGE_TAG}"
+        echo "Validating image availability: $IMAGE"
+        if ! docker manifest inspect "$IMAGE" > /dev/null 2>&1; then
+          echo "ERROR: Cannot access image manifest: $IMAGE"
+          echo "Check whether the tag exists and whether this workflow has access to GHCR."
+          exit 1
+        fi

--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -162,8 +162,10 @@ runs:
         BIN_FILE="hadolint-${ARCH}"
         SHA_FILE="${BIN_FILE}.sha256"
 
-        curl -fsSL "${BASE_URL}/${BIN_FILE}" -o "${BIN_FILE}"
-        curl -fsSL "${BASE_URL}/${SHA_FILE}" -o "${SHA_FILE}"
+        uv run retry --retries 3 --backoff 5 --max-backoff 60 -- \
+          curl -fsSL "${BASE_URL}/${BIN_FILE}" -o "${BIN_FILE}"
+        uv run retry --retries 3 --backoff 5 --max-backoff 60 -- \
+          curl -fsSL "${BASE_URL}/${SHA_FILE}" -o "${SHA_FILE}"
 
         EXPECTED_SHA="$(awk '{print $1}' "${SHA_FILE}")"
         echo "${EXPECTED_SHA}  ${BIN_FILE}" | sha256sum -c -
@@ -189,11 +191,17 @@ runs:
             ;;
         esac
 
-        TAPLO_VERSION="$(curl -fsSL https://api.github.com/repos/tamasfe/taplo/releases/latest | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p')"
+        TAPLO_VERSION="$(uv run retry --retries 3 --backoff 5 --max-backoff 60 -- \
+          curl -fsSL https://api.github.com/repos/tamasfe/taplo/releases/latest | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p')"
+        if [ -z "${TAPLO_VERSION:-}" ]; then
+          echo "ERROR: Failed to resolve Taplo version from GitHub releases API"
+          exit 1
+        fi
         BASE_URL="https://github.com/tamasfe/taplo/releases/download/${TAPLO_VERSION}"
         BIN_FILE="taplo-linux-${ARCH}.gz"
 
-        curl -fsSL "${BASE_URL}/${BIN_FILE}" -o "${BIN_FILE}"
+        uv run retry --retries 3 --backoff 5 --max-backoff 60 -- \
+          curl -fsSL "${BASE_URL}/${BIN_FILE}" -o "${BIN_FILE}"
         gunzip "${BIN_FILE}"
         sudo install -m 0755 "taplo-linux-${ARCH}" /usr/local/bin/taplo
         rm -f "taplo-linux-${ARCH}"

--- a/.github/actions/test-image/action.yml
+++ b/.github/actions/test-image/action.yml
@@ -125,21 +125,8 @@ runs:
         echo "Pulling image: $IMAGE_TAG"
 
         # Retry logic for podman pull (network flakiness)
-        RETRIES=3
-        for i in $(seq 1 $RETRIES); do
-          if podman pull "$IMAGE_TAG"; then
-            echo "Image pulled successfully"
-            break
-          else
-            if [ $i -lt $RETRIES ]; then
-              echo "Pull failed, retrying ($i/$RETRIES)..."
-              sleep 3
-            else
-              echo "Pull failed after $RETRIES attempts"
-              exit 1
-            fi
-          fi
-        done
+        uv run retry --retries 3 --backoff 3 --max-backoff 3 -- podman pull "$IMAGE_TAG"
+        echo "Image pulled successfully"
 
     - name: Verify image is available
       if: inputs.image-source == 'local'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,7 +193,9 @@ jobs:
           sync-dependencies: 'true'
 
       - name: Install safety
-        run: uv pip install safety==3.7.0
+        run: |
+          set -euo pipefail
+          uv run retry --retries 3 --backoff 5 --max-backoff 30 -- uv pip install safety==3.7.0
 
       - name: Run Bandit (Python security linting)
         id: bandit

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -185,7 +185,8 @@ jobs:
           GH_TOKEN: ${{ steps.commit-app-token.outputs.token }}
         run: |
           set -euo pipefail
-          PREPARE_START_SHA=$(gh api "repos/${{ github.repository }}/git/ref/heads/dev" --jq '.object.sha')
+          PREPARE_START_SHA=$(uv run retry --retries 3 --backoff 5 --max-backoff 60 -- \
+            gh api "repos/${{ github.repository }}/git/ref/heads/dev" --jq '.object.sha')
           echo "prepare_start_sha=$PREPARE_START_SHA" >> "$GITHUB_OUTPUT"
           echo "✓ Captured pre-prepare dev SHA: $PREPARE_START_SHA"
 
@@ -237,9 +238,11 @@ jobs:
           RELEASE_BRANCH: ${{ needs.validate.outputs.release_branch }}
         run: |
           set -euo pipefail
-          DEV_SHA=$(gh api "repos/${{ github.repository }}/git/ref/heads/dev" --jq '.object.sha')
+          DEV_SHA=$(uv run retry --retries 3 --backoff 5 --max-backoff 60 -- \
+            gh api "repos/${{ github.repository }}/git/ref/heads/dev" --jq '.object.sha')
           echo "Creating branch $RELEASE_BRANCH from dev at $DEV_SHA..."
-          gh api "repos/${{ github.repository }}/git/refs" \
+          uv run retry --retries 3 --backoff 5 --max-backoff 60 -- \
+            gh api "repos/${{ github.repository }}/git/refs" \
             -f ref="refs/heads/$RELEASE_BRANCH" \
             -f sha="$DEV_SHA"
           echo "dev_sha=$DEV_SHA" >> "$GITHUB_OUTPUT"
@@ -299,7 +302,8 @@ jobs:
           $CHANGELOG_CONTENT
           "
 
-          PR_URL=$(gh pr create \
+          PR_URL=$(uv run retry --retries 3 --backoff 5 --max-backoff 60 -- \
+            gh pr create \
             --base main \
             --head "$RELEASE_BRANCH" \
             --title "chore: release $VERSION" \
@@ -335,8 +339,10 @@ jobs:
             exit 0
           fi
 
-          if gh api "repos/${{ github.repository }}/git/ref/heads/$RELEASE_BRANCH" >/dev/null 2>&1; then
-            gh api -X DELETE "repos/${{ github.repository }}/git/refs/heads/$RELEASE_BRANCH"
+          if uv run retry --retries 3 --backoff 5 --max-backoff 60 -- \
+            gh api "repos/${{ github.repository }}/git/ref/heads/$RELEASE_BRANCH" >/dev/null 2>&1; then
+            uv run retry --retries 3 --backoff 5 --max-backoff 60 -- \
+              gh api -X DELETE "repos/${{ github.repository }}/git/refs/heads/$RELEASE_BRANCH"
             BRANCH_DELETED=true
             echo "✓ Deleted partially created release branch: $RELEASE_BRANCH"
           else
@@ -344,7 +350,8 @@ jobs:
           fi
 
           if [ -n "${POST_FREEZE_DEV_SHA:-}" ]; then
-            CURRENT_DEV_SHA="$(gh api "repos/${{ github.repository }}/git/ref/heads/dev" --jq '.object.sha')"
+            CURRENT_DEV_SHA="$(uv run retry --retries 3 --backoff 5 --max-backoff 60 -- \
+              gh api "repos/${{ github.repository }}/git/ref/heads/dev" --jq '.object.sha')"
             if [ "$CURRENT_DEV_SHA" != "$POST_FREEZE_DEV_SHA" ]; then
               echo "w dev advanced after freeze commit; skipping CHANGELOG rollback to avoid clobbering concurrent updates"
               echo "branch_deleted=$BRANCH_DELETED" >> "$GITHUB_OUTPUT"
@@ -353,8 +360,10 @@ jobs:
             fi
           fi
 
-          gh api "repos/${{ github.repository }}/contents/CHANGELOG.md?ref=$PREPARE_START_SHA" --jq '.content' | tr -d '\n' | base64 -d > /tmp/changelog.pre-prepare.md
-          gh api "repos/${{ github.repository }}/contents/CHANGELOG.md?ref=dev" --jq '.content' | tr -d '\n' | base64 -d > /tmp/changelog.current-dev.md
+          uv run retry --retries 3 --backoff 5 --max-backoff 60 -- \
+            gh api "repos/${{ github.repository }}/contents/CHANGELOG.md?ref=$PREPARE_START_SHA" --jq '.content' | tr -d '\n' | base64 -d > /tmp/changelog.pre-prepare.md
+          uv run retry --retries 3 --backoff 5 --max-backoff 60 -- \
+            gh api "repos/${{ github.repository }}/contents/CHANGELOG.md?ref=dev" --jq '.content' | tr -d '\n' | base64 -d > /tmp/changelog.current-dev.md
 
           if cmp -s /tmp/changelog.pre-prepare.md /tmp/changelog.current-dev.md; then
             echo "i dev CHANGELOG already matches pre-prepare state"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,7 +117,8 @@ jobs:
         env:
           VERSION: ${{ steps.vars.outputs.version }}
         run: |
-          git fetch origin "release/$VERSION" || {
+          set -euo pipefail
+          uv run retry --retries 3 --backoff 3 --max-backoff 20 -- git fetch origin "release/$VERSION" || {
             echo "ERROR: Release branch not found: release/$VERSION"
             echo "Did you run: just prepare-release $VERSION"
             exit 1
@@ -333,7 +334,7 @@ jobs:
           RELEASE_BRANCH="release/$VERSION"
 
           # Find PR from release branch to main
-          PR_JSON=$(gh pr list \
+          PR_JSON=$(uv run retry --retries 3 --backoff 5 --max-backoff 30 -- gh pr list \
             --head "$RELEASE_BRANCH" \
             --base main \
             --json number,isDraft,reviewDecision,statusCheckRollup \
@@ -575,7 +576,7 @@ jobs:
         run: |
           set -euo pipefail
           echo "Triggering sync-issues workflow..."
-          gh workflow run sync-issues.yml \
+          uv run retry --retries 2 --backoff 5 --max-backoff 20 -- gh workflow run sync-issues.yml \
             -f "target-branch=release/$VERSION"
           echo "✓ sync-issues workflow triggered"
 
@@ -630,7 +631,7 @@ jobs:
           VERSION: ${{ needs.validate.outputs.version }}
         run: |
           set -euo pipefail
-          git fetch origin "release/$VERSION"
+          uv run retry --retries 3 --backoff 3 --max-backoff 20 -- git fetch origin "release/$VERSION"
           git reset --hard "origin/release/$VERSION"
           echo "✓ Synced with remote release branch"
 
@@ -660,7 +661,8 @@ jobs:
           $CHANGELOG_CONTENT
           EOF
 
-          gh pr edit "$PR_NUMBER" --body-file /tmp/release-pr-body.md
+          uv run retry --retries 3 --backoff 5 --max-backoff 30 -- \
+            gh pr edit "$PR_NUMBER" --body-file /tmp/release-pr-body.md
           echo "✓ Refreshed PR #$PR_NUMBER body from finalized CHANGELOG.md"
 
       - name: Output finalize SHA
@@ -674,7 +676,8 @@ jobs:
           if [ "$RELEASE_KIND" = "final" ]; then
             FINALIZE_SHA=$(git rev-parse HEAD)
           else
-            FINALIZE_SHA=$(gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/release/$VERSION" --jq '.object.sha')
+            FINALIZE_SHA=$(uv run retry --retries 3 --backoff 5 --max-backoff 30 -- \
+              gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/release/$VERSION" --jq '.object.sha')
           fi
           echo "finalize_sha=$FINALIZE_SHA" >> $GITHUB_OUTPUT
           echo "Release kind: $RELEASE_KIND — SHA: $FINALIZE_SHA"
@@ -801,7 +804,14 @@ jobs:
             fi
           fi
 
-          git push origin "$PUBLISH_VERSION"
+          if ! uv run retry --retries 3 --backoff 5 --max-backoff 30 -- git push origin "$PUBLISH_VERSION"; then
+            if git ls-remote --tags --refs origin "$PUBLISH_VERSION" | grep -q "refs/tags/$PUBLISH_VERSION$"; then
+              echo "Tag already present on origin after push attempt: $PUBLISH_VERSION"
+            else
+              echo "ERROR: Failed to push tag $PUBLISH_VERSION"
+              exit 1
+            fi
+          fi
           echo "✓ Tag pushed: $PUBLISH_VERSION"
 
       - name: Generate final release notes from CHANGELOG
@@ -865,22 +875,8 @@ jobs:
             IMAGE_TAG="$REPO:$PUBLISH_VERSION-$arch"
             docker tag "$SOURCE_IMAGE_TAG" "$IMAGE_TAG"
             echo "Pushing $arch image: $IMAGE_TAG"
-
-            RETRIES=3
-            for i in $(seq 1 $RETRIES); do
-              if docker push "$IMAGE_TAG"; then
-                echo "✓ Pushed: $IMAGE_TAG"
-                break
-              else
-                if [ $i -lt $RETRIES ]; then
-                  echo "Push failed, retrying ($i/$RETRIES)..."
-                  sleep 3
-                else
-                  echo "ERROR: Failed to push after $RETRIES attempts"
-                  exit 1
-                fi
-              fi
-            done
+            uv run retry --retries 3 --backoff 3 --max-backoff 3 -- docker push "$IMAGE_TAG"
+            echo "✓ Pushed: $IMAGE_TAG"
           done
 
       - name: Create multi-arch manifest
@@ -902,45 +898,20 @@ jobs:
           done
 
           echo "Creating version manifest: $REPO:$PUBLISH_VERSION"
-          RETRIES=3
-          for i in $(seq 1 $RETRIES); do
-            if docker buildx imagetools create \
+          uv run retry --retries 3 --backoff 3 --max-backoff 3 -- \
+            docker buildx imagetools create \
               --tag "$REPO:$PUBLISH_VERSION" \
-              "${ARCH_IMAGES[@]}"; then
-              echo "✓ Created version manifest: $REPO:$PUBLISH_VERSION"
-              break
-            else
-              if [ $i -lt $RETRIES ]; then
-                echo "Manifest creation failed, retrying ($i/$RETRIES)..."
-                sleep 3
-              else
-                echo "ERROR: Failed to create version manifest"
-                exit 1
-              fi
-            fi
-          done
+              "${ARCH_IMAGES[@]}"
+          echo "✓ Created version manifest: $REPO:$PUBLISH_VERSION"
 
           # Update latest manifest only for final releases building both architectures.
           if [ "$RELEASE_KIND" = "final" ] && [ ${#ARCH_ARRAY[@]} -eq 2 ]; then
             echo "Creating/updating latest manifest: $REPO:latest"
-
-            RETRIES=3
-            for i in $(seq 1 $RETRIES); do
-              if docker buildx imagetools create \
+            uv run retry --retries 3 --backoff 3 --max-backoff 3 -- \
+              docker buildx imagetools create \
                 --tag "$REPO:latest" \
-                "${ARCH_IMAGES[@]}"; then
-                echo "✓ Created/updated latest manifest: $REPO:latest"
-                break
-              else
-                if [ $i -lt $RETRIES ]; then
-                  echo "Latest manifest creation failed, retrying ($i/$RETRIES)..."
-                  sleep 3
-                else
-                  echo "ERROR: Failed to create latest manifest"
-                  exit 1
-                fi
-              fi
-            done
+                "${ARCH_IMAGES[@]}"
+            echo "✓ Created/updated latest manifest: $REPO:latest"
           else
             echo "Skipping 'latest' manifest (single architecture or limited build)"
           fi
@@ -1030,24 +1001,13 @@ jobs:
           REPO="ghcr.io/vig-os/devcontainer"
 
           # Get the digest for the multi-arch manifest
-          DIGEST=$(docker buildx imagetools inspect "$REPO:$PUBLISH_VERSION" --format '{{json .Manifest.Digest}}' | tr -d '"')
+          DIGEST=$(uv run retry --retries 3 --backoff 5 --max-backoff 30 -- \
+            docker buildx imagetools inspect "$REPO:$PUBLISH_VERSION" --format '{{json .Manifest.Digest}}' | tr -d '"')
           echo "Signing image: $REPO@$DIGEST"
 
           # Keyless signing using GitHub Actions OIDC identity
-          RETRIES=3
-          for i in $(seq 1 $RETRIES); do
-            if cosign sign --yes "$REPO@$DIGEST"; then
-              break
-            fi
-
-            if [ $i -lt $RETRIES ]; then
-              echo "Cosign sign failed, retrying ($i/$RETRIES)..."
-              sleep 15
-            else
-              echo "ERROR: Failed to sign image after $RETRIES attempts"
-              exit 1
-            fi
-          done
+          uv run retry --retries 3 --backoff 15 --max-backoff 15 -- \
+            cosign sign --yes "$REPO@$DIGEST"
           echo "✓ Image signed with cosign (keyless)"
 
       - name: Capture image digest for attestation
@@ -1055,8 +1015,10 @@ jobs:
         env:
           PUBLISH_VERSION: ${{ needs.validate.outputs.publish_version }}
         run: |
+          set -euo pipefail
           REPO="ghcr.io/vig-os/devcontainer"
-          DIGEST=$(docker buildx imagetools inspect "$REPO:$PUBLISH_VERSION" --format '{{json .Manifest.Digest}}' | tr -d '"')
+          DIGEST=$(uv run retry --retries 3 --backoff 5 --max-backoff 30 -- \
+            docker buildx imagetools inspect "$REPO:$PUBLISH_VERSION" --format '{{json .Manifest.Digest}}' | tr -d '"')
           echo "digest=$DIGEST" >> $GITHUB_OUTPUT
           echo "Image digest: $DIGEST"
 
@@ -1111,15 +1073,21 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           set -euo pipefail
-          if gh release view "$PUBLISH_VERSION" >/dev/null 2>&1; then
+          if uv run retry --retries 2 --backoff 5 --max-backoff 20 -- gh release view "$PUBLISH_VERSION" >/dev/null 2>&1; then
             echo "ERROR: GitHub Release already exists for tag $PUBLISH_VERSION"
             exit 1
           fi
 
-          gh release create "$PUBLISH_VERSION" \
+          uv run retry --retries 3 --backoff 5 --max-backoff 30 -- gh release create "$PUBLISH_VERSION" \
             --title "$PUBLISH_VERSION" \
             --notes-file /tmp/github-release-notes.md \
-            --verify-tag
+            --verify-tag || {
+              if gh release view "$PUBLISH_VERSION" >/dev/null 2>&1; then
+                echo "GitHub Release already present after create attempt: $PUBLISH_VERSION"
+              else
+                exit 1
+              fi
+            }
 
           echo "✓ GitHub Release published: $PUBLISH_VERSION"
 
@@ -1186,9 +1154,8 @@ jobs:
           CORRELATION_ID: ${{ github.repository }}:${{ github.run_id }}:${{ needs.validate.outputs.publish_version }}
         run: |
           set -euo pipefail
-          RETRIES=3
-          for i in $(seq 1 $RETRIES); do
-            if gh api repos/vig-os/devcontainer-smoke-test/dispatches \
+          uv run retry --retries 3 --backoff 10 --max-backoff 10 -- \
+            gh api repos/vig-os/devcontainer-smoke-test/dispatches \
               -f event_type=smoke-test-trigger \
               -f "client_payload[tag]=$RELEASE_TAG" \
               -f "client_payload[release_kind]=$RELEASE_KIND" \
@@ -1198,18 +1165,7 @@ jobs:
               -f "client_payload[source_run_id]=$SOURCE_RUN_ID" \
               -f "client_payload[source_run_url]=$SOURCE_RUN_URL" \
               -f "client_payload[source_sha]=$SOURCE_SHA" \
-              -f "client_payload[correlation_id]=$CORRELATION_ID"; then
-              break
-            fi
-
-            if [ $i -lt $RETRIES ]; then
-              echo "Dispatch failed, retrying ($i/$RETRIES)..."
-              sleep 10
-            else
-              echo "ERROR: Failed to trigger smoke-test dispatch after $RETRIES attempts"
-              exit 1
-            fi
-          done
+              -f "client_payload[correlation_id]=$CORRELATION_ID"
           echo "✓ Triggered smoke-test dispatch for release tag: $RELEASE_TAG"
 
       - name: Summary
@@ -1286,7 +1242,7 @@ jobs:
         run: |
           set -euo pipefail
           echo "Rolling back release branch to pre-finalization state..."
-          gh api "repos/${{ github.repository }}/git/refs/heads/release/$VERSION" \
+          uv run retry --retries 3 --backoff 5 --max-backoff 30 -- gh api "repos/${{ github.repository }}/git/refs/heads/release/$VERSION" \
             -X PATCH \
             -f sha="$PRE_SHA" \
             -F force=true
@@ -1301,9 +1257,9 @@ jobs:
         run: |
           set -euo pipefail
           TAG="$PUBLISH_VERSION"
-          if gh api "repos/${{ github.repository }}/git/refs/tags/$TAG" >/dev/null 2>&1; then
+          if uv run retry --retries 2 --backoff 5 --max-backoff 20 -- gh api "repos/${{ github.repository }}/git/refs/tags/$TAG" >/dev/null 2>&1; then
             echo "Deleting remote tag: $TAG"
-            gh api "repos/${{ github.repository }}/git/refs/tags/$TAG" -X DELETE
+            uv run retry --retries 3 --backoff 5 --max-backoff 30 -- gh api "repos/${{ github.repository }}/git/refs/tags/$TAG" -X DELETE
             echo "✓ Tag deleted"
           else
             echo "Tag does not exist on remote (not created)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -797,7 +797,7 @@ jobs:
         run: |
           set -euo pipefail
           if [ "$RELEASE_KIND" = "candidate" ]; then
-            if git ls-remote --tags --refs origin "$PUBLISH_VERSION" | grep -q "refs/tags/$PUBLISH_VERSION$"; then
+            if uv run retry --retries 3 --backoff 5 --max-backoff 30 -- git ls-remote --tags --refs origin "$PUBLISH_VERSION" | grep -q "refs/tags/$PUBLISH_VERSION$"; then
               echo "ERROR: Candidate tag '$PUBLISH_VERSION' already exists on origin"
               echo "Another candidate publish likely completed concurrently; re-run workflow to infer next RC."
               exit 1
@@ -805,9 +805,9 @@ jobs:
           fi
 
           if ! uv run retry --retries 3 --backoff 5 --max-backoff 30 -- git push origin "$PUBLISH_VERSION"; then
-            if git ls-remote --tags --refs origin "$PUBLISH_VERSION" | grep -q "refs/tags/$PUBLISH_VERSION$"; then
+            if uv run retry --retries 3 --backoff 5 --max-backoff 30 -- git ls-remote --tags --refs origin "$PUBLISH_VERSION" | grep -q "refs/tags/$PUBLISH_VERSION$"; then
               LOCAL_TAG_TARGET_SHA=$(git rev-parse "$PUBLISH_VERSION^{}")
-              REMOTE_TAG_TARGET_SHA=$(git ls-remote --tags origin "refs/tags/$PUBLISH_VERSION^{}" | awk '{print $1}')
+              REMOTE_TAG_TARGET_SHA=$(uv run retry --retries 3 --backoff 5 --max-backoff 30 -- git ls-remote --tags origin "refs/tags/$PUBLISH_VERSION^{}" | awk '{print $1}')
               if [ -z "$REMOTE_TAG_TARGET_SHA" ]; then
                 echo "ERROR: Remote tag exists but target SHA could not be resolved: $PUBLISH_VERSION"
                 exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -806,7 +806,19 @@ jobs:
 
           if ! uv run retry --retries 3 --backoff 5 --max-backoff 30 -- git push origin "$PUBLISH_VERSION"; then
             if git ls-remote --tags --refs origin "$PUBLISH_VERSION" | grep -q "refs/tags/$PUBLISH_VERSION$"; then
-              echo "Tag already present on origin after push attempt: $PUBLISH_VERSION"
+              LOCAL_TAG_TARGET_SHA=$(git rev-parse "$PUBLISH_VERSION^{}")
+              REMOTE_TAG_TARGET_SHA=$(git ls-remote --tags origin "refs/tags/$PUBLISH_VERSION^{}" | awk '{print $1}')
+              if [ -z "$REMOTE_TAG_TARGET_SHA" ]; then
+                echo "ERROR: Remote tag exists but target SHA could not be resolved: $PUBLISH_VERSION"
+                exit 1
+              fi
+              if [ "$REMOTE_TAG_TARGET_SHA" != "$LOCAL_TAG_TARGET_SHA" ]; then
+                echo "ERROR: Remote tag target SHA mismatch for $PUBLISH_VERSION"
+                echo "Local tag target:  $LOCAL_TAG_TARGET_SHA"
+                echo "Remote tag target: $REMOTE_TAG_TARGET_SHA"
+                exit 1
+              fi
+              echo "Tag already present on origin with matching target SHA: $PUBLISH_VERSION"
             else
               echo "ERROR: Failed to push tag $PUBLISH_VERSION"
               exit 1
@@ -1082,7 +1094,7 @@ jobs:
             --title "$PUBLISH_VERSION" \
             --notes-file /tmp/github-release-notes.md \
             --verify-tag || {
-              if gh release view "$PUBLISH_VERSION" >/dev/null 2>&1; then
+              if uv run retry --retries 2 --backoff 5 --max-backoff 20 -- gh release view "$PUBLISH_VERSION" >/dev/null 2>&1; then
                 echo "GitHub Release already present after create attempt: $PUBLISH_VERSION"
               else
                 exit 1

--- a/.github/workflows/sync-issues.yml
+++ b/.github/workflows/sync-issues.yml
@@ -63,6 +63,11 @@ jobs:
           ref: ${{ github.event.inputs.target-branch || 'dev' }}
           persist-credentials: false
 
+      - name: Set up environment
+        uses: ./.github/actions/setup-env
+        with:
+          sync-dependencies: 'true'
+
       - name: Restore sync state (last synced timestamp)
         id: restore-state
         uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306  # v5.0.3

--- a/.github/workflows/sync-issues.yml
+++ b/.github/workflows/sync-issues.yml
@@ -36,8 +36,30 @@ on:  # yamllint disable-line rule:truthy
 permissions: {}  # restrict default; job declares its own
 
 jobs:
-  sync:
+  resolve-image:
+    name: Resolve image tag
     runs-on: ubuntu-22.04
+    timeout-minutes: 2
+    permissions:
+      contents: read
+    outputs:
+      image-tag: ${{ steps.resolve.outputs.image-tag }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          sparse-checkout: .vig-os
+          sparse-checkout-cone-mode: false
+
+      - name: Resolve container image
+        id: resolve
+        uses: ./.github/actions/resolve-image
+
+  sync:
+    needs: [resolve-image]
+    runs-on: ubuntu-22.04
+    container:
+      image: ghcr.io/vig-os/devcontainer:${{ needs.resolve-image.outputs.image-tag }}
     timeout-minutes: 10
     # Prevent concurrent runs to avoid race conditions when committing and cache collisions
     concurrency:
@@ -63,11 +85,6 @@ jobs:
           ref: ${{ github.event.inputs.target-branch || 'dev' }}
           persist-credentials: false
 
-      - name: Set up environment
-        uses: ./.github/actions/setup-env
-        with:
-          sync-dependencies: 'true'
-
       - name: Restore sync state (last synced timestamp)
         id: restore-state
         uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306  # v5.0.3
@@ -88,11 +105,11 @@ jobs:
           sleep 2
           # Try to delete cache using GitHub API
           CACHE_KEY="sync-issues-state-${{ github.repository }}"
-          CACHE_ID=$(uv run retry --retries 3 --backoff 3 --max-backoff 15 -- \
+          CACHE_ID=$(retry --retries 3 --backoff 3 --max-backoff 15 -- \
             gh api repos/${{ github.repository }}/actions/caches --jq ".actions_caches[] | select(.key == \"$CACHE_KEY\") | .id" | head -1)
           if [ -n "$CACHE_ID" ]; then
             echo "Found cache ID: $CACHE_ID, attempting deletion..."
-            uv run retry --retries 3 --backoff 3 --max-backoff 15 -- \
+            retry --retries 3 --backoff 3 --max-backoff 15 -- \
               gh api repos/${{ github.repository }}/actions/caches/$CACHE_ID -X DELETE && echo "Cache deleted successfully" || echo "Cache deletion failed (may be locked or already deleted)"
           else
             echo "No cache found with key: $CACHE_KEY (this is OK for first run)"

--- a/.github/workflows/sync-issues.yml
+++ b/.github/workflows/sync-issues.yml
@@ -83,10 +83,12 @@ jobs:
           sleep 2
           # Try to delete cache using GitHub API
           CACHE_KEY="sync-issues-state-${{ github.repository }}"
-          CACHE_ID=$(gh api repos/${{ github.repository }}/actions/caches --jq ".actions_caches[] | select(.key == \"$CACHE_KEY\") | .id" | head -1)
+          CACHE_ID=$(uv run retry --retries 3 --backoff 3 --max-backoff 15 -- \
+            gh api repos/${{ github.repository }}/actions/caches --jq ".actions_caches[] | select(.key == \"$CACHE_KEY\") | .id" | head -1)
           if [ -n "$CACHE_ID" ]; then
             echo "Found cache ID: $CACHE_ID, attempting deletion..."
-            gh api repos/${{ github.repository }}/actions/caches/$CACHE_ID -X DELETE && echo "Cache deleted successfully" || echo "Cache deletion failed (may be locked or already deleted)"
+            uv run retry --retries 3 --backoff 3 --max-backoff 15 -- \
+              gh api repos/${{ github.repository }}/actions/caches/$CACHE_ID -X DELETE && echo "Cache deleted successfully" || echo "Cache deletion failed (may be locked or already deleted)"
           else
             echo "No cache found with key: $CACHE_KEY (this is OK for first run)"
           fi

--- a/.github/workflows/sync-main-to-dev.yml
+++ b/.github/workflows/sync-main-to-dev.yml
@@ -49,6 +49,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Set up environment
+        uses: ./.github/actions/setup-env
+        with:
+          sync-dependencies: 'true'
+
       - name: Check if dev is up to date with main
         id: check
         run: |
@@ -98,6 +103,11 @@ jobs:
           ref: dev
           fetch-depth: 0
           token: ${{ steps.commit-app-token.outputs.token }}
+
+      - name: Set up environment
+        uses: ./.github/actions/setup-env
+        with:
+          sync-dependencies: 'true'
 
       - name: Re-check if dev is still behind main
         id: recheck

--- a/.github/workflows/sync-main-to-dev.yml
+++ b/.github/workflows/sync-main-to-dev.yml
@@ -53,7 +53,7 @@ jobs:
         id: check
         run: |
           set -euo pipefail
-          git fetch origin main dev
+          uv run retry --retries 3 --backoff 3 --max-backoff 20 -- git fetch origin main dev
           if ! git show-ref --verify --quiet refs/remotes/origin/main; then
             echo "Error: remote branch 'origin/main' not found after fetch."
             exit 1
@@ -103,7 +103,7 @@ jobs:
         id: recheck
         run: |
           set -euo pipefail
-          git fetch origin main dev
+          uv run retry --retries 3 --backoff 3 --max-backoff 20 -- git fetch origin main dev
           BEHIND=$(git rev-list --count origin/main ^origin/dev)
           if [ "${BEHIND}" = "0" ]; then
             echo "up_to_date=true" >> "$GITHUB_OUTPUT"
@@ -128,7 +128,8 @@ jobs:
           GH_TOKEN: ${{ steps.release-app-token.outputs.token }}
         run: |
           set -euo pipefail
-          OPEN=$(gh pr list --base dev --state open --limit 200 \
+          OPEN=$(uv run retry --retries 3 --backoff 5 --max-backoff 30 -- \
+            gh pr list --base dev --state open --limit 200 \
             --json headRefName \
             --jq '[.[] | select(.headRefName | startswith("chore/sync-main-to-dev-"))] | length')
           echo "count=${OPEN}" >> "$GITHUB_OUTPUT"
@@ -142,13 +143,16 @@ jobs:
           GH_TOKEN: ${{ steps.commit-app-token.outputs.token }}
         run: |
           set -euo pipefail
-          REFS=$(gh api --paginate "repos/${{ github.repository }}/git/matching-refs/heads/chore/sync-main-to-dev-" \
+          REFS=$(uv run retry --retries 3 --backoff 5 --max-backoff 30 -- \
+            gh api --paginate "repos/${{ github.repository }}/git/matching-refs/heads/chore/sync-main-to-dev-" \
             --jq '.[].ref' | sed 's|refs/heads/||') || true
           for branch in ${REFS}; do
-            HAS_PR=$(GH_TOKEN="${{ steps.release-app-token.outputs.token }}" gh pr list --base dev --head "${branch}" \
+            HAS_PR=$(GH_TOKEN="${{ steps.release-app-token.outputs.token }}" uv run retry --retries 3 --backoff 5 --max-backoff 30 -- \
+              gh pr list --base dev --head "${branch}" \
               --state open --json number --jq 'length')
             if [ "${HAS_PR}" = "0" ]; then
-              gh api -X DELETE "repos/${{ github.repository }}/git/refs/heads/${branch}" 2>/dev/null || true
+              uv run retry --retries 3 --backoff 5 --max-backoff 30 -- \
+                gh api -X DELETE "repos/${{ github.repository }}/git/refs/heads/${branch}" 2>/dev/null || true
               echo "Deleted stale sync branch: ${branch}"
             fi
           done
@@ -158,7 +162,7 @@ jobs:
         id: merge-check
         run: |
           set -euo pipefail
-          git fetch origin main
+          uv run retry --retries 3 --backoff 3 --max-backoff 20 -- git fetch origin main
           if git merge --no-commit --no-ff origin/main 2>/dev/null; then
             echo "conflict=false" >> "$GITHUB_OUTPUT"
           else
@@ -173,9 +177,17 @@ jobs:
         run: |
           set -euo pipefail
           MAIN_SHA=$(git rev-parse origin/main)
-          gh api "repos/${{ github.repository }}/git/refs" \
+          uv run retry --retries 3 --backoff 5 --max-backoff 30 -- \
+            gh api "repos/${{ github.repository }}/git/refs" \
             -f ref="refs/heads/${SYNC_BRANCH}" \
-            -f sha="${MAIN_SHA}"
+            -f sha="${MAIN_SHA}" || {
+              if uv run retry --retries 2 --backoff 5 --max-backoff 20 -- \
+                gh api "repos/${{ github.repository }}/git/ref/heads/${SYNC_BRANCH}" >/dev/null 2>&1; then
+                echo "Sync branch already exists: ${SYNC_BRANCH}"
+              else
+                exit 1
+              fi
+            }
           echo "Sync branch ${SYNC_BRANCH} created from main at ${MAIN_SHA}"
 
       - name: Create PR
@@ -211,14 +223,22 @@ jobs:
             BODY="Syncs \`dev\` with \`main\` (sync-main-to-dev workflow)."
           fi
 
-          PR_URL=$(gh pr create --base dev --head "${SYNC_BRANCH}" \
-            --title "${TITLE}" --body "${BODY}")
+          EXISTING_PR_URL=$(uv run retry --retries 3 --backoff 5 --max-backoff 30 -- \
+            gh pr list --base dev --head "${SYNC_BRANCH}" --state open --json url --jq '.[0].url // empty')
+          if [ -n "${EXISTING_PR_URL}" ]; then
+            PR_URL="${EXISTING_PR_URL}"
+          else
+            PR_URL=$(uv run retry --retries 3 --backoff 5 --max-backoff 30 -- \
+              gh pr create --base dev --head "${SYNC_BRANCH}" \
+                --title "${TITLE}" --body "${BODY}")
+          fi
           echo "pr_url=${PR_URL}" >> "$GITHUB_OUTPUT"
           echo "Created PR: ${PR_URL}"
 
           if [ "${CONFLICT}" = "true" ]; then
             gh label create "merge-conflict" --color "B60205" --force 2>/dev/null || true
-            gh pr edit "${SYNC_BRANCH}" --add-label "merge-conflict" || \
+            uv run retry --retries 3 --backoff 5 --max-backoff 30 -- \
+              gh pr edit "${SYNC_BRANCH}" --add-label "merge-conflict" || \
               echo "Warning: failed to add merge-conflict label."
           fi
 
@@ -231,5 +251,6 @@ jobs:
           PR_URL: ${{ steps.create-pr.outputs.pr_url }}
         run: |
           set -euo pipefail
-          gh pr merge "${PR_URL}" --auto --merge || \
+          uv run retry --retries 2 --backoff 5 --max-backoff 20 -- \
+            gh pr merge "${PR_URL}" --auto --merge || \
             echo "Warning: could not enable auto-merge (may require branch protection settings)"

--- a/.github/workflows/sync-main-to-dev.yml
+++ b/.github/workflows/sync-main-to-dev.yml
@@ -36,9 +36,29 @@ permissions:
   contents: read
 
 jobs:
+  resolve-image:
+    name: Resolve image tag
+    runs-on: ubuntu-22.04
+    timeout-minutes: 2
+    outputs:
+      image-tag: ${{ steps.resolve.outputs.image-tag }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          sparse-checkout: .vig-os
+          sparse-checkout-cone-mode: false
+
+      - name: Resolve container image
+        id: resolve
+        uses: ./.github/actions/resolve-image
+
   check:
     name: Check if dev is up to date
+    needs: [resolve-image]
     runs-on: ubuntu-22.04
+    container:
+      image: ghcr.io/vig-os/devcontainer:${{ needs.resolve-image.outputs.image-tag }}
     timeout-minutes: 5
     outputs:
       up_to_date: ${{ steps.check.outputs.up_to_date }}
@@ -49,16 +69,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up environment
-        uses: ./.github/actions/setup-env
-        with:
-          sync-dependencies: 'true'
-
       - name: Check if dev is up to date with main
         id: check
         run: |
           set -euo pipefail
-          uv run retry --retries 3 --backoff 3 --max-backoff 20 -- git fetch origin main dev
+          retry --retries 3 --backoff 3 --max-backoff 20 -- git fetch origin main dev
           if ! git show-ref --verify --quiet refs/remotes/origin/main; then
             echo "Error: remote branch 'origin/main' not found after fetch."
             exit 1
@@ -78,9 +93,11 @@ jobs:
 
   sync:
     name: Merge main into dev via PR
-    needs: check
+    needs: [resolve-image, check]
     if: needs.check.outputs.up_to_date != 'true'
     runs-on: ubuntu-22.04
+    container:
+      image: ghcr.io/vig-os/devcontainer:${{ needs.resolve-image.outputs.image-tag }}
     timeout-minutes: 10
     env:
       SYNC_BRANCH: chore/sync-main-to-dev-${{ github.run_number }}-${{ github.run_attempt }}
@@ -104,16 +121,11 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.commit-app-token.outputs.token }}
 
-      - name: Set up environment
-        uses: ./.github/actions/setup-env
-        with:
-          sync-dependencies: 'true'
-
       - name: Re-check if dev is still behind main
         id: recheck
         run: |
           set -euo pipefail
-          uv run retry --retries 3 --backoff 3 --max-backoff 20 -- git fetch origin main dev
+          retry --retries 3 --backoff 3 --max-backoff 20 -- git fetch origin main dev
           BEHIND=$(git rev-list --count origin/main ^origin/dev)
           if [ "${BEHIND}" = "0" ]; then
             echo "up_to_date=true" >> "$GITHUB_OUTPUT"
@@ -138,7 +150,7 @@ jobs:
           GH_TOKEN: ${{ steps.release-app-token.outputs.token }}
         run: |
           set -euo pipefail
-          OPEN=$(uv run retry --retries 3 --backoff 5 --max-backoff 30 -- \
+          OPEN=$(retry --retries 3 --backoff 5 --max-backoff 30 -- \
             gh pr list --base dev --state open --limit 200 \
             --json headRefName \
             --jq '[.[] | select(.headRefName | startswith("chore/sync-main-to-dev-"))] | length')
@@ -153,15 +165,15 @@ jobs:
           GH_TOKEN: ${{ steps.commit-app-token.outputs.token }}
         run: |
           set -euo pipefail
-          REFS=$(uv run retry --retries 3 --backoff 5 --max-backoff 30 -- \
+          REFS=$(retry --retries 3 --backoff 5 --max-backoff 30 -- \
             gh api --paginate "repos/${{ github.repository }}/git/matching-refs/heads/chore/sync-main-to-dev-" \
             --jq '.[].ref' | sed 's|refs/heads/||') || true
           for branch in ${REFS}; do
-            HAS_PR=$(GH_TOKEN="${{ steps.release-app-token.outputs.token }}" uv run retry --retries 3 --backoff 5 --max-backoff 30 -- \
+            HAS_PR=$(GH_TOKEN="${{ steps.release-app-token.outputs.token }}" retry --retries 3 --backoff 5 --max-backoff 30 -- \
               gh pr list --base dev --head "${branch}" \
               --state open --json number --jq 'length')
             if [ "${HAS_PR}" = "0" ]; then
-              uv run retry --retries 3 --backoff 5 --max-backoff 30 -- \
+              retry --retries 3 --backoff 5 --max-backoff 30 -- \
                 gh api -X DELETE "repos/${{ github.repository }}/git/refs/heads/${branch}" 2>/dev/null || true
               echo "Deleted stale sync branch: ${branch}"
             fi
@@ -172,7 +184,7 @@ jobs:
         id: merge-check
         run: |
           set -euo pipefail
-          uv run retry --retries 3 --backoff 3 --max-backoff 20 -- git fetch origin main
+          retry --retries 3 --backoff 3 --max-backoff 20 -- git fetch origin main
           if git merge --no-commit --no-ff origin/main 2>/dev/null; then
             echo "conflict=false" >> "$GITHUB_OUTPUT"
           else
@@ -187,11 +199,11 @@ jobs:
         run: |
           set -euo pipefail
           MAIN_SHA=$(git rev-parse origin/main)
-          uv run retry --retries 3 --backoff 5 --max-backoff 30 -- \
+          retry --retries 3 --backoff 5 --max-backoff 30 -- \
             gh api "repos/${{ github.repository }}/git/refs" \
             -f ref="refs/heads/${SYNC_BRANCH}" \
             -f sha="${MAIN_SHA}" || {
-              if uv run retry --retries 2 --backoff 5 --max-backoff 20 -- \
+              if retry --retries 2 --backoff 5 --max-backoff 20 -- \
                 gh api "repos/${{ github.repository }}/git/ref/heads/${SYNC_BRANCH}" >/dev/null 2>&1; then
                 echo "Sync branch already exists: ${SYNC_BRANCH}"
               else
@@ -233,12 +245,12 @@ jobs:
             BODY="Syncs \`dev\` with \`main\` (sync-main-to-dev workflow)."
           fi
 
-          EXISTING_PR_URL=$(uv run retry --retries 3 --backoff 5 --max-backoff 30 -- \
+          EXISTING_PR_URL=$(retry --retries 3 --backoff 5 --max-backoff 30 -- \
             gh pr list --base dev --head "${SYNC_BRANCH}" --state open --json url --jq '.[0].url // empty')
           if [ -n "${EXISTING_PR_URL}" ]; then
             PR_URL="${EXISTING_PR_URL}"
           else
-            PR_URL=$(uv run retry --retries 3 --backoff 5 --max-backoff 30 -- \
+            PR_URL=$(retry --retries 3 --backoff 5 --max-backoff 30 -- \
               gh pr create --base dev --head "${SYNC_BRANCH}" \
                 --title "${TITLE}" --body "${BODY}")
           fi
@@ -247,7 +259,7 @@ jobs:
 
           if [ "${CONFLICT}" = "true" ]; then
             gh label create "merge-conflict" --color "B60205" --force 2>/dev/null || true
-            uv run retry --retries 3 --backoff 5 --max-backoff 30 -- \
+            retry --retries 3 --backoff 5 --max-backoff 30 -- \
               gh pr edit "${SYNC_BRANCH}" --add-label "merge-conflict" || \
               echo "Warning: failed to add merge-conflict label."
           fi
@@ -261,6 +273,6 @@ jobs:
           PR_URL: ${{ steps.create-pr.outputs.pr_url }}
         run: |
           set -euo pipefail
-          uv run retry --retries 2 --backoff 5 --max-backoff 20 -- \
+          retry --retries 2 --backoff 5 --max-backoff 20 -- \
             gh pr merge "${PR_URL}" --auto --merge || \
             echo "Warning: could not enable auto-merge (may require branch protection settings)"

--- a/.vig-os
+++ b/.vig-os
@@ -1,0 +1,2 @@
+# devcontainer image configuration
+DEVCONTAINER_VERSION=latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Smoke-test release lookup no longer treats missing tags as existing releases** ([#355](https://github.com/vig-os/devcontainer/issues/355))
   - Change `assets/smoke-test/.github/workflows/repository-dispatch.yml` to branch on `gh api` exit status when querying `releases/tags/<tag>`
   - Ensure missing release tags follow the create path instead of failing with `prerelease=null` mismatch
+- **Bounded retry added for network-dependent setup and prepare-release calls** ([#357](https://github.com/vig-os/devcontainer/issues/357))
+  - Replace shell-based retry helper with pure Python `retry` CLI in `vig-utils` (`packages/vig-utils/src/vig_utils/retry.py`)
+  - Update this repository CI workflows to call `uv run retry` after `setup-env` dependency sync
+  - Update downstream workflow templates to call `retry` directly in devcontainer jobs and remove `source` lines
+  - Ensure downstream containerized jobs resolve image tags from `.vig-os` instead of hardcoded `latest`
+  - Bundle idempotency guards for branch/PR/tag/release creation paths to keep retried network calls safe on reruns
+  - Remove synced `retry.sh` artifacts and BATS retry tests in favor of `vig-utils` pytest coverage
 
 ### Security
 

--- a/assets/smoke-test/.github/workflows/repository-dispatch.yml
+++ b/assets/smoke-test/.github/workflows/repository-dispatch.yml
@@ -119,11 +119,42 @@ jobs:
           echo "source_sha=${SOURCE_SHA}" >> "${GITHUB_OUTPUT}"
           echo "correlation_id=${CORRELATION_ID}" >> "${GITHUB_OUTPUT}"
 
+  resolve-image:
+    name: Resolve image tag
+    runs-on: ubuntu-22.04
+    timeout-minutes: 2
+    outputs:
+      image-tag: ${{ steps.resolve.outputs.image-tag }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          sparse-checkout: .vig-os
+          sparse-checkout-cone-mode: false
+
+      - name: Resolve container image tag from .vig-os
+        id: resolve
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ ! -f .vig-os ]; then
+            echo "ERROR: .vig-os is required to resolve DEVCONTAINER_VERSION"
+            exit 1
+          fi
+          TAG="$(awk -F= '/^DEVCONTAINER_VERSION=/{gsub(/^[ \t"]+|[ \t"]+$/, "", $2); print $2; exit}' .vig-os || true)"
+          if [ -z "${TAG:-}" ]; then
+            echo "ERROR: DEVCONTAINER_VERSION not found in .vig-os"
+            exit 1
+          fi
+          echo "image-tag=$TAG" >> "$GITHUB_OUTPUT"
+
   deploy:
     name: Deploy tag and open PR to dev
     runs-on: ubuntu-22.04
+    needs: [validate, resolve-image]
+    container:
+      image: ghcr.io/vig-os/devcontainer:${{ needs.resolve-image.outputs.image-tag }}
     timeout-minutes: 15
-    needs: validate
     outputs:
       pr_url: ${{ steps.create_pr.outputs.pr_url }}
     steps:
@@ -155,12 +186,13 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.generate_release_token.outputs.token }}
         run: |
-          gh label create deploy --color 0E8A16 \
+          set -euo pipefail
+          retry --retries 3 --backoff 5 --max-backoff 30 -- gh label create deploy --color 0E8A16 \
             --description "Automated smoke-test deploy PRs" \
             --force
 
           mapfile -t OPEN_DEPLOY_PRS < <(
-            gh pr list --base dev --state open --label deploy \
+            retry --retries 3 --backoff 5 --max-backoff 30 -- gh pr list --base dev --state open --label deploy \
               --json number --jq '.[].number'
           )
 
@@ -171,7 +203,7 @@ jobs:
 
           for pr_number in "${OPEN_DEPLOY_PRS[@]}"; do
             echo "Closing stale deploy PR #${pr_number}"
-            gh pr close "${pr_number}" --delete-branch
+            retry --retries 3 --backoff 5 --max-backoff 30 -- gh pr close "${pr_number}" --delete-branch
           done
 
       - name: Run installer from dispatch tag
@@ -179,7 +211,8 @@ jobs:
           TAG: ${{ needs.validate.outputs.tag }}
         run: |
           set -euo pipefail
-          curl -sSf "https://raw.githubusercontent.com/vig-os/devcontainer/${TAG}/install.sh" \
+          retry --retries 3 --backoff 5 --max-backoff 30 -- \
+            curl -sSf "https://raw.githubusercontent.com/vig-os/devcontainer/${TAG}/install.sh" \
             | bash -s -- --version "${TAG}" --smoke-test --force --docker .
 
           # Docker-based initialization can leave bind-mounted files owned by root.
@@ -211,19 +244,31 @@ jobs:
           GH_TOKEN: ${{ steps.generate_release_token.outputs.token }}
           TAG: ${{ needs.validate.outputs.tag }}
         run: |
+          set -euo pipefail
           BRANCH_NAME="chore/deploy-${TAG}"
           echo "branch_name=${BRANCH_NAME}" >> "${GITHUB_OUTPUT}"
 
-          DEV_SHA="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/dev" --jq '.object.sha')"
+          DEV_SHA="$(retry --retries 3 --backoff 5 --max-backoff 30 -- \
+            gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/dev" --jq '.object.sha')"
 
-          if gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/${BRANCH_NAME}" >/dev/null 2>&1; then
-            gh api -X PATCH "repos/${GITHUB_REPOSITORY}/git/refs/heads/${BRANCH_NAME}" \
+          if retry --retries 2 --backoff 5 --max-backoff 20 -- \
+            gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/${BRANCH_NAME}" >/dev/null 2>&1; then
+            retry --retries 3 --backoff 5 --max-backoff 30 -- \
+              gh api -X PATCH "repos/${GITHUB_REPOSITORY}/git/refs/heads/${BRANCH_NAME}" \
               -f sha="${DEV_SHA}" \
               -F force=true >/dev/null
           else
-            gh api -X POST "repos/${GITHUB_REPOSITORY}/git/refs" \
+            retry --retries 3 --backoff 5 --max-backoff 30 -- \
+              gh api -X POST "repos/${GITHUB_REPOSITORY}/git/refs" \
               -f ref="refs/heads/${BRANCH_NAME}" \
-              -f sha="${DEV_SHA}" >/dev/null
+              -f sha="${DEV_SHA}" >/dev/null || {
+                if retry --retries 2 --backoff 5 --max-backoff 20 -- \
+                  gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/${BRANCH_NAME}" >/dev/null 2>&1; then
+                  echo "Deploy branch already exists: ${BRANCH_NAME}"
+                else
+                  exit 1
+                fi
+              }
           fi
 
       - name: Commit and push deploy changes via signed commit-action
@@ -244,6 +289,7 @@ jobs:
           TAG: ${{ needs.validate.outputs.tag }}
           BRANCH_NAME: ${{ steps.prepare_branch.outputs.branch_name }}
         run: |
+          set -euo pipefail
           PR_BODY="$(
             printf '%s\n' \
               "Automated smoke-test deployment commit created by repository_dispatch." \
@@ -252,14 +298,23 @@ jobs:
               "- Branch: ${BRANCH_NAME}" \
               "- Target: dev"
           )"
-          PR_URL="$(
-            gh pr create \
-              --base dev \
-              --head "${BRANCH_NAME}" \
-              --title "chore: deploy ${TAG}" \
-              --body "${PR_BODY}" \
-              --label deploy
+          EXISTING_PR_URL="$(
+            retry --retries 3 --backoff 5 --max-backoff 30 -- \
+              gh pr list --base dev --head "${BRANCH_NAME}" --state open --json url --jq '.[0].url // empty'
           )"
+          if [ -n "${EXISTING_PR_URL}" ]; then
+            PR_URL="${EXISTING_PR_URL}"
+          else
+            PR_URL="$(
+              retry --retries 3 --backoff 5 --max-backoff 30 -- \
+                gh pr create \
+                  --base dev \
+                  --head "${BRANCH_NAME}" \
+                  --title "chore: deploy ${TAG}" \
+                  --body "${PR_BODY}" \
+                  --label deploy
+            )"
+          fi
           echo "pr_url=${PR_URL}" >> "${GITHUB_OUTPUT}"
           echo "Created PR: ${PR_URL}"
 
@@ -268,14 +323,18 @@ jobs:
           GH_TOKEN: ${{ steps.generate_release_token.outputs.token }}
           PR_URL: ${{ steps.create_pr.outputs.pr_url }}
         run: |
-          gh pr merge "${PR_URL}" --auto --merge || \
+          set -euo pipefail
+          retry --retries 2 --backoff 5 --max-backoff 20 -- \
+            gh pr merge "${PR_URL}" --auto --merge || \
             echo "Warning: could not enable auto-merge"
 
   publish-release:
     name: Publish smoke-test release artifact
     runs-on: ubuntu-22.04
+    needs: [validate, resolve-image, deploy]
+    container:
+      image: ghcr.io/vig-os/devcontainer:${{ needs.resolve-image.outputs.image-tag }}
     timeout-minutes: 10
-    needs: [validate, deploy]
     permissions:
       contents: write
     env:
@@ -318,7 +377,8 @@ jobs:
 
           RELEASE_LOOKUP_OUTPUT=""
           set +e
-          RELEASE_LOOKUP_OUTPUT=$(gh api -i "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}" 2>&1)
+          RELEASE_LOOKUP_OUTPUT=$(retry --retries 3 --backoff 5 --max-backoff 30 -- \
+            gh api -i "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}" 2>&1)
           RELEASE_LOOKUP_EXIT=$?
           set -e
 
@@ -332,26 +392,27 @@ jobs:
           )"
 
           if [ "$RELEASE_LOOKUP_EXIT" -eq 0 ] && [ "$RELEASE_LOOKUP_STATUS" = "200" ]; then
-            EXISTING_RELEASE=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}")
+            EXISTING_RELEASE=$(retry --retries 3 --backoff 5 --max-backoff 30 -- \
+              gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}")
             EXISTING_PRERELEASE=$(echo "$EXISTING_RELEASE" | jq -r '.prerelease')
             if [ "$EXISTING_PRERELEASE" != "$EXPECTED_PRERELEASE" ]; then
               echo "ERROR: Existing release '$TAG' prerelease=$EXISTING_PRERELEASE (expected $EXPECTED_PRERELEASE)"
               exit 1
             fi
 
-            gh release edit "$TAG" \
+            retry --retries 3 --backoff 5 --max-backoff 30 -- gh release edit "$TAG" \
               --title "$TAG" \
               --notes-file /tmp/smoke-test-release-notes.md
             echo "Updated existing release '$TAG' with expected prerelease=$EXPECTED_PRERELEASE."
           else
             if [ "$RELEASE_LOOKUP_STATUS" = "404" ]; then
               if [ "$EXPECTED_PRERELEASE" = "true" ]; then
-                gh release create "$TAG" \
+                retry --retries 3 --backoff 5 --max-backoff 30 -- gh release create "$TAG" \
                   --title "$TAG" \
                   --notes-file /tmp/smoke-test-release-notes.md \
                   --prerelease
               else
-                gh release create "$TAG" \
+                retry --retries 3 --backoff 5 --max-backoff 30 -- gh release create "$TAG" \
                   --title "$TAG" \
                   --notes-file /tmp/smoke-test-release-notes.md
               fi
@@ -374,7 +435,7 @@ jobs:
     name: Dispatch summary
     runs-on: ubuntu-22.04
     timeout-minutes: 5
-    needs: [validate, deploy, publish-release]
+    needs: [validate, resolve-image, deploy, publish-release]
     if: always()
     steps:
       - name: Write source context summary

--- a/assets/smoke-test/.vig-os
+++ b/assets/smoke-test/.vig-os
@@ -1,0 +1,2 @@
+# smoke-test devcontainer image configuration
+DEVCONTAINER_VERSION=latest

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -73,6 +73,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Smoke-test release lookup no longer treats missing tags as existing releases** ([#355](https://github.com/vig-os/devcontainer/issues/355))
   - Change `assets/smoke-test/.github/workflows/repository-dispatch.yml` to branch on `gh api` exit status when querying `releases/tags/<tag>`
   - Ensure missing release tags follow the create path instead of failing with `prerelease=null` mismatch
+- **Bounded retry added for network-dependent setup and prepare-release calls** ([#357](https://github.com/vig-os/devcontainer/issues/357))
+  - Replace shell-based retry helper with pure Python `retry` CLI in `vig-utils` (`packages/vig-utils/src/vig_utils/retry.py`)
+  - Update this repository CI workflows to call `uv run retry` after `setup-env` dependency sync
+  - Update downstream workflow templates to call `retry` directly in devcontainer jobs and remove `source` lines
+  - Ensure downstream containerized jobs resolve image tags from `.vig-os` instead of hardcoded `latest`
+  - Bundle idempotency guards for branch/PR/tag/release creation paths to keep retried network calls safe on reruns
+  - Remove synced `retry.sh` artifacts and BATS retry tests in favor of `vig-utils` pytest coverage
 
 ### Security
 

--- a/assets/workspace/.github/actions/resolve-image/action.yml
+++ b/assets/workspace/.github/actions/resolve-image/action.yml
@@ -56,7 +56,8 @@ runs:
           fi
         fi
 
-        echo "tag=latest" >> "$GITHUB_OUTPUT"
+        echo "ERROR: Could not resolve DEVCONTAINER_VERSION from .vig-os and no image-tag override was provided."
+        exit 1
 
     - name: Validate image accessibility
       shell: bash

--- a/assets/workspace/.github/workflows/prepare-release.yml
+++ b/assets/workspace/.github/workflows/prepare-release.yml
@@ -171,7 +171,8 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          PREPARE_START_SHA=$(gh api "repos/${{ github.repository }}/git/ref/heads/dev" --jq '.object.sha')
+          PREPARE_START_SHA=$(retry --retries 3 --backoff 5 --max-backoff 60 -- \
+            gh api "repos/${{ github.repository }}/git/ref/heads/dev" --jq '.object.sha')
           echo "prepare_start_sha=$PREPARE_START_SHA" >> "$GITHUB_OUTPUT"
 
       - name: Prepare CHANGELOG (freeze + reset)
@@ -214,10 +215,19 @@ jobs:
           RELEASE_BRANCH: ${{ needs.validate.outputs.release_branch }}
         run: |
           set -euo pipefail
-          DEV_SHA=$(gh api "repos/${{ github.repository }}/git/ref/heads/dev" --jq '.object.sha')
-          gh api "repos/${{ github.repository }}/git/refs" \
+          DEV_SHA=$(retry --retries 3 --backoff 5 --max-backoff 60 -- \
+            gh api "repos/${{ github.repository }}/git/ref/heads/dev" --jq '.object.sha')
+          retry --retries 3 --backoff 5 --max-backoff 60 -- \
+            gh api "repos/${{ github.repository }}/git/refs" \
             -f ref="refs/heads/$RELEASE_BRANCH" \
-            -f sha="$DEV_SHA"
+            -f sha="$DEV_SHA" || {
+              if retry --retries 2 --backoff 5 --max-backoff 20 -- \
+                gh api "repos/${{ github.repository }}/git/ref/heads/$RELEASE_BRANCH" >/dev/null 2>&1; then
+                echo "Release branch already exists: $RELEASE_BRANCH"
+              else
+                exit 1
+              fi
+            }
           echo "dev_sha=$DEV_SHA" >> "$GITHUB_OUTPUT"
 
       - name: Strip empty Unreleased section for release branch
@@ -266,12 +276,19 @@ jobs:
           $CHANGELOG_CONTENT
           "
 
-          PR_URL=$(gh pr create \
-            --base main \
-            --head "$RELEASE_BRANCH" \
-            --title "chore: release $VERSION" \
-            --body "$PR_BODY" \
-            --draft)
+          EXISTING_PR_URL=$(retry --retries 3 --backoff 5 --max-backoff 60 -- \
+            gh pr list --head "$RELEASE_BRANCH" --base main --state open --json url --jq '.[0].url // empty')
+          if [ -n "$EXISTING_PR_URL" ]; then
+            PR_URL="$EXISTING_PR_URL"
+          else
+            PR_URL=$(retry --retries 3 --backoff 5 --max-backoff 60 -- \
+              gh pr create \
+                --base main \
+                --head "$RELEASE_BRANCH" \
+                --title "chore: release $VERSION" \
+                --body "$PR_BODY" \
+                --draft)
+          fi
 
           PR_NUMBER=$(echo "$PR_URL" | grep -oE '[0-9]+$')
           echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
@@ -287,21 +304,25 @@ jobs:
         run: |
           set -euo pipefail
           CHANGELOG_ROLLBACK_NEEDED=false
-          gh api -X DELETE "repos/${{ github.repository }}/git/refs/heads/$RELEASE_BRANCH" || true
+          retry --retries 3 --backoff 5 --max-backoff 60 -- \
+            gh api -X DELETE "repos/${{ github.repository }}/git/refs/heads/$RELEASE_BRANCH" || true
 
           if [ -z "${PREPARE_START_SHA:-}" ] || [ -z "${POST_FREEZE_DEV_SHA:-}" ]; then
             echo "changelog_rollback_needed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          CURRENT_DEV_SHA=$(gh api "repos/${{ github.repository }}/git/ref/heads/dev" --jq '.object.sha')
+          CURRENT_DEV_SHA=$(retry --retries 3 --backoff 5 --max-backoff 60 -- \
+            gh api "repos/${{ github.repository }}/git/ref/heads/dev" --jq '.object.sha')
           if [ "$CURRENT_DEV_SHA" != "$POST_FREEZE_DEV_SHA" ]; then
             echo "changelog_rollback_needed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          gh api "repos/${{ github.repository }}/contents/CHANGELOG.md?ref=$PREPARE_START_SHA" --jq '.content' | tr -d '\n' | base64 -d > /tmp/changelog.pre.md
-          gh api "repos/${{ github.repository }}/contents/CHANGELOG.md?ref=dev" --jq '.content' | tr -d '\n' | base64 -d > /tmp/changelog.current.md
+          retry --retries 3 --backoff 5 --max-backoff 60 -- \
+            gh api "repos/${{ github.repository }}/contents/CHANGELOG.md?ref=$PREPARE_START_SHA" --jq '.content' | tr -d '\n' | base64 -d > /tmp/changelog.pre.md
+          retry --retries 3 --backoff 5 --max-backoff 60 -- \
+            gh api "repos/${{ github.repository }}/contents/CHANGELOG.md?ref=dev" --jq '.content' | tr -d '\n' | base64 -d > /tmp/changelog.current.md
           if ! cmp -s /tmp/changelog.pre.md /tmp/changelog.current.md; then
             cp /tmp/changelog.pre.md CHANGELOG.md
             CHANGELOG_ROLLBACK_NEEDED=true

--- a/assets/workspace/.github/workflows/release-core.yml
+++ b/assets/workspace/.github/workflows/release-core.yml
@@ -68,9 +68,29 @@ permissions:
   contents: read
 
 jobs:
+  resolve-image:
+    name: Resolve image tag
+    runs-on: ubuntu-22.04
+    timeout-minutes: 2
+    outputs:
+      image-tag: ${{ steps.resolve.outputs.image-tag }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          sparse-checkout: .vig-os
+          sparse-checkout-cone-mode: false
+
+      - name: Resolve container image
+        id: resolve
+        uses: ./.github/actions/resolve-image
+
   validate:
     name: Validate Release Core
+    needs: [resolve-image]
     runs-on: ubuntu-22.04
+    container:
+      image: ghcr.io/vig-os/devcontainer:${{ needs.resolve-image.outputs.image-tag }}
     timeout-minutes: 10
     outputs:
       version: ${{ steps.vars.outputs.version }}
@@ -79,7 +99,7 @@ jobs:
       pre_finalize_sha: ${{ steps.pre_sha.outputs.pre_finalize_sha }}
       release_kind: ${{ steps.vars.outputs.release_kind }}
       publish_version: ${{ steps.publish_meta.outputs.publish_version }}
-      image_tag: ${{ steps.resolve_image.outputs.image_tag }}
+      image_tag: ${{ needs.resolve-image.outputs.image-tag }}
 
     steps:
       - name: Validate contract version
@@ -133,27 +153,14 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.auth.outputs.token }}
 
-      - name: Resolve container image tag
-        id: resolve_image
-        run: |
-          set -euo pipefail
-          TAG=""
-          if [ -f ".vig-os" ]; then
-            TAG=$(awk -F= '/^DEVCONTAINER_VERSION=/{gsub(/^[ \t"]+|[ \t"]+$/, "", $2); print $2; exit}' .vig-os || true)
-          fi
-          if [ -z "${TAG:-}" ]; then
-            TAG="latest"
-          fi
-          echo "image_tag=$TAG" >> "$GITHUB_OUTPUT"
-
       - name: Validate image accessibility
         env:
-          IMAGE_TAG: ${{ steps.resolve_image.outputs.image_tag }}
+          IMAGE_TAG: ${{ needs.resolve-image.outputs.image-tag }}
         run: |
           set -euo pipefail
           IMAGE="ghcr.io/vig-os/devcontainer:${IMAGE_TAG}"
           echo "Validating image availability: $IMAGE"
-          if ! docker manifest inspect "$IMAGE" > /dev/null 2>&1; then
+          if ! retry --retries 3 --backoff 5 --max-backoff 30 -- docker manifest inspect "$IMAGE" > /dev/null 2>&1; then
             echo "ERROR: Cannot access image manifest: $IMAGE"
             echo "Check whether the tag exists and whether this workflow has access to GHCR."
             exit 1
@@ -237,7 +244,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          PR_JSON=$(gh pr list \
+          PR_JSON=$(retry --retries 3 --backoff 5 --max-backoff 30 -- gh pr list \
             --head "release/$VERSION" \
             --base main \
             --json number,isDraft,reviewDecision,statusCheckRollup \
@@ -279,7 +286,7 @@ jobs:
           PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
           RELEASE_DATE: ${{ steps.vars.outputs.release_date }}
           DRY_RUN: ${{ inputs.dry_run }}
-          IMAGE_TAG: ${{ steps.resolve_image.outputs.image_tag }}
+          IMAGE_TAG: ${{ needs.resolve-image.outputs.image-tag }}
         run: |
           echo "Validation passed"
           echo ""
@@ -365,7 +372,8 @@ jobs:
           VERSION: ${{ needs.validate.outputs.version }}
         run: |
           set -euo pipefail
-          gh workflow run sync-issues.yml -f "target-branch=release/$VERSION"
+          retry --retries 2 --backoff 5 --max-backoff 20 -- \
+            gh workflow run sync-issues.yml -f "target-branch=release/$VERSION"
 
       - name: Wait for sync-issues completion
         if: ${{ inputs.release_kind == 'final' }}
@@ -417,7 +425,7 @@ jobs:
           VERSION: ${{ needs.validate.outputs.version }}
         run: |
           set -euo pipefail
-          git fetch origin "release/$VERSION"
+          retry --retries 3 --backoff 3 --max-backoff 20 -- git fetch origin "release/$VERSION"
           git reset --hard "origin/release/$VERSION"
 
       - name: Output finalize SHA
@@ -431,7 +439,8 @@ jobs:
           if [ "$RELEASE_KIND" = "final" ]; then
             FINALIZE_SHA=$(git rev-parse HEAD)
           else
-            FINALIZE_SHA=$(gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/release/$VERSION" --jq '.object.sha')
+            FINALIZE_SHA=$(retry --retries 3 --backoff 5 --max-backoff 30 -- \
+              gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/release/$VERSION" --jq '.object.sha')
           fi
           echo "finalize_sha=$FINALIZE_SHA" >> "$GITHUB_OUTPUT"
 

--- a/assets/workspace/.github/workflows/release-publish.yml
+++ b/assets/workspace/.github/workflows/release-publish.yml
@@ -134,9 +134,9 @@ jobs:
           set -euo pipefail
           git tag -a "$PUBLISH_VERSION" -m "Release $PUBLISH_VERSION"
           if ! retry --retries 3 --backoff 5 --max-backoff 30 -- git push origin "$PUBLISH_VERSION"; then
-            if git ls-remote --tags --refs origin "$PUBLISH_VERSION" | grep -q "refs/tags/$PUBLISH_VERSION$"; then
+            if retry --retries 3 --backoff 5 --max-backoff 30 -- git ls-remote --tags --refs origin "$PUBLISH_VERSION" | grep -q "refs/tags/$PUBLISH_VERSION$"; then
               LOCAL_TAG_TARGET_SHA=$(git rev-parse "$PUBLISH_VERSION^{}")
-              REMOTE_TAG_TARGET_SHA=$(git ls-remote --tags origin "refs/tags/$PUBLISH_VERSION^{}" | awk '{print $1}')
+              REMOTE_TAG_TARGET_SHA=$(retry --retries 3 --backoff 5 --max-backoff 30 -- git ls-remote --tags origin "refs/tags/$PUBLISH_VERSION^{}" | awk '{print $1}')
               if [ -z "$REMOTE_TAG_TARGET_SHA" ]; then
                 echo "ERROR: Remote tag exists but target SHA could not be resolved: $PUBLISH_VERSION"
                 exit 1

--- a/assets/workspace/.github/workflows/release-publish.yml
+++ b/assets/workspace/.github/workflows/release-publish.yml
@@ -52,9 +52,29 @@ permissions:
   contents: read
 
 jobs:
+  resolve-image:
+    name: Resolve image tag
+    runs-on: ubuntu-22.04
+    timeout-minutes: 2
+    outputs:
+      image-tag: ${{ steps.resolve.outputs.image-tag }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          sparse-checkout: .vig-os
+          sparse-checkout-cone-mode: false
+
+      - name: Resolve container image
+        id: resolve
+        uses: ./.github/actions/resolve-image
+
   publish:
     name: Publish Release
+    needs: [resolve-image]
     runs-on: ubuntu-22.04
+    container:
+      image: ghcr.io/vig-os/devcontainer:${{ needs.resolve-image.outputs.image-tag }}
     timeout-minutes: 10
     permissions:
       contents: write
@@ -113,7 +133,14 @@ jobs:
         run: |
           set -euo pipefail
           git tag -a "$PUBLISH_VERSION" -m "Release $PUBLISH_VERSION"
-          git push origin "$PUBLISH_VERSION"
+          if ! retry --retries 3 --backoff 5 --max-backoff 30 -- git push origin "$PUBLISH_VERSION"; then
+            if git ls-remote --tags --refs origin "$PUBLISH_VERSION" | grep -q "refs/tags/$PUBLISH_VERSION$"; then
+              echo "Tag already present on origin after push attempt: $PUBLISH_VERSION"
+            else
+              echo "ERROR: Failed to push tag $PUBLISH_VERSION"
+              exit 1
+            fi
+          fi
 
       - name: Extract release notes from CHANGELOG
         env:
@@ -136,14 +163,18 @@ jobs:
           GH_TOKEN: ${{ steps.auth.outputs.token }}
         run: |
           set -euo pipefail
+          if retry --retries 2 --backoff 5 --max-backoff 20 -- gh release view "$PUBLISH_VERSION" >/dev/null 2>&1; then
+            echo "ERROR: GitHub Release already exists for tag $PUBLISH_VERSION"
+            exit 1
+          fi
           if [ "$RELEASE_KIND" = "candidate" ]; then
-            gh release create "$PUBLISH_VERSION" \
+            retry --retries 3 --backoff 5 --max-backoff 30 -- gh release create "$PUBLISH_VERSION" \
               --title "$PUBLISH_VERSION" \
               --notes-file /tmp/release-notes.md \
               --verify-tag \
               --prerelease
           else
-            gh release create "$PUBLISH_VERSION" \
+            retry --retries 3 --backoff 5 --max-backoff 30 -- gh release create "$PUBLISH_VERSION" \
               --title "$PUBLISH_VERSION" \
               --notes-file /tmp/release-notes.md \
               --verify-tag

--- a/assets/workspace/.github/workflows/release-publish.yml
+++ b/assets/workspace/.github/workflows/release-publish.yml
@@ -135,7 +135,19 @@ jobs:
           git tag -a "$PUBLISH_VERSION" -m "Release $PUBLISH_VERSION"
           if ! retry --retries 3 --backoff 5 --max-backoff 30 -- git push origin "$PUBLISH_VERSION"; then
             if git ls-remote --tags --refs origin "$PUBLISH_VERSION" | grep -q "refs/tags/$PUBLISH_VERSION$"; then
-              echo "Tag already present on origin after push attempt: $PUBLISH_VERSION"
+              LOCAL_TAG_TARGET_SHA=$(git rev-parse "$PUBLISH_VERSION^{}")
+              REMOTE_TAG_TARGET_SHA=$(git ls-remote --tags origin "refs/tags/$PUBLISH_VERSION^{}" | awk '{print $1}')
+              if [ -z "$REMOTE_TAG_TARGET_SHA" ]; then
+                echo "ERROR: Remote tag exists but target SHA could not be resolved: $PUBLISH_VERSION"
+                exit 1
+              fi
+              if [ "$REMOTE_TAG_TARGET_SHA" != "$LOCAL_TAG_TARGET_SHA" ]; then
+                echo "ERROR: Remote tag target SHA mismatch for $PUBLISH_VERSION"
+                echo "Local tag target:  $LOCAL_TAG_TARGET_SHA"
+                echo "Remote tag target: $REMOTE_TAG_TARGET_SHA"
+                exit 1
+              fi
+              echo "Tag already present on origin with matching target SHA: $PUBLISH_VERSION"
             else
               echo "ERROR: Failed to push tag $PUBLISH_VERSION"
               exit 1

--- a/assets/workspace/.github/workflows/release.yml
+++ b/assets/workspace/.github/workflows/release.yml
@@ -82,6 +82,8 @@ jobs:
     name: Rollback on Failure
     needs: [core, extension, publish]
     runs-on: ubuntu-22.04
+    container:
+      image: ghcr.io/vig-os/devcontainer:${{ needs.core.outputs.image_tag }}
     timeout-minutes: 10
     if: ${{ failure() && inputs.dry-run != true }}
     permissions:
@@ -111,10 +113,10 @@ jobs:
           PRE_SHA: ${{ needs.core.outputs.pre_finalize_sha }}
         run: |
           set -euo pipefail
-          git fetch origin "release/$VERSION"
+          retry --retries 3 --backoff 3 --max-backoff 20 -- git fetch origin "release/$VERSION"
           git checkout "release/$VERSION"
           if git reset --hard "$PRE_SHA" 2>/dev/null; then
-            if git push --force-with-lease origin "release/$VERSION"; then
+            if retry --retries 3 --backoff 5 --max-backoff 30 -- git push --force-with-lease origin "release/$VERSION"; then
               echo "Release branch rolled back"
             fi
           fi
@@ -125,8 +127,9 @@ jobs:
         env:
           PUBLISH_VERSION: ${{ needs.core.outputs.publish_version }}
         run: |
+          set -euo pipefail
           if git ls-remote origin "refs/tags/$PUBLISH_VERSION" | grep -q "$PUBLISH_VERSION"; then
-            git push origin ":refs/tags/$PUBLISH_VERSION" || true
+            retry --retries 3 --backoff 5 --max-backoff 30 -- git push origin ":refs/tags/$PUBLISH_VERSION" || true
           fi
 
       - name: Create failure issue
@@ -138,7 +141,7 @@ jobs:
         run: |
           set -euo pipefail
           WORKFLOW_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          gh issue create \
+          retry --retries 3 --backoff 5 --max-backoff 30 -- gh issue create \
             --title "Release $VERSION failed — automatic rollback" \
             --label "bug" \
             --body "Release $VERSION failed during the automated release workflow.

--- a/assets/workspace/.github/workflows/sync-issues.yml
+++ b/assets/workspace/.github/workflows/sync-issues.yml
@@ -63,6 +63,11 @@ jobs:
           ref: ${{ github.event.inputs.target-branch || 'dev' }}
           persist-credentials: false
 
+      - name: Set up environment
+        uses: ./.github/actions/setup-env
+        with:
+          sync-dependencies: 'true'
+
       - name: Restore sync state (last synced timestamp)
         id: restore-state
         uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306  # v5.0.3

--- a/assets/workspace/.github/workflows/sync-issues.yml
+++ b/assets/workspace/.github/workflows/sync-issues.yml
@@ -36,8 +36,30 @@ on:  # yamllint disable-line rule:truthy
 permissions: {}  # restrict default; job declares its own
 
 jobs:
-  sync:
+  resolve-image:
+    name: Resolve image tag
     runs-on: ubuntu-22.04
+    timeout-minutes: 2
+    permissions:
+      contents: read
+    outputs:
+      image-tag: ${{ steps.resolve.outputs.image-tag }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          sparse-checkout: .vig-os
+          sparse-checkout-cone-mode: false
+
+      - name: Resolve container image
+        id: resolve
+        uses: ./.github/actions/resolve-image
+
+  sync:
+    needs: [resolve-image]
+    runs-on: ubuntu-22.04
+    container:
+      image: ghcr.io/vig-os/devcontainer:${{ needs.resolve-image.outputs.image-tag }}
     timeout-minutes: 10
     # Prevent concurrent runs to avoid race conditions when committing and cache collisions
     concurrency:
@@ -63,11 +85,6 @@ jobs:
           ref: ${{ github.event.inputs.target-branch || 'dev' }}
           persist-credentials: false
 
-      - name: Set up environment
-        uses: ./.github/actions/setup-env
-        with:
-          sync-dependencies: 'true'
-
       - name: Restore sync state (last synced timestamp)
         id: restore-state
         uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306  # v5.0.3
@@ -88,11 +105,11 @@ jobs:
           sleep 2
           # Try to delete cache using GitHub API
           CACHE_KEY="sync-issues-state-${{ github.repository }}"
-          CACHE_ID=$(uv run retry --retries 3 --backoff 3 --max-backoff 15 -- \
+          CACHE_ID=$(retry --retries 3 --backoff 3 --max-backoff 15 -- \
             gh api repos/${{ github.repository }}/actions/caches --jq ".actions_caches[] | select(.key == \"$CACHE_KEY\") | .id" | head -1)
           if [ -n "$CACHE_ID" ]; then
             echo "Found cache ID: $CACHE_ID, attempting deletion..."
-            uv run retry --retries 3 --backoff 3 --max-backoff 15 -- \
+            retry --retries 3 --backoff 3 --max-backoff 15 -- \
               gh api repos/${{ github.repository }}/actions/caches/$CACHE_ID -X DELETE && echo "Cache deleted successfully" || echo "Cache deletion failed (may be locked or already deleted)"
           else
             echo "No cache found with key: $CACHE_KEY (this is OK for first run)"

--- a/assets/workspace/.github/workflows/sync-issues.yml
+++ b/assets/workspace/.github/workflows/sync-issues.yml
@@ -83,10 +83,12 @@ jobs:
           sleep 2
           # Try to delete cache using GitHub API
           CACHE_KEY="sync-issues-state-${{ github.repository }}"
-          CACHE_ID=$(gh api repos/${{ github.repository }}/actions/caches --jq ".actions_caches[] | select(.key == \"$CACHE_KEY\") | .id" | head -1)
+          CACHE_ID=$(uv run retry --retries 3 --backoff 3 --max-backoff 15 -- \
+            gh api repos/${{ github.repository }}/actions/caches --jq ".actions_caches[] | select(.key == \"$CACHE_KEY\") | .id" | head -1)
           if [ -n "$CACHE_ID" ]; then
             echo "Found cache ID: $CACHE_ID, attempting deletion..."
-            gh api repos/${{ github.repository }}/actions/caches/$CACHE_ID -X DELETE && echo "Cache deleted successfully" || echo "Cache deletion failed (may be locked or already deleted)"
+            uv run retry --retries 3 --backoff 3 --max-backoff 15 -- \
+              gh api repos/${{ github.repository }}/actions/caches/$CACHE_ID -X DELETE && echo "Cache deleted successfully" || echo "Cache deletion failed (may be locked or already deleted)"
           else
             echo "No cache found with key: $CACHE_KEY (this is OK for first run)"
           fi

--- a/assets/workspace/.github/workflows/sync-main-to-dev.yml
+++ b/assets/workspace/.github/workflows/sync-main-to-dev.yml
@@ -49,6 +49,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Set up environment
+        uses: ./.github/actions/setup-env
+        with:
+          sync-dependencies: 'true'
+
       - name: Check if dev is up to date with main
         id: check
         run: |
@@ -98,6 +103,11 @@ jobs:
           ref: dev
           fetch-depth: 0
           token: ${{ steps.commit-app-token.outputs.token }}
+
+      - name: Set up environment
+        uses: ./.github/actions/setup-env
+        with:
+          sync-dependencies: 'true'
 
       - name: Re-check if dev is still behind main
         id: recheck

--- a/assets/workspace/.github/workflows/sync-main-to-dev.yml
+++ b/assets/workspace/.github/workflows/sync-main-to-dev.yml
@@ -53,7 +53,7 @@ jobs:
         id: check
         run: |
           set -euo pipefail
-          git fetch origin main dev
+          uv run retry --retries 3 --backoff 3 --max-backoff 20 -- git fetch origin main dev
           if ! git show-ref --verify --quiet refs/remotes/origin/main; then
             echo "Error: remote branch 'origin/main' not found after fetch."
             exit 1
@@ -103,7 +103,7 @@ jobs:
         id: recheck
         run: |
           set -euo pipefail
-          git fetch origin main dev
+          uv run retry --retries 3 --backoff 3 --max-backoff 20 -- git fetch origin main dev
           BEHIND=$(git rev-list --count origin/main ^origin/dev)
           if [ "${BEHIND}" = "0" ]; then
             echo "up_to_date=true" >> "$GITHUB_OUTPUT"
@@ -128,7 +128,8 @@ jobs:
           GH_TOKEN: ${{ steps.release-app-token.outputs.token }}
         run: |
           set -euo pipefail
-          OPEN=$(gh pr list --base dev --state open --limit 200 \
+          OPEN=$(uv run retry --retries 3 --backoff 5 --max-backoff 30 -- \
+            gh pr list --base dev --state open --limit 200 \
             --json headRefName \
             --jq '[.[] | select(.headRefName | startswith("chore/sync-main-to-dev-"))] | length')
           echo "count=${OPEN}" >> "$GITHUB_OUTPUT"
@@ -142,13 +143,16 @@ jobs:
           GH_TOKEN: ${{ steps.commit-app-token.outputs.token }}
         run: |
           set -euo pipefail
-          REFS=$(gh api --paginate "repos/${{ github.repository }}/git/matching-refs/heads/chore/sync-main-to-dev-" \
+          REFS=$(uv run retry --retries 3 --backoff 5 --max-backoff 30 -- \
+            gh api --paginate "repos/${{ github.repository }}/git/matching-refs/heads/chore/sync-main-to-dev-" \
             --jq '.[].ref' | sed 's|refs/heads/||') || true
           for branch in ${REFS}; do
-            HAS_PR=$(GH_TOKEN="${{ steps.release-app-token.outputs.token }}" gh pr list --base dev --head "${branch}" \
+            HAS_PR=$(GH_TOKEN="${{ steps.release-app-token.outputs.token }}" uv run retry --retries 3 --backoff 5 --max-backoff 30 -- \
+              gh pr list --base dev --head "${branch}" \
               --state open --json number --jq 'length')
             if [ "${HAS_PR}" = "0" ]; then
-              gh api -X DELETE "repos/${{ github.repository }}/git/refs/heads/${branch}" 2>/dev/null || true
+              uv run retry --retries 3 --backoff 5 --max-backoff 30 -- \
+                gh api -X DELETE "repos/${{ github.repository }}/git/refs/heads/${branch}" 2>/dev/null || true
               echo "Deleted stale sync branch: ${branch}"
             fi
           done
@@ -158,7 +162,7 @@ jobs:
         id: merge-check
         run: |
           set -euo pipefail
-          git fetch origin main
+          uv run retry --retries 3 --backoff 3 --max-backoff 20 -- git fetch origin main
           if git merge --no-commit --no-ff origin/main 2>/dev/null; then
             echo "conflict=false" >> "$GITHUB_OUTPUT"
           else
@@ -173,9 +177,17 @@ jobs:
         run: |
           set -euo pipefail
           MAIN_SHA=$(git rev-parse origin/main)
-          gh api "repos/${{ github.repository }}/git/refs" \
+          uv run retry --retries 3 --backoff 5 --max-backoff 30 -- \
+            gh api "repos/${{ github.repository }}/git/refs" \
             -f ref="refs/heads/${SYNC_BRANCH}" \
-            -f sha="${MAIN_SHA}"
+            -f sha="${MAIN_SHA}" || {
+              if uv run retry --retries 2 --backoff 5 --max-backoff 20 -- \
+                gh api "repos/${{ github.repository }}/git/ref/heads/${SYNC_BRANCH}" >/dev/null 2>&1; then
+                echo "Sync branch already exists: ${SYNC_BRANCH}"
+              else
+                exit 1
+              fi
+            }
           echo "Sync branch ${SYNC_BRANCH} created from main at ${MAIN_SHA}"
 
       - name: Create PR
@@ -211,14 +223,22 @@ jobs:
             BODY="Syncs \`dev\` with \`main\` (sync-main-to-dev workflow)."
           fi
 
-          PR_URL=$(gh pr create --base dev --head "${SYNC_BRANCH}" \
-            --title "${TITLE}" --body "${BODY}")
+          EXISTING_PR_URL=$(uv run retry --retries 3 --backoff 5 --max-backoff 30 -- \
+            gh pr list --base dev --head "${SYNC_BRANCH}" --state open --json url --jq '.[0].url // empty')
+          if [ -n "${EXISTING_PR_URL}" ]; then
+            PR_URL="${EXISTING_PR_URL}"
+          else
+            PR_URL=$(uv run retry --retries 3 --backoff 5 --max-backoff 30 -- \
+              gh pr create --base dev --head "${SYNC_BRANCH}" \
+                --title "${TITLE}" --body "${BODY}")
+          fi
           echo "pr_url=${PR_URL}" >> "$GITHUB_OUTPUT"
           echo "Created PR: ${PR_URL}"
 
           if [ "${CONFLICT}" = "true" ]; then
             gh label create "merge-conflict" --color "B60205" --force 2>/dev/null || true
-            gh pr edit "${SYNC_BRANCH}" --add-label "merge-conflict" || \
+            uv run retry --retries 3 --backoff 5 --max-backoff 30 -- \
+              gh pr edit "${SYNC_BRANCH}" --add-label "merge-conflict" || \
               echo "Warning: failed to add merge-conflict label."
           fi
 
@@ -231,5 +251,6 @@ jobs:
           PR_URL: ${{ steps.create-pr.outputs.pr_url }}
         run: |
           set -euo pipefail
-          gh pr merge "${PR_URL}" --auto --merge || \
+          uv run retry --retries 2 --backoff 5 --max-backoff 20 -- \
+            gh pr merge "${PR_URL}" --auto --merge || \
             echo "Warning: could not enable auto-merge (may require branch protection settings)"

--- a/assets/workspace/.github/workflows/sync-main-to-dev.yml
+++ b/assets/workspace/.github/workflows/sync-main-to-dev.yml
@@ -36,9 +36,29 @@ permissions:
   contents: read
 
 jobs:
+  resolve-image:
+    name: Resolve image tag
+    runs-on: ubuntu-22.04
+    timeout-minutes: 2
+    outputs:
+      image-tag: ${{ steps.resolve.outputs.image-tag }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          sparse-checkout: .vig-os
+          sparse-checkout-cone-mode: false
+
+      - name: Resolve container image
+        id: resolve
+        uses: ./.github/actions/resolve-image
+
   check:
     name: Check if dev is up to date
+    needs: [resolve-image]
     runs-on: ubuntu-22.04
+    container:
+      image: ghcr.io/vig-os/devcontainer:${{ needs.resolve-image.outputs.image-tag }}
     timeout-minutes: 5
     outputs:
       up_to_date: ${{ steps.check.outputs.up_to_date }}
@@ -49,16 +69,11 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up environment
-        uses: ./.github/actions/setup-env
-        with:
-          sync-dependencies: 'true'
-
       - name: Check if dev is up to date with main
         id: check
         run: |
           set -euo pipefail
-          uv run retry --retries 3 --backoff 3 --max-backoff 20 -- git fetch origin main dev
+          retry --retries 3 --backoff 3 --max-backoff 20 -- git fetch origin main dev
           if ! git show-ref --verify --quiet refs/remotes/origin/main; then
             echo "Error: remote branch 'origin/main' not found after fetch."
             exit 1
@@ -78,9 +93,11 @@ jobs:
 
   sync:
     name: Merge main into dev via PR
-    needs: check
+    needs: [resolve-image, check]
     if: needs.check.outputs.up_to_date != 'true'
     runs-on: ubuntu-22.04
+    container:
+      image: ghcr.io/vig-os/devcontainer:${{ needs.resolve-image.outputs.image-tag }}
     timeout-minutes: 10
     env:
       SYNC_BRANCH: chore/sync-main-to-dev-${{ github.run_number }}-${{ github.run_attempt }}
@@ -104,16 +121,11 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.commit-app-token.outputs.token }}
 
-      - name: Set up environment
-        uses: ./.github/actions/setup-env
-        with:
-          sync-dependencies: 'true'
-
       - name: Re-check if dev is still behind main
         id: recheck
         run: |
           set -euo pipefail
-          uv run retry --retries 3 --backoff 3 --max-backoff 20 -- git fetch origin main dev
+          retry --retries 3 --backoff 3 --max-backoff 20 -- git fetch origin main dev
           BEHIND=$(git rev-list --count origin/main ^origin/dev)
           if [ "${BEHIND}" = "0" ]; then
             echo "up_to_date=true" >> "$GITHUB_OUTPUT"
@@ -138,7 +150,7 @@ jobs:
           GH_TOKEN: ${{ steps.release-app-token.outputs.token }}
         run: |
           set -euo pipefail
-          OPEN=$(uv run retry --retries 3 --backoff 5 --max-backoff 30 -- \
+          OPEN=$(retry --retries 3 --backoff 5 --max-backoff 30 -- \
             gh pr list --base dev --state open --limit 200 \
             --json headRefName \
             --jq '[.[] | select(.headRefName | startswith("chore/sync-main-to-dev-"))] | length')
@@ -153,15 +165,15 @@ jobs:
           GH_TOKEN: ${{ steps.commit-app-token.outputs.token }}
         run: |
           set -euo pipefail
-          REFS=$(uv run retry --retries 3 --backoff 5 --max-backoff 30 -- \
+          REFS=$(retry --retries 3 --backoff 5 --max-backoff 30 -- \
             gh api --paginate "repos/${{ github.repository }}/git/matching-refs/heads/chore/sync-main-to-dev-" \
             --jq '.[].ref' | sed 's|refs/heads/||') || true
           for branch in ${REFS}; do
-            HAS_PR=$(GH_TOKEN="${{ steps.release-app-token.outputs.token }}" uv run retry --retries 3 --backoff 5 --max-backoff 30 -- \
+            HAS_PR=$(GH_TOKEN="${{ steps.release-app-token.outputs.token }}" retry --retries 3 --backoff 5 --max-backoff 30 -- \
               gh pr list --base dev --head "${branch}" \
               --state open --json number --jq 'length')
             if [ "${HAS_PR}" = "0" ]; then
-              uv run retry --retries 3 --backoff 5 --max-backoff 30 -- \
+              retry --retries 3 --backoff 5 --max-backoff 30 -- \
                 gh api -X DELETE "repos/${{ github.repository }}/git/refs/heads/${branch}" 2>/dev/null || true
               echo "Deleted stale sync branch: ${branch}"
             fi
@@ -172,7 +184,7 @@ jobs:
         id: merge-check
         run: |
           set -euo pipefail
-          uv run retry --retries 3 --backoff 3 --max-backoff 20 -- git fetch origin main
+          retry --retries 3 --backoff 3 --max-backoff 20 -- git fetch origin main
           if git merge --no-commit --no-ff origin/main 2>/dev/null; then
             echo "conflict=false" >> "$GITHUB_OUTPUT"
           else
@@ -187,11 +199,11 @@ jobs:
         run: |
           set -euo pipefail
           MAIN_SHA=$(git rev-parse origin/main)
-          uv run retry --retries 3 --backoff 5 --max-backoff 30 -- \
+          retry --retries 3 --backoff 5 --max-backoff 30 -- \
             gh api "repos/${{ github.repository }}/git/refs" \
             -f ref="refs/heads/${SYNC_BRANCH}" \
             -f sha="${MAIN_SHA}" || {
-              if uv run retry --retries 2 --backoff 5 --max-backoff 20 -- \
+              if retry --retries 2 --backoff 5 --max-backoff 20 -- \
                 gh api "repos/${{ github.repository }}/git/ref/heads/${SYNC_BRANCH}" >/dev/null 2>&1; then
                 echo "Sync branch already exists: ${SYNC_BRANCH}"
               else
@@ -233,12 +245,12 @@ jobs:
             BODY="Syncs \`dev\` with \`main\` (sync-main-to-dev workflow)."
           fi
 
-          EXISTING_PR_URL=$(uv run retry --retries 3 --backoff 5 --max-backoff 30 -- \
+          EXISTING_PR_URL=$(retry --retries 3 --backoff 5 --max-backoff 30 -- \
             gh pr list --base dev --head "${SYNC_BRANCH}" --state open --json url --jq '.[0].url // empty')
           if [ -n "${EXISTING_PR_URL}" ]; then
             PR_URL="${EXISTING_PR_URL}"
           else
-            PR_URL=$(uv run retry --retries 3 --backoff 5 --max-backoff 30 -- \
+            PR_URL=$(retry --retries 3 --backoff 5 --max-backoff 30 -- \
               gh pr create --base dev --head "${SYNC_BRANCH}" \
                 --title "${TITLE}" --body "${BODY}")
           fi
@@ -247,7 +259,7 @@ jobs:
 
           if [ "${CONFLICT}" = "true" ]; then
             gh label create "merge-conflict" --color "B60205" --force 2>/dev/null || true
-            uv run retry --retries 3 --backoff 5 --max-backoff 30 -- \
+            retry --retries 3 --backoff 5 --max-backoff 30 -- \
               gh pr edit "${SYNC_BRANCH}" --add-label "merge-conflict" || \
               echo "Warning: failed to add merge-conflict label."
           fi
@@ -261,6 +273,6 @@ jobs:
           PR_URL: ${{ steps.create-pr.outputs.pr_url }}
         run: |
           set -euo pipefail
-          uv run retry --retries 2 --backoff 5 --max-backoff 20 -- \
+          retry --retries 2 --backoff 5 --max-backoff 20 -- \
             gh pr merge "${PR_URL}" --auto --merge || \
             echo "Warning: could not enable auto-merge (may require branch protection settings)"

--- a/packages/vig-utils/pyproject.toml
+++ b/packages/vig-utils/pyproject.toml
@@ -27,6 +27,7 @@ resolve-branch = "vig_utils.resolve_branch:main"
 derive-branch-summary = "vig_utils.derive_branch_summary:main"
 check-skill-names = "vig_utils.check_skill_names:main"
 setup-labels = "vig_utils.setup_labels:main"
+retry = "vig_utils.retry:main"
 vig-utils = "vig_utils.utils:main"
 
 [tool.hatch.build.targets.wheel]

--- a/packages/vig-utils/src/vig_utils/retry.py
+++ b/packages/vig-utils/src/vig_utils/retry.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Retry CLI for transient command failures with bounded exponential backoff.
+
+Use `uv run retry -- ...` on bare runners that execute within the repository's
+Python environment, or `retry -- ...` in devcontainer jobs where the command is
+already available on PATH.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import time
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+
+def _parse_positive_int(value: str, option_name: str) -> int:
+    if not value.isdigit() or int(value) <= 0:
+        raise ValueError(f"retry: {option_name} must be a positive integer")
+    return int(value)
+
+
+def parse_cli(argv: Sequence[str]) -> tuple[int, int, int, list[str]]:
+    """Parse retry options and command from argv (without program name)."""
+    retries = 3
+    backoff = 5
+    max_backoff = 60
+    command_start = None
+    i = 0
+
+    while i < len(argv):
+        arg = argv[i]
+        if arg == "--":
+            command_start = i + 1
+            break
+        if arg == "--retries":
+            if i + 1 >= len(argv):
+                raise ValueError("retry: missing value for '--retries'")
+            retries = _parse_positive_int(argv[i + 1], "--retries")
+            i += 2
+            continue
+        if arg == "--backoff":
+            if i + 1 >= len(argv):
+                raise ValueError("retry: missing value for '--backoff'")
+            backoff = _parse_positive_int(argv[i + 1], "--backoff")
+            i += 2
+            continue
+        if arg == "--max-backoff":
+            if i + 1 >= len(argv):
+                raise ValueError("retry: missing value for '--max-backoff'")
+            max_backoff = _parse_positive_int(argv[i + 1], "--max-backoff")
+            i += 2
+            continue
+        raise ValueError(f"retry: unknown option '{arg}'")
+
+    if command_start is None or command_start >= len(argv):
+        raise ValueError("retry: missing command after '--'")
+
+    return retries, backoff, max_backoff, list(argv[command_start:])
+
+
+def retry_command(
+    command: list[str],
+    *,
+    retries: int,
+    backoff: int,
+    max_backoff: int,
+) -> int:
+    """Run command with bounded exponential retry."""
+    exit_code = 0
+    for attempt in range(1, retries + 1):
+        result = subprocess.run(
+            command,
+            stdin=sys.stdin,
+            stdout=sys.stdout,
+            stderr=sys.stderr,
+            check=False,
+        )
+        if result.returncode == 0:
+            return 0
+        exit_code = result.returncode
+
+        if attempt == retries:
+            print(
+                f"Command failed after {retries}/{retries} attempts (exit: {exit_code})",
+                file=sys.stderr,
+            )
+            return exit_code
+
+        wait_seconds = min(backoff * (1 << (attempt - 1)), max_backoff)
+        print(
+            f"Attempt {attempt}/{retries} failed (exit: {exit_code}); retrying in {wait_seconds}s...",
+            file=sys.stderr,
+        )
+        time.sleep(wait_seconds)
+    return exit_code
+
+
+def main() -> int:
+    try:
+        retries, backoff, max_backoff, command = parse_cli(sys.argv[1:])
+    except ValueError as error:
+        print(str(error), file=sys.stderr)
+        return 2
+
+    return retry_command(
+        command,
+        retries=retries,
+        backoff=backoff,
+        max_backoff=max_backoff,
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/vig-utils/src/vig_utils/retry.py
+++ b/packages/vig-utils/src/vig_utils/retry.py
@@ -17,6 +17,14 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
 
+def _execution_error_exit_code(error: OSError) -> int:
+    if isinstance(error, FileNotFoundError):
+        return 127
+    if isinstance(error, PermissionError):
+        return 126
+    return 1
+
+
 def _parse_positive_int(value: str, option_name: str) -> int:
     if not value.isdigit() or int(value) <= 0:
         raise ValueError(f"retry: {option_name} must be a positive integer")
@@ -70,15 +78,23 @@ def retry_command(
     max_backoff: int,
 ) -> int:
     """Run command with bounded exponential retry."""
+    command_display = " ".join(command)
     exit_code = 0
     for attempt in range(1, retries + 1):
-        result = subprocess.run(
-            command,
-            stdin=sys.stdin,
-            stdout=sys.stdout,
-            stderr=sys.stderr,
-            check=False,
-        )
+        try:
+            result = subprocess.run(
+                command,
+                stdin=sys.stdin,
+                stdout=sys.stdout,
+                stderr=sys.stderr,
+                check=False,
+            )
+        except OSError as error:
+            print(
+                f"retry: failed to execute command: {command_display} ({error})",
+                file=sys.stderr,
+            )
+            return _execution_error_exit_code(error)
         if result.returncode == 0:
             return 0
         exit_code = result.returncode

--- a/packages/vig-utils/tests/test_retry.py
+++ b/packages/vig-utils/tests/test_retry.py
@@ -1,0 +1,134 @@
+"""Tests for the retry CLI."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from vig_utils import retry
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def test_retry_happy_path_succeeds_first_attempt(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = {"count": 0}
+
+    def fake_run(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        calls["count"] += 1
+        return subprocess.CompletedProcess(args=["true"], returncode=0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    rc = retry.retry_command(["true"], retries=3, backoff=1, max_backoff=2)
+    assert rc == 0
+    assert calls["count"] == 1
+
+
+def test_retry_retries_then_succeeds(monkeypatch: pytest.MonkeyPatch) -> None:
+    attempts = {"count": 0}
+    sleep_calls: list[int] = []
+
+    def fake_run(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        attempts["count"] += 1
+        if attempts["count"] < 3:
+            return subprocess.CompletedProcess(args=["cmd"], returncode=42)
+        return subprocess.CompletedProcess(args=["cmd"], returncode=0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr(retry.time, "sleep", sleep_calls.append)
+
+    rc = retry.retry_command(["cmd"], retries=4, backoff=2, max_backoff=10)
+
+    assert rc == 0
+    assert attempts["count"] == 3
+    assert sleep_calls == [2, 4]
+
+
+def test_retry_exhausts_attempts_and_returns_last_exit_code(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    sleep_calls: list[int] = []
+
+    def fake_run(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(args=["cmd"], returncode=17)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr(retry.time, "sleep", sleep_calls.append)
+
+    rc = retry.retry_command(["cmd"], retries=3, backoff=1, max_backoff=5)
+    captured = capsys.readouterr()
+
+    assert rc == 17
+    assert sleep_calls == [1, 2]
+    assert "Command failed after 3/3 attempts (exit: 17)" in captured.err
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["--retries", "3", "--backoff", "1", "--max-backoff", "1", "--"],
+        ["--retries", "0", "--backoff", "1", "--max-backoff", "1", "--", "true"],
+        ["--retries", "3", "--backoff", "nope", "--max-backoff", "1", "--", "true"],
+    ],
+)
+def test_retry_input_validation_returns_exit_2(
+    monkeypatch: pytest.MonkeyPatch, argv: list[str]
+) -> None:
+    monkeypatch.setattr(sys, "argv", ["retry", *argv])
+    rc = retry.main()
+    assert rc == 2
+
+
+def test_retry_caps_backoff_with_max_backoff(monkeypatch: pytest.MonkeyPatch) -> None:
+    sleep_calls: list[int] = []
+
+    def fake_run(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(args=["cmd"], returncode=1)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr(retry.time, "sleep", sleep_calls.append)
+
+    rc = retry.retry_command(["cmd"], retries=4, backoff=5, max_backoff=6)
+
+    assert rc == 1
+    assert sleep_calls == [5, 6, 6]
+
+
+def test_retry_idempotent_for_successful_commands(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_run(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(args=["true"], returncode=0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    rc1 = retry.retry_command(["true"], retries=2, backoff=1, max_backoff=1)
+    rc2 = retry.retry_command(["true"], retries=2, backoff=1, max_backoff=1)
+
+    assert rc1 == rc2 == 0
+
+
+def test_retry_cli_module_invocation_succeeds() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "vig_utils.retry",
+            "--retries",
+            "2",
+            "--backoff",
+            "1",
+            "--max-backoff",
+            "1",
+            "--",
+            "true",
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
+        cwd=REPO_ROOT,
+    )
+    assert result.returncode == 0, result.stderr

--- a/packages/vig-utils/tests/test_retry.py
+++ b/packages/vig-utils/tests/test_retry.py
@@ -132,3 +132,24 @@ def test_retry_cli_module_invocation_succeeds() -> None:
         cwd=REPO_ROOT,
     )
     assert result.returncode == 0, result.stderr
+
+
+def test_retry_handles_command_execution_oserror(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    sleep_calls: list[int] = []
+
+    def fake_run(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
+        raise FileNotFoundError(2, "No such file or directory", "missing-cmd")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr(retry.time, "sleep", sleep_calls.append)
+
+    rc = retry.retry_command(
+        ["missing-cmd", "--flag"], retries=3, backoff=1, max_backoff=5
+    )
+    captured = capsys.readouterr()
+
+    assert rc == 127
+    assert sleep_calls == []
+    assert "retry: failed to execute command: missing-cmd --flag" in captured.err


### PR DESCRIPTION
## Description

This PR hardens network-sensitive release and CI paths by replacing shell retries with the `vig-utils` Python `retry` CLI and making retry-safe workflow operations idempotent. It also syncs the same behavior into workspace templates and smoke-test dispatch logic to keep upstream and downstream workflows aligned.

## Type of Change

- [ ] `feat` -- New feature
- [x] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [ ] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- `packages/vig-utils/src/vig_utils/retry.py`
  - Added a bounded retry CLI implementation for network-dependent command execution.
- `packages/vig-utils/tests/test_retry.py`
  - Added pytest coverage for retry behavior and failure handling.
- `.github/actions/setup-env/action.yml`, `.github/actions/test-image/action.yml`
  - Updated setup/image test paths to use the retry CLI where network calls are sensitive.
- `.github/workflows/release.yml`, `.github/workflows/prepare-release.yml`, `.github/workflows/ci.yml`, `.github/workflows/sync-issues.yml`, `.github/workflows/sync-main-to-dev.yml`
  - Hardened release/sync/CI workflow steps with retry-safe execution and idempotency guards.
- `assets/smoke-test/.github/workflows/repository-dispatch.yml`
  - Improved dispatch flow resiliency and safe rerun behavior.
- `assets/workspace/.github/workflows/release-core.yml`, `assets/workspace/.github/workflows/release-publish.yml`, `assets/workspace/.github/workflows/release.yml`, `assets/workspace/.github/workflows/prepare-release.yml`, `assets/workspace/.github/workflows/sync-issues.yml`, `assets/workspace/.github/workflows/sync-main-to-dev.yml`, `assets/workspace/.github/actions/resolve-image/action.yml`
  - Synced downstream workflow templates to the retry CLI and image tag resolution updates.
- `CHANGELOG.md`, `assets/workspace/.devcontainer/CHANGELOG.md`, `packages/vig-utils/pyproject.toml`
  - Added the issue #357 changelog entry and package wiring for the new CLI.

## Changelog Entry

### Fixed
- **Bounded retry added for network-dependent setup and prepare-release calls** ([#357](https://github.com/vig-os/devcontainer/issues/357))
  - Replace shell-based retry helper with pure Python `retry` CLI in `vig-utils` (`packages/vig-utils/src/vig_utils/retry.py`)
  - Update this repository CI workflows to call `uv run retry` after `setup-env` dependency sync
  - Update downstream workflow templates to call `retry` directly in devcontainer jobs and remove `source` lines
  - Ensure downstream containerized jobs resolve image tags from `.vig-os` instead of hardcoded `latest`
  - Bundle idempotency guards for branch/PR/tag/release creation paths to keep retried network calls safe on reruns
  - Remove synced `retry.sh` artifacts and BATS retry tests in favor of `vig-utils` pytest coverage

## Testing

- [x] Tests pass locally (`just test`)
- [ ] Manual testing performed (describe below)

### Manual Testing Details

N/A

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [ ] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

N/A

Refs: #357
