### PR TITLE
chore(ci): remove scheduled full CI from ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,6 @@
 # Triggers:
 #   - Pull requests to dev, release/**, and main (runs all suites)
 #   - Manual workflow_dispatch (select specific test suite to run)
-#   - Nightly schedule at 04:00 UTC (checks out dev; full suites)
 
 name: CI
 
@@ -36,9 +35,6 @@ on:  # yamllint disable-line rule:truthy
           - image
           - integration
           - project
-  schedule:
-    # Nightly against dev (staggered after CodeQL 02:15 UTC Mon)
-    - cron: '0 4 * * *'
 
 permissions:
   contents: read
@@ -65,8 +61,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          ref: ${{ github.event_name == 'schedule' && 'dev' || github.ref }}
 
       - name: Generate version for dev build
         id: version
@@ -119,8 +113,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          ref: ${{ github.event_name == 'schedule' && 'dev' || github.ref }}
 
       - name: Download image artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
@@ -147,8 +139,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          ref: ${{ github.event_name == 'schedule' && 'dev' || github.ref }}
 
       - name: Download image artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
@@ -184,8 +174,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          ref: ${{ github.event_name == 'schedule' && 'dev' || github.ref }}
 
       - name: Run project checks
         uses: ./.github/actions/test-project
@@ -202,8 +190,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          ref: ${{ github.event_name == 'schedule' && 'dev' || github.ref }}
 
       - name: Set up environment
         uses: ./.github/actions/setup-env
@@ -262,8 +248,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          ref: ${{ github.event_name == 'schedule' && 'dev' || github.ref }}
 
       - name: Download image artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,11 +1,11 @@
 # Scheduled Security Scan
 #
 # Nightly scan of the latest published container image from GHCR (covers main via
-# :latest) without rebuilding. Dev-branch builds are covered by nightly CI
-# (ci.yml) including Trivy + full-severity SARIF (category: container-image).
+# :latest) without rebuilding. Pull requests to dev/release/main run full CI
+# (ci.yml), including Trivy on the built image (category: container-image).
 #
 # Triggers:
