### PR TITLE
fix(ci): decouple sync-main-to-dev sync job from dev setup-env

### DIFF
--- a/.github/workflows/sync-main-to-dev.yml
+++ b/.github/workflows/sync-main-to-dev.yml
@@ -105,11 +105,79 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.commit-app-token.outputs.token }}
 
-      - name: Set up environment
-        uses: ./.github/actions/setup-env
-        with:
-          install-python: 'false'
-          install-just: 'false'
+      # Do not use ./.github/actions/setup-env here: this job checks out `dev`, so the
+      # composite action would come from `dev` while the workflow on `main` may pass
+      # inputs or rely on helpers only present on `main` (chicken-and-egg). Git + gh
+      # are on the runner; inline retry matches setup-env/action.yml.
+      - name: Export retry helper
+        shell: bash
+        run: |
+          set -euo pipefail
+          RETRY_HELPER="$RUNNER_TEMP/sync-main-to-dev-retry.sh"
+
+          cat > "$RETRY_HELPER" <<'EOF'
+          retry() {
+            local retries=3
+            local backoff=1
+            local max_backoff=60
+            local rc=1
+
+            while [ "$#" -gt 0 ]; do
+              case "$1" in
+                --retries)
+                  retries="$2"
+                  shift 2
+                  ;;
+                --backoff)
+                  backoff="$2"
+                  shift 2
+                  ;;
+                --max-backoff)
+                  max_backoff="$2"
+                  shift 2
+                  ;;
+                --)
+                  shift
+                  break
+                  ;;
+                *)
+                  echo "ERROR: Unknown retry option '$1'"
+                  return 2
+                  ;;
+              esac
+            done
+
+            if [ "$#" -eq 0 ]; then
+              echo "ERROR: retry requires a command after '--'"
+              return 2
+            fi
+
+            local attempt=1
+            local current_backoff="$backoff"
+            while [ "$attempt" -le "$retries" ]; do
+              if "$@"; then
+                return 0
+              fi
+              rc=$?
+              if [ "$attempt" -lt "$retries" ]; then
+                local wait="$current_backoff"
+                if [ "$wait" -gt "$max_backoff" ]; then
+                  wait="$max_backoff"
+                fi
+                echo "Retry $attempt/$retries failed (exit $rc), waiting ${wait}s..."
+                sleep "$wait"
+                current_backoff=$((current_backoff * 2))
+              fi
+              attempt=$((attempt + 1))
+            done
+
+            echo "ERROR: Command failed after $retries attempts: $*"
+            return "$rc"
+          }
+          export -f retry
+          EOF
+
+          echo "BASH_ENV=$RETRY_HELPER" >> "$GITHUB_ENV"
 
       - name: Re-check if dev is still behind main
         id: recheck

--- a/.github/workflows/sync-main-to-dev.yml
+++ b/.github/workflows/sync-main-to-dev.yml
@@ -108,7 +108,8 @@ jobs:
       # Do not use ./.github/actions/setup-env here: this job checks out `dev`, so the
       # composite action would come from `dev` while the workflow on `main` may pass
       # inputs or rely on helpers only present on `main` (chicken-and-egg). Git + gh
-      # are on the runner; inline retry matches setup-env/action.yml.
+      # are on the runner; this inlines a minimal retry helper similar to setup-env/action.yml
+      # but intentionally sets BASH_ENV to that helper only (setup-env merges a prior BASH_ENV).
       - name: Export retry helper
         shell: bash
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **prepare-release tolerates GitHub API ref propagation and reliable CHANGELOG rollback** ([#453](https://github.com/vig-os/devcontainer/issues/453))
   - Poll until the new release branch ref resolves before `commit-action` commits to it
   - Fetch dev `CHANGELOG.md` by resolved commit SHA during rollback so Contents API staleness does not skip the rollback commit
+- **sync-main-to-dev sync job no longer depends on dev's setup-env** ([#459](https://github.com/vig-os/devcontainer/issues/459))
+  - Inline the same `retry` shell helper used by `setup-env` so the job works when `main`'s workflow expects helpers not yet on `dev`
 
 ### Security
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -36,6 +36,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **prepare-release tolerates GitHub API ref propagation and reliable CHANGELOG rollback** ([#453](https://github.com/vig-os/devcontainer/issues/453))
   - Poll until the new release branch ref resolves before `commit-action` commits to it
   - Fetch dev `CHANGELOG.md` by resolved commit SHA during rollback so Contents API staleness does not skip the rollback commit
+- **sync-main-to-dev sync job no longer depends on dev's setup-env** ([#459](https://github.com/vig-os/devcontainer/issues/459))
+  - Inline the same `retry` shell helper used by `setup-env` so the job works when `main`'s workflow expects helpers not yet on `dev`
 
 ### Security
 


### PR DESCRIPTION
## Description

Fixes the `sync-main-to-dev` workflow failing on the **sync** job when `main` has a newer `setup-env` (e.g. `install-python` and the `retry` helper) than `dev`: that job checks out `dev`, so it was loading an older composite action and then running `retry` without it defined (exit 127). The **sync** job no longer calls `./.github/actions/setup-env`; it exports the same `retry` shell helper inline (aligned with `setup-env`) and documents the chicken-and-egg constraint. Root and workspace template changelogs include the **#459** entry.

## Type of Change

- [ ] `feat` -- New feature
- [x] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [ ] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- **`.github/workflows/sync-main-to-dev.yml`**
  - Remove `setup-env` from the **sync** job (post-`ref: dev` checkout).
  - Add **Export retry helper** step: write `retry` to `$RUNNER_TEMP/sync-main-to-dev-retry.sh`, set `BASH_ENV` (same semantics as `setup-env`).
  - Add a short comment explaining why `setup-env` must not run after checking out `dev`.
- **`CHANGELOG.md`**
  - **Fixed** entry for **#459** under `## Unreleased`.
- **`assets/workspace/.devcontainer/CHANGELOG.md`**
  - Mirror the same **Fixed** entry for downstream workspace template parity.

## Changelog Entry

### Fixed

- **sync-main-to-dev sync job no longer depends on dev's setup-env** ([#459](https://github.com/vig-os/devcontainer/issues/459))
  - Inline the same `retry` shell helper used by `setup-env` so the job works when `main`'s workflow expects helpers not yet on `dev`

## Testing

- [ ] Tests pass locally (`just test`)
- [ ] Manual testing performed (describe below)

### Manual Testing Details

N/A — GitHub Actions workflow change; validation is the next green `sync-main-to-dev` run on `main` after merge.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

N/A

Refs: #459
