### PR TITLE
fix(ci): prevent setup-env BASH_ENV self-source recursion

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -201,7 +201,7 @@ runs:
         export -f retry
         EOF
 
-        if [ -n "$PREV_BASH_ENV" ] && [ -f "$PREV_BASH_ENV" ]; then
+        if [ -n "$PREV_BASH_ENV" ] && [ -f "$PREV_BASH_ENV" ] && [ "$PREV_BASH_ENV" != "$RETRY_HELPER" ]; then
           {
             echo "source \"$PREV_BASH_ENV\""
             cat "$RETRY_HELPER"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Release test-image setup now recovers from uv sync crashes** ([#370](https://github.com/vig-os/devcontainer/issues/370))
   - Harden `.github/actions/setup-env/action.yml` to retry `uv sync --frozen --all-extras` once after clearing uv cache and removing stale `.venv`
   - Prevent repeat release test failures when `setup-env` is executed multiple times in the same job
+- **Release setup-env no longer self-sources retry helper via BASH_ENV** ([#374](https://github.com/vig-os/devcontainer/issues/374))
+  - Guard the retry-helper merge logic in `.github/actions/setup-env/action.yml` to skip merging when `PREV_BASH_ENV` already equals `RETRY_HELPER`
+  - Prevent infinite `source` recursion and exit 139 crashes when `setup-env` is invoked multiple times in one job
 
 ### Security
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -94,6 +94,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Release test-image setup now recovers from uv sync crashes** ([#370](https://github.com/vig-os/devcontainer/issues/370))
   - Harden `.github/actions/setup-env/action.yml` to retry `uv sync --frozen --all-extras` once after clearing uv cache and removing stale `.venv`
   - Prevent repeat release test failures when `setup-env` is executed multiple times in the same job
+- **Release setup-env no longer self-sources retry helper via BASH_ENV** ([#374](https://github.com/vig-os/devcontainer/issues/374))
+  - Guard the retry-helper merge logic in `.github/actions/setup-env/action.yml` to skip merging when `PREV_BASH_ENV` already equals `RETRY_HELPER`
+  - Prevent infinite `source` recursion and exit 139 crashes when `setup-env` is invoked multiple times in one job
 
 ### Security
 


### PR DESCRIPTION
## Description

Fixes a release pipeline regression where `setup-env` could crash with exit 139 when invoked multiple times in the same job.
The retry-helper `BASH_ENV` merge now avoids self-referencing recursion, and changelogs are updated for issue tracking on release `0.3.1`.

## Type of Change

- [ ] `feat` -- New feature
- [x] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [ ] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- `.github/actions/setup-env/action.yml`
  - Add guard to skip retry-helper merge when `PREV_BASH_ENV` already equals `RETRY_HELPER`
  - Prevent `setup-env-retry.sh` from sourcing itself recursively on repeated setup invocations
- `CHANGELOG.md`
  - Add `Fixed` entry for issue `#374` in `## [0.3.1] - TBD`
- `assets/workspace/.devcontainer/CHANGELOG.md`
  - Sync mirrored changelog entry for issue `#374`

## Changelog Entry

### Fixed

- **Release setup-env no longer self-sources retry helper via BASH_ENV** ([#374](https://github.com/vig-os/devcontainer/issues/374))
  - Guard the retry-helper merge logic in `.github/actions/setup-env/action.yml` to skip merging when `PREV_BASH_ENV` already equals `RETRY_HELPER`
  - Prevent infinite `source` recursion and exit 139 crashes when `setup-env` is invoked multiple times in one job

## Testing

- [ ] Tests pass locally (`just test`)
- [ ] Manual testing performed (describe below)

### Manual Testing Details

N/A

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

This addresses a regression chain related to the earlier `uv sync` stabilization work in `#370`/`#371`; root cause and implementation plan were documented on issue `#374` comments before this patch.

Refs: #374, #370
