### PR TITLE
ci: nightly CI on dev and GHCR latest security scan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@
 # Triggers:
 #   - Pull requests to dev, release/**, and main (runs all suites)
 #   - Manual workflow_dispatch (select specific test suite to run)
+#   - Nightly schedule at 04:00 UTC (checks out dev; full suites)
 
 name: CI
 
@@ -35,6 +36,9 @@ on:  # yamllint disable-line rule:truthy
           - image
           - integration
           - project
+  schedule:
+    # Nightly against dev (staggered after CodeQL 02:15 UTC Mon)
+    - cron: '0 4 * * *'
 
 permissions:
   contents: read
@@ -61,16 +65,20 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          ref: ${{ github.event_name == 'schedule' && 'dev' || github.ref }}
 
       - name: Generate version for dev build
         id: version
         run: |
           VERSION="dev-$(git rev-parse --short HEAD)"
+          VCS_REF=$(git rev-parse HEAD)
           RELEASE_DATE=$(date -u +%Y-%m-%d)
           BUILD_TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-          RELEASE_URL="https://github.com/${GITHUB_REPOSITORY}/commit/$(git rev-parse HEAD)"
+          RELEASE_URL="https://github.com/${GITHUB_REPOSITORY}/commit/${VCS_REF}"
 
           echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "vcs_ref=$VCS_REF" >> $GITHUB_OUTPUT
           echo "release_date=$RELEASE_DATE" >> $GITHUB_OUTPUT
           echo "build_timestamp=$BUILD_TIMESTAMP" >> $GITHUB_OUTPUT
           echo "release_url=$RELEASE_URL" >> $GITHUB_OUTPUT
@@ -84,7 +92,7 @@ jobs:
           release-date: ${{ steps.version.outputs.release_date }}
           release-url: ${{ steps.version.outputs.release_url }}
           build-timestamp: ${{ steps.version.outputs.build_timestamp }}
-          vcs-ref: ${{ github.sha }}
+          vcs-ref: ${{ steps.version.outputs.vcs_ref }}
           output-type: tar
           output-file: /tmp/image.tar
 
@@ -109,6 +117,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          ref: ${{ github.event_name == 'schedule' && 'dev' || github.ref }}
 
       - name: Download image artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
@@ -135,6 +145,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          ref: ${{ github.event_name == 'schedule' && 'dev' || github.ref }}
 
       - name: Download image artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
@@ -170,6 +182,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          ref: ${{ github.event_name == 'schedule' && 'dev' || github.ref }}
 
       - name: Run project checks
         uses: ./.github/actions/test-project
@@ -186,6 +200,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          ref: ${{ github.event_name == 'schedule' && 'dev' || github.ref }}
 
       - name: Set up environment
         uses: ./.github/actions/setup-env
@@ -244,6 +260,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          ref: ${{ github.event_name == 'schedule' && 'dev' || github.ref }}
 
       - name: Download image artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -60,7 +60,8 @@ jobs:
       - name: Log when latest image is unavailable
         if: steps.pull.outcome != 'success'
         run: |
-          echo "::warning::Skip scan-latest: GHCR devcontainer:latest pull failed"
+          echo "::error::Scan skipped: GHCR devcontainer:latest pull failed"
+          exit 1
 
       - name: Scan latest image for all vulnerabilities
         if: steps.pull.outcome == 'success'
@@ -163,7 +164,7 @@ jobs:
           gh label create security-scan \
             --description 'Automated nightly security scan findings for :latest image' \
             --color BFD4F2 2>/dev/null || true
-          EXISTING=$(gh issue list --label security-scan --state open --limit 1 --json number -q '.[0].number')
+          EXISTING=$(gh issue list --label security-scan --state open --limit 1 --json number -q '.[0].number // empty')
           if [ -n "$EXISTING" ]; then
             echo "Open security-scan issue already exists: #$EXISTING -- skipping create"
             exit 0

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,135 +1,194 @@
 # Scheduled Security Scan
 #
-# Runs a comprehensive container security scan on a weekly schedule to catch
-# newly published vulnerabilities between pull requests. This workflow builds
-# the image from the dev branch and performs Trivy scanning with full severity
-# reporting for awareness.
+# Nightly scan of the latest published container image from GHCR (covers main via
+# :latest) without rebuilding. Dev-branch builds are covered by nightly CI
+# (ci.yml) including Trivy + full-severity SARIF (category: container-image).
 #
 # Triggers:
