### PR TITLE
test: align container image checks with uv and just release lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -167,6 +167,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Set `GH_REPO` for rollback `gh issue create` in workspace `release.yml` when git checkout is skipped
 - **Container image tests expect current uv minor line** ([#423](https://github.com/vig-os/devcontainer/issues/423))
   - Update `tests/test_image.py` `EXPECTED_VERSIONS["uv"]` to match uv 0.11.x from the latest release install path in the image build
+- **Container image tests expect current just minor line** ([#423](https://github.com/vig-os/devcontainer/issues/423))
+  - Update `tests/test_image.py` `EXPECTED_VERSIONS["just"]` to match just 1.48.x from the latest release install path in the image build
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -165,6 +165,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Smoke-test dispatch release validate no longer runs docker inside devcontainer** ([#421](https://github.com/vig-os/devcontainer/issues/421))
   - Remove redundant `docker manifest inspect` step from `release-core.yml` validate job (container image is already proof of accessibility; `resolve-image` validates on the runner)
   - Set `GH_REPO` for rollback `gh issue create` in workspace `release.yml` when git checkout is skipped
+- **Container image tests expect current uv minor line** ([#423](https://github.com/vig-os/devcontainer/issues/423))
+  - Update `tests/test_image.py` `EXPECTED_VERSIONS["uv"]` to match uv 0.11.x from the latest release install path in the image build
 
 ### Security
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -167,6 +167,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Set `GH_REPO` for rollback `gh issue create` in workspace `release.yml` when git checkout is skipped
 - **Container image tests expect current uv minor line** ([#423](https://github.com/vig-os/devcontainer/issues/423))
   - Update `tests/test_image.py` `EXPECTED_VERSIONS["uv"]` to match uv 0.11.x from the latest release install path in the image build
+- **Container image tests expect current just minor line** ([#423](https://github.com/vig-os/devcontainer/issues/423))
+  - Update `tests/test_image.py` `EXPECTED_VERSIONS["just"]` to match just 1.48.x from the latest release install path in the image build
 
 ### Security
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -165,6 +165,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Smoke-test dispatch release validate no longer runs docker inside devcontainer** ([#421](https://github.com/vig-os/devcontainer/issues/421))
   - Remove redundant `docker manifest inspect` step from `release-core.yml` validate job (container image is already proof of accessibility; `resolve-image` validates on the runner)
   - Set `GH_REPO` for rollback `gh issue create` in workspace `release.yml` when git checkout is skipped
+- **Container image tests expect current uv minor line** ([#423](https://github.com/vig-os/devcontainer/issues/423))
+  - Update `tests/test_image.py` `EXPECTED_VERSIONS["uv"]` to match uv 0.11.x from the latest release install path in the image build
 
 ### Security
 

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -26,7 +26,7 @@ EXPECTED_VERSIONS = {
     "ruff": "0.15.",  # Minor version check (installed via uv pip)
     "bandit": "1.9.",  # Minor version check (installed via uv pip)
     "pip_licenses": "5.",  # Major version check (installed via uv pip)
-    "just": "1.47.",  # Minor version check (manually installed from latest release)
+    "just": "1.48.",  # Minor version check (manually installed from latest release)
     "hadolint": "2.14.",  # Minor version check (manually installed from pinned release)
     "taplo": "0.10.",  # Minor version check (manually installed from latest release)
     "cargo-binstall": "1.17.",  # Minor version check (installed from latest release),

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -20,7 +20,7 @@ EXPECTED_VERSIONS = {
     "git": "2.",  # Major version check (from apt package)
     "curl": "8.",  # Major version check (from apt package)
     "gh": "2.88.",  # Minor version check (GitHub CLI (manually installed from latest release)
-    "uv": "0.10.",  # Minor version check (manually installed from latest release)
+    "uv": "0.11.",  # Minor version check (manually installed from latest release)
     "python": "3.12",  # Python (from base image)
     "pre_commit": "4.5.",  # Minor version check (installed via uv pip)
     "ruff": "0.15.",  # Minor version check (installed via uv pip)


### PR DESCRIPTION
## Description

Aligns container image integration tests with the toolchain versions the Dockerfile installs from latest releases. Release CI ([#423](https://github.com/vig-os/devcontainer/issues/423)) failed because `tests/test_image.py` still expected older uv and just minor lines while the image build pulls current releases. This change updates `EXPECTED_VERSIONS` for both tools and documents it under `## [0.3.1] - TBD` in the root and workspace-template changelogs.

## Type of Change

- [ ] `feat` -- New feature
- [ ] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [x] `test` -- Adding or updating tests
- [ ] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- `tests/test_image.py` — bump `EXPECTED_VERSIONS["uv"]` to the `0.11.` prefix and `EXPECTED_VERSIONS["just"]` to the `1.48.` prefix so assertions match the image install path.
- `CHANGELOG.md` — under `## [0.3.1] - TBD` / `### Fixed`, add the two [#423](https://github.com/vig-os/devcontainer/issues/423) bullets for uv and just.
- `assets/workspace/.devcontainer/CHANGELOG.md` — same `### Fixed` entries (synced template copy).

## Changelog Entry

### Fixed

- **Container image tests expect current uv minor line** ([#423](https://github.com/vig-os/devcontainer/issues/423))
  - Update `tests/test_image.py` `EXPECTED_VERSIONS["uv"]` to match uv 0.11.x from the latest release install path in the image build
- **Container image tests expect current just minor line** ([#423](https://github.com/vig-os/devcontainer/issues/423))
  - Update `tests/test_image.py` `EXPECTED_VERSIONS["just"]` to match just 1.48.x from the latest release install path in the image build

## Testing

- [x] Tests pass locally (`just test`)
- [ ] Manual testing performed (describe below)

### Manual Testing Details

N/A. Ran `just build 1` (no-cache) so the `just` and `uv` install layers were not served from stale cache; then `just test` (267 pytest cases + BATS) completed successfully. A plain `just build` can leave older toolchain versions in cached layers and fail `test_just_version` / `test_uv_installed` until a no-cache rebuild.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [ ] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

Target branch is `release/0.3.1`; changelog edits belong under `## [0.3.1] - TBD`, not `## Unreleased`, so the checklist item about `[Unreleased]` does not apply.

Refs: #423
