### PR TITLE
fix: finalize release sync and changelog verification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -643,63 +643,6 @@ jobs:
             Refs: #${{ needs.validate.outputs.pr_number }}
           FILE_PATHS: ${{ steps.finalize-files.outputs.file_paths }}
 
-      - name: Trigger sync-issues workflow
-        if: needs.validate.outputs.release_kind == 'final'
-        env:
-          GH_TOKEN: ${{ github.token }}
-          VERSION: ${{ needs.validate.outputs.version }}
-        run: |
-          set -euo pipefail
-          echo "Triggering sync-issues workflow..."
-          retry --retries 2 --backoff 5 --max-backoff 20 -- gh workflow run sync-issues.yml \
-            -f "target-branch=release/$VERSION"
-          echo "✓ sync-issues workflow triggered"
-
-      - name: Wait for sync-issues completion
-        if: needs.validate.outputs.release_kind == 'final'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          TIMEOUT=120
-          ELAPSED=0
-          INTERVAL=10
-
-          sleep 5
-          ELAPSED=5
-
-          while [ $ELAPSED -lt $TIMEOUT ]; do
-            RUN_STATUS=$(gh run list \
-              --workflow sync-issues.yml \
-              --limit 1 \
-              --json status,conclusion \
-              --jq '.[0].status' 2>/dev/null || echo "unknown")
-
-            if [ "$RUN_STATUS" = "completed" ]; then
-              RUN_CONCLUSION=$(gh run list \
-                --workflow sync-issues.yml \
-                --limit 1 \
-                --json conclusion \
-                --jq '.[0].conclusion' 2>/dev/null || echo "unknown")
-
-              if [ "$RUN_CONCLUSION" = "success" ]; then
-                echo "✓ sync-issues workflow completed successfully"
-              else
-                echo "⚠ sync-issues workflow completed with status: $RUN_CONCLUSION"
-              fi
-              break
-            fi
-
-            sleep "$INTERVAL"
-            ELAPSED=$((ELAPSED + INTERVAL))
-            echo "Waiting for sync-issues... (${ELAPSED}s / ${TIMEOUT}s)"
-          done
-
-          if [ $ELAPSED -ge $TIMEOUT ]; then
-            echo "⚠ Timed out waiting for sync-issues workflow"
-            echo "The release may continue, but PR documentation may not be synced"
-          fi
-
       - name: Pull remote changes
         if: needs.validate.outputs.release_kind == 'final'
         env:
@@ -709,6 +652,18 @@ jobs:
           retry --retries 3 --backoff 3 --max-backoff 20 -- git fetch origin "release/$VERSION"
           git reset --hard "origin/release/$VERSION"
           echo "✓ Synced with remote release branch"
+
+      - name: Verify CHANGELOG finalized (no TBD)
+        if: needs.validate.outputs.release_kind == 'final'
+        env:
+          VERSION: ${{ needs.validate.outputs.version }}
+        run: |
+          set -euo pipefail
+          if grep -q "## \[$VERSION\] - TBD" CHANGELOG.md; then
+            echo "ERROR: CHANGELOG.md still contains TBD for $VERSION after finalize commit"
+            exit 1
+          fi
+          echo "✓ CHANGELOG.md has finalized date for $VERSION"
 
       - name: Refresh release PR body from finalized changelog
         if: needs.validate.outputs.release_kind == 'final'
@@ -782,6 +737,63 @@ jobs:
           fi
           echo "tag_already_exists=true" >> "$GITHUB_OUTPUT"
           echo "Remote tag $PUBLISH_VERSION already points to finalize SHA; publish will skip tag create/push"