-#   - Weekly schedule: Monday 06:00 UTC
+#   - Nightly schedule: 05:00 UTC (after nightly CI at 04:00 UTC)
 #
 # Jobs:
-#   1. build-image - Build container image for dev branch
-#   2. security-scan - Full Trivy vulnerability scan (non-blocking)
+#   1. scan-latest - Pull ghcr.io/vig-os/devcontainer:latest and Trivy + SBOM + SARIF
+#
+# When fixable HIGH/CRITICAL vulnerabilities are found (after .trivyignore):
+#   - Workflow fails (GitHub notifies watchers)
+#   - One open issue with label security-scan is created (deduplicated)
+#   - Step summary records verdict and links
 #
 # Artifacts:
 #   - SBOM (CycloneDX) with all packages
-#   - SARIF report uploaded to GitHub Security tab
+#   - SARIF report uploaded to GitHub Security tab (category: container-image-latest)
 
 name: Scheduled Security Scan
 
 on:  # yamllint disable-line rule:truthy
   schedule:
-    # Weekly scan: Monday 06:00 UTC (catches new CVEs between PRs)
-    - cron: '0 6 * * 1'
+    # Nightly (staggered after nightly CI at 04:00 UTC)
+    - cron: '0 5 * * *'
 
 permissions:
   contents: read
 
 jobs:
-  build-image:
-    name: Build Container Image
-    runs-on: ubuntu-22.04
-    timeout-minutes: 30
-
-    outputs:
-      version: ${{ steps.version.outputs.version }}
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          ref: dev
-
-      - name: Generate version string
-        id: version
-        run: |
-          # Version format: scheduled-YYYY-MM-DD-<commit_short>
-          COMMIT_SHORT=$(git rev-parse --short HEAD)
-          VERSION="scheduled-$(date -u +'%Y-%m-%d')-${COMMIT_SHORT}"
-          RELEASE_DATE=$(date -u +%Y-%m-%d)
-          BUILD_TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-          echo "version=${VERSION}" >> $GITHUB_OUTPUT
-          echo "release_date=$RELEASE_DATE" >> $GITHUB_OUTPUT
-          echo "build_timestamp=$BUILD_TIMESTAMP" >> $GITHUB_OUTPUT
-          echo "Generated version: ${VERSION}"
-
-      - name: Build container image
-        uses: ./.github/actions/build-image
-        with:
-          version: ${{ steps.version.outputs.version }}
-          arch: 'amd64'
-          release-date: ${{ steps.version.outputs.release_date }}
-          release-url: 'https://github.com/vig-os/devcontainer'
-          build-timestamp: ${{ steps.version.outputs.build_timestamp }}
-          vcs-ref: ${{ github.sha }}
-          output-type: tar
-          output-file: /tmp/image.tar
-
-      - name: Upload image artifact
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
-        with:
-          name: container-image-${{ steps.version.outputs.version }}-amd64
-          path: /tmp/image.tar
-          retention-days: 1
-          compression-level: 0   # Image is already compressed; avoid double-compression overhead
-
-  security-scan:
-    name: Security Scan
-    needs: build-image
+  scan-latest:
+    name: Scan GHCR Latest Image
     runs-on: ubuntu-22.04
     timeout-minutes: 20
     permissions:
       contents: read
+      issues: write               # create deduplicated security-scan issue on gate failure
       security-events: write    # upload SARIF results to GitHub Security tab
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-      - name: Download image artifact
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
-        with:
-          name: container-image-${{ needs.build-image.outputs.version }}-amd64
-          path: /tmp
+      - name: Pull latest image and save as tar
+        id: pull
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          IMAGE=ghcr.io/vig-os/devcontainer:latest
+          docker pull "$IMAGE"
+          docker save "$IMAGE" -o /tmp/image-latest.tar
+          RESOLVED=$(docker inspect --format '{{range .RepoDigests}}{{.}}{{"\n"}}{{end}}' "$IMAGE" | head -n1 | tr -d '\n')
+          if [ -z "$RESOLVED" ] || [ "$RESOLVED" = '<no value>' ]; then
+            RESOLVED=$(docker inspect --format='{{.Id}}' "$IMAGE")
+          fi
+          echo "image_ref=${RESOLVED}" >> "$GITHUB_OUTPUT"
 
