### PR TITLE
ci: fail fast in wait-deploy-merge when deploy checks fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - New `promote-release.yml` runs after downstream smoke-test publishes its final release: updates `:latest`, publishes the draft release, merges the release PR to `main`
   - Add `just promote-release` in `justfile.gh` (and workspace template copy)
 - **Smoke-test dispatch fails fast when deploy PR checks fail** ([#381](https://github.com/vig-os/devcontainer/issues/381))
-  - `wait-deploy-merge` in `assets/smoke-test/.github/workflows/repository-dispatch.yml` exits as soon as all checks have completed with failures instead of waiting for the merge poll timeout
+  - `wait-deploy-merge` in `assets/smoke-test/.github/workflows/repository-dispatch.yml` exits as soon as all required checks have completed with failures instead of waiting for the merge poll timeout (`gh pr checks --required`)
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Final `release.yml` publishes versioned GHCR tags and a draft GitHub Release but no longer updates `:latest`
   - New `promote-release.yml` runs after downstream smoke-test publishes its final release: updates `:latest`, publishes the draft release, merges the release PR to `main`
   - Add `just promote-release` in `justfile.gh` (and workspace template copy)
+- **Smoke-test dispatch fails fast when deploy PR checks fail** ([#381](https://github.com/vig-os/devcontainer/issues/381))
+  - `wait-deploy-merge` in `assets/smoke-test/.github/workflows/repository-dispatch.yml` exits as soon as all checks have completed with failures instead of waiting for the merge poll timeout
 
 ### Deprecated
 

--- a/assets/smoke-test/.github/workflows/repository-dispatch.yml
+++ b/assets/smoke-test/.github/workflows/repository-dispatch.yml
@@ -353,7 +353,7 @@ jobs:
               echo "ERROR: deploy PR closed without merge: ${PR_URL}"
               exit 1
             fi
-            CHECKS_JSON="$(gh pr checks "${PR_URL}" --json bucket 2>/dev/null || echo '[]')"
+            CHECKS_JSON="$(gh pr checks "${PR_URL}" --required --json bucket 2>/dev/null || echo '[]')"
             FAIL_COUNT="$(echo "${CHECKS_JSON}" | jq '[.[] | select(.bucket == "fail")] | length')"
             PENDING_COUNT="$(echo "${CHECKS_JSON}" | jq '[.[] | select(.bucket == "pending")] | length')"
             if [ "${FAIL_COUNT}" -gt 0 ] && [ "${PENDING_COUNT}" -eq 0 ]; then

--- a/assets/smoke-test/.github/workflows/repository-dispatch.yml
+++ b/assets/smoke-test/.github/workflows/repository-dispatch.yml
@@ -325,6 +325,7 @@ jobs:
     timeout-minutes: 35
     needs: deploy
     permissions:
+      checks: read
       pull-requests: read
     steps:
       - name: Poll deploy PR merge status
@@ -350,6 +351,13 @@ jobs:
             fi
             if [ "${STATE}" = "CLOSED" ]; then
               echo "ERROR: deploy PR closed without merge: ${PR_URL}"
+              exit 1
+            fi
+            CHECKS_JSON="$(gh pr checks "${PR_URL}" --json bucket 2>/dev/null || echo '[]')"
+            FAIL_COUNT="$(echo "${CHECKS_JSON}" | jq '[.[] | select(.bucket == "fail")] | length')"
+            PENDING_COUNT="$(echo "${CHECKS_JSON}" | jq '[.[] | select(.bucket == "pending")] | length')"
+            if [ "${FAIL_COUNT}" -gt 0 ] && [ "${PENDING_COUNT}" -eq 0 ]; then
+              echo "ERROR: deploy PR checks failed -- auto-merge will not proceed: ${PR_URL}"
               exit 1
             fi
             sleep "${INTERVAL}"

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - New `promote-release.yml` runs after downstream smoke-test publishes its final release: updates `:latest`, publishes the draft release, merges the release PR to `main`
   - Add `just promote-release` in `justfile.gh` (and workspace template copy)
 - **Smoke-test dispatch fails fast when deploy PR checks fail** ([#381](https://github.com/vig-os/devcontainer/issues/381))
-  - `wait-deploy-merge` in `assets/smoke-test/.github/workflows/repository-dispatch.yml` exits as soon as all checks have completed with failures instead of waiting for the merge poll timeout
+  - `wait-deploy-merge` in `assets/smoke-test/.github/workflows/repository-dispatch.yml` exits as soon as all required checks have completed with failures instead of waiting for the merge poll timeout (`gh pr checks --required`)
 
 ### Deprecated
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Final `release.yml` publishes versioned GHCR tags and a draft GitHub Release but no longer updates `:latest`
   - New `promote-release.yml` runs after downstream smoke-test publishes its final release: updates `:latest`, publishes the draft release, merges the release PR to `main`
   - Add `just promote-release` in `justfile.gh` (and workspace template copy)
+- **Smoke-test dispatch fails fast when deploy PR checks fail** ([#381](https://github.com/vig-os/devcontainer/issues/381))
+  - `wait-deploy-merge` in `assets/smoke-test/.github/workflows/repository-dispatch.yml` exits as soon as all checks have completed with failures instead of waiting for the merge poll timeout
 
 ### Deprecated
 


### PR DESCRIPTION
## Description

Implements [#381](https://github.com/vig-os/devcontainer/issues/381): the smoke-test `wait-deploy-merge` job now inspects PR check buckets on each poll and exits immediately when all checks have finished and at least one failed, so the workflow does not sit until the 30-minute merge timeout when auto-merge will never run. Adds `checks: read` on that job so `gh pr checks` works under minimal token permissions.

## Type of Change

- [ ] `feat` -- New feature
- [ ] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [x] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- `assets/smoke-test/.github/workflows/repository-dispatch.yml`
  - Grant `checks: read` on `wait-deploy-merge` for `gh pr checks`
  - After MERGED/CLOSED handling, parse `gh pr checks` JSON buckets; exit with error when `fail` count is positive and `pending` is zero
- `CHANGELOG.md` — Unreleased **Changed** entry for #381
- `assets/workspace/.devcontainer/CHANGELOG.md` — manifest-synced copy of the same Unreleased entry

## Changelog Entry

### Changed

- **Smoke-test dispatch fails fast when deploy PR checks fail** ([#381](https://github.com/vig-os/devcontainer/issues/381))
  - `wait-deploy-merge` in `assets/smoke-test/.github/workflows/repository-dispatch.yml` exits as soon as all checks have completed with failures instead of waiting for the merge poll timeout

## Testing

- [ ] Tests pass locally (`just test`)
- [ ] Manual testing performed (describe below)

### Manual Testing Details

Skipped per reviewer request (`just test` not run). Change is workflow YAML only; behavior is validated on the next smoke-test dispatch after the template is deployed to `vig-os/devcontainer-smoke-test`.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

Downstream smoke-test repo must pick up this template via normal promotion after merge. Same pattern as noted in the workflow header.

Refs: #381
