### PR TITLE
feat: add GitHub release link to changelog finalize headings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Bump `docker/login-action` from `4.0.0` to `4.1.0`
 - **Simplify `just pull` in `justfile.gh`** ([#482](https://github.com/vig-os/devcontainer/issues/482))
   - Pull `ghcr.io/vig-os/devcontainer` by tag; drop redundant shell fallback, per-recipe `repo` argument, and unused `REGISTRY_TEST` TLS path (imported `justfile.gh` cannot reference root `repo`)
+- **prepare-changelog finalize adds GitHub release link to version headings** ([#496](https://github.com/vig-os/devcontainer/issues/496))
+  - `finalize_release_date` writes `## [X.Y.Z](https://github.com/owner/repo/releases/tag/X.Y.Z) - date`; repository slug comes from `GITHUB_REPOSITORY` (set in Actions) or from `prepare-changelog finalize ... --github-repository owner/repo`
+  - `unprepare` recognizes linked `## [semver](url) - …` headings
 
 ### Removed
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -42,6 +42,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Bump `docker/login-action` from `4.0.0` to `4.1.0`
 - **Simplify `just pull` in `justfile.gh`** ([#482](https://github.com/vig-os/devcontainer/issues/482))
   - Pull `ghcr.io/vig-os/devcontainer` by tag; drop redundant shell fallback, per-recipe `repo` argument, and unused `REGISTRY_TEST` TLS path (imported `justfile.gh` cannot reference root `repo`)
+- **prepare-changelog finalize adds GitHub release link to version headings** ([#496](https://github.com/vig-os/devcontainer/issues/496))
+  - `finalize_release_date` writes `## [X.Y.Z](https://github.com/owner/repo/releases/tag/X.Y.Z) - date`; repository slug comes from `GITHUB_REPOSITORY` (set in Actions) or from `prepare-changelog finalize ... --github-repository owner/repo`
+  - `unprepare` recognizes linked `## [semver](url) - …` headings
 
 ### Removed
 

--- a/docs/RELEASE_CYCLE.md
+++ b/docs/RELEASE_CYCLE.md
@@ -505,11 +505,12 @@ Create fresh Unreleased section when one doesn't exist. **Safety:** Fails if Unr
 uv run prepare-changelog reset [CHANGELOG.md]
 ```
 
-#### `finalize VERSION DATE [FILE]`
-Replace TBD date with actual release date. Used by `release.yml` (final releases only) to set the date.
+#### `finalize VERSION DATE [FILE] [--github-repository OWNER/REPO]`
+Replace TBD with the release date and add a markdown link on the version heading to `https://github.com/OWNER/REPO/releases/tag/VERSION`. Used by `release.yml` (final releases only). In Actions the slug comes from `GITHUB_REPOSITORY`; locally pass `--github-repository` after the file path (or export `GITHUB_REPOSITORY`).
 
 ```bash
 uv run prepare-changelog finalize 1.0.0 2026-02-11 [CHANGELOG.md]
+uv run prepare-changelog finalize 1.0.0 2026-02-11 CHANGELOG.md --github-repository my-org/my-repo
 ```
 
 **Tests:** `packages/vig-utils/tests/test_prepare_changelog.py`

--- a/packages/vig-utils/README.md
+++ b/packages/vig-utils/README.md
@@ -83,10 +83,12 @@ Manages `CHANGELOG.md` in Keep a Changelog format.
 ```bash
 prepare-changelog validate [FILE]
 prepare-changelog prepare <VERSION> [FILE]
-prepare-changelog finalize <VERSION> <YYYY-MM-DD> [FILE]
+prepare-changelog finalize <VERSION> <YYYY-MM-DD> [FILE] [--github-repository OWNER/REPO]
 prepare-changelog reset [FILE]
 prepare-changelog unprepare [FILE]
 ```
+
+`finalize` needs a repository slug for the release link: use `GITHUB_REPOSITORY` (as in GitHub Actions) or pass `--github-repository` after the optional file path.
 
 Examples:
 
@@ -94,6 +96,7 @@ Examples:
 prepare-changelog validate
 prepare-changelog prepare 0.3.0
 prepare-changelog finalize 0.3.0 2026-03-04
+prepare-changelog finalize 0.3.0 2026-03-04 CHANGELOG.md --github-repository my-org/my-repo
 prepare-changelog reset
 prepare-changelog unprepare
 ```

--- a/packages/vig-utils/src/vig_utils/prepare_changelog.py
+++ b/packages/vig-utils/src/vig_utils/prepare_changelog.py
@@ -6,6 +6,7 @@ Provides commands for managing CHANGELOG.md during the release workflow.
 """
 
 import argparse
+import os
 import re
 import sys
 from pathlib import Path
@@ -206,9 +207,9 @@ def unprepare_changelog(filepath="CHANGELOG.md"):
     if line == "## Unreleased":
         return False
 
-    # Match ## [X.Y.Z] - TBD or ## [X.Y.Z] - YYYY-MM-DD (same semver rule as prepare)
+    # Match ## [X.Y.Z] - … or ## [X.Y.Z](url) - … (optional release link, same semver rule as prepare)
     version_heading = re.compile(
-        r"^## \[(\d+\.\d+\.\d+)\] - .+$",
+        r"^## \[(\d+\.\d+\.\d+)\](?:\([^)]+\))? - .+$",
     )
     if not version_heading.match(line):
         raise ValueError(
@@ -316,18 +317,54 @@ def cmd_unprepare(args):
         print(f"✓ Top section already ## Unreleased in {args.file} (no changes)")
 
 
-def finalize_release_date(version, release_date, filepath="CHANGELOG.md"):
+def _validate_github_repository_slug(raw: str) -> str:
+    parts = raw.split("/")
+    if len(parts) != 2 or not parts[0] or not parts[1]:
+        raise ValueError(
+            f"Invalid github_repository {raw!r} (expected a single 'owner/repo' slug)"
+        )
+    return raw
+
+
+def _resolve_github_repository(github_repository: str | None) -> str:
+    """Return owner/repo for release links from an explicit value or GITHUB_REPOSITORY."""
+    if github_repository is not None:
+        stripped = github_repository.strip()
+        if stripped:
+            return _validate_github_repository_slug(stripped)
+    env = os.environ.get("GITHUB_REPOSITORY", "").strip()
+    if env:
+        return _validate_github_repository_slug(env)
+    raise ValueError(
+        "GitHub repository is required to finalize the changelog heading "
+        "(set GITHUB_REPOSITORY or pass github_repository='owner/repo', "
+        "or use prepare-changelog finalize --github-repository owner/repo)"
+    )
+
+
+def finalize_release_date(
+    version,
+    release_date,
+    filepath="CHANGELOG.md",
+    *,
+    github_repository: str | None = None,
+):
     """
     Replace TBD date with actual release date for a version.
+
+    The version heading becomes a linked title pointing at the GitHub release tag
+    for this repository (``owner/repo`` from ``github_repository`` or the
+    ``GITHUB_REPOSITORY`` environment variable).
 
     Args:
         version: Semantic version (e.g., "1.0.0")
         release_date: Release date in ISO format (YYYY-MM-DD)
         filepath: Path to CHANGELOG.md
+        github_repository: ``owner/repo`` slug; when omitted, ``GITHUB_REPOSITORY`` is used
 
     Raises:
         ValueError: If version format is invalid, date format is invalid,
-                   or version section with TBD not found
+                   repository slug is missing or invalid, or version section with TBD not found
         FileNotFoundError: If CHANGELOG file doesn't exist
     """
     # Validate version format
@@ -352,8 +389,9 @@ def finalize_release_date(version, release_date, filepath="CHANGELOG.md"):
             f"Version section '## [{version}] - TBD' not found in CHANGELOG"
         )
 
-    # Replace TBD with release date
-    replacement = f"## [{version}] - {release_date}"
+    repo_slug = _resolve_github_repository(github_repository)
+    tag_url = f"https://github.com/{repo_slug}/releases/tag/{version}"
+    replacement = f"## [{version}]({tag_url}) - {release_date}"
     new_content = re.sub(version_pattern, replacement, content)
 
     # Write back
@@ -362,7 +400,12 @@ def finalize_release_date(version, release_date, filepath="CHANGELOG.md"):
 
 def cmd_finalize(args):
     """Handle finalize command."""
-    finalize_release_date(args.version, args.date, args.file)
+    finalize_release_date(
+        args.version,
+        args.date,
+        args.file,
+        github_repository=args.github_repository,
+    )
 
     print(f"✓ Set release date for version {args.version}")
     print(f"✓ Date: {args.date}")
@@ -381,8 +424,9 @@ Examples:
   # Validate CHANGELOG has unreleased changes
   %(prog)s validate
 
-  # Set release date for version 1.0.0
+  # Set release date for version 1.0.0 (uses GITHUB_REPOSITORY if set)
   %(prog)s finalize 1.0.0 2026-02-11
+  %(prog)s finalize 1.0.0 2026-02-11 CHANGELOG.md --github-repository my-org/my-repo
 
   # Reset Unreleased section after release merge
   %(prog)s reset
@@ -473,6 +517,16 @@ Examples:
         nargs="?",
         default="CHANGELOG.md",
         help="Path to CHANGELOG file (default: CHANGELOG.md)",
+    )
+    finalize_parser.add_argument(
+        "--github-repository",
+        dest="github_repository",
+        default=None,
+        metavar="OWNER/REPO",
+        help=(
+            "Repository slug for the release tag link "
+            "(default: GITHUB_REPOSITORY environment variable)"
+        ),
     )
     finalize_parser.set_defaults(func=cmd_finalize)
 

--- a/packages/vig-utils/src/vig_utils/prepare_changelog.py
+++ b/packages/vig-utils/src/vig_utils/prepare_changelog.py
@@ -318,10 +318,10 @@ def cmd_unprepare(args):
 
 
 def _validate_github_repository_slug(raw: str) -> str:
-    parts = raw.split("/")
-    if len(parts) != 2 or not parts[0] or not parts[1]:
+    if not re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", raw):
         raise ValueError(
-            f"Invalid github_repository {raw!r} (expected a single 'owner/repo' slug)"
+            f"Invalid github_repository {raw!r} "
+            "(owner and repo must contain only letters, numbers, '_', '.', or '-')"
         )
     return raw
 

--- a/packages/vig-utils/tests/test_prepare_changelog.py
+++ b/packages/vig-utils/tests/test_prepare_changelog.py
@@ -1179,8 +1179,16 @@ class TestFinalizeReleaseDate:
         with pytest.raises(ValueError, match="GitHub repository is required"):
             finalize_release_date("1.0.0", "2026-02-11", str(f))
 
-    def test_rejects_invalid_github_repository_slug(self, tmp_path):
-        """Should raise for owner/repo slug that is not exactly two segments."""
+    @pytest.mark.parametrize(
+        "bad_slug",
+        [
+            "too-many/slash/parts",
+            "has spaces/repo",
+            "owner/re(po)",
+        ],
+    )
+    def test_rejects_invalid_github_repository_slug(self, tmp_path, bad_slug):
+        """Should raise for invalid owner/repo slug (segment count or characters)."""
         f = tmp_path / "CHANGELOG.md"
         f.write_text(CHANGELOG_WITH_TBD)
         with pytest.raises(ValueError, match="Invalid github_repository"):
@@ -1188,7 +1196,7 @@ class TestFinalizeReleaseDate:
                 "1.0.0",
                 "2026-02-11",
                 str(f),
-                github_repository="too-many/slash/parts",
+                github_repository=bad_slug,
             )
 
     def test_fails_version_not_found(self, tmp_path):

--- a/packages/vig-utils/tests/test_prepare_changelog.py
+++ b/packages/vig-utils/tests/test_prepare_changelog.py
@@ -10,6 +10,7 @@ Comprehensive coverage including:
 Tests are organized by function under test, from low-level helpers up to the CLI layer.
 """
 
+import os
 import re
 import shutil
 import subprocess
@@ -35,6 +36,9 @@ from vig_utils.prepare_changelog import (
 
 # Find the CLI entry point installed by the package
 ENTRY_POINT = shutil.which("prepare-changelog")
+
+# Owner/repo slug for finalize_release_date tests (not hardcoded in production code)
+_FINALIZE_TEST_REPO = "vig-os/devcontainer"
 
 # ─── Test data constants ──────────────────────────────────────────────────────
 
@@ -933,6 +937,24 @@ class TestUnprepareChangelog:
         assert f.read_text().split("\n")[2] == "## Unreleased"
         assert "- Bug" in f.read_text()
 
+    def test_renames_linked_dated_header(self, tmp_path):
+        """Top ## [semver](url) - YYYY-MM-DD becomes ## Unreleased."""
+        body = """\
+# Changelog
+
+## [2.0.0](https://github.com/o/r/releases/tag/2.0.0) - 2026-03-23
+
+### Fixed
+
+- Bug
+
+"""
+        f = tmp_path / "CHANGELOG.md"
+        f.write_text(body)
+        assert unprepare_changelog(str(f)) is True
+        assert f.read_text().split("\n")[2] == "## Unreleased"
+        assert "- Bug" in f.read_text()
+
     def test_noop_when_already_unreleased(self, tmp_path):
         """Returns False and leaves file unchanged."""
         f = tmp_path / "CHANGELOG.md"
@@ -995,21 +1017,29 @@ class TestFinalizeReleaseDate:
     # ── Happy path ────────────────────────────────────────────────────────
 
     def test_replaces_tbd_with_date(self, tmp_path):
-        """Should substitute TBD → actual date."""
+        """Should substitute TBD → actual date and add release tag link."""
         f = tmp_path / "CHANGELOG.md"
         f.write_text(CHANGELOG_WITH_TBD)
-        finalize_release_date("1.0.0", "2026-02-11", str(f))
+        finalize_release_date(
+            "1.0.0", "2026-02-11", str(f), github_repository=_FINALIZE_TEST_REPO
+        )
         content = f.read_text()
-        assert "## [1.0.0] - 2026-02-11" in content
+        assert (
+            f"## [1.0.0](https://github.com/{_FINALIZE_TEST_REPO}/releases/tag/1.0.0) - 2026-02-11"
+            in content
+        )
         assert "## [1.0.0] - TBD" not in content
 
     def test_preserves_version_content(self, tmp_path):
         """All bullets in the version section should remain."""
         f = tmp_path / "CHANGELOG.md"
         f.write_text(CHANGELOG_WITH_TBD)
-        finalize_release_date("1.0.0", "2026-02-11", str(f))
+        finalize_release_date(
+            "1.0.0", "2026-02-11", str(f), github_repository=_FINALIZE_TEST_REPO
+        )
         content = f.read_text()
-        version_start = content.find("## [1.0.0] - 2026-02-11")
+        heading = f"## [1.0.0](https://github.com/{_FINALIZE_TEST_REPO}/releases/tag/1.0.0) - 2026-02-11"
+        version_start = content.find(heading)
         version_end = content.find("## [0.2.0]")
         version_section = content[version_start:version_end]
         assert "- Feature X" in version_section
@@ -1020,7 +1050,9 @@ class TestFinalizeReleaseDate:
         """Other versions and Unreleased should stay untouched."""
         f = tmp_path / "CHANGELOG.md"
         f.write_text(CHANGELOG_WITH_TBD)
-        finalize_release_date("1.0.0", "2026-02-11", str(f))
+        finalize_release_date(
+            "1.0.0", "2026-02-11", str(f), github_repository=_FINALIZE_TEST_REPO
+        )
         content = f.read_text()
         assert "## [0.2.0] - 2026-01-01" in content
         assert "## Unreleased" in content
@@ -1029,9 +1061,14 @@ class TestFinalizeReleaseDate:
         """Only the specified version's TBD should be replaced."""
         f = tmp_path / "CHANGELOG.md"
         f.write_text(MULTIPLE_TBD_CHANGELOG)
-        finalize_release_date("1.0.0", "2026-02-11", str(f))
+        finalize_release_date(
+            "1.0.0", "2026-02-11", str(f), github_repository=_FINALIZE_TEST_REPO
+        )
         content = f.read_text()
-        assert "## [1.0.0] - 2026-02-11" in content
+        assert (
+            f"## [1.0.0](https://github.com/{_FINALIZE_TEST_REPO}/releases/tag/1.0.0) - 2026-02-11"
+            in content
+        )
         assert "## [2.0.0] - TBD" in content
 
     def test_special_characters_in_content(self, tmp_path):
@@ -1048,11 +1085,40 @@ class TestFinalizeReleaseDate:
 """
         f = tmp_path / "CHANGELOG.md"
         f.write_text(changelog)
-        finalize_release_date("1.0.0", "2026-02-11", str(f))
+        finalize_release_date(
+            "1.0.0", "2026-02-11", str(f), github_repository=_FINALIZE_TEST_REPO
+        )
         content = f.read_text()
-        assert "## [1.0.0] - 2026-02-11" in content
+        assert (
+            f"## [1.0.0](https://github.com/{_FINALIZE_TEST_REPO}/releases/tag/1.0.0) - 2026-02-11"
+            in content
+        )
         assert "[brackets]" in content
         assert "$chars*" in content
+
+    def test_uses_github_repository_from_env(self, tmp_path, monkeypatch):
+        """GITHUB_REPOSITORY should supply the owner/repo slug when unset on the call."""
+        monkeypatch.setenv("GITHUB_REPOSITORY", "acme/cool-widget")
+        f = tmp_path / "CHANGELOG.md"
+        f.write_text(CHANGELOG_WITH_TBD)
+        finalize_release_date("1.0.0", "2026-02-11", str(f))
+        assert "https://github.com/acme/cool-widget/releases/tag/1.0.0" in f.read_text()
+
+    def test_github_repository_param_overrides_env(self, tmp_path, monkeypatch):
+        """Explicit github_repository wins over GITHUB_REPOSITORY."""
+        monkeypatch.setenv("GITHUB_REPOSITORY", "wrong/repo")
+        f = tmp_path / "CHANGELOG.md"
+        f.write_text(CHANGELOG_WITH_TBD)
+        finalize_release_date(
+            "1.0.0",
+            "2026-02-11",
+            str(f),
+            github_repository="right/correct-repo",
+        )
+        assert (
+            "https://github.com/right/correct-repo/releases/tag/1.0.0" in f.read_text()
+        )
+        assert "wrong/repo" not in f.read_text()
 
     # ── Version validation ────────────────────────────────────────────────
 
@@ -1061,14 +1127,24 @@ class TestFinalizeReleaseDate:
         f = tmp_path / "CHANGELOG.md"
         f.write_text(CHANGELOG_WITH_TBD)
         with pytest.raises(ValueError, match="Invalid semantic version"):
-            finalize_release_date("1.0", "2026-02-11", str(f))
+            finalize_release_date(
+                "1.0",
+                "2026-02-11",
+                str(f),
+                github_repository=_FINALIZE_TEST_REPO,
+            )
 
     def test_rejects_v_prefix(self, tmp_path):
         """Should raise for 'v' prefixed versions."""
         f = tmp_path / "CHANGELOG.md"
         f.write_text(CHANGELOG_WITH_TBD)
         with pytest.raises(ValueError, match="Invalid semantic version"):
-            finalize_release_date("v1.0.0", "2026-02-11", str(f))
+            finalize_release_date(
+                "v1.0.0",
+                "2026-02-11",
+                str(f),
+                github_repository=_FINALIZE_TEST_REPO,
+            )
 
     # ── Date validation ───────────────────────────────────────────────────
 
@@ -1089,28 +1165,59 @@ class TestFinalizeReleaseDate:
         f = tmp_path / "CHANGELOG.md"
         f.write_text(CHANGELOG_WITH_TBD)
         with pytest.raises(ValueError, match="Invalid date"):
-            finalize_release_date("1.0.0", bad_date, str(f))
+            finalize_release_date(
+                "1.0.0", bad_date, str(f), github_repository=_FINALIZE_TEST_REPO
+            )
 
     # ── Error handling ────────────────────────────────────────────────────
+
+    def test_raises_without_github_repository(self, tmp_path, monkeypatch):
+        """Should raise when neither argument nor GITHUB_REPOSITORY is set."""
+        monkeypatch.delenv("GITHUB_REPOSITORY", raising=False)
+        f = tmp_path / "CHANGELOG.md"
+        f.write_text(CHANGELOG_WITH_TBD)
+        with pytest.raises(ValueError, match="GitHub repository is required"):
+            finalize_release_date("1.0.0", "2026-02-11", str(f))
+
+    def test_rejects_invalid_github_repository_slug(self, tmp_path):
+        """Should raise for owner/repo slug that is not exactly two segments."""
+        f = tmp_path / "CHANGELOG.md"
+        f.write_text(CHANGELOG_WITH_TBD)
+        with pytest.raises(ValueError, match="Invalid github_repository"):
+            finalize_release_date(
+                "1.0.0",
+                "2026-02-11",
+                str(f),
+                github_repository="too-many/slash/parts",
+            )
 
     def test_fails_version_not_found(self, tmp_path):
         """Should raise when the specified version doesn't exist."""
         f = tmp_path / "CHANGELOG.md"
         f.write_text(CHANGELOG_WITH_TBD)
         with pytest.raises(ValueError, match="not found"):
-            finalize_release_date("9.9.9", "2026-02-11", str(f))
+            finalize_release_date(
+                "9.9.9", "2026-02-11", str(f), github_repository=_FINALIZE_TEST_REPO
+            )
 
     def test_fails_already_finalized(self, tmp_path):
         """Should raise when version already has a real date (not TBD)."""
         f = tmp_path / "CHANGELOG.md"
         f.write_text(CHANGELOG_WITH_TBD)
         with pytest.raises(ValueError, match="not found"):
-            finalize_release_date("0.2.0", "2026-02-11", str(f))
+            finalize_release_date(
+                "0.2.0", "2026-02-11", str(f), github_repository=_FINALIZE_TEST_REPO
+            )
 
     def test_raises_for_missing_file(self, tmp_path):
         """Should raise FileNotFoundError for nonexistent file."""
         with pytest.raises(FileNotFoundError, match="CHANGELOG not found"):
-            finalize_release_date("1.0.0", "2026-02-11", str(tmp_path / "nope.md"))
+            finalize_release_date(
+                "1.0.0",
+                "2026-02-11",
+                str(tmp_path / "nope.md"),
+                github_repository=_FINALIZE_TEST_REPO,
+            )
 
 
 # ═════════════════════════════════════════════════════════════════════════════
@@ -1127,10 +1234,15 @@ class TestPrepareThenFinalize:
         f.write_text(basic_changelog)
 
         prepare_changelog("1.0.0", str(f))
-        finalize_release_date("1.0.0", "2026-02-11", str(f))
+        finalize_release_date(
+            "1.0.0", "2026-02-11", str(f), github_repository=_FINALIZE_TEST_REPO
+        )
 
         content = f.read_text()
-        assert "## [1.0.0] - 2026-02-11" in content
+        assert (
+            f"## [1.0.0](https://github.com/{_FINALIZE_TEST_REPO}/releases/tag/1.0.0) - 2026-02-11"
+            in content
+        )
         assert "TBD" not in content
         assert "## Unreleased" in content
         assert content.index("## Unreleased") < content.index("## [1.0.0]")
@@ -1141,7 +1253,9 @@ class TestPrepareThenFinalize:
         f.write_text(MINIMAL_CHANGELOG)
 
         prepare_changelog("1.0.0", str(f))
-        finalize_release_date("1.0.0", "2026-02-11", str(f))
+        finalize_release_date(
+            "1.0.0", "2026-02-11", str(f), github_repository=_FINALIZE_TEST_REPO
+        )
 
         # Simulate merging to main: remove the Unreleased block
         content = f.read_text()
@@ -1253,10 +1367,17 @@ class TestCmdReset:
 class TestCmdFinalize:
     """Tests for cmd_finalize handler."""
 
-    def _make_args(self, version, date, filepath):
+    def _make_args(
+        self, version, date, filepath, github_repository=_FINALIZE_TEST_REPO
+    ):
         from argparse import Namespace
 
-        return Namespace(version=version, date=date, file=filepath)
+        return Namespace(
+            version=version,
+            date=date,
+            file=filepath,
+            github_repository=github_repository,
+        )
 
     def test_success_output(self, tmp_path, capsys):
         """Should print version and date."""
@@ -1315,12 +1436,26 @@ class TestMainCLI:
         assert "## Unreleased" in f.read_text()
 
     def test_finalize_via_main(self, tmp_path):
-        """main() with 'finalize' should replace TBD with date."""
+        """main() with 'finalize' should replace TBD with date and release link."""
         f = tmp_path / "CHANGELOG.md"
         f.write_text(CHANGELOG_WITH_TBD)
-        with patch("sys.argv", ["prog", "finalize", "1.0.0", "2026-02-11", str(f)]):
+        with patch(
+            "sys.argv",
+            [
+                "prog",
+                "finalize",
+                "1.0.0",
+                "2026-02-11",
+                str(f),
+                "--github-repository",
+                _FINALIZE_TEST_REPO,
+            ],
+        ):
             main()
-        assert "## [1.0.0] - 2026-02-11" in f.read_text()
+        assert (
+            f"## [1.0.0](https://github.com/{_FINALIZE_TEST_REPO}/releases/tag/1.0.0) - 2026-02-11"
+            in f.read_text()
+        )
 
     def test_unprepare_via_main(self, tmp_path):
         """main() with 'unprepare' should rename top version heading."""
@@ -1352,7 +1487,7 @@ class TestCLISubprocess:
     standalone process.  These complement the import-based unit tests above.
     """
 
-    def _run(self, *args):
+    def _run(self, *args, env=None):
         """Helper to invoke the CLI entry point."""
         if ENTRY_POINT is None:
             pytest.skip("prepare-changelog entry point not installed")
@@ -1360,6 +1495,7 @@ class TestCLISubprocess:
             [ENTRY_POINT, *args],
             capture_output=True,
             text=True,
+            env=env,
         )
 
     # ── prepare ───────────────────────────────────────────────────────────
@@ -1425,18 +1561,44 @@ class TestCLISubprocess:
     # ── finalize ──────────────────────────────────────────────────────────
 
     def test_finalize_e2e(self, tmp_path):
-        """Finalize should replace TBD with date."""
+        """Finalize should replace TBD with date and release tag URL."""
         f = tmp_path / "CHANGELOG.md"
         f.write_text(CHANGELOG_WITH_TBD)
-        result = self._run("finalize", "1.0.0", "2026-02-11", str(f))
+        result = self._run(
+            "finalize",
+            "1.0.0",
+            "2026-02-11",
+            str(f),
+            "--github-repository",
+            _FINALIZE_TEST_REPO,
+        )
         assert result.returncode == 0
-        assert "## [1.0.0] - 2026-02-11" in f.read_text()
+        assert (
+            f"## [1.0.0](https://github.com/{_FINALIZE_TEST_REPO}/releases/tag/1.0.0) - 2026-02-11"
+            in f.read_text()
+        )
+
+    def test_finalize_e2e_requires_repo_without_env(self, tmp_path):
+        """Finalize fails when GITHUB_REPOSITORY is unset and flag omitted."""
+        f = tmp_path / "CHANGELOG.md"
+        f.write_text(CHANGELOG_WITH_TBD)
+        env = {k: v for k, v in os.environ.items() if k != "GITHUB_REPOSITORY"}
+        result = self._run("finalize", "1.0.0", "2026-02-11", str(f), env=env)
+        assert result.returncode != 0
+        assert "GitHub repository" in result.stderr
 
     def test_finalize_invalid_date_e2e(self, tmp_path):
         """Invalid date via subprocess should exit non-zero."""
         f = tmp_path / "CHANGELOG.md"
         f.write_text(CHANGELOG_WITH_TBD)
-        result = self._run("finalize", "1.0.0", "02/11/2026", str(f))
+        result = self._run(
+            "finalize",
+            "1.0.0",
+            "02/11/2026",
+            str(f),
+            "--github-repository",
+            _FINALIZE_TEST_REPO,
+        )
         assert result.returncode != 0
         assert "Invalid" in result.stderr or "date" in result.stderr.lower()
 
@@ -1444,7 +1606,14 @@ class TestCLISubprocess:
         """Non-existent version via subprocess should exit non-zero."""
         f = tmp_path / "CHANGELOG.md"
         f.write_text(CHANGELOG_WITH_TBD)
-        result = self._run("finalize", "9.9.9", "2026-02-11", str(f))
+        result = self._run(
+            "finalize",
+            "9.9.9",
+            "2026-02-11",
+            str(f),
+            "--github-repository",
+            _FINALIZE_TEST_REPO,
+        )
         assert result.returncode != 0
 
     # ── unprepare ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Description

`prepare-changelog finalize` now writes version headings with a markdown link to the GitHub release tag (`https://github.com/owner/repo/releases/tag/X.Y.Z`). The repository slug is taken from `GITHUB_REPOSITORY` (as in GitHub Actions) or from a new `--github-repository` CLI flag. `unprepare` accepts linked `## [semver](url) - …` headings so release rollback still works.

## Type of Change

- [x] `feat` -- New feature
- [ ] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [ ] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- **`packages/vig-utils/src/vig_utils/prepare_changelog.py`**
  - Add `_validate_github_repository_slug` and `_resolve_github_repository`; `finalize_release_date` accepts optional `github_repository` and emits linked headings; `unprepare_changelog` regex allows optional `(url)` after the version; `finalize` subcommand adds `--github-repository`; help text updated.
- **`packages/vig-utils/tests/test_prepare_changelog.py`**
  - Coverage for linked headings, env vs flag slug, validation errors, and subprocess/CLI behavior.
- **`docs/RELEASE_CYCLE.md`**, **`packages/vig-utils/README.md`**
  - Document `finalize` signature, `GITHUB_REPOSITORY`, and `--github-repository` example.
- **`CHANGELOG.md`**, **`assets/workspace/.devcontainer/CHANGELOG.md`**
  - Unreleased entry for #496.

**Commits (vs `release/0.3.2`):** `test: …`, `feat(vigutils): …`, `docs: …` (Refs: #496).

## Changelog Entry

### Changed

- **prepare-changelog finalize adds GitHub release link to version headings** ([#496](https://github.com/vig-os/devcontainer/issues/496))
  - `finalize_release_date` writes `## [X.Y.Z](https://github.com/owner/repo/releases/tag/X.Y.Z) - date`; repository slug comes from `GITHUB_REPOSITORY` (set in Actions) or from `prepare-changelog finalize ... --github-repository owner/repo`
  - `unprepare` recognizes linked `## [semver](url) - …` headings

## Testing

- [ ] Tests pass locally (`just test`)
- [ ] Manual testing performed (describe below)

Full `just test` was not run. **vig-utils only:** `uv run pytest packages/vig-utils/tests/test_prepare_changelog.py` — 121 passed.

### Manual Testing Details

N/A (CLI and library behavior covered by unit and subprocess tests in `packages/vig-utils/tests/test_prepare_changelog.py`).

## Checklist

- [x] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

N/A

Refs: #496
