### PR TITLE
fix: add jq to devcontainer image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Add project-owned `release-extension.yml` stub and preserve it during `init-workspace.sh --force` upgrades
   - Add `validate-contract` composite action for single-source contract version validation
   - Add downstream release contract documentation and GHCR extension example in `docs/DOWNSTREAM_RELEASE.md`
+- **`jq` in devcontainer image** ([#425](https://github.com/vig-os/devcontainer/issues/425))
+  - Install the `jq` CLI in the GHCR image so containerized workflows (e.g. `release-core` validate / downstream Release Core) can pipe JSON through `jq`
 
 ### Changed
 

--- a/Containerfile
+++ b/Containerfile
@@ -53,6 +53,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     git \
+    jq \
     openssh-client \
     locales \
     ca-certificates \

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Add project-owned `release-extension.yml` stub and preserve it during `init-workspace.sh --force` upgrades
   - Add `validate-contract` composite action for single-source contract version validation
   - Add downstream release contract documentation and GHCR extension example in `docs/DOWNSTREAM_RELEASE.md`
+- **`jq` in devcontainer image** ([#425](https://github.com/vig-os/devcontainer/issues/425))
+  - Install the `jq` CLI in the GHCR image so containerized workflows (e.g. `release-core` validate / downstream Release Core) can pipe JSON through `jq`
 
 ### Changed
 


### PR DESCRIPTION
## Description

Install the Debian `jq` package in the vig-os devcontainer image so jobs that run inside `ghcr.io/vig-os/devcontainer:<tag>` can execute shell pipelines that pipe JSON through `jq`. This fixes downstream **Release Core / Validate Release Core** failures (exit 127 on **Find and verify PR**) when smoke-test (or any workspace) runs `release-core.yml` in-container; `gh … --jq` was never the problem—standalone `jq` was missing from the image.

## Type of Change

- [ ] `feat` -- New feature
- [x] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [ ] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- **`Containerfile`**: add `jq` to the minimal `apt-get install` list (alphabetical with other packages).
- **`CHANGELOG.md`**: document under `## [0.3.1] - TBD` → `### Added` (sync-manifest also updates `assets/workspace/.devcontainer/CHANGELOG.md`).

## Changelog Entry

This PR targets `release/0.3.1`; the entry lives under the active **`## [0.3.1] - TBD`** section (not `## Unreleased`).

```markdown
- **`jq` in devcontainer image** ([#425](https://github.com/vig-os/devcontainer/issues/425))
  - Install the `jq` CLI in the GHCR image so containerized workflows (e.g. `release-core` validate / downstream Release Core) can pipe JSON through `jq`
```

## Testing

- [ ] Tests pass locally (`just test`)
- [ ] Manual testing performed (describe below)

### Manual Testing Details

N/A — image change only; optional verification: `docker build -f Containerfile .` then `docker run --rm <image> jq --version`.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [ ] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

Note: Changelog entry is under **`## [0.3.1] - TBD` → `### Added`** (release branch), not `## Unreleased`, so the checklist item above is intentionally unchecked. No new tests for an OS package in the OCI image.

## Additional Notes

- Failing job context: [Release Core / Validate Release Core](https://github.com/vig-os/devcontainer-smoke-test/actions/runs/23478133458/job/68315258492) (exit 127 on **Find and verify PR**).
- After merge, a published image tag that includes this commit is required for downstream repos to pick up `jq` via `.vig-os` / `DEVCONTAINER_VERSION`.

Refs: #425
