### PR TITLE
fix: harden smoke-test dispatch workflow contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Smoke-test dispatch gh jobs now set explicit repo context** ([#386](https://github.com/vig-os/devcontainer/issues/386))
   - Add job-level `GH_REPO: ${{ github.repository }}` to `cleanup-release`, `trigger-prepare-release`, `ready-release-pr`, and `trigger-release` in `assets/smoke-test/.github/workflows/repository-dispatch.yml`
   - Prevent `gh` CLI failures (`fatal: not a git repository`) in runner jobs that do not perform `actions/checkout`
+- **Smoke-test release orchestration now validates workflow contract before dispatch** ([#389](https://github.com/vig-os/devcontainer/issues/389))
+  - Add a preflight check that verifies `prepare-release.yml` and `release.yml` are resolvable on dispatch ref `dev` before downstream orchestration starts
+  - Dispatch and polling now use explicit ref/branch context (`--ref dev` / `--branch dev`) to avoid default-branch workflow registry drift and `404 workflow not found` failures
 
 ### Security
 

--- a/assets/smoke-test/.github/workflows/repository-dispatch.yml
+++ b/assets/smoke-test/.github/workflows/repository-dispatch.yml
@@ -9,8 +9,9 @@ name: Repository Dispatch Listener
 #
 # Dispatch payload:
 # - Preferred:   client_payload.tag
-# - Optional:    client_payload.event_type, client_payload.source_repo,
-#                client_payload.source_workflow, client_payload.source_run_id,
+# - Optional:    client_payload.event_type, client_payload.release_kind,
+#                client_payload.source_repo, client_payload.source_workflow,
+#                client_payload.source_run_id,
 #                client_payload.source_run_url, client_payload.source_sha,
 #                client_payload.correlation_id
 #

--- a/assets/smoke-test/.github/workflows/repository-dispatch.yml
+++ b/assets/smoke-test/.github/workflows/repository-dispatch.yml
@@ -389,6 +389,7 @@ jobs:
     timeout-minutes: 25
     env:
       GH_REPO: ${{ github.repository }}
+      WORKFLOW_REF: dev
     needs: [validate, cleanup-release]
     outputs:
       before_run_id: ${{ steps.capture_prepare_before.outputs.before_run_id }}
@@ -402,6 +403,23 @@ jobs:
           owner: ${{ github.repository_owner }}
           repositories: ${{ github.event.repository.name }}
 
+      - name: Preflight check required release workflows on dispatch ref
+        env:
+          GH_TOKEN: ${{ steps.generate_release_token.outputs.token }}
+        run: |
+          set -euo pipefail
+          # Canonical cross-repo dispatch contract lives in docs/CROSS_REPO_RELEASE_GATE.md.
+          REQUIRED_WORKFLOWS="prepare-release.yml release.yml"
+          for workflow_file in ${REQUIRED_WORKFLOWS}; do
+            if gh workflow view "${workflow_file}" --ref "${WORKFLOW_REF}" >/dev/null 2>&1; then
+              echo "Workflow available on ${WORKFLOW_REF}: ${workflow_file}"
+            else
+              echo "ERROR: required workflow '${workflow_file}' is not resolvable on ref '${WORKFLOW_REF}'"
+              echo "Dispatch contract drift detected; aborting before orchestration dispatch."
+              exit 1
+            fi
+          done
+
       - name: Capture latest prepare-release run id
         id: capture_prepare_before
         env:
@@ -409,7 +427,7 @@ jobs:
         run: |
           set -euo pipefail
           BEFORE_RUN_ID="$(
-            gh run list --workflow prepare-release.yml --limit 1 --json databaseId --jq '.[0].databaseId // 0' 2>/dev/null || echo 0
+            gh run list --workflow prepare-release.yml --branch "${WORKFLOW_REF}" --limit 1 --json databaseId --jq '.[0].databaseId // 0' 2>/dev/null || echo 0
           )"
           echo "before_run_id=${BEFORE_RUN_ID}" >> "${GITHUB_OUTPUT}"
 
@@ -419,7 +437,7 @@ jobs:
           BASE_VERSION: ${{ needs.validate.outputs.base_version }}
         run: |
           set -euo pipefail
-          gh workflow run prepare-release.yml -f version="${BASE_VERSION}"
+          gh workflow run prepare-release.yml --ref "${WORKFLOW_REF}" -f version="${BASE_VERSION}"
 
       - name: Wait for prepare-release completion
         env:
@@ -432,7 +450,7 @@ jobs:
           ELAPSED=0
 
           while [ "${ELAPSED}" -lt "${TIMEOUT}" ]; do
-            RUN_ID="$(gh run list --workflow prepare-release.yml --limit 1 --json databaseId --jq '.[0].databaseId // empty' 2>/dev/null || true)"
+            RUN_ID="$(gh run list --workflow prepare-release.yml --branch "${WORKFLOW_REF}" --limit 1 --json databaseId --jq '.[0].databaseId // empty' 2>/dev/null || true)"
             if [ -n "${RUN_ID}" ] && [ "${RUN_ID}" -gt "${BEFORE_RUN_ID}" ]; then
               STATUS="$(gh run view "${RUN_ID}" --json status --jq '.status' 2>/dev/null || echo unknown)"
               if [ "${STATUS}" = "completed" ]; then
@@ -582,6 +600,7 @@ jobs:
     timeout-minutes: 35
     env:
       GH_REPO: ${{ github.repository }}
+      WORKFLOW_REF: dev
     needs: [validate, ready-release-pr]
     outputs:
       before_run_id: ${{ steps.capture_release_before.outputs.before_run_id }}
@@ -602,7 +621,7 @@ jobs:
         run: |
           set -euo pipefail
           BEFORE_RUN_ID="$(
-            gh run list --workflow release.yml --limit 1 --json databaseId --jq '.[0].databaseId // 0' 2>/dev/null || echo 0
+            gh run list --workflow release.yml --branch "${WORKFLOW_REF}" --limit 1 --json databaseId --jq '.[0].databaseId // 0' 2>/dev/null || echo 0
           )"
           echo "before_run_id=${BEFORE_RUN_ID}" >> "${GITHUB_OUTPUT}"
 
@@ -614,6 +633,7 @@ jobs:
         run: |
           set -euo pipefail
           gh workflow run release.yml \
+            --ref "${WORKFLOW_REF}" \
             -f version="${BASE_VERSION}" \
             -f release-kind="${RELEASE_KIND}"
 
@@ -628,7 +648,7 @@ jobs:
           ELAPSED=0
 
           while [ "${ELAPSED}" -lt "${TIMEOUT}" ]; do
-            RUN_ID="$(gh run list --workflow release.yml --limit 1 --json databaseId --jq '.[0].databaseId // empty' 2>/dev/null || true)"
+            RUN_ID="$(gh run list --workflow release.yml --branch "${WORKFLOW_REF}" --limit 1 --json databaseId --jq '.[0].databaseId // empty' 2>/dev/null || true)"
             if [ -n "${RUN_ID}" ] && [ "${RUN_ID}" -gt "${BEFORE_RUN_ID}" ]; then
               STATUS="$(gh run view "${RUN_ID}" --json status --jq '.status' 2>/dev/null || echo unknown)"
               if [ "${STATUS}" = "completed" ]; then

--- a/assets/smoke-test/.github/workflows/repository-dispatch.yml
+++ b/assets/smoke-test/.github/workflows/repository-dispatch.yml
@@ -29,6 +29,9 @@ concurrency:
 permissions:
   contents: read
 
+env:
+  WORKFLOW_REF: dev
+
 jobs:
   validate:
     name: Validate dispatch payload
@@ -389,7 +392,6 @@ jobs:
     timeout-minutes: 25
     env:
       GH_REPO: ${{ github.repository }}
-      WORKFLOW_REF: dev
     needs: [validate, cleanup-release]
     outputs:
       before_run_id: ${{ steps.capture_prepare_before.outputs.before_run_id }}
@@ -409,13 +411,19 @@ jobs:
         run: |
           set -euo pipefail
           # Canonical cross-repo dispatch contract lives in docs/CROSS_REPO_RELEASE_GATE.md.
-          REQUIRED_WORKFLOWS="prepare-release.yml release.yml"
-          for workflow_file in ${REQUIRED_WORKFLOWS}; do
-            if gh workflow view "${workflow_file}" --ref "${WORKFLOW_REF}" >/dev/null 2>&1; then
+          REQUIRED_WORKFLOWS=(prepare-release.yml release.yml)
+          for workflow_file in "${REQUIRED_WORKFLOWS[@]}"; do
+            if WORKFLOW_CHECK_OUTPUT="$(gh workflow view "${workflow_file}" --ref "${WORKFLOW_REF}" 2>&1)"; then
               echo "Workflow available on ${WORKFLOW_REF}: ${workflow_file}"
             else
-              echo "ERROR: required workflow '${workflow_file}' is not resolvable on ref '${WORKFLOW_REF}'"
-              echo "Dispatch contract drift detected; aborting before orchestration dispatch."
+              if printf '%s' "${WORKFLOW_CHECK_OUTPUT}" | grep -Eqi "404|not found"; then
+                echo "ERROR: required workflow '${workflow_file}' is not resolvable on ref '${WORKFLOW_REF}'"
+                echo "Dispatch contract drift detected; aborting before orchestration dispatch."
+              else
+                echo "ERROR: failed to validate workflow '${workflow_file}' on ref '${WORKFLOW_REF}'"
+                echo "Validation failed due to a non-contract error (auth/permission/API/network)."
+              fi
+              echo "${WORKFLOW_CHECK_OUTPUT}"
               exit 1
             fi
           done
@@ -600,7 +608,6 @@ jobs:
     timeout-minutes: 35
     env:
       GH_REPO: ${{ github.repository }}
-      WORKFLOW_REF: dev
     needs: [validate, ready-release-pr]
     outputs:
       before_run_id: ${{ steps.capture_release_before.outputs.before_run_id }}

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -106,6 +106,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Smoke-test dispatch gh jobs now set explicit repo context** ([#386](https://github.com/vig-os/devcontainer/issues/386))
   - Add job-level `GH_REPO: ${{ github.repository }}` to `cleanup-release`, `trigger-prepare-release`, `ready-release-pr`, and `trigger-release` in `assets/smoke-test/.github/workflows/repository-dispatch.yml`
   - Prevent `gh` CLI failures (`fatal: not a git repository`) in runner jobs that do not perform `actions/checkout`
+- **Smoke-test release orchestration now validates workflow contract before dispatch** ([#389](https://github.com/vig-os/devcontainer/issues/389))
+  - Add a preflight check that verifies `prepare-release.yml` and `release.yml` are resolvable on dispatch ref `dev` before downstream orchestration starts
+  - Dispatch and polling now use explicit ref/branch context (`--ref dev` / `--branch dev`) to avoid default-branch workflow registry drift and `404 workflow not found` failures
 
 ### Security
 

--- a/docs/CROSS_REPO_RELEASE_GATE.md
+++ b/docs/CROSS_REPO_RELEASE_GATE.md
@@ -34,6 +34,17 @@ Payload contract:
   - `client_payload[source_sha]`
   - `client_payload[correlation_id]`
 
+Workflow dispatch contract:
+
+- Required downstream workflow IDs/files:
+  - `prepare-release.yml`
+  - `release.yml`
+- Required dispatch ref:
+  - `dev`
+- Dispatch and wait operations must use the same ref context to avoid default-branch drift:
+  - dispatch via `gh workflow run <workflow> --ref dev ...`
+  - run discovery via `gh run list --workflow <workflow> --branch dev ...`
+
 ### Receiver Responsibilities
 
 The receiver workflow (`assets/smoke-test/.github/workflows/repository-dispatch.yml`) performs:
@@ -44,6 +55,7 @@ The receiver workflow (`assets/smoke-test/.github/workflows/repository-dispatch.
    - candidate tag -> GitHub pre-release
    - final tag -> GitHub release
 4. idempotency checks when a release object already exists
+5. preflight validation that required downstream workflow IDs are resolvable on the dispatch ref before orchestration starts
 
 ### Gate Checks in the Orchestrator
 
@@ -92,6 +104,7 @@ Common failure patterns:
 - downstream release type mismatch (`prerelease` flag differs from expected)
 - malformed/insufficient dispatch payload
 - downstream workflow failure prior to release artifact publication
+- workflow contract drift (required workflow ID missing on expected dispatch ref), which must fail fast in preflight
 
 ## Operational Verification
 

--- a/tests/bats/just.bats
+++ b/tests/bats/just.bats
@@ -101,17 +101,22 @@ setup() {
 }
 
 @test "smoke-test dispatch triggers downstream prepare and release workflows" {
-    run bash -lc "grep -Fq -- 'cleanup-release:' assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- 'gh workflow run prepare-release.yml' assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- 'gh workflow run release.yml' assets/smoke-test/.github/workflows/repository-dispatch.yml"
+    run bash -lc "grep -Fq -- 'cleanup-release:' assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- 'gh workflow run prepare-release.yml --ref \"\${WORKFLOW_REF}\"' assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- 'gh workflow run release.yml \\' assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- '--ref \"\${WORKFLOW_REF}\" \\' assets/smoke-test/.github/workflows/repository-dispatch.yml"
+    assert_success
+}
+
+@test "smoke-test dispatch preflight validates required workflow contract" {
+    run bash -lc "grep -Fq -- 'Preflight check required release workflows on dispatch ref' assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- 'REQUIRED_WORKFLOWS=\"prepare-release.yml release.yml\"' assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- 'gh workflow view \"\${workflow_file}\" --ref \"\${WORKFLOW_REF}\"' assets/smoke-test/.github/workflows/repository-dispatch.yml"
     assert_success
 }
 
 @test "smoke-test dispatch wait logic tracks prepare-release run after dispatch" {
-    run bash -lc 'grep -Fq -- "Capture latest prepare-release run id" assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- "BEFORE_RUN_ID: \${{ steps.capture_prepare_before.outputs.before_run_id }}" assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- "[ \"\${RUN_ID}\" -gt \"\${BEFORE_RUN_ID}\" ]" assets/smoke-test/.github/workflows/repository-dispatch.yml'
+    run bash -lc 'grep -Fq -- "Capture latest prepare-release run id" assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- "gh run list --workflow prepare-release.yml --branch \"\${WORKFLOW_REF}\"" assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- "BEFORE_RUN_ID: \${{ steps.capture_prepare_before.outputs.before_run_id }}" assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- "[ \"\${RUN_ID}\" -gt \"\${BEFORE_RUN_ID}\" ]" assets/smoke-test/.github/workflows/repository-dispatch.yml'
     assert_success
 }
 
 @test "smoke-test dispatch wait logic tracks release run after dispatch" {
-    run bash -lc 'grep -Fq -- "Capture latest release run id" assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- "BEFORE_RUN_ID: \${{ steps.capture_release_before.outputs.before_run_id }}" assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- "[ \"\${RUN_ID}\" -gt \"\${BEFORE_RUN_ID}\" ]" assets/smoke-test/.github/workflows/repository-dispatch.yml'
+    run bash -lc 'grep -Fq -- "Capture latest release run id" assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- "gh run list --workflow release.yml --branch \"\${WORKFLOW_REF}\"" assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- "BEFORE_RUN_ID: \${{ steps.capture_release_before.outputs.before_run_id }}" assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- "[ \"\${RUN_ID}\" -gt \"\${BEFORE_RUN_ID}\" ]" assets/smoke-test/.github/workflows/repository-dispatch.yml'
     assert_success
 }
 

--- a/tests/bats/just.bats
+++ b/tests/bats/just.bats
@@ -106,7 +106,7 @@ setup() {
 }
 
 @test "smoke-test dispatch preflight validates required workflow contract" {
-    run bash -lc "grep -Fq -- 'Preflight check required release workflows on dispatch ref' assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- 'REQUIRED_WORKFLOWS=\"prepare-release.yml release.yml\"' assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- 'gh workflow view \"\${workflow_file}\" --ref \"\${WORKFLOW_REF}\"' assets/smoke-test/.github/workflows/repository-dispatch.yml"
+    run bash -lc "grep -Fq -- 'Preflight check required release workflows on dispatch ref' assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- 'REQUIRED_WORKFLOWS=(prepare-release.yml release.yml)' assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- 'for workflow_file in \"\${REQUIRED_WORKFLOWS[@]}\"; do' assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- 'WORKFLOW_CHECK_OUTPUT=\"\$(gh workflow view \"\${workflow_file}\" --ref \"\${WORKFLOW_REF}\" 2>&1)\"' assets/smoke-test/.github/workflows/repository-dispatch.yml"
     assert_success
 }
 


### PR DESCRIPTION
## Description

Fixes smoke-test release orchestration drift that caused downstream dispatch to fail with `prepare-release.yml` not found on the default branch, and adds a docs-only follow-up to keep the dispatch payload header comment aligned with supported inputs (`client_payload.release_kind`).

## Type of Change

- [ ] `feat` -- New feature
- [x] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [ ] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- `assets/smoke-test/.github/workflows/repository-dispatch.yml`
  - Add preflight validation that checks `prepare-release.yml` and `release.yml` resolve on `dev` before orchestration dispatch.
  - Dispatch `prepare-release.yml` and `release.yml` with explicit `--ref "${WORKFLOW_REF}"`.
  - Poll runs with explicit `--branch "${WORKFLOW_REF}"` to keep dispatch and wait contexts aligned.
  - Update dispatch payload header comment optional keys to include `client_payload.release_kind` (issue #388 docs consistency follow-up).
- `tests/bats/just.bats`
  - Add/adjust assertions for preflight contract checks and explicit ref/branch usage in dispatch and wait paths.
- `docs/CROSS_REPO_RELEASE_GATE.md`
  - Document required workflow IDs, required dispatch ref (`dev`), and preflight drift-failure behavior as canonical contract.
- `CHANGELOG.md`
  - Add Unreleased Fixed entry for issue #389.
- `assets/workspace/.devcontainer/CHANGELOG.md`
  - Sync mirrored changelog entry generated by project hooks.

## Changelog Entry

### Fixed
- **Smoke-test release orchestration now validates workflow contract before dispatch** ([#389](https://github.com/vig-os/devcontainer/issues/389))
  - Add a preflight check that verifies `prepare-release.yml` and `release.yml` are resolvable on dispatch ref `dev` before downstream orchestration starts
  - Dispatch and polling now use explicit ref/branch context (`--ref dev` / `--branch dev`) to avoid default-branch workflow registry drift and `404 workflow not found` failures

No additional changelog entry was added for #388 because it is a docs-only comment alignment follow-up with issue-marked changelog category "No changelog needed".

## Testing

- [ ] Tests pass locally (`just test`)
- [x] Manual testing performed (describe below)

### Manual Testing Details

- Ran `npx bats tests/bats/just.bats`
- Result: `26/26` tests passed, including updated smoke-test dispatch contract checks

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

Downstream operational compatibility step from the implementation plan still applies: ensure `vig-os/devcontainer-smoke-test` default branch contains a valid `prepare-release` entrypoint during transition.

Refs: #389, #388
