### PR TITLE
ci: split final release into publish and promote phases

### DIFF
--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -141,7 +141,7 @@ jobs:
           REPO="ghcr.io/vig-os/devcontainer"
           retry --retries 3 --backoff 10 --max-backoff 30 -- \
             cosign verify "$REPO:$VERSION" \
-              --certificate-identity-regexp='https://github.com/vig-os/devcontainer/' \
+              --certificate-identity-regexp='https://github.com/vig-os/devcontainer/.github/workflows/release.yml@refs/heads/release/' \
               --certificate-oidc-issuer='https://token.actions.githubusercontent.com'
           echo "✓ Cosign verification passed for $REPO:$VERSION"
 

--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -1,0 +1,472 @@
+# Promote Release — after publish (finalize) workflow
+#
+# Run after release.yml (final) has produced versioned GHCR images, draft GitHub Release,
+# and downstream smoke-test has published a non-draft, non-prerelease release for the same tag.
+#
+# 1. validate: GHCR X.Y.Z + cosign, draft release on this repo, downstream final release
+# 2. promote: GHCR :latest manifest, publish (undraft) GitHub Release
+# 3. merge: merge release/X.Y.Z PR to main (triggers sync-main-to-dev)
+
+name: Promote Release
+
+on:  # yamllint disable-line rule:truthy
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Semantic version to promote (e.g., 1.2.3)'
+        required: true
+        type: string
+      architectures:
+        description: 'Architectures that were published (comma-separated: amd64,arm64)'
+        required: false
+        default: 'amd64,arm64'
+        type: string
+
+concurrency:
+  group: publish-image
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Validate promote prerequisites
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      packages: read
+    outputs:
+      version: ${{ steps.vars.outputs.version }}
+      architectures: ${{ steps.vars.outputs.architectures }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Set up environment
+        uses: ./.github/actions/setup-env
+        with:
+          install-python: 'false'
+          install-just: 'false'
+
+      - name: Validate version and architectures
+        id: vars
+        env:
+          INPUT_VERSION: ${{ github.event.inputs.version }}
+          INPUT_ARCHITECTURES: ${{ github.event.inputs.architectures }}
+        run: |
+          set -euo pipefail
+          VERSION="$INPUT_VERSION"
+          if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "ERROR: Invalid version format '$VERSION'"
+            echo "Version must follow semantic versioning: MAJOR.MINOR.PATCH (e.g., 1.2.3)"
+            exit 1
+          fi
+
+          ARCHS=$(echo "$INPUT_ARCHITECTURES" | tr -d ' ')
+          IFS=',' read -ra ARCH_ARRAY <<< "$ARCHS"
+          VALID_ARCHS="amd64 arm64"
+          VALIDATED_ARCHS=()
+          for arch in "${ARCH_ARRAY[@]}"; do
+            [ -z "$arch" ] && continue
+            if [[ " $VALID_ARCHS " =~ " $arch " ]]; then
+              VALIDATED_ARCHS+=("$arch")
+            else
+              echo "ERROR: Invalid architecture '$arch'"
+              exit 1
+            fi
+          done
+          UNIQUE_ARCHS=($(echo "${VALIDATED_ARCHS[@]}" | tr ' ' '\n' | sort -u))
+          if [ ${#UNIQUE_ARCHS[@]} -ne ${#VALIDATED_ARCHS[@]} ]; then
+            echo "ERROR: Duplicate architectures found"
+            exit 1
+          fi
+          if [ ${#VALIDATED_ARCHS[@]} -ne 2 ]; then
+            echo "ERROR: Promoting :latest requires exactly two architectures (got ${#VALIDATED_ARCHS[@]})"
+            exit 1
+          fi
+
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "architectures=${VALIDATED_ARCHS[*]}" >> "$GITHUB_OUTPUT"
+          echo "✓ Version=$VERSION architectures=${VALIDATED_ARCHS[*]}"
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2  # v4.0.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ github.token }}
+
+      - name: Verify GHCR images and version manifest
+        env:
+          VERSION: ${{ steps.vars.outputs.version }}
+          ARCHS: ${{ steps.vars.outputs.architectures }}
+        run: |
+          set -euo pipefail
+          REPO="ghcr.io/vig-os/devcontainer"
+          IFS=' ' read -ra ARCH_ARRAY <<< "$ARCHS"
+          for arch in "${ARCH_ARRAY[@]}"; do
+            echo "Verifying image: $REPO:$VERSION-$arch"
+            if ! docker buildx imagetools inspect "$REPO:$VERSION-$arch" >/dev/null 2>&1; then
+              echo "ERROR: Missing image $REPO:$VERSION-$arch"
+              exit 1
+            fi
+          done
+          echo "Verifying version manifest: $REPO:$VERSION"
+          RETRIES=5
+          for i in $(seq 1 $RETRIES); do
+            if docker buildx imagetools inspect "$REPO:$VERSION" >/dev/null 2>&1; then
+              echo "✓ Version manifest present"
+              break
+            fi
+            if [ "$i" -lt "$RETRIES" ]; then
+              echo "Retry $i/$RETRIES..."
+              sleep 5
+            else
+              echo "ERROR: Version manifest not found: $REPO:$VERSION"
+              exit 1
+            fi
+          done
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@ba7bc0a3fef59531c69a25acd34668d6d3fe6f22  # v4
+
+      - name: Verify cosign signature
+        env:
+          VERSION: ${{ steps.vars.outputs.version }}
+        run: |
+          set -euo pipefail
+          REPO="ghcr.io/vig-os/devcontainer"
+          retry --retries 3 --backoff 10 --max-backoff 30 -- \
+            cosign verify "$REPO:$VERSION" \
+              --certificate-identity-regexp='https://github.com/vig-os/devcontainer/' \
+              --certificate-oidc-issuer='https://token.actions.githubusercontent.com'
+          echo "✓ Cosign verification passed for $REPO:$VERSION"
+
+      - name: Verify draft GitHub Release exists
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.vars.outputs.version }}
+        run: |
+          set -euo pipefail
+          RETRIES=5
+          LAST_ERROR=""
+          RELEASE_JSON=""
+          for i in $(seq 1 "$RETRIES"); do
+            API_OUTPUT=""
+            if API_OUTPUT=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${VERSION}" 2>&1); then
+              RELEASE_JSON="$API_OUTPUT"
+              break
+            fi
+            LAST_ERROR="$API_OUTPUT"
+            if printf '%s' "$API_OUTPUT" | grep -Eqi "401|403|forbidden|bad credentials"; then
+              echo "$API_OUTPUT"
+              exit 1
+            fi
+            if printf '%s' "$API_OUTPUT" | grep -Eqi "404|not found"; then
+              if [ "$i" -lt "$RETRIES" ]; then
+                sleep $((i * 5))
+                continue
+              fi
+              break
+            fi
+            if printf '%s' "$API_OUTPUT" | grep -Eqi "429|5[0-9]{2}"; then
+              if [ "$i" -lt "$RETRIES" ]; then
+                sleep $((i * 5))
+                continue
+              fi
+            fi
+            echo "ERROR: Unexpected response querying release for tag $VERSION"
+            echo "$API_OUTPUT"
+            exit 1
+          done
+          if [ -z "$RELEASE_JSON" ]; then
+            echo "ERROR: No GitHub Release for tag $VERSION"
+            if [ -n "$LAST_ERROR" ]; then
+              echo "$LAST_ERROR"
+            fi
+            exit 1
+          fi
+          IS_DRAFT=$(printf '%s' "$RELEASE_JSON" | jq -r '.draft')
+          if [ "$IS_DRAFT" != "true" ]; then
+            echo "ERROR: GitHub Release for $VERSION must still be a draft (got draft=$IS_DRAFT)"
+            exit 1
+          fi
+          echo "✓ Draft GitHub Release exists for $VERSION"
+
+      - name: Generate cross-repo token for downstream gate
+        id: smoke-check-token
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859  # v3
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          owner: vig-os
+          repositories: devcontainer-smoke-test
+
+      - name: Verify downstream published final release
+        env:
+          GH_TOKEN: ${{ steps.smoke-check-token.outputs.token }}
+          VERSION: ${{ steps.vars.outputs.version }}
+        run: |
+          set -euo pipefail
+          echo "Checking downstream release for tag $VERSION..."
+          RETRIES=5
+          RELEASE_JSON=""
+          LAST_ERROR=""
+          for i in $(seq 1 "$RETRIES"); do
+            API_OUTPUT=""
+            if API_OUTPUT=$(gh api "repos/vig-os/devcontainer-smoke-test/releases/tags/$VERSION" 2>&1); then
+              RELEASE_JSON="$API_OUTPUT"
+              break
+            fi
+            LAST_ERROR="$API_OUTPUT"
+            if printf '%s' "$API_OUTPUT" | grep -Eqi "401|403|forbidden|bad credentials"; then
+              echo "$API_OUTPUT"
+              exit 1
+            fi
+            if printf '%s' "$API_OUTPUT" | grep -Eqi "404|not found"; then
+              if [ "$i" -lt "$RETRIES" ]; then
+                echo "Downstream release not ready, retry $i/$RETRIES..."
+                sleep $((i * 10))
+                continue
+              fi
+              break
+            fi
+            if printf '%s' "$API_OUTPUT" | grep -Eqi "429|5[0-9]{2}"; then
+              if [ "$i" -lt "$RETRIES" ]; then
+                echo "Downstream API transient error, retry $i/$RETRIES..."
+                sleep $((i * 10))
+                continue
+              fi
+            fi
+            echo "ERROR: Failed querying downstream release API for $VERSION"
+            echo "$API_OUTPUT"
+            exit 1
+          done
+          if [ -z "$RELEASE_JSON" ]; then
+            echo "ERROR: No downstream release for tag $VERSION on devcontainer-smoke-test"
+            if [ -n "$LAST_ERROR" ]; then
+              echo "$LAST_ERROR"
+            fi
+            echo "Wait for the smoke-test workflow to publish its final release, then retry."
+            exit 1
+          fi
+          IS_DRAFT=$(printf '%s' "$RELEASE_JSON" | jq -r '.draft')
+          IS_PRERELEASE=$(printf '%s' "$RELEASE_JSON" | jq -r '.prerelease')
+          if [ "$IS_DRAFT" = "true" ]; then
+            echo "ERROR: Downstream release for $VERSION is still a draft"
+            exit 1
+          fi
+          if [ "$IS_PRERELEASE" = "true" ]; then
+            echo "ERROR: Downstream release for $VERSION is still a pre-release (expected final)"
+            exit 1
+          fi
+          echo "✓ Downstream published final release verified for $VERSION"
+
+      - name: Summary
+        env:
+          VERSION: ${{ steps.vars.outputs.version }}
+        run: |
+          echo "✓ All promote validation checks passed for $VERSION"
+
+  promote:
+    name: Promote GHCR latest and publish release
+    needs: [validate]
+    runs-on: ubuntu-22.04
+    timeout-minutes: 20
+    permissions:
+      contents: write
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Set up environment
+        uses: ./.github/actions/setup-env
+        with:
+          install-python: 'false'
+          install-just: 'false'
+
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859  # v3
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2  # v4.0.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ github.token }}
+
+      - name: Create and verify latest manifest
+        env:
+          VERSION: ${{ needs.validate.outputs.version }}
+          ARCHS: ${{ needs.validate.outputs.architectures }}
+        run: |
+          set -euo pipefail
+          REPO="ghcr.io/vig-os/devcontainer"
+          IFS=' ' read -ra ARCH_ARRAY <<< "$ARCHS"
+          ARCH_IMAGES=()
+          for arch in "${ARCH_ARRAY[@]}"; do
+            ARCH_IMAGES+=("$REPO:$VERSION-$arch")
+          done
+          echo "Creating/updating latest manifest: $REPO:latest"
+          retry --retries 3 --backoff 3 --max-backoff 3 -- \
+            docker buildx imagetools create \
+              --tag "$REPO:latest" \
+              "${ARCH_IMAGES[@]}"
+          echo "✓ Created/updated latest manifest"
+          RETRIES=5
+          for i in $(seq 1 $RETRIES); do
+            if docker buildx imagetools inspect "$REPO:latest" >/dev/null 2>&1; then
+              echo "✓ Latest manifest verified"
+              break
+            fi
+            if [ "$i" -lt "$RETRIES" ]; then
+              sleep 5
+            else
+              echo "ERROR: Latest manifest verification failed"
+              exit 1
+            fi
+          done
+
+      - name: Publish GitHub Release
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          VERSION: ${{ needs.validate.outputs.version }}
+        run: |
+          set -euo pipefail
+          retry --retries 3 --backoff 5 --max-backoff 30 -- \
+            gh release edit "$VERSION" --draft=false
+          echo "✓ GitHub Release $VERSION published (no longer draft)"
+
+      - name: Summary
+        env:
+          VERSION: ${{ needs.validate.outputs.version }}
+        run: |
+          echo "✓ Promoted $VERSION: GHCR :latest updated, GitHub Release published"
+
+  merge:
+    name: Merge release PR to main
+    needs: [validate, promote]
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Set up environment
+        uses: ./.github/actions/setup-env
+        with:
+          install-python: 'false'
+          install-just: 'false'
+
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859  # v3
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
+      - name: Find and verify release PR
+        id: pr
+        env:
+          VERSION: ${{ needs.validate.outputs.version }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          RELEASE_BRANCH="release/$VERSION"
+
+          PR_JSON=$(retry --retries 3 --backoff 5 --max-backoff 30 -- gh pr list \
+            --head "$RELEASE_BRANCH" \
+            --base main \
+            --json number,isDraft,reviewDecision,statusCheckRollup \
+            --limit 1)
+
+          PR_COUNT=$(echo "$PR_JSON" | jq 'length')
+
+          if [ "$PR_COUNT" != "1" ]; then
+            if [ "$PR_COUNT" = "0" ]; then
+              echo "ERROR: No PR found from $RELEASE_BRANCH to main"
+              exit 1
+            else
+              echo "ERROR: Multiple PRs found from $RELEASE_BRANCH to main"
+              exit 1
+            fi
+          fi
+
+          PR_NUMBER=$(echo "$PR_JSON" | jq -r '.[0].number')
+          IS_DRAFT=$(echo "$PR_JSON" | jq -r '.[0].isDraft')
+          REVIEW_DECISION=$(echo "$PR_JSON" | jq -r '.[0].reviewDecision')
+
+          echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+
+          if [ "$IS_DRAFT" = "true" ]; then
+            echo "ERROR: PR #$PR_NUMBER is still in draft status"
+            exit 1
+          fi
+
+          if [ "$REVIEW_DECISION" = "APPROVED" ]; then
+            echo "PR #$PR_NUMBER is approved"
+          elif [ "$REVIEW_DECISION" = "null" ] || [ -z "$REVIEW_DECISION" ]; then
+            APPROVED_COUNT=$(retry --retries 3 --backoff 5 --max-backoff 30 -- gh api \
+              --paginate --slurp \
+              "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/reviews" \
+              | jq 'add | map(select(.state == "APPROVED")) | length')
+            if [ "$APPROVED_COUNT" -eq 0 ]; then
+              echo "ERROR: PR #$PR_NUMBER does not have approvals"
+              exit 1
+            fi
+            echo "PR #$PR_NUMBER has $APPROVED_COUNT approved review(s)"
+          else
+            echo "ERROR: PR #$PR_NUMBER does not have approvals (status: $REVIEW_DECISION)"
+            exit 1
+          fi
+
+          STATUS_ROLLUP=$(echo "$PR_JSON" | jq -r '.[0].statusCheckRollup // []')
+          CI_FAILED=$(echo "$STATUS_ROLLUP" | jq '[.[] | select(.conclusion == "FAILURE" or .conclusion == "ERROR")] | length')
+          if [ "$CI_FAILED" != "0" ]; then
+            echo "ERROR: PR #$PR_NUMBER has failed CI checks"
+            exit 1
+          fi
+
+          CI_PENDING=$(echo "$STATUS_ROLLUP" | jq '[.[] | select(.conclusion == null or .conclusion == "" or .conclusion == "PENDING" or .conclusion == "IN_PROGRESS" or .conclusion == "QUEUED")] | length')
+          if [ "$CI_PENDING" != "0" ]; then
+            echo "ERROR: PR #$PR_NUMBER has checks still in progress"
+            exit 1
+          fi
+
+          CI_SUCCESS=$(echo "$STATUS_ROLLUP" | jq '[.[] | select(.conclusion == "SUCCESS")] | length')
+          if [ "$CI_SUCCESS" = "0" ]; then
+            echo "ERROR: PR #$PR_NUMBER has no successful CI checks"
+            exit 1
+          fi
+
+          echo "✓ PR #$PR_NUMBER verified for merge"
+
+      - name: Merge release PR
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
+        run: |
+          set -euo pipefail
+          retry --retries 3 --backoff 5 --max-backoff 30 -- \
+            gh pr merge "$PR_NUMBER" --merge
+          echo "✓ Merged PR #$PR_NUMBER to main"
+
+      - name: Summary
+        env:
+          VERSION: ${{ needs.validate.outputs.version }}
+          PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
+        run: |
+          echo "✓ Release $VERSION promoted; PR #$PR_NUMBER merged to main (sync-main-to-dev may run next)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,15 +4,16 @@
 # 1. Validate: Check all prerequisites (PR status, CI passed, CHANGELOG ready)
 # 2. Finalize: For final releases only, set release date in CHANGELOG
 # 3. Build & Test: Build and test images for all architectures
-# 4. Publish: Create tag, publish images, and create draft final GitHub Release
-# 5. Rollback (on failure): Reset release branch, create issue (tags are not deleted—forward-fix policy; GitHub immutability applies only after a published release locks the tag when that setting is enabled)
+# 4. Publish: Create tag, publish versioned images to GHCR, sign/attest, create draft final GitHub Release (final only)
+# 5. Smoke-test: Dispatch downstream validation
+# 6. Rollback (on failure): Reset release branch, create issue (tags are not deleted—forward-fix policy; GitHub immutability applies only after a published release locks the tag when that setting is enabled)
 #
 # Release kinds:
 #   candidate: Publishes X.Y.Z-rcN. No CHANGELOG changes, no sync-issues.
 #   final:     Publishes X.Y.Z. Sets release date in CHANGELOG, triggers sync-issues, creates draft GitHub Release.
+#              GHCR :latest and publishing that draft release run in promote-release.yml after verification (see just promote-release).
 #
-# Design: Everything happens in one workflow dispatch before creating the tag.
-# This ensures no broken releases are tagged.
+# Design: Tag and versioned artifacts are created in this workflow; final promotion to :latest is a separate human-gated step.
 
 name: Release
 
@@ -1025,7 +1026,6 @@ jobs:
       - name: Create multi-arch manifest
         env:
           PUBLISH_VERSION: ${{ needs.validate.outputs.publish_version }}
-          RELEASE_KIND: ${{ needs.validate.outputs.release_kind }}
           ARCHS: ${{ needs.validate.outputs.architectures }}
         run: |
           set -euo pipefail
@@ -1047,22 +1047,9 @@ jobs:
               "${ARCH_IMAGES[@]}"
           echo "✓ Created version manifest: $REPO:$PUBLISH_VERSION"
 
-          # Update latest manifest only for final releases building both architectures.
-          if [ "$RELEASE_KIND" = "final" ] && [ ${#ARCH_ARRAY[@]} -eq 2 ]; then
-            echo "Creating/updating latest manifest: $REPO:latest"
-            retry --retries 3 --backoff 3 --max-backoff 3 -- \
-              docker buildx imagetools create \
-                --tag "$REPO:latest" \
-                "${ARCH_IMAGES[@]}"
-            echo "✓ Created/updated latest manifest: $REPO:latest"
-          else
-            echo "Skipping 'latest' manifest (single architecture or limited build)"
-          fi
-
       - name: Verify manifests
         env:
           PUBLISH_VERSION: ${{ needs.validate.outputs.publish_version }}
-          RELEASE_KIND: ${{ needs.validate.outputs.release_kind }}
           ARCHS: ${{ needs.validate.outputs.architectures }}
         run: |
           set -euo pipefail
@@ -1086,25 +1073,6 @@ jobs:
               fi
             fi
           done
-
-          if [ "$RELEASE_KIND" = "final" ] && [ ${#ARCH_ARRAY[@]} -eq 2 ]; then
-            echo "Verifying latest manifest: $REPO:latest"
-            RETRIES=5
-            for i in $(seq 1 $RETRIES); do
-              if docker buildx imagetools inspect "$REPO:latest" >/dev/null 2>&1; then
-                echo "✓ Latest manifest verified"
-                break
-              else
-                if [ $i -lt $RETRIES ]; then
-                  echo "Verification failed, retrying ($i/$RETRIES)..."
-                  sleep 5
-                else
-                  echo "ERROR: Latest manifest verification failed"
-                  exit 1
-                fi
-              fi
-            done
-          fi
 
       - name: Generate SBOM (attempt 1)
         id: sbom_generate
@@ -1216,7 +1184,7 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           set -euo pipefail
-          # Draft first: human publishes from the UI when ready (GitHub immutable-releases best practice).
+          # Draft first; promote-release.yml publishes (undrafts) after downstream verification (GitHub immutable-releases best practice).
           RETRIES=5
           LAST_ERROR=""
           for i in $(seq 1 "$RETRIES"); do
@@ -1225,7 +1193,7 @@ jobs:
               IS_DRAFT=$(printf '%s' "$API_OUTPUT" | jq -r '.draft')
               if [ "$IS_DRAFT" = "true" ]; then
                 echo "✓ Draft GitHub Release already exists for $PUBLISH_VERSION; skipping create (retry path)."
-                echo "Review and publish from: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/releases"
+                echo "Publish via promote workflow when ready: just promote-release $PUBLISH_VERSION"
                 exit 0
               fi
               echo "ERROR: Published (non-draft) GitHub Release already exists for tag $PUBLISH_VERSION"
@@ -1322,7 +1290,7 @@ jobs:
             }
 
           echo "✓ Draft GitHub Release created: $PUBLISH_VERSION"
-          echo "Review and publish from: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/releases (publishing locks the linked tag and assets when immutable releases are enabled)"
+          echo "After smoke-test passes downstream, run: just promote-release $PUBLISH_VERSION (publishing locks the linked tag and assets when immutable releases are enabled)"
 
       - name: Summary
         env:
@@ -1339,7 +1307,7 @@ jobs:
           echo "  Images:"
           echo "    - ghcr.io/vig-os/devcontainer:$PUBLISH_VERSION"
           if [ "$RELEASE_KIND" = "final" ]; then
-            echo "    - ghcr.io/vig-os/devcontainer:latest"
+            echo "    - ghcr.io/vig-os/devcontainer:latest (after just promote-release $BASE_VERSION)"
           fi
           echo "  Security:"
           echo "    - Cosign signature attached"
@@ -1351,9 +1319,8 @@ jobs:
             echo "  1. Smoke-test dispatch runs in the smoke-test job."
             echo "  2. If downstream pre-release passes, run: just finalize-release $BASE_VERSION"
           else
-            echo "  1. Smoke-test dispatch runs in the smoke-test job."
-            echo "  2. Review the draft GitHub Release and publish it from the Releases UI (publishing applies immutable-release lock-in for the tag and assets when that setting is enabled)."
-            echo "  3. Merge release PR to main (triggers sync-main-to-dev workflow automatically)"
+            echo "  1. Smoke-test dispatch runs in the smoke-test job; wait for downstream final release on devcontainer-smoke-test."
+            echo "  2. Run: just promote-release $BASE_VERSION — updates :latest, publishes the draft GitHub Release, merges the release PR to main."
           fi
 
   smoke-test:
@@ -1420,7 +1387,7 @@ jobs:
           echo "✓ Triggered smoke-test dispatch for release tag: $RELEASE_TAG"
           echo "Downstream validation is asynchronous; verify in devcontainer-smoke-test."
           if [ "$RELEASE_KIND" = "final" ]; then
-            echo "Final: review the draft GitHub Release in this repo and publish it from the Releases UI when validation is complete."
+            echo "Final: when downstream smoke-test has published its release for this tag, run: just promote-release $RELEASE_TAG"
           fi
 
       - name: Create issue for smoke dispatch failure

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Downstream release helper recipes via GitHub justfile import** ([#373](https://github.com/vig-os/devcontainer/issues/373))
   - Move `prepare-release`, `finalize-release`, `publish-candidate`, `reset-changelog`, and `pull` into `justfile.gh` so downstream workspace templates expose them by default
   - Keep root recipe availability through `import 'justfile.gh'` while consolidating release helper ownership in the GitHub-focused recipe file
+- **Split final release into publish and promote phases** ([#456](https://github.com/vig-os/devcontainer/issues/456))
+  - Final `release.yml` publishes versioned GHCR tags and a draft GitHub Release but no longer updates `:latest`
+  - New `promote-release.yml` runs after downstream smoke-test publishes its final release: updates `:latest`, publishes the draft release, merges the release PR to `main`
+  - Add `just promote-release` in `justfile.gh` (and workspace template copy)
 
 ### Deprecated
 

--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -199,6 +199,7 @@ Available recipes:
     [release]
     finalize-release version ref="" *flags     # Finalize and publish release via GitHub Actions workflow (step 3, after testing)
     prepare-release version ref="" *flags      # Prepare release branch for testing (step 1)
+    promote-release version ref="" *flags      # Promote final release: GHCR :latest, publish draft GitHub Release, merge release PR (after downstream smoke-test final release)
     publish-candidate version ref="" *flags    # Publish release candidate via GitHub Actions workflow
     pull version="latest" repo=""              # Pull image from registry (default: latest)
     reset-changelog                            # Reset CHANGELOG Unreleased section (after merging release to dev)

--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ Available recipes:
     [release]
     finalize-release version ref="" *flags     # Finalize and publish release via GitHub Actions workflow (step 3, after testing)
     prepare-release version ref="" *flags      # Prepare release branch for testing (step 1)
+    promote-release version ref="" *flags      # Promote final release: GHCR :latest, publish draft GitHub Release, merge release PR (after downstream smoke-test final release)
     publish-candidate version ref="" *flags    # Publish release candidate via GitHub Actions workflow
     pull version="latest" repo=""              # Pull image from registry (default: latest)
     reset-changelog                            # Reset CHANGELOG Unreleased section (after merging release to dev)

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Downstream release helper recipes via GitHub justfile import** ([#373](https://github.com/vig-os/devcontainer/issues/373))
   - Move `prepare-release`, `finalize-release`, `publish-candidate`, `reset-changelog`, and `pull` into `justfile.gh` so downstream workspace templates expose them by default
   - Keep root recipe availability through `import 'justfile.gh'` while consolidating release helper ownership in the GitHub-focused recipe file
+- **Split final release into publish and promote phases** ([#456](https://github.com/vig-os/devcontainer/issues/456))
+  - Final `release.yml` publishes versioned GHCR tags and a draft GitHub Release but no longer updates `:latest`
+  - New `promote-release.yml` runs after downstream smoke-test publishes its final release: updates `:latest`, publishes the draft release, merges the release PR to `main`
+  - Add `just promote-release` in `justfile.gh` (and workspace template copy)
 
 ### Deprecated
 

--- a/assets/workspace/.devcontainer/justfile.gh
+++ b/assets/workspace/.devcontainer/justfile.gh
@@ -68,6 +68,20 @@ finalize-release version ref="" *flags:
     echo "✓ Release workflow triggered for version {{ version }}"
     echo "Monitor progress: gh run list --workflow release.yml"
 
+# Promote final release: GHCR :latest, publish draft GitHub Release, merge release PR (after downstream smoke-test final release)
+[group('release')]
+promote-release version ref="" *flags:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    REF="{{ ref }}"
+    if [ -z "$REF" ]; then
+        REF="release/{{ version }}"
+    fi
+    gh workflow run promote-release.yml --ref "$REF" -f "version={{ version }}" {{ flags }}
+    echo ""
+    echo "✓ Promote-release workflow triggered for version {{ version }}"
+    echo "Monitor progress: gh run list --workflow promote-release.yml"
+
 # Publish release candidate via GitHub Actions workflow
 [group('release')]
 publish-candidate version ref="" *flags:

--- a/justfile
+++ b/justfile
@@ -198,10 +198,10 @@ test version="dev":
 #   5. just finalize-release X.Y.Z   - Triggers release.yml (final) that:
 #      - Validates PR status and all prerequisites
 #      - Sets release date in CHANGELOG, syncs PR docs
-#      - Builds and tests container images; creates vX.Y.Z tag; pushes versioned GHCR images
+#      - Builds and tests container images; creates X.Y.Z tag; pushes versioned GHCR images
 #      - Creates draft GitHub Release; dispatches smoke-test (not :latest yet)
 #      - On failure: automatic rollback and issue creation
-#   6. Wait for devcontainer-smoke-test to publish its final release for vX.Y.Z
+#   6. Wait for devcontainer-smoke-test to publish its final release for X.Y.Z
 #   7. just promote-release X.Y.Z    - Triggers promote-release.yml that:
 #      - Updates GHCR :latest, publishes the draft GitHub Release, merges release PR to main
 #      - Merging to main triggers sync-main-to-dev.yml (PR main -> dev, auto-merge if clean)

--- a/justfile
+++ b/justfile
@@ -188,23 +188,23 @@ test version="dev":
 # ===============================================================================
 # RELEASE MANAGEMENT
 # ===============================================================================
-# Unified release workflow via GitHub Actions (.github/workflows/release.yml)
+# Unified release via GitHub Actions (.github/workflows/release.yml, promote-release.yml)
 #
 # Process:
 #   1. just prepare-release X.Y.Z    - Create release/X.Y.Z branch, draft PR
 #   2. Test release branch, fix bugs as needed via PRs to release branch
 #   3. Mark PR ready for review (gh pr ready PR_NUMBER)
 #   4. Get PR approval from reviewer
-#   5. just finalize-release X.Y.Z   - Triggers GitHub Actions workflow that:
+#   5. just finalize-release X.Y.Z   - Triggers release.yml (final) that:
 #      - Validates PR status and all prerequisites
 #      - Sets release date in CHANGELOG, syncs PR docs
-#      - Builds and tests container images
-#      - Creates vX.Y.Z tag
-#      - Publishes images to GHCR
+#      - Builds and tests container images; creates vX.Y.Z tag; pushes versioned GHCR images
+#      - Creates draft GitHub Release; dispatches smoke-test (not :latest yet)
 #      - On failure: automatic rollback and issue creation
-#   6. Merge release PR to main       - Triggers sync-main-to-dev.yml automatically:
-#      - Opens PR to merge main into dev
-#      - Auto-merges if no conflicts
+#   6. Wait for devcontainer-smoke-test to publish its final release for vX.Y.Z
+#   7. just promote-release X.Y.Z    - Triggers promote-release.yml that:
+#      - Updates GHCR :latest, publishes the draft GitHub Release, merges release PR to main
+#      - Merging to main triggers sync-main-to-dev.yml (PR main -> dev, auto-merge if clean)
 # ===============================================================================
 # ===============================================================================
 # BUILD / CLEAN

--- a/justfile.gh
+++ b/justfile.gh
@@ -68,6 +68,20 @@ finalize-release version ref="" *flags:
     echo "✓ Release workflow triggered for version {{ version }}"
     echo "Monitor progress: gh run list --workflow release.yml"
 
+# Promote final release: GHCR :latest, publish draft GitHub Release, merge release PR (after downstream smoke-test final release)
+[group('release')]
+promote-release version ref="" *flags:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    REF="{{ ref }}"
+    if [ -z "$REF" ]; then
+        REF="release/{{ version }}"
+    fi
+    gh workflow run promote-release.yml --ref "$REF" -f "version={{ version }}" {{ flags }}
+    echo ""
+    echo "✓ Promote-release workflow triggered for version {{ version }}"
+    echo "Monitor progress: gh run list --workflow promote-release.yml"
+
 # Publish release candidate via GitHub Actions workflow
 [group('release')]
 publish-candidate version ref="" *flags:

--- a/tests/bats/just.bats
+++ b/tests/bats/just.bats
@@ -25,6 +25,11 @@ setup() {
     assert_success
 }
 
+@test "promote-release dispatches workflow from release branch ref" {
+    run bash -lc "awk '/^promote-release version ref=\"\" \\*flags:/{flag=1; next} /^$/{if(flag){exit}} flag' justfile.gh | grep -Fq -- 'REF=\"release/{{ version }}\"'"
+    assert_success
+}
+
 @test "publish-candidate dispatches workflow from release branch ref" {
     run bash -lc "awk '/^publish-candidate version ref=\"\" \\*flags:/{flag=1; next} /^$/{if(flag){exit}} flag' justfile.gh | grep -Fq -- 'REF=\"release/{{ version }}\"'"
     assert_success

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2080,6 +2080,7 @@ class TestJustRecipes:
         for recipe_name in [
             "prepare-release",
             "finalize-release",
+            "promote-release",
             "publish-candidate",
             "reset-changelog",
             "pull",
@@ -2097,6 +2098,7 @@ class TestJustRecipes:
         assert 'gh workflow run prepare-release.yml --ref "$REF"' in content
         assert 'REF="dev"' in content
         assert 'gh workflow run release.yml --ref "$REF"' in content
+        assert 'gh workflow run promote-release.yml --ref "$REF"' in content
         assert "release-kind=final" in content
         assert "release-kind=candidate" in content
         assert "uv run prepare-changelog reset CHANGELOG.md" in content


### PR DESCRIPTION
## Description

Splits the final release into two phases: **publish** (existing `release.yml` final run) and **promote** (new human-gated workflow after downstream smoke-test). Final `release.yml` no longer updates GHCR `:latest` or publishes the draft GitHub Release from the UI path alone; operators run `just promote-release` after `devcontainer-smoke-test` has published its final release for the same tag. The promote workflow validates prerequisites, updates `:latest`, undrafts the GitHub Release, and merges the release PR to `main`.

## Type of Change

- [ ] `feat` -- New feature
- [ ] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [x] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- **`.github/workflows/promote-release.yml`** — New workflow: validate version, GHCR images and cosign, draft release on this repo, downstream final release on `devcontainer-smoke-test`; job `promote` creates `:latest` manifest and publishes the draft release; job `merge` merges `release/X.Y.Z` PR to `main`.
- **`.github/workflows/release.yml`** — Remove `:latest` manifest create/verify for final releases; document smoke-test → `just promote-release` operator path; adjust summary and draft-release messaging.
- **`justfile.gh`** / **`assets/workspace/.devcontainer/justfile.gh`** — Add `promote-release` recipe dispatching `promote-release.yml` from `release/{{ version }}` by default.
- **`justfile`** — Update release-management comment block for the seven-step flow including promote.
- **`CHANGELOG.md`** / **`assets/workspace/.devcontainer/CHANGELOG.md`** — Unreleased entry for #456.
- **`README.md`** / **`CONTRIBUTE.md`** — Regenerated recipe listing including `promote-release`.
- **`tests/bats/just.bats`** — BATS coverage for `promote-release` default ref in `justfile.gh`.
- **`tests/test_integration.py`** — Integration assertions for `promote-release` recipe and `promote-release.yml` dispatch.

## Changelog Entry

```markdown
### Changed

- **Split final release into publish and promote phases** ([#456](https://github.com/vig-os/devcontainer/issues/456))
  - Final `release.yml` publishes versioned GHCR tags and a draft GitHub Release but no longer updates `:latest`
  - New `promote-release.yml` runs after downstream smoke-test publishes its final release: updates `:latest`, publishes the draft release, merges the release PR to `main`
  - Add `just promote-release` in `justfile.gh` (and workspace template copy)
```

## Testing

- [x] Tests pass locally (`just test`)
- [ ] Manual testing performed (describe below)

### Manual Testing Details

N/A — workflow behavior is validated in CI; operator flow documented in `justfile` and workflow comments.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

N/A

Refs: #456