-#   - Nightly schedule: 05:00 UTC (after nightly CI at 04:00 UTC)
+#   - Nightly schedule: 05:00 UTC
 #
 # Jobs:
 #   1. scan-latest - Pull ghcr.io/vig-os/devcontainer:latest and Trivy + SBOM + SARIF

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,8 +32,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Add `just promote-release` in `justfile.gh` (and workspace template copy)
 - **Smoke-test dispatch fails fast when deploy PR checks fail** ([#381](https://github.com/vig-os/devcontainer/issues/381))
   - `wait-deploy-merge` in `assets/smoke-test/.github/workflows/repository-dispatch.yml` exits as soon as all required checks have completed with failures instead of waiting for the merge poll timeout (`gh pr checks --required`)
-- **Nightly CI schedule** ([#461](https://github.com/vig-os/devcontainer/issues/461))
-  - `ci.yml` adds a `schedule` trigger at 04:00 UTC that checks out `dev` and runs all test suites; checkout `ref` and `vcs-ref` are resolved correctly for scheduled runs
 - **Scheduled security scan pulls GHCR `:latest` instead of rebuilding** ([#461](https://github.com/vig-os/devcontainer/issues/461))
   - Runs nightly at 05:00 UTC, pulls the published image, gates on fixable HIGH/CRITICAL vulnerabilities, auto-creates a deduplicated GitHub issue on failure, and uploads SARIF under `container-image-latest`
 - **Dependabot dependency update batch** ([#474](https://github.com/vig-os/devcontainer/pull/474))
@@ -51,6 +49,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Remove `scripts/prune-ghcr-tags.sh`; RC and `sha256-*` orphan cleanup remains in root `promote-release.yml`
 - **Downstream RC pre-release gate from release validate job** ([#463](https://github.com/vig-os/devcontainer/issues/463))
   - Removed dead `if: false` steps from `release.yml`; downstream final release is verified only in `promote-release.yml` before promote
+- **Nightly full CI schedule from `ci.yml`** ([#492](https://github.com/vig-os/devcontainer/issues/492))
+  - Remove the `schedule` trigger and schedule-only checkout overrides; CI remains on pull requests and `workflow_dispatch` only
+  - Nightly GHCR `:latest` scan in `security-scan.yml` is unchanged
 
 ### Fixed
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -32,8 +32,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Add `just promote-release` in `justfile.gh` (and workspace template copy)
 - **Smoke-test dispatch fails fast when deploy PR checks fail** ([#381](https://github.com/vig-os/devcontainer/issues/381))
   - `wait-deploy-merge` in `assets/smoke-test/.github/workflows/repository-dispatch.yml` exits as soon as all required checks have completed with failures instead of waiting for the merge poll timeout (`gh pr checks --required`)
-- **Nightly CI schedule** ([#461](https://github.com/vig-os/devcontainer/issues/461))
-  - `ci.yml` adds a `schedule` trigger at 04:00 UTC that checks out `dev` and runs all test suites; checkout `ref` and `vcs-ref` are resolved correctly for scheduled runs
 - **Scheduled security scan pulls GHCR `:latest` instead of rebuilding** ([#461](https://github.com/vig-os/devcontainer/issues/461))
   - Runs nightly at 05:00 UTC, pulls the published image, gates on fixable HIGH/CRITICAL vulnerabilities, auto-creates a deduplicated GitHub issue on failure, and uploads SARIF under `container-image-latest`
 - **Dependabot dependency update batch** ([#474](https://github.com/vig-os/devcontainer/pull/474))
@@ -51,6 +49,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Remove `scripts/prune-ghcr-tags.sh`; RC and `sha256-*` orphan cleanup remains in root `promote-release.yml`
 - **Downstream RC pre-release gate from release validate job** ([#463](https://github.com/vig-os/devcontainer/issues/463))
   - Removed dead `if: false` steps from `release.yml`; downstream final release is verified only in `promote-release.yml` before promote
+- **Nightly full CI schedule from `ci.yml`** ([#492](https://github.com/vig-os/devcontainer/issues/492))
+  - Remove the `schedule` trigger and schedule-only checkout overrides; CI remains on pull requests and `workflow_dispatch` only
+  - Nightly GHCR `:latest` scan in `security-scan.yml` is unchanged
 
 ### Fixed
 


### PR DESCRIPTION
## Description

Removes the nightly `schedule` trigger from `.github/workflows/ci.yml` and all schedule-only checkout `ref` overrides, as agreed in #492. PR and `workflow_dispatch` behavior is unchanged. Updates `security-scan.yml` header comments so they no longer reference the removed 04:00 UTC CI run. Changelog for 0.3.2 is adjusted: drop the unreleased “Nightly CI schedule” (#461) bullet from **Changed** and document the removal under **Removed** (#492).

## Type of Change

- [ ] `feat` -- New feature
- [ ] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [x] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [x] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- **`.github/workflows/ci.yml`** — Remove `schedule` (`cron: '0 4 * * *'`); remove nightly trigger from file header; drop `with: ref: ${{ github.event_name == 'schedule' && 'dev' || github.ref }}` from all checkout steps (default ref for PR/dispatch).
- **`.github/workflows/security-scan.yml`** — Header: describe PR-based full CI + Trivy; remove “after nightly CI at 04:00 UTC”; keep nightly 05:00 UTC scan behavior unchanged.
- **`CHANGELOG.md`** / **`assets/workspace/.devcontainer/CHANGELOG.md`** — Remove **Nightly CI schedule** (#461) from **Changed**; add **Nightly full CI schedule from `ci.yml`** (#492) under **Removed** with sub-bullets.

## Changelog Entry

Release section `## [0.3.2] - TBD` (this branch targets `release/0.3.2`, not `## Unreleased`):

### Removed

- **Nightly full CI schedule from `ci.yml`** ([#492](https://github.com/vig-os/devcontainer/issues/492))
  - Remove the `schedule` trigger and schedule-only checkout overrides; CI remains on pull requests and `workflow_dispatch` only
  - Nightly GHCR `:latest` scan in `security-scan.yml` is unchanged

### Changed (edit relative to prior 0.3.2 draft)

- Removed the **Nightly CI schedule** ([#461](https://github.com/vig-os/devcontainer/issues/461)) bullet from **Changed** so the release notes no longer claim a nightly full CI run.

## Testing

- [ ] Tests pass locally (`just test`)
- [ ] Manual testing performed (describe below)

### Manual Testing Details

N/A — workflow YAML and changelog only; validation via CI on this PR.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` in the `[0.3.2] - TBD` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

N/A

Refs: #492
