### PR TITLE
ci: Align release automation with draft finals and forward-fix rollback

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,12 +4,12 @@
 # 1. Validate: Check all prerequisites (PR status, CI passed, CHANGELOG ready)
 # 2. Finalize: For final releases only, set release date in CHANGELOG
 # 3. Build & Test: Build and test images for all architectures
-# 4. Publish: Create tag, publish images, and publish final GitHub Release
-# 5. Rollback (on failure): Revert changes and create issue
+# 4. Publish: Create tag, publish images, and create draft final GitHub Release
+# 5. Rollback (on failure): Reset release branch, create issue (tags are not deleted—forward-fix policy; GitHub immutability applies only after a published release locks the tag when that setting is enabled)
 #
 # Release kinds:
 #   candidate: Publishes X.Y.Z-rcN. No CHANGELOG changes, no sync-issues.
-#   final:     Publishes X.Y.Z. Sets release date in CHANGELOG, triggers sync-issues, publishes GitHub Release.
+#   final:     Publishes X.Y.Z. Sets release date in CHANGELOG, triggers sync-issues, creates draft GitHub Release.
 #
 # Design: Everything happens in one workflow dispatch before creating the tag.
 # This ensures no broken releases are tagged.
@@ -318,18 +318,10 @@ jobs:
             exit 1
           fi
 
-      - name: Verify tag does not exist
+      - name: Verify GitHub Release does not block publish
         env:
           PUBLISH_VERSION: ${{ steps.publish_meta.outputs.publish_version }}
-        run: |
-          if git tag -l | grep -q "^${PUBLISH_VERSION}$"; then
-            echo "ERROR: Tag $PUBLISH_VERSION already exists"
-            exit 1
-          fi
-
-      - name: Verify GitHub Release does not exist
-        env:
-          PUBLISH_VERSION: ${{ steps.publish_meta.outputs.publish_version }}
+          RELEASE_KIND: ${{ steps.vars.outputs.release_kind }}
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
@@ -339,8 +331,17 @@ jobs:
           for i in $(seq 1 "$RETRIES"); do
             API_OUTPUT=""
             if API_OUTPUT=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${PUBLISH_VERSION}" 2>&1); then
+              if [ "$RELEASE_KIND" = "final" ]; then
+                IS_DRAFT=$(printf '%s' "$API_OUTPUT" | jq -r '.draft')
+                if [ "$IS_DRAFT" = "true" ]; then
+                  echo "Draft GitHub Release already exists for $PUBLISH_VERSION; publish job may retry release creation."
+                  exit 0
+                fi
+                echo "ERROR: Published (non-draft) GitHub Release already exists for $PUBLISH_VERSION"
+                echo "Immutable releases cannot be replaced; use a patch version if a new release is required."
+                exit 1
+              fi
               echo "ERROR: GitHub Release already exists for $PUBLISH_VERSION"
-              echo "Delete it manually before retrying: gh release delete $PUBLISH_VERSION --yes"
               exit 1
             fi
 
@@ -552,6 +553,7 @@ jobs:
       actions: write     # trigger sync-issues workflow
     outputs:
       finalize_sha: ${{ steps.finalize.outputs.finalize_sha }}
+      tag_already_exists: ${{ steps.tag_state.outputs.tag_already_exists }}
 
     steps:
       - name: Generate GitHub App Token
@@ -755,6 +757,31 @@ jobs:
           echo "finalize_sha=$FINALIZE_SHA" >> $GITHUB_OUTPUT
           echo "Release kind: $RELEASE_KIND — SHA: $FINALIZE_SHA"
 
+      - name: Check if publish tag already exists at finalize SHA
+        id: tag_state
+        env:
+          PUBLISH_VERSION: ${{ needs.validate.outputs.publish_version }}
+          FINALIZE_SHA: ${{ steps.finalize.outputs.finalize_sha }}
+        run: |
+          set -euo pipefail
+          REMOTE_LINE=$(git ls-remote origin "refs/tags/${PUBLISH_VERSION}^{}" || true)
+          if [ -z "$REMOTE_LINE" ]; then
+            echo "tag_already_exists=false" >> "$GITHUB_OUTPUT"
+            echo "No remote tag ${PUBLISH_VERSION} yet"
+            exit 0
+          fi
+          REMOTE_PEEL=$(printf '%s\n' "$REMOTE_LINE" | awk '{print $1}')
+          if [ -z "$REMOTE_PEEL" ]; then
+            echo "tag_already_exists=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ "$REMOTE_PEEL" != "$FINALIZE_SHA" ]; then
+            echo "ERROR: Tag $PUBLISH_VERSION exists but peeled commit is $REMOTE_PEEL; expected $FINALIZE_SHA (finalize SHA)"
+            exit 1
+          fi
+          echo "tag_already_exists=true" >> "$GITHUB_OUTPUT"
+          echo "Remote tag $PUBLISH_VERSION already points to finalize SHA; publish will skip tag create/push"
+
   build-and-test:
     name: Build and Test (${{ matrix.arch }})
     needs: [validate, finalize]
@@ -862,6 +889,7 @@ jobs:
           git config user.email "$GIT_USER_EMAIL"
 
       - name: Create annotated tag
+        if: ${{ needs.finalize.outputs.tag_already_exists != 'true' }}
         env:
           PUBLISH_VERSION: ${{ needs.validate.outputs.publish_version }}
         run: |
@@ -870,6 +898,7 @@ jobs:
           echo "✓ Tag created: $PUBLISH_VERSION"
 
       - name: Push tag
+        if: ${{ needs.finalize.outputs.tag_already_exists != 'true' }}
         env:
           PUBLISH_VERSION: ${{ needs.validate.outputs.publish_version }}
           RELEASE_KIND: ${{ needs.validate.outputs.release_kind }}
@@ -1164,13 +1193,19 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           set -euo pipefail
-          # Fail if release already exists; only treat API "not found" as absent (same semantics as Validate job).
+          # Draft first: human publishes from the UI when ready (GitHub immutable-releases best practice).
           RETRIES=5
           LAST_ERROR=""
           for i in $(seq 1 "$RETRIES"); do
             API_OUTPUT=""
             if API_OUTPUT=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${PUBLISH_VERSION}" 2>&1); then
-              echo "ERROR: GitHub Release already exists for tag $PUBLISH_VERSION"
+              IS_DRAFT=$(printf '%s' "$API_OUTPUT" | jq -r '.draft')
+              if [ "$IS_DRAFT" = "true" ]; then
+                echo "✓ Draft GitHub Release already exists for $PUBLISH_VERSION; skipping create (retry path)."
+                echo "Review and publish from: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/releases"
+                exit 0
+              fi
+              echo "ERROR: Published (non-draft) GitHub Release already exists for tag $PUBLISH_VERSION"
               exit 1
             fi
 
@@ -1211,14 +1246,17 @@ jobs:
           retry --retries 3 --backoff 5 --max-backoff 30 -- gh release create "$PUBLISH_VERSION" \
             --title "$PUBLISH_VERSION" \
             --notes-file /tmp/github-release-notes.md \