-      - name: Scan image for all vulnerabilities
+      - name: Log when latest image is unavailable
+        if: steps.pull.outcome != 'success'
+        run: |
+          echo "::warning::Skip scan-latest: GHCR devcontainer:latest pull failed"
+
+      - name: Scan latest image for all vulnerabilities
+        if: steps.pull.outcome == 'success'
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1  # v0.35.0
         with:
           version: 'v0.69.3'
-          input: /tmp/image.tar
+          input: /tmp/image-latest.tar
           format: 'table'
           severity: 'UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL'
           exit-code: '0'  # Non-blocking: for awareness only
           trivyignores: '.trivyignore'
 
-      - name: Generate container SBOM (CycloneDX)
+      - name: Gate on fixable HIGH/CRITICAL vulnerabilities
+        id: gate
+        if: steps.pull.outcome == 'success'
+        continue-on-error: true
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1  # v0.35.0
         with:
           version: 'v0.69.3'
-          input: /tmp/image.tar
-          format: 'cyclonedx'
-          output: 'sbom-cyclonedx.json'
+          input: /tmp/image-latest.tar
+          format: 'table'
+          severity: 'HIGH,CRITICAL'
+          exit-code: '1'
+          ignore-unfixed: true
+          trivyignores: '.trivyignore'
 
-      - name: Generate SARIF report
+      - name: Generate latest image SBOM (CycloneDX)
+        if: steps.pull.outcome == 'success'
         uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1  # v0.35.0
         with:
           version: 'v0.69.3'
-          input: /tmp/image.tar
+          input: /tmp/image-latest.tar
+          format: 'cyclonedx'
+          output: 'sbom-latest-cyclonedx.json'
+
+      - name: Generate latest image SARIF report
+        if: steps.pull.outcome == 'success'
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1  # v0.35.0
+        with:
+          version: 'v0.69.3'
+          input: /tmp/image-latest.tar
           format: 'sarif'
-          output: 'trivy-results.sarif'
+          output: 'trivy-latest-results.sarif'
           severity: 'UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL'
           trivyignores: '.trivyignore'
 
-      - name: Upload SBOM artifact
+      - name: Upload latest SBOM artifact
+        if: steps.pull.outcome == 'success'
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
         with:
-          name: sbom-${{ needs.build-image.outputs.version }}-amd64
-          path: sbom-cyclonedx.json
+          name: sbom-latest
+          path: sbom-latest-cyclonedx.json
           retention-days: 90
 
-      - name: Upload SARIF to GitHub Security
+      - name: Upload latest SARIF to GitHub Security
+        if: steps.pull.outcome == 'success'
         uses: github/codeql-action/upload-sarif@38697555549f1db7851b81482ff19f1fa5c4fedc  # v4
         with:
