### PR TITLE
fix(ci): split smoke-test dispatch into two-phase orchestration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,12 +62,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Replace premature `publish-release` behavior with full downstream orchestration: deploy-to-dev merge gate, `prepare-release.yml`, release PR readiness/approval, and `release.yml` dispatch polling
   - Add release-branch CHANGELOG sync so smoke-test `main` ends with the same `CHANGELOG.md` content as `vig-os/devcontainer` at the dispatched tag
   - Add upstream failure issue reporting with job-phase results and cleanup guidance when dispatch orchestration fails
+- **Smoke-test release orchestration now runs as two phases** ([#402](https://github.com/vig-os/devcontainer/issues/402))
+  - Keep `repository-dispatch.yml` focused on deploy/prepare/release-PR readiness and move release dispatch to a dedicated merged-PR workflow (`on-release-pr-merge.yml`)
+  - Add release-kind labeling and auto-merge enablement for release PRs, and keep upstream failure notifications in both phases
 
 ### Fixed
 
 - **Release app permission docs now include downstream workflow dispatch requirements** ([#397](https://github.com/vig-os/devcontainer/issues/397))
   - Update `docs/RELEASE_CYCLE.md` to require `Actions` read/write for `RELEASE_APP` on the validation repository
   - Clarify this is required so downstream `repository-dispatch.yml` can trigger release orchestration workflows via `workflow_dispatch`
+- **Smoke-test dispatch no longer fails on release PR self-approval** ([#402](https://github.com/vig-os/devcontainer/issues/402))
+  - Remove bot self-approval from `repository-dispatch.yml` and replace with release-kind labeling plus auto-merge enablement
+  - Remove in-job polling for release PR merge and downstream release execution from phase 1 orchestration
+- **Sync-main-to-dev PRs now trigger CI reliably in downstream repos** ([#398](https://github.com/vig-os/devcontainer/issues/398))
+  - Replace API-based sync branch creation with `git push` in `assets/workspace/.github/workflows/sync-main-to-dev.yml` so PR-related CI checks are emitted
 
 - **Release finalization now commits generated docs and refreshes PR content** ([#300](https://github.com/vig-os/devcontainer/issues/300))
   - Final release automation regenerates docs before committing so pre-commit `generate-docs` does not fail CI with tracked file diffs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Smoke-test dispatch no longer fails on release PR self-approval** ([#402](https://github.com/vig-os/devcontainer/issues/402))
   - Remove bot self-approval from `repository-dispatch.yml` and replace with release-kind labeling plus auto-merge enablement
   - Remove in-job polling for release PR merge and downstream release execution from phase 1 orchestration
+  - Phase 2 (`on-release-pr-merge.yml`) fails validation unless the merged release PR has `release-kind:final` or `release-kind:candidate`
 - **Sync-main-to-dev PRs now trigger CI reliably in downstream repos** ([#398](https://github.com/vig-os/devcontainer/issues/398))
   - Replace API-based sync branch creation with `git push` in `assets/workspace/.github/workflows/sync-main-to-dev.yml` so PR-related CI checks are emitted
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,11 +60,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Handle smoke-test dispatch failures with a targeted issue while avoiding destructive rollback after publish artifacts are already released
 - **Redesigned smoke-test dispatch release orchestration** ([#358](https://github.com/vig-os/devcontainer/issues/358))
   - Replace premature `publish-release` behavior with full downstream orchestration: deploy-to-dev merge gate, `prepare-release.yml`, release PR readiness/approval, and `release.yml` dispatch polling
-  - Add release-branch CHANGELOG sync so smoke-test `main` ends with the same `CHANGELOG.md` content as `vig-os/devcontainer` at the dispatched tag
   - Add upstream failure issue reporting with job-phase results and cleanup guidance when dispatch orchestration fails
 - **Smoke-test release orchestration now runs as two phases** ([#402](https://github.com/vig-os/devcontainer/issues/402))
   - Keep `repository-dispatch.yml` focused on deploy/prepare/release-PR readiness and move release dispatch to a dedicated merged-PR workflow (`on-release-pr-merge.yml`)
   - Add release-kind labeling and auto-merge enablement for release PRs, and keep upstream failure notifications in both phases
+  - Remove release-branch upstream `CHANGELOG.md` sync from `repository-dispatch.yml` (previously added in [#358](https://github.com/vig-os/devcontainer/issues/358))
 
 ### Fixed
 

--- a/assets/smoke-test/.github/workflows/on-release-pr-merge.yml
+++ b/assets/smoke-test/.github/workflows/on-release-pr-merge.yml
@@ -55,11 +55,14 @@ jobs:
             exit 1
           fi
 
-          RELEASE_KIND="candidate"
+          RELEASE_KIND=""
           if jq -e '.pull_request.labels[]? | select(.name=="release-kind:final")' "${GITHUB_EVENT_PATH}" >/dev/null; then
             RELEASE_KIND="final"
           elif jq -e '.pull_request.labels[]? | select(.name=="release-kind:candidate")' "${GITHUB_EVENT_PATH}" >/dev/null; then
             RELEASE_KIND="candidate"
+          else
+            echo "ERROR: missing required release-kind label (expected 'release-kind:final' or 'release-kind:candidate')"
+            exit 1
           fi
 
           echo "version=${VERSION}" >> "${GITHUB_OUTPUT}"

--- a/assets/smoke-test/.github/workflows/on-release-pr-merge.yml
+++ b/assets/smoke-test/.github/workflows/on-release-pr-merge.yml
@@ -1,0 +1,229 @@
+name: Trigger release from merged release PR
+#
+# Purpose:
+# - Continue smoke-test orchestration after the release PR is merged to main.
+# - Dispatch release.yml and wait for completion.
+# - Notify upstream if this second phase fails.
+#
+# NOTE: This workflow is part of the smoke-test template under assets/smoke-test
+# and must be manually deployed/promoted in the downstream repo before use.
+
+on:  # yamllint disable-line rule:truthy
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+concurrency:
+  group: smoke-test-release-phase2-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  WORKFLOW_REF: dev
+
+jobs:
+  validate:
+    name: Validate merged release PR event
+    if: >-
+      github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.head.ref, 'release/')
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    outputs:
+      version: ${{ steps.extract.outputs.version }}
+      release_kind: ${{ steps.extract.outputs.release_kind }}
+      release_pr_url: ${{ steps.extract.outputs.release_pr_url }}
+      release_pr_number: ${{ steps.extract.outputs.release_pr_number }}
+    steps:
+      - name: Extract version and release kind
+        id: extract
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          VERSION="${HEAD_REF#release/}"
+          if [ "${VERSION}" = "${HEAD_REF}" ]; then
+            echo "ERROR: expected release/* head ref, got '${HEAD_REF}'"
+            exit 1
+          fi
+          if ! printf '%s' "${VERSION}" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "ERROR: invalid release version parsed from head ref '${HEAD_REF}'"
+            exit 1
+          fi
+
+          RELEASE_KIND="candidate"
+          if jq -e '.pull_request.labels[]? | select(.name=="release-kind:final")' "${GITHUB_EVENT_PATH}" >/dev/null; then
+            RELEASE_KIND="final"
+          elif jq -e '.pull_request.labels[]? | select(.name=="release-kind:candidate")' "${GITHUB_EVENT_PATH}" >/dev/null; then
+            RELEASE_KIND="candidate"
+          fi
+
+          echo "version=${VERSION}" >> "${GITHUB_OUTPUT}"
+          echo "release_kind=${RELEASE_KIND}" >> "${GITHUB_OUTPUT}"
+          echo "release_pr_url=${PR_URL}" >> "${GITHUB_OUTPUT}"
+          echo "release_pr_number=${PR_NUMBER}" >> "${GITHUB_OUTPUT}"
+
+  trigger-release:
+    name: Trigger and wait for release workflow
+    runs-on: ubuntu-22.04
+    timeout-minutes: 35
+    env:
+      GH_REPO: ${{ github.repository }}
+    needs: [validate]
+    outputs:
+      before_run_id: ${{ steps.capture_release_before.outputs.before_run_id }}
+    steps:
+      - name: Generate release app token for release workflow dispatch
+        id: generate_release_token
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859  # v3
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+
+      - name: Capture latest release run id
+        id: capture_release_before
+        env:
+          GH_TOKEN: ${{ steps.generate_release_token.outputs.token }}
+        run: |
+          set -euo pipefail
+          BEFORE_RUN_ID="$(
+            gh run list --workflow release.yml --branch "${WORKFLOW_REF}" --limit 1 --json databaseId --jq '.[0].databaseId // 0' 2>/dev/null || echo 0
+          )"
+          echo "before_run_id=${BEFORE_RUN_ID}" >> "${GITHUB_OUTPUT}"
+
+      - name: Trigger release workflow
+        env:
+          GH_TOKEN: ${{ steps.generate_release_token.outputs.token }}
+          VERSION: ${{ needs.validate.outputs.version }}
+          RELEASE_KIND: ${{ needs.validate.outputs.release_kind }}
+        run: |
+          set -euo pipefail
+          gh workflow run release.yml \
+            --ref "${WORKFLOW_REF}" \
+            -f version="${VERSION}" \
+            -f release-kind="${RELEASE_KIND}"
+
+      - name: Wait for release workflow completion
+        env:
+          GH_TOKEN: ${{ steps.generate_release_token.outputs.token }}
+          BEFORE_RUN_ID: ${{ steps.capture_release_before.outputs.before_run_id }}
+        run: |
+          set -euo pipefail
+          TIMEOUT=1800
+          INTERVAL=30
+          ELAPSED=0
+
+          while [ "${ELAPSED}" -lt "${TIMEOUT}" ]; do
+            RUN_ID="$(gh run list --workflow release.yml --branch "${WORKFLOW_REF}" --limit 1 --json databaseId --jq '.[0].databaseId // empty' 2>/dev/null || true)"
+            if [ -n "${RUN_ID}" ] && [ "${RUN_ID}" -gt "${BEFORE_RUN_ID}" ]; then
+              STATUS="$(gh run view "${RUN_ID}" --json status --jq '.status' 2>/dev/null || echo unknown)"
+              if [ "${STATUS}" = "completed" ]; then
+                CONCLUSION="$(gh run view "${RUN_ID}" --json conclusion --jq '.conclusion' 2>/dev/null || echo unknown)"
+                if [ "${CONCLUSION}" != "success" ]; then
+                  echo "ERROR: release workflow concluded with '${CONCLUSION}'"
+                  exit 1
+                fi
+                echo "release workflow completed successfully"
+                exit 0
+              fi
+            fi
+
+            sleep "${INTERVAL}"
+            ELAPSED=$((ELAPSED + INTERVAL))
+            echo "Waiting for release workflow... (${ELAPSED}s/${TIMEOUT}s)"
+          done
+
+          echo "ERROR: timed out waiting for release workflow completion"
+          exit 1
+
+  summary:
+    name: Release phase 2 summary
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    needs:
+      - validate
+      - trigger-release
+    if: always() && needs.validate.result != 'skipped'
+    steps:
+      - name: Check release phase 2 results
+        run: |
+          echo "Release Phase 2 Results Summary"
+          echo "==============================="
+          echo ""
+          echo "Validate: ${{ needs.validate.result }}"
+          echo "Release:  ${{ needs.trigger-release.result }}"
+          echo "Release PR: ${{ needs.validate.outputs.release_pr_url }}"
+          echo ""
+
+          FAILED=false
+          if [ "${{ needs.validate.result }}" != "success" ]; then
+            echo "ERROR: validation failed"
+            FAILED=true
+          fi
+          if [ "${{ needs.trigger-release.result }}" != "success" ]; then
+            echo "ERROR: release workflow orchestration failed"
+            FAILED=true
+          fi
+          if [ "${FAILED}" = "true" ]; then
+            exit 1
+          fi
+
+  notify-failure:
+    name: Notify upstream on smoke-test release phase 2 failure
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+    if: failure() && needs.validate.result != 'skipped'
+    needs:
+      - validate
+      - trigger-release
+      - summary
+    steps:
+      - name: Generate release app token for upstream issue creation
+        id: generate_release_token
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859  # v3
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          owner: vig-os
+          repositories: devcontainer
+
+      - name: Create upstream failure issue
+        env:
+          GH_TOKEN: ${{ steps.generate_release_token.outputs.token }}
+          VERSION: ${{ needs.validate.outputs.version }}
+          RELEASE_KIND: ${{ needs.validate.outputs.release_kind }}
+          RELEASE_PR_URL: ${{ needs.validate.outputs.release_pr_url }}
+        run: |
+          set -euo pipefail
+          WORKFLOW_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+
+          ISSUE_BODY="$(
+            cat <<EOF
+          Smoke-test release phase 2 failed while triggering downstream release workflow.
+
+          ## Release metadata
+          - version: \`${VERSION:-unknown}\`
+          - release_kind: \`${RELEASE_KIND:-unknown}\`
+          - release_pr: ${RELEASE_PR_URL:-n/a}
+
+          ## Workflow context
+          - downstream workflow run: ${WORKFLOW_URL}
+
+          ## Job results
+          - validate: \`${{ needs.validate.result }}\`
+          - trigger-release: \`${{ needs.trigger-release.result }}\`
+          - summary: \`${{ needs.summary.result }}\`
+          EOF
+          )"
+
+          gh issue create \
+            --repo vig-os/devcontainer \
+            --title "Smoke-test release phase 2 failed for ${VERSION:-unknown}" \
+            --label bug \
+            --body "${ISSUE_BODY}"

--- a/assets/smoke-test/.github/workflows/repository-dispatch.yml
+++ b/assets/smoke-test/.github/workflows/repository-dispatch.yml
@@ -482,7 +482,7 @@ jobs:
           exit 1
 
   ready-release-pr:
-    name: Sync changelog and prepare release PR
+    name: Prepare release PR
     runs-on: ubuntu-22.04
     timeout-minutes: 35
     env:
@@ -492,7 +492,7 @@ jobs:
       release_pr: ${{ steps.locate_release_pr.outputs.release_pr }}
       release_pr_url: ${{ steps.locate_release_pr.outputs.release_pr_url }}
     steps:
-      - name: Generate release app token for PR and contents operations
+      - name: Generate release app token for PR operations
         id: generate_release_token
         uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859  # v3
         with:
@@ -500,41 +500,6 @@ jobs:
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: ${{ github.event.repository.name }}
-
-      - name: Sync upstream CHANGELOG onto release branch
-        env:
-          GH_TOKEN: ${{ steps.generate_release_token.outputs.token }}
-          TAG: ${{ needs.validate.outputs.tag }}
-          BASE_VERSION: ${{ needs.validate.outputs.base_version }}
-        run: |
-          set -euo pipefail
-          CHANGELOG_URL="https://raw.githubusercontent.com/vig-os/devcontainer/${TAG}/CHANGELOG.md"
-          ATTEMPT=1
-          MAX_ATTEMPTS=3
-          until [ "${ATTEMPT}" -gt "${MAX_ATTEMPTS}" ]; do
-            if curl -sSf "${CHANGELOG_URL}" -o /tmp/upstream-changelog.md; then
-              break
-            fi
-            if [ "${ATTEMPT}" -eq "${MAX_ATTEMPTS}" ]; then
-              echo "ERROR: failed to download upstream changelog after ${MAX_ATTEMPTS} attempts: ${CHANGELOG_URL}"
-              exit 1
-            fi
-            echo "Changelog download attempt ${ATTEMPT}/${MAX_ATTEMPTS} failed; retrying in 5s..."
-            ATTEMPT=$((ATTEMPT + 1))
-            sleep 5
-          done
-
-          FILE_SHA="$(gh api \
-            "repos/${GITHUB_REPOSITORY}/contents/CHANGELOG.md?ref=release/${BASE_VERSION}" \
-            --jq '.sha')"
-          CONTENT="$(base64 -w0 < /tmp/upstream-changelog.md)"
-
-          gh api -X PUT "repos/${GITHUB_REPOSITORY}/contents/CHANGELOG.md" \
-            -f message="chore: sync CHANGELOG from devcontainer ${TAG}" \
-            -f content="${CONTENT}" \
-            -f sha="${FILE_SHA}" \
-            -f branch="release/${BASE_VERSION}" >/dev/null
-          echo "Synced upstream CHANGELOG to release/${BASE_VERSION}"
 
       - name: Locate release PR
         id: locate_release_pr
@@ -552,7 +517,7 @@ jobs:
           echo "release_pr=${PR_NUMBER}" >> "${GITHUB_OUTPUT}"
           echo "release_pr_url=${PR_URL}" >> "${GITHUB_OUTPUT}"
 
-      - name: Mark release PR ready and approve
+      - name: Mark release PR ready
         env:
           GH_TOKEN: ${{ steps.generate_release_token.outputs.token }}
           PR_NUMBER: ${{ steps.locate_release_pr.outputs.release_pr }}
@@ -562,121 +527,30 @@ jobs:
           if [ "${IS_DRAFT}" = "true" ]; then
             gh pr ready "${PR_NUMBER}"
           fi
-          gh pr review "${PR_NUMBER}" --approve
 
-      - name: Wait for release PR CI and merge
+      - name: Label release PR with release kind
+        env:
+          GH_TOKEN: ${{ steps.generate_release_token.outputs.token }}
+          PR_NUMBER: ${{ steps.locate_release_pr.outputs.release_pr }}
+          RELEASE_KIND: ${{ needs.validate.outputs.release_kind }}
+        run: |
+          set -euo pipefail
+          LABEL="release-kind:${RELEASE_KIND}"
+          gh label create "${LABEL}" --color "5319E7" \
+            --description "Automated release kind label for dispatch orchestration" \
+            --force >/dev/null 2>&1 || true
+          gh pr edit "${PR_NUMBER}" --remove-label "release-kind:candidate" >/dev/null 2>&1 || true
+          gh pr edit "${PR_NUMBER}" --remove-label "release-kind:final" >/dev/null 2>&1 || true
+          gh pr edit "${PR_NUMBER}" --add-label "${LABEL}"
+
+      - name: Enable release PR auto-merge
         env:
           GH_TOKEN: ${{ steps.generate_release_token.outputs.token }}
           PR_NUMBER: ${{ steps.locate_release_pr.outputs.release_pr }}
         run: |
           set -euo pipefail
-          TIMEOUT=1800
-          INTERVAL=30
-          ELAPSED=0
-          AUTO_MERGE_SET=false
-
-          while [ "${ELAPSED}" -lt "${TIMEOUT}" ]; do
-            PR_STATE="$(gh pr view "${PR_NUMBER}" --json state --jq '.state' 2>/dev/null || echo unknown)"
-            if [ "${PR_STATE}" = "MERGED" ]; then
-              echo "Release PR merged: #${PR_NUMBER}"
-              exit 0
-            fi
-            if [ "${PR_STATE}" = "CLOSED" ]; then
-              echo "ERROR: release PR closed without merge: #${PR_NUMBER}"
-              exit 1
-            fi
-
-            MERGE_STATE="$(gh pr view "${PR_NUMBER}" --json mergeStateStatus --jq '.mergeStateStatus' 2>/dev/null || echo unknown)"
-            if [ "${MERGE_STATE}" = "CLEAN" ] && [ "${AUTO_MERGE_SET}" = "false" ]; then
-              if gh pr merge "${PR_NUMBER}" --auto --merge; then
-                AUTO_MERGE_SET=true
-              else
-                echo "Warning: could not enable auto-merge yet; will retry"
-              fi
-            fi
-
-            sleep "${INTERVAL}"
-            ELAPSED=$((ELAPSED + INTERVAL))
-            echo "Waiting for release PR merge... (${ELAPSED}s/${TIMEOUT}s)"
-          done
-
-          echo "ERROR: timed out waiting for release PR merge"
-          exit 1
-
-  trigger-release:
-    name: Trigger and wait for release workflow
-    runs-on: ubuntu-22.04
-    timeout-minutes: 35
-    env:
-      GH_REPO: ${{ github.repository }}
-    needs: [validate, ready-release-pr]
-    outputs:
-      before_run_id: ${{ steps.capture_release_before.outputs.before_run_id }}
-    steps:
-      - name: Generate release app token for release workflow dispatch
-        id: generate_release_token
-        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859  # v3
-        with:
-          app-id: ${{ secrets.RELEASE_APP_ID }}
-          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          repositories: ${{ github.event.repository.name }}
-
-      - name: Capture latest release run id
-        id: capture_release_before
-        env:
-          GH_TOKEN: ${{ steps.generate_release_token.outputs.token }}
-        run: |
-          set -euo pipefail
-          BEFORE_RUN_ID="$(
-            gh run list --workflow release.yml --branch "${WORKFLOW_REF}" --limit 1 --json databaseId --jq '.[0].databaseId // 0' 2>/dev/null || echo 0
-          )"
-          echo "before_run_id=${BEFORE_RUN_ID}" >> "${GITHUB_OUTPUT}"
-
-      - name: Trigger release workflow
-        env:
-          GH_TOKEN: ${{ steps.generate_release_token.outputs.token }}
-          BASE_VERSION: ${{ needs.validate.outputs.base_version }}
-          RELEASE_KIND: ${{ needs.validate.outputs.release_kind }}
-        run: |
-          set -euo pipefail
-          gh workflow run release.yml \
-            --ref "${WORKFLOW_REF}" \
-            -f version="${BASE_VERSION}" \
-            -f release-kind="${RELEASE_KIND}"
-
-      - name: Wait for release workflow completion
-        env:
-          GH_TOKEN: ${{ steps.generate_release_token.outputs.token }}
-          BEFORE_RUN_ID: ${{ steps.capture_release_before.outputs.before_run_id }}
-        run: |
-          set -euo pipefail
-          TIMEOUT=1800
-          INTERVAL=30
-          ELAPSED=0
-
-          while [ "${ELAPSED}" -lt "${TIMEOUT}" ]; do
-            RUN_ID="$(gh run list --workflow release.yml --branch "${WORKFLOW_REF}" --limit 1 --json databaseId --jq '.[0].databaseId // empty' 2>/dev/null || true)"
-            if [ -n "${RUN_ID}" ] && [ "${RUN_ID}" -gt "${BEFORE_RUN_ID}" ]; then
-              STATUS="$(gh run view "${RUN_ID}" --json status --jq '.status' 2>/dev/null || echo unknown)"
-              if [ "${STATUS}" = "completed" ]; then
-                CONCLUSION="$(gh run view "${RUN_ID}" --json conclusion --jq '.conclusion' 2>/dev/null || echo unknown)"
-                if [ "${CONCLUSION}" != "success" ]; then
-                  echo "ERROR: release workflow concluded with '${CONCLUSION}'"
-                  exit 1
-                fi
-                echo "release workflow completed successfully"
-                exit 0
-              fi
-            fi
-
-            sleep "${INTERVAL}"
-            ELAPSED=$((ELAPSED + INTERVAL))
-            echo "Waiting for release workflow... (${ELAPSED}s/${TIMEOUT}s)"
-          done
-
-          echo "ERROR: timed out waiting for release workflow completion"
-          exit 1
+          gh pr merge "${PR_NUMBER}" --auto --merge || \
+            echo "Warning: could not enable auto-merge yet"
 
   summary:
     name: Dispatch summary
@@ -689,7 +563,6 @@ jobs:
       - cleanup-release
       - trigger-prepare-release
       - ready-release-pr
-      - trigger-release
     if: always()
     steps:
       - name: Write source context summary
@@ -725,7 +598,6 @@ jobs:
           echo "Cleanup:      ${{ needs.cleanup-release.result }}"
           echo "Prepare:      ${{ needs.trigger-prepare-release.result }}"
           echo "Release PR:   ${{ needs.ready-release-pr.result }}"
-          echo "Release:      ${{ needs.trigger-release.result }}"
           echo "Deploy PR:    ${{ needs.deploy.outputs.pr_url }}"
           echo "Release PR:   ${{ needs.ready-release-pr.outputs.release_pr_url }}"
           echo ""
@@ -762,11 +634,6 @@ jobs:
             FAILED=true
           fi
 
-          if [ "${{ needs.trigger-release.result }}" != "success" ]; then
-            echo "ERROR: Release workflow orchestration job failed"
-            FAILED=true
-          fi
-
           if [ "${FAILED}" = "true" ]; then
             echo ""
             echo "Dispatch orchestration failed"
@@ -788,7 +655,6 @@ jobs:
       - cleanup-release
       - trigger-prepare-release
       - ready-release-pr
-      - trigger-release
       - summary
     steps:
       - name: Generate release app token for upstream issue creation
@@ -843,7 +709,6 @@ jobs:
           - cleanup-release: \`${{ needs.cleanup-release.result }}\`
           - trigger-prepare-release: \`${{ needs.trigger-prepare-release.result }}\`
           - ready-release-pr: \`${{ needs.ready-release-pr.result }}\`
-          - trigger-release: \`${{ needs.trigger-release.result }}\`
           - summary: \`${{ needs.summary.result }}\`
 
           ## Manual cleanup guidance

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -62,12 +62,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Replace premature `publish-release` behavior with full downstream orchestration: deploy-to-dev merge gate, `prepare-release.yml`, release PR readiness/approval, and `release.yml` dispatch polling
   - Add release-branch CHANGELOG sync so smoke-test `main` ends with the same `CHANGELOG.md` content as `vig-os/devcontainer` at the dispatched tag
   - Add upstream failure issue reporting with job-phase results and cleanup guidance when dispatch orchestration fails
+- **Smoke-test release orchestration now runs as two phases** ([#402](https://github.com/vig-os/devcontainer/issues/402))
+  - Keep `repository-dispatch.yml` focused on deploy/prepare/release-PR readiness and move release dispatch to a dedicated merged-PR workflow (`on-release-pr-merge.yml`)
+  - Add release-kind labeling and auto-merge enablement for release PRs, and keep upstream failure notifications in both phases
 
 ### Fixed
 
 - **Release app permission docs now include downstream workflow dispatch requirements** ([#397](https://github.com/vig-os/devcontainer/issues/397))
   - Update `docs/RELEASE_CYCLE.md` to require `Actions` read/write for `RELEASE_APP` on the validation repository
   - Clarify this is required so downstream `repository-dispatch.yml` can trigger release orchestration workflows via `workflow_dispatch`
+- **Smoke-test dispatch no longer fails on release PR self-approval** ([#402](https://github.com/vig-os/devcontainer/issues/402))
+  - Remove bot self-approval from `repository-dispatch.yml` and replace with release-kind labeling plus auto-merge enablement
+  - Remove in-job polling for release PR merge and downstream release execution from phase 1 orchestration
+- **Sync-main-to-dev PRs now trigger CI reliably in downstream repos** ([#398](https://github.com/vig-os/devcontainer/issues/398))
+  - Replace API-based sync branch creation with `git push` in `assets/workspace/.github/workflows/sync-main-to-dev.yml` so PR-related CI checks are emitted
 
 - **Release finalization now commits generated docs and refreshes PR content** ([#300](https://github.com/vig-os/devcontainer/issues/300))
   - Final release automation regenerates docs before committing so pre-commit `generate-docs` does not fail CI with tracked file diffs

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -74,6 +74,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Smoke-test dispatch no longer fails on release PR self-approval** ([#402](https://github.com/vig-os/devcontainer/issues/402))
   - Remove bot self-approval from `repository-dispatch.yml` and replace with release-kind labeling plus auto-merge enablement
   - Remove in-job polling for release PR merge and downstream release execution from phase 1 orchestration
+  - Phase 2 (`on-release-pr-merge.yml`) fails validation unless the merged release PR has `release-kind:final` or `release-kind:candidate`
 - **Sync-main-to-dev PRs now trigger CI reliably in downstream repos** ([#398](https://github.com/vig-os/devcontainer/issues/398))
   - Replace API-based sync branch creation with `git push` in `assets/workspace/.github/workflows/sync-main-to-dev.yml` so PR-related CI checks are emitted
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -60,11 +60,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Handle smoke-test dispatch failures with a targeted issue while avoiding destructive rollback after publish artifacts are already released
 - **Redesigned smoke-test dispatch release orchestration** ([#358](https://github.com/vig-os/devcontainer/issues/358))
   - Replace premature `publish-release` behavior with full downstream orchestration: deploy-to-dev merge gate, `prepare-release.yml`, release PR readiness/approval, and `release.yml` dispatch polling
-  - Add release-branch CHANGELOG sync so smoke-test `main` ends with the same `CHANGELOG.md` content as `vig-os/devcontainer` at the dispatched tag
   - Add upstream failure issue reporting with job-phase results and cleanup guidance when dispatch orchestration fails
 - **Smoke-test release orchestration now runs as two phases** ([#402](https://github.com/vig-os/devcontainer/issues/402))
   - Keep `repository-dispatch.yml` focused on deploy/prepare/release-PR readiness and move release dispatch to a dedicated merged-PR workflow (`on-release-pr-merge.yml`)
   - Add release-kind labeling and auto-merge enablement for release PRs, and keep upstream failure notifications in both phases
+  - Remove release-branch upstream `CHANGELOG.md` sync from `repository-dispatch.yml` (previously added in [#358](https://github.com/vig-os/devcontainer/issues/358))
 
 ### Fixed
 

--- a/assets/workspace/.github/workflows/sync-main-to-dev.yml
+++ b/assets/workspace/.github/workflows/sync-main-to-dev.yml
@@ -8,7 +8,7 @@
 #   check - (early exit if dev already contains all main commits)
 #   sync  - clean up stale sync branches
 #         - trial merge to detect conflicts
-#         - create chore/sync-main-to-dev-<run>-<attempt> branch via API
+#         - create chore/sync-main-to-dev-<run>-<attempt> branch via git push
 #         - open PR (auto-merge enabled, or labelled "merge-conflict" with
 #           resolution instructions when conflicts exist)
 #
@@ -211,23 +211,13 @@ jobs:
 
       - name: Create sync branch from main
         if: steps.existing-pr.outputs.count == '0' && steps.recheck.outputs.up_to_date != 'true'
-        env:
-          GH_TOKEN: ${{ steps.commit-app-token.outputs.token }}
         run: |
           set -euo pipefail
           MAIN_SHA=$(git rev-parse origin/main)
+          git checkout -b "${SYNC_BRANCH}" origin/main
           retry --retries 3 --backoff 5 --max-backoff 30 -- \
-            gh api "repos/${{ github.repository }}/git/refs" \
-            -f ref="refs/heads/${SYNC_BRANCH}" \
-            -f sha="${MAIN_SHA}" || {
-              if retry --retries 2 --backoff 5 --max-backoff 20 -- \
-                gh api "repos/${{ github.repository }}/git/ref/heads/${SYNC_BRANCH}" >/dev/null 2>&1; then
-                echo "Sync branch already exists: ${SYNC_BRANCH}"
-              else
-                exit 1
-              fi
-            }
-          echo "Sync branch ${SYNC_BRANCH} created from main at ${MAIN_SHA}"
+            git push origin "${SYNC_BRANCH}"
+          echo "Sync branch ${SYNC_BRANCH} pushed from main at ${MAIN_SHA}"
 
       - name: Create PR
         if: steps.existing-pr.outputs.count == '0' && steps.recheck.outputs.up_to_date != 'true'

--- a/tests/bats/just.bats
+++ b/tests/bats/just.bats
@@ -100,8 +100,8 @@ setup() {
     assert_success
 }
 
-@test "smoke-test dispatch triggers downstream prepare and release workflows" {
-    run bash -lc "grep -Fq -- 'cleanup-release:' assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- 'gh workflow run prepare-release.yml --ref \"\${WORKFLOW_REF}\"' assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- 'gh workflow run release.yml \\' assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- '--ref \"\${WORKFLOW_REF}\" \\' assets/smoke-test/.github/workflows/repository-dispatch.yml"
+@test "smoke-test dispatch triggers downstream prepare-release workflow" {
+    run bash -lc 'grep -Fq -- "cleanup-release:" assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- "gh workflow run prepare-release.yml" assets/smoke-test/.github/workflows/repository-dispatch.yml'
     assert_success
 }
 
@@ -115,18 +115,18 @@ setup() {
     assert_success
 }
 
-@test "smoke-test dispatch wait logic tracks release run after dispatch" {
-    run bash -lc 'grep -Fq -- "Capture latest release run id" assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- "gh run list --workflow release.yml --branch \"\${WORKFLOW_REF}\"" assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- "BEFORE_RUN_ID: \${{ steps.capture_release_before.outputs.before_run_id }}" assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- "[ \"\${RUN_ID}\" -gt \"\${BEFORE_RUN_ID}\" ]" assets/smoke-test/.github/workflows/repository-dispatch.yml'
+@test "smoke-test phase 2 wait logic tracks release run after dispatch" {
+    run bash -lc 'grep -Fq -- "Capture latest release run id" assets/smoke-test/.github/workflows/on-release-pr-merge.yml && grep -Fq -- "gh run list --workflow release.yml --branch \"\${WORKFLOW_REF}\"" assets/smoke-test/.github/workflows/on-release-pr-merge.yml && grep -Fq -- "BEFORE_RUN_ID: \${{ steps.capture_release_before.outputs.before_run_id }}" assets/smoke-test/.github/workflows/on-release-pr-merge.yml && grep -Fq -- "[ \"\${RUN_ID}\" -gt \"\${BEFORE_RUN_ID}\" ]" assets/smoke-test/.github/workflows/on-release-pr-merge.yml'
     assert_success
 }
 
-@test "smoke-test dispatch readies release PR and syncs upstream changelog" {
-    run bash -lc "grep -Fq -- 'gh pr ready' assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- 'gh pr review' assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- 'raw.githubusercontent.com/vig-os/devcontainer' assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- 'contents/CHANGELOG.md' assets/smoke-test/.github/workflows/repository-dispatch.yml"
+@test "smoke-test dispatch readies release PR with release kind label and auto-merge" {
+    run bash -lc 'grep -Fq -- "gh pr ready" assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- "release-kind:candidate" assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- "gh pr merge" assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- "--auto --merge" assets/smoke-test/.github/workflows/repository-dispatch.yml'
     assert_success
 }
 
 @test "smoke-test dispatch tolerates transient auto-merge enable failures" {
-    run bash -lc 'grep -Fq -- "could not enable auto-merge yet; will retry" assets/smoke-test/.github/workflows/repository-dispatch.yml'
+    run bash -lc 'grep -Fq -- "Warning: could not enable auto-merge yet" assets/smoke-test/.github/workflows/repository-dispatch.yml'
     assert_success
 }
 
@@ -136,7 +136,32 @@ setup() {
 }
 
 @test "smoke-test dispatch summary includes release-orchestration job results" {
-    run bash -lc "grep -Fq -- 'needs.wait-deploy-merge.result' assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- 'needs.cleanup-release.result' assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- 'needs.trigger-prepare-release.result' assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- 'needs.ready-release-pr.result' assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- 'needs.trigger-release.result' assets/smoke-test/.github/workflows/repository-dispatch.yml"
+    run bash -lc "grep -Fq -- 'needs.wait-deploy-merge.result' assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- 'needs.cleanup-release.result' assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- 'needs.trigger-prepare-release.result' assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- 'needs.ready-release-pr.result' assets/smoke-test/.github/workflows/repository-dispatch.yml"
+    assert_success
+}
+
+@test "smoke-test phase 2 triggers on merged release PR to main" {
+    run bash -lc 'grep -Fq -- "types: [closed]" assets/smoke-test/.github/workflows/on-release-pr-merge.yml && grep -Fq -- "branches: [main]" assets/smoke-test/.github/workflows/on-release-pr-merge.yml && grep -Fq -- "github.event.pull_request.merged == true" assets/smoke-test/.github/workflows/on-release-pr-merge.yml && grep -Fq -- "startsWith(github.event.pull_request.head.ref, '\''release/'\'')" assets/smoke-test/.github/workflows/on-release-pr-merge.yml'
+    assert_success
+}
+
+@test "smoke-test phase 2 extracts semver version from release head ref" {
+    run bash -lc 'grep -Fq -- "VERSION=\"\${HEAD_REF#release/}\"" assets/smoke-test/.github/workflows/on-release-pr-merge.yml && grep -Fq -- "invalid release version parsed from head ref" assets/smoke-test/.github/workflows/on-release-pr-merge.yml'
+    assert_success
+}
+
+@test "smoke-test phase 2 fails when release-kind label is missing" {
+    run bash -lc 'grep -Fq -- "ERROR: missing required release-kind label" assets/smoke-test/.github/workflows/on-release-pr-merge.yml'
+    assert_success
+}
+
+@test "smoke-test phase 2 dispatches release workflow with version inputs" {
+    run bash -lc 'grep -Fq -- "gh workflow run release.yml \\" assets/smoke-test/.github/workflows/on-release-pr-merge.yml && grep -Fq -- "-f version=\"\${VERSION}\"" assets/smoke-test/.github/workflows/on-release-pr-merge.yml && grep -Fq -- "-f release-kind=\"\${RELEASE_KIND}\"" assets/smoke-test/.github/workflows/on-release-pr-merge.yml'
+    assert_success
+}
+
+@test "smoke-test phase 2 notifies upstream on failure" {
+    run bash -lc 'grep -Fq -- "notify-failure:" assets/smoke-test/.github/workflows/on-release-pr-merge.yml && grep -Fq -- "gh issue create \\" assets/smoke-test/.github/workflows/on-release-pr-merge.yml && grep -Fq -- "--repo vig-os/devcontainer" assets/smoke-test/.github/workflows/on-release-pr-merge.yml'
     assert_success
 }
 


### PR DESCRIPTION
## Description

Split smoke-test dispatch into two phases to remove release PR self-approval and long in-job merge polling, while preserving automated upstream failure reporting. Also fix sync-to-dev branch creation so downstream CI is triggered reliably on sync PRs.

## Type of Change

- [ ] `feat` -- New feature
- [x] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [ ] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- `assets/smoke-test/.github/workflows/repository-dispatch.yml`
  - Remove release-branch CHANGELOG sync, PR self-approval, release PR merge polling, and in-workflow `trigger-release` job
  - Keep phase 1 focused on release PR readiness; add release-kind labeling and auto-merge enablement
  - Update summary/failure reporting to the new phase 1 scope
- `assets/smoke-test/.github/workflows/on-release-pr-merge.yml` (new)
  - Add phase 2 workflow triggered by merged `release/*` PRs into `main`
  - Extract version + release kind, dispatch `release.yml`, wait for completion, and report failures upstream
- `assets/workspace/.github/workflows/sync-main-to-dev.yml`
  - Replace API ref creation with `git checkout -b ...` + `git push` so push/pull_request CI checks are emitted
- `CHANGELOG.md` and `assets/workspace/.devcontainer/CHANGELOG.md`
  - Add Unreleased entries for #402 and #398

## Changelog Entry

### Changed

- **Smoke-test release orchestration now runs as two phases** ([#402](https://github.com/vig-os/devcontainer/issues/402))
  - Keep `repository-dispatch.yml` focused on deploy/prepare/release-PR readiness and move release dispatch to a dedicated merged-PR workflow (`on-release-pr-merge.yml`)
  - Add release-kind labeling and auto-merge enablement for release PRs, and keep upstream failure notifications in both phases

### Fixed

- **Smoke-test dispatch no longer fails on release PR self-approval** ([#402](https://github.com/vig-os/devcontainer/issues/402))
  - Remove bot self-approval from `repository-dispatch.yml` and replace with release-kind labeling plus auto-merge enablement
  - Remove in-job polling for release PR merge and downstream release execution from phase 1 orchestration
- **Sync-main-to-dev PRs now trigger CI reliably in downstream repos** ([#398](https://github.com/vig-os/devcontainer/issues/398))
  - Replace API-based sync branch creation with `git push` in `assets/workspace/.github/workflows/sync-main-to-dev.yml` so PR-related CI checks are emitted

## Testing

- [ ] Tests pass locally (`just test`)
- [ ] Manual testing performed (describe below)

### Manual Testing Details

N/A

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

- Base branch for this PR is `release/0.3.1`.
- The new workflow under `assets/smoke-test/` requires manual deploy/promotion in `vig-os/devcontainer-smoke-test` to become effective on downstream `main`.

Refs: #402, #398
