### PR TITLE
fix: restore release PR body on rollback after finalize failure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1376,6 +1376,13 @@ jobs:
           app-id: ${{ secrets.COMMIT_APP_ID }}
           private-key: ${{ secrets.COMMIT_APP_PRIVATE_KEY }}
 
+      - name: Generate Release App Token
+        id: release-app-token
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859  # v3
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
@@ -1421,6 +1428,46 @@ jobs:
               -f sha="$REVERT_SHA"
           echo "✓ Release branch rolled back via revert commit $REVERT_SHA (tree at $PRE_SHA)"
 
+      - name: Restore release PR body from pre-finalization CHANGELOG
+        id: restore-pr-body
+        if: ${{ needs.validate.outputs.release_kind == 'final' && needs.validate.outputs.pr_number != '' }}
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ steps.release-app-token.outputs.token }}
+          VERSION: ${{ needs.validate.outputs.version }}
+          PRE_SHA: ${{ needs.validate.outputs.pre_finalize_sha }}
+          PR_NUMBER: ${{ needs.validate.outputs.pr_number }}
+        run: |
+          set -euo pipefail
+          REPO="${{ github.repository }}"
+          echo "Restoring release PR #$PR_NUMBER body from CHANGELOG at pre-finalization SHA..."
+
+          retry --retries 3 --backoff 5 --max-backoff 30 -- \
+            gh api "repos/$REPO/contents/CHANGELOG.md?ref=$PRE_SHA" --jq '.content' | tr -d '\n' | base64 -d > /tmp/changelog-pre.md
+
+          CHANGELOG_CONTENT=$(awk -v hdr="## [${VERSION}]" '
+            index($0, hdr) == 1 { p = 1; print; next }
+            p && /^## \[/ { exit }
+            p { print }
+          ' /tmp/changelog-pre.md)
+
+          if [ -z "$CHANGELOG_CONTENT" ]; then
+            echo "ERROR: Could not extract release section for version $VERSION from CHANGELOG at $PRE_SHA"
+            exit 1
+          fi
+
+          {
+            echo "# Release $VERSION"
+            echo ""
+            echo "This PR prepares release $VERSION for merge to main."
+            echo ""
+            echo "$CHANGELOG_CONTENT"
+          } > /tmp/release-pr-body.md
+
+          retry --retries 3 --backoff 5 --max-backoff 30 -- \
+            gh pr edit "$PR_NUMBER" --body-file /tmp/release-pr-body.md
+          echo "✓ Restored PR #$PR_NUMBER body to prepare-release format (TBD)"
+
       - name: Create failure issue
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8.0.0
         with:
@@ -1436,6 +1483,7 @@ jobs:
             if ('${{ needs.publish.result }}' !== 'success') failedJobs.push('publish');
 
             const rollbackBranch = '${{ steps.rollback-branch.outcome }}';
+            const prBodyRestore = '${{ steps.restore-pr-body.outcome }}';
 
             const title = `Release ${publishVersion} failed -- automatic rollback`;
             const body = `
@@ -1449,6 +1497,7 @@ jobs:
 
             **Rollback Results:**
             - Branch rollback: ${rollbackBranch}
+            - PR body restoration: ${prBodyRestore}
 
             **Tag status (forward-fix policy):**
             - Release tags are **not** deleted by automation (workflow choice; not the same as GitHub immutable-release lock-in).
@@ -1456,6 +1505,7 @@ jobs:
 
             **Actions Taken:**
             - Release branch reset to pre-finalization state (best-effort)
+            - Release PR body restored to TBD / prepare-release format when applicable (best-effort)
             - This issue created for investigation
 
             **Manual Cleanup May Be Needed:**
@@ -1487,6 +1537,7 @@ jobs:
           echo ""
           echo "Automatic rollback completed:"
           echo "  - Release branch reset to pre-finalization state (best-effort)"
+          echo "  - Release PR body restoration: ${{ steps.restore-pr-body.outcome }} (skipped if not a final release or no PR number)"
           echo "  - Tags were not deleted (forward-fix policy)"
           echo "  - GitHub issue created for investigation"
           echo ""

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1378,6 +1378,7 @@ jobs:
 
       - name: Generate Release App Token
         id: release-app-token
+        if: ${{ needs.validate.outputs.release_kind == 'final' && needs.validate.outputs.pr_number != '' }}
         uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859  # v3
         with:
           app-id: ${{ secrets.RELEASE_APP_ID }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Release rollback creates a fast-forward revert commit via the Git API instead of force-pushing, compatible with branch protection on `release/*`
   - Rollback Git Data API steps authenticate with the Commit app token (same as finalize) so protected `release/*` ref updates are not blocked
   - Canonical `retry()` implementation lives in `.github/scripts/retry.sh`; `setup-env` and BATS source it so CI and tests stay aligned (`sync-main-to-dev.yml` keeps an inline copy documented as in sync)
+- **Release rollback restores release PR body after finalize** ([#502](https://github.com/vig-os/devcontainer/issues/502))
+  - `rollback` job in `release.yml` restores the PR description from pre-finalization `CHANGELOG.md` (TBD / prepare-release format) using RELEASE_APP when `release_kind` is final, after branch rollback; failure issue and job summary report the step outcome
 
 ### Security
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -91,6 +91,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Release rollback creates a fast-forward revert commit via the Git API instead of force-pushing, compatible with branch protection on `release/*`
   - Rollback Git Data API steps authenticate with the Commit app token (same as finalize) so protected `release/*` ref updates are not blocked
   - Canonical `retry()` implementation lives in `.github/scripts/retry.sh`; `setup-env` and BATS source it so CI and tests stay aligned (`sync-main-to-dev.yml` keeps an inline copy documented as in sync)
+- **Release rollback restores release PR body after finalize** ([#502](https://github.com/vig-os/devcontainer/issues/502))
+  - `rollback` job in `release.yml` restores the PR description from pre-finalization `CHANGELOG.md` (TBD / prepare-release format) using RELEASE_APP when `release_kind` is final, after branch rollback; failure issue and job summary report the step outcome
 
 ### Security
 


### PR DESCRIPTION
## Description

When finalize fails and the release workflow rolls back the release branch, the release PR description could be left out of sync. This change extends the `rollback` job in `release.yml` so that, for final releases, it restores the PR body from the pre-finalization `CHANGELOG.md` (TBD / prepare-release format) using `RELEASE_APP`, and surfaces the outcome in the failure issue and job summary.

## Type of Change

- [ ] `feat` -- New feature
- [x] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [ ] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- `.github/workflows/release.yml`
  - Add rollback step(s) to restore release PR body after branch rollback when `release_kind` is final, using changelog-derived description and `RELEASE_APP`.
- `CHANGELOG.md` / `assets/workspace/.devcontainer/CHANGELOG.md`
  - Document the fix under `## [0.3.2] - TBD` → Fixed.

## Changelog Entry

```diff
@@ -91,6 +91,8 @@
   - Release rollback creates a fast-forward revert commit via the Git API instead of force-pushing, compatible with branch protection on `release/*`
   - Rollback Git Data API steps authenticate with the Commit app token (same as finalize) so protected `release/*` ref updates are not blocked
   - Canonical `retry()` implementation lives in `.github/scripts/retry.sh`; `setup-env` and BATS source it so CI and tests stay aligned (`sync-main-to-dev.yml` keeps an inline copy documented as in sync)
+- **Release rollback restores release PR body after finalize** ([#502](https://github.com/vig-os/devcontainer/issues/502))
+  - `rollback` job in `release.yml` restores the PR description from pre-finalization `CHANGELOG.md` (TBD / prepare-release format) using RELEASE_APP when `release_kind` is final, after branch rollback; failure issue and job summary report the step outcome
 
 ### Security
```

## Testing

- [ ] Tests pass locally (`just test`)
- [ ] Manual testing performed (describe below)

### Manual Testing Details

N/A (CI workflow change; tests not run for this submission.)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` under `## [0.3.2] - TBD` (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

N/A

Refs: #502