+
+      - name: Trigger sync-issues workflow
+        if: needs.validate.outputs.release_kind == 'final'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs.validate.outputs.version }}
+        run: |
+          set -euo pipefail
+          echo "Triggering sync-issues workflow..."
+          retry --retries 2 --backoff 5 --max-backoff 20 -- gh workflow run sync-issues.yml \
+            -f "target-branch=release/$VERSION"
+          echo "✓ sync-issues workflow triggered"
+
+      - name: Wait for sync-issues completion
+        if: needs.validate.outputs.release_kind == 'final'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          TIMEOUT=120
+          ELAPSED=0
+          INTERVAL=10
+
+          sleep 5
+          ELAPSED=5
+
+          while [ $ELAPSED -lt $TIMEOUT ]; do
+            RUN_STATUS=$(gh run list \
+              --workflow sync-issues.yml \
+              --limit 1 \
+              --json status,conclusion \
+              --jq '.[0].status' 2>/dev/null || echo "unknown")
+
+            if [ "$RUN_STATUS" = "completed" ]; then
+              RUN_CONCLUSION=$(gh run list \
+                --workflow sync-issues.yml \
+                --limit 1 \
+                --json conclusion \
+                --jq '.[0].conclusion' 2>/dev/null || echo "unknown")
+
+              if [ "$RUN_CONCLUSION" = "success" ]; then
+                echo "✓ sync-issues workflow completed successfully"
+              else
+                echo "⚠ sync-issues workflow completed with status: $RUN_CONCLUSION"
+              fi
+              break
+            fi
+
+            sleep "$INTERVAL"
+            ELAPSED=$((ELAPSED + INTERVAL))
+            echo "Waiting for sync-issues... (${ELAPSED}s / ${TIMEOUT}s)"
+          done
+
+          if [ $ELAPSED -ge $TIMEOUT ]; then
+            echo "⚠ Timed out waiting for sync-issues workflow"
+            echo "The release may continue, but PR documentation may not be synced"
+          fi
 
   build-and-test:
     name: Build and Test (${{ matrix.arch }})

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -659,7 +659,7 @@ jobs:
           VERSION: ${{ needs.validate.outputs.version }}
         run: |
           set -euo pipefail
-          if grep -q "## \[$VERSION\] - TBD" CHANGELOG.md; then
+          if grep -Fq "## [${VERSION}] - TBD" CHANGELOG.md; then
             echo "ERROR: CHANGELOG.md still contains TBD for $VERSION after finalize commit"
             exit 1
           fi
@@ -674,7 +674,11 @@ jobs:
           PR_NUMBER: ${{ needs.validate.outputs.pr_number }}
         run: |
           set -euo pipefail
-          CHANGELOG_CONTENT=$(sed -n "/## \[$VERSION\]/,/^## \[/p" CHANGELOG.md | sed '$d')
+          CHANGELOG_CONTENT=$(awk -v hdr="## [${VERSION}]" '
+            index($0, hdr) == 1 { p = 1; print; next }
+            p && /^## \[/ { exit }
+            p { print }
+          ' CHANGELOG.md)
 
           if [ -z "$CHANGELOG_CONTENT" ]; then
             echo "ERROR: Could not extract release section for version $VERSION from CHANGELOG.md"
@@ -738,51 +742,54 @@ jobs:
           echo "tag_already_exists=true" >> "$GITHUB_OUTPUT"
           echo "Remote tag $PUBLISH_VERSION already points to finalize SHA; publish will skip tag create/push"
 
-      - name: Trigger sync-issues workflow
+      - name: Trigger sync-issues workflow and wait
         if: needs.validate.outputs.release_kind == 'final'
         env:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ needs.validate.outputs.version }}
         run: |
           set -euo pipefail
+          TIMEOUT=120
+          INTERVAL=10
+          ELAPSED=0
+
+          declare -A before_map=()
+          while read -r id; do
+            [ -z "$id" ] && continue
+            before_map[$id]=1
+          done < <(gh run list --workflow sync-issues.yml --json databaseId --jq -r '.[].databaseId')
+
           echo "Triggering sync-issues workflow..."
           retry --retries 2 --backoff 5 --max-backoff 20 -- gh workflow run sync-issues.yml \
             -f "target-branch=release/$VERSION"
           echo "✓ sync-issues workflow triggered"
 
-      - name: Wait for sync-issues completion
-        if: needs.validate.outputs.release_kind == 'final'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          TIMEOUT=120
-          ELAPSED=0
-          INTERVAL=10
+          RUN_ID=""
+          sleep 3
+          ELAPSED=3
 
