### PR TITLE
fix(ci): ensure release retry steps do not require implicit uv

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -7,11 +7,15 @@
 # - hadolint (for Containerfile linting in pre-commit)
 # - BATS + helper libraries (for shell script testing)
 #
-# IMPORTANT: The caller must checkout the repository before using this action.
-# This action does NOT checkout code, allowing callers to control ref, token,
-# persist-credentials, and other checkout options.
+# IMPORTANT:
+# - This action does NOT checkout code, allowing callers to control ref, token,
+#   persist-credentials, and other checkout options.
+# - Checkout is only required for operations that read repository files
+#   (for example, sync-dependencies or devcontainer CLI version lookup).
 #
 # Inputs:
+#   install-python:           Install Python (default: true)
+#   python-version:           Python version fallback when pyproject.toml is unavailable (default: '3.12')
 #   sync-dependencies:        Run uv sync to install project deps (default: false)
 #   install-podman:           Install podman (default: false)
 #   install-node:             Install Node.js (default: false)
@@ -25,9 +29,14 @@
 #   uv-version: The version of uv that was installed
 #
 # Usage:
-#   # Minimal (Python + uv only)
+#   # Default (Python + uv only)
 #   - uses: actions/checkout@v4
 #   - uses: ./.github/actions/setup-env
+#
+#   # uv only (skip Python setup)
+#   - uses: ./.github/actions/setup-env
+#     with:
+#       install-python: 'false'
 #
 #   # With project dependencies
 #   - uses: actions/checkout@v4
@@ -47,6 +56,14 @@ name: 'Setup Environment'
 description: 'Set up CI environment with Python, uv, and optional tools (podman, Node.js, devcontainer CLI, hadolint, BATS)'
 
 inputs:
+  install-python:
+    description: 'Install Python runtime'
+    required: false
+    default: 'true'
+  python-version:
+    description: 'Python version fallback when pyproject.toml is unavailable'
+    required: false
+    default: '3.12'
   sync-dependencies:
     description: 'Run uv sync to install project dependencies'
     required: false
@@ -93,10 +110,17 @@ runs:
   using: composite
   steps:
     # ── Python ───────────────────────────────────────────────────────────
-    - name: "Set up Python"
+    - name: "Set up Python from pyproject"
+      if: inputs.install-python == 'true' && hashFiles('pyproject.toml') != ''
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
       with:
         python-version-file: "pyproject.toml"
+
+    - name: "Set up Python fallback"
+      if: inputs.install-python == 'true' && hashFiles('pyproject.toml') == ''
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
+      with:
+        python-version: ${{ inputs.python-version }}
 
     # ── uv ─────────────────────────────────────────────────────────────
     - name: Install uv
@@ -106,6 +130,86 @@ runs:
         enable-cache: true
         # Install a specific version of uv.
         version: "0.10.0"
+
+    # ── retry() shell helper ───────────────────────────────────────────
+    - name: Export retry helper function
+      shell: bash
+      run: |
+        set -euo pipefail
+        RETRY_HELPER="$RUNNER_TEMP/setup-env-retry.sh"
+        PREV_BASH_ENV="${BASH_ENV:-}"
+
+        cat > "$RETRY_HELPER" <<'EOF'
+        retry() {
+          local retries=3
+          local backoff=1
+          local max_backoff=60
+          local rc=1
+
+          while [ "$#" -gt 0 ]; do
+            case "$1" in
+              --retries)
+                retries="$2"
+                shift 2
+                ;;
+              --backoff)
+                backoff="$2"
+                shift 2
+                ;;
+              --max-backoff)
+                max_backoff="$2"
+                shift 2
+                ;;
+              --)
+                shift
+                break
+                ;;
+              *)
+                echo "ERROR: Unknown retry option '$1'"
+                return 2
+                ;;
+            esac
+          done
+
+          if [ "$#" -eq 0 ]; then
+            echo "ERROR: retry requires a command after '--'"
+            return 2
+          fi
+
+          local attempt=1
+          local current_backoff="$backoff"
+          while [ "$attempt" -le "$retries" ]; do
+            if "$@"; then
+              return 0
+            fi
+            rc=$?
+            if [ "$attempt" -lt "$retries" ]; then
+              local wait="$current_backoff"
+              if [ "$wait" -gt "$max_backoff" ]; then
+                wait="$max_backoff"
+              fi
+              echo "Retry $attempt/$retries failed (exit $rc), waiting ${wait}s..."
+              sleep "$wait"
+              current_backoff=$((current_backoff * 2))
+            fi
+            attempt=$((attempt + 1))
+          done
+
+          echo "ERROR: Command failed after $retries attempts: $*"
+          return "$rc"
+        }
+        export -f retry
+        EOF
+
+        if [ -n "$PREV_BASH_ENV" ] && [ -f "$PREV_BASH_ENV" ]; then
+          {
+            echo "source \"$PREV_BASH_ENV\""
+            cat "$RETRY_HELPER"
+          } > "${RETRY_HELPER}.merged"
+          mv "${RETRY_HELPER}.merged" "$RETRY_HELPER"
+        fi
+
+        echo "BASH_ENV=$RETRY_HELPER" >> "$GITHUB_ENV"
 
     # ── Python dependencies ───────────────────────────────────────────────
     - name: Sync Python dependencies
