### PR TITLE
fix: remediate nightly Trivy gate vulnerabilities (OpenSSL, gh, typos)

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -48,73 +48,87 @@ CVE-2025-7709
 Expiration: 2026-05-15
 CVE-2023-50495
 
-# CVE-2025-68121: crypto/tls unexpected session resumption
-# Risk Assessment: LOW
-# - CRITICAL severity in Go stdlib v1.25.5 embedded in gh (GitHub CLI) binary
-# - Requires specific TLS 1.3 session resumption patterns
-# - gh connects only to GitHub APIs; no user-facing TLS server in devcontainer
-# - Impact would be session hijacking in TLS connections, unlikely in dev context
-# - Source: gh CLI binary (Go stdlib v1.25.5, statically linked)
-# - Fixed in Go 1.25.7, 1.24.13, 1.26.0-rc.3; awaiting upstream gh release
-Expiration: 2026-05-15
-CVE-2025-68121
-
-# CVE-2025-61726: net/url memory exhaustion via query parameter parsing
-# Risk Assessment: LOW
-# - HIGH severity in Go stdlib v1.25.5 embedded in gh binary
-# - Requires attacker-controlled URLs with crafted query parameters
-# - gh parses URLs from GitHub API responses and user input (issues, PRs)
-# - Exploitation requires deliberate attack via malicious GitHub content
-# - Low risk in devcontainer where gh is used with trusted GitHub accounts
-# - Source: gh CLI binary (Go stdlib v1.25.5, statically linked)
-# - Fixed in Go 1.25.6, 1.24.12; awaiting upstream gh release
-Expiration: 2026-05-15
-CVE-2025-61726
-
-# CVE-2025-61728: archive/zip excessive CPU consumption
-# Risk Assessment: LOW
-# - HIGH severity in Go stdlib v1.25.5 embedded in gh binary
-# - Requires attacker to craft malicious ZIP archives with pathological indices
-# - gh does not extract or process user-supplied zip archives in normal devcontainer usage
-# - Would trigger only during release artifact handling with untrusted zips
-# - Impact is denial of service (CPU spike), not code execution
-# - Source: gh CLI binary (Go stdlib v1.25.5, statically linked)
-# - Fixed in Go 1.25.7; awaiting upstream gh release
-Expiration: 2026-05-15
-CVE-2025-61728
-
-# CVE-2025-61730: TLS 1.3 handshake message handling
-# Risk Assessment: LOW
-# - HIGH severity in Go stdlib v1.25.5 embedded in gh binary
-# - Requires multiple TLS records sent in specific sequence during handshake
-# - gh connects only to GitHub APIs; no user-facing TLS server in devcontainer
-# - Attack surface limited to client-side TLS handshakes with untrusted servers
-# - Low likelihood in dev context with trusted infrastructure
-# - Source: gh CLI binary (Go stdlib v1.25.5, statically linked)
-# - Fixed in Go 1.25.7; awaiting upstream gh release
-Expiration: 2026-05-15
-CVE-2025-61730
-
-# CVE-2025-15558: docker/cli plugin search path privilege escalation
+# CVE-2025-69720: ncurses buffer overflow
 # Risk Assessment: LOW (devcontainer context)
-# - Reported against github.com/docker/cli v29.0.3 embedded in gh v2.87.3
-# - Fix is in github.com/docker/cli >= 29.2.0 and requires upstream gh rebuild
-# - gh in this image is used for trusted GitHub workflows, not privileged plugin execution
-# - Temporary exception to unblock CI until upstream gh release includes the patched dependency
-# - Tracking: https://github.com/vig-os/devcontainer/issues/162
-Expiration: 2026-04-15
-CVE-2025-15558
+# - HIGH severity; may lead to arbitrary code execution via crafted terminal sequences
+# - Terminal environment is controlled by the container operator, not untrusted remote users
+# - No Debian stable fix available yet (Trivy status: affected)
+# - Tracking: https://github.com/vig-os/devcontainer/issues/512
+Expiration: 2026-06-01
+CVE-2025-69720
 
-# CVE-2026-33186: gRPC-Go authorization bypass via missing leading slash in :path
+# CVE-2025-7458: SQLite integer overflow
 # Risk Assessment: LOW (devcontainer context)
