### PR TITLE
fix: sync-main-to-dev conflict detection with merge-tree

### DIFF
--- a/.github/workflows/sync-main-to-dev.yml
+++ b/.github/workflows/sync-main-to-dev.yml
@@ -7,7 +7,7 @@
 # Pipeline:
 #   check - (early exit if dev already contains all main commits)
 #   sync  - clean up stale sync branches
-#         - trial merge to detect conflicts
+#         - merge-tree (in-memory) merge to detect conflicts
 #         - create chore/sync-main-to-dev-<run>-<attempt> branch via API
 #         - open PR; enable auto-merge when clean, or label "merge-conflict" with
 #           resolution instructions when conflicts exist
@@ -174,13 +174,22 @@ jobs:
         id: merge-check
         run: |
           set -euo pipefail
-          retry --retries 3 --backoff 3 --max-backoff 20 -- git fetch origin main
-          if git merge --no-commit --no-ff origin/main 2>/dev/null; then
+          retry --retries 3 --backoff 3 --max-backoff 20 -- git fetch origin main dev
+          if merge_out="$(git merge-tree --write-tree origin/dev origin/main 2>&1)"; then
             echo "conflict=false" >> "$GITHUB_OUTPUT"
+            echo "Merge-tree check: no conflicts between origin/dev and origin/main."
           else
-            echo "conflict=true" >> "$GITHUB_OUTPUT"
+            merge_rc=$?
+            if [ "${merge_rc}" -eq 1 ]; then
+              echo "conflict=true" >> "$GITHUB_OUTPUT"
+              echo "::warning::Merge conflicts detected between origin/dev and origin/main."
+              echo "${merge_out}"
+            else
+              echo "::error::git merge-tree failed with exit code ${merge_rc}"
+              echo "${merge_out}"
+              exit "${merge_rc}"
+            fi
           fi
