### PR TITLE
fix(ci): include resolve-image action in sparse checkout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Smoke-test dispatch now checks out repository before local setup action** ([#376](https://github.com/vig-os/devcontainer/issues/376))
   - Add `actions/checkout` to the `smoke-test` job in `.github/workflows/release.yml` before invoking `./.github/actions/setup-env`
   - Prevent dispatch failures caused by missing local action metadata (`action.yml`) in a fresh job workspace
+- **Workspace resolve-image jobs now checkout local action metadata** ([#380](https://github.com/vig-os/devcontainer/issues/380))
+  - Update `sparse-checkout` in workspace `resolve-image` jobs to include `.github/actions/resolve-image` in addition to `.vig-os`
+  - Prevent CI failures in downstream deploy PRs where local composite actions were missing from sparse checkout
 
 ### Security
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -100,6 +100,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Smoke-test dispatch now checks out repository before local setup action** ([#376](https://github.com/vig-os/devcontainer/issues/376))
   - Add `actions/checkout` to the `smoke-test` job in `.github/workflows/release.yml` before invoking `./.github/actions/setup-env`
   - Prevent dispatch failures caused by missing local action metadata (`action.yml`) in a fresh job workspace
+- **Workspace resolve-image jobs now checkout local action metadata** ([#380](https://github.com/vig-os/devcontainer/issues/380))
+  - Update `sparse-checkout` in workspace `resolve-image` jobs to include `.github/actions/resolve-image` in addition to `.vig-os`
+  - Prevent CI failures in downstream deploy PRs where local composite actions were missing from sparse checkout
 
 ### Security
 

--- a/assets/workspace/.github/workflows/ci.yml
+++ b/assets/workspace/.github/workflows/ci.yml
@@ -53,7 +53,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
-          sparse-checkout: .vig-os
+          sparse-checkout: |
+            .vig-os
+            .github/actions/resolve-image
           sparse-checkout-cone-mode: false
 
       - name: Resolve container image

--- a/assets/workspace/.github/workflows/release-core.yml
+++ b/assets/workspace/.github/workflows/release-core.yml
@@ -74,7 +74,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
-          sparse-checkout: .vig-os
+          sparse-checkout: |
+            .vig-os
+            .github/actions/resolve-image
           sparse-checkout-cone-mode: false
 
       - name: Resolve container image

--- a/assets/workspace/.github/workflows/release-publish.yml
+++ b/assets/workspace/.github/workflows/release-publish.yml
@@ -58,7 +58,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
-          sparse-checkout: .vig-os
+          sparse-checkout: |
+            .vig-os
+            .github/actions/resolve-image
           sparse-checkout-cone-mode: false
 
       - name: Resolve container image

--- a/assets/workspace/.github/workflows/sync-issues.yml
+++ b/assets/workspace/.github/workflows/sync-issues.yml
@@ -50,7 +50,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
-          sparse-checkout: .vig-os
+          sparse-checkout: |
+            .vig-os
+            .github/actions/resolve-image
           sparse-checkout-cone-mode: false
 
       - name: Resolve container image

--- a/assets/workspace/.github/workflows/sync-main-to-dev.yml
+++ b/assets/workspace/.github/workflows/sync-main-to-dev.yml
@@ -49,7 +49,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
-          sparse-checkout: .vig-os
+          sparse-checkout: |
+            .vig-os
+            .github/actions/resolve-image
           sparse-checkout-cone-mode: false
 
       - name: Resolve container image


### PR DESCRIPTION
## Description

Fix workspace CI/release templates so local composite action metadata is available during `resolve-image` jobs. The sparse checkout now includes both `.vig-os` and `.github/actions/resolve-image`, preventing downstream deploy PR checks from failing with missing `action.yml`.

## Type of Change

- [x] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [ ] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- `assets/workspace/.github/workflows/ci.yml`
  - Expand `sparse-checkout` in `resolve-image` checkout step to include `.github/actions/resolve-image`
- `assets/workspace/.github/workflows/release-core.yml`
  - Expand `sparse-checkout` in `resolve-image` checkout step to include `.github/actions/resolve-image`
- `assets/workspace/.github/workflows/release-publish.yml`
  - Expand `sparse-checkout` in `resolve-image` checkout step to include `.github/actions/resolve-image`
- `assets/workspace/.github/workflows/sync-issues.yml`
  - Expand `sparse-checkout` in `resolve-image` checkout step to include `.github/actions/resolve-image`
- `assets/workspace/.github/workflows/sync-main-to-dev.yml`
  - Expand `sparse-checkout` in `resolve-image` checkout step to include `.github/actions/resolve-image`
- `CHANGELOG.md`
  - Add `#380` entry under `### Fixed` in active `0.3.1` section
- `assets/workspace/.devcontainer/CHANGELOG.md`
  - Mirror the same `#380` changelog entry for workspace payload consistency

## Changelog Entry

### Fixed

- **Workspace resolve-image jobs now checkout local action metadata** ([#380](https://github.com/vig-os/devcontainer/issues/380))
  - Update `sparse-checkout` in workspace `resolve-image` jobs to include `.github/actions/resolve-image` in addition to `.vig-os`
  - Prevent CI failures in downstream deploy PRs where local composite actions were missing from sparse checkout

## Testing

- [ ] Tests pass locally (`just test`)
- [x] Manual testing performed (describe below)

### Manual Testing Details

- Copied the workflow and changelog changes into downstream `vig-os/devcontainer-smoke-test` deploy branch `chore/deploy-0.3.1-rc5`
- Verified PR checks passed and deployment PR merged: https://github.com/vig-os/devcontainer-smoke-test/pull/40

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

- This fix addresses the RCA from issue `#380` and was validated through downstream smoke-test deploy checks.

Refs: #380