-# - CRITICAL severity in google.golang.org/grpc v1.79.2 embedded in gh v2.88.1
-# - Upstream gh latest release still ships grpc v1.79.2 in go.mod
-# - Fix is available in grpc v1.79.3 and requires upstream gh release/rebuild
-# - gh is used as a client to GitHub APIs in trusted workflows in this image
-# - Temporary exception to keep blocking policy for other HIGH/CRITICAL findings
-# - Tracking: https://github.com/vig-os/devcontainer/issues/361
+# - CRITICAL severity in Trivy/NVD; no Debian stable fix available yet (Trivy status: affected)
+# - SQLite used only for pre-commit and build tooling caches, not as an app database
+# - No attacker-controlled SQL/query surface in primary devcontainer workflows
+# - Tracking: https://github.com/vig-os/devcontainer/issues/512
+Expiration: 2026-06-01
+CVE-2025-7458
+
+# CVE-2026-29111: systemd arbitrary code execution or DoS via spurious IPC
+# Risk Assessment: LOW (devcontainer context)
+# - HIGH severity; libsystemd0/libudev1 pulled transitively by base image and tools
+# - Single-user dev environment; not a multi-tenant service exposing systemd IPC to attackers
+# - No Debian stable fix available yet (Trivy status: affected)
+# - Tracking: https://github.com/vig-os/devcontainer/issues/512
+Expiration: 2026-06-01
+CVE-2026-29111
+
+# CVE-2023-45853: zlib/minizip integer overflow and heap buffer overflow
+# Risk Assessment: LOW (devcontainer context)
+# - CRITICAL in vendor DBs; Debian marks will_not_fix (minizip code path not exposed by package)
+# - Core zlib usage in image does not invoke the vulnerable minizip entry point as shipped
+# - No actionable package upgrade in bookworm; accept until base image rebases
+# - Tracking: https://github.com/vig-os/devcontainer/issues/512
+Expiration: 2026-06-01
+CVE-2023-45853
+
+# CVE-2026-32281: crypto/x509 inefficient certificate chain validation (DoS)
+# Risk Assessment: LOW (devcontainer context)
+# - HIGH severity in Go stdlib embedded in gh (GitHub CLI) binary
+# - Requires pathological certificate chains; gh validates chains for GitHub API TLS only
+# - gh connects only to GitHub APIs; no user-facing TLS server in devcontainer
+# - Fixed in newer Go releases; awaiting upstream gh rebuild with patched stdlib
+# - Tracking: https://github.com/vig-os/devcontainer/issues/512
 Expiration: 2026-05-15
-CVE-2026-33186
+CVE-2026-32281
+
+# CVE-2026-32288: archive/tar denial of service via malicious archive
+# Risk Assessment: LOW (devcontainer context)
+# - HIGH severity in Go stdlib embedded in gh binary
+# - Requires attacker-supplied tar archives; gh does not process untrusted archives in typical devcontainer flows
+# - Impact is denial of service, not code execution
+# - Fixed in newer Go releases; awaiting upstream gh release
+# - Tracking: https://github.com/vig-os/devcontainer/issues/512
+Expiration: 2026-05-15
+CVE-2026-32288
+
+# CVE-2026-32289: html/template XSS via JS template literal context
+# Risk Assessment: LOW (devcontainer context)
+# - HIGH severity in Go stdlib embedded in gh binary
+# - Affects HTML template rendering; gh is a CLI client, not a web server serving user HTML
+# - Fixed in newer Go releases; awaiting upstream gh release
+# - Tracking: https://github.com/vig-os/devcontainer/issues/512
+Expiration: 2026-05-15
+CVE-2026-32289
+
+# CVE-2026-25727: time stack exhaustion denial of service
+# Risk Assessment: LOW (devcontainer context)
+# - HIGH severity; reported in typos (pre-commit hook) dependency tree / Cargo.lock
+# - typos runs offline spell-check on repo files; no attacker-controlled time parsing surface
+# - Awaiting upstream typos or dependency release with patched version
+# - Tracking: https://github.com/vig-os/devcontainer/issues/512
+Expiration: 2026-05-15
+CVE-2026-25727
+
+# jwt-token: Trivy secret scan false positive
+# Risk Assessment: N/A (not a vulnerability)
+# - JWT-like string in typos crate test fixtures under /opt/pre-commit-cache (e.g. tokens.rs)
+# - Not a live credential; embedded test data only
+# - Tracking: https://github.com/vig-os/devcontainer/issues/512
+Expiration: 2026-05-15
+jwt-token
 
 # CVE-2026-31812: quinn-proto unauthenticated remote DoS via QUIC transport parameter panic
 # Risk Assessment: LOW (devcontainer context)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **Nightly Trivy gate remediation (OpenSSL, gh, typos)** ([#512](https://github.com/vig-os/devcontainer/issues/512))
+  - Pin `python:3.12-slim-bookworm` to current digest and add targeted `libssl3`/`openssl` upgrade to `3.0.19-1~deb12u2` (CVE-2026-28390, CVE-2026-31790)
+  - Refresh `.trivyignore`: drop resolved gh/docker-cli and gRPC entries; add Go stdlib and typos-related suppressions plus `jwt-token` false positive
+  - Suppress unfixable base-image CVEs: ncurses (CVE-2025-69720), SQLite (CVE-2025-7458), systemd (CVE-2026-29111), zlib/minizip (CVE-2023-45853)
+
 ## [0.3.2](https://github.com/vig-os/devcontainer/releases/tag/0.3.2) - 2026-04-08
 
 ### Added

