### PR TITLE
fix: restore smoke-test workspace changelog for prepare-release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Smoke-test deploy restores workspace CHANGELOG for prepare-release** ([#417](https://github.com/vig-os/devcontainer/issues/417))
+  - Add `prepare-changelog unprepare` to rename the top `## [semver] - …` heading to `## Unreleased`
+  - `init-workspace.sh --smoke-test` copies `.devcontainer/CHANGELOG.md` into workspace `CHANGELOG.md` and runs unprepare; remove duplicate remap from smoke-test dispatch workflow
 - **Release app permission docs now include downstream workflow dispatch requirements** ([#397](https://github.com/vig-os/devcontainer/issues/397))
   - Update `docs/RELEASE_CYCLE.md` to require `Actions` read/write for `RELEASE_APP` on the validation repository
   - Clarify this is required so downstream `repository-dispatch.yml` can trigger release orchestration workflows via `workflow_dispatch`

--- a/assets/init-workspace.sh
+++ b/assets/init-workspace.sh
@@ -228,6 +228,18 @@ if [[ "$SMOKE_TEST" == "true" ]]; then
     else
         echo "Warning: Smoke-test directory not found at $SMOKE_TEST_DIR" >&2
     fi
+
+    # Workspace scaffold CHANGELOG is empty; copy devcontainer changelog and
+    # rename top ## [version] - … to ## Unreleased for downstream prepare-release.
+    if [[ -f "$WORKSPACE_DIR/.devcontainer/CHANGELOG.md" ]]; then
+        echo "Syncing workspace CHANGELOG from .devcontainer/CHANGELOG.md (smoke-test)..."
+        cp "$WORKSPACE_DIR/.devcontainer/CHANGELOG.md" "$WORKSPACE_DIR/CHANGELOG.md"
+        if ! command -v prepare-changelog >/dev/null 2>&1; then
+            echo "ERROR: prepare-changelog not found (required for smoke-test CHANGELOG sync)" >&2
+            exit 1
+        fi
+        prepare-changelog unprepare "$WORKSPACE_DIR/CHANGELOG.md"
+    fi
 else
     # Build exclude list for preserved files that already exist
     EXCLUDE_ARGS=()

--- a/assets/smoke-test/.github/workflows/repository-dispatch.yml
+++ b/assets/smoke-test/.github/workflows/repository-dispatch.yml
@@ -240,16 +240,6 @@ jobs:
             echo "ERROR: CHANGELOG.md is not readable after ownership repair"
             exit 1
           fi
-          FIRST_CHANGELOG_SECTION="$(awk '/^## / { print; exit }' CHANGELOG.md)"
-          if [ "${FIRST_CHANGELOG_SECTION}" = "## Unreleased" ]; then
-            :
-          elif printf '%s\n' "${FIRST_CHANGELOG_SECTION}" | grep -Eq '^## \[[^]]+\] - '; then
-            echo "Remapping top ## [version] - <date> to ## Unreleased for prepare-release"
-            sed -i '0,/^## \[[^]]*\] - /s/^## \[[^]]*\] - .*/## Unreleased/' CHANGELOG.md
-          else
-            echo "ERROR: CHANGELOG.md first section is neither ## Unreleased nor ## [version] - <date>: ${FIRST_CHANGELOG_SECTION:-<empty>}"
-            exit 1
-          fi
 
       - name: Prepare deploy branch and metadata
         id: prepare_branch

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -73,6 +73,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Smoke-test deploy restores workspace CHANGELOG for prepare-release** ([#417](https://github.com/vig-os/devcontainer/issues/417))
+  - Add `prepare-changelog unprepare` to rename the top `## [semver] - …` heading to `## Unreleased`
+  - `init-workspace.sh --smoke-test` copies `.devcontainer/CHANGELOG.md` into workspace `CHANGELOG.md` and runs unprepare; remove duplicate remap from smoke-test dispatch workflow
 - **Release app permission docs now include downstream workflow dispatch requirements** ([#397](https://github.com/vig-os/devcontainer/issues/397))
   - Update `docs/RELEASE_CYCLE.md` to require `Actions` read/write for `RELEASE_APP` on the validation repository
   - Clarify this is required so downstream `repository-dispatch.yml` can trigger release orchestration workflows via `workflow_dispatch`

--- a/packages/vig-utils/README.md
+++ b/packages/vig-utils/README.md
@@ -25,7 +25,7 @@ uv run check-action-pins --help
 |---|---|---|
 | `validate-commit-msg` | Python | Enforce commit message standard |
 | `check-action-pins` | Python | Ensure GitHub Actions are SHA pinned |
-| `prepare-changelog` | Python | Validate/prepare/finalize/reset changelog |
+| `prepare-changelog` | Python | Validate/prepare/finalize/reset/unprepare changelog |
 | `gh-issues` | Python | Rich issue/PR dashboard via `gh` |
 | `prepare-commit-msg-strip-trailers` | Python | Remove blocked trailers from commit messages |
 | `check-agent-identity` | Python | Block commits from agent fingerprints in author identity |
@@ -87,6 +87,7 @@ prepare-changelog validate [FILE]
 prepare-changelog prepare <VERSION> [FILE]
 prepare-changelog finalize <VERSION> <YYYY-MM-DD> [FILE]
 prepare-changelog reset [FILE]
+prepare-changelog unprepare [FILE]
 ```
 
 Examples:
@@ -96,6 +97,7 @@ prepare-changelog validate
 prepare-changelog prepare 0.3.0
 prepare-changelog finalize 0.3.0 2026-03-04
 prepare-changelog reset
+prepare-changelog unprepare
 ```
 
 ### `gh-issues`

--- a/packages/vig-utils/src/vig_utils/prepare_changelog.py
+++ b/packages/vig-utils/src/vig_utils/prepare_changelog.py
@@ -176,8 +176,49 @@ def reset_unreleased(filepath="CHANGELOG.md"):
 
 
 def unprepare_changelog(filepath="CHANGELOG.md"):
-    """Rename top version section to ## Unreleased (implemented in next commit)."""
-    raise NotImplementedError
+    """
+    Rename the first top-level version section to ## Unreleased (inverse of prepare).
+
+    Used when the workspace CHANGELOG was replaced by a scaffold but the canonical
+    entries live under ``## [X.Y.Z] - …`` (e.g. copied from ``.devcontainer/CHANGELOG.md``).
+
+    - If the first ``## `` heading is already ``## Unreleased``, no-op.
+    - If it matches ``## [MAJOR.MINOR.PATCH] - …`` (semver + suffix), replace with
+      ``## Unreleased``.
+    - Otherwise raises ValueError.
+
+    Args:
+        filepath: Path to CHANGELOG.md
+
+    Returns:
+        True if the file was modified, False if already ``## Unreleased``.
+    """
+    path = Path(filepath)
+    if not path.exists():
+        raise FileNotFoundError(f"CHANGELOG not found: {filepath}")
+
+    content = path.read_text()
+    match = re.search(r"^## .+$", content, re.MULTILINE)
+    if not match:
+        raise ValueError("No top-level ## heading found in CHANGELOG")
+
+    line = match.group(0).rstrip("\r\n")
+    if line == "## Unreleased":
+        return False
+
+    # Match ## [X.Y.Z] - TBD or ## [X.Y.Z] - YYYY-MM-DD (same semver rule as prepare)
+    version_heading = re.compile(
+        r"^## \[(\d+\.\d+\.\d+)\] - .+$",
+    )
+    if not version_heading.match(line):
+        raise ValueError(
+            f"Unexpected first CHANGELOG section heading: {line!r} "
+            "(expected ## Unreleased or ## [semver] - …)"
+        )
+
+    new_content = content[: match.start()] + "## Unreleased" + content[match.end() :]
+    path.write_text(new_content)
+    return True
 
 
 def prepare_changelog(version, filepath="CHANGELOG.md"):

--- a/packages/vig-utils/src/vig_utils/prepare_changelog.py
+++ b/packages/vig-utils/src/vig_utils/prepare_changelog.py
@@ -175,6 +175,11 @@ def reset_unreleased(filepath="CHANGELOG.md"):
         raise ValueError("Could not find appropriate location for Unreleased section")
 
 
+def unprepare_changelog(filepath="CHANGELOG.md"):
+    """Rename top version section to ## Unreleased (implemented in next commit)."""
+    raise NotImplementedError
+
+
 def prepare_changelog(version, filepath="CHANGELOG.md"):
     """
     Prepare CHANGELOG for release.
@@ -262,6 +267,14 @@ def cmd_reset(args):
     print("✓ Created fresh empty section for next release")
 
 
+def cmd_unprepare(args):
+    """Handle unprepare command."""
+    if unprepare_changelog(args.file):
+        print(f"✓ Renamed top version section to ## Unreleased in {args.file}")
+    else:
+        print(f"✓ Top section already ## Unreleased in {args.file} (no changes)")
+
+
 def finalize_release_date(version, release_date, filepath="CHANGELOG.md"):
     """
     Replace TBD date with actual release date for a version.
@@ -332,6 +345,9 @@ Examples:
 
   # Reset Unreleased section after release merge
   %(prog)s reset
+
+  # Rename top ## [version] - … to ## Unreleased (smoke-test deploy sync)
+  %(prog)s unprepare
         """,
     )
 
@@ -384,6 +400,19 @@ Examples:
         help="Path to CHANGELOG file (default: CHANGELOG.md)",
     )
     reset_parser.set_defaults(func=cmd_reset)
+
+    # unprepare command
+    unprepare_parser = subparsers.add_parser(
+        "unprepare",
+        help="Rename first ## [semver] - … heading to ## Unreleased",
+    )
+    unprepare_parser.add_argument(
+        "file",
+        nargs="?",
+        default="CHANGELOG.md",
+        help="Path to CHANGELOG file (default: CHANGELOG.md)",
+    )
+    unprepare_parser.set_defaults(func=cmd_unprepare)
 
     # finalize command
     finalize_parser = subparsers.add_parser(

--- a/packages/vig-utils/tests/test_prepare_changelog.py
+++ b/packages/vig-utils/tests/test_prepare_changelog.py
@@ -10,6 +10,7 @@ Comprehensive coverage including:
 Tests are organized by function under test, from low-level helpers up to the CLI layer.
 """
 
+import re
 import shutil
 import subprocess
 from unittest.mock import patch
@@ -20,6 +21,7 @@ from vig_utils.prepare_changelog import (
     cmd_finalize,
     cmd_prepare,
     cmd_reset,
+    cmd_unprepare,
     cmd_validate,
     create_new_changelog,
     extract_unreleased_content,
@@ -27,6 +29,7 @@ from vig_utils.prepare_changelog import (
     main,
     prepare_changelog,
     reset_unreleased,
+    unprepare_changelog,
     validate_changelog,
 )
 
@@ -873,6 +876,115 @@ class TestResetUnreleased:
 
 
 # ═════════════════════════════════════════════════════════════════════════════
+# unprepare_changelog
+# ═════════════════════════════════════════════════════════════════════════════
+
+TOP_VERSION_TBD_THEN_OLDER = """\
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [1.0.0] - TBD
+
+### Added
+
+- **Feature** ([#1](https://example.com/1))
+
+## [0.9.0] - 2026-01-01
+
+### Added
+
+- Prior
+"""
+
+
+class TestUnprepareChangelog:
+    """Unit tests for unprepare_changelog()."""
+
+    def test_renames_tbd_header(self, tmp_path):
+        """Top ## [semver] - TBD becomes ## Unreleased; body preserved."""
+        f = tmp_path / "CHANGELOG.md"
+        f.write_text(TOP_VERSION_TBD_THEN_OLDER)
+        assert unprepare_changelog(str(f)) is True
+        text = f.read_text()
+        assert text.startswith("# Changelog")
+        first_h2 = re.search(r"^## .+$", text, re.MULTILINE)
+        assert first_h2 is not None
+        assert first_h2.group(0) == "## Unreleased"
+        assert "## [1.0.0] - TBD" not in text
+        assert "**Feature**" in text
+        assert "## [0.9.0] - 2026-01-01" in text
+
+    def test_renames_dated_header(self, tmp_path):
+        """Top ## [semver] - YYYY-MM-DD becomes ## Unreleased."""
+        body = """\
+# Changelog
+
+## [2.0.0] - 2026-03-23
+
+### Fixed
+
+- Bug
+
+"""
+        f = tmp_path / "CHANGELOG.md"
+        f.write_text(body)
+        assert unprepare_changelog(str(f)) is True
+        assert f.read_text().split("\n")[2] == "## Unreleased"
+        assert "- Bug" in f.read_text()
+
+    def test_noop_when_already_unreleased(self, tmp_path):
+        """Returns False and leaves file unchanged."""
+        f = tmp_path / "CHANGELOG.md"
+        f.write_text(BASIC_CHANGELOG)
+        before = f.read_text()
+        assert unprepare_changelog(str(f)) is False
+        assert f.read_text() == before
+
+    def test_raises_no_heading(self, tmp_path):
+        """No ## line raises ValueError."""
+        f = tmp_path / "CHANGELOG.md"
+        f.write_text("# Title only\n\nNo section.\n")
+        with pytest.raises(ValueError, match="No top-level"):
+            unprepare_changelog(str(f))
+
+    def test_raises_unexpected_heading(self, tmp_path):
+        """Non-version first ## heading raises."""
+        f = tmp_path / "CHANGELOG.md"
+        f.write_text("# C\n\n## Random\n\n- x\n")
+        with pytest.raises(ValueError, match="Unexpected first"):
+            unprepare_changelog(str(f))
+
+    def test_raises_missing_file(self, tmp_path):
+        with pytest.raises(FileNotFoundError, match="CHANGELOG not found"):
+            unprepare_changelog(str(tmp_path / "missing.md"))
+
+
+class TestCmdUnprepare:
+    """Tests for cmd_unprepare handler."""
+
+    def _make_args(self, filepath):
+        from argparse import Namespace
+
+        return Namespace(file=filepath)
+
+    def test_output_when_modified(self, tmp_path, capsys):
+        f = tmp_path / "CHANGELOG.md"
+        f.write_text(TOP_VERSION_TBD_THEN_OLDER)
+        cmd_unprepare(self._make_args(str(f)))
+        out = capsys.readouterr().out
+        assert "Renamed" in out
+        assert "## Unreleased" in f.read_text()
+
+    def test_output_when_noop(self, tmp_path, capsys):
+        f = tmp_path / "CHANGELOG.md"
+        f.write_text(BASIC_CHANGELOG)
+        cmd_unprepare(self._make_args(str(f)))
+        out = capsys.readouterr().out
+        assert "no changes" in out.lower() or "already" in out.lower()
+
+
+# ═════════════════════════════════════════════════════════════════════════════
 # finalize_release_date
 # ═════════════════════════════════════════════════════════════════════════════
 
@@ -1210,6 +1322,16 @@ class TestMainCLI:
             main()
         assert "## [1.0.0] - 2026-02-11" in f.read_text()
 
+    def test_unprepare_via_main(self, tmp_path):
+        """main() with 'unprepare' should rename top version heading."""
+        f = tmp_path / "CHANGELOG.md"
+        f.write_text(TOP_VERSION_TBD_THEN_OLDER)
+        with patch("sys.argv", ["prog", "unprepare", str(f)]):
+            main()
+        first = re.search(r"^## .+$", f.read_text(), re.MULTILINE)
+        assert first is not None
+        assert first.group(0) == "## Unreleased"
+
     def test_main_catches_exceptions(self, tmp_path):
         """main() should convert exceptions to stderr + exit(1)."""
         with (
@@ -1324,3 +1446,24 @@ class TestCLISubprocess:
         f.write_text(CHANGELOG_WITH_TBD)
         result = self._run("finalize", "9.9.9", "2026-02-11", str(f))
         assert result.returncode != 0
+
+    # ── unprepare ─────────────────────────────────────────────────────────
+
+    def test_unprepare_e2e(self, tmp_path):
+        """unprepare via subprocess renames top version heading."""
+        f = tmp_path / "CHANGELOG.md"
+        f.write_text(TOP_VERSION_TBD_THEN_OLDER)
+        result = self._run("unprepare", str(f))
+        assert result.returncode == 0
+        first = re.search(r"^## .+$", f.read_text(), re.MULTILINE)
+        assert first is not None
+        assert first.group(0) == "## Unreleased"
+
+    def test_unprepare_noop_e2e(self, tmp_path):
+        """unprepare leaves Unreleased changelog unchanged."""
+        f = tmp_path / "CHANGELOG.md"
+        f.write_text(BASIC_CHANGELOG)
+        before = f.read_text()
+        result = self._run("unprepare", str(f))
+        assert result.returncode == 0
+        assert f.read_text() == before

--- a/tests/bats/just.bats
+++ b/tests/bats/just.bats
@@ -75,8 +75,8 @@ setup() {
     assert_success
 }
 
-@test "smoke-test dispatch normalizes workspace changelog for prepare-release freeze" {
-    run bash -lc 'grep -Fq -- "expected CHANGELOG.md after install (workspace scaffold)" assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- "FIRST_CHANGELOG_SECTION" assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- "## Unreleased" assets/smoke-test/.github/workflows/repository-dispatch.yml'
+@test "smoke-test dispatch validates workspace changelog exists after install" {
+    run bash -lc 'grep -Fq -- "expected CHANGELOG.md after install (workspace scaffold)" assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- "CHANGELOG.md is not readable after ownership repair" assets/smoke-test/.github/workflows/repository-dispatch.yml'
     assert_success
 }
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -908,13 +908,15 @@ class TestSmokeRepo:
         root_content = root_changelog.read_text(encoding="utf-8")
         devcontainer_content = devcontainer_changelog.read_text(encoding="utf-8")
 
-        # Root changelog is workspace-owned; .devcontainer changelog is the canonical
-        # upstream release history synced from the template manifest.
-        assert "## Unreleased" in root_content, (
-            "Root changelog should expose workspace Unreleased section"
+        # Root changelog is a copy of .devcontainer/CHANGELOG.md with the top semver
+        # heading renamed via prepare-changelog unprepare; older release sections stay.
+        first_h2 = re.search(r"^## .+$", root_content, re.MULTILINE)
+        assert first_h2 is not None, "Root changelog should have a top-level ## heading"
+        assert first_h2.group(0).rstrip("\r\n") == "## Unreleased", (
+            "Root changelog top section should be ## Unreleased after smoke-test unprepare"
         )
-        assert "## [" not in root_content, (
-            "Root changelog should remain a workspace stub without versioned releases"
+        assert re.search(r"^## \[\d+\.\d+\.\d+\]", root_content, re.MULTILINE), (
+            "Root changelog should retain semver release sections below Unreleased"
         )
         assert re.search(
             r"^## \[\d+\.\d+\.\d+\]", devcontainer_content, re.MULTILINE


### PR DESCRIPTION
## Description

Smoke-test RC deploy left workspace `CHANGELOG.md` as the empty scaffold after `init-workspace.sh --smoke-test`, so downstream `prepare-release.yml` failed validation (`Unreleased section has no entries`). This change copies `.devcontainer/CHANGELOG.md` to the workspace root during smoke-test install, runs new `prepare-changelog unprepare` to rename the top `## [semver] - …` heading to `## Unreleased`, and drops the redundant remap block from the smoke-test dispatch workflow.

## Type of Change

- [ ] `feat` -- New feature
- [x] `fix` -- Bug fix
- [x] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [x] `test` -- Adding or updating tests
- [x] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- **`packages/vig-utils/src/vig_utils/prepare_changelog.py`** — Add `unprepare_changelog()` and `prepare-changelog unprepare` CLI subcommand (rename first top-level `## [semver] - …` to `## Unreleased`).
- **`packages/vig-utils/tests/test_prepare_changelog.py`** — Unit tests, command-handler tests, `main()` and subprocess coverage for `unprepare`.
- **`assets/init-workspace.sh`** — After smoke-test rsyncs, copy `.devcontainer/CHANGELOG.md` → `CHANGELOG.md` and run `prepare-changelog unprepare` (requires `prepare-changelog` on PATH in the install image).
- **`assets/smoke-test/.github/workflows/repository-dispatch.yml`** — Remove inline `awk`/`sed` remap; keep existence/readability checks for changelogs.
- **`CHANGELOG.md`** / **`assets/workspace/.devcontainer/CHANGELOG.md`** — Document the fix under the active release section.
- **`packages/vig-utils/README.md`** — Document `unprepare` in the CLI list and examples.

**Diff vs `release/0.3.1`:** 7 files, +234 / −11 lines.

## Changelog Entry

Paste from `## [0.3.1] - TBD` → `### Fixed`:

### Fixed

- **Smoke-test deploy restores workspace CHANGELOG for prepare-release** ([#417](https://github.com/vig-os/devcontainer/issues/417))
  - Add `prepare-changelog unprepare` to rename the top `## [semver] - …` heading to `## Unreleased`
  - `init-workspace.sh --smoke-test` copies `.devcontainer/CHANGELOG.md` into workspace `CHANGELOG.md` and runs unprepare; remove duplicate remap from smoke-test dispatch workflow

## Testing

- [x] Tests pass locally (`just test`)
- [ ] Manual testing performed (describe below)

### Manual Testing Details

N/A (not run in a full smoke-test dispatch; verify with next RC after promoting templates).

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` under the active `## [0.3.1] - TBD` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

Target base branch: **`release/0.3.1`**. After merge, promote updated smoke-test templates / tag an RC so `vig-os/devcontainer-smoke-test` picks up the fix.

Refs: #417
