### PR TITLE
fix(ci): use H1 release title and drop Release Content in PR bodies

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -295,11 +295,9 @@ jobs:
         run: |
           set -euo pipefail
 
-          PR_BODY="## Release $VERSION
+          PR_BODY="# Release $VERSION
 
           This PR prepares release $VERSION for merge to main.
-
-          ### Release Content
 
           $CHANGELOG_CONTENT
           "

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -731,8 +731,6 @@ jobs:
 
           This PR prepares release $VERSION for merge to main.
 
-          ### Release Content
-
           $CHANGELOG_CONTENT
           EOF
 

--- a/assets/workspace/.github/workflows/prepare-release.yml
+++ b/assets/workspace/.github/workflows/prepare-release.yml
@@ -286,11 +286,9 @@ jobs:
           CHANGELOG_CONTENT: ${{ steps.changelog.outputs.changelog }}
         run: |
           set -euo pipefail
-          PR_BODY="## Release $VERSION
+          PR_BODY="# Release $VERSION
 
           This PR prepares release $VERSION for merge to main.
-
-          ### Release Content
 
           $CHANGELOG_CONTENT
           "


### PR DESCRIPTION
## Description

Release PR bodies from `prepare-release` and the finalize step in `release.yml` used `## Release` plus a redundant `### Release Content` wrapper, so the Keep a Changelog `## [version]` block was nested under an extra heading. This PR uses `# Release $VERSION` for draft PRs, keeps the existing linked H1 on finalize, and removes `### Release Content` everywhere. Downstream consumer template under `assets/workspace/` is kept in sync.

## Type of Change

- [ ] `feat` -- New feature
- [ ] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [x] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- `.github/workflows/prepare-release.yml` — Draft PR `PR_BODY`: H1 `# Release $VERSION`, drop `### Release Content`, changelog slice unchanged.
- `.github/workflows/release.yml` — Finalize refresh heredoc: drop `### Release Content`; keep `# [Release …](tag) - date` and intro.
- `assets/workspace/.github/workflows/prepare-release.yml` — Mirror draft PR body formatting for downstream installs.

## Changelog Entry

No changelog needed — internal automation / PR body Markdown only; issue #449 tracked as no user-facing CHANGELOG entry.

## Testing

- [ ] Tests pass locally (`just test`)
- [x] Manual testing performed (describe below)

### Manual Testing Details

- `rg` over workflow paths: no `### Release Content`, no `PR_BODY="## Release`; both `prepare-release.yml` files contain `PR_BODY="# Release`.
- Pre-commit passed on commit `fix(ci): use H1 release title and drop Release Content in PR bodies`.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [ ] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

Targets **release/0.3.1** so the fix can ride the current release line. See issue #449 for acceptance criteria.

Refs: #449

