### PR TITLE
fix(ci): accept bot PR approval when reviewDecision is empty

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,9 @@ jobs:
     name: Validate Release
     runs-on: ubuntu-22.04
     timeout-minutes: 10
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       version: ${{ steps.vars.outputs.version }}
       pr_number: ${{ steps.pr.outputs.pr_number }}
@@ -370,8 +373,12 @@ jobs:
             exit 1
           fi
 
-          if [ "$REVIEW_DECISION" != "APPROVED" ]; then
+          if [ "$REVIEW_DECISION" = "APPROVED" ]; then
+            echo "PR #$PR_NUMBER is approved"
+          elif [ "$REVIEW_DECISION" = "null" ] || [ -z "$REVIEW_DECISION" ]; then
+            # Bot approval fallback when gh pr list leaves reviewDecision empty (#438)
             APPROVED_COUNT=$(retry --retries 3 --backoff 5 --max-backoff 30 -- gh api \
+              --paginate \
               "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/reviews" \
               --jq '[.[] | select(.state == "APPROVED")] | length')
             if [ "$APPROVED_COUNT" -eq 0 ]; then
@@ -379,6 +386,9 @@ jobs:
               exit 1
             fi
             echo "reviewDecision='$REVIEW_DECISION' but $APPROVED_COUNT approved review(s) found"
+          else
+            echo "ERROR: PR #$PR_NUMBER does not have approvals (status: $REVIEW_DECISION)"
+            exit 1
           fi
 
           # Check CI status

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -378,9 +378,9 @@ jobs:
           elif [ "$REVIEW_DECISION" = "null" ] || [ -z "$REVIEW_DECISION" ]; then
             # Bot approval fallback when gh pr list leaves reviewDecision empty (#438)
             APPROVED_COUNT=$(retry --retries 3 --backoff 5 --max-backoff 30 -- gh api \
-              --paginate \
+              --paginate --slurp \
               "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/reviews" \
-              --jq '[.[] | select(.state == "APPROVED")] | length')
+              | jq 'add | map(select(.state == "APPROVED")) | length')
             if [ "$APPROVED_COUNT" -eq 0 ]; then
               echo "ERROR: PR #$PR_NUMBER does not have approvals (reviewDecision: $REVIEW_DECISION, approved reviews: 0)"
               exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -371,8 +371,14 @@ jobs:
           fi
 
           if [ "$REVIEW_DECISION" != "APPROVED" ]; then
