### PR TITLE
fix(ci): harden prepare-release ref wait and rollback changelog fetch

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -249,6 +249,16 @@ jobs:
           echo "dev_sha=$DEV_SHA" >> "$GITHUB_OUTPUT"
           echo "✓ Release branch created on remote"
 
+      - name: Verify release branch is resolvable
+        env:
+          GH_TOKEN: ${{ steps.commit-app-token.outputs.token }}
+          RELEASE_BRANCH: ${{ needs.validate.outputs.release_branch }}
+        run: |
+          set -euo pipefail
+          uv run retry --retries 10 --backoff 2 --max-backoff 30 -- \
+            gh api "repos/${{ github.repository }}/git/ref/heads/$RELEASE_BRANCH" --jq '.object.sha'
+          echo "✓ Release branch ref verified as resolvable"
+
       - name: Strip empty Unreleased section for release branch
         run: |
           set -euo pipefail
@@ -349,21 +359,19 @@ jobs:
             echo "i Release branch not present; nothing to delete"
           fi
 
-          if [ -n "${POST_FREEZE_DEV_SHA:-}" ]; then
-            CURRENT_DEV_SHA="$(uv run retry --retries 3 --backoff 5 --max-backoff 60 -- \
-              gh api "repos/${{ github.repository }}/git/ref/heads/dev" --jq '.object.sha')"
-            if [ "$CURRENT_DEV_SHA" != "$POST_FREEZE_DEV_SHA" ]; then
-              echo "w dev advanced after freeze commit; skipping CHANGELOG rollback to avoid clobbering concurrent updates"
-              echo "branch_deleted=$BRANCH_DELETED" >> "$GITHUB_OUTPUT"
-              echo "changelog_rollback_needed=false" >> "$GITHUB_OUTPUT"
-              exit 0
-            fi
+          CURRENT_DEV_SHA="$(uv run retry --retries 3 --backoff 5 --max-backoff 60 -- \
+            gh api "repos/${{ github.repository }}/git/ref/heads/dev" --jq '.object.sha')"
+          if [ -n "${POST_FREEZE_DEV_SHA:-}" ] && [ "$CURRENT_DEV_SHA" != "$POST_FREEZE_DEV_SHA" ]; then
+            echo "w dev advanced after freeze commit; skipping CHANGELOG rollback to avoid clobbering concurrent updates"
+            echo "branch_deleted=$BRANCH_DELETED" >> "$GITHUB_OUTPUT"
+            echo "changelog_rollback_needed=false" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
 
           uv run retry --retries 3 --backoff 5 --max-backoff 60 -- \
             gh api "repos/${{ github.repository }}/contents/CHANGELOG.md?ref=$PREPARE_START_SHA" --jq '.content' | tr -d '\n' | base64 -d > /tmp/changelog.pre-prepare.md
           uv run retry --retries 3 --backoff 5 --max-backoff 60 -- \
