### PR TITLE
fix: resolve draft releases in promote-release validation

### DIFF
--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -160,8 +160,17 @@ jobs:
           RELEASE_JSON=""
           for i in $(seq 1 "$RETRIES"); do
             API_OUTPUT=""
-            if API_OUTPUT=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${VERSION}" 2>&1); then
-              RELEASE_JSON="$API_OUTPUT"
+            if API_OUTPUT=$(gh api "repos/${GITHUB_REPOSITORY}/releases" --paginate \
+              --jq 'first(.[] | select(.tag_name == $tag))' --arg tag "$VERSION" 2>&1); then
+              if printf '%s' "$API_OUTPUT" | jq -e 'type == "object"' >/dev/null 2>&1; then
+                RELEASE_JSON="$API_OUTPUT"
+                break
+              fi
+              LAST_ERROR="No release found for tag $VERSION (not in releases list yet)"
+              if [ "$i" -lt "$RETRIES" ]; then
+                sleep $((i * 5))
+                continue
+              fi
               break
             fi
             LAST_ERROR="$API_OUTPUT"
@@ -585,8 +594,10 @@ jobs:
           fi
           while IFS= read -r tag; do
             [ -z "$tag" ] && continue
-            if retry --retries 2 --backoff 3 --max-backoff 10 -- \
-              gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${tag}" >/dev/null 2>&1; then
+            if REL_JSON=$(retry --retries 2 --backoff 3 --max-backoff 10 -- \
+              gh api "repos/${GITHUB_REPOSITORY}/releases" --paginate \
+              --jq 'first(.[] | select(.tag_name == $tag))' --arg tag "$tag" 2>&1) && \
+              printf '%s' "$REL_JSON" | jq -e 'type == "object"' >/dev/null 2>&1; then
               echo "Skipping tag $tag (GitHub Release exists)"
               continue
             fi

--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -160,10 +160,11 @@ jobs:
           RELEASE_JSON=""
           for i in $(seq 1 "$RETRIES"); do
             API_OUTPUT=""
-            if API_OUTPUT=$(gh api "repos/${GITHUB_REPOSITORY}/releases" --paginate \
-              --jq 'first(.[] | select(.tag_name == $tag))' --arg tag "$VERSION" 2>&1); then
-              if printf '%s' "$API_OUTPUT" | jq -e 'type == "object"' >/dev/null 2>&1; then
-                RELEASE_JSON="$API_OUTPUT"
+            if API_OUTPUT=$(gh api "repos/${GITHUB_REPOSITORY}/releases" --paginate 2>&1); then
+              MATCHED=$(printf '%s' "$API_OUTPUT" | \
+                jq -s --arg tag "$VERSION" 'flatten | map(select(.tag_name == $tag)) | .[0] // empty' 2>/dev/null)
+              if printf '%s' "$MATCHED" | jq -e 'type == "object"' >/dev/null 2>&1; then
+                RELEASE_JSON="$MATCHED"
                 break
               fi
               LAST_ERROR="No release found for tag $VERSION (not in releases list yet)"
@@ -594,10 +595,15 @@ jobs:
           fi
           while IFS= read -r tag; do
             [ -z "$tag" ] && continue
