### PR TITLE
fix: coerce workspace release tag_already_exists for workflow_call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -206,6 +206,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Release tag resolution and GitHub Release view retries** ([#446](https://github.com/vig-os/devcontainer/issues/446))
   - Fall back to plain `refs/tags/<tag>` when the peeled ref is empty (lightweight remote tags) in `.github/workflows/release.yml`, `release-core.yml`, and `release-publish.yml`
   - Use one retried `gh release view` in workspace `release-publish.yml` so draft/prerelease skip paths parse JSON from the same successful response
+- **Workspace release publish `tag_already_exists` input coercion** ([#451](https://github.com/vig-os/devcontainer/issues/451))
+  - Pass a boolean into `release-publish.yml` via `needs.core.outputs.tag_already_exists == 'true'` so `workflow_call` does not reject string `"true"`/`"false"` job outputs
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Final releases create a **draft** GitHub Release for human review before publishing; rollback no longer deletes remote tags
   - Release workflows skip redundant tag push when the tag already matches the finalized commit; workspace `release-core` / `release-publish` and smoke-test failure guidance updated accordingly
   - Document tag rulesets, immutable releases, and recovery in `docs/RELEASE_CYCLE.md`, `docs/DOWNSTREAM_RELEASE.md`, and `docs/CROSS_REPO_RELEASE_GATE.md`
+- **Container image tests expect current GitHub CLI minor line**
+  - Update `tests/test_image.py` `EXPECTED_VERSIONS["gh"]` to `2.89.` to match the CLI shipped in the image
 
 ### Removed
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -206,6 +206,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Release tag resolution and GitHub Release view retries** ([#446](https://github.com/vig-os/devcontainer/issues/446))
   - Fall back to plain `refs/tags/<tag>` when the peeled ref is empty (lightweight remote tags) in `.github/workflows/release.yml`, `release-core.yml`, and `release-publish.yml`
   - Use one retried `gh release view` in workspace `release-publish.yml` so draft/prerelease skip paths parse JSON from the same successful response
+- **Workspace release publish `tag_already_exists` input coercion** ([#451](https://github.com/vig-os/devcontainer/issues/451))
+  - Pass a boolean into `release-publish.yml` via `needs.core.outputs.tag_already_exists == 'true'` so `workflow_call` does not reject string `"true"`/`"false"` job outputs
 
 ### Security
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -79,6 +79,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Final releases create a **draft** GitHub Release for human review before publishing; rollback no longer deletes remote tags
   - Release workflows skip redundant tag push when the tag already matches the finalized commit; workspace `release-core` / `release-publish` and smoke-test failure guidance updated accordingly
   - Document tag rulesets, immutable releases, and recovery in `docs/RELEASE_CYCLE.md`, `docs/DOWNSTREAM_RELEASE.md`, and `docs/CROSS_REPO_RELEASE_GATE.md`
+- **Container image tests expect current GitHub CLI minor line**
+  - Update `tests/test_image.py` `EXPECTED_VERSIONS["gh"]` to `2.89.` to match the CLI shipped in the image
 
 ### Removed
 

--- a/assets/workspace/.github/workflows/release.yml
+++ b/assets/workspace/.github/workflows/release.yml
@@ -104,7 +104,7 @@ jobs:
       release_kind: ${{ needs.core.outputs.release_kind }}
       git_user_name: ${{ inputs.git-user-name }}
       git_user_email: ${{ inputs.git-user-email }}
-      tag_already_exists: ${{ needs.core.outputs.tag_already_exists }}
+      tag_already_exists: ${{ needs.core.outputs.tag_already_exists == 'true' }}
     secrets: inherit
 
   rollback:

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -19,7 +19,7 @@ import pytest
 EXPECTED_VERSIONS = {
     "git": "2.",  # Major version check (from apt package)
     "curl": "8.",  # Major version check (from apt package)
-    "gh": "2.88.",  # Minor version check (GitHub CLI (manually installed from latest release)
+    "gh": "2.89.",  # Minor version check (GitHub CLI (manually installed from latest release)
     "uv": "0.11.",  # Minor version check (manually installed from latest release)
     "python": "3.12",  # Python (from base image)
     "pre_commit": "4.5.",  # Minor version check (installed via uv pip)


### PR DESCRIPTION
## Description

Smoke-test orchestration failed for `0.3.1-rc24` because the workspace `release.yml` passed `needs.core.outputs.tag_already_exists` (a string from job outputs) into `release-publish.yml`, which declares that input as `type: boolean`. GitHub Actions rejects the reusable workflow call, so the Publish job never spawns sub-jobs and the downstream Release run fails. This PR coerces the value with `== 'true'` so the call receives a real boolean.

## Type of Change

- [ ] `feat` -- New feature
- [x] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [ ] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- `assets/workspace/.github/workflows/release.yml` — pass `tag_already_exists: ${{ needs.core.outputs.tag_already_exists == 'true' }}` into `release-publish.yml`.
- `CHANGELOG.md` — document the fix under `## [0.3.1] - TBD` → **Fixed**.
- `assets/workspace/.devcontainer/CHANGELOG.md` — same entry (workspace SSoT mirror).

## Changelog Entry

Pasted from `CHANGELOG.md` on this branch (under `## [0.3.1] - TBD` → **Fixed**; this release branch uses the TBD section instead of `## Unreleased`):

```markdown
- **Workspace release publish `tag_already_exists` input coercion** ([#451](https://github.com/vig-os/devcontainer/issues/451))
  - Pass a boolean into `release-publish.yml` via `needs.core.outputs.tag_already_exists == 'true'` so `workflow_call` does not reject string `"true"`/`"false"` job outputs
```

## Testing

- [ ] Tests pass locally (`just test`)
- [ ] Manual testing performed (describe below)

### Manual Testing Details

N/A — workflow expression change only; behavior verified via RCA against failed run logs. Follow-up validation is a new smoke-test dispatch after template reaches the validation repo.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [ ] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

RCA draft for posting on the issue: `docs/issues/issue-451-github-comment.md` (optional).

Refs: #451