-            --verify-tag || {
+            --verify-tag \
+            --draft || {
               RELEASE_PRESENT=0
+              IS_DRAFT_RETRY=0
               rb_retries=5
               rb_last=""
               for j in $(seq 1 "$rb_retries"); do
                 rb_out=""
                 if rb_out=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${PUBLISH_VERSION}" 2>&1); then
                   RELEASE_PRESENT=1
+                  IS_DRAFT_RETRY=$(printf '%s' "$rb_out" | jq -r '.draft')
                   break
                 fi
                 rb_last="$rb_out"
@@ -1244,7 +1282,12 @@ jobs:
                 exit 1
               done
               if [ "$RELEASE_PRESENT" -eq 1 ]; then
-                echo "GitHub Release already present after create attempt: $PUBLISH_VERSION"
+                if [ "$IS_DRAFT_RETRY" = "true" ]; then
+                  echo "✓ Draft GitHub Release present after create attempt: $PUBLISH_VERSION"
+                else
+                  echo "ERROR: Published (non-draft) GitHub Release appeared for $PUBLISH_VERSION during create fallback — expected draft."
+                  exit 1
+                fi
               else
                 if [ "$j" -eq "$rb_retries" ] && ! printf '%s' "$rb_last" | grep -Eqi "not found|HTTP 404"; then
                   echo "ERROR: Unable to verify GitHub Release state for $PUBLISH_VERSION after create failure (fail closed)."
@@ -1255,7 +1298,8 @@ jobs:
               fi
             }
 
-          echo "✓ GitHub Release published: $PUBLISH_VERSION"
+          echo "✓ Draft GitHub Release created: $PUBLISH_VERSION"
+          echo "Review and publish from: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/releases (publishing locks the linked tag and assets when immutable releases are enabled)"
 
       - name: Summary
         env:
@@ -1285,7 +1329,8 @@ jobs:
             echo "  2. If downstream pre-release passes, run: just finalize-release $BASE_VERSION"
           else
             echo "  1. Smoke-test dispatch runs in the smoke-test job."
-            echo "  2. Merge release PR to main (triggers sync-main-to-dev workflow automatically)"
+            echo "  2. Review the draft GitHub Release and publish it from the Releases UI (publishing applies immutable-release lock-in for the tag and assets when that setting is enabled)."
+            echo "  3. Merge release PR to main (triggers sync-main-to-dev workflow automatically)"
           fi
 
   smoke-test:
@@ -1347,9 +1392,13 @@ jobs:
       - name: Summary
         env:
           RELEASE_TAG: ${{ needs.validate.outputs.publish_version }}
+          RELEASE_KIND: ${{ needs.validate.outputs.release_kind }}
         run: |
           echo "✓ Triggered smoke-test dispatch for release tag: $RELEASE_TAG"
           echo "Downstream validation is asynchronous; verify in devcontainer-smoke-test."
+          if [ "$RELEASE_KIND" = "final" ]; then
+            echo "Final: review the draft GitHub Release in this repo and publish it from the Releases UI when validation is complete."
+          fi
 
       - name: Create issue for smoke dispatch failure
         if: ${{ failure() }}
@@ -1368,7 +1417,7 @@ jobs:
 
             **Important:**
             - Upstream publish already completed before this dispatch step.
-            - Published artifacts (GHCR images, tag, signatures, attestations, and final GitHub Release if applicable) are intentionally left intact.
+            - Published artifacts (GHCR images, tag, signatures, attestations, and draft or published GitHub Release if applicable) are intentionally left intact.
             - No branch reset or tag deletion is performed for dispatch-only failures.
 
             **Next Steps:**
@@ -1390,7 +1439,7 @@ jobs:
   rollback:
     name: Rollback on Failure
     # Rollback is intentionally scoped to pre-publish/publish failures.
-    # Dispatch-only smoke-test failures happen after publish and should not delete tags or reset branches.
+    # Dispatch-only smoke-test failures happen after publish; automation does not delete tags or reset branches (forward-fix policy).
     needs: [validate, finalize, build-and-test, publish]
     runs-on: ubuntu-22.04
     timeout-minutes: 10
@@ -1398,7 +1447,7 @@ jobs:
     permissions:
       contents: read        # required by actions/checkout in rollback job
       issues: write          # create failure issue
-      # Branch rollback and tag deletion use the RELEASE_APP token (not GITHUB_TOKEN),
+      # Branch rollback uses the RELEASE_APP token (not GITHUB_TOKEN),
       # which has Contents read/write configured on the GitHub App.
 
     steps:
@@ -1434,23 +1483,6 @@ jobs:
             -F force=true
           echo "✓ Release branch rolled back to $PRE_SHA"
 
-      - name: Delete tag if created
-        id: rollback-tag
-        continue-on-error: true
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          PUBLISH_VERSION: ${{ needs.validate.outputs.publish_version }}
-        run: |
-          set -euo pipefail
-          TAG="$PUBLISH_VERSION"
-          if retry --retries 2 --backoff 5 --max-backoff 20 -- gh api "repos/${{ github.repository }}/git/refs/tags/$TAG" >/dev/null 2>&1; then
-            echo "Deleting remote tag: $TAG"
-            retry --retries 3 --backoff 5 --max-backoff 30 -- gh api "repos/${{ github.repository }}/git/refs/tags/$TAG" -X DELETE
-            echo "✓ Tag deleted"
-          else
-            echo "Tag does not exist on remote (not created)"
-          fi
-
       - name: Create failure issue
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8.0.0
         with:
@@ -1466,7 +1498,6 @@ jobs:
             if ('${{ needs.publish.result }}' !== 'success') failedJobs.push('publish');
 
             const rollbackBranch = '${{ steps.rollback-branch.outcome }}';
-            const rollbackTag = '${{ steps.rollback-tag.outcome }}';
 
             const title = `Release ${publishVersion} failed -- automatic rollback`;
             const body = `
@@ -1480,21 +1511,24 @@ jobs:
 
             **Rollback Results:**
             - Branch rollback: ${rollbackBranch}
-            - Tag deletion: ${rollbackTag}
+
+            **Tag status (forward-fix policy):**
+            - Release tags are **not** deleted by automation (workflow choice; not the same as GitHub immutable-release lock-in).
+            - If the tag was pushed before the failure, it remains on the remote; use a new release candidate to validate fixes, then re-run the final release when ready.
 
             **Actions Taken:**
-            - Release branch rolled back to pre-finalization state
-            - Release tag deleted (if created)
+            - Release branch reset to pre-finalization state (best-effort)
             - This issue created for investigation
 
             **Manual Cleanup May Be Needed:**
             - If images were pushed to GHCR before the failure, they are **not** automatically deleted. Check \`ghcr.io/vig-os/devcontainer:${publishVersion}-*\` and remove any orphaned images manually.
+            - If a **draft** GitHub Release exists for this tag, edit or manage it from the Releases UI (**publishing** locks the linked tag and assets when **immutable releases** are enabled).
 
             **Next Steps:**
             1. Review the workflow logs to identify the root cause
             2. Check rollback results above; fix any partial rollback manually
             3. Fix the issue on the release branch
-            4. Re-run the workflow when ready
+            4. Publish a new release candidate to validate the fix; re-run the final workflow when ready
 
             For details, check the workflow run linked above.
             `;
@@ -1514,8 +1548,8 @@ jobs:
           echo "✗ Release workflow failed"
           echo ""
           echo "Automatic rollback completed:"
-          echo "  - Release branch reset to pre-finalization state"
-          echo "  - Release tag deleted (if created)"
+          echo "  - Release branch reset to pre-finalization state (best-effort)"
+          echo "  - Tags were not deleted (forward-fix policy)"
           echo "  - GitHub issue created for investigation"
           echo ""
           echo "Check the workflow logs and issue for details"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -766,17 +766,20 @@ jobs:
           set -euo pipefail
           REMOTE_LINE=$(git ls-remote origin "refs/tags/${PUBLISH_VERSION}^{}" || true)
           if [ -z "$REMOTE_LINE" ]; then
+            REMOTE_LINE=$(git ls-remote origin "refs/tags/${PUBLISH_VERSION}" || true)
+          fi
+          if [ -z "$REMOTE_LINE" ]; then
             echo "tag_already_exists=false" >> "$GITHUB_OUTPUT"
             echo "No remote tag ${PUBLISH_VERSION} yet"
             exit 0
           fi
-          REMOTE_PEEL=$(printf '%s\n' "$REMOTE_LINE" | awk '{print $1}')
-          if [ -z "$REMOTE_PEEL" ]; then
+          REMOTE_TARGET_SHA=$(printf '%s\n' "$REMOTE_LINE" | awk '{print $1}')
+          if [ -z "$REMOTE_TARGET_SHA" ]; then
             echo "tag_already_exists=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          if [ "$REMOTE_PEEL" != "$FINALIZE_SHA" ]; then
-            echo "ERROR: Tag $PUBLISH_VERSION exists but peeled commit is $REMOTE_PEEL; expected $FINALIZE_SHA (finalize SHA)"
+          if [ "$REMOTE_TARGET_SHA" != "$FINALIZE_SHA" ]; then
+            echo "ERROR: Tag $PUBLISH_VERSION exists but target commit is $REMOTE_TARGET_SHA; expected $FINALIZE_SHA (finalize SHA)"
             exit 1
           fi
           echo "tag_already_exists=true" >> "$GITHUB_OUTPUT"
@@ -916,6 +919,9 @@ jobs:
             if retry --retries 3 --backoff 5 --max-backoff 30 -- git ls-remote --tags --refs origin "$PUBLISH_VERSION" | grep -q "refs/tags/$PUBLISH_VERSION$"; then
               LOCAL_TAG_TARGET_SHA=$(git rev-parse "$PUBLISH_VERSION^{}")
               REMOTE_TAG_TARGET_SHA=$(retry --retries 3 --backoff 5 --max-backoff 30 -- git ls-remote --tags origin "refs/tags/$PUBLISH_VERSION^{}" | awk '{print $1}')
+              if [ -z "$REMOTE_TAG_TARGET_SHA" ]; then
+                REMOTE_TAG_TARGET_SHA=$(retry --retries 3 --backoff 5 --max-backoff 30 -- git ls-remote --tags origin "refs/tags/$PUBLISH_VERSION" | awk '{print $1}')
+              fi
               if [ -z "$REMOTE_TAG_TARGET_SHA" ]; then
                 echo "ERROR: Remote tag exists but target SHA could not be resolved: $PUBLISH_VERSION"
                 exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **cursor-agent install is now resilient to CDN failures** ([#434](https://github.com/vig-os/devcontainer/issues/434))
   - Retries 3 times with backoff before giving up
   - Build succeeds without cursor-agent when Cursor's CDN is unavailable
+- **Immutable GitHub releases, tag rulesets, and forward-fix policy** ([#446](https://github.com/vig-os/devcontainer/issues/446))
+  - Final releases create a **draft** GitHub Release for human review before publishing; rollback no longer deletes remote tags
+  - Release workflows skip redundant tag push when the tag already matches the finalized commit; workspace `release-core` / `release-publish` and smoke-test failure guidance updated accordingly
+  - Document tag rulesets, immutable releases, and recovery in `docs/RELEASE_CYCLE.md`, `docs/DOWNSTREAM_RELEASE.md`, and `docs/CROSS_REPO_RELEASE_GATE.md`
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -203,6 +203,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Release validate fails early when GitHub Release already exists** ([#443](https://github.com/vig-os/devcontainer/issues/443))
   - Validate job in `.github/workflows/release.yml` queries `GET /repos/.../releases/tags/<PUBLISH_VERSION>` with retries and classifies errors like the downstream RC gate; only a documented not-found response is treated as “no release,” and ambiguous API failures fail closed before build/sign/publish
   - Publish job uses the same existence checks before and after `gh release create` instead of `gh release view` with discarded stderr
+- **Release tag resolution and GitHub Release view retries** ([#446](https://github.com/vig-os/devcontainer/issues/446))
+  - Fall back to plain `refs/tags/<tag>` when the peeled ref is empty (lightweight remote tags) in `.github/workflows/release.yml`, `release-core.yml`, and `release-publish.yml`
+  - Use one retried `gh release view` in workspace `release-publish.yml` so draft/prerelease skip paths parse JSON from the same successful response
 
 ### Security
 

--- a/assets/smoke-test/.github/workflows/repository-dispatch.yml
+++ b/assets/smoke-test/.github/workflows/repository-dispatch.yml
@@ -894,7 +894,8 @@ jobs:
           ## Manual cleanup guidance
           - Inspect deploy/release PRs and workflow logs before retrying.
           - If needed, close stale release PRs and delete stale \`release/<version>\` branch.
-          - Re-dispatch using a new RC tag/version once root cause is fixed.
+          - Do not rewrite or delete **published** GitHub Releases (or their linked tags when **immutable releases** are enabled) to retry the same version; bare git tags without a published release are not locked by that feature unless a tag ruleset applies.
+          - After fixing the root cause upstream, publish a **new** RC tag (or a new final attempt only after branch/tag state matches your release policy), then rely on a fresh dispatch.
           EOF
           )"
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -75,6 +75,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **cursor-agent install is now resilient to CDN failures** ([#434](https://github.com/vig-os/devcontainer/issues/434))
   - Retries 3 times with backoff before giving up
   - Build succeeds without cursor-agent when Cursor's CDN is unavailable
+- **Immutable GitHub releases, tag rulesets, and forward-fix policy** ([#446](https://github.com/vig-os/devcontainer/issues/446))
+  - Final releases create a **draft** GitHub Release for human review before publishing; rollback no longer deletes remote tags
+  - Release workflows skip redundant tag push when the tag already matches the finalized commit; workspace `release-core` / `release-publish` and smoke-test failure guidance updated accordingly
+  - Document tag rulesets, immutable releases, and recovery in `docs/RELEASE_CYCLE.md`, `docs/DOWNSTREAM_RELEASE.md`, and `docs/CROSS_REPO_RELEASE_GATE.md`
 
 ### Removed
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -203,6 +203,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Release validate fails early when GitHub Release already exists** ([#443](https://github.com/vig-os/devcontainer/issues/443))
   - Validate job in `.github/workflows/release.yml` queries `GET /repos/.../releases/tags/<PUBLISH_VERSION>` with retries and classifies errors like the downstream RC gate; only a documented not-found response is treated as “no release,” and ambiguous API failures fail closed before build/sign/publish
   - Publish job uses the same existence checks before and after `gh release create` instead of `gh release view` with discarded stderr
+- **Release tag resolution and GitHub Release view retries** ([#446](https://github.com/vig-os/devcontainer/issues/446))
+  - Fall back to plain `refs/tags/<tag>` when the peeled ref is empty (lightweight remote tags) in `.github/workflows/release.yml`, `release-core.yml`, and `release-publish.yml`
+  - Use one retried `gh release view` in workspace `release-publish.yml` so draft/prerelease skip paths parse JSON from the same successful response
 
 ### Security
 

--- a/assets/workspace/.github/workflows/release-core.yml
+++ b/assets/workspace/.github/workflows/release-core.yml
@@ -494,17 +494,20 @@ jobs:
           set -euo pipefail
           REMOTE_LINE=$(git ls-remote origin "refs/tags/${PUBLISH_VERSION}^{}" || true)
           if [ -z "$REMOTE_LINE" ]; then
+            REMOTE_LINE=$(git ls-remote origin "refs/tags/${PUBLISH_VERSION}" || true)
+          fi
+          if [ -z "$REMOTE_LINE" ]; then
             echo "tag_already_exists=false" >> "$GITHUB_OUTPUT"
             echo "No remote tag ${PUBLISH_VERSION} yet"
             exit 0
           fi
-          REMOTE_PEEL=$(printf '%s\n' "$REMOTE_LINE" | awk '{print $1}')
-          if [ -z "$REMOTE_PEEL" ]; then
+          REMOTE_TARGET_SHA=$(printf '%s\n' "$REMOTE_LINE" | awk '{print $1}')
+          if [ -z "$REMOTE_TARGET_SHA" ]; then
             echo "tag_already_exists=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          if [ "$REMOTE_PEEL" != "$FINALIZE_SHA" ]; then
-            echo "ERROR: Tag $PUBLISH_VERSION exists but peeled commit is $REMOTE_PEEL; expected $FINALIZE_SHA (finalize SHA)"
+          if [ "$REMOTE_TARGET_SHA" != "$FINALIZE_SHA" ]; then
+            echo "ERROR: Tag $PUBLISH_VERSION exists but target commit is $REMOTE_TARGET_SHA; expected $FINALIZE_SHA (finalize SHA)"
             exit 1
           fi
           echo "tag_already_exists=true" >> "$GITHUB_OUTPUT"

--- a/assets/workspace/.github/workflows/release-core.yml
+++ b/assets/workspace/.github/workflows/release-core.yml
@@ -57,6 +57,9 @@ on:  # yamllint disable-line rule:truthy
       finalize_sha:
         description: "Release branch SHA after finalization"
         value: ${{ jobs.finalize.outputs.finalize_sha }}
+      tag_already_exists:
+        description: "Remote publish tag already exists at finalize SHA (retry path)"
+        value: ${{ jobs.finalize.outputs.tag_already_exists }}
       image_tag:
         description: "Resolved devcontainer image tag"
         value: ${{ jobs.validate.outputs.image_tag }}
@@ -239,18 +242,7 @@ jobs:
           echo "publish_version=$PUBLISH_VERSION" >> "$GITHUB_OUTPUT"
           echo "next_rc=$NEXT_RC" >> "$GITHUB_OUTPUT"
 
-      - name: Verify publish tag does not exist
-        env:
-          PUBLISH_VERSION: ${{ steps.publish_meta.outputs.publish_version }}
-        run: |
-          if git ls-remote --exit-code --tags --refs origin "refs/tags/$PUBLISH_VERSION" > /dev/null 2>&1; then
-            echo "ERROR: Tag $PUBLISH_VERSION already exists"
-            exit 1
-          fi
-          if git rev-parse -q --verify "refs/tags/$PUBLISH_VERSION" > /dev/null; then
-            echo "ERROR: Local tag $PUBLISH_VERSION already exists"
-            exit 1
-          fi
+      # Remote tag vs finalize SHA is validated in the finalize job (tag_state) after finalize_sha is known.
 
       - name: Find and verify PR
         id: pr
@@ -349,6 +341,7 @@ jobs:
     if: ${{ inputs.dry_run != true }}
     outputs:
       finalize_sha: ${{ steps.finalize.outputs.finalize_sha }}
+      tag_already_exists: ${{ steps.tag_state.outputs.tag_already_exists }}
 
     steps:
       - name: Generate commit app token
@@ -491,6 +484,31 @@ jobs:
               gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/release/$VERSION" --jq '.object.sha')
           fi
           echo "finalize_sha=$FINALIZE_SHA" >> "$GITHUB_OUTPUT"
+
+      - name: Check if publish tag already exists at finalize SHA
+        id: tag_state
+        env:
+          PUBLISH_VERSION: ${{ needs.validate.outputs.publish_version }}
+          FINALIZE_SHA: ${{ steps.finalize.outputs.finalize_sha }}
+        run: |
+          set -euo pipefail
+          REMOTE_LINE=$(git ls-remote origin "refs/tags/${PUBLISH_VERSION}^{}" || true)
+          if [ -z "$REMOTE_LINE" ]; then
+            echo "tag_already_exists=false" >> "$GITHUB_OUTPUT"
+            echo "No remote tag ${PUBLISH_VERSION} yet"
+            exit 0
+          fi
+          REMOTE_PEEL=$(printf '%s\n' "$REMOTE_LINE" | awk '{print $1}')
+          if [ -z "$REMOTE_PEEL" ]; then
+            echo "tag_already_exists=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ "$REMOTE_PEEL" != "$FINALIZE_SHA" ]; then
+            echo "ERROR: Tag $PUBLISH_VERSION exists but peeled commit is $REMOTE_PEEL; expected $FINALIZE_SHA (finalize SHA)"
+            exit 1
+          fi
+          echo "tag_already_exists=true" >> "$GITHUB_OUTPUT"
+          echo "Remote tag $PUBLISH_VERSION already points to finalize SHA; publish will skip tag create/push"
 
   test:
     name: Test Finalized Release

--- a/assets/workspace/.github/workflows/release-publish.yml
+++ b/assets/workspace/.github/workflows/release-publish.yml
@@ -150,6 +150,9 @@ jobs:
               LOCAL_TAG_TARGET_SHA=$(git rev-parse "$PUBLISH_VERSION^{}")
               REMOTE_TAG_TARGET_SHA=$(retry --retries 3 --backoff 5 --max-backoff 30 -- git ls-remote --tags origin "refs/tags/$PUBLISH_VERSION^{}" | awk '{print $1}')
               if [ -z "$REMOTE_TAG_TARGET_SHA" ]; then
+                REMOTE_TAG_TARGET_SHA=$(retry --retries 3 --backoff 5 --max-backoff 30 -- git ls-remote --tags origin "refs/tags/$PUBLISH_VERSION" | awk '{print $1}')
+              fi
+              if [ -z "$REMOTE_TAG_TARGET_SHA" ]; then
                 echo "ERROR: Remote tag exists but target SHA could not be resolved: $PUBLISH_VERSION"
                 exit 1
               fi
@@ -187,8 +190,7 @@ jobs:
           GH_TOKEN: ${{ steps.auth.outputs.token }}
         run: |
           set -euo pipefail
-          if retry --retries 2 --backoff 5 --max-backoff 20 -- gh release view "$PUBLISH_VERSION" --json isDraft,isPrerelease >/dev/null 2>&1; then
-            RELEASE_JSON=$(gh release view "$PUBLISH_VERSION" --json isDraft,isPrerelease)
+          if RELEASE_JSON=$(retry --retries 2 --backoff 5 --max-backoff 20 -- gh release view "$PUBLISH_VERSION" --json isDraft,isPrerelease 2>/dev/null); then
             IS_DRAFT=$(printf '%s' "$RELEASE_JSON" | jq -r '.isDraft')
             if [ "$IS_DRAFT" = "true" ]; then
               echo "Draft GitHub Release already exists for $PUBLISH_VERSION; skipping create (retry path)."

--- a/assets/workspace/.github/workflows/release-publish.yml
+++ b/assets/workspace/.github/workflows/release-publish.yml
@@ -33,6 +33,11 @@ on:  # yamllint disable-line rule:truthy
         required: false
         default: "41898282+github-actions[bot]@users.noreply.github.com"
         type: string
+      tag_already_exists:
+        description: "Skip tag create/push when remote tag already points at finalize SHA"
+        required: false
+        default: false
+        type: boolean
     secrets:
       token:
         required: false
@@ -134,6 +139,7 @@ jobs:
           git config user.email "$GIT_USER_EMAIL"
 
       - name: Create and push tag
+        if: ${{ !inputs.tag_already_exists }}
         env:
           PUBLISH_VERSION: ${{ inputs.publish_version }}
         run: |
@@ -181,8 +187,21 @@ jobs:
           GH_TOKEN: ${{ steps.auth.outputs.token }}
         run: |
           set -euo pipefail
-          if retry --retries 2 --backoff 5 --max-backoff 20 -- gh release view "$PUBLISH_VERSION" >/dev/null 2>&1; then
-            echo "ERROR: GitHub Release already exists for tag $PUBLISH_VERSION"
+          if retry --retries 2 --backoff 5 --max-backoff 20 -- gh release view "$PUBLISH_VERSION" --json isDraft,isPrerelease >/dev/null 2>&1; then
+            RELEASE_JSON=$(gh release view "$PUBLISH_VERSION" --json isDraft,isPrerelease)
+            IS_DRAFT=$(printf '%s' "$RELEASE_JSON" | jq -r '.isDraft')
+            if [ "$IS_DRAFT" = "true" ]; then
+              echo "Draft GitHub Release already exists for $PUBLISH_VERSION; skipping create (retry path)."
+              exit 0
+            fi
+            if [ "$RELEASE_KIND" = "candidate" ]; then
+              IS_PRERELEASE=$(printf '%s' "$RELEASE_JSON" | jq -r '.isPrerelease')
+              if [ "$IS_PRERELEASE" = "true" ]; then
+                echo "Pre-release already exists for $PUBLISH_VERSION; skipping create (candidate retry path)."
+                exit 0
+              fi
+            fi
+            echo "ERROR: Published (non-draft) GitHub Release already exists for tag $PUBLISH_VERSION"
             exit 1
           fi
           if [ "$RELEASE_KIND" = "candidate" ]; then
@@ -195,7 +214,9 @@ jobs:
             retry --retries 3 --backoff 5 --max-backoff 30 -- gh release create "$PUBLISH_VERSION" \
               --title "$PUBLISH_VERSION" \
               --notes-file /tmp/release-notes.md \
-              --verify-tag
+              --verify-tag \
+              --draft
+            echo "Draft GitHub Release created; publish from ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/releases when review is complete."
           fi
 
       - name: Set outputs

--- a/assets/workspace/.github/workflows/release.yml
+++ b/assets/workspace/.github/workflows/release.yml
@@ -104,6 +104,7 @@ jobs:
       release_kind: ${{ needs.core.outputs.release_kind }}
       git_user_name: ${{ inputs.git-user-name }}
       git_user_email: ${{ inputs.git-user-email }}
+      tag_already_exists: ${{ needs.core.outputs.tag_already_exists }}
     secrets: inherit
 
   rollback:
@@ -183,17 +184,6 @@ jobs:
             fi
           fi
 
-      - name: Delete tag if created
-        if: ${{ needs.core.outputs.publish_version != '' }}
-        continue-on-error: true
-        env:
-          PUBLISH_VERSION: ${{ needs.core.outputs.publish_version }}
-        run: |
-          set -euo pipefail
-          if git ls-remote origin "refs/tags/$PUBLISH_VERSION" | grep -q "$PUBLISH_VERSION"; then
-            retry --retries 3 --backoff 5 --max-backoff 30 -- git push origin ":refs/tags/$PUBLISH_VERSION" || true
-          fi
-
       - name: Create failure issue
         if: ${{ needs.core.outputs.version != '' }}
         env:
@@ -213,5 +203,9 @@ jobs:
           **Release PR:** #$PR_NUMBER
 
           **Automatic rollback attempted:**
-          - Release branch reset to pre-finalization state
-          - Release tag deleted (if created)"
+          - Release branch reset to pre-finalization state (best-effort)
+
+          **Tag status (forward-fix policy):**
+          - Release tags are not deleted by automation (workflow choice; GitHub immutable-release lock-in applies only after a release is **published** when that setting is enabled). If a tag was pushed before the failure, it remains on the remote.
+          - Use a new release candidate to validate fixes, then re-run the final release when ready.
+          - If a draft GitHub Release exists, manage it from the Releases UI; **publishing** locks the linked tag and assets when **immutable releases** are enabled."

--- a/docs/CROSS_REPO_RELEASE_GATE.md
+++ b/docs/CROSS_REPO_RELEASE_GATE.md
@@ -71,6 +71,8 @@ The orchestrator validates:
 
 If any of these checks fail, the release workflow fails and rollback handling is evaluated by workflow conditions.
 
+**Immutable releases:** Where **immutable releases** are enabled, a **published** GitHub Release (including a published **pre-release**) locks its **linked** tag and assets; they cannot be rewritten via normal GitHub UI/API. Downstream and smoke-test flows should fix forward with a new RC or version rather than deleting tags or releases. See [Immutable releases, tag rulesets, and forward-fix policy](RELEASE_CYCLE.md#immutable-releases-tag-rulesets-and-forward-fix-policy) for full policy and recovery procedures (including tags without a published release and the forward-fix no-delete policy).
+
 ## Expected Output
 
 ### Success Signals

--- a/docs/DOWNSTREAM_RELEASE.md
+++ b/docs/DOWNSTREAM_RELEASE.md
@@ -1,6 +1,6 @@
 # Downstream Release Workflows
 
-This document describes the downstream release workflows shipped in `assets/workspace/.github/workflows/`.
+This document is the **only** place that describes the release process for **consumer projects** that install workflows from `assets/workspace/`. The upstream devcontainer and smoke-test validation flow is documented in [`docs/RELEASE_CYCLE.md`](RELEASE_CYCLE.md) and [`docs/CROSS_REPO_RELEASE_GATE.md`](CROSS_REPO_RELEASE_GATE.md).
 
 ## Overview
 
@@ -14,16 +14,22 @@ The downstream template uses a split release architecture:
 
 All files are deployed from `assets/workspace/` by `init-workspace.sh`.
 
-On failure, the orchestrator runs a single consolidated rollback that resets the release branch, removes any created tag, and opens a failure issue.
+On failure, the orchestrator runs a single consolidated rollback that resets the release branch (best-effort), does **not** delete tags (forward-fix policy), and opens a failure issue with forward-fix guidance.
 
 ## Release Modes
 
 `release.yml` supports two release modes via `release_kind`:
 
 - `candidate` (default): computes and publishes the next `X.Y.Z-rcN` tag as a GitHub pre-release (or use optional `rc-number` to pin `N` when orchestrating from an upstream dispatch; see `docs/CROSS_REPO_RELEASE_GATE.md`)
-- `final`: publishes `X.Y.Z`, finalizes `CHANGELOG.md` release date, and runs `sync-issues`
+- `final`: publishes `X.Y.Z`, finalizes `CHANGELOG.md` release date, runs `sync-issues`, and creates a **draft** GitHub Release (publish from the UI when review is complete; aligns with GitHub’s [immutable releases](https://docs.github.com/en/code-security/concepts/supply-chain-security/immutable-releases) and [draft-first guidance](https://docs.github.com/en/code-security/concepts/supply-chain-security/immutable-releases#best-practices-for-publishing-immutable-releases))
 
 Candidate mode keeps release branch content unchanged (no CHANGELOG date finalization). Final mode performs changelog finalization before publish.
+
+## Immutable releases, tag rulesets, and forward-fix policy (downstream)
+
+- **Candidate (`X.Y.Z-rcN`)**: `release-publish.yml` creates a **published** GitHub **pre-release** for the RC tag. With **immutable releases** enabled, **publishing** that pre-release locks the **linked** tag and assets (see [upstream policy](RELEASE_CYCLE.md#immutable-releases-tag-rulesets-and-forward-fix-policy)); iterate with a **new** RC tag.
+- **Final (`X.Y.Z`)**: Automation creates a **draft** GitHub Release; a human **publishes** it from the Releases UI when ready—**publishing** applies immutable-release lock-in for the linked tag and assets when that setting is enabled. Enable **immutable releases** and **tag rulesets** on each consumer repository (and org policy) as needed; see [Preventing changes to your releases](https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/preventing-changes-to-your-releases).
+- **Rollback**: The orchestrator resets the release branch and does **not** delete tags (forward-fix policy); recover with a new RC or a careful final retry per workflow logs.
 
 ## Workflow Interface
 

--- a/docs/RELEASE_CYCLE.md
+++ b/docs/RELEASE_CYCLE.md
@@ -124,7 +124,7 @@ graph TB
     N --> O["Workflow: set release date<br/>build & test"]
     O --> P{Tests pass?}
     P -->|No| Q["Automatic rollback<br/>+ issue creation"]
-    P -->|Yes| R["Workflow: create tag<br/>publish images<br/>publish GitHub Release (final only)"]
+    P -->|Yes| R["Workflow: create tag<br/>publish images<br/>draft GitHub Release (final only)"]
     R --> S["Merge PR to main"]
     S --> T["Workflow: sync-main-to-dev<br/>PR-based sync"]
 ```
@@ -134,9 +134,21 @@ graph TB
 1. **Preparation** (`prepare-release`): Freeze CHANGELOG on dev, create release branch, reset Unreleased on dev, open draft PR
 2. **Review & Testing**: CI validation, mark PR ready, fix issues, get approvals
 3. **Candidate Publish** (`publish-candidate`): Build/test/publish `X.Y.Z-rcN` and dispatch cross-repo validation workflow
-4. **Cross-Repo Validation Gate (automated prerequisite)**: Final release validate step requires downstream pre-release for the latest RC tag
-5. **Finalization & Post-Release**: Publish final image/tag, then merge PR to main and let sync automation update dev
+4. **Cross-Repo Validation Gate (automated prerequisite)**: Final release validate step requires a GitHub **pre-release** for the latest RC tag in the validation repo (`vig-os/devcontainer-smoke-test`); see `docs/CROSS_REPO_RELEASE_GATE.md`
+5. **Finalization & Post-Release**: Publish final image/tag, open a **draft** GitHub Release for human review, then merge PR to main and let sync automation update dev
 
+## Immutable releases, tag rulesets, and forward-fix policy
+
+This section applies to **`vig-os/devcontainer`** (this repo) and, for matching supply-chain posture, **`vig-os/devcontainer-smoke-test`**. It does **not** describe release workflows in consumer projects; those are documented in [Downstream release workflows](DOWNSTREAM_RELEASE.md).
+
+**GitHub immutability (organization settings):** With **immutable releases** enabled, a **published** GitHub Release (including a published **pre-release**) locks its **linked** tag and release assets. A git tag with **no** linked published release is **not** immutable via that feature. **Tag rulesets** are separate: they can restrict creating, updating, or deleting tags regardless of releases.
+
+**Policy (behavior in [`.github/workflows/release.yml`](../.github/workflows/release.yml) for this repository):**
+
+- **Final releases (`X.Y.Z`)**: After build/publish, automation creates a **draft** GitHub Release (see GitHub’s [immutable releases](https://docs.github.com/en/code-security/concepts/supply-chain-security/immutable-releases) and [draft-first best practice](https://docs.github.com/en/code-security/concepts/supply-chain-security/immutable-releases#best-practices-for-publishing-immutable-releases)). A human **publishes** the draft from the **Releases** UI when satisfied; with **immutable releases** enabled, **publishing** makes the linked tag and assets immutable.
+- **Candidates (`X.Y.Z-rcN`)**: Candidate mode creates and pushes the **git tag**, publishes **GHCR** images (and related signing/attestations), and triggers smoke-test dispatch. It does **not** create a GitHub **Release** object for the RC—only **final** runs use `gh release create` (as a draft). The RC tag is therefore **not** locked by immutable releases until/unless you add a published release or a tag ruleset applies.
+- **Forward-fix (automation)**: Rollback **does not** delete remote tags—this is a **workflow choice** to avoid rewriting history, not GitHub declaring the tag immutable. Recovery is **forward-fix** (new RC, then final when ready). If a retry publishes the same tag, the workflow skips re-creating the tag when it already points at the finalized commit.
+- **Repository settings** (manual; not stored in git): enable **immutable releases** and **tag rulesets** as appropriate for `vig-os/devcontainer` and `vig-os/devcontainer-smoke-test`. See GitHub: [Preventing changes to your releases](https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/preventing-changes-to-your-releases). Use **RELEASE_APP** in bypass lists only where tag creation requires it.
 
 ---
 
@@ -342,7 +354,7 @@ The `release.yml` workflow performs the entire remaining release process. Behavi
    - Validates semantic version format
    - Checks release branch exists
    - Verifies CHANGELOG has `## [X.Y.Z] - TBD`
-   - Verifies tag doesn't already exist
+   - For **final**: allows an existing **draft** GitHub Release for the publish tag (retry path); rejects a **published** (non-draft) release for the same tag
    - Confirms PR exists, is not draft, is approved, and CI passed
    - Records pre-finalization commit for rollback
 
@@ -359,9 +371,9 @@ The `release.yml` workflow performs the entire remaining release process. Behavi
 
 4. ✅ **Publish** job (runs only if all builds/tests pass)
    - Candidate mode: infers next `rcN`, creates annotated tag `X.Y.Z-rcN`, publishes candidate manifests
-   - Final mode: creates annotated tag `X.Y.Z`, publishes final manifests
-   - Pushes tag to origin
-   - Final mode only: extracts release notes from finalized `CHANGELOG.md` and publishes GitHub Release for `X.Y.Z`
+   - Final mode: creates annotated tag `X.Y.Z` (or skips create/push if the tag already points at the finalized commit), publishes final manifests
+   - Pushes tag to origin when needed
+   - Final mode only: extracts release notes from finalized `CHANGELOG.md` and creates a **draft** GitHub Release for `X.Y.Z`
    - Downloads tested images from artifacts
    - Logs in to GitHub Container Registry
    - Pushes images to GHCR with architecture-specific tags
@@ -370,10 +382,10 @@ The `release.yml` workflow performs the entire remaining release process. Behavi
    - Verifies manifests exist
    - Candidate and final modes: trigger cross-repository validation dispatch with `client_payload[tag]` plus source metadata (`source_repo`, `source_workflow`, `source_run_id`, `source_run_url`, `source_sha`, `correlation_id`)
 
-5. ✅ **Rollback** job (runs if ANY job failed)
-   - Resets release branch to pre-finalization state
-   - Deletes tag if it was created
-   - Creates GitHub issue with failure details for investigation
+5. ✅ **Rollback** job (runs if ANY job failed among validate/finalize/build-and-test/publish)
+   - Resets release branch to pre-finalization state (best-effort)
+   - Does **not** delete tags (forward-fix policy)
+   - Creates GitHub issue with failure details and forward-fix guidance
 
 **Output example:**
 
@@ -398,7 +410,7 @@ Release Summary:
 
 - **Earlier validation**: All checks happen at the start in CI
 - **Safer workflow**: Tag is created AFTER successful build/test, not before
-- **Automatic rollback**: Failed releases are automatically cleaned up
+- **Automatic rollback**: Failed releases roll back the release branch; tags are not deleted (forward-fix policy, independent of whether GitHub immutability applies)—recover with a new RC or a careful final retry per docs above
 - **Audit trail**: All steps are recorded in GitHub Actions logs with actor information
 - **Reproducible**: Uses consistent CI environment, not dependent on local tooling
 
@@ -408,7 +420,11 @@ Cross-repository validation gate rationale, mechanics, payload contract, and pas
 
 ### Phase 5: Post-Release Cleanup
 
-**Manual step:** Merge the release PR to main.
+**Manual steps (final releases):**
+
+1. Verify the workflow run succeeded and smoke-test dispatch completed as expected.
+2. Open **Releases** in GitHub, review the **draft** release for `X.Y.Z`, and **Publish** it when ready (with **immutable releases** enabled, **publishing** is what locks the linked tag and assets).
+3. Merge the release PR to `main`.
 
 ```bash
 # Verify release workflow succeeded
@@ -529,7 +545,7 @@ Release automation relies on two GitHub Apps with different scopes:
 
 Additional requirement:
 - `COMMIT_APP` must be allowed in branch protection bypass rules for `dev` so sync commits can be pushed by automation.
-- `RELEASE_APP` must be installed on the validation repository with Contents read and Actions read/write permissions so `release.yml` can send `repository_dispatch` and `repository-dispatch.yml` can trigger downstream workflow dispatch events for candidate and final release validation.
+- `RELEASE_APP` must be installed on the validation repository (`vig-os/devcontainer-smoke-test`) with Contents read and Actions read/write permissions so `release.yml` can send `repository_dispatch` and `repository-dispatch.yml` can trigger workflow runs there for candidate and final release validation.
 
 #### prepare-release.yml (Release Preparation Workflow)
 
@@ -586,7 +602,7 @@ gh workflow run prepare-release.yml --ref dev -f "version=1.0.0" -f "dry-run=tru
    - Computes publish tag (`X.Y.Z-rcN` for candidate, `X.Y.Z` for final)
    - Verifies release branch exists
    - Checks CHANGELOG has `[X.Y.Z] - TBD`
-   - Confirms publish tag doesn't exist
+   - For **final**: rejects a **published** GitHub Release for the publish tag; allows an existing **draft** (retry path)
    - Verifies PR: not draft, approved, CI passed
    - Records pre-finalization commit for rollback
    - Outputs: PR number, release date, pre-finalization SHA, publish tag metadata
@@ -594,6 +610,7 @@ gh workflow run prepare-release.yml --ref dev -f "version=1.0.0" -f "dry-run=tru
 2. **finalize** (skipped if dry-run) - Conditionally updates release branch
    - **Candidate**: No CHANGELOG changes, no sync-issues. Outputs current release branch HEAD SHA.
    - **Final**: Sets release date in CHANGELOG (TBD → YYYY-MM-DD), regenerates docs, commits all tracked finalization changes via dynamic file list, refreshes release PR body from finalized changelog content, triggers sync-issues, outputs finalized SHA.
+   - After computing `finalize_sha`, checks whether the remote publish tag already points at that SHA (retry path; skips redundant tag push in **publish**).
 
 3. **build-and-test** (matrix: amd64, arm64) - Builds and validates images
    - Builds container image for architecture
@@ -604,24 +621,23 @@ gh workflow run prepare-release.yml --ref dev -f "version=1.0.0" -f "dry-run=tru
 
 4. **publish** (runs if all builds/tests pass) - Creates tag and publishes
    - Candidate mode creates and pushes `X.Y.Z-rcN` (next available `N`)
-   - Final mode creates and pushes `X.Y.Z`
-   - Pushes tag
-   - Final mode only: publishes GitHub Release `X.Y.Z` with notes sourced from finalized `CHANGELOG.md`
+   - Final mode creates and pushes `X.Y.Z` unless the tag already exists at `finalize_sha`
+   - Final mode only: creates a **draft** GitHub Release `X.Y.Z` with notes sourced from finalized `CHANGELOG.md`
    - Downloads tested images from artifacts
    - Pushes images to GHCR
    - Creates multi-architecture manifest for computed publish tag
    - Updates `latest` only in final mode
    - Verifies manifests exist
 
-5. **smoke-test** (runs after publish) - Triggers downstream validation
+5. **smoke-test** (runs after publish) - Triggers `repository_dispatch` on `vig-os/devcontainer-smoke-test` (validation repo)
    - Candidate and final modes trigger cross-repository validation `repository_dispatch` with `client_payload[tag]=<publish-tag>`
    - Dispatch failures mark the workflow as failed and create a targeted issue
-   - Dispatch failures do **not** rollback branch/tag, because published artifacts are already immutable at this point
+   - Dispatch failures do **not** rollback branch/tag: publish outputs are already public. Only a **published** GitHub Release locks its tag via **immutable releases**; RC tags in this repo have no release object. Automation still avoids tag deletion (forward-fix policy).
 
 6. **rollback** (runs if validate/finalize/build-and-test/publish fails) - Cleans up partial state
-   - Resets release branch to pre-finalization state
-   - Deletes tag if it was created
-   - Creates GitHub issue with failure details
+   - Resets release branch to pre-finalization state (best-effort)
+   - Does **not** delete tags (forward-fix policy)
+   - Creates GitHub issue with failure details and forward-fix guidance
 
 **Manual trigger (for testing):**
 
@@ -643,7 +659,8 @@ gh workflow run release.yml \
 
 **Key characteristics:**
 - Tag created AFTER successful build/test (safer than before)
-- Automatic rollback on validate/finalize/build-and-test/publish failure
+- Final GitHub Release is a **draft** until a human publishes it from the UI
+- Automatic rollback resets the release branch only; tags are not deleted (forward-fix policy)
 - All in one workflow for atomic operation
 - Audit trail in GitHub Actions logs
 - Dispatch is pinned to `release/X.Y.Z` so candidate/final runs use the release branch workflow definition
@@ -709,19 +726,10 @@ gh workflow run release.yml \
 
 ---
 
-## Downstream Integration
+## Related documentation
 
-Downstream repositories that use the workspace template consume release workflows from:
-
-- `assets/workspace/.github/workflows/prepare-release.yml`
-- `assets/workspace/.github/workflows/release.yml`
-- `assets/workspace/.github/workflows/release-core.yml`
-- `assets/workspace/.github/workflows/release-extension.yml`
-- `assets/workspace/.github/workflows/release-publish.yml`
-
-The orchestrator (`release.yml`) runs core -> extension -> publish and uses contract validation for local `workflow_call` interfaces. Cross-repository validation details are documented in `docs/CROSS_REPO_RELEASE_GATE.md`.
-
-For contract details and extension ownership boundaries, see `docs/DOWNSTREAM_RELEASE.md`.
+- **[Downstream release workflows](DOWNSTREAM_RELEASE.md)** — release process for **consumer projects** that deploy templates from `assets/workspace/` (prepare-release, release orchestration, extension hook, publish). This guide does not duplicate that material.
+- **[Cross-repo release validation gate](CROSS_REPO_RELEASE_GATE.md)** — contract between this repo’s `release.yml` and `vig-os/devcontainer-smoke-test` (`repository_dispatch`, RC/final gates).
 
 ## QMS and Compliance
 
@@ -880,19 +888,15 @@ gh run view <RUN_ID>
 # If it failed, check the sync-issues workflow logs and fix the issue
 ```
 
-#### "Tag already exists"
+#### "Tag already exists" / wrong tag target
 
-**Cause:** A previous release attempt didn't clean up the tag
+**Cause:** A previous run pushed the tag, or the tag points at a different commit than the current finalized release.
 
 **Solution:**
 
-```bash
-# Delete the old tag
-git push origin :refs/tags/<VERSION>
-
-# Try again
-just finalize-release <VERSION>
-```
+- If the tag already points at the **same** finalized commit, re-run `just finalize-release <VERSION>`: the workflow skips re-pushing the tag and can complete the draft release step.
+- If the tag points at the **wrong** commit, do **not** delete or move the tag when GitHub blocks it (published **immutable release** for that tag, or a restrictive **tag ruleset**)—publish a **new release candidate** with fixes, then run the final release again when ready.
+- For a mistaken **draft** GitHub Release only, you may edit or delete the draft from the Releases UI per repository policy.
 
 ### Recovery Procedures
 
@@ -921,8 +925,8 @@ gh issue list --label release
 
 # 3. Examine what was rolled back (issue will document this)
 # The workflow automatically:
-#   - Reset release branch to pre-finalization state
-#   - Deleted any tag that was created
+#   - Reset release branch to pre-finalization state (best-effort)
+#   - Left any pushed tags in place (forward-fix policy)
 #   - Created this issue for investigation
 
 # 4. Fix the underlying issue on the release branch
@@ -936,7 +940,7 @@ git commit -m "fix: address release issue
 Refs: #<ISSUE_NUMBER>"
 git push origin release/X.Y.Z
 
-# 5. Re-run the workflow
+# 5. Re-run the workflow (or publish a new RC first if the tag already exists at the wrong commit)
 just finalize-release X.Y.Z
 ```
 
@@ -952,10 +956,8 @@ git checkout release/X.Y.Z
 git reset --hard $PRE_SHA
 git push --force-with-lease origin release/X.Y.Z
 
-# Delete tag if it exists
-git push origin :refs/tags/X.Y.Z
-
-# Fix the issue and re-run workflow
+# Do not delete or force-move release tags when a tag ruleset or published immutable release blocks it.
+# Fix forward with a new RC, then re-run the final workflow when ready.
 just finalize-release X.Y.Z
 ```
 
@@ -1000,7 +1002,7 @@ Follow [Semantic Versioning 2.0.0](https://semver.org/):
 
 - [CHANGELOG Format](../CHANGELOG.md) - Keep a Changelog standard
 - [Commit Message Standard](COMMIT_MESSAGE_STANDARD.md) - Commit format and validation
-- [Downstream Release Workflows](DOWNSTREAM_RELEASE.md) - Downstream release contract and extension model
+- [Downstream Release Workflows](DOWNSTREAM_RELEASE.md) - Release process for consumer projects using `assets/workspace/` templates (not this repo’s pipeline)
 - [Branch Naming Rules](../.cursor/rules/branch-naming.mdc) - Topic branch conventions
 - [IEC 62304](https://www.iso.org/standard/38421.html) - Medical device software lifecycle
 - [Semantic Versioning](https://semver.org/) - Version numbering scheme


### PR DESCRIPTION
## Description

Aligns release automation with GitHub **immutable releases** and **draft-first** practice for finals: `release.yml` creates a **draft** GitHub Release for human review, allows retry when a draft or matching remote tag already exists, skips redundant tag push when the tag peels to the finalize SHA, and stops deleting remote tags on rollback (forward-fix policy). Workspace downstream workflows, smoke-test dispatch guidance, and release docs are updated to match.

## Type of Change

- [ ] `feat` -- New feature
- [ ] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [x] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- **`.github/workflows/release.yml`** — Draft final GitHub Release; validate/publish tolerate existing draft vs published; `tag_state` / skip tag create-push when remote tag matches finalize SHA; rollback removes tag deletion step; summaries and failure issues document forward-fix and draft handling.
- **`assets/workspace/.github/workflows/release-core.yml`** — Move tag-vs-SHA check to finalize job; expose `tag_already_exists`; drop blunt “tag must not exist” validate gate.
- **`assets/workspace/.github/workflows/release-publish.yml`** — Input `tag_already_exists`; conditional tag step; draft final release create; draft/prerelease retry semantics for candidates.
- **`assets/workspace/.github/workflows/release.yml`** — Pass `tag_already_exists`; rollback no longer deletes tags; issue body updated.
- **`assets/smoke-test/.github/workflows/repository-dispatch.yml`** — Failure copy: immutable/published release guidance and fresh RC dispatch.
- **`docs/RELEASE_CYCLE.md`**, **`docs/DOWNSTREAM_RELEASE.md`**, **`docs/CROSS_REPO_RELEASE_GATE.md`** — Immutable releases vs tag rulesets, operator steps, downstream scope, recovery.
- **`CHANGELOG.md`** and **`assets/workspace/.devcontainer/CHANGELOG.md`** — `## [0.3.1] - TBD` entry for #446 (template mirror).

**Commits (vs `release/0.3.1`):** `1bb5f78` — feat(ci): draft final releases, idempotent tags, and forward-fix rollback

## Changelog Entry

On this branch the active section is `## [0.3.1] - TBD` (not `## Unreleased`). Added under **### Changed**:

```markdown
- **Immutable GitHub releases, tag rulesets, and forward-fix policy** ([#446](https://github.com/vig-os/devcontainer/issues/446))
  - Final releases create a **draft** GitHub Release for human review before publishing; rollback no longer deletes remote tags
  - Release workflows skip redundant tag push when the tag already matches the finalized commit; workspace `release-core` / `release-publish` and smoke-test failure guidance updated accordingly
  - Document tag rulesets, immutable releases, and recovery in `docs/RELEASE_CYCLE.md`, `docs/DOWNSTREAM_RELEASE.md`, and `docs/CROSS_REPO_RELEASE_GATE.md`
```

## Testing

- [ ] Tests pass locally (`just test`)
- [ ] Manual testing performed (describe below)

### Manual Testing Details

N/A — workflow and documentation changes; validate in Actions on merge / release dry-run as appropriate.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` under `## [0.3.1] - TBD` (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

Target base is **`release/0.3.1`** (release train), not `dev`. Operators must **publish** the draft GitHub Release from the UI when ready for finals; see `docs/RELEASE_CYCLE.md`.

Refs: #446
