### PR TITLE
chore(ci): sync release workflows from dev

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -249,6 +249,16 @@ jobs:
           echo "dev_sha=$DEV_SHA" >> "$GITHUB_OUTPUT"
           echo "✓ Release branch created on remote"
 
+      - name: Verify release branch is resolvable
+        env:
+          GH_TOKEN: ${{ steps.commit-app-token.outputs.token }}
+          RELEASE_BRANCH: ${{ needs.validate.outputs.release_branch }}
+        run: |
+          set -euo pipefail
+          uv run retry --retries 10 --backoff 2 --max-backoff 30 -- \
+            gh api "repos/${{ github.repository }}/git/ref/heads/$RELEASE_BRANCH" --jq '.object.sha'
+          echo "✓ Release branch ref verified as resolvable"
+
       - name: Strip empty Unreleased section for release branch
         run: |
           set -euo pipefail
@@ -349,21 +359,19 @@ jobs:
             echo "i Release branch not present; nothing to delete"
           fi
 
-          if [ -n "${POST_FREEZE_DEV_SHA:-}" ]; then
-            CURRENT_DEV_SHA="$(uv run retry --retries 3 --backoff 5 --max-backoff 60 -- \
-              gh api "repos/${{ github.repository }}/git/ref/heads/dev" --jq '.object.sha')"
-            if [ "$CURRENT_DEV_SHA" != "$POST_FREEZE_DEV_SHA" ]; then
-              echo "w dev advanced after freeze commit; skipping CHANGELOG rollback to avoid clobbering concurrent updates"
-              echo "branch_deleted=$BRANCH_DELETED" >> "$GITHUB_OUTPUT"
-              echo "changelog_rollback_needed=false" >> "$GITHUB_OUTPUT"
-              exit 0
-            fi
+          CURRENT_DEV_SHA="$(uv run retry --retries 3 --backoff 5 --max-backoff 60 -- \
+            gh api "repos/${{ github.repository }}/git/ref/heads/dev" --jq '.object.sha')"
+          if [ -n "${POST_FREEZE_DEV_SHA:-}" ] && [ "$CURRENT_DEV_SHA" != "$POST_FREEZE_DEV_SHA" ]; then
+            echo "w dev advanced after freeze commit; skipping CHANGELOG rollback to avoid clobbering concurrent updates"
+            echo "branch_deleted=$BRANCH_DELETED" >> "$GITHUB_OUTPUT"
+            echo "changelog_rollback_needed=false" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
 
           uv run retry --retries 3 --backoff 5 --max-backoff 60 -- \
             gh api "repos/${{ github.repository }}/contents/CHANGELOG.md?ref=$PREPARE_START_SHA" --jq '.content' | tr -d '\n' | base64 -d > /tmp/changelog.pre-prepare.md
           uv run retry --retries 3 --backoff 5 --max-backoff 60 -- \
-            gh api "repos/${{ github.repository }}/contents/CHANGELOG.md?ref=dev" --jq '.content' | tr -d '\n' | base64 -d > /tmp/changelog.current-dev.md
+            gh api "repos/${{ github.repository }}/contents/CHANGELOG.md?ref=$CURRENT_DEV_SHA" --jq '.content' | tr -d '\n' | base64 -d > /tmp/changelog.current-dev.md
 
           if cmp -s /tmp/changelog.pre-prepare.md /tmp/changelog.current-dev.md; then
             echo "i dev CHANGELOG already matches pre-prepare state"