--- a/Containerfile
+++ b/Containerfile
@@ -1,7 +1,7 @@
 # Use Python 3.12 as base image (pinned to digest for supply chain integrity)
 # Dependabot (docker ecosystem) will propose digest updates automatically
 # Updated to bookworm (stable) for better security patch cadence
-FROM python:3.12-slim-bookworm@sha256:4c50375fc4b8ea5ca06ac9485186ccb50171c99390b0e9300c2bac871cc2dc3e
+FROM python:3.12-slim-bookworm@sha256:d97792894a6a4162cae14da44542a83c75e56c77a27b92d58f3f83b7bc961292
 
 # Add metadata
 # By default, we build the dev version unless specified as an argument
@@ -48,6 +48,12 @@ ENV DEBIAN_FRONTEND=noninteractive
 # RUN apt-get update && apt-get install -y --only-upgrade \
 #     <package>=<version> \  # CVE-XXXX-XXXXX
 #     && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# CVE-2026-28390, CVE-2026-31790 (OpenSSL; bookworm-security ahead of base digest)
+RUN apt-get update && apt-get install -y --no-install-recommends --only-upgrade \
+    libssl3=3.0.19-1~deb12u2 \
+    openssl=3.0.19-1~deb12u2 \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Install minimal system dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -43,6 +43,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **Nightly Trivy gate remediation (OpenSSL, gh, typos)** ([#512](https://github.com/vig-os/devcontainer/issues/512))
+  - Pin `python:3.12-slim-bookworm` to current digest and add targeted `libssl3`/`openssl` upgrade to `3.0.19-1~deb12u2` (CVE-2026-28390, CVE-2026-31790)
+  - Refresh `.trivyignore`: drop resolved gh/docker-cli and gRPC entries; add Go stdlib and typos-related suppressions plus `jwt-token` false positive
+  - Suppress unfixable base-image CVEs: ncurses (CVE-2025-69720), SQLite (CVE-2025-7458), systemd (CVE-2026-29111), zlib/minizip (CVE-2023-45853)
+
 ## [0.3.2](https://github.com/vig-os/devcontainer/releases/tag/0.3.2) - 2026-04-08
 
 ### Added


### PR DESCRIPTION
## Description

Remediate HIGH/CRITICAL vulnerabilities found by the nightly Trivy security scan on the `:latest` image. Upgrades fixable packages (OpenSSL) and refreshes `.trivyignore` with properly documented suppressions for unfixable base-image CVEs and Go stdlib issues in vendored binaries.

## Type of Change

- [ ] `feat` -- New feature
- [x] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [ ] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- **`Containerfile`** — Update `python:3.12-slim-bookworm` pinned digest; add targeted `apt-get install --only-upgrade` for `libssl3` and `openssl` to `3.0.19-1~deb12u2` (CVE-2026-28390, CVE-2026-31790).
- **`.trivyignore`** — Drop resolved suppressions (gh/docker-cli CVE-2025-15558, gRPC CVE-2026-33186, older Go stdlib CVEs); add suppressions for unfixable base-image CVEs (ncurses CVE-2025-69720, SQLite CVE-2025-7458, systemd CVE-2026-29111, zlib/minizip CVE-2023-45853), new Go stdlib CVEs in gh (CVE-2026-32281, CVE-2026-32288, CVE-2026-32289), typos dependency (CVE-2026-25727), and `jwt-token` false positive.
- **`CHANGELOG.md`** / **`assets/workspace/.devcontainer/CHANGELOG.md`** — Add Security entry under Unreleased.

## Changelog Entry

### Security

- **Nightly Trivy gate remediation (OpenSSL, gh, typos)** ([#512](https://github.com/vig-os/devcontainer/issues/512))
  - Pin `python:3.12-slim-bookworm` to current digest and add targeted `libssl3`/`openssl` upgrade to `3.0.19-1~deb12u2` (CVE-2026-28390, CVE-2026-31790)
  - Refresh `.trivyignore`: drop resolved gh/docker-cli and gRPC entries; add Go stdlib and typos-related suppressions plus `jwt-token` false positive
  - Suppress unfixable base-image CVEs: ncurses (CVE-2025-69720), SQLite (CVE-2025-7458), systemd (CVE-2026-29111), zlib/minizip (CVE-2023-45853)

## Testing

- [ ] Tests pass locally (`just test`)
- [ ] Manual testing performed (describe below)

### Manual Testing Details

N/A — changes are to Containerfile build directives and Trivy suppression metadata. Verification will occur via the CI image build and nightly Trivy scan.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

This PR addresses the automated issue opened by the nightly Trivy security scan workflow. The OpenSSL CVEs are fixable via an apt upgrade; remaining findings are unfixable in Debian bookworm stable and are suppressed with risk assessments and expiration dates in `.trivyignore`.

Refs: #512
