### PR TITLE
fix(ci): set explicit gh repo context in smoke-test dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Workspace resolve-image jobs now checkout local action metadata** ([#380](https://github.com/vig-os/devcontainer/issues/380))
   - Update `sparse-checkout` in workspace `resolve-image` jobs to include `.github/actions/resolve-image` in addition to `.vig-os`
   - Prevent CI failures in downstream deploy PRs where local composite actions were missing from sparse checkout
+- **Smoke-test dispatch gh jobs now set explicit repo context** ([#386](https://github.com/vig-os/devcontainer/issues/386))
+  - Add job-level `GH_REPO: ${{ github.repository }}` to `cleanup-release`, `trigger-prepare-release`, `ready-release-pr`, and `trigger-release` in `assets/smoke-test/.github/workflows/repository-dispatch.yml`
+  - Prevent `gh` CLI failures (`fatal: not a git repository`) in runner jobs that do not perform `actions/checkout`
 
 ### Security
 

--- a/assets/smoke-test/.github/workflows/repository-dispatch.yml
+++ b/assets/smoke-test/.github/workflows/repository-dispatch.yml
@@ -346,6 +346,8 @@ jobs:
     name: Cleanup stale release branch and PR
     runs-on: ubuntu-22.04
     timeout-minutes: 5
+    env:
+      GH_REPO: ${{ github.repository }}
     needs: [validate, wait-deploy-merge]
     steps:
       - name: Generate release app token for PR/branch cleanup
@@ -385,6 +387,8 @@ jobs:
     name: Trigger and wait for prepare-release workflow
     runs-on: ubuntu-22.04
     timeout-minutes: 25
+    env:
+      GH_REPO: ${{ github.repository }}
     needs: [validate, cleanup-release]
     outputs:
       before_run_id: ${{ steps.capture_prepare_before.outputs.before_run_id }}
@@ -454,6 +458,8 @@ jobs:
     name: Sync changelog and prepare release PR
     runs-on: ubuntu-22.04
     timeout-minutes: 35
+    env:
+      GH_REPO: ${{ github.repository }}
     needs: [validate, trigger-prepare-release]
     outputs:
       release_pr: ${{ steps.locate_release_pr.outputs.release_pr }}
@@ -574,6 +580,8 @@ jobs:
     name: Trigger and wait for release workflow
     runs-on: ubuntu-22.04
     timeout-minutes: 35
+    env:
+      GH_REPO: ${{ github.repository }}
     needs: [validate, ready-release-pr]
     outputs:
       before_run_id: ${{ steps.capture_release_before.outputs.before_run_id }}

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -103,6 +103,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Workspace resolve-image jobs now checkout local action metadata** ([#380](https://github.com/vig-os/devcontainer/issues/380))
   - Update `sparse-checkout` in workspace `resolve-image` jobs to include `.github/actions/resolve-image` in addition to `.vig-os`
   - Prevent CI failures in downstream deploy PRs where local composite actions were missing from sparse checkout
+- **Smoke-test dispatch gh jobs now set explicit repo context** ([#386](https://github.com/vig-os/devcontainer/issues/386))
+  - Add job-level `GH_REPO: ${{ github.repository }}` to `cleanup-release`, `trigger-prepare-release`, `ready-release-pr`, and `trigger-release` in `assets/smoke-test/.github/workflows/repository-dispatch.yml`
+  - Prevent `gh` CLI failures (`fatal: not a git repository`) in runner jobs that do not perform `actions/checkout`
 
 ### Security
 


### PR DESCRIPTION
## Description

Fix downstream smoke-test release orchestration jobs that invoke `gh` without a local Git checkout by setting explicit repository context via `GH_REPO`. This prevents `fatal: not a git repository` failures in `trigger-prepare-release` and guards later release-phase jobs with the same pattern.

## Type of Change

- [ ] `feat` -- New feature
- [x] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [ ] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- `assets/smoke-test/.github/workflows/repository-dispatch.yml`
  - Add job-level `GH_REPO: ${{ github.repository }}` to `cleanup-release`
  - Add job-level `GH_REPO: ${{ github.repository }}` to `trigger-prepare-release`
  - Add job-level `GH_REPO: ${{ github.repository }}` to `ready-release-pr`
  - Add job-level `GH_REPO: ${{ github.repository }}` to `trigger-release`
- `CHANGELOG.md`
  - Add `#386` entry under `### Fixed` in active `0.3.1` section
- `assets/workspace/.devcontainer/CHANGELOG.md`
  - Mirror the same `#386` changelog entry for workspace payload consistency

## Changelog Entry

### Fixed

- **Smoke-test dispatch gh jobs now set explicit repo context** ([#386](https://github.com/vig-os/devcontainer/issues/386))
  - Add job-level `GH_REPO: ${{ github.repository }}` to `cleanup-release`, `trigger-prepare-release`, `ready-release-pr`, and `trigger-release` in `assets/smoke-test/.github/workflows/repository-dispatch.yml`
  - Prevent `gh` CLI failures (`fatal: not a git repository`) in runner jobs that do not perform `actions/checkout`

## Testing

- [ ] Tests pass locally (`just test`)
- [x] Manual testing performed (describe below)

### Manual Testing Details

- Reviewed `repository-dispatch.yml` for all release-phase jobs invoking `gh` without checkout and confirmed explicit repo context is now set in each affected job
- Verified staged diff is limited to workflow + changelog updates for `#386`
- Ran linter diagnostics on touched files with no reported issues

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

- This addresses issue `#386` and also closes the same latent failure mode in later release-orchestration jobs (`ready-release-pr`, `trigger-release`) and cleanup paths.

Refs: #384, #386
