### PR TITLE
fix(ci): match linked changelog headings in release notes awk

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -892,8 +892,8 @@ jobs:
           VERSION: ${{ needs.validate.outputs.version }}
         run: |
           set -euo pipefail
-          awk -v version="$VERSION" '
-            index($0, "## [" version "] - ") == 1 {found=1; next}
+          awk -v hdr="## [${VERSION}]" '
+            index($0, hdr) == 1 {found=1; next}
             /^## \[/ && found {found=0}
             found {print}
           ' CHANGELOG.md > /tmp/github-release-notes.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -900,7 +900,7 @@ jobs:
 
           if [ ! -s /tmp/github-release-notes.md ]; then
             echo "ERROR: Failed to generate GitHub Release notes for $VERSION from CHANGELOG.md"
-            echo "Expected section heading: ## [$VERSION] - YYYY-MM-DD"
+            echo "Expected heading like: ## [$VERSION] - YYYY-MM-DD or ## [$VERSION](url) - YYYY-MM-DD"
             exit 1
           fi
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Canonical `retry()` implementation lives in `.github/scripts/retry.sh`; `setup-env` and BATS source it so CI and tests stay aligned (`sync-main-to-dev.yml` keeps an inline copy documented as in sync)
 - **Release rollback restores release PR body after finalize** ([#502](https://github.com/vig-os/devcontainer/issues/502))
   - `rollback` job in `release.yml` restores the PR description from pre-finalization `CHANGELOG.md` (TBD / prepare-release format) using RELEASE_APP when `release_kind` is final, after branch rollback; failure issue and job summary report the step outcome
+- **Final release notes extraction after linked changelog headings** ([#504](https://github.com/vig-os/devcontainer/issues/504))
+  - Publish job `awk` matches `## [VERSION]` prefix so finalized `## [X.Y.Z](url) - date` headings produce GitHub Release notes (regression after prepare-changelog linked headings in #496)
 
 ### Security
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -93,6 +93,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Canonical `retry()` implementation lives in `.github/scripts/retry.sh`; `setup-env` and BATS source it so CI and tests stay aligned (`sync-main-to-dev.yml` keeps an inline copy documented as in sync)
 - **Release rollback restores release PR body after finalize** ([#502](https://github.com/vig-os/devcontainer/issues/502))
   - `rollback` job in `release.yml` restores the PR description from pre-finalization `CHANGELOG.md` (TBD / prepare-release format) using RELEASE_APP when `release_kind` is final, after branch rollback; failure issue and job summary report the step outcome
+- **Final release notes extraction after linked changelog headings** ([#504](https://github.com/vig-os/devcontainer/issues/504))
+  - Publish job `awk` matches `## [VERSION]` prefix so finalized `## [X.Y.Z](url) - date` headings produce GitHub Release notes (regression after prepare-changelog linked headings in #496)
 
 ### Security
 


### PR DESCRIPTION
## Description

Fix release notes extraction in the `publish` job of `release.yml`. After #496 added GitHub release links to finalized changelog headings, the `awk` command that extracts version-specific notes stopped matching because it expected `## [X.Y.Z] - date` but got `## [X.Y.Z](url) - date`. This changes the match to use the `## [VERSION]` prefix only.

## Type of Change

- [ ] `feat` -- New feature
- [x] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [ ] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- **`.github/workflows/release.yml`** -- Changed the `awk` command in the publish job to match on `## [VERSION]` prefix instead of `## [VERSION] - `, so that linked headings (`## [X.Y.Z](url) - date`) are correctly matched for GitHub Release notes extraction.
- **`CHANGELOG.md`** / **`assets/workspace/.devcontainer/CHANGELOG.md`** -- Added changelog entry under Fixed for #504.

## Changelog Entry

### Fixed

- **Final release notes extraction after linked changelog headings** ([#504](https://github.com/vig-os/devcontainer/issues/504))
  - Publish job `awk` matches `## [VERSION]` prefix so finalized `## [X.Y.Z](url) - date` headings produce GitHub Release notes (regression after prepare-changelog linked headings in #496)

## Testing

- [ ] Tests pass locally (`just test`)
- [ ] Manual testing performed (describe below)

### Manual Testing Details

N/A

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

N/A

Refs: #504
