### PR TITLE
chore: add temporary trivy ignore for CVE-2026-33186

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -105,6 +105,17 @@ CVE-2025-61730
 Expiration: 2026-04-15
 CVE-2025-15558
 
+# CVE-2026-33186: gRPC-Go authorization bypass via missing leading slash in :path
+# Risk Assessment: LOW (devcontainer context)
+# - CRITICAL severity in google.golang.org/grpc v1.79.2 embedded in gh v2.88.1
+# - Upstream gh latest release still ships grpc v1.79.2 in go.mod
+# - Fix is available in grpc v1.79.3 and requires upstream gh release/rebuild
+# - gh is used as a client to GitHub APIs in trusted workflows in this image
+# - Temporary exception to keep blocking policy for other HIGH/CRITICAL findings
+# - Tracking: https://github.com/vig-os/devcontainer/issues/361
+Expiration: 2026-05-15
+CVE-2026-33186
+
 # CVE-2026-31812: quinn-proto unauthenticated remote DoS via QUIC transport parameter panic
 # Risk Assessment: LOW (devcontainer context)
 # - HIGH severity in quinn-proto v0.11.12 embedded in uv/uvx Rust binaries


### PR DESCRIPTION
## Description

Add a temporary, time-bounded Trivy ignore entry for `CVE-2026-33186` to unblock CI while upstream `gh` still ships `google.golang.org/grpc v1.79.2`.

This preserves the blocking `HIGH,CRITICAL` gate behavior for all other findings and links the exception to the tracking issue.

## Type of Change

- [ ] `feat` -- New feature
- [ ] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [x] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [ ] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- Updated `.trivyignore` with a new exception block for `CVE-2026-33186`.
  - Added risk rationale specific to devcontainer usage.
  - Added expiration date (`2026-05-15`) for bounded acceptance.
  - Added issue tracking link to `#361`.

## Changelog Entry

No changelog needed: this is an internal CI vulnerability policy exception in `.trivyignore` to unblock scanning on `release/0.3.1`; it does not change runtime behavior, API, or user-facing functionality.

## Testing

- [ ] Tests pass locally (`just test`)
- [ ] Manual testing performed (describe below)

### Manual Testing Details

N/A

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [ ] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

Upstream verification at draft time:
- `cli/cli v2.88.1` still includes `google.golang.org/grpc v1.79.2` in `go.mod`.
- Trivy reports `CVE-2026-33186` as fixed in `1.79.3`.
- Exception is intentionally temporary and tracked by issue `#361`.

Refs: #361
