### PR TITLE
fix: authenticate Docker Hub pulls to avoid CI rate limits

### DIFF
--- a/.github/actions/build-image/action.yml
+++ b/.github/actions/build-image/action.yml
@@ -5,6 +5,13 @@
 # - Builds architecture-specific container image
 # - Outputs image as tar file or pushes to registry
 #
+# Docker Hub (optional, Refs: #473):
+#   docker/setup-buildx-action pulls moby/buildkit from Docker Hub; anonymous pulls on
+#   shared runners hit rate limits. Pass dockerhub-username and dockerhub-token from
+#   workflow secrets (DOCKERHUB_USERNAME, DOCKERHUB_TOKEN) to log in before Buildx.
+#   Recommended for org/repo CI; omit for forks (secrets unavailable) — behavior matches
+#   pre-auth CI (anonymous pulls).
+#
 # Inputs:
 #   version: Semantic version (e.g., 1.0.0, dev-abc123)
 #   arch: Target architecture (amd64, arm64)
@@ -16,6 +23,8 @@
 #   output-type: Output type - "tar" saves to file, "registry" pushes to registry
 #   output-file: Path for tar output (used if output-type=tar)
 #   push: Whether to push to registry (used if output-type=registry)
+#   dockerhub-username: Docker Hub user (optional; from secrets.DOCKERHUB_USERNAME)
+#   dockerhub-token: Docker Hub access token (optional; from secrets.DOCKERHUB_TOKEN)
 #
 # Outputs:
 #   image-tag: Full image tag (e.g., ghcr.io/vig-os/devcontainer:1.0.0-amd64)
@@ -30,6 +39,8 @@
 #       release-url: 'https://github.com/vig-os/devcontainer/releases/tag/1.0.0'
 #       build-timestamp: '2026-02-06T12:00:00Z'
 #       vcs-ref: ${{ github.sha }}
+#       dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
+#       dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
 
 name: 'Build Container Image'
 description: 'Build architecture-specific container image'
@@ -69,6 +80,14 @@ inputs:
     description: 'Whether to push to registry (if output-type=registry)'
     required: false
     default: 'false'
+  dockerhub-username:
+    description: 'Docker Hub username for authenticated pulls (optional; omit on forks)'
+    required: false
+    default: ''
+  dockerhub-token:
+    description: 'Docker Hub access token for authenticated pulls (optional; omit on forks)'
+    required: false
+    default: ''
 
 outputs:
   image-tag:
@@ -81,6 +100,14 @@ outputs:
 runs:
   using: composite
   steps:
+    - name: Login to Docker Hub
+      if: inputs.dockerhub-username != '' && inputs.dockerhub-token != ''
+      uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2  # v4.0.0
+      with:
+        registry: docker.io
+        username: ${{ inputs.dockerhub-username }}
+        password: ${{ inputs.dockerhub-token }}
+
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4.0.0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,8 @@ jobs:
           release-url: ${{ steps.version.outputs.release_url }}
           build-timestamp: ${{ steps.version.outputs.build_timestamp }}
           vcs-ref: ${{ steps.version.outputs.vcs_ref }}
+          dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
+          dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
           output-type: tar
           output-file: /tmp/image.tar
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -748,6 +748,8 @@ jobs:
           release-url: ${{ needs.validate.outputs.release_url }}
           build-timestamp: ${{ needs.validate.outputs.build_timestamp }}
           vcs-ref: ${{ github.sha }}
+          dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
+          dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
           output-type: tar
           output-file: /tmp/image.tar
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Fetch dev `CHANGELOG.md` by resolved commit SHA during rollback so Contents API staleness does not skip the rollback commit
 - **sync-main-to-dev sync job no longer depends on dev's setup-env** ([#459](https://github.com/vig-os/devcontainer/issues/459))
   - Inline the same `retry` shell helper used by `setup-env` so the job works when `main`'s workflow expects helpers not yet on `dev`
+- **CI container build avoids shared-runner Docker Hub rate limits** ([#473](https://github.com/vig-os/devcontainer/issues/473))
+  - `build-image` logs in to `docker.io` before `setup-buildx-action` when `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` secrets are set; `ci.yml` and `release.yml` pass them
+  - Omitting secrets (e.g. forks) keeps prior anonymous-pull behavior
 
 ### Security
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -61,6 +61,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Fetch dev `CHANGELOG.md` by resolved commit SHA during rollback so Contents API staleness does not skip the rollback commit
 - **sync-main-to-dev sync job no longer depends on dev's setup-env** ([#459](https://github.com/vig-os/devcontainer/issues/459))
   - Inline the same `retry` shell helper used by `setup-env` so the job works when `main`'s workflow expects helpers not yet on `dev`
+- **CI container build avoids shared-runner Docker Hub rate limits** ([#473](https://github.com/vig-os/devcontainer/issues/473))
+  - `build-image` logs in to `docker.io` before `setup-buildx-action` when `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` secrets are set; `ci.yml` and `release.yml` pass them
+  - Omitting secrets (e.g. forks) keeps prior anonymous-pull behavior
 
 ### Security
 


### PR DESCRIPTION
## Description

Fix Docker Hub rate-limit failures on shared GitHub Actions runners. The `docker/setup-buildx-action` step pulls `moby/buildkit` from Docker Hub; anonymous pulls on shared runners hit rate limits, causing intermittent CI failures. This PR adds optional Docker Hub authentication to the `build-image` composite action and wires the credentials through `ci.yml` and `release.yml`.

## Type of Change

- [ ] `feat` -- New feature
- [x] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [x] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- **`.github/actions/build-image/action.yml`** — Added optional `dockerhub-username` and `dockerhub-token` inputs; added a `Login to Docker Hub` step (using `docker/login-action@v4.0.0`, SHA-pinned) that runs before `setup-buildx-action` when both inputs are provided; added documentation header explaining the Docker Hub auth rationale.
- **`.github/workflows/ci.yml`** — Passed `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` secrets to the `build-image` action.
- **`.github/workflows/release.yml`** — Same as `ci.yml`.
- **`CHANGELOG.md`** / **`assets/workspace/.devcontainer/CHANGELOG.md`** — Added entry under `## Unreleased > ### Fixed`.

## Changelog Entry

### Fixed

- **CI container build avoids shared-runner Docker Hub rate limits** ([#473](https://github.com/vig-os/devcontainer/issues/473))
  - `build-image` logs in to `docker.io` before `setup-buildx-action` when `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` secrets are set; `ci.yml` and `release.yml` pass them
  - Omitting secrets (e.g. forks) keeps prior anonymous-pull behavior

## Testing

- [ ] Tests pass locally (`just test`)
- [ ] Manual testing performed (describe below)

### Manual Testing Details

N/A — CI-only change; verified that the action YAML is syntactically valid via `yamllint` (pre-commit) and that `check-action-pins` passes for the new `docker/login-action` SHA pin.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

The new inputs default to empty strings, so forks or repos without `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` secrets simply skip the login step — identical to pre-PR behavior.

Refs: #473
