### PR TITLE
fix: require checkout before smoke-test setup-env

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1165,6 +1165,10 @@ jobs:
           owner: vig-os
           repositories: devcontainer-smoke-test
 
+      # Local actions from ./.github/actions/* require repository checkout in this job workspace.
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
       - name: Set up environment
         uses: ./.github/actions/setup-env
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Release setup-env no longer self-sources retry helper via BASH_ENV** ([#374](https://github.com/vig-os/devcontainer/issues/374))
   - Guard the retry-helper merge logic in `.github/actions/setup-env/action.yml` to skip merging when `PREV_BASH_ENV` already equals `RETRY_HELPER`
   - Prevent infinite `source` recursion and exit 139 crashes when `setup-env` is invoked multiple times in one job
+- **Smoke-test dispatch now checks out repository before local setup action** ([#376](https://github.com/vig-os/devcontainer/issues/376))
+  - Add `actions/checkout` to the `smoke-test` job in `.github/workflows/release.yml` before invoking `./.github/actions/setup-env`
+  - Prevent dispatch failures caused by missing local action metadata (`action.yml`) in a fresh job workspace
 
 ### Security
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -97,6 +97,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Release setup-env no longer self-sources retry helper via BASH_ENV** ([#374](https://github.com/vig-os/devcontainer/issues/374))
   - Guard the retry-helper merge logic in `.github/actions/setup-env/action.yml` to skip merging when `PREV_BASH_ENV` already equals `RETRY_HELPER`
   - Prevent infinite `source` recursion and exit 139 crashes when `setup-env` is invoked multiple times in one job
+- **Smoke-test dispatch now checks out repository before local setup action** ([#376](https://github.com/vig-os/devcontainer/issues/376))
+  - Add `actions/checkout` to the `smoke-test` job in `.github/workflows/release.yml` before invoking `./.github/actions/setup-env`
+  - Prevent dispatch failures caused by missing local action metadata (`action.yml`) in a fresh job workspace
 
 ### Security
 


### PR DESCRIPTION
## Description

Fix the release smoke-test dispatch failure by making the `smoke-test` job check out repository contents before invoking the local composite action `./.github/actions/setup-env`.
This aligns job setup with GitHub Actions workspace isolation so local action metadata is present when the step runs.

## Type of Change

- [x] `fix` -- Bug fix
- [ ] `feat` -- New feature
- [ ] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [ ] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- `.github/workflows/release.yml`
  - Add `actions/checkout` in `smoke-test` job before `./.github/actions/setup-env`
  - Add inline guardrail comment clarifying local action checkout requirement
- `CHANGELOG.md`
  - Add `### Fixed` entry for issue `#376` under `## [0.3.1] - TBD`
- `assets/workspace/.devcontainer/CHANGELOG.md`
  - Mirror the same `#376` changelog entry for workspace payload consistency

## Changelog Entry

### Fixed

- **Smoke-test dispatch now checks out repository before local setup action** ([#376](https://github.com/vig-os/devcontainer/issues/376))
  - Add `actions/checkout` to the `smoke-test` job in `.github/workflows/release.yml` before invoking `./.github/actions/setup-env`
  - Prevent dispatch failures caused by missing local action metadata (`action.yml`) in a fresh job workspace

## Testing

- [ ] Tests pass locally (`just test`)
- [ ] Manual testing performed (describe below)

### Manual Testing Details

N/A

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [ ] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

Implements the RCA/implementation plan posted on issue `#376`; scope is intentionally minimal to fix the failed smoke dispatch path without changing token, dispatch payload, or rollback behavior.

Refs: #376
