### PR TITLE
chore: cherry-pick dependency updates (#488, #489)

### DIFF
--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -97,7 +97,7 @@ jobs:
           echo "✓ Version=$VERSION architectures=${VALIDATED_ARCHS[*]}"
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2  # v4.0.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121  # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -302,7 +302,7 @@ jobs:
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2  # v4.0.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121  # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -909,7 +909,7 @@ jobs:
         uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003  # v4
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2  # v4.0.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121  # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Dependabot dependency update batch** ([#474](https://github.com/vig-os/devcontainer/pull/474))
   - Bump `github/codeql-action` from `4.34.1` to `4.35.1`
   - Bump `sigstore/cosign-installer` from `4.1.0` to `4.1.1`
+- **Dependabot dependency update batch** ([#488](https://github.com/vig-os/devcontainer/pull/488), [#489](https://github.com/vig-os/devcontainer/pull/489))
+  - Bump `@devcontainers/cli` from `0.84.1` to `0.85.0`
+  - Bump `docker/login-action` from `4.0.0` to `4.1.0`
 - **Simplify `just pull` in `justfile.gh`** ([#482](https://github.com/vig-os/devcontainer/issues/482))
   - Pull `ghcr.io/vig-os/devcontainer` by tag; drop redundant shell fallback, per-recipe `repo` argument, and unused `REGISTRY_TEST` TLS path (imported `justfile.gh` cannot reference root `repo`)
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -39,6 +39,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Dependabot dependency update batch** ([#474](https://github.com/vig-os/devcontainer/pull/474))
   - Bump `github/codeql-action` from `4.34.1` to `4.35.1`
   - Bump `sigstore/cosign-installer` from `4.1.0` to `4.1.1`
+- **Dependabot dependency update batch** ([#488](https://github.com/vig-os/devcontainer/pull/488), [#489](https://github.com/vig-os/devcontainer/pull/489))
+  - Bump `@devcontainers/cli` from `0.84.1` to `0.85.0`
+  - Bump `docker/login-action` from `4.0.0` to `4.1.0`
 - **Simplify `just pull` in `justfile.gh`** ([#482](https://github.com/vig-os/devcontainer/issues/482))
   - Pull `ghcr.io/vig-os/devcontainer` by tag; drop redundant shell fallback, per-recipe `repo` argument, and unused `REGISTRY_TEST` TLS path (imported `justfile.gh` cannot reference root `repo`)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "devcontainer-ci-deps",
       "dependencies": {
-        "@devcontainers/cli": "0.84.1",
+        "@devcontainers/cli": "0.85.0",
         "bats": "1.13.0",
         "bats-assert": "github:bats-core/bats-assert#v2.2.4",
         "bats-file": "github:bats-core/bats-file#v0.4.0",
@@ -14,9 +14,9 @@
       }
     },
     "node_modules/@devcontainers/cli": {
-      "version": "0.84.1",
-      "resolved": "https://registry.npmjs.org/@devcontainers/cli/-/cli-0.84.1.tgz",
-      "integrity": "sha512-r+JR/4R8lznPQNwLyHPIzHJ1mj3p2l5lGyHeq2FetEfpe6s6BVLE9mFl7MxQI4wKNqfWCIO7DSokoCWRlzQSIg==",
+      "version": "0.85.0",
+      "resolved": "https://registry.npmjs.org/@devcontainers/cli/-/cli-0.85.0.tgz",
+      "integrity": "sha512-lRbTDtDuFPTxZ6tnVXz3CbrzAaLQQ4Ys9LIpFilIFmo6zD1iuhHssC/YXEmu5WBbGro9PlgcFOmgIUAWErfa3Q==",
       "license": "MIT",
       "bin": {
         "devcontainer": "devcontainer.js"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "description": "CI-only npm dependencies tracked by Dependabot",
   "dependencies": {
-    "@devcontainers/cli": "0.84.1",
+    "@devcontainers/cli": "0.85.0",
     "bats": "1.13.0",
     "bats-support": "github:bats-core/bats-support#v0.3.0",
     "bats-assert": "github:bats-core/bats-assert#v2.2.4",


### PR DESCRIPTION
## Summary

Cherry-picks dependency updates from open Dependabot PRs targeting `dev` so `release/0.3.2` stays aligned.

## Changes

- **#488** — Bump `@devcontainers/cli` from `0.84.1` to `0.85.0` (`package.json`, `package-lock.json`)
- **#489** — Bump `docker/login-action` from `4.0.0` to `4.1.0` (`.github/workflows/release.yml`, `.github/workflows/promote-release.yml`)

## Changelog

- Added Dependabot batch entry under `## [0.3.2] - TBD` → `### Changed` in root and workspace `CHANGELOG.md`.

Refs: #488, #489