### PR TITLE
fix(ci): harden smoke-test preflight and release workflow orchestration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Add missing `git config --global --add safe.directory "$GITHUB_WORKSPACE"` in containerized release and sync jobs that run git after checkout
   - Decouple `release.yml` rollback container startup from `needs.core.outputs.image_tag` by resolving the image in a dedicated `resolve-image` job
   - Add explicit release caller/reusable workflow permissions for `actions` and `pull-requests` operations, and update dispatch header comments to reference only current CI workflows
+- **Workspace containerized workflows now pin bash for run steps** ([#395](https://github.com/vig-os/devcontainer/issues/395))
+  - Set `defaults.run.shell: bash` in containerized workspace release and prepare jobs so `set -euo pipefail` scripts do not execute under POSIX `sh`
+  - Prevent downstream smoke-test failures caused by `set: Illegal option -o pipefail` in container jobs
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Smoke-test release orchestration now validates workflow contract before dispatch** ([#389](https://github.com/vig-os/devcontainer/issues/389))
   - Add a preflight check that verifies `prepare-release.yml` and `release.yml` are resolvable on dispatch ref `dev` before downstream orchestration starts
   - Dispatch and polling now use explicit ref/branch context (`--ref dev` / `--branch dev`) to avoid default-branch workflow registry drift and `404 workflow not found` failures
+- **Smoke-test preflight now uses gh CLI ref-compatible workflow validation** ([#392](https://github.com/vig-os/devcontainer/issues/392))
+  - Update `assets/smoke-test/.github/workflows/repository-dispatch.yml` preflight checks to call `gh workflow view` with `--yaml` when `--ref` is set
+  - Prevent false preflight failures caused by newer GitHub CLI argument validation before `prepare-release` dispatch
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Smoke-test preflight now uses gh CLI ref-compatible workflow validation** ([#392](https://github.com/vig-os/devcontainer/issues/392))
   - Update `assets/smoke-test/.github/workflows/repository-dispatch.yml` preflight checks to call `gh workflow view` with `--yaml` when `--ref` is set
   - Prevent false preflight failures caused by newer GitHub CLI argument validation before `prepare-release` dispatch
+- **Downstream release workflow templates hardened for smoke-test orchestration** ([#394](https://github.com/vig-os/devcontainer/issues/394))
+  - Add missing `git config --global --add safe.directory "$GITHUB_WORKSPACE"` in containerized release and sync jobs that run git after checkout
+  - Decouple `release.yml` rollback container startup from `needs.core.outputs.image_tag` by resolving the image in a dedicated `resolve-image` job
+  - Add explicit release caller/reusable workflow permissions for `actions` and `pull-requests` operations, and update dispatch header comments to reference only current CI workflows
 
 ### Security
 

--- a/assets/smoke-test/.github/workflows/repository-dispatch.yml
+++ b/assets/smoke-test/.github/workflows/repository-dispatch.yml
@@ -420,9 +420,6 @@ jobs:
               if printf '%s' "${WORKFLOW_CHECK_OUTPUT}" | grep -Eqi "404|not found"; then
                 echo "ERROR: required workflow '${workflow_file}' is not resolvable on ref '${WORKFLOW_REF}'"
                 echo "Dispatch contract drift detected; aborting before orchestration dispatch."
-              elif printf '%s' "${WORKFLOW_CHECK_OUTPUT}" | grep -Eqi -- "--yaml required|--yaml"; then
-                echo "ERROR: workflow preflight invocation invalid for current gh CLI (missing required --yaml with --ref)"
-                echo "Update preflight command to include --yaml when using --ref."
               else
                 echo "ERROR: failed to validate workflow '${workflow_file}' on ref '${WORKFLOW_REF}'"
                 echo "Validation failed due to a non-contract error (auth/permission/API/network)."

--- a/assets/smoke-test/.github/workflows/repository-dispatch.yml
+++ b/assets/smoke-test/.github/workflows/repository-dispatch.yml
@@ -414,12 +414,15 @@ jobs:
           # Canonical cross-repo dispatch contract lives in docs/CROSS_REPO_RELEASE_GATE.md.
           REQUIRED_WORKFLOWS=(prepare-release.yml release.yml)
           for workflow_file in "${REQUIRED_WORKFLOWS[@]}"; do
-            if WORKFLOW_CHECK_OUTPUT="$(gh workflow view "${workflow_file}" --ref "${WORKFLOW_REF}" 2>&1)"; then
+            if WORKFLOW_CHECK_OUTPUT="$(gh workflow view "${workflow_file}" --ref "${WORKFLOW_REF}" --yaml 2>&1 >/dev/null)"; then
               echo "Workflow available on ${WORKFLOW_REF}: ${workflow_file}"
             else
               if printf '%s' "${WORKFLOW_CHECK_OUTPUT}" | grep -Eqi "404|not found"; then
                 echo "ERROR: required workflow '${workflow_file}' is not resolvable on ref '${WORKFLOW_REF}'"
                 echo "Dispatch contract drift detected; aborting before orchestration dispatch."
+              elif printf '%s' "${WORKFLOW_CHECK_OUTPUT}" | grep -Eqi -- "--yaml required|--yaml"; then
+                echo "ERROR: workflow preflight invocation invalid for current gh CLI (missing required --yaml with --ref)"
+                echo "Update preflight command to include --yaml when using --ref."
               else
                 echo "ERROR: failed to validate workflow '${workflow_file}' on ref '${WORKFLOW_REF}'"
                 echo "Validation failed due to a non-contract error (auth/permission/API/network)."

--- a/assets/smoke-test/.github/workflows/repository-dispatch.yml
+++ b/assets/smoke-test/.github/workflows/repository-dispatch.yml
@@ -5,7 +5,7 @@ name: Repository Dispatch Listener
 # - Deploy the requested tag into the smoke-test repo.
 # - Always create a `chore/deploy-<tag>` branch and PR to `dev`.
 # - Create signed deploy commits via `vig-os/commit-action`.
-# - CI (`ci.yml` + `ci-container.yml`) triggers on the deploy PR.
+# - CI (`ci.yml`) triggers on the deploy PR.
 #
 # Dispatch payload:
 # - Preferred:   client_payload.tag

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -116,6 +116,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Add missing `git config --global --add safe.directory "$GITHUB_WORKSPACE"` in containerized release and sync jobs that run git after checkout
   - Decouple `release.yml` rollback container startup from `needs.core.outputs.image_tag` by resolving the image in a dedicated `resolve-image` job
   - Add explicit release caller/reusable workflow permissions for `actions` and `pull-requests` operations, and update dispatch header comments to reference only current CI workflows
+- **Workspace containerized workflows now pin bash for run steps** ([#395](https://github.com/vig-os/devcontainer/issues/395))
+  - Set `defaults.run.shell: bash` in containerized workspace release and prepare jobs so `set -euo pipefail` scripts do not execute under POSIX `sh`
+  - Prevent downstream smoke-test failures caused by `set: Illegal option -o pipefail` in container jobs
 
 ### Security
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -109,6 +109,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Smoke-test release orchestration now validates workflow contract before dispatch** ([#389](https://github.com/vig-os/devcontainer/issues/389))
   - Add a preflight check that verifies `prepare-release.yml` and `release.yml` are resolvable on dispatch ref `dev` before downstream orchestration starts
   - Dispatch and polling now use explicit ref/branch context (`--ref dev` / `--branch dev`) to avoid default-branch workflow registry drift and `404 workflow not found` failures
+- **Smoke-test preflight now uses gh CLI ref-compatible workflow validation** ([#392](https://github.com/vig-os/devcontainer/issues/392))
+  - Update `assets/smoke-test/.github/workflows/repository-dispatch.yml` preflight checks to call `gh workflow view` with `--yaml` when `--ref` is set
+  - Prevent false preflight failures caused by newer GitHub CLI argument validation before `prepare-release` dispatch
 
 ### Security
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -112,6 +112,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Smoke-test preflight now uses gh CLI ref-compatible workflow validation** ([#392](https://github.com/vig-os/devcontainer/issues/392))
   - Update `assets/smoke-test/.github/workflows/repository-dispatch.yml` preflight checks to call `gh workflow view` with `--yaml` when `--ref` is set
   - Prevent false preflight failures caused by newer GitHub CLI argument validation before `prepare-release` dispatch
+- **Downstream release workflow templates hardened for smoke-test orchestration** ([#394](https://github.com/vig-os/devcontainer/issues/394))
+  - Add missing `git config --global --add safe.directory "$GITHUB_WORKSPACE"` in containerized release and sync jobs that run git after checkout
+  - Decouple `release.yml` rollback container startup from `needs.core.outputs.image_tag` by resolving the image in a dedicated `resolve-image` job
+  - Add explicit release caller/reusable workflow permissions for `actions` and `pull-requests` operations, and update dispatch header comments to reference only current CI workflows
 
 ### Security
 

--- a/assets/workspace/.github/workflows/prepare-release.yml
+++ b/assets/workspace/.github/workflows/prepare-release.yml
@@ -150,6 +150,9 @@ jobs:
       env:
         UV_PROJECT_ENVIRONMENT: /root/assets/workspace/.venv
     timeout-minutes: 15
+    defaults:
+      run:
+        shell: bash
     if: ${{ inputs.dry-run != true }}
     permissions:
       contents: write

--- a/assets/workspace/.github/workflows/release-core.yml
+++ b/assets/workspace/.github/workflows/release-core.yml
@@ -93,6 +93,9 @@ jobs:
     container:
       image: ghcr.io/vig-os/devcontainer:${{ needs.resolve-image.outputs.image-tag }}
     timeout-minutes: 10
+    defaults:
+      run:
+        shell: bash
     outputs:
       version: ${{ steps.vars.outputs.version }}
       pr_number: ${{ steps.pr.outputs.pr_number }}
@@ -313,6 +316,9 @@ jobs:
       env:
         UV_PROJECT_ENVIRONMENT: /root/assets/workspace/.venv
     timeout-minutes: 15
+    defaults:
+      run:
+        shell: bash
     if: ${{ inputs.dry_run != true }}
     outputs:
       finalize_sha: ${{ steps.finalize.outputs.finalize_sha }}
@@ -453,6 +459,9 @@ jobs:
       env:
         UV_PROJECT_ENVIRONMENT: /root/assets/workspace/.venv
     timeout-minutes: 20
+    defaults:
+      run:
+        shell: bash
     if: ${{ inputs.dry_run != true }}
 
     steps:

--- a/assets/workspace/.github/workflows/release-core.yml
+++ b/assets/workspace/.github/workflows/release-core.yml
@@ -87,6 +87,9 @@ jobs:
     name: Validate Release Core
     needs: [resolve-image]
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      pull-requests: read
     container:
       image: ghcr.io/vig-os/devcontainer:${{ needs.resolve-image.outputs.image-tag }}
     timeout-minutes: 10
@@ -145,6 +148,9 @@ jobs:
           ref: release/${{ steps.vars.outputs.version }}
           fetch-depth: 0
           token: ${{ steps.auth.outputs.token }}
+
+      - name: Fix git safe.directory
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - name: Validate image accessibility
         env:
@@ -299,14 +305,15 @@ jobs:
     name: Finalize Release Core
     needs: validate
     runs-on: ubuntu-22.04
+    permissions:
+      actions: write
+      contents: write
     container:
       image: ghcr.io/vig-os/devcontainer:${{ needs.validate.outputs.image_tag }}
       env:
         UV_PROJECT_ENVIRONMENT: /root/assets/workspace/.venv
     timeout-minutes: 15
     if: ${{ inputs.dry_run != true }}
-    permissions:
-      contents: write
     outputs:
       finalize_sha: ${{ steps.finalize.outputs.finalize_sha }}
 

--- a/assets/workspace/.github/workflows/release-publish.yml
+++ b/assets/workspace/.github/workflows/release-publish.yml
@@ -74,6 +74,9 @@ jobs:
     container:
       image: ghcr.io/vig-os/devcontainer:${{ needs.resolve-image.outputs.image-tag }}
     timeout-minutes: 10
+    defaults:
+      run:
+        shell: bash
     permissions:
       contents: write
     outputs:

--- a/assets/workspace/.github/workflows/release-publish.yml
+++ b/assets/workspace/.github/workflows/release-publish.yml
@@ -112,6 +112,9 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.auth.outputs.token }}
 
+      - name: Fix git safe.directory
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
       - name: Configure git
         env:
           GIT_USER_NAME: ${{ inputs.git_user_name }}

--- a/assets/workspace/.github/workflows/release.yml
+++ b/assets/workspace/.github/workflows/release.yml
@@ -107,6 +107,9 @@ jobs:
     container:
       image: ghcr.io/vig-os/devcontainer:${{ needs.resolve-image.outputs.image-tag }}
     timeout-minutes: 10
+    defaults:
+      run:
+        shell: bash
     if: ${{ failure() && inputs.dry-run != true }}
     permissions:
       contents: write

--- a/assets/workspace/.github/workflows/release.yml
+++ b/assets/workspace/.github/workflows/release.yml
@@ -36,9 +36,32 @@ permissions:
   contents: read
 
 jobs:
+  resolve-image:
+    name: Resolve image tag
+    runs-on: ubuntu-22.04
+    timeout-minutes: 2
+    outputs:
+      image-tag: ${{ steps.resolve.outputs.image-tag }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          sparse-checkout: |
+            .vig-os
+            .github/actions/resolve-image
+          sparse-checkout-cone-mode: false
+
+      - name: Resolve container image
+        id: resolve
+        uses: ./.github/actions/resolve-image
+
   core:
     name: Release Core
     uses: ./.github/workflows/release-core.yml
+    permissions:
+      actions: write
+      contents: write
+      pull-requests: read
     with:
       version: ${{ inputs.version }}
       release_kind: ${{ inputs.release-kind }}
@@ -65,6 +88,8 @@ jobs:
     needs: [core, extension]
     if: ${{ inputs.dry-run != true }}
     uses: ./.github/workflows/release-publish.yml
+    permissions:
+      contents: write
     with:
       version: ${{ needs.core.outputs.version }}
       finalize_sha: ${{ needs.core.outputs.finalize_sha }}
@@ -77,10 +102,10 @@ jobs:
 
   rollback:
     name: Rollback on Failure
-    needs: [core, extension, publish]
+    needs: [resolve-image, core, extension, publish]
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/vig-os/devcontainer:${{ needs.core.outputs.image_tag }}
+      image: ghcr.io/vig-os/devcontainer:${{ needs.resolve-image.outputs.image-tag }}
     timeout-minutes: 10
     if: ${{ failure() && inputs.dry-run != true }}
     permissions:
@@ -92,6 +117,10 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
+
+      - name: Fix git safe.directory
+        if: ${{ needs.core.outputs.pre_finalize_sha != '' }}
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - name: Configure git
         if: ${{ needs.core.outputs.pre_finalize_sha != '' }}

--- a/assets/workspace/.github/workflows/release.yml
+++ b/assets/workspace/.github/workflows/release.yml
@@ -110,7 +110,17 @@ jobs:
     defaults:
       run:
         shell: bash
-    if: ${{ failure() && inputs.dry-run != true }}
+    if: >-
+      ${{
+        always() &&
+        inputs.dry-run != true &&
+        needs.resolve-image.result == 'success' &&
+        (
+          needs.core.result == 'failure' ||
+          needs.extension.result == 'failure' ||
+          needs.publish.result == 'failure'
+        )
+      }}
     permissions:
       contents: write
       issues: write

--- a/assets/workspace/.github/workflows/sync-main-to-dev.yml
+++ b/assets/workspace/.github/workflows/sync-main-to-dev.yml
@@ -65,6 +65,9 @@ jobs:
     container:
       image: ghcr.io/vig-os/devcontainer:${{ needs.resolve-image.outputs.image-tag }}
     timeout-minutes: 5
+    defaults:
+      run:
+        shell: bash
     outputs:
       up_to_date: ${{ steps.check.outputs.up_to_date }}
 
@@ -107,6 +110,9 @@ jobs:
     container:
       image: ghcr.io/vig-os/devcontainer:${{ needs.resolve-image.outputs.image-tag }}
     timeout-minutes: 10
+    defaults:
+      run:
+        shell: bash
     env:
       SYNC_BRANCH: chore/sync-main-to-dev-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:

--- a/assets/workspace/.github/workflows/sync-main-to-dev.yml
+++ b/assets/workspace/.github/workflows/sync-main-to-dev.yml
@@ -74,6 +74,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Fix git safe.directory
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
       - name: Check if dev is up to date with main
         id: check
         run: |
@@ -125,6 +128,9 @@ jobs:
           ref: dev
           fetch-depth: 0
           token: ${{ steps.commit-app-token.outputs.token }}
+
+      - name: Fix git safe.directory
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
       - name: Re-check if dev is still behind main
         id: recheck

--- a/tests/bats/just.bats
+++ b/tests/bats/just.bats
@@ -139,3 +139,18 @@ setup() {
     run bash -lc "grep -Fq -- 'needs.wait-deploy-merge.result' assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- 'needs.cleanup-release.result' assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- 'needs.trigger-prepare-release.result' assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- 'needs.ready-release-pr.result' assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- 'needs.trigger-release.result' assets/smoke-test/.github/workflows/repository-dispatch.yml"
     assert_success
 }
+
+@test "release workflow rollback resolves container image independently of core outputs" {
+    run bash -lc "grep -Fq -- 'resolve-image:' assets/workspace/.github/workflows/release.yml && grep -Fq -- 'needs: [resolve-image, core, extension, publish]' assets/workspace/.github/workflows/release.yml && grep -Fq -- 'image: ghcr.io/vig-os/devcontainer:\${{ needs.resolve-image.outputs.image-tag }}' assets/workspace/.github/workflows/release.yml"
+    assert_success
+}
+
+@test "release workflows configure safe.directory in container jobs that run git" {
+    run bash -lc "awk '/^  validate:/{flag=1} /^  finalize:/{flag=0} flag {print}' assets/workspace/.github/workflows/release-core.yml | grep -Fq -- 'name: Fix git safe.directory' && grep -Fq -- 'name: Fix git safe.directory' assets/workspace/.github/workflows/release-publish.yml && [ \"$(grep -Fc -- 'name: Fix git safe.directory' assets/workspace/.github/workflows/sync-main-to-dev.yml)\" -ge 2 ] && grep -Fq -- 'name: Fix git safe.directory' assets/workspace/.github/workflows/release.yml"
+    assert_success
+}
+
+@test "release caller and reusable workflows define explicit minimal permissions for gh operations" {
+    run bash -lc "awk '/^  core:/{flag=1} /^  extension:/{flag=0} flag {print}' assets/workspace/.github/workflows/release.yml | grep -Fq -- 'actions: write' && awk '/^  core:/{flag=1} /^  extension:/{flag=0} flag {print}' assets/workspace/.github/workflows/release.yml | grep -Fq -- 'pull-requests: read' && awk '/^  publish:/{flag=1} /^  rollback:/{flag=0} flag {print}' assets/workspace/.github/workflows/release.yml | grep -Fq -- 'contents: write' && awk '/^  validate:/{flag=1} /^  finalize:/{flag=0} flag {print}' assets/workspace/.github/workflows/release-core.yml | grep -Fq -- 'pull-requests: read' && awk '/^  finalize:/{flag=1} /^  test:/{flag=0} flag {print}' assets/workspace/.github/workflows/release-core.yml | grep -Fq -- 'actions: write'"
+    assert_success
+}

--- a/tests/bats/just.bats
+++ b/tests/bats/just.bats
@@ -106,7 +106,7 @@ setup() {
 }
 
 @test "smoke-test dispatch preflight validates required workflow contract" {
-    run bash -lc "grep -Fq -- 'Preflight check required release workflows on dispatch ref' assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- 'REQUIRED_WORKFLOWS=(prepare-release.yml release.yml)' assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- 'for workflow_file in \"\${REQUIRED_WORKFLOWS[@]}\"; do' assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- 'WORKFLOW_CHECK_OUTPUT=\"\$(gh workflow view \"\${workflow_file}\" --ref \"\${WORKFLOW_REF}\" 2>&1)\"' assets/smoke-test/.github/workflows/repository-dispatch.yml"
+    run bash -lc "grep -Fq -- 'Preflight check required release workflows on dispatch ref' assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- 'REQUIRED_WORKFLOWS=(prepare-release.yml release.yml)' assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- 'for workflow_file in \"\${REQUIRED_WORKFLOWS[@]}\"; do' assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- 'WORKFLOW_CHECK_OUTPUT=\"\$(gh workflow view \"\${workflow_file}\" --ref \"\${WORKFLOW_REF}\" --yaml 2>&1 >/dev/null)\"' assets/smoke-test/.github/workflows/repository-dispatch.yml"
     assert_success
 }
 


### PR DESCRIPTION
## Description

Fix smoke-test dispatch failures caused by GitHub CLI `--ref` argument validation changes and downstream release workflow issues in containerized jobs. The preflight check now uses `--yaml` with `--ref` for workflow validation, release workflows are hardened with proper image resolution and permissions, and containerized jobs explicitly pin bash to avoid POSIX `sh` incompatibilities.

## Type of Change

- [ ] `feat` -- New feature
- [x] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [x] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- **`assets/workspace/.github/workflows/repository-dispatch.yml`** — Update preflight to use `gh workflow view --yaml --ref` instead of bare `--ref`, preventing false failures from newer gh CLI argument validation
- **`assets/workspace/.github/workflows/release.yml`** — Decouple rollback container startup from `needs.core.outputs.image_tag` by adding a dedicated `resolve-image` job; add dispatch header comments
- **`assets/workspace/.github/workflows/release-core.yml`** — Add `safe.directory` config and explicit `actions`/`pull-requests` permissions for containerized release jobs
- **`assets/workspace/.github/workflows/release-publish.yml`** — Add `safe.directory` config in containerized publish steps
- **`assets/workspace/.github/workflows/prepare-release.yml`** — Add `defaults.run.shell: bash` for containerized prepare jobs
- **`assets/workspace/.github/workflows/sync-main-to-dev.yml`** — Add `safe.directory` config and explicit shell in containerized sync jobs
- **`tests/bats/just.bats`** — Assert preflight uses `--yaml` with `--ref`; cover rollback image resolution and workflow hardening
- **`CHANGELOG.md`** / **`assets/workspace/.devcontainer/CHANGELOG.md`** — Document fixes under Unreleased

## Changelog Entry

### Fixed
- **Smoke-test preflight now uses gh CLI ref-compatible workflow validation** ([#392](https://github.com/vig-os/devcontainer/issues/392))
  - Update `assets/smoke-test/.github/workflows/repository-dispatch.yml` preflight checks to call `gh workflow view` with `--yaml` when `--ref` is set
  - Prevent false preflight failures caused by newer GitHub CLI argument validation before `prepare-release` dispatch
- **Downstream release workflow templates hardened for smoke-test orchestration** ([#394](https://github.com/vig-os/devcontainer/issues/394))
  - Add missing `git config --global --add safe.directory "$GITHUB_WORKSPACE"` in containerized release and sync jobs that run git after checkout
  - Decouple `release.yml` rollback container startup from `needs.core.outputs.image_tag` by resolving the image in a dedicated `resolve-image` job
  - Add explicit release caller/reusable workflow permissions for `actions` and `pull-requests` operations, and update dispatch header comments to reference only current CI workflows
- **Workspace containerized workflows now pin bash for run steps** ([#395](https://github.com/vig-os/devcontainer/issues/395))
  - Set `defaults.run.shell: bash` in containerized workspace release and prepare jobs so `set -euo pipefail` scripts do not execute under POSIX `sh`
  - Prevent downstream smoke-test failures caused by `set: Illegal option -o pipefail` in container jobs

## Testing

- [x] Tests pass locally (`just test`)
- [ ] Manual testing performed (describe below)

### Manual Testing Details

N/A

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

This PR bundles three closely related smoke-test orchestration fixes discovered during the 0.3.1 release candidate cycle. Each fix addresses a different failure point in the dispatch-to-rollback pipeline.

Refs: #392, #394, #395
