### PR TITLE
ci(ci): dependabot actions and devcontainers/cli for release 0.3.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -313,7 +313,7 @@ jobs:
 
       - name: Upload SARIF to GitHub Security
         if: always()
-        uses: github/codeql-action/upload-sarif@0d579ffd059c29b07949a3cce3983f0780820c98  # v4
+        uses: github/codeql-action/upload-sarif@38697555549f1db7851b81482ff19f1fa5c4fedc  # v4
         with:
           sarif_file: trivy-results.sarif
           category: 'container-image'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -48,11 +48,11 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@0d579ffd059c29b07949a3cce3983f0780820c98  # v4
+        uses: github/codeql-action/init@38697555549f1db7851b81482ff19f1fa5c4fedc  # v4
         with:
           languages: ${{ matrix.language }}
 
       - name: Run CodeQL analysis
-        uses: github/codeql-action/analyze@0d579ffd059c29b07949a3cce3983f0780820c98  # v4
+        uses: github/codeql-action/analyze@38697555549f1db7851b81482ff19f1fa5c4fedc  # v4
         with:
           category: '/language:${{ matrix.language }}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -990,7 +990,7 @@ jobs:
       - name: Generate SBOM (attempt 1)
         id: sbom_generate
         continue-on-error: true
-        uses: anchore/sbom-action@57aae528053a48a3f6235f2d9461b05fbcb7366d  # v0.23.1
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610  # v0.24.0
         with:
           image: ghcr.io/vig-os/devcontainer:${{ needs.validate.outputs.publish_version }}
           artifact-name: sbom-${{ needs.validate.outputs.publish_version }}.spdx.json
@@ -1003,7 +1003,7 @@ jobs:
 
       - name: Generate SBOM (retry)
         if: steps.sbom_generate.outcome == 'failure'
-        uses: anchore/sbom-action@57aae528053a48a3f6235f2d9461b05fbcb7366d  # v0.23.1
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610  # v0.24.0
         with:
           image: ghcr.io/vig-os/devcontainer:${{ needs.validate.outputs.publish_version }}
           artifact-name: sbom-${{ needs.validate.outputs.publish_version }}.spdx.json

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -44,7 +44,7 @@ jobs:
           publish_results: true
 
       - name: Upload SARIF to GitHub Security
-        uses: github/codeql-action/upload-sarif@0d579ffd059c29b07949a3cce3983f0780820c98  # v4
+        uses: github/codeql-action/upload-sarif@38697555549f1db7851b81482ff19f1fa5c4fedc  # v4
         with:
           sarif_file: results.sarif
           category: 'scorecard'

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -129,7 +129,7 @@ jobs:
           retention-days: 90
 
       - name: Upload SARIF to GitHub Security
-        uses: github/codeql-action/upload-sarif@0d579ffd059c29b07949a3cce3983f0780820c98  # v4
+        uses: github/codeql-action/upload-sarif@38697555549f1db7851b81482ff19f1fa5c4fedc  # v4
         with:
           sarif_file: trivy-results.sarif
           category: 'container-image-scheduled'

--- a/.github/workflows/sync-issues.yml
+++ b/.github/workflows/sync-issues.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: Restore sync state (last synced timestamp)
         id: restore-state
-        uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306  # v5.0.3
+        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7  # v5.0.4
         with:
           path: .sync-state
           key: sync-issues-state-${{ github.repository }}
@@ -126,7 +126,7 @@ jobs:
 
       - name: Save sync state
         if: always()
