### PR TITLE
fix(ci): require app tokens in downstream release templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Update `assets/workspace/.github/workflows/prepare-release.yml`, `release-core.yml`, `release-publish.yml`, `release.yml`, and `sync-issues.yml` to remove `github.token` fallback from protected write operations
   - Route protected branch/ref writes through Commit App tokens and release orchestration/issue operations through Release App tokens
   - Document downstream token requirements in `docs/DOWNSTREAM_RELEASE.md` and `docs/CROSS_REPO_RELEASE_GATE.md`
+  - Use `github.token` specifically for Actions cache deletion in `sync-issues.yml` because that API path requires explicit `actions: write` job token scope
+  - Use Commit App credentials for rollback checkout in `release.yml` so rollback branch/tag writes can still bypass protected refs
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Workspace containerized workflows now pin bash for run steps** ([#395](https://github.com/vig-os/devcontainer/issues/395))
   - Set `defaults.run.shell: bash` in containerized workspace release and prepare jobs so `set -euo pipefail` scripts do not execute under POSIX `sh`
   - Prevent downstream smoke-test failures caused by `set: Illegal option -o pipefail` in container jobs
+- **Downstream release templates now require explicit app tokens for write paths** ([#400](https://github.com/vig-os/devcontainer/issues/400))
+  - Update `assets/workspace/.github/workflows/prepare-release.yml`, `release-core.yml`, `release-publish.yml`, `release.yml`, and `sync-issues.yml` to remove `github.token` fallback from protected write operations
+  - Route protected branch/ref writes through Commit App tokens and release orchestration/issue operations through Release App tokens
+  - Document downstream token requirements in `docs/DOWNSTREAM_RELEASE.md` and `docs/CROSS_REPO_RELEASE_GATE.md`
 
 ### Security
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -127,6 +127,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Update `assets/workspace/.github/workflows/prepare-release.yml`, `release-core.yml`, `release-publish.yml`, `release.yml`, and `sync-issues.yml` to remove `github.token` fallback from protected write operations
   - Route protected branch/ref writes through Commit App tokens and release orchestration/issue operations through Release App tokens
   - Document downstream token requirements in `docs/DOWNSTREAM_RELEASE.md` and `docs/CROSS_REPO_RELEASE_GATE.md`
+  - Use `github.token` specifically for Actions cache deletion in `sync-issues.yml` because that API path requires explicit `actions: write` job token scope
+  - Use Commit App credentials for rollback checkout in `release.yml` so rollback branch/tag writes can still bypass protected refs
 
 ### Security
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -123,6 +123,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Workspace containerized workflows now pin bash for run steps** ([#395](https://github.com/vig-os/devcontainer/issues/395))
   - Set `defaults.run.shell: bash` in containerized workspace release and prepare jobs so `set -euo pipefail` scripts do not execute under POSIX `sh`
   - Prevent downstream smoke-test failures caused by `set: Illegal option -o pipefail` in container jobs
+- **Downstream release templates now require explicit app tokens for write paths** ([#400](https://github.com/vig-os/devcontainer/issues/400))
+  - Update `assets/workspace/.github/workflows/prepare-release.yml`, `release-core.yml`, `release-publish.yml`, `release.yml`, and `sync-issues.yml` to remove `github.token` fallback from protected write operations
+  - Route protected branch/ref writes through Commit App tokens and release orchestration/issue operations through Release App tokens
+  - Document downstream token requirements in `docs/DOWNSTREAM_RELEASE.md` and `docs/CROSS_REPO_RELEASE_GATE.md`
 
 ### Security
 

--- a/assets/workspace/.github/workflows/prepare-release.yml
+++ b/assets/workspace/.github/workflows/prepare-release.yml
@@ -159,6 +159,20 @@ jobs:
       pull-requests: write
 
     steps:
+      - name: Generate Commit App Token
+        id: commit_app_token
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859  # v3
+        with:
+          app-id: ${{ secrets.COMMIT_APP_ID }}
+          private-key: ${{ secrets.COMMIT_APP_PRIVATE_KEY }}
+
+      - name: Generate Release App Token
+        id: release_app_token
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859  # v3
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Checkout dev branch
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
@@ -171,7 +185,7 @@ jobs:
       - name: Capture pre-prepare dev SHA
         id: pre_state
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.commit_app_token.outputs.token }}
         run: |
           set -euo pipefail
           PREPARE_START_SHA=$(retry --retries 3 --backoff 5 --max-backoff 60 -- \
@@ -201,7 +215,7 @@ jobs:
       - name: Commit prepared CHANGELOG to dev via API
         uses: vig-os/commit-action@c0024cbad0e501764127cccab732c6cd465b4646  # v0.1.5
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.commit_app_token.outputs.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           TARGET_BRANCH: refs/heads/dev
           COMMIT_MESSAGE: |-
@@ -214,7 +228,7 @@ jobs:
       - name: Create release branch from dev
         id: create_branch
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.commit_app_token.outputs.token }}
           RELEASE_BRANCH: ${{ needs.validate.outputs.release_branch }}
         run: |
           set -euo pipefail
@@ -251,7 +265,7 @@ jobs:
       - name: Commit stripped CHANGELOG to release branch via API
         uses: vig-os/commit-action@c0024cbad0e501764127cccab732c6cd465b4646  # v0.1.5
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.commit_app_token.outputs.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           TARGET_BRANCH: refs/heads/${{ needs.validate.outputs.release_branch }}
           COMMIT_MESSAGE: |-
@@ -264,7 +278,7 @@ jobs:
       - name: Create draft PR to main
         id: pr
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.release_app_token.outputs.token }}
           VERSION: ${{ needs.validate.outputs.version }}
           RELEASE_BRANCH: ${{ needs.validate.outputs.release_branch }}
           CHANGELOG_CONTENT: ${{ steps.changelog.outputs.changelog }}
@@ -300,7 +314,7 @@ jobs:
         id: rollback_prepare
         if: ${{ failure() }}
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.commit_app_token.outputs.token }}
           RELEASE_BRANCH: ${{ needs.validate.outputs.release_branch }}
           PREPARE_START_SHA: ${{ steps.pre_state.outputs.prepare_start_sha }}
           POST_FREEZE_DEV_SHA: ${{ steps.create_branch.outputs.dev_sha }}
@@ -336,7 +350,7 @@ jobs:
         if: ${{ failure() && steps.rollback_prepare.outputs.changelog_rollback_needed == 'true' }}
         uses: vig-os/commit-action@c0024cbad0e501764127cccab732c6cd465b4646  # v0.1.5
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.commit_app_token.outputs.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           TARGET_BRANCH: refs/heads/dev
           COMMIT_MESSAGE: |-

--- a/assets/workspace/.github/workflows/release-core.yml
+++ b/assets/workspace/.github/workflows/release-core.yml
@@ -106,11 +106,18 @@ jobs:
       image_tag: ${{ needs.resolve-image.outputs.image-tag }}
 
     steps:
+      - name: Generate release app token
+        id: release_app_token
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859  # v3
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Resolve auth token
         id: auth
         env:
           PROVIDED_TOKEN: ${{ secrets.token }}
-          FALLBACK_TOKEN: ${{ github.token }}
+          FALLBACK_TOKEN: ${{ steps.release_app_token.outputs.token }}
         run: |
           set -euo pipefail
           if [ -n "${PROVIDED_TOKEN:-}" ]; then
@@ -324,11 +331,25 @@ jobs:
       finalize_sha: ${{ steps.finalize.outputs.finalize_sha }}
 
     steps:
+      - name: Generate commit app token
+        id: commit_app_token
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859  # v3
+        with:
+          app-id: ${{ secrets.COMMIT_APP_ID }}
+          private-key: ${{ secrets.COMMIT_APP_PRIVATE_KEY }}
+
+      - name: Generate release app token
+        id: release_app_token
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859  # v3
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Resolve auth token
         id: auth
         env:
           PROVIDED_TOKEN: ${{ secrets.token }}
-          FALLBACK_TOKEN: ${{ github.token }}
+          FALLBACK_TOKEN: ${{ steps.release_app_token.outputs.token }}
         run: |
           set -euo pipefail
           if [ -n "${PROVIDED_TOKEN:-}" ]; then
@@ -360,7 +381,7 @@ jobs:
         if: ${{ inputs.release_kind == 'final' }}
         uses: vig-os/commit-action@c0024cbad0e501764127cccab732c6cd465b4646  # v0.1.5
         env:
-          GH_TOKEN: ${{ steps.auth.outputs.token }}
+          GH_TOKEN: ${{ steps.commit_app_token.outputs.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           TARGET_BRANCH: refs/heads/release/${{ needs.validate.outputs.version }}
           COMMIT_MESSAGE: |-
@@ -465,11 +486,18 @@ jobs:
     if: ${{ inputs.dry_run != true }}
 
     steps:
+      - name: Generate release app token
+        id: release_app_token
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859  # v3
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Resolve auth token
         id: auth
         env:
           PROVIDED_TOKEN: ${{ secrets.token }}
-          FALLBACK_TOKEN: ${{ github.token }}
+          FALLBACK_TOKEN: ${{ steps.release_app_token.outputs.token }}
         run: |
           set -euo pipefail
           if [ -n "${PROVIDED_TOKEN:-}" ]; then

--- a/assets/workspace/.github/workflows/release-publish.yml
+++ b/assets/workspace/.github/workflows/release-publish.yml
@@ -84,11 +84,18 @@ jobs:
       release_url: ${{ steps.out.outputs.release_url }}
 
     steps:
+      - name: Generate release app token
+        id: release_app_token
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859  # v3
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Resolve auth token
         id: auth
         env:
           PROVIDED_TOKEN: ${{ secrets.token }}
-          FALLBACK_TOKEN: ${{ github.token }}
+          FALLBACK_TOKEN: ${{ steps.release_app_token.outputs.token }}
         run: |
           set -euo pipefail
           if [ -n "${PROVIDED_TOKEN:-}" ]; then

--- a/assets/workspace/.github/workflows/release.yml
+++ b/assets/workspace/.github/workflows/release.yml
@@ -133,11 +133,20 @@ jobs:
           app-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
+      - name: Generate commit app token
+        id: commit_app_token
+        if: ${{ needs.core.outputs.pre_finalize_sha != '' }}
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859  # v3
+        with:
+          app-id: ${{ secrets.COMMIT_APP_ID }}
+          private-key: ${{ secrets.COMMIT_APP_PRIVATE_KEY }}
+
       - name: Checkout repository
         if: ${{ needs.core.outputs.pre_finalize_sha != '' }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
+          token: ${{ steps.commit_app_token.outputs.token }}
 
       - name: Fix git safe.directory
         if: ${{ needs.core.outputs.pre_finalize_sha != '' }}

--- a/assets/workspace/.github/workflows/release.yml
+++ b/assets/workspace/.github/workflows/release.yml
@@ -125,6 +125,14 @@ jobs:
       contents: write
       issues: write
     steps:
+      - name: Generate release app token
+        id: release_app_token
+        if: ${{ needs.core.outputs.version != '' }}
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859  # v3
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Checkout repository
         if: ${{ needs.core.outputs.pre_finalize_sha != '' }}
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -176,7 +184,7 @@ jobs:
         env:
           VERSION: ${{ needs.core.outputs.version }}
           PR_NUMBER: ${{ needs.core.outputs.pr_number }}
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.release_app_token.outputs.token }}
         run: |
           set -euo pipefail
           WORKFLOW_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/assets/workspace/.github/workflows/sync-issues.yml
+++ b/assets/workspace/.github/workflows/sync-issues.yml
@@ -102,7 +102,7 @@ jobs:
         if: always()
         continue-on-error: true
         env:
-          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           echo "Attempting to delete old cache to prevent save collisions..."
           # Wait a moment to ensure any previous cache saves have completed

--- a/assets/workspace/.github/workflows/sync-issues.yml
+++ b/assets/workspace/.github/workflows/sync-issues.yml
@@ -102,7 +102,7 @@ jobs:
         if: always()
         continue-on-error: true
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
           echo "Attempting to delete old cache to prevent save collisions..."
           # Wait a moment to ensure any previous cache saves have completed
@@ -138,7 +138,7 @@ jobs:
         uses: vig-os/commit-action@c0024cbad0e501764127cccab732c6cd465b4646  # v0.1.5
         env:
           # Use App token so push can bypass branch protection when App is in bypass list
-          GH_TOKEN: ${{ steps.generate-token.outputs.token || github.token }}
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           TARGET_BRANCH: refs/heads/${{ github.event.inputs.target-branch || 'dev' }}
           COMMIT_MESSAGE: "${{ github.event.inputs.commit-msg || 'chore: sync issues and PRs' }}"

--- a/docs/CROSS_REPO_RELEASE_GATE.md
+++ b/docs/CROSS_REPO_RELEASE_GATE.md
@@ -120,3 +120,12 @@ gh -R vig-os/devcontainer-smoke-test release view <TAG>
 
 - Orchestrator logic: `.github/workflows/release.yml`
 - Validation receiver template: `assets/smoke-test/.github/workflows/repository-dispatch.yml`
+
+## Token Model for Downstream Write Paths
+
+For downstream workflow templates used by this gate, repositories must provide both Commit and Release app credentials.
+
+- Commit App token is required for protected branch writes performed by release preparation/finalization flows.
+- Release App token is required for PR/release/workflow dispatch orchestration.
+
+Using `github.token` for protected downstream write paths is not supported by this gate contract because branch rulesets may reject direct writes without app bypass.

--- a/docs/DOWNSTREAM_RELEASE.md
+++ b/docs/DOWNSTREAM_RELEASE.md
@@ -35,6 +35,22 @@ The orchestrator `release.yml` passes release context directly to the called reu
 
 There is no separate contract-version handshake; compatibility is defined by the `workflow_call` input schema in each workflow file.
 
+## Required App Secrets
+
+Downstream repositories are expected to provide both app credentials:
+
+- `COMMIT_APP_ID`
+- `COMMIT_APP_PRIVATE_KEY`
+- `RELEASE_APP_ID`
+- `RELEASE_APP_PRIVATE_KEY`
+
+Template behavior relies on explicit app-token generation for release operations:
+
+- use **Commit App** token for protected branch/ref writes (`commit-action`, branch/tag mutation)
+- use **Release App** token for release orchestration and PR/release API operations
+
+`github.token` is intentionally not used as a fallback for these release write paths.
+
 ## Input Naming Convention
 
 All `workflow_call` inputs use underscores (e.g. `release_kind`, `dry_run`, `git_user_name`). The orchestrator `release.yml` translates its own `workflow_dispatch` hyphenated inputs at each call site.


### PR DESCRIPTION
## Description

Hardens downstream release workflow templates to avoid protected-branch failures by requiring explicit Commit/Release app tokens instead of falling back to `github.token` on write paths.

## Type of Change

- [x] `fix` -- Bug fix
- [ ] `feat` -- New feature
- [ ] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [ ] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- Updated `assets/workspace/.github/workflows/prepare-release.yml`
  - Generate Commit App and Release App tokens
  - Route protected branch/ref writes to Commit App token
  - Route PR operations to Release App token
- Updated `assets/workspace/.github/workflows/release-core.yml`
  - Remove `github.token` fallback in auth resolution
  - Generate explicit app tokens and use Commit App token for `commit-action` writes
- Updated `assets/workspace/.github/workflows/release-publish.yml`
  - Remove `github.token` fallback in auth resolution
  - Resolve fallback to explicit Release App token
- Updated `assets/workspace/.github/workflows/release.yml`
  - Use explicit Release App token for rollback issue creation
- Updated `assets/workspace/.github/workflows/sync-issues.yml`
  - Remove `github.token` fallback from cache deletion and commit-action steps
- Updated docs:
  - `docs/DOWNSTREAM_RELEASE.md`
  - `docs/CROSS_REPO_RELEASE_GATE.md`
  - Added required token/secrets model for downstream projects
- Updated changelog:
  - `CHANGELOG.md`
  - `assets/workspace/.devcontainer/CHANGELOG.md`

## Changelog Entry

### Changed

- **Downstream release templates now require explicit app tokens for write paths** ([#400](https://github.com/vig-os/devcontainer/issues/400))
  - Update `assets/workspace/.github/workflows/prepare-release.yml`, `release-core.yml`, `release-publish.yml`, `release.yml`, and `sync-issues.yml` to remove `github.token` fallback from protected write operations
  - Route protected branch/ref writes through Commit App tokens and release orchestration/issue operations through Release App tokens
  - Document downstream token requirements in `docs/DOWNSTREAM_RELEASE.md` and `docs/CROSS_REPO_RELEASE_GATE.md`

## Testing

- [ ] Tests pass locally (`just test`)
- [x] Manual testing performed (describe below)

### Manual Testing Details

- Ran repository hooks via commit flow (YAML lint/checks, commit message validation, manifest sync checks) and all passed.
- Verified no `github.token` usages remain in `assets/workspace/.github/workflows/*.yml`.
- Verified branch is rebased/merged with `origin/release/0.3.1` and has no merge conflicts.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

Assumes downstream repositories provide both `COMMIT_APP_*` and `RELEASE_APP_*` secrets, matching the documented gate contract.

Refs: #400