-          sarif_file: trivy-results.sarif
-          category: 'container-image-scheduled'
+          sarif_file: trivy-latest-results.sarif
+          category: 'container-image-latest'
+
+      - name: Write scan summary
+        if: steps.pull.outcome == 'success'
+        env:
+          IMAGE_REF: ${{ steps.pull.outputs.image_ref }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          SECURITY_URL: ${{ github.server_url }}/${{ github.repository }}/security
+        run: |
+          set -euo pipefail
+          {
+            echo "## Scheduled security scan (:latest)"
+            echo ""
+            echo "- **Image (resolved):** \`${IMAGE_REF}\`"
+            echo "- **Tag pulled:** \`ghcr.io/vig-os/devcontainer:latest\`"
+            echo "- **Date (UTC):** $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+            echo "- **Workflow run:** [${{ github.run_id }}](${RUN_URL})"
+            echo ""
+            if [ "${{ steps.gate.outcome }}" = "failure" ]; then
+              echo "### Result"
+              echo ""
+              echo "**Fixable HIGH/CRITICAL vulnerabilities detected** (see Trivy table in job logs and [Security](${SECURITY_URL}))."
+            else
+              echo "### Result"
+              echo ""
+              echo "No fixable HIGH/CRITICAL vulnerabilities passed the gate (after \`.trivyignore\`)."
+            fi
+            echo ""
+            echo "Full dependency results: [Code security](${SECURITY_URL})."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Create GitHub issue on gate failure
+        if: steps.pull.outcome == 'success' && steps.gate.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          IMAGE_REF: ${{ steps.pull.outputs.image_ref }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          SECURITY_URL: ${{ github.server_url }}/${{ github.repository }}/security
+        run: |
+          set -euo pipefail
+          gh label create security-scan \
+            --description 'Automated nightly security scan findings for :latest image' \
+            --color BFD4F2 2>/dev/null || true
+          EXISTING=$(gh issue list --label security-scan --state open --limit 1 --json number -q '.[0].number')
+          if [ -n "$EXISTING" ]; then
+            echo "Open security-scan issue already exists: #$EXISTING -- skipping create"
+            exit 0
+          fi
+          BODY="$(cat <<EOF
+          Nightly scan found **fixable HIGH/CRITICAL** vulnerabilities in the resolved image below (after \`.trivyignore\`).
+
+          - **Image (resolved):** \`${IMAGE_REF}\`
+          - **Tag pulled:** \`ghcr.io/vig-os/devcontainer:latest\`
+          - **Scan date (UTC):** $(date -u +%Y-%m-%dT%H:%M:%SZ)
+          - **Workflow run:** ${RUN_URL}
+          - **Security tab:** ${SECURITY_URL}
+
+          Close this issue after the image is remediated and the next scheduled run passes the gate.
+          EOF
+          )"
+          gh issue create \
+            --title "Nightly security scan: HIGH/CRITICAL vulnerabilities in :latest" \
+            --label security-scan --label security \
+            --body "$BODY"
+
+      - name: Fail if fixable HIGH/CRITICAL vulnerabilities found
+        if: steps.pull.outcome == 'success' && steps.gate.outcome == 'failure'
+        env:
+          IMAGE_REF: ${{ steps.pull.outputs.image_ref }}
+        run: |
+          echo "::error::Fixable HIGH/CRITICAL vulnerabilities detected in ${IMAGE_REF} (pulled as ghcr.io/vig-os/devcontainer:latest)"
+          exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Add `just promote-release` in `justfile.gh` (and workspace template copy)
 - **Smoke-test dispatch fails fast when deploy PR checks fail** ([#381](https://github.com/vig-os/devcontainer/issues/381))
   - `wait-deploy-merge` in `assets/smoke-test/.github/workflows/repository-dispatch.yml` exits as soon as all required checks have completed with failures instead of waiting for the merge poll timeout (`gh pr checks --required`)
+- **Nightly CI schedule** ([#461](https://github.com/vig-os/devcontainer/issues/461))
+  - `ci.yml` adds a `schedule` trigger at 04:00 UTC that checks out `dev` and runs all test suites; checkout `ref` and `vcs-ref` are resolved correctly for scheduled runs
+- **Scheduled security scan pulls GHCR `:latest` instead of rebuilding** ([#461](https://github.com/vig-os/devcontainer/issues/461))
+  - Runs nightly at 05:00 UTC, pulls the published image, gates on fixable HIGH/CRITICAL vulnerabilities, auto-creates a deduplicated GitHub issue on failure, and uploads SARIF under `container-image-latest`
 
 ### Deprecated
 
@@ -59,6 +63,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Inline the same `retry` shell helper used by `setup-env` so the job works when `main`'s workflow expects helpers not yet on `dev`
 
 ### Security
+
+- **Nightly vulnerability gate for published container image** ([#461](https://github.com/vig-os/devcontainer/issues/461))
+  - Scheduled security scan now fails on fixable HIGH/CRITICAL CVEs and auto-files a GitHub issue, replacing the previous non-blocking weekly scan
 
 ## [0.3.1](https://github.com/vig-os/devcontainer/releases/tag/0.3.1) - 2026-03-26
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -32,6 +32,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Add `just promote-release` in `justfile.gh` (and workspace template copy)
 - **Smoke-test dispatch fails fast when deploy PR checks fail** ([#381](https://github.com/vig-os/devcontainer/issues/381))
   - `wait-deploy-merge` in `assets/smoke-test/.github/workflows/repository-dispatch.yml` exits as soon as all required checks have completed with failures instead of waiting for the merge poll timeout (`gh pr checks --required`)
+- **Nightly CI schedule** ([#461](https://github.com/vig-os/devcontainer/issues/461))
+  - `ci.yml` adds a `schedule` trigger at 04:00 UTC that checks out `dev` and runs all test suites; checkout `ref` and `vcs-ref` are resolved correctly for scheduled runs
+- **Scheduled security scan pulls GHCR `:latest` instead of rebuilding** ([#461](https://github.com/vig-os/devcontainer/issues/461))
+  - Runs nightly at 05:00 UTC, pulls the published image, gates on fixable HIGH/CRITICAL vulnerabilities, auto-creates a deduplicated GitHub issue on failure, and uploads SARIF under `container-image-latest`
 
 ### Deprecated
 
@@ -59,6 +63,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Inline the same `retry` shell helper used by `setup-env` so the job works when `main`'s workflow expects helpers not yet on `dev`
 
 ### Security
+
+- **Nightly vulnerability gate for published container image** ([#461](https://github.com/vig-os/devcontainer/issues/461))
+  - Scheduled security scan now fails on fixable HIGH/CRITICAL CVEs and auto-files a GitHub issue, replacing the previous non-blocking weekly scan
 
 ## [0.3.1](https://github.com/vig-os/devcontainer/releases/tag/0.3.1) - 2026-03-26
 


### PR DESCRIPTION
## Description

Adds a nightly CI schedule on `dev` so the full pipeline (build, tests, Python security, Trivy) runs without waiting for a PR. Reworks the scheduled security workflow to run nightly, pull `ghcr.io/vig-os/devcontainer:latest` (no rebuild), run Trivy/SBOM/SARIF with category `container-image-latest`, and fail the workflow when fixable HIGH/CRITICAL findings remain after `.trivyignore`, with a deduplicated GitHub issue on failure. PR and `workflow_dispatch` behavior for CI is unchanged aside from scheduled checkout ref handling.

## Type of Change

- [ ] `feat` -- New feature
- [ ] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [x] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- `.github/workflows/ci.yml`
  - Add `schedule` cron at 04:00 UTC; on `schedule`, checkout `ref: dev` across jobs.
  - Emit `vcs_ref` from the checked-out commit and pass it to `build-image` as `vcs-ref` so the image metadata matches the scheduled tree.
- `.github/workflows/security-scan.yml`
  - Replace weekly `dev` rebuild + scan with nightly `scan-latest`: pull GHCR `:latest`, Trivy table (awareness), gated scan on fixable HIGH/CRITICAL, SBOM + SARIF upload, step summary, optional `gh issue create` when the gate fails, distinct SARIF category `container-image-latest`.
- `CHANGELOG.md` and `assets/workspace/.devcontainer/CHANGELOG.md`
  - Document nightly CI, scheduled scan behavior, and security gate under Unreleased.

## Changelog Entry

```diff
@@ -32,6 +32,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Add `just promote-release` in `justfile.gh` (and workspace template copy)
 - **Smoke-test dispatch fails fast when deploy PR checks fail** ([#381](https://github.com/vig-os/devcontainer/issues/381))
   - `wait-deploy-merge` in `assets/smoke-test/.github/workflows/repository-dispatch.yml` exits as soon as all required checks have completed with failures instead of waiting for the merge poll timeout (`gh pr checks --required`)
+- **Nightly CI schedule** ([#461](https://github.com/vig-os/devcontainer/issues/461))
+  - `ci.yml` adds a `schedule` trigger at 04:00 UTC that checks out `dev` and runs all test suites; checkout `ref` and `vcs-ref` are resolved correctly for scheduled runs
+- **Scheduled security scan pulls GHCR `:latest` instead of rebuilding** ([#461](https://github.com/vig-os/devcontainer/issues/461))
+  - Runs nightly at 05:00 UTC, pulls the published image, gates on fixable HIGH/CRITICAL vulnerabilities, auto-creates a deduplicated GitHub issue on failure, and uploads SARIF under `container-image-latest`
 
 ### Deprecated
 
@@ -60,6 +64,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **Nightly vulnerability gate for published container image** ([#461](https://github.com/vig-os/devcontainer/issues/461))
+  - Scheduled security scan now fails on fixable HIGH/CRITICAL CVEs and auto-files a GitHub issue, replacing the previous non-blocking weekly scan
+
 ## [0.3.1](https://github.com/vig-os/devcontainer/releases/tag/0.3.1) - 2026-03-26
```

## Testing

- [ ] Tests pass locally (`just test`)
- [ ] Manual testing performed (describe below)

### Manual Testing Details

`just test-bats` was run successfully before the workflow commits (shell/just coverage). Full `just test` (image + integration) was not run for this PR.

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

N/A

Refs: #461
