### PR TITLE
fix(ci): fail validate when GitHub Release already exists

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -332,11 +332,50 @@ jobs:
           PUBLISH_VERSION: ${{ steps.publish_meta.outputs.publish_version }}
           GH_TOKEN: ${{ github.token }}
         run: |
-          if gh release view "$PUBLISH_VERSION" >/dev/null 2>&1; then
-            echo "ERROR: GitHub Release already exists for $PUBLISH_VERSION"
-            echo "Delete it manually before retrying: gh release delete $PUBLISH_VERSION --yes"
+          set -euo pipefail
+          # Same error-classification pattern as "Verify downstream pre-release for latest RC" above.
+          RETRIES=5
+          LAST_ERROR=""
+          for i in $(seq 1 "$RETRIES"); do
+            API_OUTPUT=""
+            if API_OUTPUT=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${PUBLISH_VERSION}" 2>&1); then
+              echo "ERROR: GitHub Release already exists for $PUBLISH_VERSION"
+              echo "Delete it manually before retrying: gh release delete $PUBLISH_VERSION --yes"
+              exit 1
+            fi
+
+            LAST_ERROR="$API_OUTPUT"
+            if printf '%s' "$API_OUTPUT" | grep -Eqi "401|403|forbidden|bad credentials|authentication|authorization|insufficient scopes"; then
+              echo "ERROR: Non-retryable authentication/authorization failure while checking for existing GitHub Release for $PUBLISH_VERSION"
+              echo "$API_OUTPUT"
+              exit 1
+            fi
+
+            if printf '%s' "$API_OUTPUT" | grep -Eqi "not found|HTTP 404"; then
+              echo "No existing GitHub Release for $PUBLISH_VERSION (API reports not found)."
+              exit 0
+            fi
+
+            if printf '%s' "$API_OUTPUT" | grep -Eqi "429|5[0-9]{2}|timed out|timeout|temporary|connection reset|connection refused|network|tls"; then
+              if [ "$i" -lt "$RETRIES" ]; then
+                BACKOFF=$((i * 5))
+                echo "Release existence check failed transiently, retrying in ${BACKOFF}s ($i/$RETRIES)..."
+                sleep "$BACKOFF"
+              fi
+              continue
+            fi
+
+            echo "ERROR: Unexpected response while checking for existing GitHub Release for $PUBLISH_VERSION"
+            echo "$API_OUTPUT"
             exit 1
+          done
+
+          echo "ERROR: Unable to determine whether a GitHub Release exists for $PUBLISH_VERSION after $RETRIES attempts (fail closed)."
+          if [ -n "$LAST_ERROR" ]; then
+            echo "Last API error:"
+            echo "$LAST_ERROR"
           fi
+          exit 1
 
       - name: Set up GitHub CLI
         run: |
@@ -1125,8 +1164,47 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           set -euo pipefail
-          if retry --retries 2 --backoff 5 --max-backoff 20 -- gh release view "$PUBLISH_VERSION" >/dev/null 2>&1; then
-            echo "ERROR: GitHub Release already exists for tag $PUBLISH_VERSION"
+          # Fail if release already exists; only treat API "not found" as absent (same semantics as Validate job).
+          RETRIES=5
+          LAST_ERROR=""
+          for i in $(seq 1 "$RETRIES"); do
+            API_OUTPUT=""
+            if API_OUTPUT=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${PUBLISH_VERSION}" 2>&1); then
+              echo "ERROR: GitHub Release already exists for tag $PUBLISH_VERSION"
+              exit 1
+            fi
+
+            LAST_ERROR="$API_OUTPUT"
+            if printf '%s' "$API_OUTPUT" | grep -Eqi "401|403|forbidden|bad credentials|authentication|authorization|insufficient scopes"; then
+              echo "ERROR: Non-retryable authentication/authorization failure while checking for existing GitHub Release for $PUBLISH_VERSION"
+              echo "$API_OUTPUT"
+              exit 1
+            fi
+
+            if printf '%s' "$API_OUTPUT" | grep -Eqi "not found|HTTP 404"; then
+              break
+            fi
+
+            if printf '%s' "$API_OUTPUT" | grep -Eqi "429|5[0-9]{2}|timed out|timeout|temporary|connection reset|connection refused|network|tls"; then
+              if [ "$i" -lt "$RETRIES" ]; then
+                BACKOFF=$((i * 5))
+                echo "Release existence check failed transiently, retrying in ${BACKOFF}s ($i/$RETRIES)..."
+                sleep "$BACKOFF"
+              fi
+              continue
+            fi
+
+            echo "ERROR: Unexpected response while checking for existing GitHub Release for $PUBLISH_VERSION"
+            echo "$API_OUTPUT"
+            exit 1
+          done
+
+          if ! printf '%s' "$LAST_ERROR" | grep -Eqi "not found|HTTP 404"; then
+            echo "ERROR: Unable to determine whether a GitHub Release exists for $PUBLISH_VERSION after $RETRIES attempts (fail closed)."
+            if [ -n "$LAST_ERROR" ]; then
+              echo "Last API error:"
+              echo "$LAST_ERROR"
+            fi
             exit 1
           fi
 
