### PR TITLE
fix: add git editor fallback in devcontainer setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Git commit now falls back to nano when editor config is unusable** ([#383](https://github.com/vig-os/devcontainer/issues/383))
+  - `setup-git-conf.sh` now validates the effective Git editor and sets `core.editor=nano` only when the configured editor is missing or invalid in-container
+  - Add integration regression coverage to ensure invalid editor settings are corrected during setup
+
 ### Security
 
 ## [0.3.1] - TBD

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Git commit now falls back to nano when editor config is unusable** ([#383](https://github.com/vig-os/devcontainer/issues/383))
+  - `setup-git-conf.sh` now validates the effective Git editor and sets `core.editor=nano` only when the configured editor is missing or invalid in-container
+  - Add integration regression coverage to ensure invalid editor settings are corrected during setup
+
 ### Security
 
 ## [0.3.1] - TBD

--- a/assets/workspace/.devcontainer/scripts/setup-git-conf.sh
+++ b/assets/workspace/.devcontainer/scripts/setup-git-conf.sh
@@ -22,6 +22,37 @@ else
 	echo "Run this from host's project root: .devcontainer/scripts/copy-host-user-conf.sh"
 fi
 
+ensure_git_editor_fallback() {
+	configured_editor=$(git config --global --get core.editor 2>/dev/null || true)
+	configured_editor_cmd=$(printf "%s" "$configured_editor" | awk '{print $1}')
+	configured_editor_cmd="${configured_editor_cmd#\"}"
+	configured_editor_cmd="${configured_editor_cmd%\"}"
+	configured_editor_cmd="${configured_editor_cmd#\'}"
+	configured_editor_cmd="${configured_editor_cmd%\'}"
+
+	if [ -n "$configured_editor" ] && ! command -v "$configured_editor_cmd" >/dev/null 2>&1; then
+		git config --global core.editor nano
+		echo "Configured git core.editor fallback to nano"
+		return
+	fi
+
+	effective_editor=$(git var GIT_EDITOR 2>/dev/null || true)
+	editor_cmd=$(printf "%s" "$effective_editor" | awk '{print $1}')
+	editor_cmd="${editor_cmd#\"}"
+	editor_cmd="${editor_cmd%\"}"
+	editor_cmd="${editor_cmd#\'}"
+	editor_cmd="${editor_cmd%\'}"
+
+	if [ -z "$editor_cmd" ] || ! command -v "$editor_cmd" >/dev/null 2>&1; then
+		git config --global core.editor nano
+		echo "Configured git core.editor fallback to nano"
+	else
+		echo "Using existing git editor: $effective_editor"
+	fi
+}
+
+ensure_git_editor_fallback
+
 # ── SSH public key for signing ─────────────────────────────────────────────────
 
 HOST_SSH_PUBKEY="$DEVCONTAINER_DIR/.conf/id_ed25519_github.pub"

--- a/assets/workspace/.devcontainer/scripts/setup-git-conf.sh
+++ b/assets/workspace/.devcontainer/scripts/setup-git-conf.sh
@@ -18,7 +18,8 @@ if [ -f "$HOST_GITCONFIG_FILE" ]; then
 	echo "Applying git configuration from $HOST_GITCONFIG_FILE..."
 	cp "$HOST_GITCONFIG_FILE" "$CONTAINER_GITCONFIG_FILE"
 else
-	echo "No git config file found, skipping git setup"
+	echo "No host git config file found at $HOST_GITCONFIG_FILE"
+	echo "Skipping host git config copy; continuing setup"
 	echo "Run this from host's project root: .devcontainer/scripts/copy-host-user-conf.sh"
 fi
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1231,7 +1231,14 @@ class TestDevContainerUserConf:
             (
                 "set -e && "
                 "cd /workspace/test_project && "
-                "printf '[core]\\n\\teditor = does-not-exist-editor\\n' > .devcontainer/.conf/.gitconfig && "
+                "orig_conf=.devcontainer/.conf/.gitconfig && "
+                "bak_conf=.devcontainer/.conf/.gitconfig.test-bak && "
+                '[ -f "$orig_conf" ] && cp "$orig_conf" "$bak_conf" || true && '
+                "export HOME=/tmp/setup-git-conf-home && "
+                'rm -rf "$HOME" && mkdir -p "$HOME" && '
+                'cleanup(){ rm -rf "$HOME"; if [ -f "$bak_conf" ]; then mv "$bak_conf" "$orig_conf"; else rm -f "$orig_conf"; fi; } && '
+                "trap cleanup EXIT && "
+                "printf '[core]\\n\\teditor = missing-editor-command-zzzz-12345\\n' > \"$orig_conf\" && "
                 ".devcontainer/scripts/setup-git-conf.sh >/tmp/setup-git-conf.log 2>&1 && "
                 "git config --global --get core.editor"
             ),

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1180,8 +1180,6 @@ class TestDevContainerUserConf:
     def test_files_copied_to_home(self, devcontainer_up):
         """Test that files from .devcontainer/.conf have been copied to their destinations."""
         workspace_path = str(devcontainer_up.resolve())
-        # .devcontainer is inside the project subdirectory
-        conf_dir = "/workspace/test_project/.devcontainer/.conf"
 
         # Check that .gitconfig was copied to ~/.gitconfig
         check_gitconfig_cmd = [
@@ -1211,6 +1209,53 @@ class TestDevContainerUserConf:
             f"stdout: {result.stdout}\n"
             f"stderr: {result.stderr}\n"
             f"command: {' '.join(check_gitconfig_cmd)}"
+        )
+
+    def test_setup_git_conf_falls_back_to_nano_for_invalid_editor(
+        self, devcontainer_up
+    ):
+        """Regression: setup-git-conf should enforce a usable editor fallback."""
+        workspace_path = str(devcontainer_up.resolve())
+        conf_dir = "/workspace/test_project/.devcontainer/.conf"
+        exec_cmd = [
+            "devcontainer",
+            "exec",
+            "--workspace-folder",
+            workspace_path,
+            "--config",
+            f"{workspace_path}/.devcontainer/devcontainer.json",
+            "--docker-path",
+            "podman",
+            "bash",
+            "-c",
+            (
+                "set -e && "
+                "cd /workspace/test_project && "
+                "printf '[core]\\n\\teditor = does-not-exist-editor\\n' > .devcontainer/.conf/.gitconfig && "
+                ".devcontainer/scripts/setup-git-conf.sh >/tmp/setup-git-conf.log 2>&1 && "
+                "git config --global --get core.editor"
+            ),
+        ]
+
+        result = subprocess.run(
+            exec_cmd,
+            capture_output=True,
+            text=True,
+            cwd=workspace_path,
+            env=os.environ.copy(),
+            timeout=60,
+        )
+
+        assert result.returncode == 0, (
+            f"Failed to re-run setup-git-conf.sh\n"
+            f"stdout: {result.stdout}\n"
+            f"stderr: {result.stderr}\n"
+            f"command: {' '.join(exec_cmd)}"
+        )
+        assert result.stdout.strip() == "nano", (
+            "setup-git-conf.sh should replace invalid core.editor with nano\n"
+            f"stdout: {result.stdout}\n"
+            f"stderr: {result.stderr}"
         )
 
         # Check that SSH public key was copied (if it exists in .conf)


### PR DESCRIPTION
## Description

Fixes the devcontainer bug where `git commit` without `-m` can fail if a host-provided `core.editor` is unavailable inside the container. The setup script now applies a safe fallback editor only when needed, and regression coverage validates the behavior.

## Type of Change

- [x] `fix` -- Bug fix
- [ ] `feat` -- New feature
- [ ] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [ ] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- `assets/workspace/.devcontainer/scripts/setup-git-conf.sh`
  - Add editor fallback guard that checks configured/effective Git editor availability
  - Set `git config --global core.editor nano` only when the editor is missing/invalid in-container
- `tests/test_integration.py`
  - Add regression test `test_setup_git_conf_falls_back_to_nano_for_invalid_editor`
  - Reproduce invalid editor config in `.devcontainer/.conf/.gitconfig`, rerun setup script, assert fallback to `nano`
- `CHANGELOG.md`
  - Add Unreleased/Fixed entry for issue `#383`
- `assets/workspace/.devcontainer/CHANGELOG.md`
  - Sync mirrored changelog entry for the workspace template

## Changelog Entry

### Fixed

- **Git commit now falls back to nano when editor config is unusable** ([#383](https://github.com/vig-os/devcontainer/issues/383))
  - `setup-git-conf.sh` now validates the effective Git editor and sets `core.editor=nano` only when the configured editor is missing or invalid in-container
  - Add integration regression coverage to ensure invalid editor settings are corrected during setup

## Testing

- [ ] Tests pass locally (`just test`)
- [ ] Manual testing performed (describe below)

### Manual Testing Details

N/A

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

- TDD commit sequence used:
  - `test(setup): add regression for invalid git editor fallback`
  - `fix(setup): add git core.editor fallback for container shells`
  - `docs(image): record git editor fallback fix in changelog`
- Verification commands executed:
  - `just build`
  - `uv run pytest tests/test_integration.py -k test_setup_git_conf_falls_back_to_nano_for_invalid_editor -v --tb=short`

Refs: #383
