### PR TITLE
feat(ci): smoke-test dispatch runs promote-release for final tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Sync workflows run in devcontainer image** ([#509](https://github.com/vig-os/devcontainer/issues/509))
   - `sync-issues` and `sync-main-to-dev` use `resolve-image` and run inside the pinned devcontainer, removing the `setup-env` composite action dependency and the inlined retry helper
   - `sync-main-to-dev` creates sync branches via `git push` instead of the GitHub refs API
+- **Smoke-test dispatch triggers promote-release for final releases** ([#511](https://github.com/vig-os/devcontainer/issues/511))
+  - Final releases dispatch downstream `promote-release.yml` instead of merging the release PR directly, publishing the draft GitHub Release and satisfying the upstream promote-time downstream gate
+  - RC releases wait for release PR required checks but no longer merge the PR to `main`
 
 ### Deprecated
 

--- a/assets/smoke-test/.github/workflows/repository-dispatch.yml
+++ b/assets/smoke-test/.github/workflows/repository-dispatch.yml
@@ -435,7 +435,7 @@ jobs:
         run: |
           set -euo pipefail
           # Canonical cross-repo dispatch contract lives in docs/CROSS_REPO_RELEASE_GATE.md.
-          REQUIRED_WORKFLOWS=(prepare-release.yml release.yml)
+          REQUIRED_WORKFLOWS=(prepare-release.yml release.yml promote-release.yml)
           for workflow_file in "${REQUIRED_WORKFLOWS[@]}"; do
             if WORKFLOW_CHECK_OUTPUT="$(gh workflow view "${workflow_file}" --ref "${WORKFLOW_REF}" --yaml 2>&1 >/dev/null)"; then
               echo "Workflow available on ${WORKFLOW_REF}: ${workflow_file}"
@@ -661,15 +661,15 @@ jobs:
           echo "ERROR: timed out waiting for release workflow completion"
           exit 1
 
-  merge-release-pr:
-    name: Enable auto-merge and wait for release PR merge
+  wait-release-pr-ci:
+    name: Wait for release PR required checks
     runs-on: ubuntu-22.04
     timeout-minutes: 35
     env:
       GH_REPO: ${{ github.repository }}
     needs: [ready-release-pr, trigger-release]
     steps:
-      - name: Generate release app token for PR merge
+      - name: Generate release app token for PR checks
         id: generate_release_token
         uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859  # v3
         with:
@@ -678,23 +678,15 @@ jobs:
           owner: ${{ github.repository_owner }}
           repositories: ${{ github.event.repository.name }}
 
-      - name: Enable release PR auto-merge
+      - name: Poll release PR required checks until green
         env:
           GH_TOKEN: ${{ steps.generate_release_token.outputs.token }}
           PR_NUMBER: ${{ needs.ready-release-pr.outputs.release_pr }}
-        run: |
-          set -euo pipefail
-          gh pr merge "${PR_NUMBER}" --auto --merge || \
-            echo "Warning: could not enable auto-merge yet"
-
-      - name: Poll release PR merge status
-        env:
-          GH_TOKEN: ${{ steps.generate_release_token.outputs.token }}
           PR_URL: ${{ needs.ready-release-pr.outputs.release_pr_url }}
         run: |
           set -euo pipefail
-          if [ -z "${PR_URL}" ]; then
-            echo "ERROR: missing release PR URL"
+          if [ -z "${PR_NUMBER}" ] || [ -z "${PR_URL}" ]; then
+            echo "ERROR: missing release PR number or URL"
             exit 1
           fi
 
@@ -703,21 +695,106 @@ jobs:
           ELAPSED=0
 
           while [ "${ELAPSED}" -lt "${TIMEOUT}" ]; do
-            STATE="$(gh pr view "${PR_URL}" --json state --jq '.state' 2>/dev/null || echo unknown)"
-            if [ "${STATE}" = "MERGED" ]; then
-              echo "Release PR merged: ${PR_URL}"
-              exit 0
-            fi
-            if [ "${STATE}" = "CLOSED" ]; then
-              echo "ERROR: release PR closed without merge: ${PR_URL}"
+            CHECKS_JSON="$(gh pr checks "${PR_NUMBER}" --required --json bucket 2>/dev/null || echo '[]')"
+            TOTAL="$(echo "${CHECKS_JSON}" | jq 'length')"
+            FAIL_COUNT="$(echo "${CHECKS_JSON}" | jq '[.[] | select(.bucket == "fail")] | length')"
+            CANCEL_COUNT="$(echo "${CHECKS_JSON}" | jq '[.[] | select(.bucket == "cancel")] | length')"
+            PENDING_COUNT="$(echo "${CHECKS_JSON}" | jq '[.[] | select(.bucket == "pending" or .bucket == "skipping")] | length')"
+            PASS_COUNT="$(echo "${CHECKS_JSON}" | jq '[.[] | select(.bucket == "pass")] | length')"
+
+            if [ "${FAIL_COUNT}" -gt 0 ] && [ "${PENDING_COUNT}" -eq 0 ]; then
+              echo "ERROR: release PR required checks failed: ${PR_URL}"
               exit 1
             fi
+
+            if [ "${CANCEL_COUNT}" -gt 0 ] && [ "${PENDING_COUNT}" -eq 0 ]; then
+              echo "ERROR: release PR required checks cancelled: ${PR_URL}"
+              exit 1
+            fi
+
+            if [ "${TOTAL}" -gt 0 ] && [ "${PASS_COUNT}" -eq "${TOTAL}" ] && [ "${PENDING_COUNT}" -eq 0 ] && [ "${FAIL_COUNT}" -eq 0 ]; then
+              echo "Release PR required checks passed: ${PR_URL}"
+              exit 0
+            fi
+
             sleep "${INTERVAL}"
             ELAPSED=$((ELAPSED + INTERVAL))
-            echo "Waiting for release PR merge... (${ELAPSED}s/${TIMEOUT}s)"
+            echo "Waiting for release PR required checks... (${ELAPSED}s/${TIMEOUT}s)"
           done
 
-          echo "ERROR: timed out waiting for release PR merge"
+          echo "ERROR: timed out waiting for release PR required checks"
+          exit 1
+
+  trigger-promote-release:
+    name: Trigger and wait for promote-release workflow
+    runs-on: ubuntu-22.04
+    timeout-minutes: 35
+    env:
+      GH_REPO: ${{ github.repository }}
+    needs: [validate, wait-release-pr-ci]
+    if: ${{ needs.validate.outputs.release_kind == 'final' }}
+    steps:
+      - name: Generate release app token for promote-release dispatch
+        id: generate_release_token
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859  # v3
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+
+      - name: Capture latest promote-release run id
+        id: capture_promote_before
+        env:
+          GH_TOKEN: ${{ steps.generate_release_token.outputs.token }}
+        run: |
+          set -euo pipefail
+          BEFORE_RUN_ID="$(
+            gh run list --workflow promote-release.yml --branch "${WORKFLOW_REF}" --limit 1 --json databaseId --jq '.[0].databaseId // 0' 2>/dev/null || echo 0
+          )"
+          echo "before_run_id=${BEFORE_RUN_ID}" >> "${GITHUB_OUTPUT}"
+
+      - name: Trigger promote-release workflow
+        env:
+          GH_TOKEN: ${{ steps.generate_release_token.outputs.token }}
+          BASE_VERSION: ${{ needs.validate.outputs.base_version }}
+        run: |
+          set -euo pipefail
+          gh workflow run promote-release.yml \
+            --ref "${WORKFLOW_REF}" \
+            -f version="${BASE_VERSION}"
+
+      - name: Wait for promote-release workflow completion
+        env:
+          GH_TOKEN: ${{ steps.generate_release_token.outputs.token }}
+          BEFORE_RUN_ID: ${{ steps.capture_promote_before.outputs.before_run_id }}
+        run: |
+          set -euo pipefail
+          TIMEOUT=1800
+          INTERVAL=30
+          ELAPSED=0
+
+          while [ "${ELAPSED}" -lt "${TIMEOUT}" ]; do
+            RUN_ID="$(gh run list --workflow promote-release.yml --branch "${WORKFLOW_REF}" --limit 1 --json databaseId --jq '.[0].databaseId // empty' 2>/dev/null || true)"
+            if [ -n "${RUN_ID}" ] && [ "${RUN_ID}" -gt "${BEFORE_RUN_ID}" ]; then
+              STATUS="$(gh run view "${RUN_ID}" --json status --jq '.status' 2>/dev/null || echo unknown)"
+              if [ "${STATUS}" = "completed" ]; then
+                CONCLUSION="$(gh run view "${RUN_ID}" --json conclusion --jq '.conclusion' 2>/dev/null || echo unknown)"
+                if [ "${CONCLUSION}" != "success" ]; then
+                  echo "ERROR: promote-release workflow concluded with '${CONCLUSION}'"
+                  exit 1
+                fi
+                echo "promote-release workflow completed successfully"
+                exit 0
+              fi
+            fi
+
+            sleep "${INTERVAL}"
+            ELAPSED=$((ELAPSED + INTERVAL))
+            echo "Waiting for promote-release workflow... (${ELAPSED}s/${TIMEOUT}s)"
+          done
+
+          echo "ERROR: timed out waiting for promote-release workflow completion"
           exit 1
 
   summary:
@@ -732,7 +809,8 @@ jobs:
       - trigger-prepare-release
       - ready-release-pr
       - trigger-release
-      - merge-release-pr
+      - wait-release-pr-ci
+      - trigger-promote-release
     if: always()
     steps:
       - name: Write source context summary
@@ -773,7 +851,8 @@ jobs:
           echo "Prepare:      ${{ needs.trigger-prepare-release.result }}"
           echo "Release PR:   ${{ needs.ready-release-pr.result }}"
           echo "Release run:  ${{ needs.trigger-release.result }}"
-          echo "Release merge: ${{ needs.merge-release-pr.result }}"
+          echo "Release CI:   ${{ needs.wait-release-pr-ci.result }}"
+          echo "Promote run:  ${{ needs.trigger-promote-release.result }}"
           echo "Deploy PR:    ${{ needs.deploy.outputs.pr_url }}"
           echo "Release PR:   ${{ needs.ready-release-pr.outputs.release_pr_url }}"
           echo ""
@@ -815,9 +894,23 @@ jobs:
             FAILED=true
           fi
 
-          if [ "${{ needs.merge-release-pr.result }}" != "success" ]; then
-            echo "ERROR: Merge-release-pr job failed"
+          if [ "${{ needs.wait-release-pr-ci.result }}" != "success" ]; then
+            echo "ERROR: Wait-release-pr-ci job failed"
             FAILED=true
+          fi
+
+          RELEASE_KIND="${{ needs.validate.outputs.release_kind }}"
+          PROMOTE_RESULT="${{ needs.trigger-promote-release.result }}"
+          if [ "${RELEASE_KIND}" = "final" ]; then
+            if [ "${PROMOTE_RESULT}" != "success" ]; then
+              echo "ERROR: Trigger-promote-release must succeed for final releases (got '${PROMOTE_RESULT}')"
+              FAILED=true
+            fi
+          else
+            if [ "${PROMOTE_RESULT}" != "skipped" ]; then
+              echo "ERROR: Trigger-promote-release must be skipped for candidate releases (got '${PROMOTE_RESULT}')"
+              FAILED=true
+            fi
           fi
 
           if [ "${FAILED}" = "true" ]; then
@@ -842,7 +935,8 @@ jobs:
       - trigger-prepare-release
       - ready-release-pr
       - trigger-release
-      - merge-release-pr
+      - wait-release-pr-ci
+      - trigger-promote-release
       - summary
     steps:
       - name: Generate release app token for upstream issue creation
@@ -898,7 +992,8 @@ jobs:
           - trigger-prepare-release: \`${{ needs.trigger-prepare-release.result }}\`
           - ready-release-pr: \`${{ needs.ready-release-pr.result }}\`
           - trigger-release: \`${{ needs.trigger-release.result }}\`
-          - merge-release-pr: \`${{ needs.merge-release-pr.result }}\`
+          - wait-release-pr-ci: \`${{ needs.wait-release-pr-ci.result }}\`
+          - trigger-promote-release: \`${{ needs.trigger-promote-release.result }}\`
           - summary: \`${{ needs.summary.result }}\`
 
           ## Manual cleanup guidance

--- a/assets/smoke-test/.github/workflows/repository-dispatch.yml
+++ b/assets/smoke-test/.github/workflows/repository-dispatch.yml
@@ -695,8 +695,29 @@ jobs:
           ELAPSED=0
 
           while [ "${ELAPSED}" -lt "${TIMEOUT}" ]; do
-            CHECKS_JSON="$(gh pr checks "${PR_NUMBER}" --required --json bucket 2>/dev/null || echo '[]')"
+            PR_STATE="$(gh pr view "${PR_NUMBER}" --json state --jq '.state' 2>/dev/null || echo "UNKNOWN")"
+            if [ "${PR_STATE}" = "CLOSED" ]; then
+              echo "ERROR: release PR was closed unexpectedly: ${PR_URL}"
+              exit 1
+            fi
+            if [ "${PR_STATE}" = "MERGED" ]; then
+              echo "WARNING: release PR was merged unexpectedly -- skipping check wait: ${PR_URL}"
+              exit 0
+            fi
+
+            CHECKS_JSON="$(gh pr checks "${PR_NUMBER}" --required --json bucket 2>&1)" || {
+              echo "WARNING: gh pr checks failed (attempt $((ELAPSED / INTERVAL + 1))): ${CHECKS_JSON}"
+              sleep "${INTERVAL}"
+              ELAPSED=$((ELAPSED + INTERVAL))
+              continue
+            }
             TOTAL="$(echo "${CHECKS_JSON}" | jq 'length')"
+            if [ "${TOTAL}" -eq 0 ]; then
+              echo "WARNING: no required checks reported yet (attempt $((ELAPSED / INTERVAL + 1)))"
+              sleep "${INTERVAL}"
+              ELAPSED=$((ELAPSED + INTERVAL))
+              continue
+            fi
             FAIL_COUNT="$(echo "${CHECKS_JSON}" | jq '[.[] | select(.bucket == "fail")] | length')"
             CANCEL_COUNT="$(echo "${CHECKS_JSON}" | jq '[.[] | select(.bucket == "cancel")] | length')"
             PENDING_COUNT="$(echo "${CHECKS_JSON}" | jq '[.[] | select(.bucket == "pending" or .bucket == "skipping")] | length')"

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -27,6 +27,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Sync workflows run in devcontainer image** ([#509](https://github.com/vig-os/devcontainer/issues/509))
   - `sync-issues` and `sync-main-to-dev` use `resolve-image` and run inside the pinned devcontainer, removing the `setup-env` composite action dependency and the inlined retry helper
   - `sync-main-to-dev` creates sync branches via `git push` instead of the GitHub refs API
+- **Smoke-test dispatch triggers promote-release for final releases** ([#511](https://github.com/vig-os/devcontainer/issues/511))
+  - Final releases dispatch downstream `promote-release.yml` instead of merging the release PR directly, publishing the draft GitHub Release and satisfying the upstream promote-time downstream gate
+  - RC releases wait for release PR required checks but no longer merge the PR to `main`
 
 ### Deprecated
 

--- a/docs/CROSS_REPO_RELEASE_GATE.md
+++ b/docs/CROSS_REPO_RELEASE_GATE.md
@@ -39,6 +39,7 @@ Workflow dispatch contract:
 - Required downstream workflow IDs/files:
   - `prepare-release.yml`
   - `release.yml`
+  - `promote-release.yml`
 - Required dispatch ref:
   - `dev`
 - Dispatch and wait operations must use the same ref context to avoid default-branch drift:
@@ -53,9 +54,11 @@ The receiver workflow (`assets/smoke-test/.github/workflows/repository-dispatch.
 2. deploy orchestration in the validation repository
 3. release artifact publication for the dispatched tag:
    - candidate tag -> GitHub pre-release
-   - final tag -> GitHub release
+   - final tag -> GitHub release (draft until promoted)
 4. idempotency checks when a release object already exists
 5. preflight validation that required downstream workflow IDs are resolvable on the dispatch ref before orchestration starts
+6. after downstream `release.yml` completes: wait until required checks on the release PR are green (candidate and final)
+7. **final only:** dispatch downstream `promote-release.yml` on `dev` with `version` set to the base semver so the draft GitHub Release is published, the release PR is merged to `main`, and RC git tags are cleaned up (see workspace `promote-release.yml`). **Candidate:** the release PR stays open after checks pass; it is not merged by the receiver.
 
 If the validation repository also runs the shipped workspace `release.yml` workflow for a **candidate** (separate from publishing a release for the dispatched tag), pass workflow input `rc-number` set to the numeric RC suffix of `client_payload.tag` (for example `21` for `0.3.1-rc21`). That keeps the downstream candidate tag aligned with the upstream publish tag. The smoke-test template exposes this value as job output `needs.validate.outputs.rc_number`.
 
@@ -63,7 +66,7 @@ If the validation repository also runs the shipped workspace `release.yml` workf
 
 **`vig-os/devcontainer` `release.yml`:** Dispatches downstream validation during publish but does **not** block on downstream GitHub Release state for RC or final tags. The former validate step that required a published downstream pre-release for the latest RC before finalization was **removed**; it duplicated concerns now owned by promotion.
 
-**`vig-os/devcontainer` `promote-release.yml`:** Before updating GHCR `:latest`, publishing the draft GitHub Release, and merging the release PR, the `validate` job requires a **published** downstream release for the final version tag on `vig-os/devcontainer-smoke-test` that is **not** a draft and **not** a pre-release (`Verify downstream published final release`). Operators must ensure smoke-test has published that final release (including any manual acceptance step on the downstream repo) before running promote.
+**`vig-os/devcontainer` `promote-release.yml`:** Before updating GHCR `:latest`, publishing the draft GitHub Release, and merging the release PR, the `validate` job requires a **published** downstream release for the final version tag on `vig-os/devcontainer-smoke-test` that is **not** a draft and **not** a pre-release (`Verify downstream published final release`). For the canonical smoke-test flow, the receiver dispatches downstream `promote-release.yml` after `release.yml` and required release PR checks succeed, which publishes the downstream final release so this gate is satisfied without a manual publish step on the smoke-test repo.
 
 If promote validation fails, retry after the downstream release is in the expected state; `release.yml` rollback handling applies only to failures within that workflow.
 

--- a/tests/bats/just.bats
+++ b/tests/bats/just.bats
@@ -116,7 +116,7 @@ setup() {
 }
 
 @test "smoke-test dispatch preflight validates required workflow contract" {
-    run bash -lc "grep -Fq -- 'Preflight check required release workflows on dispatch ref' assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- 'REQUIRED_WORKFLOWS=(prepare-release.yml release.yml)' assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- 'for workflow_file in \"\${REQUIRED_WORKFLOWS[@]}\"; do' assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- 'WORKFLOW_CHECK_OUTPUT=\"\$(gh workflow view \"\${workflow_file}\" --ref \"\${WORKFLOW_REF}\" --yaml 2>&1 >/dev/null)\"' assets/smoke-test/.github/workflows/repository-dispatch.yml"
+    run bash -lc "grep -Fq -- 'Preflight check required release workflows on dispatch ref' assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- 'REQUIRED_WORKFLOWS=(prepare-release.yml release.yml promote-release.yml)' assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- 'for workflow_file in \"\${REQUIRED_WORKFLOWS[@]}\"; do' assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- 'WORKFLOW_CHECK_OUTPUT=\"\$(gh workflow view \"\${workflow_file}\" --ref \"\${WORKFLOW_REF}\" --yaml 2>&1 >/dev/null)\"' assets/smoke-test/.github/workflows/repository-dispatch.yml"
     assert_success
 }
 
@@ -135,18 +135,13 @@ setup() {
     assert_success
 }
 
-@test "smoke-test dispatch merges release PR after successful release workflow" {
-    run bash -lc 'grep -Fq -- "merge-release-pr:" assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- "Poll release PR merge status" assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- "Waiting for release PR merge" assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- "needs: [ready-release-pr, trigger-release]" assets/smoke-test/.github/workflows/repository-dispatch.yml'
+@test "smoke-test dispatch waits for release PR required checks after release workflow" {
+    run bash -lc 'grep -Fq -- "wait-release-pr-ci:" assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- "Poll release PR required checks until green" assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- "Waiting for release PR required checks" assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- "needs: [ready-release-pr, trigger-release]" assets/smoke-test/.github/workflows/repository-dispatch.yml'
     assert_success
 }
 
 @test "smoke-test dispatch readies release PR with release kind label" {
     run bash -lc 'grep -Fq -- "gh pr ready" assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- "release-kind:candidate" assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- "Label release PR with release kind" assets/smoke-test/.github/workflows/repository-dispatch.yml'
-    assert_success
-}
-
-@test "smoke-test dispatch tolerates transient auto-merge enable failures" {
-    run bash -lc 'grep -Fq -- "Warning: could not enable auto-merge yet" assets/smoke-test/.github/workflows/repository-dispatch.yml'
     assert_success
 }
 
@@ -156,7 +151,7 @@ setup() {
 }
 
 @test "smoke-test dispatch summary includes release-orchestration job results" {
-    run bash -lc "grep -Fq -- 'needs.wait-deploy-merge.result' assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- 'needs.cleanup-release.result' assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- 'needs.trigger-prepare-release.result' assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- 'needs.ready-release-pr.result' assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- 'needs.trigger-release.result' assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- 'needs.merge-release-pr.result' assets/smoke-test/.github/workflows/repository-dispatch.yml"
+    run bash -lc "grep -Fq -- 'needs.wait-deploy-merge.result' assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- 'needs.cleanup-release.result' assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- 'needs.trigger-prepare-release.result' assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- 'needs.ready-release-pr.result' assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- 'needs.trigger-release.result' assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- 'needs.wait-release-pr-ci.result' assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- 'needs.trigger-promote-release.result' assets/smoke-test/.github/workflows/repository-dispatch.yml"
     assert_success
 }
 


### PR DESCRIPTION
## Description

Updates the smoke-test `repository-dispatch` workflow so **final** releases dispatch downstream `promote-release.yml` (publish draft release, merge release PR, RC tag cleanup) instead of merging the release PR from the listener alone. **RC** dispatches wait for required checks on the release PR and stop with the PR left open. Preflight now requires `promote-release.yml` on the `dev` ref. Cross-repo gate docs describe the split behavior and that the canonical flow no longer needs a manual publish on smoke-test before upstream promote.

## Type of Change

- [ ] `feat` -- New feature
- [ ] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [x] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- `assets/smoke-test/.github/workflows/repository-dispatch.yml`
  - Add `promote-release.yml` to preflight `REQUIRED_WORKFLOWS`.
  - Replace `merge-release-pr` with `wait-release-pr-ci` (`gh pr checks --required`, fail/cancel handling, 30m timeout).
  - Add `trigger-promote-release` for `release_kind == final` only: dispatch and poll `promote-release.yml` on `dev` with `version` = base semver.
  - Update `summary` / `notify-failure` dependencies and result checks (final requires promote success; candidate requires promote skipped).
- `docs/CROSS_REPO_RELEASE_GATE.md` — contract, receiver steps, promote gate wording for automated downstream publish.
- `CHANGELOG.md` and `assets/workspace/.devcontainer/CHANGELOG.md` — Unreleased **Changed** entry for #511.

## Changelog Entry

```diff
@@ -27,6 +27,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Sync workflows run in devcontainer image** ([#509](https://github.com/vig-os/devcontainer/issues/509))
   - `sync-issues` and `sync-main-to-dev` use `resolve-image` and run inside the pinned devcontainer, removing the `setup-env` composite action dependency and the inlined retry helper
   - `sync-main-to-dev` creates sync branches via `git push` instead of the GitHub refs API
+- **Smoke-test dispatch triggers promote-release for final releases** ([#511](https://github.com/vig-os/devcontainer/issues/511))
+  - Final releases dispatch downstream `promote-release.yml` instead of merging the release PR directly, publishing the draft GitHub Release and satisfying the upstream promote-time downstream gate
+  - RC releases wait for release PR required checks but no longer merge the PR to `main`
 
 ### Deprecated
```

## Testing

- [ ] Tests pass locally (`just test`)
- [ ] Manual testing performed (describe below)

### Manual Testing Details

N/A — GitHub Actions workflow and documentation only; end-to-end validation happens after the template is deployed to `vig-os/devcontainer-smoke-test` (see issue prerequisite: PR #510 merged there).

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

N/A

Refs: #511