@@ -1134,9 +1212,45 @@ jobs:
             --title "$PUBLISH_VERSION" \
             --notes-file /tmp/github-release-notes.md \
             --verify-tag || {
-              if retry --retries 2 --backoff 5 --max-backoff 20 -- gh release view "$PUBLISH_VERSION" >/dev/null 2>&1; then
+              RELEASE_PRESENT=0
+              rb_retries=5
+              rb_last=""
+              for j in $(seq 1 "$rb_retries"); do
+                rb_out=""
+                if rb_out=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${PUBLISH_VERSION}" 2>&1); then
+                  RELEASE_PRESENT=1
+                  break
+                fi
+                rb_last="$rb_out"
+                if printf '%s' "$rb_out" | grep -Eqi "401|403|forbidden|bad credentials|authentication|authorization|insufficient scopes"; then
+                  echo "ERROR: Non-retryable authentication/authorization failure while verifying GitHub Release after create for $PUBLISH_VERSION"
+                  echo "$rb_out"
+                  exit 1
+                fi
+                if printf '%s' "$rb_out" | grep -Eqi "not found|HTTP 404"; then
+                  RELEASE_PRESENT=0
+                  break
+                fi
+                if printf '%s' "$rb_out" | grep -Eqi "429|5[0-9]{2}|timed out|timeout|temporary|connection reset|connection refused|network|tls"; then
+                  if [ "$j" -lt "$rb_retries" ]; then
+                    rb_backoff=$((j * 5))
+                    echo "Post-create release check failed transiently, retrying in ${rb_backoff}s ($j/$rb_retries)..."
+                    sleep "$rb_backoff"
+                  fi
+                  continue
+                fi
+                echo "ERROR: Unexpected response while verifying GitHub Release after create for $PUBLISH_VERSION"
+                echo "$rb_out"
+                exit 1
+              done
+              if [ "$RELEASE_PRESENT" -eq 1 ]; then
                 echo "GitHub Release already present after create attempt: $PUBLISH_VERSION"
               else
+                if [ "$j" -eq "$rb_retries" ] && ! printf '%s' "$rb_last" | grep -Eqi "not found|HTTP 404"; then
+                  echo "ERROR: Unable to verify GitHub Release state for $PUBLISH_VERSION after create failure (fail closed)."
+                  echo "$rb_last"
+                  exit 1
+                fi
                 exit 1
               fi
             }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -327,6 +327,17 @@ jobs:
             exit 1
           fi
 
