### PR TITLE
fix(ci): retry setup-env uv install on transient download failure

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -104,7 +104,7 @@ inputs:
 outputs:
   uv-version:
     description: 'Version of uv installed'
-    value: ${{ steps.setup-uv.outputs.uv-version }}
+    value: ${{ steps.setup-uv-retry.outputs.uv-version || steps.setup-uv.outputs.uv-version }}
 
 runs:
   using: composite
@@ -125,6 +125,21 @@ runs:
     # ── uv ─────────────────────────────────────────────────────────────
     - name: Install uv
       id: setup-uv
+      continue-on-error: true
+      uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098  # v7
+      with:
+        enable-cache: true
+        # Install a specific version of uv.
+        version: "0.10.0"
+
+    - name: Wait before retrying uv install
+      if: steps.setup-uv.outcome == 'failure'
+      shell: bash
+      run: sleep 15
+
+    - name: Install uv (retry)
+      id: setup-uv-retry
+      if: steps.setup-uv.outcome == 'failure'
       uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098  # v7
       with:
         enable-cache: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,6 +141,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Document downstream token requirements in `docs/DOWNSTREAM_RELEASE.md` and `docs/CROSS_REPO_RELEASE_GATE.md`
   - Use `github.token` specifically for Actions cache deletion in `sync-issues.yml` because that API path requires explicit `actions: write` job token scope
   - Use Commit App credentials for rollback checkout in `release.yml` so rollback branch/tag writes can still bypass protected refs
+- **setup-env retries uv install on transient GitHub Releases download failures** ([#407](https://github.com/vig-os/devcontainer/issues/407))
+  - Add `continue-on-error` plus a delayed second attempt for `astral-sh/setup-uv` in `.github/actions/setup-env/action.yml`
+  - Reduce flaky release publish failures when GitHub CDN returns transient HTTP errors for uv release assets
 
 ### Security
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -141,6 +141,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Document downstream token requirements in `docs/DOWNSTREAM_RELEASE.md` and `docs/CROSS_REPO_RELEASE_GATE.md`
   - Use `github.token` specifically for Actions cache deletion in `sync-issues.yml` because that API path requires explicit `actions: write` job token scope
   - Use Commit App credentials for rollback checkout in `release.yml` so rollback branch/tag writes can still bypass protected refs
+- **setup-env retries uv install on transient GitHub Releases download failures** ([#407](https://github.com/vig-os/devcontainer/issues/407))
+  - Add `continue-on-error` plus a delayed second attempt for `astral-sh/setup-uv` in `.github/actions/setup-env/action.yml`
+  - Reduce flaky release publish failures when GitHub CDN returns transient HTTP errors for uv release assets
 
 ### Security
 


### PR DESCRIPTION
## Description

Hardens `.github/actions/setup-env` so a transient failure while `astral-sh/setup-uv` downloads `uv` from GitHub Releases (e.g. HTTP 404 from CDN) does not immediately fail the job. The first attempt uses `continue-on-error`; on failure we wait 15s and run a second identical install step. The composite action output `uv-version` prefers the retry step output when present.

Addresses the **Publish Release** failure described in #407 (RCA posted on the issue).

## Type of Change

- [ ] `feat` -- New feature
- [x] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [ ] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- **`.github/actions/setup-env/action.yml`**
  - First `Install uv` step: `continue-on-error: true`
  - New `Wait before retrying uv install` (`sleep 15`) when first attempt fails
  - New `Install uv (retry)` step (same `astral-sh/setup-uv` inputs), id `setup-uv-retry`
  - `outputs.uv-version`: `steps.setup-uv-retry.outputs.uv-version || steps.setup-uv.outputs.uv-version`
- **`CHANGELOG.md`**
  - ### Fixed entry under `## [0.3.1] - TBD` for #407
- **`assets/workspace/.devcontainer/CHANGELOG.md`**
  - Synced from root `CHANGELOG.md` via pre-commit manifest sync

## Changelog Entry

This branch targets `release/0.3.1`; per project changelog rules, the entry is under **`## [0.3.1] - TBD`** (not `## Unreleased`).

### Fixed

- **setup-env retries uv install on transient GitHub Releases download failures** ([#407](https://github.com/vig-os/devcontainer/issues/407))
  - Add `continue-on-error` plus a delayed second attempt for `astral-sh/setup-uv` in `.github/actions/setup-env/action.yml`
  - Reduce flaky release publish failures when GitHub CDN returns transient HTTP errors for uv release assets

## Testing

- [ ] Tests pass locally (`just test`)
- [ ] Manual testing performed (describe below)

### Manual Testing Details

N/A — workflow behavior is validated on GitHub Actions after merge; change mirrors existing retry patterns in `release.yml` (SBOM / attestation).

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` in the active release section (`## [0.3.1] - TBD`; see entry above)
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

N/A

Refs: #407