--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -1,0 +1,472 @@
+# Promote Release — after publish (finalize) workflow
+#
+# Run after release.yml (final) has produced versioned GHCR images, draft GitHub Release,
+# and downstream smoke-test has published a non-draft, non-prerelease release for the same tag.
+#
+# 1. validate: GHCR X.Y.Z + cosign, draft release on this repo, downstream final release
+# 2. promote: GHCR :latest manifest, publish (undraft) GitHub Release
+# 3. merge: merge release/X.Y.Z PR to main (triggers sync-main-to-dev)
+
+name: Promote Release
+
+on:  # yamllint disable-line rule:truthy
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Semantic version to promote (e.g., 1.2.3)'
+        required: true
+        type: string
+      architectures:
+        description: 'Architectures that were published (comma-separated: amd64,arm64)'
+        required: false
+        default: 'amd64,arm64'
+        type: string
+
+concurrency:
+  group: publish-image
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: Validate promote prerequisites
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      packages: read
+    outputs:
+      version: ${{ steps.vars.outputs.version }}
+      architectures: ${{ steps.vars.outputs.architectures }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Set up environment
+        uses: ./.github/actions/setup-env
+        with:
+          install-python: 'false'
+          install-just: 'false'
+
+      - name: Validate version and architectures
+        id: vars
+        env:
+          INPUT_VERSION: ${{ github.event.inputs.version }}
+          INPUT_ARCHITECTURES: ${{ github.event.inputs.architectures }}
+        run: |
+          set -euo pipefail
+          VERSION="$INPUT_VERSION"
+          if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "ERROR: Invalid version format '$VERSION'"
+            echo "Version must follow semantic versioning: MAJOR.MINOR.PATCH (e.g., 1.2.3)"
+            exit 1
+          fi
+
+          ARCHS=$(echo "$INPUT_ARCHITECTURES" | tr -d ' ')
+          IFS=',' read -ra ARCH_ARRAY <<< "$ARCHS"
+          VALID_ARCHS="amd64 arm64"
+          VALIDATED_ARCHS=()
+          for arch in "${ARCH_ARRAY[@]}"; do
+            [ -z "$arch" ] && continue
+            if [[ " $VALID_ARCHS " =~ " $arch " ]]; then
+              VALIDATED_ARCHS+=("$arch")
+            else
+              echo "ERROR: Invalid architecture '$arch'"
+              exit 1
+            fi
+          done
+          UNIQUE_ARCHS=($(echo "${VALIDATED_ARCHS[@]}" | tr ' ' '\n' | sort -u))
+          if [ ${#UNIQUE_ARCHS[@]} -ne ${#VALIDATED_ARCHS[@]} ]; then
+            echo "ERROR: Duplicate architectures found"
+            exit 1
+          fi
+          if [ ${#VALIDATED_ARCHS[@]} -ne 2 ]; then
+            echo "ERROR: Promoting :latest requires exactly two architectures (got ${#VALIDATED_ARCHS[@]})"
+            exit 1
+          fi
+
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "architectures=${VALIDATED_ARCHS[*]}" >> "$GITHUB_OUTPUT"
+          echo "✓ Version=$VERSION architectures=${VALIDATED_ARCHS[*]}"
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2  # v4.0.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ github.token }}
+
+      - name: Verify GHCR images and version manifest
+        env:
+          VERSION: ${{ steps.vars.outputs.version }}
+          ARCHS: ${{ steps.vars.outputs.architectures }}
+        run: |
+          set -euo pipefail
+          REPO="ghcr.io/vig-os/devcontainer"
+          IFS=' ' read -ra ARCH_ARRAY <<< "$ARCHS"
+          for arch in "${ARCH_ARRAY[@]}"; do
+            echo "Verifying image: $REPO:$VERSION-$arch"
+            if ! docker buildx imagetools inspect "$REPO:$VERSION-$arch" >/dev/null 2>&1; then
+              echo "ERROR: Missing image $REPO:$VERSION-$arch"
+              exit 1
+            fi
+          done
+          echo "Verifying version manifest: $REPO:$VERSION"
+          RETRIES=5
+          for i in $(seq 1 $RETRIES); do
+            if docker buildx imagetools inspect "$REPO:$VERSION" >/dev/null 2>&1; then
+              echo "✓ Version manifest present"
+              break
+            fi
+            if [ "$i" -lt "$RETRIES" ]; then
+              echo "Retry $i/$RETRIES..."
+              sleep 5
+            else
+              echo "ERROR: Version manifest not found: $REPO:$VERSION"
+              exit 1
+            fi
+          done
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@ba7bc0a3fef59531c69a25acd34668d6d3fe6f22  # v4
+
+      - name: Verify cosign signature
+        env:
+          VERSION: ${{ steps.vars.outputs.version }}
+        run: |
+          set -euo pipefail
+          REPO="ghcr.io/vig-os/devcontainer"
+          retry --retries 3 --backoff 10 --max-backoff 30 -- \
+            cosign verify "$REPO:$VERSION" \
+              --certificate-identity-regexp='https://github.com/vig-os/devcontainer/.github/workflows/release.yml@refs/heads/release/' \
+              --certificate-oidc-issuer='https://token.actions.githubusercontent.com'
+          echo "✓ Cosign verification passed for $REPO:$VERSION"
+
+      - name: Verify draft GitHub Release exists
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.vars.outputs.version }}
+        run: |
+          set -euo pipefail
+          RETRIES=5
+          LAST_ERROR=""
+          RELEASE_JSON=""
+          for i in $(seq 1 "$RETRIES"); do
+            API_OUTPUT=""
+            if API_OUTPUT=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${VERSION}" 2>&1); then
+              RELEASE_JSON="$API_OUTPUT"
+              break
+            fi
+            LAST_ERROR="$API_OUTPUT"
+            if printf '%s' "$API_OUTPUT" | grep -Eqi "401|403|forbidden|bad credentials"; then
+              echo "$API_OUTPUT"
+              exit 1
+            fi
+            if printf '%s' "$API_OUTPUT" | grep -Eqi "404|not found"; then
+              if [ "$i" -lt "$RETRIES" ]; then
+                sleep $((i * 5))
+                continue
+              fi
+              break
+            fi
+            if printf '%s' "$API_OUTPUT" | grep -Eqi "429|5[0-9]{2}"; then
+              if [ "$i" -lt "$RETRIES" ]; then
+                sleep $((i * 5))
+                continue
+              fi
+            fi
+            echo "ERROR: Unexpected response querying release for tag $VERSION"
+            echo "$API_OUTPUT"
+            exit 1
+          done
+          if [ -z "$RELEASE_JSON" ]; then
+            echo "ERROR: No GitHub Release for tag $VERSION"
+            if [ -n "$LAST_ERROR" ]; then
+              echo "$LAST_ERROR"
+            fi
+            exit 1
+          fi
+          IS_DRAFT=$(printf '%s' "$RELEASE_JSON" | jq -r '.draft')
+          if [ "$IS_DRAFT" != "true" ]; then
+            echo "ERROR: GitHub Release for $VERSION must still be a draft (got draft=$IS_DRAFT)"
+            exit 1
+          fi
+          echo "✓ Draft GitHub Release exists for $VERSION"
+
+      - name: Generate cross-repo token for downstream gate
+        id: smoke-check-token
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859  # v3
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          owner: vig-os
+          repositories: devcontainer-smoke-test
+
+      - name: Verify downstream published final release
+        env:
+          GH_TOKEN: ${{ steps.smoke-check-token.outputs.token }}
+          VERSION: ${{ steps.vars.outputs.version }}
+        run: |
+          set -euo pipefail
+          echo "Checking downstream release for tag $VERSION..."
+          RETRIES=5
+          RELEASE_JSON=""
+          LAST_ERROR=""
+          for i in $(seq 1 "$RETRIES"); do
+            API_OUTPUT=""
+            if API_OUTPUT=$(gh api "repos/vig-os/devcontainer-smoke-test/releases/tags/$VERSION" 2>&1); then
+              RELEASE_JSON="$API_OUTPUT"
+              break
+            fi
+            LAST_ERROR="$API_OUTPUT"
+            if printf '%s' "$API_OUTPUT" | grep -Eqi "401|403|forbidden|bad credentials"; then
+              echo "$API_OUTPUT"
+              exit 1
+            fi
+            if printf '%s' "$API_OUTPUT" | grep -Eqi "404|not found"; then
+              if [ "$i" -lt "$RETRIES" ]; then
+                echo "Downstream release not ready, retry $i/$RETRIES..."
+                sleep $((i * 10))
+                continue
+              fi
+              break
+            fi
+            if printf '%s' "$API_OUTPUT" | grep -Eqi "429|5[0-9]{2}"; then
+              if [ "$i" -lt "$RETRIES" ]; then
+                echo "Downstream API transient error, retry $i/$RETRIES..."
+                sleep $((i * 10))
+                continue
+              fi
+            fi
+            echo "ERROR: Failed querying downstream release API for $VERSION"
+            echo "$API_OUTPUT"
+            exit 1
+          done
+          if [ -z "$RELEASE_JSON" ]; then
+            echo "ERROR: No downstream release for tag $VERSION on devcontainer-smoke-test"
+            if [ -n "$LAST_ERROR" ]; then
+              echo "$LAST_ERROR"
+            fi
+            echo "Wait for the smoke-test workflow to publish its final release, then retry."
+            exit 1
+          fi
+          IS_DRAFT=$(printf '%s' "$RELEASE_JSON" | jq -r '.draft')
+          IS_PRERELEASE=$(printf '%s' "$RELEASE_JSON" | jq -r '.prerelease')
+          if [ "$IS_DRAFT" = "true" ]; then
+            echo "ERROR: Downstream release for $VERSION is still a draft"
+            exit 1
+          fi
+          if [ "$IS_PRERELEASE" = "true" ]; then
+            echo "ERROR: Downstream release for $VERSION is still a pre-release (expected final)"
+            exit 1
+          fi
+          echo "✓ Downstream published final release verified for $VERSION"
+
+      - name: Summary
+        env:
+          VERSION: ${{ steps.vars.outputs.version }}
+        run: |
+          echo "✓ All promote validation checks passed for $VERSION"
+
+  promote:
+    name: Promote GHCR latest and publish release
+    needs: [validate]
+    runs-on: ubuntu-22.04
+    timeout-minutes: 20
+    permissions:
+      contents: write
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Set up environment
+        uses: ./.github/actions/setup-env
+        with:
+          install-python: 'false'
+          install-just: 'false'
+
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859  # v3
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2  # v4.0.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ github.token }}
+
+      - name: Create and verify latest manifest
+        env:
+          VERSION: ${{ needs.validate.outputs.version }}
+          ARCHS: ${{ needs.validate.outputs.architectures }}
+        run: |
+          set -euo pipefail
+          REPO="ghcr.io/vig-os/devcontainer"
+          IFS=' ' read -ra ARCH_ARRAY <<< "$ARCHS"
+          ARCH_IMAGES=()
+          for arch in "${ARCH_ARRAY[@]}"; do
+            ARCH_IMAGES+=("$REPO:$VERSION-$arch")
+          done
+          echo "Creating/updating latest manifest: $REPO:latest"
+          retry --retries 3 --backoff 3 --max-backoff 3 -- \
+            docker buildx imagetools create \
+              --tag "$REPO:latest" \
+              "${ARCH_IMAGES[@]}"
+          echo "✓ Created/updated latest manifest"
+          RETRIES=5
+          for i in $(seq 1 $RETRIES); do
+            if docker buildx imagetools inspect "$REPO:latest" >/dev/null 2>&1; then
+              echo "✓ Latest manifest verified"
+              break
+            fi
+            if [ "$i" -lt "$RETRIES" ]; then
+              sleep 5
+            else
+              echo "ERROR: Latest manifest verification failed"
+              exit 1
+            fi
+          done
+
+      - name: Publish GitHub Release
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          VERSION: ${{ needs.validate.outputs.version }}
+        run: |
+          set -euo pipefail
+          retry --retries 3 --backoff 5 --max-backoff 30 -- \
+            gh release edit "$VERSION" --draft=false
+          echo "✓ GitHub Release $VERSION published (no longer draft)"
+
+      - name: Summary
+        env:
+          VERSION: ${{ needs.validate.outputs.version }}
+        run: |
+          echo "✓ Promoted $VERSION: GHCR :latest updated, GitHub Release published"
+
+  merge:
+    name: Merge release PR to main
+    needs: [validate, promote]
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Set up environment
+        uses: ./.github/actions/setup-env
+        with:
+          install-python: 'false'
+          install-just: 'false'
+
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859  # v3
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
+      - name: Find and verify release PR
+        id: pr
+        env:
+          VERSION: ${{ needs.validate.outputs.version }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          RELEASE_BRANCH="release/$VERSION"
+
+          PR_JSON=$(retry --retries 3 --backoff 5 --max-backoff 30 -- gh pr list \
+            --head "$RELEASE_BRANCH" \
+            --base main \
+            --json number,isDraft,reviewDecision,statusCheckRollup \
+            --limit 1)
+
+          PR_COUNT=$(echo "$PR_JSON" | jq 'length')
+
+          if [ "$PR_COUNT" != "1" ]; then
+            if [ "$PR_COUNT" = "0" ]; then
+              echo "ERROR: No PR found from $RELEASE_BRANCH to main"
+              exit 1
+            else
+              echo "ERROR: Multiple PRs found from $RELEASE_BRANCH to main"
+              exit 1
+            fi
+          fi
+
+          PR_NUMBER=$(echo "$PR_JSON" | jq -r '.[0].number')
+          IS_DRAFT=$(echo "$PR_JSON" | jq -r '.[0].isDraft')
+          REVIEW_DECISION=$(echo "$PR_JSON" | jq -r '.[0].reviewDecision')
+
+          echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+
+          if [ "$IS_DRAFT" = "true" ]; then
+            echo "ERROR: PR #$PR_NUMBER is still in draft status"
+            exit 1
+          fi
+
+          if [ "$REVIEW_DECISION" = "APPROVED" ]; then
+            echo "PR #$PR_NUMBER is approved"
+          elif [ "$REVIEW_DECISION" = "null" ] || [ -z "$REVIEW_DECISION" ]; then
+            APPROVED_COUNT=$(retry --retries 3 --backoff 5 --max-backoff 30 -- gh api \
+              --paginate --slurp \
+              "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/reviews" \
+              | jq 'add | map(select(.state == "APPROVED")) | length')
+            if [ "$APPROVED_COUNT" -eq 0 ]; then
+              echo "ERROR: PR #$PR_NUMBER does not have approvals"
+              exit 1
+            fi
+            echo "PR #$PR_NUMBER has $APPROVED_COUNT approved review(s)"
+          else
+            echo "ERROR: PR #$PR_NUMBER does not have approvals (status: $REVIEW_DECISION)"
+            exit 1
+          fi
+
+          STATUS_ROLLUP=$(echo "$PR_JSON" | jq -r '.[0].statusCheckRollup // []')
+          CI_FAILED=$(echo "$STATUS_ROLLUP" | jq '[.[] | select(.conclusion == "FAILURE" or .conclusion == "ERROR")] | length')
+          if [ "$CI_FAILED" != "0" ]; then
+            echo "ERROR: PR #$PR_NUMBER has failed CI checks"
+            exit 1
+          fi
+
+          CI_PENDING=$(echo "$STATUS_ROLLUP" | jq '[.[] | select(.conclusion == null or .conclusion == "" or .conclusion == "PENDING" or .conclusion == "IN_PROGRESS" or .conclusion == "QUEUED")] | length')
+          if [ "$CI_PENDING" != "0" ]; then
+            echo "ERROR: PR #$PR_NUMBER has checks still in progress"
+            exit 1
+          fi
+
+          CI_SUCCESS=$(echo "$STATUS_ROLLUP" | jq '[.[] | select(.conclusion == "SUCCESS")] | length')
+          if [ "$CI_SUCCESS" = "0" ]; then
+            echo "ERROR: PR #$PR_NUMBER has no successful CI checks"
+            exit 1
+          fi
+
+          echo "✓ PR #$PR_NUMBER verified for merge"
+
+      - name: Merge release PR
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
+        run: |
+          set -euo pipefail
+          retry --retries 3 --backoff 5 --max-backoff 30 -- \
+            gh pr merge "$PR_NUMBER" --merge
+          echo "✓ Merged PR #$PR_NUMBER to main"
+
+      - name: Summary
+        env:
+          VERSION: ${{ needs.validate.outputs.version }}
+          PR_NUMBER: ${{ steps.pr.outputs.pr_number }}
+        run: |
+          echo "✓ Release $VERSION promoted; PR #$PR_NUMBER merged to main (sync-main-to-dev may run next)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,15 +4,16 @@
 # 1. Validate: Check all prerequisites (PR status, CI passed, CHANGELOG ready)
 # 2. Finalize: For final releases only, set release date in CHANGELOG
 # 3. Build & Test: Build and test images for all architectures
-# 4. Publish: Create tag, publish images, and create draft final GitHub Release
-# 5. Rollback (on failure): Reset release branch, create issue (tags are not deleted—forward-fix policy; GitHub immutability applies only after a published release locks the tag when that setting is enabled)
+# 4. Publish: Create tag, publish versioned images to GHCR, sign/attest, create draft final GitHub Release (final only)
+# 5. Smoke-test: Dispatch downstream validation
+# 6. Rollback (on failure): Reset release branch, create issue (tags are not deleted—forward-fix policy; GitHub immutability applies only after a published release locks the tag when that setting is enabled)
 #
 # Release kinds:
 #   candidate: Publishes X.Y.Z-rcN. No CHANGELOG changes, no sync-issues.
 #   final:     Publishes X.Y.Z. Sets release date in CHANGELOG, triggers sync-issues, creates draft GitHub Release.
+#              GHCR :latest and publishing that draft release run in promote-release.yml after verification (see just promote-release).
 #
-# Design: Everything happens in one workflow dispatch before creating the tag.
-# This ensures no broken releases are tagged.
+# Design: Tag and versioned artifacts are created in this workflow; final promotion to :latest is a separate human-gated step.
 
 name: Release
 
@@ -643,63 +644,6 @@ jobs:
             Refs: #${{ needs.validate.outputs.pr_number }}
           FILE_PATHS: ${{ steps.finalize-files.outputs.file_paths }}
 
-      - name: Trigger sync-issues workflow
-        if: needs.validate.outputs.release_kind == 'final'
-        env:
-          GH_TOKEN: ${{ github.token }}
-          VERSION: ${{ needs.validate.outputs.version }}
-        run: |
-          set -euo pipefail
-          echo "Triggering sync-issues workflow..."
-          retry --retries 2 --backoff 5 --max-backoff 20 -- gh workflow run sync-issues.yml \
-            -f "target-branch=release/$VERSION"
-          echo "✓ sync-issues workflow triggered"
-
-      - name: Wait for sync-issues completion
-        if: needs.validate.outputs.release_kind == 'final'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          TIMEOUT=120
-          ELAPSED=0
-          INTERVAL=10
-
-          sleep 5
-          ELAPSED=5
-
-          while [ $ELAPSED -lt $TIMEOUT ]; do
-            RUN_STATUS=$(gh run list \
-              --workflow sync-issues.yml \
-              --limit 1 \
-              --json status,conclusion \
-              --jq '.[0].status' 2>/dev/null || echo "unknown")
-
-            if [ "$RUN_STATUS" = "completed" ]; then
-              RUN_CONCLUSION=$(gh run list \
-                --workflow sync-issues.yml \
-                --limit 1 \
-                --json conclusion \
-                --jq '.[0].conclusion' 2>/dev/null || echo "unknown")
-
-              if [ "$RUN_CONCLUSION" = "success" ]; then
-                echo "✓ sync-issues workflow completed successfully"
-              else
-                echo "⚠ sync-issues workflow completed with status: $RUN_CONCLUSION"
-              fi
-              break
-            fi
-
-            sleep "$INTERVAL"
-            ELAPSED=$((ELAPSED + INTERVAL))
-            echo "Waiting for sync-issues... (${ELAPSED}s / ${TIMEOUT}s)"
-          done
-
-          if [ $ELAPSED -ge $TIMEOUT ]; then
-            echo "⚠ Timed out waiting for sync-issues workflow"
-            echo "The release may continue, but PR documentation may not be synced"
-          fi
-
       - name: Pull remote changes
         if: needs.validate.outputs.release_kind == 'final'
         env:
@@ -710,6 +654,18 @@ jobs:
           git reset --hard "origin/release/$VERSION"
           echo "✓ Synced with remote release branch"
 
+      - name: Verify CHANGELOG finalized (no TBD)
+        if: needs.validate.outputs.release_kind == 'final'
+        env:
+          VERSION: ${{ needs.validate.outputs.version }}
+        run: |
+          set -euo pipefail
+          if grep -Fq "## [${VERSION}] - TBD" CHANGELOG.md; then
+            echo "ERROR: CHANGELOG.md still contains TBD for $VERSION after finalize commit"
+            exit 1
+          fi
+          echo "✓ CHANGELOG.md has finalized date for $VERSION"
+
       - name: Refresh release PR body from finalized changelog
         if: needs.validate.outputs.release_kind == 'final'
         env:
@@ -719,7 +675,11 @@ jobs:
           PR_NUMBER: ${{ needs.validate.outputs.pr_number }}
         run: |
           set -euo pipefail
-          CHANGELOG_CONTENT=$(sed -n "/## \[$VERSION\]/,/^## \[/p" CHANGELOG.md | sed '$d')
+          CHANGELOG_CONTENT=$(awk -v hdr="## [${VERSION}]" '
+            index($0, hdr) == 1 { p = 1; print; next }
+            p && /^## \[/ { exit }
+            p { print }
+          ' CHANGELOG.md)
 
           if [ -z "$CHANGELOG_CONTENT" ]; then
             echo "ERROR: Could not extract release section for version $VERSION from CHANGELOG.md"
@@ -782,6 +742,66 @@ jobs:
           fi
           echo "tag_already_exists=true" >> "$GITHUB_OUTPUT"
           echo "Remote tag $PUBLISH_VERSION already points to finalize SHA; publish will skip tag create/push"
+
+      - name: Trigger sync-issues workflow and wait
+        if: needs.validate.outputs.release_kind == 'final'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs.validate.outputs.version }}
+        run: |
+          set -euo pipefail
+          TIMEOUT=120
+          INTERVAL=10
+          ELAPSED=0
+
+          declare -A before_map=()
+          while read -r id; do
+            [ -z "$id" ] && continue
+            before_map[$id]=1
+          done < <(gh run list --workflow sync-issues.yml --json databaseId --jq -r '.[].databaseId')
+
+          echo "Triggering sync-issues workflow..."
+          retry --retries 2 --backoff 5 --max-backoff 20 -- gh workflow run sync-issues.yml \
+            -f "target-branch=release/$VERSION"
+          echo "✓ sync-issues workflow triggered"
+
+          RUN_ID=""
+          sleep 3
+          ELAPSED=3
+
+          while [ "$ELAPSED" -lt "$TIMEOUT" ]; do
+            if [ -z "$RUN_ID" ]; then
+              while read -r id; do
+                [ -z "$id" ] && continue
+                [ -n "${before_map[$id]+x}" ] && continue
+                RUN_ID=$id
+                echo "Resolved sync-issues run id: $RUN_ID"
+                break
+              done < <(gh run list --workflow sync-issues.yml --json databaseId --jq -r '.[].databaseId')
+            fi
+
+            if [ -n "$RUN_ID" ]; then
+              RUN_STATUS=$(gh run view "$RUN_ID" --json status --jq -r '.status' 2>/dev/null || echo "unknown")
+              if [ "$RUN_STATUS" = "completed" ]; then
+                RUN_CONCLUSION=$(gh run view "$RUN_ID" --json conclusion --jq -r '.conclusion' 2>/dev/null || echo "unknown")
+                if [ "$RUN_CONCLUSION" = "success" ]; then
+                  echo "✓ sync-issues workflow completed successfully"
+                else
+                  echo "⚠ sync-issues workflow completed with status: $RUN_CONCLUSION"
+                fi
+                break
+              fi
+            fi
+
+            sleep "$INTERVAL"
+            ELAPSED=$((ELAPSED + INTERVAL))
+            echo "Waiting for sync-issues... (${ELAPSED}s / ${TIMEOUT}s)"
+          done
+
+          if [ "$ELAPSED" -ge "$TIMEOUT" ]; then
+            echo "⚠ Timed out waiting for sync-issues workflow"
+            echo "The release may continue, but PR documentation may not be synced"
+          fi
 
   build-and-test:
     name: Build and Test (${{ matrix.arch }})
@@ -1006,7 +1026,6 @@ jobs:
       - name: Create multi-arch manifest
         env:
           PUBLISH_VERSION: ${{ needs.validate.outputs.publish_version }}
-          RELEASE_KIND: ${{ needs.validate.outputs.release_kind }}
           ARCHS: ${{ needs.validate.outputs.architectures }}
         run: |
           set -euo pipefail
@@ -1028,22 +1047,9 @@ jobs:
               "${ARCH_IMAGES[@]}"
           echo "✓ Created version manifest: $REPO:$PUBLISH_VERSION"
 
-          # Update latest manifest only for final releases building both architectures.
-          if [ "$RELEASE_KIND" = "final" ] && [ ${#ARCH_ARRAY[@]} -eq 2 ]; then
-            echo "Creating/updating latest manifest: $REPO:latest"
-            retry --retries 3 --backoff 3 --max-backoff 3 -- \
-              docker buildx imagetools create \
-                --tag "$REPO:latest" \
-                "${ARCH_IMAGES[@]}"
-            echo "✓ Created/updated latest manifest: $REPO:latest"
-          else
-            echo "Skipping 'latest' manifest (single architecture or limited build)"
-          fi
-
       - name: Verify manifests
         env:
           PUBLISH_VERSION: ${{ needs.validate.outputs.publish_version }}
-          RELEASE_KIND: ${{ needs.validate.outputs.release_kind }}
           ARCHS: ${{ needs.validate.outputs.architectures }}
         run: |
           set -euo pipefail
@@ -1067,25 +1073,6 @@ jobs:
               fi
             fi
           done
-
-          if [ "$RELEASE_KIND" = "final" ] && [ ${#ARCH_ARRAY[@]} -eq 2 ]; then
-            echo "Verifying latest manifest: $REPO:latest"
-            RETRIES=5
-            for i in $(seq 1 $RETRIES); do
-              if docker buildx imagetools inspect "$REPO:latest" >/dev/null 2>&1; then
-                echo "✓ Latest manifest verified"
-                break
-              else
-                if [ $i -lt $RETRIES ]; then
-                  echo "Verification failed, retrying ($i/$RETRIES)..."
-                  sleep 5
-                else
-                  echo "ERROR: Latest manifest verification failed"
-                  exit 1
-                fi
-              fi
-            done
-          fi
 
       - name: Generate SBOM (attempt 1)
         id: sbom_generate
@@ -1197,7 +1184,7 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           set -euo pipefail
-          # Draft first: human publishes from the UI when ready (GitHub immutable-releases best practice).
+          # Draft first; promote-release.yml publishes (undrafts) after downstream verification (GitHub immutable-releases best practice).
           RETRIES=5
           LAST_ERROR=""
           for i in $(seq 1 "$RETRIES"); do
@@ -1206,7 +1193,7 @@ jobs:
               IS_DRAFT=$(printf '%s' "$API_OUTPUT" | jq -r '.draft')
               if [ "$IS_DRAFT" = "true" ]; then
                 echo "✓ Draft GitHub Release already exists for $PUBLISH_VERSION; skipping create (retry path)."
-                echo "Review and publish from: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/releases"
+                echo "Publish via promote workflow when ready: just promote-release $PUBLISH_VERSION"
                 exit 0
               fi
               echo "ERROR: Published (non-draft) GitHub Release already exists for tag $PUBLISH_VERSION"
@@ -1303,7 +1290,7 @@ jobs:
             }
 
           echo "✓ Draft GitHub Release created: $PUBLISH_VERSION"
-          echo "Review and publish from: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/releases (publishing locks the linked tag and assets when immutable releases are enabled)"
+          echo "After smoke-test passes downstream, run: just promote-release $PUBLISH_VERSION (publishing locks the linked tag and assets when immutable releases are enabled)"
 
       - name: Summary
         env:
@@ -1320,7 +1307,7 @@ jobs:
           echo "  Images:"
           echo "    - ghcr.io/vig-os/devcontainer:$PUBLISH_VERSION"
           if [ "$RELEASE_KIND" = "final" ]; then
-            echo "    - ghcr.io/vig-os/devcontainer:latest"
+            echo "    - ghcr.io/vig-os/devcontainer:latest (after just promote-release $BASE_VERSION)"
           fi
           echo "  Security:"
           echo "    - Cosign signature attached"
@@ -1332,9 +1319,8 @@ jobs:
             echo "  1. Smoke-test dispatch runs in the smoke-test job."
             echo "  2. If downstream pre-release passes, run: just finalize-release $BASE_VERSION"
           else
-            echo "  1. Smoke-test dispatch runs in the smoke-test job."
-            echo "  2. Review the draft GitHub Release and publish it from the Releases UI (publishing applies immutable-release lock-in for the tag and assets when that setting is enabled)."
-            echo "  3. Merge release PR to main (triggers sync-main-to-dev workflow automatically)"
+            echo "  1. Smoke-test dispatch runs in the smoke-test job; wait for downstream final release on devcontainer-smoke-test."
+            echo "  2. Run: just promote-release $BASE_VERSION — updates :latest, publishes the draft GitHub Release, merges the release PR to main."
           fi
 
   smoke-test:
@@ -1401,7 +1387,7 @@ jobs:
           echo "✓ Triggered smoke-test dispatch for release tag: $RELEASE_TAG"
           echo "Downstream validation is asynchronous; verify in devcontainer-smoke-test."
           if [ "$RELEASE_KIND" = "final" ]; then
-            echo "Final: review the draft GitHub Release in this repo and publish it from the Releases UI when validation is complete."
+            echo "Final: when downstream smoke-test has published its release for this tag, run: just promote-release $RELEASE_TAG"
           fi
 
       - name: Create issue for smoke dispatch failure

--- a/.github/workflows/sync-main-to-dev.yml
+++ b/.github/workflows/sync-main-to-dev.yml
@@ -105,11 +105,80 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.commit-app-token.outputs.token }}
 
-      - name: Set up environment
-        uses: ./.github/actions/setup-env
-        with:
-          install-python: 'false'
-          install-just: 'false'
+      # Do not use ./.github/actions/setup-env here: this job checks out `dev`, so the
+      # composite action would come from `dev` while the workflow on `main` may pass
+      # inputs or rely on helpers only present on `main` (chicken-and-egg). Git + gh
+      # are on the runner; this inlines a minimal retry helper similar to setup-env/action.yml
+      # but intentionally sets BASH_ENV to that helper only (setup-env merges a prior BASH_ENV).
+      - name: Export retry helper
+        shell: bash
+        run: |
+          set -euo pipefail
+          RETRY_HELPER="$RUNNER_TEMP/sync-main-to-dev-retry.sh"
+
+          cat > "$RETRY_HELPER" <<'EOF'
+          retry() {
+            local retries=3
+            local backoff=1
+            local max_backoff=60
+            local rc=1
+
+            while [ "$#" -gt 0 ]; do
+              case "$1" in
+                --retries)
+                  retries="$2"
+                  shift 2
+                  ;;
+                --backoff)
+                  backoff="$2"
+                  shift 2
+                  ;;
+                --max-backoff)
+                  max_backoff="$2"
+                  shift 2
+                  ;;
+                --)
+                  shift
+                  break
+                  ;;
+                *)
+                  echo "ERROR: Unknown retry option '$1'"
+                  return 2
+                  ;;
+              esac
+            done
+
+            if [ "$#" -eq 0 ]; then
+              echo "ERROR: retry requires a command after '--'"
+              return 2
+            fi
+
+            local attempt=1
+            local current_backoff="$backoff"
+            while [ "$attempt" -le "$retries" ]; do
+              if "$@"; then
+                return 0
+              fi
+              rc=$?
+              if [ "$attempt" -lt "$retries" ]; then
+                local wait="$current_backoff"
+                if [ "$wait" -gt "$max_backoff" ]; then
+                  wait="$max_backoff"
+                fi
+                echo "Retry $attempt/$retries failed (exit $rc), waiting ${wait}s..."
+                sleep "$wait"
+                current_backoff=$((current_backoff * 2))
+              fi
+              attempt=$((attempt + 1))
+            done
+
+            echo "ERROR: Command failed after $retries attempts: $*"
+            return "$rc"
+          }
+          export -f retry
+          EOF
+
+          echo "BASH_ENV=$RETRY_HELPER" >> "$GITHUB_ENV"
 
       - name: Re-check if dev is still behind main
         id: recheck

--- a/tests/bats/just.bats
+++ b/tests/bats/just.bats
@@ -56,7 +56,7 @@ setup() {
 }
 
 @test "release workflow refreshes release PR body from changelog" {
-    run bash -lc 'grep -Fq -- "name: Refresh release PR body from finalized changelog" .github/workflows/release.yml && grep -Fq -- "CHANGELOG_CONTENT=\$(sed -n" .github/workflows/release.yml && grep -Fq -- "gh pr edit \"\$PR_NUMBER\" --body-file /tmp/release-pr-body.md" .github/workflows/release.yml'
+    run bash -lc 'grep -Fq -- "name: Refresh release PR body from finalized changelog" .github/workflows/release.yml && grep -Fq -- "CHANGELOG_CONTENT=\$(awk" .github/workflows/release.yml && grep -Fq -- "gh pr edit \"\$PR_NUMBER\" --body-file /tmp/release-pr-body.md" .github/workflows/release.yml'
     assert_success
 }
 


### PR DESCRIPTION
Sync GitHub workflows from `dev` to `main` to:

- Register the new `promote-release.yml`
- Test the latest `sync-main-to-dev.yml`

Refs: #456, #459