### PR TITLE
chore: simplify pull recipe in justfile.gh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Dependabot dependency update batch** ([#474](https://github.com/vig-os/devcontainer/pull/474))
   - Bump `github/codeql-action` from `4.34.1` to `4.35.1`
   - Bump `sigstore/cosign-installer` from `4.1.0` to `4.1.1`
+- **Simplify `just pull` in `justfile.gh`** ([#482](https://github.com/vig-os/devcontainer/issues/482))
+  - Pull `ghcr.io/vig-os/devcontainer` by tag; drop redundant shell fallback, per-recipe `repo` argument, and unused `REGISTRY_TEST` TLS path (imported `justfile.gh` cannot reference root `repo`)
 
 ### Deprecated
 

--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -201,7 +201,7 @@ Available recipes:
     prepare-release version ref="" *flags      # Prepare release branch for testing (step 1)
     promote-release version ref="" *flags      # Promote final release: GHCR :latest, publish draft GitHub Release, merge release PR (after downstream smoke-test final release)
     publish-candidate version ref="" *flags    # Publish release candidate via GitHub Actions workflow
-    pull version="latest" repo=""              # Pull image from registry (default: latest)
+    pull version="latest"                      # Pull image from registry (default: latest)
     reset-changelog                            # Reset CHANGELOG Unreleased section (after merging release to dev)
 
     [test]

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Available recipes:
     prepare-release version ref="" *flags      # Prepare release branch for testing (step 1)
     promote-release version ref="" *flags      # Promote final release: GHCR :latest, publish draft GitHub Release, merge release PR (after downstream smoke-test final release)
     publish-candidate version ref="" *flags    # Publish release candidate via GitHub Actions workflow
-    pull version="latest" repo=""              # Pull image from registry (default: latest)
+    pull version="latest"                      # Pull image from registry (default: latest)
     reset-changelog                            # Reset CHANGELOG Unreleased section (after merging release to dev)
 
     [test]

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -39,6 +39,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Dependabot dependency update batch** ([#474](https://github.com/vig-os/devcontainer/pull/474))
   - Bump `github/codeql-action` from `4.34.1` to `4.35.1`
   - Bump `sigstore/cosign-installer` from `4.1.0` to `4.1.1`
+- **Simplify `just pull` in `justfile.gh`** ([#482](https://github.com/vig-os/devcontainer/issues/482))
+  - Pull `ghcr.io/vig-os/devcontainer` by tag; drop redundant shell fallback, per-recipe `repo` argument, and unused `REGISTRY_TEST` TLS path (imported `justfile.gh` cannot reference root `repo`)
 
 ### Deprecated
 

--- a/justfile.gh
+++ b/justfile.gh
@@ -104,12 +104,5 @@ reset-changelog:
 
 # Pull image from registry (default: latest)
 [group('release')]
-pull version="latest" repo="":
-    #!/usr/bin/env bash
-    RESOLVED_REPO="${repo:-${TEST_REGISTRY:-ghcr.io/vig-os/devcontainer}}"
-    echo "Pulling image ${RESOLVED_REPO}:{{ version }}..."
-    TLS_FLAG=""
-    if [ "${REGISTRY_TEST:-}" = "1" ]; then
-        TLS_FLAG="--tls-verify=false"
-    fi
-    podman pull $TLS_FLAG "${RESOLVED_REPO}:{{ version }}" || echo "[!]  Failed to pull ${RESOLVED_REPO}:{{ version }}"
+pull version="latest":
+    podman pull "ghcr.io/vig-os/devcontainer:{{ version }}"


### PR DESCRIPTION
## Description

Simplifies the `pull` recipe in root `justfile.gh` per #482: remove the unused `repo` recipe argument, redundant shell `TEST_REGISTRY` resolution, and dead `REGISTRY_TEST` / `--tls-verify=false` logic. The recipe now runs a single `podman pull` against `ghcr.io/vig-os/devcontainer:<version>` (hard-coded registry path because imported `justfile.gh` does not inherit the root `repo` variable). README and CONTRIBUTE recipe listings are aligned; workspace `CHANGELOG.md` copy stays in sync with the root changelog.

## Type of Change

- [ ] `feat` -- New feature
- [ ] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [x] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [ ] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- **`justfile.gh`** — Replace multi-line bash `pull` with `podman pull "ghcr.io/vig-os/devcontainer:{{ version }}"`; remove `repo` parameter, `RESOLVED_REPO`, and `REGISTRY_TEST` TLS branch.
- **`CHANGELOG.md`** — Unreleased **Changed** entry for #482.
- **`assets/workspace/.devcontainer/CHANGELOG.md`** — Same Unreleased entry (manifest sync).
- **`README.md`** / **`CONTRIBUTE.md`** — Recipe help line: drop `repo=""` from documented `pull` signature.

## Changelog Entry

```markdown
### Changed

- **Simplify `just pull` in `justfile.gh`** ([#482](https://github.com/vig-os/devcontainer/issues/482))
  - Pull `ghcr.io/vig-os/devcontainer` by tag; drop redundant shell fallback, per-recipe `repo` argument, and unused `REGISTRY_TEST` TLS path (imported `justfile.gh` cannot reference root `repo`)
```

## Testing

- [ ] Tests pass locally (`just test`)
- [x] Manual testing performed (describe below)

### Manual Testing Details

- `just --list` — confirms `pull` parses and lists correctly.
- `uv run pytest tests/test_integration.py::TestJustRecipes::test_template_justfile_gh_includes_release_recipes tests/test_integration.py::TestJustRecipes::test_template_release_helpers_dispatch_expected_workflows` — 2 passed.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

`just pull` no longer honors `TEST_REGISTRY` or a per-invocation `repo=` override; use `build` / other root recipes for alternate registries. N/A beyond #482.

Refs: #482