@@ -162,9 +266,9 @@ runs:
         BIN_FILE="hadolint-${ARCH}"
         SHA_FILE="${BIN_FILE}.sha256"
 
-        uv run retry --retries 3 --backoff 5 --max-backoff 60 -- \
+        retry --retries 3 --backoff 5 --max-backoff 60 -- \
           curl -fsSL "${BASE_URL}/${BIN_FILE}" -o "${BIN_FILE}"
-        uv run retry --retries 3 --backoff 5 --max-backoff 60 -- \
+        retry --retries 3 --backoff 5 --max-backoff 60 -- \
           curl -fsSL "${BASE_URL}/${SHA_FILE}" -o "${SHA_FILE}"
 
         EXPECTED_SHA="$(awk '{print $1}' "${SHA_FILE}")"
@@ -191,7 +295,7 @@ runs:
             ;;
         esac
 
-        TAPLO_VERSION="$(uv run retry --retries 3 --backoff 5 --max-backoff 60 -- \
+        TAPLO_VERSION="$(retry --retries 3 --backoff 5 --max-backoff 60 -- \
           curl -fsSL https://api.github.com/repos/tamasfe/taplo/releases/latest | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p')"
         if [ -z "${TAPLO_VERSION:-}" ]; then
           echo "ERROR: Failed to resolve Taplo version from GitHub releases API"
@@ -200,7 +304,7 @@ runs:
         BASE_URL="https://github.com/tamasfe/taplo/releases/download/${TAPLO_VERSION}"
         BIN_FILE="taplo-linux-${ARCH}.gz"
 
-        uv run retry --retries 3 --backoff 5 --max-backoff 60 -- \
+        retry --retries 3 --backoff 5 --max-backoff 60 -- \
           curl -fsSL "${BASE_URL}/${BIN_FILE}" -o "${BIN_FILE}"
         gunzip "${BIN_FILE}"
         sudo install -m 0755 "taplo-linux-${ARCH}" /usr/local/bin/taplo

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,14 +80,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098  # v7
+      - name: Set up environment
+        uses: ./.github/actions/setup-env
         with:
-          enable-cache: true
-          version: "0.10.0"
-
-      - name: Sync Python dependencies
-        run: uv sync --frozen --all-extras
+          install-python: 'false'
+          install-just: 'false'
 
       - name: Validate and prepare variables
         id: vars
@@ -127,7 +124,7 @@ jobs:
           VERSION: ${{ steps.vars.outputs.version }}
         run: |
           set -euo pipefail
-          uv run retry --retries 3 --backoff 3 --max-backoff 20 -- git fetch origin "release/$VERSION" || {
+          retry --retries 3 --backoff 3 --max-backoff 20 -- git fetch origin "release/$VERSION" || {
             echo "ERROR: Release branch not found: release/$VERSION"
             echo "Did you run: just prepare-release $VERSION"
             exit 1
@@ -343,7 +340,7 @@ jobs:
           RELEASE_BRANCH="release/$VERSION"
 
           # Find PR from release branch to main
-          PR_JSON=$(uv run retry --retries 3 --backoff 5 --max-backoff 30 -- gh pr list \
+          PR_JSON=$(retry --retries 3 --backoff 5 --max-backoff 30 -- gh pr list \
             --head "$RELEASE_BRANCH" \
             --base main \
             --json number,isDraft,reviewDecision,statusCheckRollup \
@@ -509,6 +506,7 @@ jobs:
         uses: ./.github/actions/setup-env
         with:
           sync-dependencies: 'true'
+          install-just: 'false'
 
       - name: Set release date in CHANGELOG
         if: needs.validate.outputs.release_kind == 'final'
@@ -584,7 +582,7 @@ jobs:
         run: |
           set -euo pipefail
           echo "Triggering sync-issues workflow..."
-          uv run retry --retries 2 --backoff 5 --max-backoff 20 -- gh workflow run sync-issues.yml \
+          retry --retries 2 --backoff 5 --max-backoff 20 -- gh workflow run sync-issues.yml \
             -f "target-branch=release/$VERSION"
           echo "✓ sync-issues workflow triggered"
 
@@ -639,7 +637,7 @@ jobs:
           VERSION: ${{ needs.validate.outputs.version }}
         run: |
           set -euo pipefail
-          uv run retry --retries 3 --backoff 3 --max-backoff 20 -- git fetch origin "release/$VERSION"
+          retry --retries 3 --backoff 3 --max-backoff 20 -- git fetch origin "release/$VERSION"
           git reset --hard "origin/release/$VERSION"
           echo "✓ Synced with remote release branch"
 
@@ -669,7 +667,7 @@ jobs:
           $CHANGELOG_CONTENT
           EOF
 
-          uv run retry --retries 3 --backoff 5 --max-backoff 30 -- \
+          retry --retries 3 --backoff 5 --max-backoff 30 -- \
             gh pr edit "$PR_NUMBER" --body-file /tmp/release-pr-body.md
           echo "✓ Refreshed PR #$PR_NUMBER body from finalized CHANGELOG.md"
 
@@ -684,7 +682,7 @@ jobs:
           if [ "$RELEASE_KIND" = "final" ]; then
             FINALIZE_SHA=$(git rev-parse HEAD)
           else
-            FINALIZE_SHA=$(uv run retry --retries 3 --backoff 5 --max-backoff 30 -- \
+            FINALIZE_SHA=$(retry --retries 3 --backoff 5 --max-backoff 30 -- \
               gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/release/$VERSION" --jq '.object.sha')
           fi
           echo "finalize_sha=$FINALIZE_SHA" >> $GITHUB_OUTPUT
@@ -782,14 +780,11 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
           persist-credentials: true
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098  # v7
+      - name: Set up environment
+        uses: ./.github/actions/setup-env
         with:
-          enable-cache: true
-          version: "0.10.0"
-
-      - name: Sync Python dependencies
-        run: uv sync --frozen --all-extras
+          install-python: 'false'
+          install-just: 'false'
 
       - name: Configure git
         env:
@@ -814,17 +809,17 @@ jobs:
         run: |
           set -euo pipefail
           if [ "$RELEASE_KIND" = "candidate" ]; then
-            if uv run retry --retries 3 --backoff 5 --max-backoff 30 -- git ls-remote --tags --refs origin "$PUBLISH_VERSION" | grep -q "refs/tags/$PUBLISH_VERSION$"; then
+            if retry --retries 3 --backoff 5 --max-backoff 30 -- git ls-remote --tags --refs origin "$PUBLISH_VERSION" | grep -q "refs/tags/$PUBLISH_VERSION$"; then
               echo "ERROR: Candidate tag '$PUBLISH_VERSION' already exists on origin"
               echo "Another candidate publish likely completed concurrently; re-run workflow to infer next RC."
               exit 1
             fi
           fi
 
-          if ! uv run retry --retries 3 --backoff 5 --max-backoff 30 -- git push origin "$PUBLISH_VERSION"; then
-            if uv run retry --retries 3 --backoff 5 --max-backoff 30 -- git ls-remote --tags --refs origin "$PUBLISH_VERSION" | grep -q "refs/tags/$PUBLISH_VERSION$"; then
+          if ! retry --retries 3 --backoff 5 --max-backoff 30 -- git push origin "$PUBLISH_VERSION"; then
+            if retry --retries 3 --backoff 5 --max-backoff 30 -- git ls-remote --tags --refs origin "$PUBLISH_VERSION" | grep -q "refs/tags/$PUBLISH_VERSION$"; then
               LOCAL_TAG_TARGET_SHA=$(git rev-parse "$PUBLISH_VERSION^{}")
-              REMOTE_TAG_TARGET_SHA=$(uv run retry --retries 3 --backoff 5 --max-backoff 30 -- git ls-remote --tags origin "refs/tags/$PUBLISH_VERSION^{}" | awk '{print $1}')
+              REMOTE_TAG_TARGET_SHA=$(retry --retries 3 --backoff 5 --max-backoff 30 -- git ls-remote --tags origin "refs/tags/$PUBLISH_VERSION^{}" | awk '{print $1}')
               if [ -z "$REMOTE_TAG_TARGET_SHA" ]; then
                 echo "ERROR: Remote tag exists but target SHA could not be resolved: $PUBLISH_VERSION"
                 exit 1
@@ -904,7 +899,7 @@ jobs:
             IMAGE_TAG="$REPO:$PUBLISH_VERSION-$arch"
             docker tag "$SOURCE_IMAGE_TAG" "$IMAGE_TAG"
             echo "Pushing $arch image: $IMAGE_TAG"
-            uv run retry --retries 3 --backoff 3 --max-backoff 3 -- docker push "$IMAGE_TAG"
+            retry --retries 3 --backoff 3 --max-backoff 3 -- docker push "$IMAGE_TAG"
             echo "✓ Pushed: $IMAGE_TAG"
           done
 
@@ -927,7 +922,7 @@ jobs:
           done
 
           echo "Creating version manifest: $REPO:$PUBLISH_VERSION"
-          uv run retry --retries 3 --backoff 3 --max-backoff 3 -- \
+          retry --retries 3 --backoff 3 --max-backoff 3 -- \
             docker buildx imagetools create \
               --tag "$REPO:$PUBLISH_VERSION" \
               "${ARCH_IMAGES[@]}"
@@ -936,7 +931,7 @@ jobs:
           # Update latest manifest only for final releases building both architectures.
           if [ "$RELEASE_KIND" = "final" ] && [ ${#ARCH_ARRAY[@]} -eq 2 ]; then
             echo "Creating/updating latest manifest: $REPO:latest"
-            uv run retry --retries 3 --backoff 3 --max-backoff 3 -- \
+            retry --retries 3 --backoff 3 --max-backoff 3 -- \
               docker buildx imagetools create \
                 --tag "$REPO:latest" \
                 "${ARCH_IMAGES[@]}"
@@ -1030,12 +1025,12 @@ jobs:
           REPO="ghcr.io/vig-os/devcontainer"
 
           # Get the digest for the multi-arch manifest
-          DIGEST=$(uv run retry --retries 3 --backoff 5 --max-backoff 30 -- \
+          DIGEST=$(retry --retries 3 --backoff 5 --max-backoff 30 -- \
             docker buildx imagetools inspect "$REPO:$PUBLISH_VERSION" --format '{{json .Manifest.Digest}}' | tr -d '"')
           echo "Signing image: $REPO@$DIGEST"
 
           # Keyless signing using GitHub Actions OIDC identity
-          uv run retry --retries 3 --backoff 15 --max-backoff 15 -- \
+          retry --retries 3 --backoff 15 --max-backoff 15 -- \
             cosign sign --yes "$REPO@$DIGEST"
           echo "✓ Image signed with cosign (keyless)"
 
@@ -1046,7 +1041,7 @@ jobs:
         run: |
           set -euo pipefail
           REPO="ghcr.io/vig-os/devcontainer"
-          DIGEST=$(uv run retry --retries 3 --backoff 5 --max-backoff 30 -- \
+          DIGEST=$(retry --retries 3 --backoff 5 --max-backoff 30 -- \
             docker buildx imagetools inspect "$REPO:$PUBLISH_VERSION" --format '{{json .Manifest.Digest}}' | tr -d '"')
           echo "digest=$DIGEST" >> $GITHUB_OUTPUT
           echo "Image digest: $DIGEST"
@@ -1102,16 +1097,16 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           set -euo pipefail
-          if uv run retry --retries 2 --backoff 5 --max-backoff 20 -- gh release view "$PUBLISH_VERSION" >/dev/null 2>&1; then
+          if retry --retries 2 --backoff 5 --max-backoff 20 -- gh release view "$PUBLISH_VERSION" >/dev/null 2>&1; then
             echo "ERROR: GitHub Release already exists for tag $PUBLISH_VERSION"
             exit 1
           fi
 
-          uv run retry --retries 3 --backoff 5 --max-backoff 30 -- gh release create "$PUBLISH_VERSION" \
+          retry --retries 3 --backoff 5 --max-backoff 30 -- gh release create "$PUBLISH_VERSION" \
             --title "$PUBLISH_VERSION" \
             --notes-file /tmp/github-release-notes.md \
             --verify-tag || {
-              if uv run retry --retries 2 --backoff 5 --max-backoff 20 -- gh release view "$PUBLISH_VERSION" >/dev/null 2>&1; then
+              if retry --retries 2 --backoff 5 --max-backoff 20 -- gh release view "$PUBLISH_VERSION" >/dev/null 2>&1; then
                 echo "GitHub Release already present after create attempt: $PUBLISH_VERSION"
               else
                 exit 1
@@ -1170,6 +1165,12 @@ jobs:
           owner: vig-os
           repositories: devcontainer-smoke-test
 
+      - name: Set up environment
+        uses: ./.github/actions/setup-env
+        with:
+          install-python: 'false'
+          install-just: 'false'
+
       - name: Trigger smoke-test repository dispatch
         env:
           GH_TOKEN: ${{ steps.smoke-app-token.outputs.token }}
@@ -1183,32 +1184,7 @@ jobs:
           CORRELATION_ID: ${{ github.repository }}:${{ github.run_id }}:${{ needs.validate.outputs.publish_version }}
         run: |
           set -euo pipefail
-          retry() {
-            local retries=$1
-            local backoff=$2
-            local max_backoff=$3
-            shift 3
-            local attempt=1
-            while [ "$attempt" -le "$retries" ]; do
-              if "$@"; then
-                return 0
-              fi
-              if [ "$attempt" -lt "$retries" ]; then
-                local wait="$backoff"
-                if [ "$wait" -gt "$max_backoff" ]; then
-                  wait="$max_backoff"
-                fi
-                echo "Retry $attempt/$retries failed, waiting ${wait}s..."
-                sleep "$wait"
-                backoff=$((backoff * 2))
-              fi
-              attempt=$((attempt + 1))
-            done
-            echo "ERROR: Command failed after $retries attempts: $*"
-            return 1
-          }
-
-          retry 3 10 10 \
+          retry --retries 3 --backoff 10 --max-backoff 10 -- \
             gh api repos/vig-os/devcontainer-smoke-test/dispatches \
               -f event_type=smoke-test-trigger \
               -f "client_payload[tag]=$RELEASE_TAG" \
@@ -1286,6 +1262,12 @@ jobs:
           app-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
+      - name: Set up environment
+        uses: ./.github/actions/setup-env
+        with:
+          install-python: 'false'
+          install-just: 'false'
+
       - name: Rollback release branch
         id: rollback-branch
         continue-on-error: true
@@ -1295,33 +1277,8 @@ jobs:
           PRE_SHA: ${{ needs.validate.outputs.pre_finalize_sha }}
         run: |
           set -euo pipefail
-          retry() {
-            local retries=$1
-            local backoff=$2
-            local max_backoff=$3
-            shift 3
-            local attempt=1
-            while [ "$attempt" -le "$retries" ]; do
-              if "$@"; then
-                return 0
-              fi
-              if [ "$attempt" -lt "$retries" ]; then
-                local wait="$backoff"
-                if [ "$wait" -gt "$max_backoff" ]; then
-                  wait="$max_backoff"
-                fi
-                echo "Retry $attempt/$retries failed, waiting ${wait}s..."
-                sleep "$wait"
-                backoff=$((backoff * 2))
-              fi
-              attempt=$((attempt + 1))
-            done
-            echo "ERROR: Command failed after $retries attempts: $*"
-            return 1
-          }
-
           echo "Rolling back release branch to pre-finalization state..."
-          retry 3 5 30 gh api "repos/${{ github.repository }}/git/refs/heads/release/$VERSION" \
+          retry --retries 3 --backoff 5 --max-backoff 30 -- gh api "repos/${{ github.repository }}/git/refs/heads/release/$VERSION" \
             -X PATCH \
             -f sha="$PRE_SHA" \
             -F force=true
@@ -1335,35 +1292,10 @@ jobs:
           PUBLISH_VERSION: ${{ needs.validate.outputs.publish_version }}
         run: |
           set -euo pipefail
-          retry() {
-            local retries=$1
-            local backoff=$2
-            local max_backoff=$3
-            shift 3
-            local attempt=1
-            while [ "$attempt" -le "$retries" ]; do
-              if "$@"; then
-                return 0
-              fi
-              if [ "$attempt" -lt "$retries" ]; then
-                local wait="$backoff"
-                if [ "$wait" -gt "$max_backoff" ]; then
-                  wait="$max_backoff"
-                fi
-                echo "Retry $attempt/$retries failed, waiting ${wait}s..."
-                sleep "$wait"
-                backoff=$((backoff * 2))
-              fi
-              attempt=$((attempt + 1))
-            done
-            echo "ERROR: Command failed after $retries attempts: $*"
-            return 1
-          }
-
           TAG="$PUBLISH_VERSION"
-          if retry 2 5 20 gh api "repos/${{ github.repository }}/git/refs/tags/$TAG" >/dev/null 2>&1; then
+          if retry --retries 2 --backoff 5 --max-backoff 20 -- gh api "repos/${{ github.repository }}/git/refs/tags/$TAG" >/dev/null 2>&1; then
             echo "Deleting remote tag: $TAG"
-            retry 3 5 30 gh api "repos/${{ github.repository }}/git/refs/tags/$TAG" -X DELETE
+            retry --retries 3 --backoff 5 --max-backoff 30 -- gh api "repos/${{ github.repository }}/git/refs/tags/$TAG" -X DELETE
             echo "✓ Tag deleted"
           else
             echo "Tag does not exist on remote (not created)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,6 +80,15 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098  # v7
+        with:
+          enable-cache: true
+          version: "0.10.0"
+
+      - name: Sync Python dependencies
+        run: uv sync --frozen --all-extras
+
       - name: Validate and prepare variables
         id: vars
         env:
@@ -497,7 +506,6 @@ jobs:
           persist-credentials: true
 
       - name: Set up environment
-        if: needs.validate.outputs.release_kind == 'final'
         uses: ./.github/actions/setup-env
         with:
           sync-dependencies: 'true'
@@ -773,6 +781,15 @@ jobs:
           ref: ${{ needs.finalize.outputs.finalize_sha }}
           token: ${{ steps.app-token.outputs.token }}
           persist-credentials: true
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098  # v7
+        with:
+          enable-cache: true
+          version: "0.10.0"
+
+      - name: Sync Python dependencies
+        run: uv sync --frozen --all-extras
 
       - name: Configure git
         env:
@@ -1166,7 +1183,32 @@ jobs:
           CORRELATION_ID: ${{ github.repository }}:${{ github.run_id }}:${{ needs.validate.outputs.publish_version }}
         run: |
           set -euo pipefail
-          uv run retry --retries 3 --backoff 10 --max-backoff 10 -- \
+          retry() {
+            local retries=$1
+            local backoff=$2
+            local max_backoff=$3
+            shift 3
+            local attempt=1
+            while [ "$attempt" -le "$retries" ]; do
+              if "$@"; then
+                return 0
+              fi
+              if [ "$attempt" -lt "$retries" ]; then
+                local wait="$backoff"
+                if [ "$wait" -gt "$max_backoff" ]; then
+                  wait="$max_backoff"
+                fi
+                echo "Retry $attempt/$retries failed, waiting ${wait}s..."
+                sleep "$wait"
+                backoff=$((backoff * 2))
+              fi
+              attempt=$((attempt + 1))
+            done
+            echo "ERROR: Command failed after $retries attempts: $*"
+            return 1
+          }
+
+          retry 3 10 10 \
             gh api repos/vig-os/devcontainer-smoke-test/dispatches \
               -f event_type=smoke-test-trigger \
               -f "client_payload[tag]=$RELEASE_TAG" \
@@ -1253,8 +1295,33 @@ jobs:
           PRE_SHA: ${{ needs.validate.outputs.pre_finalize_sha }}
         run: |
           set -euo pipefail
+          retry() {
+            local retries=$1
+            local backoff=$2
+            local max_backoff=$3
+            shift 3
+            local attempt=1
+            while [ "$attempt" -le "$retries" ]; do
+              if "$@"; then
+                return 0
+              fi
+              if [ "$attempt" -lt "$retries" ]; then
+                local wait="$backoff"
+                if [ "$wait" -gt "$max_backoff" ]; then
+                  wait="$max_backoff"
+                fi
+                echo "Retry $attempt/$retries failed, waiting ${wait}s..."
+                sleep "$wait"
+                backoff=$((backoff * 2))
+              fi
+              attempt=$((attempt + 1))
+            done
+            echo "ERROR: Command failed after $retries attempts: $*"
+            return 1
+          }
+
           echo "Rolling back release branch to pre-finalization state..."
-          uv run retry --retries 3 --backoff 5 --max-backoff 30 -- gh api "repos/${{ github.repository }}/git/refs/heads/release/$VERSION" \
+          retry 3 5 30 gh api "repos/${{ github.repository }}/git/refs/heads/release/$VERSION" \
             -X PATCH \
             -f sha="$PRE_SHA" \
             -F force=true
@@ -1268,10 +1335,35 @@ jobs:
           PUBLISH_VERSION: ${{ needs.validate.outputs.publish_version }}
         run: |
           set -euo pipefail
+          retry() {
+            local retries=$1
+            local backoff=$2
+            local max_backoff=$3
+            shift 3
+            local attempt=1
+            while [ "$attempt" -le "$retries" ]; do
+              if "$@"; then
+                return 0
+              fi
+              if [ "$attempt" -lt "$retries" ]; then
+                local wait="$backoff"
+                if [ "$wait" -gt "$max_backoff" ]; then
+                  wait="$max_backoff"
+                fi
+                echo "Retry $attempt/$retries failed, waiting ${wait}s..."
+                sleep "$wait"
+                backoff=$((backoff * 2))
+              fi
+              attempt=$((attempt + 1))
+            done
+            echo "ERROR: Command failed after $retries attempts: $*"
+            return 1
+          }
+
           TAG="$PUBLISH_VERSION"
-          if uv run retry --retries 2 --backoff 5 --max-backoff 20 -- gh api "repos/${{ github.repository }}/git/refs/tags/$TAG" >/dev/null 2>&1; then
+          if retry 2 5 20 gh api "repos/${{ github.repository }}/git/refs/tags/$TAG" >/dev/null 2>&1; then
             echo "Deleting remote tag: $TAG"
-            uv run retry --retries 3 --backoff 5 --max-backoff 30 -- gh api "repos/${{ github.repository }}/git/refs/tags/$TAG" -X DELETE
+            retry 3 5 30 gh api "repos/${{ github.repository }}/git/refs/tags/$TAG" -X DELETE
             echo "✓ Tag deleted"
           else
             echo "Tag does not exist on remote (not created)"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,8 +85,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Bundle idempotency guards for branch/PR/tag/release creation paths to keep retried network calls safe on reruns
   - Remove synced `retry.sh` artifacts and BATS retry tests in favor of `vig-utils` pytest coverage
 - **Release workflow no longer fails when retry tooling is unavailable** ([#365](https://github.com/vig-os/devcontainer/issues/365))
-  - Provision `uv` and synced dependencies before `uv run retry` calls in validate, finalize, and publish release jobs
-  - Replace `uv run retry` in no-checkout smoke-test and rollback jobs with inline shell retry helpers to keep rollback paths reliable
+  - Extend `.github/actions/setup-env/action.yml` with a reusable `retry` shell function exported via `BASH_ENV` as the retry single source of truth
+  - Add `setup-env` input support for uv-only usage by allowing Python setup to be disabled when jobs only need retry tooling
+  - Switch release workflow retry calls from `uv run retry` to shared `retry` and remove duplicated inline retry implementations
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Ensure downstream containerized jobs resolve image tags from `.vig-os` instead of hardcoded `latest`
   - Bundle idempotency guards for branch/PR/tag/release creation paths to keep retried network calls safe on reruns
   - Remove synced `retry.sh` artifacts and BATS retry tests in favor of `vig-utils` pytest coverage
+- **Release workflow no longer fails when retry tooling is unavailable** ([#365](https://github.com/vig-os/devcontainer/issues/365))
+  - Provision `uv` and synced dependencies before `uv run retry` calls in validate, finalize, and publish release jobs
+  - Replace `uv run retry` in no-checkout smoke-test and rollback jobs with inline shell retry helpers to keep rollback paths reliable
 
 ### Security
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -85,8 +85,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Bundle idempotency guards for branch/PR/tag/release creation paths to keep retried network calls safe on reruns
   - Remove synced `retry.sh` artifacts and BATS retry tests in favor of `vig-utils` pytest coverage
 - **Release workflow no longer fails when retry tooling is unavailable** ([#365](https://github.com/vig-os/devcontainer/issues/365))
-  - Provision `uv` and synced dependencies before `uv run retry` calls in validate, finalize, and publish release jobs
-  - Replace `uv run retry` in no-checkout smoke-test and rollback jobs with inline shell retry helpers to keep rollback paths reliable
+  - Extend `.github/actions/setup-env/action.yml` with a reusable `retry` shell function exported via `BASH_ENV` as the retry single source of truth
+  - Add `setup-env` input support for uv-only usage by allowing Python setup to be disabled when jobs only need retry tooling
+  - Switch release workflow retry calls from `uv run retry` to shared `retry` and remove duplicated inline retry implementations
 
 ### Security
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -84,6 +84,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Ensure downstream containerized jobs resolve image tags from `.vig-os` instead of hardcoded `latest`
   - Bundle idempotency guards for branch/PR/tag/release creation paths to keep retried network calls safe on reruns
   - Remove synced `retry.sh` artifacts and BATS retry tests in favor of `vig-utils` pytest coverage
+- **Release workflow no longer fails when retry tooling is unavailable** ([#365](https://github.com/vig-os/devcontainer/issues/365))
+  - Provision `uv` and synced dependencies before `uv run retry` calls in validate, finalize, and publish release jobs
+  - Replace `uv run retry` in no-checkout smoke-test and rollback jobs with inline shell retry helpers to keep rollback paths reliable
 
 ### Security
 


### PR DESCRIPTION
## Description

Fix release workflow retry failures from issue #365 by removing implicit runtime assumptions and centralizing retry behavior. This update moves retry setup to the shared setup action, adds an explicit uv-only setup mode for jobs that do not need Python bootstrap, and aligns all release retry calls on one helper path.

## Type of Change

- [ ] `feat` -- New feature
- [x] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [x] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- `.github/actions/setup-env/action.yml`
  - Add `install-python` and `python-version` inputs to support uv-only usage where Python setup is unnecessary
  - Export shared `retry` helper via `BASH_ENV` so retry behavior is centralized and reused across steps/jobs
  - Replace internal `uv run retry` usage in setup-env tool installation paths with shared `retry`
- `.github/workflows/release.yml`
  - Use `./.github/actions/setup-env` in validate, finalize, publish, smoke-test, and rollback jobs
  - Replace release workflow `uv run retry` invocations with shared `retry --retries ... -- <command>` calls
  - Remove duplicated inline `retry()` definitions from smoke-test and rollback job steps
- `CHANGELOG.md`
  - Add/update fixed entry for `#365` reflecting the centralized retry + uv-only setup approach
- `assets/workspace/.devcontainer/CHANGELOG.md`
  - Sync generated changelog changes through manifest hook

## Changelog Entry

### Fixed
- **Release workflow no longer fails when retry tooling is unavailable** ([#365](https://github.com/vig-os/devcontainer/issues/365))
  - Extend `.github/actions/setup-env/action.yml` with a reusable `retry` shell function exported via `BASH_ENV` as the retry single source of truth
  - Add `setup-env` input support for uv-only usage by allowing Python setup to be disabled when jobs only need retry tooling
  - Switch release workflow retry calls from `uv run retry` to shared `retry` and remove duplicated inline retry implementations

## Testing

- [ ] Tests pass locally (`just test`)
- [ ] Manual testing performed (describe below)

### Manual Testing Details

N/A

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

Copilot review comments on the previous revision were addressed in commit `3aa4f4c` by standardizing setup and retry across release jobs.

Refs: #365