-          sleep 5
-          ELAPSED=5
+          while [ "$ELAPSED" -lt "$TIMEOUT" ]; do
+            if [ -z "$RUN_ID" ]; then
+              while read -r id; do
+                [ -z "$id" ] && continue
+                [ -n "${before_map[$id]+x}" ] && continue
+                RUN_ID=$id
+                echo "Resolved sync-issues run id: $RUN_ID"
+                break
+              done < <(gh run list --workflow sync-issues.yml --json databaseId --jq -r '.[].databaseId')
+            fi
 
-          while [ $ELAPSED -lt $TIMEOUT ]; do
-            RUN_STATUS=$(gh run list \
-              --workflow sync-issues.yml \
-              --limit 1 \
-              --json status,conclusion \
-              --jq '.[0].status' 2>/dev/null || echo "unknown")
-
-            if [ "$RUN_STATUS" = "completed" ]; then
-              RUN_CONCLUSION=$(gh run list \
-                --workflow sync-issues.yml \
-                --limit 1 \
-                --json conclusion \
-                --jq '.[0].conclusion' 2>/dev/null || echo "unknown")
-
-              if [ "$RUN_CONCLUSION" = "success" ]; then
-                echo "✓ sync-issues workflow completed successfully"
-              else
-                echo "⚠ sync-issues workflow completed with status: $RUN_CONCLUSION"
+            if [ -n "$RUN_ID" ]; then
+              RUN_STATUS=$(gh run view "$RUN_ID" --json status --jq -r '.status' 2>/dev/null || echo "unknown")
+              if [ "$RUN_STATUS" = "completed" ]; then
+                RUN_CONCLUSION=$(gh run view "$RUN_ID" --json conclusion --jq -r '.conclusion' 2>/dev/null || echo "unknown")
+                if [ "$RUN_CONCLUSION" = "success" ]; then
+                  echo "✓ sync-issues workflow completed successfully"
+                else
+                  echo "⚠ sync-issues workflow completed with status: $RUN_CONCLUSION"
+                fi
+                break
               fi
-              break
             fi
 
             sleep "$INTERVAL"
@@ -790,7 +797,7 @@ jobs:
             echo "Waiting for sync-issues... (${ELAPSED}s / ${TIMEOUT}s)"
           done
 
-          if [ $ELAPSED -ge $TIMEOUT ]; then
+          if [ "$ELAPSED" -ge "$TIMEOUT" ]; then
             echo "⚠ Timed out waiting for sync-issues workflow"
             echo "The release may continue, but PR documentation may not be synced"
           fi

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -107,7 +107,7 @@ repos:
         name: generate-docs (regenerate from templates)
         entry: uv run python docs/generate.py
         language: system
-        files: ^(docs/templates/.*\.j2|docs/narrative/.*\.md|scripts/requirements\.yaml|justfile)$
+        files: ^(docs/templates/.*\.j2|docs/narrative/.*\.md|scripts/requirements\.yaml|justfile|CHANGELOG\.md)$
         pass_filenames: false
 
   # Workspace sync (keep assets/workspace in sync with manifest)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Git commit now falls back to nano when editor config is unusable** ([#383](https://github.com/vig-os/devcontainer/issues/383))
   - `setup-git-conf.sh` now validates the effective Git editor and sets `core.editor=nano` only when the configured editor is missing or invalid in-container
   - Add integration regression coverage to ensure invalid editor settings are corrected during setup