-            if REL_JSON=$(retry --retries 2 --backoff 3 --max-backoff 10 -- \
-              gh api "repos/${GITHUB_REPOSITORY}/releases" --paginate \
-              --jq 'first(.[] | select(.tag_name == $tag))' --arg tag "$tag" 2>&1) && \
-              printf '%s' "$REL_JSON" | jq -e 'type == "object"' >/dev/null 2>&1; then
+            RAW=""
+            if ! RAW=$(retry --retries 2 --backoff 3 --max-backoff 10 -- \
+              gh api "repos/${GITHUB_REPOSITORY}/releases" --paginate 2>&1); then
+              echo "WARN: release lookup failed for tag $tag, skipping deletion"
+              continue
+            fi
+            if printf '%s' "$RAW" | \
+              jq -s --arg tag "$tag" 'flatten | map(select(.tag_name == $tag)) | .[0] // empty' 2>/dev/null | \
+              jq -e 'type == "object"' >/dev/null 2>&1; then
               echo "Skipping tag $tag (GitHub Release exists)"
               continue
             fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Promote-release draft release validation** ([#507](https://github.com/vig-os/devcontainer/issues/507))
+  - Use the paginated releases list API with jq instead of `GET /releases/tags/{tag}`, which returns 404 for draft releases
+  - Apply the same release lookup for RC git tag cleanup in upstream and workspace `promote-release.yml`
+
 ### Security
 
 ## [0.3.2](https://github.com/vig-os/devcontainer/releases/tag/0.3.2) - 2026-04-08

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Promote-release draft release validation** ([#507](https://github.com/vig-os/devcontainer/issues/507))
+  - Use the paginated releases list API with jq instead of `GET /releases/tags/{tag}`, which returns 404 for draft releases
+  - Apply the same release lookup for RC git tag cleanup in upstream and workspace `promote-release.yml`
+
 ### Security
 
 ## [0.3.2](https://github.com/vig-os/devcontainer/releases/tag/0.3.2) - 2026-04-08

--- a/assets/workspace/.github/workflows/promote-release.yml
+++ b/assets/workspace/.github/workflows/promote-release.yml
@@ -96,8 +96,17 @@ jobs:
           RELEASE_JSON=""
           for i in $(seq 1 "$RETRIES"); do
             API_OUTPUT=""
-            if API_OUTPUT=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${VERSION}" 2>&1); then
-              RELEASE_JSON="$API_OUTPUT"
+            if API_OUTPUT=$(gh api "repos/${GITHUB_REPOSITORY}/releases" --paginate \
+              --jq 'first(.[] | select(.tag_name == $tag))' --arg tag "$VERSION" 2>&1); then
+              if printf '%s' "$API_OUTPUT" | jq -e 'type == "object"' >/dev/null 2>&1; then
+                RELEASE_JSON="$API_OUTPUT"
+                break
+              fi
+              LAST_ERROR="No release found for tag $VERSION (not in releases list yet)"
+              if [ "$i" -lt "$RETRIES" ]; then
+                sleep $((i * 5))
+                continue
+              fi
               break
             fi
             LAST_ERROR="$API_OUTPUT"
@@ -401,8 +410,10 @@ jobs:
           fi
           while IFS= read -r tag; do
             [ -z "$tag" ] && continue
-            if retry --retries 2 --backoff 3 --max-backoff 10 -- \
-              gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${tag}" >/dev/null 2>&1; then
+            if REL_JSON=$(retry --retries 2 --backoff 3 --max-backoff 10 -- \
+              gh api "repos/${GITHUB_REPOSITORY}/releases" --paginate \
+              --jq 'first(.[] | select(.tag_name == $tag))' --arg tag "$tag" 2>&1) && \
+              printf '%s' "$REL_JSON" | jq -e 'type == "object"' >/dev/null 2>&1; then
               echo "Skipping tag $tag (GitHub Release exists)"
               continue
             fi

--- a/assets/workspace/.github/workflows/promote-release.yml
+++ b/assets/workspace/.github/workflows/promote-release.yml
@@ -96,10 +96,11 @@ jobs:
           RELEASE_JSON=""
           for i in $(seq 1 "$RETRIES"); do
             API_OUTPUT=""
-            if API_OUTPUT=$(gh api "repos/${GITHUB_REPOSITORY}/releases" --paginate \
-              --jq 'first(.[] | select(.tag_name == $tag))' --arg tag "$VERSION" 2>&1); then
-              if printf '%s' "$API_OUTPUT" | jq -e 'type == "object"' >/dev/null 2>&1; then
-                RELEASE_JSON="$API_OUTPUT"
+            if API_OUTPUT=$(gh api "repos/${GITHUB_REPOSITORY}/releases" --paginate 2>&1); then
+              MATCHED=$(printf '%s' "$API_OUTPUT" | \
+                jq -s --arg tag "$VERSION" 'flatten | map(select(.tag_name == $tag)) | .[0] // empty' 2>/dev/null)
+              if printf '%s' "$MATCHED" | jq -e 'type == "object"' >/dev/null 2>&1; then
+                RELEASE_JSON="$MATCHED"
                 break
               fi
               LAST_ERROR="No release found for tag $VERSION (not in releases list yet)"
@@ -410,10 +411,15 @@ jobs:
           fi
           while IFS= read -r tag; do
             [ -z "$tag" ] && continue
-            if REL_JSON=$(retry --retries 2 --backoff 3 --max-backoff 10 -- \
-              gh api "repos/${GITHUB_REPOSITORY}/releases" --paginate \
-              --jq 'first(.[] | select(.tag_name == $tag))' --arg tag "$tag" 2>&1) && \
-              printf '%s' "$REL_JSON" | jq -e 'type == "object"' >/dev/null 2>&1; then
+            RAW=""
+            if ! RAW=$(retry --retries 2 --backoff 3 --max-backoff 10 -- \
+              gh api "repos/${GITHUB_REPOSITORY}/releases" --paginate 2>&1); then
+              echo "WARN: release lookup failed for tag $tag, skipping deletion"
+              continue
+            fi
+            if printf '%s' "$RAW" | \
+              jq -s --arg tag "$tag" 'flatten | map(select(.tag_name == $tag)) | .[0] // empty' 2>/dev/null | \
+              jq -e 'type == "object"' >/dev/null 2>&1; then
               echo "Skipping tag $tag (GitHub Release exists)"
               continue
             fi


### PR DESCRIPTION
## Description

The promote-release validate step queried `GET /repos/{owner}/{repo}/releases/tags/{tag}`, which does not return draft releases (404). The workflow now uses the paginated releases list API and jq to select the release by `tag_name`, so draft releases created by `release.yml` are found. The RC git tag cleanup step uses the same lookup so “release exists” stays correct for drafts if they ever apply.

## Type of Change

- [ ] `feat` -- New feature
- [x] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [x] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- `.github/workflows/promote-release.yml` — Draft release verification and RC tag cleanup use `gh api …/releases --paginate` with `jq` to match `tag_name` instead of the per-tag endpoint.
- `assets/workspace/.github/workflows/promote-release.yml` — Same behavior for the downstream template.
- `CHANGELOG.md` — Unreleased **Fixed** entry for #507.
- `assets/workspace/.devcontainer/CHANGELOG.md` — Synced copy of the changelog entry (manifest sync).

## Changelog Entry

### Fixed

- **Promote-release draft release validation** ([#507](https://github.com/vig-os/devcontainer/issues/507))
  - Use the paginated releases list API with jq instead of `GET /releases/tags/{tag}`, which returns 404 for draft releases
  - Apply the same release lookup for RC git tag cleanup in upstream and workspace `promote-release.yml`

## Testing

- [ ] Tests pass locally (`just test`)
- [ ] Manual testing performed (describe below)

### Manual Testing Details

N/A — workflow-only change; not exercised locally against GitHub. Pre-commit (yaml/yamllint) passed on commit.

## Checklist

- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [ ] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

N/A

Refs: #507