+      - name: Verify GitHub Release does not exist
+        env:
+          PUBLISH_VERSION: ${{ steps.publish_meta.outputs.publish_version }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if gh release view "$PUBLISH_VERSION" >/dev/null 2>&1; then
+            echo "ERROR: GitHub Release already exists for $PUBLISH_VERSION"
+            echo "Delete it manually before retrying: gh release delete $PUBLISH_VERSION --yes"
+            exit 1
+          fi
+
       - name: Set up GitHub CLI
         run: |
           gh version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -191,7 +191,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Workspace `release.yml` / `release-core.yml` accept optional `rc-number` so candidate tags are not always recomputed from local tags only
   - Smoke-test `repository-dispatch.yml` exposes `base_version` and `rc_number` job outputs for orchestration that calls workspace `release.yml`
 - **Release validate fails early when GitHub Release already exists** ([#443](https://github.com/vig-os/devcontainer/issues/443))
-  - Validate job in `.github/workflows/release.yml` now checks `gh release view` for `PUBLISH_VERSION` so an existing release is rejected before build/sign/publish
+  - Validate job in `.github/workflows/release.yml` queries `GET /repos/.../releases/tags/<PUBLISH_VERSION>` with retries and classifies errors like the downstream RC gate; only a documented not-found response is treated as “no release,” and ambiguous API failures fail closed before build/sign/publish
+  - Publish job uses the same existence checks before and after `gh release create` instead of `gh release view` with discarded stderr
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -190,6 +190,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Downstream candidate RC tag can match upstream dispatch** ([#441](https://github.com/vig-os/devcontainer/issues/441))
   - Workspace `release.yml` / `release-core.yml` accept optional `rc-number` so candidate tags are not always recomputed from local tags only
   - Smoke-test `repository-dispatch.yml` exposes `base_version` and `rc_number` job outputs for orchestration that calls workspace `release.yml`
+- **Release validate fails early when GitHub Release already exists** ([#443](https://github.com/vig-os/devcontainer/issues/443))
+  - Validate job in `.github/workflows/release.yml` now checks `gh release view` for `PUBLISH_VERSION` so an existing release is rejected before build/sign/publish
 
 ### Security
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -191,7 +191,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Workspace `release.yml` / `release-core.yml` accept optional `rc-number` so candidate tags are not always recomputed from local tags only
   - Smoke-test `repository-dispatch.yml` exposes `base_version` and `rc_number` job outputs for orchestration that calls workspace `release.yml`
 - **Release validate fails early when GitHub Release already exists** ([#443](https://github.com/vig-os/devcontainer/issues/443))
-  - Validate job in `.github/workflows/release.yml` now checks `gh release view` for `PUBLISH_VERSION` so an existing release is rejected before build/sign/publish
+  - Validate job in `.github/workflows/release.yml` queries `GET /repos/.../releases/tags/<PUBLISH_VERSION>` with retries and classifies errors like the downstream RC gate; only a documented not-found response is treated as “no release,” and ambiguous API failures fail closed before build/sign/publish
+  - Publish job uses the same existence checks before and after `gh release create` instead of `gh release view` with discarded stderr
 
 ### Security
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -190,6 +190,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Downstream candidate RC tag can match upstream dispatch** ([#441](https://github.com/vig-os/devcontainer/issues/441))
   - Workspace `release.yml` / `release-core.yml` accept optional `rc-number` so candidate tags are not always recomputed from local tags only
   - Smoke-test `repository-dispatch.yml` exposes `base_version` and `rc_number` job outputs for orchestration that calls workspace `release.yml`
+- **Release validate fails early when GitHub Release already exists** ([#443](https://github.com/vig-os/devcontainer/issues/443))
+  - Validate job in `.github/workflows/release.yml` now checks `gh release view` for `PUBLISH_VERSION` so an existing release is rejected before build/sign/publish
 
 ### Security
 


### PR DESCRIPTION
## Description

Adds an early validation step in the release workflow so a final release fails in **Validate Release** if a GitHub Release for `PUBLISH_VERSION` already exists. That avoids spending build/sign/publish time when the publish step would hit the same guard anyway (see investigation on #443).

## Type of Change

- [ ] `feat` -- New feature
- [x] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [x] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- **`.github/workflows/release.yml`**
  - New step **Verify GitHub Release does not exist** after **Verify tag does not exist**, using `gh release view` and `github.token`.
- **`CHANGELOG.md`**
  - Fixed entry for #443 under `## [0.3.1] - TBD`.
- **`assets/workspace/.devcontainer/CHANGELOG.md`**
  - Same changelog bullet kept in sync with root manifest.

## Changelog Entry

This PR targets `release/0.3.1`; the entry is under `## [0.3.1] - TBD` (not `## Unreleased`).

### Fixed

- **Release validate fails early when GitHub Release already exists** ([#443](https://github.com/vig-os/devcontainer/issues/443))
  - Validate job in `.github/workflows/release.yml` now checks `gh release view` for `PUBLISH_VERSION` so an existing release is rejected before build/sign/publish

## Testing

- [ ] Tests pass locally (`just test`)
- [ ] Manual testing performed (describe below)

### Manual Testing Details

N/A — workflow-only change; validation is exercised on the next release run.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` under `## [0.3.1] - TBD` (release branch; entry pasted above)
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

N/A

Refs: #443
