### PR TITLE
fix(ci): grant validate job contents:write to see draft releases

### DIFF
--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 15
     permissions:
-      contents: read
+      contents: write
       packages: read
     outputs:
       version: ${{ steps.vars.outputs.version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Promote-release draft release validation** ([#507](https://github.com/vig-os/devcontainer/issues/507))
   - Use the paginated releases list API with jq instead of `GET /releases/tags/{tag}`, which returns 404 for draft releases
   - Apply the same release lookup for RC git tag cleanup in upstream and workspace `promote-release.yml`
+- **Promote-release validate job cannot see draft releases** ([#517](https://github.com/vig-os/devcontainer/issues/517))
+  - Elevate `validate` job permissions to `contents: write` so the token has push-level access required by the GitHub API to list draft releases
+  - Use `github.token` instead of the release app token for the draft release check in workspace `promote-release.yml`
 
 ### Security
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -41,6 +41,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Promote-release draft release validation** ([#507](https://github.com/vig-os/devcontainer/issues/507))
   - Use the paginated releases list API with jq instead of `GET /releases/tags/{tag}`, which returns 404 for draft releases
   - Apply the same release lookup for RC git tag cleanup in upstream and workspace `promote-release.yml`
+- **Promote-release validate job cannot see draft releases** ([#517](https://github.com/vig-os/devcontainer/issues/517))
+  - Elevate `validate` job permissions to `contents: write` so the token has push-level access required by the GitHub API to list draft releases
+  - Use `github.token` instead of the release app token for the draft release check in workspace `promote-release.yml`
 
 ### Security
 

--- a/assets/workspace/.github/workflows/promote-release.yml
+++ b/assets/workspace/.github/workflows/promote-release.yml
@@ -53,7 +53,7 @@ jobs:
     outputs:
       version: ${{ steps.vars.outputs.version }}
     permissions:
-      contents: read
+      contents: write
       pull-requests: read
     defaults:
       run:
@@ -87,7 +87,7 @@ jobs:
 
       - name: Verify draft GitHub Release exists
         env:
-          GH_TOKEN: ${{ steps.release_app_token.outputs.token }}
+          GH_TOKEN: ${{ github.token }}
           VERSION: ${{ steps.vars.outputs.version }}
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Description

The Promote Release workflow always fails at the "Verify draft GitHub Release exists" step in the `validate` job. The GitHub API only returns draft releases to tokens with push access (`contents: write`), but the `validate` job had `contents: read` and the workspace template variant was using the release app token which also lacked push-level permissions.

This PR elevates the `validate` job permissions to `contents: write` in both the upstream and workspace `promote-release.yml`, and switches the workspace template's draft release check to use `github.token` (the upstream already used it).

## Type of Change

- [ ] `feat` -- New feature
- [x] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [x] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- `.github/workflows/promote-release.yml` — change `validate` job `contents: read` to `contents: write`
- `assets/workspace/.github/workflows/promote-release.yml` — change `validate` job `contents: read` to `contents: write`; switch `GH_TOKEN` in the draft release check step from the release app token to `${{ github.token }}`
- `CHANGELOG.md` — add Fixed entry for #517
- `assets/workspace/.devcontainer/CHANGELOG.md` — synced by pre-commit hook

## Changelog Entry

### Fixed

- **Promote-release validate job cannot see draft releases** ([#517](https://github.com/vig-os/devcontainer/issues/517))
  - Elevate `validate` job permissions to `contents: write` so the token has push-level access required by the GitHub API to list draft releases
  - Use `github.token` instead of the release app token for the draft release check in workspace `promote-release.yml`

## Testing

- [ ] Tests pass locally (`just test`)
- [ ] Manual testing performed (describe below)

### Manual Testing Details

TDD skipped: CI workflow YAML changes can only be verified by running the actual GitHub Actions pipeline. Verification will occur when the Promote Release workflow is re-run for 0.3.3.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

This fix affects both the upstream and workspace template `promote-release.yml`. The upstream workflow already used `${{ github.token }}` for the draft release check but still had `contents: read`, so only the permission needed changing. The workspace template also needed the token source switched from the release app token to `${{ github.token }}`.

Refs: #517
