### PR TITLE
fix(ci): use comma-separated FILE_PATHS for commit-action

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -230,7 +230,7 @@ jobs:
 
             Move Unreleased content to [${{ needs.validate.outputs.version }}] - TBD
             and create fresh empty Unreleased section for continued development.
-          FILE_PATHS: CHANGELOG.md assets/workspace/.devcontainer/CHANGELOG.md
+          FILE_PATHS: CHANGELOG.md,assets/workspace/.devcontainer/CHANGELOG.md
 
       - name: Create release branch from dev
         id: create-branch
@@ -293,7 +293,7 @@ jobs:
 
             Strip empty Unreleased section from release branch.
             Release date TBD (set during finalization).
-          FILE_PATHS: CHANGELOG.md assets/workspace/.devcontainer/CHANGELOG.md
+          FILE_PATHS: CHANGELOG.md,assets/workspace/.devcontainer/CHANGELOG.md
 
       - name: Create draft PR to main
         id: pr
@@ -397,7 +397,7 @@ jobs:
             chore: rollback failed prepare-release ${{ needs.validate.outputs.version }}
 
             Restore CHANGELOG.md on dev to pre-prepare state after prepare-release failed.
-          FILE_PATHS: CHANGELOG.md assets/workspace/.devcontainer/CHANGELOG.md
+          FILE_PATHS: CHANGELOG.md,assets/workspace/.devcontainer/CHANGELOG.md
 
       - name: Rollback summary
         if: ${{ failure() }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -534,7 +534,7 @@ jobs:
             exit 1
           fi
 
-          FILE_PATHS="$(echo "$CHANGED_FILES" | tr '\n' ' ' | sed 's/[[:space:]]*$//')"
+          FILE_PATHS="$(echo "$CHANGED_FILES" | tr '\n' ',' | sed 's/,$//')"
           echo "file_paths=$FILE_PATHS" >> "$GITHUB_OUTPUT"
           echo "Finalization files: $FILE_PATHS"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Prepare-release changelog commits silently skipped due to FILE_PATHS delimiter mismatch** ([#483](https://github.com/vig-os/devcontainer/issues/483))
+  - Change `FILE_PATHS` from space-separated to comma-separated in all `commit-action` steps of `prepare-release.yml` so the action correctly commits both `CHANGELOG.md` and `assets/workspace/.devcontainer/CHANGELOG.md`
 - **`publish-candidate` recipe sends unknown `create-release` input** ([#479](https://github.com/vig-os/devcontainer/issues/479))
   - Remove `create-release` parameter and `-f` flag from upstream `justfile.gh`; the input was added to the downstream workflow only but the recipe was updated in both places
 - **Image tests expect current `just` minor** ([#479](https://github.com/vig-os/devcontainer/issues/479))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Prepare-release changelog commits silently skipped due to FILE_PATHS delimiter mismatch** ([#483](https://github.com/vig-os/devcontainer/issues/483))
   - Change `FILE_PATHS` from space-separated to comma-separated in all `commit-action` steps of `prepare-release.yml` so the action correctly commits both `CHANGELOG.md` and `assets/workspace/.devcontainer/CHANGELOG.md`
+  - Join finalization changed files with commas in `release.yml` (`Collect finalization files`) so `commit-action` receives multiple paths correctly
 - **`publish-candidate` recipe sends unknown `create-release` input** ([#479](https://github.com/vig-os/devcontainer/issues/479))
   - Remove `create-release` parameter and `-f` flag from upstream `justfile.gh`; the input was added to the downstream workflow only but the recipe was updated in both places
 - **Image tests expect current `just` minor** ([#479](https://github.com/vig-os/devcontainer/issues/479))

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -53,6 +53,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Prepare-release changelog commits silently skipped due to FILE_PATHS delimiter mismatch** ([#483](https://github.com/vig-os/devcontainer/issues/483))
+  - Change `FILE_PATHS` from space-separated to comma-separated in all `commit-action` steps of `prepare-release.yml` so the action correctly commits both `CHANGELOG.md` and `assets/workspace/.devcontainer/CHANGELOG.md`
 - **`publish-candidate` recipe sends unknown `create-release` input** ([#479](https://github.com/vig-os/devcontainer/issues/479))
   - Remove `create-release` parameter and `-f` flag from upstream `justfile.gh`; the input was added to the downstream workflow only but the recipe was updated in both places
 - **Image tests expect current `just` minor** ([#479](https://github.com/vig-os/devcontainer/issues/479))

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -55,6 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Prepare-release changelog commits silently skipped due to FILE_PATHS delimiter mismatch** ([#483](https://github.com/vig-os/devcontainer/issues/483))
   - Change `FILE_PATHS` from space-separated to comma-separated in all `commit-action` steps of `prepare-release.yml` so the action correctly commits both `CHANGELOG.md` and `assets/workspace/.devcontainer/CHANGELOG.md`
+  - Join finalization changed files with commas in `release.yml` (`Collect finalization files`) so `commit-action` receives multiple paths correctly
 - **`publish-candidate` recipe sends unknown `create-release` input** ([#479](https://github.com/vig-os/devcontainer/issues/479))
   - Remove `create-release` parameter and `-f` flag from upstream `justfile.gh`; the input was added to the downstream workflow only but the recipe was updated in both places
 - **Image tests expect current `just` minor** ([#479](https://github.com/vig-os/devcontainer/issues/479))

--- a/tests/bats/just.bats
+++ b/tests/bats/just.bats
@@ -186,7 +186,7 @@ setup() {
 }
 
 @test "prepare-release workflow FILE_PATHS uses comma delimiter for multi-file values" {
-    run bash -lc "! grep -E 'FILE_PATHS:.*CHANGELOG\.md [a-zA-Z]' .github/workflows/prepare-release.yml"
+    run bash -lc "[ -r .github/workflows/prepare-release.yml ] && ! grep -E 'FILE_PATHS:.*CHANGELOG\.md[[:space:]]+[^[:space:]]' .github/workflows/prepare-release.yml"
     assert_success
 }
 

--- a/tests/bats/just.bats
+++ b/tests/bats/just.bats
@@ -189,3 +189,8 @@ setup() {
     run bash -lc "! grep -E 'FILE_PATHS:.*CHANGELOG\.md [a-zA-Z]' .github/workflows/prepare-release.yml"
     assert_success
 }
+
+@test "release workflow joins finalization file paths with commas for commit-action" {
+    run bash -lc "awk '/^      - name: Collect finalization files/{flag=1} /^      - name: Commit finalization changes via API/{flag=0} flag {print}' .github/workflows/release.yml | grep -Fq \"tr '\\n' ','\""
+    assert_success
+}

--- a/tests/bats/just.bats
+++ b/tests/bats/just.bats
@@ -184,3 +184,8 @@ setup() {
     run bash -lc "grep -Fq -- 'rc-number:' assets/workspace/.github/workflows/release.yml && grep -Fq -- 'rc_number:' assets/workspace/.github/workflows/release.yml && grep -Fq -- 'rc_number:' assets/workspace/.github/workflows/release-core.yml"
     assert_success
 }
+
+@test "prepare-release workflow FILE_PATHS uses comma delimiter for multi-file values" {
+    run bash -lc "! grep -E 'FILE_PATHS:.*CHANGELOG\.md [a-zA-Z]' .github/workflows/prepare-release.yml"
+    assert_success
+}


### PR DESCRIPTION
## Description

Fix `FILE_PATHS` delimiter mismatch in `prepare-release.yml` and `release.yml` workflows. The `commit-action` splits on commas, but `FILE_PATHS` was passed as space-separated values, causing both commit steps to silently no-op with "No files to commit." This PR switches all `FILE_PATHS` values to comma-separated so `commit-action` correctly commits both `CHANGELOG.md` and `assets/workspace/.devcontainer/CHANGELOG.md`.

## Type of Change

- [ ] `feat` -- New feature
- [x] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [ ] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- **`.github/workflows/prepare-release.yml`** (+3 −3)
  - Change `FILE_PATHS` from space-separated to comma-separated in all three `commit-action` steps (freeze changelog on dev, strip changelog on release branch, rollback on failure)
- **`.github/workflows/release.yml`** (+1 −1)
  - Change `tr '\n' ' '` to `tr '\n' ','` in the "Collect finalization files" step so `commit-action` receives comma-delimited paths
- **`tests/bats/just.bats`** (+10)
  - Add BATS test asserting `prepare-release.yml` does not use space-separated `FILE_PATHS` for multi-file values
  - Add BATS test asserting `release.yml` joins finalization file paths with commas
- **`CHANGELOG.md`** (+3)
  - Add Fixed entry under Unreleased for issue #483
- **`assets/workspace/.devcontainer/CHANGELOG.md`** (+3)
  - Mirror CHANGELOG entry

## Changelog Entry

### Fixed

- **Prepare-release changelog commits silently skipped due to FILE_PATHS delimiter mismatch** ([#483](https://github.com/vig-os/devcontainer/issues/483))
  - Change `FILE_PATHS` from space-separated to comma-separated in all `commit-action` steps of `prepare-release.yml` so the action correctly commits both `CHANGELOG.md` and `assets/workspace/.devcontainer/CHANGELOG.md`
  - Join finalization changed files with commas in `release.yml` (`Collect finalization files`) so `commit-action` receives multiple paths correctly

## Testing

- [x] Tests pass locally (`just test`)
- [ ] Manual testing performed (describe below)

### Manual Testing Details

N/A

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

N/A

Refs: #483
