### PR TITLE
chore: merge dev dependabot patches into release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -331,7 +331,7 @@ jobs:
 
       - name: Upload SARIF to GitHub Security
         if: always()
-        uses: github/codeql-action/upload-sarif@38697555549f1db7851b81482ff19f1fa5c4fedc  # v4
+        uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13  # v4
         with:
           sarif_file: trivy-results.sarif
           category: 'container-image'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -48,11 +48,11 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@38697555549f1db7851b81482ff19f1fa5c4fedc  # v4
+        uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13  # v4
         with:
           languages: ${{ matrix.language }}
 
       - name: Run CodeQL analysis
-        uses: github/codeql-action/analyze@38697555549f1db7851b81482ff19f1fa5c4fedc  # v4
+        uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13  # v4
         with:
           category: '/language:${{ matrix.language }}'

--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -135,7 +135,7 @@ jobs:
           done
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@ba7bc0a3fef59531c69a25acd34668d6d3fe6f22  # v4
+        uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003  # v4
 
       - name: Verify cosign signature
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -897,7 +897,7 @@ jobs:
           fi
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@ba7bc0a3fef59531c69a25acd34668d6d3fe6f22  # v4
+        uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003  # v4
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2  # v4.0.0

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -44,7 +44,7 @@ jobs:
           publish_results: true
 
       - name: Upload SARIF to GitHub Security
-        uses: github/codeql-action/upload-sarif@38697555549f1db7851b81482ff19f1fa5c4fedc  # v4
+        uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13  # v4
         with:
           sarif_file: results.sarif
           category: 'scorecard'

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -118,7 +118,7 @@ jobs:
 
       - name: Upload latest SARIF to GitHub Security
         if: steps.pull.outcome == 'success'
-        uses: github/codeql-action/upload-sarif@38697555549f1db7851b81482ff19f1fa5c4fedc  # v4
+        uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13  # v4
         with:
           sarif_file: trivy-latest-results.sarif
           category: 'container-image-latest'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `ci.yml` adds a `schedule` trigger at 04:00 UTC that checks out `dev` and runs all test suites; checkout `ref` and `vcs-ref` are resolved correctly for scheduled runs
 - **Scheduled security scan pulls GHCR `:latest` instead of rebuilding** ([#461](https://github.com/vig-os/devcontainer/issues/461))
   - Runs nightly at 05:00 UTC, pulls the published image, gates on fixable HIGH/CRITICAL vulnerabilities, auto-creates a deduplicated GitHub issue on failure, and uploads SARIF under `container-image-latest`
+- **Dependabot dependency update batch** ([#474](https://github.com/vig-os/devcontainer/pull/474))
+  - Bump `github/codeql-action` from `4.34.1` to `4.35.1`
+  - Bump `sigstore/cosign-installer` from `4.1.0` to `4.1.1`
 
 ### Deprecated
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -36,6 +36,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `ci.yml` adds a `schedule` trigger at 04:00 UTC that checks out `dev` and runs all test suites; checkout `ref` and `vcs-ref` are resolved correctly for scheduled runs
 - **Scheduled security scan pulls GHCR `:latest` instead of rebuilding** ([#461](https://github.com/vig-os/devcontainer/issues/461))
   - Runs nightly at 05:00 UTC, pulls the published image, gates on fixable HIGH/CRITICAL vulnerabilities, auto-creates a deduplicated GitHub issue on failure, and uploads SARIF under `container-image-latest`
+- **Dependabot dependency update batch** ([#474](https://github.com/vig-os/devcontainer/pull/474))
+  - Bump `github/codeql-action` from `4.34.1` to `4.35.1`
+  - Bump `sigstore/cosign-installer` from `4.1.0` to `4.1.1`
 
 ### Deprecated
 

--- a/assets/workspace/.github/workflows/codeql.yml
+++ b/assets/workspace/.github/workflows/codeql.yml
@@ -48,11 +48,11 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@38697555549f1db7851b81482ff19f1fa5c4fedc  # v4
+        uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13  # v4
         with:
           languages: ${{ matrix.language }}
 
       - name: Run CodeQL analysis
-        uses: github/codeql-action/analyze@38697555549f1db7851b81482ff19f1fa5c4fedc  # v4
+        uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13  # v4
         with:
           category: '/language:${{ matrix.language }}'

--- a/assets/workspace/.github/workflows/scorecard.yml
+++ b/assets/workspace/.github/workflows/scorecard.yml
@@ -44,7 +44,7 @@ jobs:
           publish_results: true
 
       - name: Upload SARIF to GitHub Security
-        uses: github/codeql-action/upload-sarif@38697555549f1db7851b81482ff19f1fa5c4fedc  # v4
+        uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13  # v4
         with:
           sarif_file: results.sarif
           category: 'scorecard'


### PR DESCRIPTION
## Description

Merge `dev` into `release/0.3.2` to apply latest Dependabot GitHub Actions SHA pin bumps.

## Type of Change

- [x] `chore` -- Maintenance task (deps, config, etc.)

## Changes Made

Fast-forward merge of 3 commits from `dev` (PR #474) bumping GitHub Actions SHA pins:

- `github/codeql-action` from `4.34.1` to `4.35.1` (ci.yml, codeql.yml, scorecard.yml, security-scan.yml, and workspace templates)
- `sigstore/cosign-installer` from `4.1.0` to `4.1.1` (promote-release.yml, release.yml)

Plus a changelog entry documenting the batch.

## Changelog Entry

### Changed

- **Dependabot dependency update batch** ([#474](https://github.com/vig-os/devcontainer/pull/474))
  - Bump `github/codeql-action` from `4.34.1` to `4.35.1`
  - Bump `sigstore/cosign-installer` from `4.1.0` to `4.1.1`

## Testing

- [x] No functional changes -- SHA pin updates only
- [x] Pre-commit hooks pass locally

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors

## Additional Notes

Chore maintenance -- no linked issue.

Refs: N/A (chore, no issue)