-            gh api "repos/${{ github.repository }}/contents/CHANGELOG.md?ref=dev" --jq '.content' | tr -d '\n' | base64 -d > /tmp/changelog.current-dev.md
+            gh api "repos/${{ github.repository }}/contents/CHANGELOG.md?ref=$CURRENT_DEV_SHA" --jq '.content' | tr -d '\n' | base64 -d > /tmp/changelog.current-dev.md
 
           if cmp -s /tmp/changelog.pre-prepare.md /tmp/changelog.current-dev.md; then
             echo "i dev CHANGELOG already matches pre-prepare state"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Fail finalize if `CHANGELOG.md` still contains `## [version] - TBD` after `git reset --hard`
 - **generate-docs pre-commit runs when CHANGELOG.md changes** ([#455](https://github.com/vig-os/devcontainer/issues/455))
   - Keeps README “Latest Version” and other generated docs aligned with the changelog
+- **prepare-release tolerates GitHub API ref propagation and reliable CHANGELOG rollback** ([#453](https://github.com/vig-os/devcontainer/issues/453))
+  - Poll until the new release branch ref resolves before `commit-action` commits to it
+  - Fetch dev `CHANGELOG.md` by resolved commit SHA during rollback so Contents API staleness does not skip the rollback commit
 
 ### Security
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -33,6 +33,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Fail finalize if `CHANGELOG.md` still contains `## [version] - TBD` after `git reset --hard`
 - **generate-docs pre-commit runs when CHANGELOG.md changes** ([#455](https://github.com/vig-os/devcontainer/issues/455))
   - Keeps README “Latest Version” and other generated docs aligned with the changelog
+- **prepare-release tolerates GitHub API ref propagation and reliable CHANGELOG rollback** ([#453](https://github.com/vig-os/devcontainer/issues/453))
+  - Poll until the new release branch ref resolves before `commit-action` commits to it
+  - Fetch dev `CHANGELOG.md` by resolved commit SHA during rollback so Contents API staleness does not skip the rollback commit
 
 ### Security
 

--- a/assets/workspace/.github/workflows/prepare-release.yml
+++ b/assets/workspace/.github/workflows/prepare-release.yml
@@ -248,6 +248,16 @@ jobs:
             }
           echo "dev_sha=$DEV_SHA" >> "$GITHUB_OUTPUT"
 
+      - name: Verify release branch is resolvable
+        env:
+          GH_TOKEN: ${{ steps.commit_app_token.outputs.token }}
+          RELEASE_BRANCH: ${{ needs.validate.outputs.release_branch }}
+        run: |
+          set -euo pipefail
+          retry --retries 10 --backoff 2 --max-backoff 30 -- \
+            gh api "repos/${{ github.repository }}/git/ref/heads/$RELEASE_BRANCH" --jq '.object.sha'
+          echo "✓ Release branch ref verified as resolvable"
+
       - name: Strip empty Unreleased section for release branch
         run: |
           set -euo pipefail
@@ -339,7 +349,7 @@ jobs:
           retry --retries 3 --backoff 5 --max-backoff 60 -- \
             gh api "repos/${{ github.repository }}/contents/CHANGELOG.md?ref=$PREPARE_START_SHA" --jq '.content' | tr -d '\n' | base64 -d > /tmp/changelog.pre.md
           retry --retries 3 --backoff 5 --max-backoff 60 -- \
-            gh api "repos/${{ github.repository }}/contents/CHANGELOG.md?ref=dev" --jq '.content' | tr -d '\n' | base64 -d > /tmp/changelog.current.md
+            gh api "repos/${{ github.repository }}/contents/CHANGELOG.md?ref=$CURRENT_DEV_SHA" --jq '.content' | tr -d '\n' | base64 -d > /tmp/changelog.current.md
           if ! cmp -s /tmp/changelog.pre.md /tmp/changelog.current.md; then
             cp /tmp/changelog.pre.md CHANGELOG.md
             CHANGELOG_ROLLBACK_NEEDED=true


### PR DESCRIPTION
## Description

Hardens `prepare-release` against GitHub API eventual consistency after the smoke-test dispatch failure analyzed in #453: poll until the new release branch ref resolves before `commit-action` runs, and fetch dev `CHANGELOG.md` by resolved commit SHA during rollback so the Contents API does not return stale branch content and skip the rollback commit.

## Type of Change

- [ ] `feat` -- New feature
- [ ] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [x] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- **`.github/workflows/prepare-release.yml`**
  - Add **Verify release branch is resolvable** step after creating the release branch (`uv run retry` polling `git/ref/heads/$RELEASE_BRANCH`).
  - Rollback: always resolve `CURRENT_DEV_SHA` from `git/ref/heads/dev`; skip CHANGELOG rollback only when `POST_FREEZE_DEV_SHA` is set and differs; load current changelog via Contents API `?ref=$CURRENT_DEV_SHA` instead of `?ref=dev`.
- **`assets/workspace/.github/workflows/prepare-release.yml`**
  - Same verification step using `retry` (no `uv run`).
  - Same Contents API change for rollback.
- **`CHANGELOG.md`** / **`assets/workspace/.devcontainer/CHANGELOG.md`**
  - Document the fix under `## Unreleased` → `### Fixed` (#453).

## Changelog Entry

```markdown
### Fixed

- **prepare-release tolerates GitHub API ref propagation and reliable CHANGELOG rollback** ([#453](https://github.com/vig-os/devcontainer/issues/453))
  - Poll until the new release branch ref resolves before `commit-action` commits to it
  - Fetch dev `CHANGELOG.md` by resolved commit SHA during rollback so Contents API staleness does not skip the rollback commit
```

## Testing

- [ ] Tests pass locally (`just test`)
- [x] Manual testing performed (describe below)

### Manual Testing Details

Ran `just test-bats` locally. Full `just test` not run for this PR.

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

RCA: [comment on #453](https://github.com/vig-os/devcontainer/issues/453#issuecomment-4141304019). Node 20 migration for `vig-os/commit-action` is tracked separately: [vig-os/commit-action#28](https://github.com/vig-os/commit-action/issues/28).

Refs: #453