+- **Release finalize no longer races sync-issues; CHANGELOG TBD verified after reset** ([#455](https://github.com/vig-os/devcontainer/issues/455))
+  - Run `sync-issues` after capturing finalize SHA so downstream build/publish use the finalized commit
+  - Fail finalize if `CHANGELOG.md` still contains `## [version] - TBD` after `git reset --hard`
+- **generate-docs pre-commit runs when CHANGELOG.md changes** ([#455](https://github.com/vig-os/devcontainer/issues/455))
+  - Keeps README “Latest Version” and other generated docs aligned with the changelog
 
 ### Security
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -24,6 +24,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Git commit now falls back to nano when editor config is unusable** ([#383](https://github.com/vig-os/devcontainer/issues/383))
   - `setup-git-conf.sh` now validates the effective Git editor and sets `core.editor=nano` only when the configured editor is missing or invalid in-container
   - Add integration regression coverage to ensure invalid editor settings are corrected during setup
+- **Release finalize no longer races sync-issues; CHANGELOG TBD verified after reset** ([#455](https://github.com/vig-os/devcontainer/issues/455))
+  - Run `sync-issues` after capturing finalize SHA so downstream build/publish use the finalized commit
+  - Fail finalize if `CHANGELOG.md` still contains `## [version] - TBD` after `git reset --hard`
+- **generate-docs pre-commit runs when CHANGELOG.md changes** ([#455](https://github.com/vig-os/devcontainer/issues/455))
+  - Keeps README “Latest Version” and other generated docs aligned with the changelog
 
 ### Security
 

--- a/tests/bats/just.bats
+++ b/tests/bats/just.bats
@@ -56,7 +56,7 @@ setup() {
 }
 
 @test "release workflow refreshes release PR body from changelog" {
-    run bash -lc 'grep -Fq -- "name: Refresh release PR body from finalized changelog" .github/workflows/release.yml && grep -Fq -- "CHANGELOG_CONTENT=\$(sed -n" .github/workflows/release.yml && grep -Fq -- "gh pr edit \"\$PR_NUMBER\" --body-file /tmp/release-pr-body.md" .github/workflows/release.yml'
+    run bash -lc 'grep -Fq -- "name: Refresh release PR body from finalized changelog" .github/workflows/release.yml && grep -Fq -- "CHANGELOG_CONTENT=\$(awk" .github/workflows/release.yml && grep -Fq -- "gh pr edit \"\$PR_NUMBER\" --body-file /tmp/release-pr-body.md" .github/workflows/release.yml'
     assert_success
 }
 


### PR DESCRIPTION
## Description

Reorders release finalize so `sync-issues` runs after the finalize SHA is captured, avoiding a race where downstream build/publish could use a pre-finalize commit. Finalize now fails if `CHANGELOG.md` still contains `## [version] - TBD` after `git reset --hard`. Pre-commit runs `generate-docs` when `CHANGELOG.md` changes so generated README sections stay aligned with the changelog.

## Type of Change

- [ ] `feat` -- New feature
- [x] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [ ] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- `.github/workflows/release.yml` — finalize job: capture SHA, then `sync-issues`; verify no TBD changelog line after reset; related step ordering and conditions
- `.pre-commit-config.yaml` — run `generate-docs` when `CHANGELOG.md` changes
- `CHANGELOG.md` — Unreleased Fixed entries for #455
- `assets/workspace/.devcontainer/CHANGELOG.md` — synced Unreleased Fixed entries for #455

## Changelog Entry

### Fixed

- **Release finalize no longer races sync-issues; CHANGELOG TBD verified after reset** ([#455](https://github.com/vig-os/devcontainer/issues/455))
  - Run `sync-issues` after capturing finalize SHA so downstream build/publish use the finalized commit
  - Fail finalize if `CHANGELOG.md` still contains `## [version] - TBD` after `git reset --hard`
- **generate-docs pre-commit runs when CHANGELOG.md changes** ([#455](https://github.com/vig-os/devcontainer/issues/455))
  - Keeps README "Latest Version" and other generated docs aligned with the changelog

## Testing

- [ ] Tests pass locally (`just test`)
- [ ] Manual testing performed (describe below)

### Manual Testing Details

N/A. Local `just test`: 268 passed, 2 failed — `test_manifest_files` (workspace `CHANGELOG.md` checksum vs `TEST_CONTAINER_TAG=dev` image; likely stale image vs working tree) and `test_setup_git_conf_falls_back_to_nano_for_invalid_editor` (unrelated to workflow/pre-commit changes in this branch).

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

N/A

Refs: #455
