### PR TITLE
fix(ci): align downstream candidate RC with upstream dispatch tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -187,6 +187,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Covers smoke-test deploy, prepare-release, release finalization, sync-issues, and workspace templates
 - **Release validation fails when bot approves PR** ([#438](https://github.com/vig-os/devcontainer/issues/438))
   - Add fallback to individual PR review check when `reviewDecision` is empty (bot approvals not counted by branch protection)
+- **Downstream candidate RC tag can match upstream dispatch** ([#441](https://github.com/vig-os/devcontainer/issues/441))
+  - Workspace `release.yml` / `release-core.yml` accept optional `rc-number` so candidate tags are not always recomputed from local tags only
+  - Smoke-test `repository-dispatch.yml` exposes `base_version` and `rc_number` job outputs for orchestration that calls workspace `release.yml`
 
 ### Security
 

--- a/assets/smoke-test/.github/workflows/repository-dispatch.yml
+++ b/assets/smoke-test/.github/workflows/repository-dispatch.yml
@@ -19,7 +19,7 @@ name: Repository Dispatch Listener
 # vig-os/devcontainer-smoke-test and promotion through PRs until merged to main.
 #
 # If this repo (or a fork) orchestrates workspace release.yml for candidates,
-# pass workflow_dispatch input rc-number=<N> where N is validate.outputs.rc_number
+# pass workflow_dispatch input rc-number=<N> where N is needs.validate.outputs.rc_number
 # so downstream candidate tags match the upstream dispatch tag (cross-repo gate).
 
 on:  # yamllint disable-line rule:truthy

--- a/assets/smoke-test/.github/workflows/repository-dispatch.yml
+++ b/assets/smoke-test/.github/workflows/repository-dispatch.yml
@@ -17,6 +17,10 @@ name: Repository Dispatch Listener
 #
 # NOTE: Changes to this template may require manual redeploy to
 # vig-os/devcontainer-smoke-test and promotion through PRs until merged to main.
+#
+# If this repo (or a fork) orchestrates workspace release.yml for candidates,
+# pass workflow_dispatch input rc-number=<N> where N is validate.outputs.rc_number
+# so downstream candidate tags match the upstream dispatch tag (cross-repo gate).
 
 on:  # yamllint disable-line rule:truthy
   repository_dispatch:
@@ -41,6 +45,7 @@ jobs:
     outputs:
       tag: ${{ steps.extract.outputs.tag }}
       base_version: ${{ steps.extract.outputs.base_version }}
+      rc_number: ${{ steps.extract.outputs.rc_number }}
       release_kind: ${{ steps.extract.outputs.release_kind }}
       source_repo: ${{ steps.extract.outputs.source_repo }}
       source_workflow: ${{ steps.extract.outputs.source_workflow }}
@@ -111,6 +116,11 @@ jobs:
           fi
 
           BASE_VERSION="$(printf '%s' "${TAG}" | sed 's/-rc[0-9]*$//')"
+          RC_NUMBER=""
+          if printf '%s' "${TAG}" | grep -Eq -- '-rc[0-9]+$'; then
+            RC_NUMBER="$(printf '%s' "${TAG}" | sed 's/^.*-rc//')"
+          fi
+
           EFFECTIVE_SOURCE_RUN_URL="${SOURCE_RUN_URL}"
           if [ -z "${EFFECTIVE_SOURCE_RUN_URL}" ] && [ -n "${SOURCE_REPO}" ] && [ -n "${SOURCE_RUN_ID}" ]; then
             EFFECTIVE_SOURCE_RUN_URL="${GITHUB_SERVER_URL}/${SOURCE_REPO}/actions/runs/${SOURCE_RUN_ID}"
@@ -118,6 +128,7 @@ jobs:
 
           echo "tag=${TAG}" >> "${GITHUB_OUTPUT}"
           echo "base_version=${BASE_VERSION}" >> "${GITHUB_OUTPUT}"
+          echo "rc_number=${RC_NUMBER}" >> "${GITHUB_OUTPUT}"
           echo "release_kind=${EFFECTIVE_RELEASE_KIND}" >> "${GITHUB_OUTPUT}"
           echo "source_repo=${SOURCE_REPO}" >> "${GITHUB_OUTPUT}"
           echo "source_workflow=${SOURCE_WORKFLOW}" >> "${GITHUB_OUTPUT}"
@@ -593,13 +604,19 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.generate_release_token.outputs.token }}
           BASE_VERSION: ${{ needs.validate.outputs.base_version }}
+          RC_NUMBER: ${{ needs.validate.outputs.rc_number }}
           RELEASE_KIND: ${{ needs.validate.outputs.release_kind }}
         run: |
           set -euo pipefail
+          EXTRA=()
+          if [ "${RELEASE_KIND}" = "candidate" ] && [ -n "${RC_NUMBER}" ]; then
+            EXTRA=( -f "rc-number=${RC_NUMBER}" )
+          fi
           gh workflow run release.yml \
             --ref "${WORKFLOW_REF}" \
             -f version="${BASE_VERSION}" \
-            -f release-kind="${RELEASE_KIND}"
+            -f release-kind="${RELEASE_KIND}" \
+            "${EXTRA[@]}"
 
       - name: Wait for release workflow completion
         env:
@@ -711,6 +728,8 @@ jobs:
       - name: Write source context summary
         env:
           TAG: ${{ needs.validate.outputs.tag }}
+          BASE_VERSION: ${{ needs.validate.outputs.base_version }}
+          RC_NUMBER: ${{ needs.validate.outputs.rc_number }}
           SOURCE_REPO: ${{ needs.validate.outputs.source_repo }}
           SOURCE_WORKFLOW: ${{ needs.validate.outputs.source_workflow }}
           SOURCE_RUN_ID: ${{ needs.validate.outputs.source_run_id }}
@@ -722,6 +741,8 @@ jobs:
             echo "## Source Dispatch Context"
             echo ""
             echo "- Tag: ${TAG:-n/a}"
+            echo "- Base version: ${BASE_VERSION:-n/a}"
+            echo "- RC number (suffix): ${RC_NUMBER:-n/a}"
             echo "- Source Repo: ${SOURCE_REPO:-n/a}"
             echo "- Source Workflow: ${SOURCE_WORKFLOW:-n/a}"
             echo "- Source Run ID: ${SOURCE_RUN_ID:-n/a}"

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -187,6 +187,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Covers smoke-test deploy, prepare-release, release finalization, sync-issues, and workspace templates
 - **Release validation fails when bot approves PR** ([#438](https://github.com/vig-os/devcontainer/issues/438))
   - Add fallback to individual PR review check when `reviewDecision` is empty (bot approvals not counted by branch protection)
+- **Downstream candidate RC tag can match upstream dispatch** ([#441](https://github.com/vig-os/devcontainer/issues/441))
+  - Workspace `release.yml` / `release-core.yml` accept optional `rc-number` so candidate tags are not always recomputed from local tags only
+  - Smoke-test `repository-dispatch.yml` exposes `base_version` and `rc_number` job outputs for orchestration that calls workspace `release.yml`
 
 ### Security
 

--- a/assets/workspace/.github/workflows/release-core.yml
+++ b/assets/workspace/.github/workflows/release-core.yml
@@ -195,7 +195,7 @@ jobs:
           if [ "$RELEASE_KIND" = "candidate" ]; then
             if [ -n "${INPUT_RC_NUMBER}" ]; then
               if ! printf '%s' "${INPUT_RC_NUMBER}" | grep -qE '^[0-9]+$'; then
-                echo "ERROR: rc_number must be a non-negative integer (got '${INPUT_RC_NUMBER}')"
+                echo "ERROR: rc_number must be a positive integer (got '${INPUT_RC_NUMBER}')"
                 exit 1
               fi
               if [ "${INPUT_RC_NUMBER}" -lt 1 ]; then

--- a/assets/workspace/.github/workflows/release-core.yml
+++ b/assets/workspace/.github/workflows/release-core.yml
@@ -27,6 +27,11 @@ on:  # yamllint disable-line rule:truthy
         required: false
         default: "41898282+github-actions[bot]@users.noreply.github.com"
         type: string
+      rc_number:
+        description: "Candidate RC index (e.g. 21 for X.Y.Z-rc21). Omit to auto-increment from existing tags."
+        required: false
+        default: ""
+        type: string
     secrets:
       token:
         required: false
@@ -183,36 +188,51 @@ jobs:
         env:
           VERSION: ${{ steps.vars.outputs.version }}
           RELEASE_KIND: ${{ steps.vars.outputs.release_kind }}
+          INPUT_RC_NUMBER: ${{ inputs.rc_number }}
         run: |
           set -euo pipefail
           NEXT_RC=""
           if [ "$RELEASE_KIND" = "candidate" ]; then
-            TAG_PATTERN="${VERSION}-rc*"
-            EXISTING_TAGS=$(git ls-remote --tags --refs origin "$TAG_PATTERN" | awk '{print $2}' | sed 's#refs/tags/##')
+            if [ -n "${INPUT_RC_NUMBER}" ]; then
+              if ! printf '%s' "${INPUT_RC_NUMBER}" | grep -qE '^[0-9]+$'; then
+                echo "ERROR: rc_number must be a non-negative integer (got '${INPUT_RC_NUMBER}')"
+                exit 1
+              fi
+              if [ "${INPUT_RC_NUMBER}" -lt 1 ]; then
+                echo "ERROR: rc_number must be >= 1 (got '${INPUT_RC_NUMBER}')"
+                exit 1
+              fi
+              NEXT_RC="${INPUT_RC_NUMBER}"
+              PUBLISH_VERSION="${VERSION}-rc${NEXT_RC}"
+              echo "Using explicit rc_number=$NEXT_RC -> publish_version=$PUBLISH_VERSION"
+            else
+              TAG_PATTERN="${VERSION}-rc*"
+              EXISTING_TAGS=$(git ls-remote --tags --refs origin "$TAG_PATTERN" | awk '{print $2}' | sed 's#refs/tags/##')
 
-            MAX_RC=0
-            if [ -n "$EXISTING_TAGS" ]; then
-              while IFS= read -r tag; do
-                [ -z "$tag" ] && continue
-                if [ "${tag#${VERSION}-rc}" = "$tag" ]; then
-                  echo "ERROR: Malformed candidate tag detected: $tag"
-                  echo "Expected format: ${VERSION}-rcN"
-                  exit 1
-                fi
-                rc_num="${tag#${VERSION}-rc}"
-                if ! echo "$rc_num" | grep -qE '^[0-9]+$'; then
-                  echo "ERROR: Malformed candidate tag detected: $tag"
-                  echo "Expected format: ${VERSION}-rcN"
-                  exit 1
-                fi
-                if [ "$rc_num" -gt "$MAX_RC" ]; then
-                  MAX_RC="$rc_num"
-                fi
-              done <<< "$EXISTING_TAGS"
+              MAX_RC=0
+              if [ -n "$EXISTING_TAGS" ]; then
+                while IFS= read -r tag; do
+                  [ -z "$tag" ] && continue
+                  if [ "${tag#${VERSION}-rc}" = "$tag" ]; then
+                    echo "ERROR: Malformed candidate tag detected: $tag"
+                    echo "Expected format: ${VERSION}-rcN"
+                    exit 1
+                  fi
+                  rc_num="${tag#${VERSION}-rc}"
+                  if ! echo "$rc_num" | grep -qE '^[0-9]+$'; then
+                    echo "ERROR: Malformed candidate tag detected: $tag"
+                    echo "Expected format: ${VERSION}-rcN"
+                    exit 1
+                  fi
+                  if [ "$rc_num" -gt "$MAX_RC" ]; then
+                    MAX_RC="$rc_num"
+                  fi
+                done <<< "$EXISTING_TAGS"
+              fi
+
+              NEXT_RC=$((MAX_RC + 1))
+              PUBLISH_VERSION="${VERSION}-rc${NEXT_RC}"
             fi
-
-            NEXT_RC=$((MAX_RC + 1))
-            PUBLISH_VERSION="${VERSION}-rc${NEXT_RC}"
           else
             PUBLISH_VERSION="$VERSION"
           fi

--- a/assets/workspace/.github/workflows/release.yml
+++ b/assets/workspace/.github/workflows/release.yml
@@ -27,6 +27,11 @@ on:  # yamllint disable-line rule:truthy
         required: false
         default: "41898282+github-actions[bot]@users.noreply.github.com"
         type: string
+      rc-number:
+        description: "Candidate RC index (e.g. 21 for X.Y.Z-rc21). Omit to auto-increment from existing tags."
+        required: false
+        default: ""
+        type: string
 
 concurrency:
   group: release
@@ -68,6 +73,7 @@ jobs:
       dry_run: ${{ inputs.dry-run }}
       git_user_name: ${{ inputs.git-user-name }}
       git_user_email: ${{ inputs.git-user-email }}
+      rc_number: ${{ inputs.rc-number || '' }}
     secrets: inherit
 
   extension:

--- a/docs/CROSS_REPO_RELEASE_GATE.md
+++ b/docs/CROSS_REPO_RELEASE_GATE.md
@@ -57,6 +57,8 @@ The receiver workflow (`assets/smoke-test/.github/workflows/repository-dispatch.
 4. idempotency checks when a release object already exists
 5. preflight validation that required downstream workflow IDs are resolvable on the dispatch ref before orchestration starts
 
+If the validation repository also runs the shipped workspace `release.yml` workflow for a **candidate** (separate from publishing a release for the dispatched tag), pass workflow input `rc-number` set to the numeric RC suffix of `client_payload.tag` (for example `21` for `0.3.1-rc21`). That keeps the downstream candidate tag aligned with the upstream publish tag and satisfies the orchestrator’s latest-RC gate. The smoke-test template exposes this value as job output `needs.validate.outputs.rc_number`.
+
 ### Gate Checks in the Orchestrator
 
 The orchestrator validates:

--- a/docs/DOWNSTREAM_RELEASE.md
+++ b/docs/DOWNSTREAM_RELEASE.md
@@ -20,7 +20,7 @@ On failure, the orchestrator runs a single consolidated rollback that resets the
 
 `release.yml` supports two release modes via `release_kind`:
 
-- `candidate` (default): computes and publishes the next `X.Y.Z-rcN` tag as a GitHub pre-release
+- `candidate` (default): computes and publishes the next `X.Y.Z-rcN` tag as a GitHub pre-release (or use optional `rc-number` to pin `N` when orchestrating from an upstream dispatch; see `docs/CROSS_REPO_RELEASE_GATE.md`)
 - `final`: publishes `X.Y.Z`, finalizes `CHANGELOG.md` release date, and runs `sync-issues`
 
 Candidate mode keeps release branch content unchanged (no CHANGELOG date finalization). Final mode performs changelog finalization before publish.

--- a/tests/bats/just.bats
+++ b/tests/bats/just.bats
@@ -164,3 +164,8 @@ setup() {
     run bash -lc "awk '/^  core:/{flag=1} /^  extension:/{flag=0} flag {print}' assets/workspace/.github/workflows/release.yml | grep -Fq -- 'actions: write' && awk '/^  core:/{flag=1} /^  extension:/{flag=0} flag {print}' assets/workspace/.github/workflows/release.yml | grep -Fq -- 'pull-requests: read' && awk '/^  publish:/{flag=1} /^  rollback:/{flag=0} flag {print}' assets/workspace/.github/workflows/release.yml | grep -Fq -- 'contents: write' && awk '/^  validate:/{flag=1} /^  finalize:/{flag=0} flag {print}' assets/workspace/.github/workflows/release-core.yml | grep -Fq -- 'pull-requests: read' && awk '/^  finalize:/{flag=1} /^  test:/{flag=0} flag {print}' assets/workspace/.github/workflows/release-core.yml | grep -Fq -- 'actions: write'"
     assert_success
 }
+
+@test "smoke-test dispatch exposes base_version and rc_number for cross-repo RC alignment" {
+    run bash -lc "grep -Fq -- 'base_version=' assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- 'rc_number=' assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- 'steps.extract.outputs.base_version' assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- 'steps.extract.outputs.rc_number' assets/smoke-test/.github/workflows/repository-dispatch.yml"
+    assert_success
+}

--- a/tests/bats/just.bats
+++ b/tests/bats/just.bats
@@ -169,3 +169,8 @@ setup() {
     run bash -lc "grep -Fq -- 'base_version=' assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- 'rc_number=' assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- 'steps.extract.outputs.base_version' assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- 'steps.extract.outputs.rc_number' assets/smoke-test/.github/workflows/repository-dispatch.yml"
     assert_success
 }
+
+@test "workspace release workflows accept rc-number for pinned candidate RC" {
+    run bash -lc "grep -Fq -- 'rc-number:' assets/workspace/.github/workflows/release.yml && grep -Fq -- 'rc_number:' assets/workspace/.github/workflows/release.yml && grep -Fq -- 'rc_number:' assets/workspace/.github/workflows/release-core.yml"
+    assert_success
+}


### PR DESCRIPTION
## Description

When upstream publishes a candidate such as `0.3.1-rc21` and dispatches to `devcontainer-smoke-test`, the downstream workspace `release.yml` used to auto-increment the RC from local tags only, producing `0.3.1-rc1` and breaking the upstream final-release gate that expects a downstream pre-release at the same RC tag.

This change passes the numeric RC suffix from the dispatch tag through smoke-test orchestration into workspace `release.yml` / `release-core.yml` via optional `rc-number`, and documents the contract for cross-repo alignment.

## Type of Change

- [ ] `feat` -- New feature
- [x] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [ ] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- **`assets/smoke-test/.github/workflows/repository-dispatch.yml`**
  - Derive `rc_number` from `client_payload.tag` when it matches `X.Y.Z-rcN`
  - Expose `rc_number` on `validate` job outputs; pass `-f rc-number=…` when triggering downstream `release.yml` for candidates
  - Extend dispatch summary with base version and RC suffix
- **`assets/workspace/.github/workflows/release.yml`**
  - Add optional `workflow_dispatch` input `rc-number`; forward to `release-core` as `rc_number`
- **`assets/workspace/.github/workflows/release-core.yml`**
  - Add optional `workflow_call` input `rc_number`; when set for candidate mode, use it instead of scanning remote tags for the next RC (with validation `>= 1`)
- **`tests/bats/just.bats`**
  - Smoke tests for dispatch `rc_number` wiring and workspace `rc-number` / `rc_number` inputs
- **`docs/CROSS_REPO_RELEASE_GATE.md`**, **`docs/DOWNSTREAM_RELEASE.md`**
  - Document when and how to pass `rc-number` for cross-repo RC alignment
- **`CHANGELOG.md`**, **`assets/workspace/.devcontainer/CHANGELOG.md`**
  - Fixed entry for #441 under the `0.3.1` TBD section

## Changelog Entry

Under `## [0.3.1] - TBD` → `### Fixed`:

```markdown
- **Downstream candidate RC tag can match upstream dispatch** ([#441](https://github.com/vig-os/devcontainer/issues/441))
  - Workspace `release.yml` / `release-core.yml` accept optional `rc-number` so candidate tags are not always recomputed from local tags only
  - Smoke-test `repository-dispatch.yml` exposes `base_version` and `rc_number` job outputs for orchestration that calls workspace `release.yml`
```

## Testing

- [x] Tests pass locally (`just test`)
- [ ] Manual testing performed (describe below)

### Manual Testing Details

N/A — workflow and template changes; BATS coverage exercises template invariants.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` in the active release section (`## [0.3.1] - TBD`) (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

Branch was created from `release/0.3.1`; this PR should target **`release/0.3.1`** (patch line), not `dev`.

Refs: #441