-        uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306  # v5.0.3
+        uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7  # v5.0.4
         with:
           path: .sync-state
           key: sync-issues-state-${{ github.repository }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Keep `repository-dispatch.yml` focused on deploy/prepare/release-PR readiness and move release dispatch to a dedicated merged-PR workflow (`on-release-pr-merge.yml`)
   - Add release-kind labeling and auto-merge enablement for release PRs, and keep upstream failure notifications in both phases
   - Remove release-branch upstream `CHANGELOG.md` sync from `repository-dispatch.yml` (previously added in [#358](https://github.com/vig-os/devcontainer/issues/358))
+- **Dependabot dependency update batch** ([#414](https://github.com/vig-os/devcontainer/pull/414))
+  - Bump `github/codeql-action` from `4.32.6` to `4.34.1` and `anchore/sbom-action` from `0.23.1` to `0.24.0`
+  - Bump `actions/cache` restore/save pins from `5.0.3` to `5.0.4` in `sync-issues.yml`
+- **Dependabot dependency update batch** ([#413](https://github.com/vig-os/devcontainer/pull/413))
+  - Bump `@devcontainers/cli` from `0.84.0` to `0.84.1`
 
 ### Fixed
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -65,6 +65,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Keep `repository-dispatch.yml` focused on deploy/prepare/release-PR readiness and move release dispatch to a dedicated merged-PR workflow (`on-release-pr-merge.yml`)
   - Add release-kind labeling and auto-merge enablement for release PRs, and keep upstream failure notifications in both phases
   - Remove release-branch upstream `CHANGELOG.md` sync from `repository-dispatch.yml` (previously added in [#358](https://github.com/vig-os/devcontainer/issues/358))
+- **Dependabot dependency update batch** ([#414](https://github.com/vig-os/devcontainer/pull/414))
+  - Bump `github/codeql-action` from `4.32.6` to `4.34.1` and `anchore/sbom-action` from `0.23.1` to `0.24.0`
+  - Bump `actions/cache` restore/save pins from `5.0.3` to `5.0.4` in `sync-issues.yml`
+- **Dependabot dependency update batch** ([#413](https://github.com/vig-os/devcontainer/pull/413))
+  - Bump `@devcontainers/cli` from `0.84.0` to `0.84.1`
 
 ### Fixed
 

--- a/assets/workspace/.github/workflows/codeql.yml
+++ b/assets/workspace/.github/workflows/codeql.yml
@@ -48,11 +48,11 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@0d579ffd059c29b07949a3cce3983f0780820c98  # v4
+        uses: github/codeql-action/init@38697555549f1db7851b81482ff19f1fa5c4fedc  # v4
         with:
           languages: ${{ matrix.language }}
 
       - name: Run CodeQL analysis
-        uses: github/codeql-action/analyze@0d579ffd059c29b07949a3cce3983f0780820c98  # v4
+        uses: github/codeql-action/analyze@38697555549f1db7851b81482ff19f1fa5c4fedc  # v4
         with:
           category: '/language:${{ matrix.language }}'

--- a/assets/workspace/.github/workflows/scorecard.yml
+++ b/assets/workspace/.github/workflows/scorecard.yml
@@ -44,7 +44,7 @@ jobs:
           publish_results: true
 
       - name: Upload SARIF to GitHub Security
-        uses: github/codeql-action/upload-sarif@0d579ffd059c29b07949a3cce3983f0780820c98  # v4
+        uses: github/codeql-action/upload-sarif@38697555549f1db7851b81482ff19f1fa5c4fedc  # v4
         with:
           sarif_file: results.sarif
           category: 'scorecard'

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "devcontainer-ci-deps",
       "dependencies": {
-        "@devcontainers/cli": "0.84.0",
+        "@devcontainers/cli": "0.84.1",
         "bats": "1.13.0",
         "bats-assert": "github:bats-core/bats-assert#v2.2.4",
         "bats-file": "github:bats-core/bats-file#v0.4.0",
@@ -14,9 +14,9 @@
       }
     },
     "node_modules/@devcontainers/cli": {
-      "version": "0.84.0",
-      "resolved": "https://registry.npmjs.org/@devcontainers/cli/-/cli-0.84.0.tgz",
-      "integrity": "sha512-zAG9Kvj8qH6bAvReYTO5ZtDUHNr6OEsUqXxK1L1856XZN6c2RVV7aSAp/qIADGqqe0poqPr+ighFlvui2CH2LQ==",
+      "version": "0.84.1",
+      "resolved": "https://registry.npmjs.org/@devcontainers/cli/-/cli-0.84.1.tgz",
+      "integrity": "sha512-r+JR/4R8lznPQNwLyHPIzHJ1mj3p2l5lGyHeq2FetEfpe6s6BVLE9mFl7MxQI4wKNqfWCIO7DSokoCWRlzQSIg==",
       "license": "MIT",
       "bin": {
         "devcontainer": "devcontainer.js"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "description": "CI-only npm dependencies tracked by Dependabot",
   "dependencies": {
-    "@devcontainers/cli": "0.84.0",
+    "@devcontainers/cli": "0.84.1",
     "bats": "1.13.0",
     "bats-support": "github:bats-core/bats-support#v0.3.0",
     "bats-assert": "github:bats-core/bats-assert#v2.2.4",


### PR DESCRIPTION
## Summary

Cherry-picks onto `release/0.3.1` (via `chore/dependabot-updates`):

- **#414** — GitHub Actions minor/patch group (codeql-action, anchore/sbom-action, actions/cache in sync-issues); `release.yml` keeps SBOM retry steps and `actions/attest` for SBOM attestation.
- **#413** — `@devcontainers/cli` `0.84.0` → `0.84.1` (`package.json` / `package-lock.json`).

## Changelog

- `CHANGELOG.md` + synced `assets/workspace/.devcontainer/CHANGELOG.md`

## After merge

Close superseded dependabot PRs **#413** and **#414** (delete branches). `dev` will catch up via `sync-main-to-dev.yml` when this release reaches `main`.

Refs: #413, #414