### PR TITLE
fix(ci): remove sync-main-to-dev workflow_dispatch CI trigger

### DIFF
--- a/.github/workflows/sync-main-to-dev.yml
+++ b/.github/workflows/sync-main-to-dev.yml
@@ -9,8 +9,10 @@
 #   sync  - clean up stale sync branches
 #         - trial merge to detect conflicts
 #         - create chore/sync-main-to-dev-<run>-<attempt> branch via API
-#         - open PR (auto-merge enabled, or labelled "merge-conflict" with
-#           resolution instructions when conflicts exist)
+#         - open PR, then workflow_dispatch CI on sync branch (before auto-merge;
+#           runs for conflict PRs too)
+#         - enable auto-merge when clean, or label "merge-conflict" with
+#           resolution instructions when conflicts exist
 #
 # Auth: Two GitHub App tokens:
 # - COMMIT_APP_* for git/ref operations (least-privilege commit identity)
@@ -255,6 +257,16 @@ jobs:
               echo "Warning: failed to add merge-conflict label."
           fi
 
+      - name: Trigger CI on sync branch
+        if: steps.create-pr.outputs.pr_url != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          retry --retries 3 --backoff 5 --max-backoff 30 -- \
+            gh workflow run ci.yml --ref "${SYNC_BRANCH}"
+          echo "Dispatched CI workflow on ${SYNC_BRANCH}"
+
       - name: Enable auto-merge
         if: >-
           steps.create-pr.outputs.pr_url != ''
@@ -267,15 +279,3 @@ jobs:
           retry --retries 2 --backoff 5 --max-backoff 20 -- \
             gh pr merge "${PR_URL}" --auto --merge || \
             echo "Warning: could not enable auto-merge (may require branch protection settings)"
-
-      - name: Trigger CI on sync branch
-        if: >-
-          steps.create-pr.outputs.pr_url != ''
-          && steps.merge-check.outputs.conflict != 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          retry --retries 3 --backoff 5 --max-backoff 30 -- \
-            gh workflow run ci.yml --ref "${SYNC_BRANCH}"
-          echo "Dispatched CI workflow on ${SYNC_BRANCH}"

--- a/.github/workflows/sync-main-to-dev.yml
+++ b/.github/workflows/sync-main-to-dev.yml
@@ -9,9 +9,7 @@
 #   sync  - clean up stale sync branches
 #         - trial merge to detect conflicts
 #         - create chore/sync-main-to-dev-<run>-<attempt> branch via API
-#         - open PR, then workflow_dispatch CI on sync branch (before auto-merge;
-#           runs for conflict PRs too)
-#         - enable auto-merge when clean, or label "merge-conflict" with
+#         - open PR; enable auto-merge when clean, or label "merge-conflict" with
 #           resolution instructions when conflicts exist
 #
 # Auth: Two GitHub App tokens:
@@ -88,7 +86,6 @@ jobs:
     env:
       SYNC_BRANCH: chore/sync-main-to-dev-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
-      actions: write
       contents: write
       pull-requests: write
       issues: write
@@ -256,16 +253,6 @@ jobs:
               gh pr edit "${SYNC_BRANCH}" --add-label "merge-conflict" || \
               echo "Warning: failed to add merge-conflict label."
           fi
-
-      - name: Trigger CI on sync branch
-        if: steps.create-pr.outputs.pr_url != ''
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          retry --retries 3 --backoff 5 --max-backoff 30 -- \
-            gh workflow run ci.yml --ref "${SYNC_BRANCH}"
-          echo "Dispatched CI workflow on ${SYNC_BRANCH}"
 
       - name: Enable auto-merge
         if: >-

--- a/.github/workflows/sync-main-to-dev.yml
+++ b/.github/workflows/sync-main-to-dev.yml
@@ -86,6 +86,7 @@ jobs:
     env:
       SYNC_BRANCH: chore/sync-main-to-dev-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
+      actions: write
       contents: write
       pull-requests: write
       issues: write
