### PR TITLE
fix(ci): enable commit-action MAX_ATTEMPTS for transient ref failures

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -224,6 +224,7 @@ jobs:
           GH_TOKEN: ${{ steps.commit-app-token.outputs.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           TARGET_BRANCH: refs/heads/dev
+          MAX_ATTEMPTS: "3"
           COMMIT_MESSAGE: |-
             chore: freeze changelog for release ${{ needs.validate.outputs.version }}
 
@@ -276,6 +277,7 @@ jobs:
           GH_TOKEN: ${{ steps.commit-app-token.outputs.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           TARGET_BRANCH: refs/heads/${{ needs.validate.outputs.release_branch }}
+          MAX_ATTEMPTS: "3"
           COMMIT_MESSAGE: |-
             chore: prepare release ${{ needs.validate.outputs.version }}
 
@@ -384,6 +386,7 @@ jobs:
           GH_TOKEN: ${{ steps.commit-app-token.outputs.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           TARGET_BRANCH: refs/heads/dev
+          MAX_ATTEMPTS: "3"
           COMMIT_MESSAGE: |-
             chore: rollback failed prepare-release ${{ needs.validate.outputs.version }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -566,6 +566,7 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           TARGET_BRANCH: refs/heads/release/${{ needs.validate.outputs.version }}
+          MAX_ATTEMPTS: "3"
           COMMIT_MESSAGE: |-
             chore: finalize release ${{ needs.validate.outputs.version }}
 

--- a/.github/workflows/sync-issues.yml
+++ b/.github/workflows/sync-issues.yml
@@ -121,6 +121,7 @@ jobs:
           GH_TOKEN: ${{ steps.generate-token.outputs.token || github.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           TARGET_BRANCH: refs/heads/${{ github.event.inputs.target-branch || 'dev' }}
+          MAX_ATTEMPTS: "3"
           COMMIT_MESSAGE: "${{ github.event.inputs.commit-msg || 'chore: sync issues and PRs' }}"
           FILE_PATHS: ${{ steps.sync.outputs.modified-files }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,6 +182,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Smoke-test dispatch approves release PR before downstream release** ([#430](https://github.com/vig-os/devcontainer/issues/430))
   - Grant `pull-requests: write` on `ready-release-pr` and approve with `github.token` (`github-actions[bot]`)
   - Satisfy `release-core.yml` approval gate without the release app self-approving its own PR
+- **commit-action retries enabled for transient git ref API failures** ([#436](https://github.com/vig-os/devcontainer/issues/436))
+  - Set `MAX_ATTEMPTS: "3"` on every `vig-os/commit-action` step so v0.2.0 bounded retry actually runs (default was 1)
+  - Covers smoke-test deploy, prepare-release, release finalization, sync-issues, and workspace templates
 
 ### Security
 

--- a/assets/smoke-test/.github/workflows/repository-dispatch.yml
+++ b/assets/smoke-test/.github/workflows/repository-dispatch.yml
@@ -268,6 +268,7 @@ jobs:
           GH_TOKEN: ${{ steps.generate_commit_token.outputs.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           TARGET_BRANCH: refs/heads/${{ steps.prepare_branch.outputs.branch_name }}
+          MAX_ATTEMPTS: "3"
           ALLOW_EMPTY: "true"
           COMMIT_MESSAGE: |-
             chore: deploy ${{ needs.validate.outputs.tag }}

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -182,6 +182,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Smoke-test dispatch approves release PR before downstream release** ([#430](https://github.com/vig-os/devcontainer/issues/430))
   - Grant `pull-requests: write` on `ready-release-pr` and approve with `github.token` (`github-actions[bot]`)
   - Satisfy `release-core.yml` approval gate without the release app self-approving its own PR
+- **commit-action retries enabled for transient git ref API failures** ([#436](https://github.com/vig-os/devcontainer/issues/436))
+  - Set `MAX_ATTEMPTS: "3"` on every `vig-os/commit-action` step so v0.2.0 bounded retry actually runs (default was 1)
+  - Covers smoke-test deploy, prepare-release, release finalization, sync-issues, and workspace templates
 
 ### Security
 

--- a/assets/workspace/.github/workflows/prepare-release.yml
+++ b/assets/workspace/.github/workflows/prepare-release.yml
@@ -218,6 +218,7 @@ jobs:
           GH_TOKEN: ${{ steps.commit_app_token.outputs.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           TARGET_BRANCH: refs/heads/dev
+          MAX_ATTEMPTS: "3"
           COMMIT_MESSAGE: |-
             chore: freeze changelog for release ${{ needs.validate.outputs.version }}
 
@@ -268,6 +269,7 @@ jobs:
           GH_TOKEN: ${{ steps.commit_app_token.outputs.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           TARGET_BRANCH: refs/heads/${{ needs.validate.outputs.release_branch }}
+          MAX_ATTEMPTS: "3"
           COMMIT_MESSAGE: |-
             chore: prepare release ${{ needs.validate.outputs.version }}
 
@@ -353,6 +355,7 @@ jobs:
           GH_TOKEN: ${{ steps.commit_app_token.outputs.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           TARGET_BRANCH: refs/heads/dev
+          MAX_ATTEMPTS: "3"
           COMMIT_MESSAGE: |-
             chore: rollback failed prepare-release ${{ needs.validate.outputs.version }}
 

--- a/assets/workspace/.github/workflows/release-core.yml
+++ b/assets/workspace/.github/workflows/release-core.yml
@@ -371,6 +371,7 @@ jobs:
           GH_TOKEN: ${{ steps.commit_app_token.outputs.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           TARGET_BRANCH: refs/heads/release/${{ needs.validate.outputs.version }}
+          MAX_ATTEMPTS: "3"
           COMMIT_MESSAGE: |-
             chore: finalize release ${{ needs.validate.outputs.version }}
 

--- a/assets/workspace/.github/workflows/sync-issues.yml
+++ b/assets/workspace/.github/workflows/sync-issues.yml
@@ -141,6 +141,7 @@ jobs:
           GH_TOKEN: ${{ steps.generate-token.outputs.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           TARGET_BRANCH: refs/heads/${{ github.event.inputs.target-branch || 'dev' }}
+          MAX_ATTEMPTS: "3"
           COMMIT_MESSAGE: "${{ github.event.inputs.commit-msg || 'chore: sync issues and PRs' }}"
           FILE_PATHS: ${{ steps.sync.outputs.modified-files }}
 


### PR DESCRIPTION
## Description

Smoke-test dispatch for `0.3.1-rc19` failed in the deploy job with `Not Found` on `git/refs#get-a-reference` when `commit-action` looked up the freshly created `chore/deploy-*` branch. `commit-action` v0.2.0 already ships bounded retries, but they only run when `MAX_ATTEMPTS` is set; the default is 1 (no retries). This PR sets `MAX_ATTEMPTS: "3"` on every `vig-os/commit-action` step in upstream and workspace templates so transient API propagation errors are retried.

## Type of Change

- [ ] `feat` -- New feature
- [x] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [x] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- `.github/workflows/prepare-release.yml` — `MAX_ATTEMPTS: "3"` on three `commit-action` steps
- `.github/workflows/release.yml` — `MAX_ATTEMPTS: "3"` on finalization `commit-action` step
- `.github/workflows/sync-issues.yml` — `MAX_ATTEMPTS: "3"` on sync commit step
- `assets/smoke-test/.github/workflows/repository-dispatch.yml` — `MAX_ATTEMPTS: "3"` on deploy `commit-action` step
- `assets/workspace/.github/workflows/prepare-release.yml` — same for three steps (template)
- `assets/workspace/.github/workflows/release-core.yml` — same for finalization step
- `assets/workspace/.github/workflows/sync-issues.yml` — same for sync commit step
- `CHANGELOG.md` — Fixed entry for [#436](https://github.com/vig-os/devcontainer/issues/436) under `## [0.3.1] - TBD`
- `assets/workspace/.devcontainer/CHANGELOG.md` — mirrored changelog entry (manifest copy)

## Changelog Entry

Target branch uses `## [0.3.1] - TBD` (not `## Unreleased`). Added under **Fixed**:

### Fixed

- **commit-action retries enabled for transient git ref API failures** ([#436](https://github.com/vig-os/devcontainer/issues/436))
  - Set `MAX_ATTEMPTS: "3"` on every `vig-os/commit-action` step so v0.2.0 bounded retry actually runs (default was 1)
  - Covers smoke-test deploy, prepare-release, release finalization, sync-issues, and workspace templates

## Testing

- [ ] Tests pass locally (`just test`)
- [ ] Manual testing performed (describe below)

### Manual Testing Details

N/A — workflow env-only change; CI will exercise workflows after merge.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` under `## [0.3.1] - TBD` (release-branch convention; entry pasted above)
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

Changelog entry lives under `## [0.3.1] - TBD` because the PR targets `release/0.3.1`, not `dev`.

Refs: #436