-          git merge --abort 2>/dev/null || true
 
       - name: Create sync branch from main
         if: steps.existing-pr.outputs.count == '0' && steps.recheck.outputs.up_to_date != 'true'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Sync-main-to-dev no longer dispatches CI via workflow_dispatch** ([#405](https://github.com/vig-os/devcontainer/issues/405))
   - `workflow_dispatch` runs are omitted from the PR status check rollup, so they do not satisfy branch protection on the sync PR
   - Remove the post-PR `gh workflow run ci.yml` step and drop `actions: write` from the sync job in `.github/workflows/sync-main-to-dev.yml` and `assets/workspace/.github/workflows/sync-main-to-dev.yml`
+- **Sync-main-to-dev conflict detection uses merge-tree** ([#410](https://github.com/vig-os/devcontainer/issues/410))
+  - Replace working-tree trial merge with `git merge-tree --write-tree` so clean merges are not mislabeled as conflicts
+  - Enable auto-merge when dev merges cleanly with main; print merge-tree output on conflicts; fail the step on unexpected errors
 
 - **Release finalization now commits generated docs and refreshes PR content** ([#300](https://github.com/vig-os/devcontainer/issues/300))
   - Final release automation regenerates docs before committing so pre-commit `generate-docs` does not fail CI with tracked file diffs

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -80,6 +80,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Sync-main-to-dev no longer dispatches CI via workflow_dispatch** ([#405](https://github.com/vig-os/devcontainer/issues/405))
   - `workflow_dispatch` runs are omitted from the PR status check rollup, so they do not satisfy branch protection on the sync PR
   - Remove the post-PR `gh workflow run ci.yml` step and drop `actions: write` from the sync job in `.github/workflows/sync-main-to-dev.yml` and `assets/workspace/.github/workflows/sync-main-to-dev.yml`
+- **Sync-main-to-dev conflict detection uses merge-tree** ([#410](https://github.com/vig-os/devcontainer/issues/410))
+  - Replace working-tree trial merge with `git merge-tree --write-tree` so clean merges are not mislabeled as conflicts
+  - Enable auto-merge when dev merges cleanly with main; print merge-tree output on conflicts; fail the step on unexpected errors
 
 - **Release finalization now commits generated docs and refreshes PR content** ([#300](https://github.com/vig-os/devcontainer/issues/300))
   - Final release automation regenerates docs before committing so pre-commit `generate-docs` does not fail CI with tracked file diffs

--- a/assets/workspace/.github/workflows/sync-main-to-dev.yml
+++ b/assets/workspace/.github/workflows/sync-main-to-dev.yml
@@ -7,7 +7,7 @@
 # Pipeline:
 #   check - (early exit if dev already contains all main commits)
 #   sync  - clean up stale sync branches
-#         - trial merge to detect conflicts
+#         - merge-tree (in-memory) merge to detect conflicts
 #         - create chore/sync-main-to-dev-<run>-<attempt> branch via git push
 #         - open PR; enable auto-merge when clean, or label "merge-conflict" with
 #           resolution instructions when conflicts exist
@@ -201,13 +201,22 @@ jobs:
         id: merge-check
         run: |
           set -euo pipefail
-          retry --retries 3 --backoff 3 --max-backoff 20 -- git fetch origin main
-          if git merge --no-commit --no-ff origin/main 2>/dev/null; then
+          retry --retries 3 --backoff 3 --max-backoff 20 -- git fetch origin main dev
+          if merge_out="$(git merge-tree --write-tree origin/dev origin/main 2>&1)"; then
             echo "conflict=false" >> "$GITHUB_OUTPUT"
+            echo "Merge-tree check: no conflicts between origin/dev and origin/main."
           else
-            echo "conflict=true" >> "$GITHUB_OUTPUT"
+            merge_rc=$?
+            if [ "${merge_rc}" -eq 1 ]; then
+              echo "conflict=true" >> "$GITHUB_OUTPUT"
+              echo "::warning::Merge conflicts detected between origin/dev and origin/main."
+              echo "${merge_out}"
+            else
+              echo "::error::git merge-tree failed with exit code ${merge_rc}"
+              echo "${merge_out}"
+              exit "${merge_rc}"
+            fi
           fi
-          git merge --abort 2>/dev/null || true
 
       - name: Create sync branch from main
         if: steps.existing-pr.outputs.count == '0' && steps.recheck.outputs.up_to_date != 'true'


### PR DESCRIPTION
## Description

Fixes false-positive merge conflict detection in `sync-main-to-dev`: the workflow used a working-tree `git merge` with stderr discarded, so any non-zero exit was treated as conflicts. Sync PRs were mislabeled `merge-conflict`, titles got `(conflicts)`, and auto-merge was skipped even when GitHub reported a clean merge.

Replaces that with `git merge-tree --write-tree origin/dev origin/main` (in-memory, same merge semantics as `git merge`), distinguishes exit 1 (real conflicts) from other failures, and fails the step on unexpected errors instead of mislabeling.

## Type of Change

- [ ] `feat` -- New feature
- [x] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [x] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- **`.github/workflows/sync-main-to-dev.yml`**
  - Document pipeline as merge-tree-based conflict detection
  - Replace trial `git merge` + `merge --abort` with `git fetch origin main dev` and `git merge-tree --write-tree`; set `conflict` output from exit code; log/warn/error accordingly
- **`assets/workspace/.github/workflows/sync-main-to-dev.yml`**
  - Same conflict-detection logic for the workspace/downstream template
- **`CHANGELOG.md`**
  - Add Fixed entry for #410 under `## [0.3.1] - TBD`
- **`assets/workspace/.devcontainer/CHANGELOG.md`**
  - Synced from root `CHANGELOG.md` via manifest (pre-commit)

## Changelog Entry

This PR targets `release/0.3.1`; the entry is under **`## [0.3.1] - TBD` → `### Fixed`** (not `## Unreleased`):

```markdown
- **Sync-main-to-dev conflict detection uses merge-tree** ([#410](https://github.com/vig-os/devcontainer/issues/410))
  - Replace working-tree trial merge with `git merge-tree --write-tree` so clean merges are not mislabeled as conflicts
  - Enable auto-merge when dev merges cleanly with main; print merge-tree output on conflicts; fail the step on unexpected errors
```

## Testing

- [ ] Tests pass locally (`just test`)
- [ ] Manual testing performed (describe below)

### Manual Testing Details

N/A — workflow-only change; verify on next `sync-main-to-dev` run (clean merge → auto-merge enabled, no false `merge-conflict` label).

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [ ] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

Release branch: changelog entry is under `## [0.3.1] - TBD` → `### Fixed` (not `## Unreleased`), per project changelog rules.

Downstream `devcontainer-smoke-test` keeps a decoupled copy of this workflow; align it on the next template sync or a follow-up PR there.

Refs: #410
