### PR TITLE
fix: approve smoke-test release PR before downstream release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -176,6 +176,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Update `tests/test_image.py` `EXPECTED_VERSIONS["uv"]` to match uv 0.11.x from the latest release install path in the image build
 - **Container image tests expect current just minor line** ([#423](https://github.com/vig-os/devcontainer/issues/423))
   - Update `tests/test_image.py` `EXPECTED_VERSIONS["just"]` to match just 1.48.x from the latest release install path in the image build
+- **Smoke-test dispatch approves release PR before downstream release** ([#430](https://github.com/vig-os/devcontainer/issues/430))
+  - Grant `pull-requests: write` on `ready-release-pr` and approve with `github.token` (`github-actions[bot]`)
+  - Satisfy `release-core.yml` approval gate without the release app self-approving its own PR
 
 ### Security
 

--- a/assets/smoke-test/.github/workflows/repository-dispatch.yml
+++ b/assets/smoke-test/.github/workflows/repository-dispatch.yml
@@ -553,8 +553,12 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ steps.locate_release_pr.outputs.release_pr }}
         run: |
+          set -euo pipefail
           gh pr review "${PR_NUMBER}" --approve \
-            --body "Automated approval by smoke-test dispatch orchestration."
+            --body "Automated approval by smoke-test dispatch orchestration." || {
+            echo "::error::Auto-approve failed. If you see a permissions error, enable repository (or organization) setting 'Allow GitHub Actions to create and approve pull requests'. See this PR description for context."
+            exit 1
+          }
 
   trigger-release:
     name: Trigger and wait for release workflow

--- a/assets/smoke-test/.github/workflows/repository-dispatch.yml
+++ b/assets/smoke-test/.github/workflows/repository-dispatch.yml
@@ -487,6 +487,9 @@ jobs:
     name: Prepare release PR
     runs-on: ubuntu-22.04
     timeout-minutes: 35
+    permissions:
+      contents: read
+      pull-requests: write
     env:
       GH_REPO: ${{ github.repository }}
     needs: [validate, trigger-prepare-release]
@@ -544,6 +547,14 @@ jobs:
           gh pr edit "${PR_NUMBER}" --remove-label "release-kind:candidate" >/dev/null 2>&1 || true
           gh pr edit "${PR_NUMBER}" --remove-label "release-kind:final" >/dev/null 2>&1 || true
           gh pr edit "${PR_NUMBER}" --add-label "${LABEL}"
+
+      - name: Approve release PR for automated dispatch
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.locate_release_pr.outputs.release_pr }}
+        run: |
+          gh pr review "${PR_NUMBER}" --approve \
+            --body "Automated approval by smoke-test dispatch orchestration."
 
   trigger-release:
     name: Trigger and wait for release workflow

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -176,6 +176,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Update `tests/test_image.py` `EXPECTED_VERSIONS["uv"]` to match uv 0.11.x from the latest release install path in the image build
 - **Container image tests expect current just minor line** ([#423](https://github.com/vig-os/devcontainer/issues/423))
   - Update `tests/test_image.py` `EXPECTED_VERSIONS["just"]` to match just 1.48.x from the latest release install path in the image build
+- **Smoke-test dispatch approves release PR before downstream release** ([#430](https://github.com/vig-os/devcontainer/issues/430))
+  - Grant `pull-requests: write` on `ready-release-pr` and approve with `github.token` (`github-actions[bot]`)
+  - Satisfy `release-core.yml` approval gate without the release app self-approving its own PR
 
 ### Security
 


### PR DESCRIPTION
## Description

Smoke-test `repository_dispatch` orchestration marks the release PR ready and dispatches `release.yml`, but `release-core.yml` requires `reviewDecision == APPROVED`. The release app cannot self-approve its own PR. This PR adds a `ready-release-pr` job step that approves the release PR using `github.token`, with job-scoped `pull-requests: write`, so downstream Release Core validation passes without manual approval.

## Type of Change

- [x] `fix` -- Bug fix
- [ ] `feat` -- New feature
- [ ] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [ ] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- `assets/smoke-test/.github/workflows/repository-dispatch.yml`
  - Set `permissions: contents: read` and `pull-requests: write` on job `ready-release-pr`.
  - Add step **Approve release PR for automated dispatch** using `GH_TOKEN: ${{ github.token }}` and `gh pr review … --approve` after release-kind labeling.
- `CHANGELOG.md` / `assets/workspace/.devcontainer/CHANGELOG.md`
  - Document fix under `## [0.3.1] - TBD` → `### Fixed` ([#430](https://github.com/vig-os/devcontainer/issues/430)).

## Changelog Entry

This PR targets `release/0.3.1`; the active section is `## [0.3.1] - TBD` (not `## Unreleased`). Added under `### Fixed`:

```markdown
- **Smoke-test dispatch approves release PR before downstream release** ([#430](https://github.com/vig-os/devcontainer/issues/430))
  - Grant `pull-requests: write` on `ready-release-pr` and approve with `github.token` (`git*hub-actions[bot]`)
  - Satisfy `release-core.yml` approval gate without the release app self-approving its own PR
```

## Testing

- [ ] Tests pass locally (`just test`)
- [ ] Manual testing performed (describe below)

### Manual Testing Details

N/A — workflow change; verify on next smoke-test dispatch after template is deployed to `devcontainer-smoke-test`.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [ ] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

Base branch: `release/0.3.1`. Changelog entries are under `## [0.3.1] - TBD` (release branch), not `## Unreleased` — the template checklist item above is left unchecked for that reason.

Branch protection on the smoke-test repo must allow `git*hub-actions[bot]` reviews to count toward required approvals if applicable.

Refs: #430