-            echo "ERROR: PR #$PR_NUMBER does not have approvals (status: $REVIEW_DECISION)"
-            exit 1
+            APPROVED_COUNT=$(retry --retries 3 --backoff 5 --max-backoff 30 -- gh api \
+              "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/reviews" \
+              --jq '[.[] | select(.state == "APPROVED")] | length')
+            if [ "$APPROVED_COUNT" -eq 0 ]; then
+              echo "ERROR: PR #$PR_NUMBER does not have approvals (reviewDecision: $REVIEW_DECISION, approved reviews: 0)"
+              exit 1
+            fi
+            echo "reviewDecision='$REVIEW_DECISION' but $APPROVED_COUNT approved review(s) found"
           fi
 
           # Check CI status

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -185,6 +185,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **commit-action retries enabled for transient git ref API failures** ([#436](https://github.com/vig-os/devcontainer/issues/436))
   - Set `MAX_ATTEMPTS: "3"` on every `vig-os/commit-action` step so v0.2.0 bounded retry actually runs (default was 1)
   - Covers smoke-test deploy, prepare-release, release finalization, sync-issues, and workspace templates
+- **Release validation fails when bot approves PR** ([#438](https://github.com/vig-os/devcontainer/issues/438))
+  - Add fallback to individual PR review check when `reviewDecision` is empty (bot approvals not counted by branch protection)
 
 ### Security
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -185,6 +185,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **commit-action retries enabled for transient git ref API failures** ([#436](https://github.com/vig-os/devcontainer/issues/436))
   - Set `MAX_ATTEMPTS: "3"` on every `vig-os/commit-action` step so v0.2.0 bounded retry actually runs (default was 1)
   - Covers smoke-test deploy, prepare-release, release finalization, sync-issues, and workspace templates
+- **Release validation fails when bot approves PR** ([#438](https://github.com/vig-os/devcontainer/issues/438))
+  - Add fallback to individual PR review check when `reviewDecision` is empty (bot approvals not counted by branch protection)
 
 ### Security
 

--- a/assets/workspace/.github/workflows/release-core.yml
+++ b/assets/workspace/.github/workflows/release-core.yml
@@ -261,8 +261,12 @@ jobs:
             echo "ERROR: PR #$PR_NUMBER is still in draft"
             exit 1
           fi
-          if [ "$REVIEW_DECISION" != "APPROVED" ]; then
+          if [ "$REVIEW_DECISION" = "APPROVED" ]; then
+            echo "PR #$PR_NUMBER is approved"
+          elif [ "$REVIEW_DECISION" = "null" ] || [ -z "$REVIEW_DECISION" ]; then
+            # Bot approval fallback when gh pr list leaves reviewDecision empty (#438)
             APPROVED_COUNT=$(retry --retries 3 --backoff 5 --max-backoff 30 -- gh api \
+              --paginate \
               "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/reviews" \
               --jq '[.[] | select(.state == "APPROVED")] | length')
             if [ "$APPROVED_COUNT" -eq 0 ]; then
@@ -270,6 +274,9 @@ jobs:
               exit 1
             fi
             echo "reviewDecision='$REVIEW_DECISION' but $APPROVED_COUNT approved review(s) found"
+          else
+            echo "ERROR: PR #$PR_NUMBER is not approved (status: $REVIEW_DECISION)"
+            exit 1
           fi
 
           STATUS_ROLLUP=$(echo "$PR_JSON" | jq -r '.[0].statusCheckRollup // []')

--- a/assets/workspace/.github/workflows/release-core.yml
+++ b/assets/workspace/.github/workflows/release-core.yml
@@ -262,8 +262,14 @@ jobs:
             exit 1
           fi
           if [ "$REVIEW_DECISION" != "APPROVED" ]; then
-            echo "ERROR: PR #$PR_NUMBER is not approved (status: $REVIEW_DECISION)"
-            exit 1
+            APPROVED_COUNT=$(retry --retries 3 --backoff 5 --max-backoff 30 -- gh api \
+              "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/reviews" \
+              --jq '[.[] | select(.state == "APPROVED")] | length')
+            if [ "$APPROVED_COUNT" -eq 0 ]; then
+              echo "ERROR: PR #$PR_NUMBER is not approved (reviewDecision: $REVIEW_DECISION, approved reviews: 0)"
+              exit 1
+            fi
+            echo "reviewDecision='$REVIEW_DECISION' but $APPROVED_COUNT approved review(s) found"
           fi
 
           STATUS_ROLLUP=$(echo "$PR_JSON" | jq -r '.[0].statusCheckRollup // []')

--- a/assets/workspace/.github/workflows/release-core.yml
+++ b/assets/workspace/.github/workflows/release-core.yml
@@ -266,9 +266,9 @@ jobs:
           elif [ "$REVIEW_DECISION" = "null" ] || [ -z "$REVIEW_DECISION" ]; then
             # Bot approval fallback when gh pr list leaves reviewDecision empty (#438)
             APPROVED_COUNT=$(retry --retries 3 --backoff 5 --max-backoff 30 -- gh api \
-              --paginate \
+              --paginate --slurp \
               "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/reviews" \
-              --jq '[.[] | select(.state == "APPROVED")] | length')
+              | jq 'add | map(select(.state == "APPROVED")) | length')
             if [ "$APPROVED_COUNT" -eq 0 ]; then
               echo "ERROR: PR #$PR_NUMBER is not approved (reviewDecision: $REVIEW_DECISION, approved reviews: 0)"
               exit 1


### PR DESCRIPTION
## Description

Release validation used only `reviewDecision` from `gh pr list`. When smoke-test orchestration approves the release PR with `git*ub-actions[bot]`, branch protection can leave `reviewDecision` empty while individual reviews still show `APPROVED`. This change falls back to the REST reviews API when `reviewDecision` is not `APPROVED`, matching the RCA on #438.

## Type of Change

- [ ] `feat` -- New feature
- [x] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [ ] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- `.github/workflows/release.yml` — extend **Find and verify PR** with retry-wrapped `gh api …/pulls/{n}/reviews` fallback when `reviewDecision != APPROVED`.
- `assets/workspace/.github/workflows/release-core.yml` — same logic for the workspace/downstream template.
- `CHANGELOG.md` and `assets/workspace/.devcontainer/CHANGELOG.md` — document the fix under `## [0.3.1] - TBD` / **Fixed**.

## Changelog Entry

Under `## [0.3.1] - TBD` / `### Fixed`:

- **Release validation fails when bot approves PR** ([#438](https://github.com/vig-os/devcontainer/issues/438))
  - Add fallback to individual PR review check when `reviewDecision` is empty (bot approvals not counted by branch protection)

## Testing

- [ ] Tests pass locally (`just test`)
- [ ] Manual testing performed (describe below)

### Manual Testing Details

N/A — workflow-only change; pre-commit hooks passed on commit.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` under `## [0.3.1] - TBD` (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

Targets `release/0.3.1` per release-line fix. Downstream `devcontainer-smoke-test` still needs template sync after merge.

Refs: #438