@@ -266,3 +267,15 @@ jobs:
           retry --retries 2 --backoff 5 --max-backoff 20 -- \
             gh pr merge "${PR_URL}" --auto --merge || \
             echo "Warning: could not enable auto-merge (may require branch protection settings)"
+
+      - name: Trigger CI on sync branch
+        if: >-
+          steps.create-pr.outputs.pr_url != ''
+          && steps.merge-check.outputs.conflict != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          retry --retries 3 --backoff 5 --max-backoff 30 -- \
+            gh workflow run ci.yml --ref "${SYNC_BRANCH}"
+          echo "Dispatched CI workflow on ${SYNC_BRANCH}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,7 +76,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Remove in-job polling for release PR merge and downstream release execution from phase 1 orchestration
   - Phase 2 (`on-release-pr-merge.yml`) fails validation unless the merged release PR has `release-kind:final` or `release-kind:candidate`
 - **Sync-main-to-dev PRs now trigger CI reliably in downstream repos** ([#398](https://github.com/vig-os/devcontainer/issues/398))
-  - Replace API-based sync branch creation with `git push` in `assets/workspace/.github/workflows/sync-main-to-dev.yml` so PR-related CI checks are emitted
+  - Replace API-based sync branch creation with `git push` in `assets/workspace/.github/workflows/sync-main-to-dev.yml`
+- **Sync-main-to-dev PRs dispatch CI after opening the sync PR** ([#405](https://github.com/vig-os/devcontainer/issues/405))
+  - GitHub App push and PR creation do not start workflows that listen on `pull_request` / `push`; the sync job now calls `workflow_dispatch` on `ci.yml` with `GITHUB_TOKEN` on the sync branch
+  - Grant `actions: write` on the sync job in `.github/workflows/sync-main-to-dev.yml` and `assets/workspace/.github/workflows/sync-main-to-dev.yml`
 
 - **Release finalization now commits generated docs and refreshes PR content** ([#300](https://github.com/vig-os/devcontainer/issues/300))
   - Final release automation regenerates docs before committing so pre-commit `generate-docs` does not fail CI with tracked file diffs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Sync-main-to-dev PRs dispatch CI after opening the sync PR** ([#405](https://github.com/vig-os/devcontainer/issues/405))
   - GitHub App push and PR creation do not start workflows that listen on `pull_request` / `push`; the sync job now calls `workflow_dispatch` on `ci.yml` with `GITHUB_TOKEN` on the sync branch
   - Grant `actions: write` on the sync job in `.github/workflows/sync-main-to-dev.yml` and `assets/workspace/.github/workflows/sync-main-to-dev.yml`
+  - Dispatch runs before auto-merge and whenever a sync PR is opened, including merge-conflict PRs
 
 - **Release finalization now commits generated docs and refreshes PR content** ([#300](https://github.com/vig-os/devcontainer/issues/300))
   - Final release automation regenerates docs before committing so pre-commit `generate-docs` does not fail CI with tracked file diffs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,10 +77,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Phase 2 (`on-release-pr-merge.yml`) fails validation unless the merged release PR has `release-kind:final` or `release-kind:candidate`
 - **Sync-main-to-dev PRs now trigger CI reliably in downstream repos** ([#398](https://github.com/vig-os/devcontainer/issues/398))
   - Replace API-based sync branch creation with `git push` in `assets/workspace/.github/workflows/sync-main-to-dev.yml`
-- **Sync-main-to-dev PRs dispatch CI after opening the sync PR** ([#405](https://github.com/vig-os/devcontainer/issues/405))
-  - GitHub App push and PR creation do not start workflows that listen on `pull_request` / `push`; the sync job now calls `workflow_dispatch` on `ci.yml` with `GITHUB_TOKEN` on the sync branch
-  - Grant `actions: write` on the sync job in `.github/workflows/sync-main-to-dev.yml` and `assets/workspace/.github/workflows/sync-main-to-dev.yml`
-  - Dispatch runs before auto-merge and whenever a sync PR is opened, including merge-conflict PRs
+- **Sync-main-to-dev no longer dispatches CI via workflow_dispatch** ([#405](https://github.com/vig-os/devcontainer/issues/405))
+  - `workflow_dispatch` runs are omitted from the PR status check rollup, so they do not satisfy branch protection on the sync PR
+  - Remove the post-PR `gh workflow run ci.yml` step and drop `actions: write` from the sync job in `.github/workflows/sync-main-to-dev.yml` and `assets/workspace/.github/workflows/sync-main-to-dev.yml`
 
 - **Release finalization now commits generated docs and refreshes PR content** ([#300](https://github.com/vig-os/devcontainer/issues/300))
   - Final release automation regenerates docs before committing so pre-commit `generate-docs` does not fail CI with tracked file diffs

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -76,7 +76,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Remove in-job polling for release PR merge and downstream release execution from phase 1 orchestration
   - Phase 2 (`on-release-pr-merge.yml`) fails validation unless the merged release PR has `release-kind:final` or `release-kind:candidate`
 - **Sync-main-to-dev PRs now trigger CI reliably in downstream repos** ([#398](https://github.com/vig-os/devcontainer/issues/398))
-  - Replace API-based sync branch creation with `git push` in `assets/workspace/.github/workflows/sync-main-to-dev.yml` so PR-related CI checks are emitted
+  - Replace API-based sync branch creation with `git push` in `assets/workspace/.github/workflows/sync-main-to-dev.yml`
+- **Sync-main-to-dev PRs dispatch CI after opening the sync PR** ([#405](https://github.com/vig-os/devcontainer/issues/405))
+  - GitHub App push and PR creation do not start workflows that listen on `pull_request` / `push`; the sync job now calls `workflow_dispatch` on `ci.yml` with `GITHUB_TOKEN` on the sync branch
+  - Grant `actions: write` on the sync job in `.github/workflows/sync-main-to-dev.yml` and `assets/workspace/.github/workflows/sync-main-to-dev.yml`
 
 - **Release finalization now commits generated docs and refreshes PR content** ([#300](https://github.com/vig-os/devcontainer/issues/300))
   - Final release automation regenerates docs before committing so pre-commit `generate-docs` does not fail CI with tracked file diffs

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -80,6 +80,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Sync-main-to-dev PRs dispatch CI after opening the sync PR** ([#405](https://github.com/vig-os/devcontainer/issues/405))
   - GitHub App push and PR creation do not start workflows that listen on `pull_request` / `push`; the sync job now calls `workflow_dispatch` on `ci.yml` with `GITHUB_TOKEN` on the sync branch
   - Grant `actions: write` on the sync job in `.github/workflows/sync-main-to-dev.yml` and `assets/workspace/.github/workflows/sync-main-to-dev.yml`
+  - Dispatch runs before auto-merge and whenever a sync PR is opened, including merge-conflict PRs
 
 - **Release finalization now commits generated docs and refreshes PR content** ([#300](https://github.com/vig-os/devcontainer/issues/300))
   - Final release automation regenerates docs before committing so pre-commit `generate-docs` does not fail CI with tracked file diffs

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -77,10 +77,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Phase 2 (`on-release-pr-merge.yml`) fails validation unless the merged release PR has `release-kind:final` or `release-kind:candidate`
 - **Sync-main-to-dev PRs now trigger CI reliably in downstream repos** ([#398](https://github.com/vig-os/devcontainer/issues/398))
   - Replace API-based sync branch creation with `git push` in `assets/workspace/.github/workflows/sync-main-to-dev.yml`
-- **Sync-main-to-dev PRs dispatch CI after opening the sync PR** ([#405](https://github.com/vig-os/devcontainer/issues/405))
-  - GitHub App push and PR creation do not start workflows that listen on `pull_request` / `push`; the sync job now calls `workflow_dispatch` on `ci.yml` with `GITHUB_TOKEN` on the sync branch
-  - Grant `actions: write` on the sync job in `.github/workflows/sync-main-to-dev.yml` and `assets/workspace/.github/workflows/sync-main-to-dev.yml`
-  - Dispatch runs before auto-merge and whenever a sync PR is opened, including merge-conflict PRs
+- **Sync-main-to-dev no longer dispatches CI via workflow_dispatch** ([#405](https://github.com/vig-os/devcontainer/issues/405))
+  - `workflow_dispatch` runs are omitted from the PR status check rollup, so they do not satisfy branch protection on the sync PR
+  - Remove the post-PR `gh workflow run ci.yml` step and drop `actions: write` from the sync job in `.github/workflows/sync-main-to-dev.yml` and `assets/workspace/.github/workflows/sync-main-to-dev.yml`
 
 - **Release finalization now commits generated docs and refreshes PR content** ([#300](https://github.com/vig-os/devcontainer/issues/300))
   - Final release automation regenerates docs before committing so pre-commit `generate-docs` does not fail CI with tracked file diffs

--- a/assets/workspace/.github/workflows/sync-main-to-dev.yml
+++ b/assets/workspace/.github/workflows/sync-main-to-dev.yml
@@ -9,8 +9,10 @@
 #   sync  - clean up stale sync branches
 #         - trial merge to detect conflicts
 #         - create chore/sync-main-to-dev-<run>-<attempt> branch via git push
-#         - open PR (auto-merge enabled, or labelled "merge-conflict" with
-#           resolution instructions when conflicts exist)
+#         - open PR, then workflow_dispatch CI on sync branch (before auto-merge;
+#           runs for conflict PRs too)
+#         - enable auto-merge when clean, or label "merge-conflict" with
+#           resolution instructions when conflicts exist
 #
 # Auth: Two GitHub App tokens:
 # - COMMIT_APP_* for git/ref operations (least-privilege commit identity)
@@ -272,6 +274,16 @@ jobs:
               echo "Warning: failed to add merge-conflict label."
           fi
 
+      - name: Trigger CI on sync branch
+        if: steps.create-pr.outputs.pr_url != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          retry --retries 3 --backoff 5 --max-backoff 30 -- \
+            gh workflow run ci.yml --ref "${SYNC_BRANCH}"
+          echo "Dispatched CI workflow on ${SYNC_BRANCH}"
+
       - name: Enable auto-merge
         if: >-
           steps.create-pr.outputs.pr_url != ''
@@ -284,15 +296,3 @@ jobs:
           retry --retries 2 --backoff 5 --max-backoff 20 -- \
             gh pr merge "${PR_URL}" --auto --merge || \
             echo "Warning: could not enable auto-merge (may require branch protection settings)"
-
-      - name: Trigger CI on sync branch
-        if: >-
-          steps.create-pr.outputs.pr_url != ''
-          && steps.merge-check.outputs.conflict != 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          retry --retries 3 --backoff 5 --max-backoff 30 -- \
-            gh workflow run ci.yml --ref "${SYNC_BRANCH}"
-          echo "Dispatched CI workflow on ${SYNC_BRANCH}"

--- a/assets/workspace/.github/workflows/sync-main-to-dev.yml
+++ b/assets/workspace/.github/workflows/sync-main-to-dev.yml
@@ -116,6 +116,7 @@ jobs:
     env:
       SYNC_BRANCH: chore/sync-main-to-dev-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
+      actions: write
       contents: write
       pull-requests: write
       issues: write
@@ -283,3 +284,15 @@ jobs:
           retry --retries 2 --backoff 5 --max-backoff 20 -- \
             gh pr merge "${PR_URL}" --auto --merge || \
             echo "Warning: could not enable auto-merge (may require branch protection settings)"
+
+      - name: Trigger CI on sync branch
+        if: >-
+          steps.create-pr.outputs.pr_url != ''
+          && steps.merge-check.outputs.conflict != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          retry --retries 3 --backoff 5 --max-backoff 30 -- \
+            gh workflow run ci.yml --ref "${SYNC_BRANCH}"
+          echo "Dispatched CI workflow on ${SYNC_BRANCH}"

--- a/assets/workspace/.github/workflows/sync-main-to-dev.yml
+++ b/assets/workspace/.github/workflows/sync-main-to-dev.yml
@@ -9,9 +9,7 @@
 #   sync  - clean up stale sync branches
 #         - trial merge to detect conflicts
 #         - create chore/sync-main-to-dev-<run>-<attempt> branch via git push
-#         - open PR, then workflow_dispatch CI on sync branch (before auto-merge;
-#           runs for conflict PRs too)
-#         - enable auto-merge when clean, or label "merge-conflict" with
+#         - open PR; enable auto-merge when clean, or label "merge-conflict" with
 #           resolution instructions when conflicts exist
 #
 # Auth: Two GitHub App tokens:
@@ -118,7 +116,6 @@ jobs:
     env:
       SYNC_BRANCH: chore/sync-main-to-dev-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
-      actions: write
       contents: write
       pull-requests: write
       issues: write
@@ -273,16 +270,6 @@ jobs:
               gh pr edit "${SYNC_BRANCH}" --add-label "merge-conflict" || \
               echo "Warning: failed to add merge-conflict label."
           fi
-
-      - name: Trigger CI on sync branch
-        if: steps.create-pr.outputs.pr_url != ''
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          retry --retries 3 --backoff 5 --max-backoff 30 -- \
-            gh workflow run ci.yml --ref "${SYNC_BRANCH}"
-          echo "Dispatched CI workflow on ${SYNC_BRANCH}"
 
       - name: Enable auto-merge
         if: >-


### PR DESCRIPTION
## Description

Removes the post–sync-PR `workflow_dispatch` step from `sync-main-to-dev` in this repo and in the workspace template. That dispatch did not appear in the PR status check rollup, so it could not satisfy branch protection ([issue #405](https://github.com/vig-os/devcontainer/issues/405) analysis). Also drops `actions: write` from the sync job, which was only needed to run workflows via the API.

## Type of Change

- [ ] `feat` -- New feature
- [x] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [x] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- `.github/workflows/sync-main-to-dev.yml`
  - Remove "Trigger CI on sync branch" step (`gh workflow run ci.yml`)
  - Remove `actions: write` from the sync job
  - Update header pipeline comment
- `assets/workspace/.github/workflows/sync-main-to-dev.yml` — same workflow changes for downstream copies
- `CHANGELOG.md` — replace the prior #405 entry describing the dispatch workaround with one documenting its removal
- `assets/workspace/.devcontainer/CHANGELOG.md` — manifest sync of root changelog

`git diff --stat origin/release/0.3.1...HEAD`: 4 files, +12 / −6 lines.

## Changelog Entry

Target branch is `release/0.3.1`; entry is under `## [0.3.1] - TBD` (not `## Unreleased`).

### Fixed

- **Sync-main-to-dev no longer dispatches CI via workflow_dispatch** ([#405](https://github.com/vig-os/devcontainer/issues/405))
  - `workflow_dispatch` runs are omitted from the PR status check rollup, so they do not satisfy branch protection on the sync PR
  - Remove the post-PR `gh workflow run ci.yml` step and drop `actions: write` from the sync job in `.github/workflows/sync-main-to-dev.yml` and `assets/workspace/.github/workflows/sync-main-to-dev.yml`

## Testing

- [ ] Tests pass locally (`just test`)
- [ ] Manual testing performed (describe below)

### Manual Testing Details

N/A — workflow YAML and changelog only; behavior verified via analysis on #405.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [ ] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

- Changelog updated under `## [0.3.1] - TBD` per release-branch convention (see `.cursor/rules/changelog.mdc`).
- Branch history vs `release/0.3.1` includes earlier commits that introduced then adjusted the dispatch; net result matches the final commit message.

Refs: #405
