### PR TITLE
fix: harden downstream release validate and rollback context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -162,6 +162,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Stop overwriting `CHANGELOG.md` with a minimal stub in `assets/smoke-test/.github/workflows/repository-dispatch.yml`
   - Require the workspace `CHANGELOG.md` from `init-workspace` so downstream `prepare-release` validation matches shipped layout
   - When the first changelog section is `## [X.Y.Z] - …` (TBD or a release date), remap that top version header to `## Unreleased` so downstream `prepare-release` can run
+- **Smoke-test dispatch release validate no longer runs docker inside devcontainer** ([#421](https://github.com/vig-os/devcontainer/issues/421))
+  - Remove redundant `docker manifest inspect` step from `release-core.yml` validate job (container image is already proof of accessibility; `resolve-image` validates on the runner)
+  - Set `GH_REPO` for rollback `gh issue create` in workspace `release.yml` when git checkout is skipped
 
 ### Security
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -162,6 +162,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Stop overwriting `CHANGELOG.md` with a minimal stub in `assets/smoke-test/.github/workflows/repository-dispatch.yml`
   - Require the workspace `CHANGELOG.md` from `init-workspace` so downstream `prepare-release` validation matches shipped layout
   - When the first changelog section is `## [X.Y.Z] - …` (TBD or a release date), remap that top version header to `## Unreleased` so downstream `prepare-release` can run
+- **Smoke-test dispatch release validate no longer runs docker inside devcontainer** ([#421](https://github.com/vig-os/devcontainer/issues/421))
+  - Remove redundant `docker manifest inspect` step from `release-core.yml` validate job (container image is already proof of accessibility; `resolve-image` validates on the runner)
+  - Set `GH_REPO` for rollback `gh issue create` in workspace `release.yml` when git checkout is skipped
 
 ### Security
 

--- a/assets/workspace/.github/workflows/release-core.yml
+++ b/assets/workspace/.github/workflows/release-core.yml
@@ -162,19 +162,6 @@ jobs:
       - name: Fix git safe.directory
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
-      - name: Validate image accessibility
-        env:
-          IMAGE_TAG: ${{ needs.resolve-image.outputs.image-tag }}
-        run: |
-          set -euo pipefail
-          IMAGE="ghcr.io/vig-os/devcontainer:${IMAGE_TAG}"
-          echo "Validating image availability: $IMAGE"
-          if ! retry --retries 3 --backoff 5 --max-backoff 30 -- docker manifest inspect "$IMAGE" > /dev/null 2>&1; then
-            echo "ERROR: Cannot access image manifest: $IMAGE"
-            echo "Check whether the tag exists and whether this workflow has access to GHCR."
-            exit 1
-          fi
-
       - name: Record pre-finalization SHA
         id: pre_sha
         run: |

--- a/assets/workspace/.github/workflows/release.yml
+++ b/assets/workspace/.github/workflows/release.yml
@@ -194,6 +194,7 @@ jobs:
           VERSION: ${{ needs.core.outputs.version }}
           PR_NUMBER: ${{ needs.core.outputs.pr_number }}
           GH_TOKEN: ${{ steps.release_app_token.outputs.token }}
+          GH_REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
           WORKFLOW_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"


### PR DESCRIPTION
## Description

Addresses smoke-test dispatch failure in downstream release orchestration ([#421](https://github.com/vig-os/devcontainer/issues/421)): `trigger-release` failed while validating the image from inside the devcontainer job. The validate job no longer runs `docker manifest inspect` in the container (redundant with runner-side `resolve-image` and the running image). Rollback `gh issue create` now receives `GH_REPO` when the job skips checkout so `gh` has an explicit repository context.

## Type of Change

- [ ] `feat` -- New feature
- [x] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [ ] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- `CHANGELOG.md` — document fix under `## [0.3.1] - TBD` / `### Fixed`
- `assets/workspace/.devcontainer/CHANGELOG.md` — mirror changelog entry
- `assets/workspace/.github/workflows/release-core.yml` — remove container `docker manifest inspect` step from validate job
- `assets/workspace/.github/workflows/release.yml` — set `GH_REPO: ${{ github.repository }}` for rollback `gh issue create` env

## Changelog Entry

Target branch is `release/0.3.1`; there is no `## Unreleased` section. Entry was added under **`## [0.3.1] - TBD` → `### Fixed`**:

```markdown
- **Smoke-test dispatch release validate no longer runs docker inside devcontainer** ([#421](https://github.com/vig-os/devcontainer/issues/421))
  - Remove redundant `docker manifest inspect` step from `release-core.yml` validate job (container image is already proof of accessibility; `resolve-image` validates on the runner)
  - Set `GH_REPO` for rollback `gh issue create` in workspace `release.yml` when git checkout is skipped
```

## Testing

- [ ] Tests pass locally (`just test`)
- [x] Manual testing performed (describe below)

### Manual Testing Details

`uv run pre-commit run --all-files` passed on the branch before commit.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [ ] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

N/A

Refs: #421
