### PR TITLE
fix(ci): unblock Renovate PR CI gates (#550)

### DIFF
--- a/.github/dependency-review-allow.txt
+++ b/.github/dependency-review-allow.txt
@@ -18,5 +18,5 @@
 # - Upstream package.json has never updated its version field from 0.2.0
 # - The lock file records 0.2.0 regardless of which git tag is used
 # Mitigation: Source is verified GitHub repository, not npm registry
-Expiration: 2026-06-01
+Expiration: 2026-09-01
 GHSA-wvrr-2x4r-394v

--- a/.github/workflows/renovate-changelog.yml
+++ b/.github/workflows/renovate-changelog.yml
@@ -69,6 +69,7 @@ jobs:
 
       - name: Update CHANGELOG.md from Renovate PR metadata
         id: update
+        shell: bash
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_TITLE: ${{ github.event.pull_request.title }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,7 +59,7 @@ repos:
         types: [toml]
       - id: taplo-lint
         name: taplo-lint
-        entry: taplo lint --config .taplo.toml --no-default-schema-catalogs
+        entry: taplo lint --config .taplo.toml
         language: system
         types: [toml]
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,7 +59,7 @@ repos:
         types: [toml]
       - id: taplo-lint
         name: taplo-lint
-        entry: taplo lint --config .taplo.toml --default-schema-catalogs
+        entry: taplo lint --config .taplo.toml --no-default-schema-catalogs
         language: system
         types: [toml]
 

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,144 +1,25 @@
 # Trivy Vulnerability Ignore Policy
 # This file documents known vulnerabilities that are either:
 # 1. Not exploitable in container context
-# 2. Fixed in the latest patches but may lag in Trivy DB
+# 2. Fixed upstream but awaiting propagation to shipped binaries/packages
 # 3. Have acceptable risk for devcontainer usage
+#
+# Each entry requires an Expiration date. Expired entries cause CI to fail,
+# forcing periodic review. Tracking: https://github.com/vig-os/devcontainer/issues/512
 
-# CVE-2026-0861: glibc integer overflow in memalign
-# Risk Assessment: LOW
-# - Requires specific malloc patterns not triggered by normal Python/tool usage
-# - No known public exploits targeting memalign in containerized environments
-# - System library; cannot be removed without breaking core functionality
-# - Patched upstream; awaiting propagation to stable Debian releases
-# Mitigation: Image updated to latest Debian stable with available patches
-Expiration: 2026-06-01
-CVE-2026-0861
-
-# CVE-2025-14831: GnuTLS DoS via certificate verification
-# Risk Assessment: LOW
-# - Requires attacker control of certificate chain during connection
-# - Devcontainer uses GnuTLS only for SSH/TLS connections to known hosts
-# - Impact is denial of service only, not code execution
-# - Will be patched in Debian stable updates
-Expiration: 2026-05-15
-CVE-2025-14831
-
-# CVE-2025-59375: libexpat DoS via crafted file
-# Risk Assessment: LOW
-# - Requires attacker to provide malicious XML files
-# - Used indirectly by system tools; not directly exposed in devcontainer
-# - No user-controlled XML parsing in primary workflows
-Expiration: 2026-05-15
-CVE-2025-59375
-
-# CVE-2025-7709: SQLite integer overflow in FTS5
-# Risk Assessment: LOW
-# - Requires specific FTS5 query patterns
-# - SQLite in container used only for pre-commit and build caching
-# - No direct user input to SQLite databases
-# - Impact would be denial of service, not code execution
-Expiration: 2026-05-15
-CVE-2025-7709
-
-# CVE-2023-50495: ncurses segmentation fault
-# Risk Assessment: LOW
-# - Requires specific terminal control sequences
-# - Terminal environment is controlled by container operator
-# - No public exploits known
-Expiration: 2026-05-15
-CVE-2023-50495
-
-# CVE-2025-69720: ncurses buffer overflow
-# Risk Assessment: LOW (devcontainer context)
-# - HIGH severity; may lead to arbitrary code execution via crafted terminal sequences
-# - Terminal environment is controlled by the container operator, not untrusted remote users
-# - No Debian stable fix available yet (Trivy status: affected)
-# - Tracking: https://github.com/vig-os/devcontainer/issues/512
-Expiration: 2026-06-01
-CVE-2025-69720
-
-# CVE-2025-7458: SQLite integer overflow
-# Risk Assessment: LOW (devcontainer context)
-# - CRITICAL severity in Trivy/NVD; no Debian stable fix available yet (Trivy status: affected)
-# - SQLite used only for pre-commit and build tooling caches, not as an app database
-# - No attacker-controlled SQL/query surface in primary devcontainer workflows
-# - Tracking: https://github.com/vig-os/devcontainer/issues/512
-Expiration: 2026-06-01
-CVE-2025-7458
-
-# CVE-2026-29111: systemd arbitrary code execution or DoS via spurious IPC
-# Risk Assessment: LOW (devcontainer context)
-# - HIGH severity; libsystemd0/libudev1 pulled transitively by base image and tools
-# - Single-user dev environment; not a multi-tenant service exposing systemd IPC to attackers
-# - No Debian stable fix available yet (Trivy status: affected)
-# - Tracking: https://github.com/vig-os/devcontainer/issues/512
-Expiration: 2026-06-01
-CVE-2026-29111
-
-# CVE-2023-45853: zlib/minizip integer overflow and heap buffer overflow
-# Risk Assessment: LOW (devcontainer context)
-# - CRITICAL in vendor DBs; Debian marks will_not_fix (minizip code path not exposed by package)
-# - Core zlib usage in image does not invoke the vulnerable minizip entry point as shipped
-# - No actionable package upgrade in bookworm; accept until base image rebases
-# - Tracking: https://github.com/vig-os/devcontainer/issues/512
-Expiration: 2026-06-01
-CVE-2023-45853
-
-# CVE-2026-32281: crypto/x509 inefficient certificate chain validation (DoS)
+# CVE-2026-42504: Go stdlib MIME header DoS in gh binary
 # Risk Assessment: LOW (devcontainer context)
 # - HIGH severity in Go stdlib embedded in gh (GitHub CLI) binary
-# - Requires pathological certificate chains; gh validates chains for GitHub API TLS only
-# - gh connects only to GitHub APIs; no user-facing TLS server in devcontainer
-# - Fixed in newer Go releases; awaiting upstream gh rebuild with patched stdlib
+# - Requires maliciously-crafted MIME headers; gh validates GitHub API responses only
+# - Fixed in Go 1.26.4; awaiting upstream gh release rebuilt with patched stdlib
 # - Tracking: https://github.com/vig-os/devcontainer/issues/512
-Expiration: 2026-05-15
-CVE-2026-32281
-
-# CVE-2026-32288: archive/tar denial of service via malicious archive
-# Risk Assessment: LOW (devcontainer context)
-# - HIGH severity in Go stdlib embedded in gh binary
-# - Requires attacker-supplied tar archives; gh does not process untrusted archives in typical devcontainer flows
-# - Impact is denial of service, not code execution
-# - Fixed in newer Go releases; awaiting upstream gh release
-# - Tracking: https://github.com/vig-os/devcontainer/issues/512
-Expiration: 2026-05-15
-CVE-2026-32288
-
-# CVE-2026-32289: html/template XSS via JS template literal context
-# Risk Assessment: LOW (devcontainer context)
-# - HIGH severity in Go stdlib embedded in gh binary
-# - Affects HTML template rendering; gh is a CLI client, not a web server serving user HTML
-# - Fixed in newer Go releases; awaiting upstream gh release
-# - Tracking: https://github.com/vig-os/devcontainer/issues/512
-Expiration: 2026-05-15
-CVE-2026-32289
-
-# CVE-2026-25727: time stack exhaustion denial of service
-# Risk Assessment: LOW (devcontainer context)
-# - HIGH severity; reported in typos (pre-commit hook) dependency tree / Cargo.lock
-# - typos runs offline spell-check on repo files; no attacker-controlled time parsing surface
-# - Awaiting upstream typos or dependency release with patched version
-# - Tracking: https://github.com/vig-os/devcontainer/issues/512
-Expiration: 2026-05-15
-CVE-2026-25727
+Expiration: 2026-09-01
+CVE-2026-42504
 
 # jwt-token: Trivy secret scan false positive
 # Risk Assessment: N/A (not a vulnerability)
-# - JWT-like string in typos crate test fixtures under /opt/pre-commit-cache (e.g. tokens.rs)
+# - JWT-like string in typos crate test fixtures under /opt/pre-commit-cache
 # - Not a live credential; embedded test data only
 # - Tracking: https://github.com/vig-os/devcontainer/issues/512
-Expiration: 2026-05-15
+Expiration: 2026-09-01
 jwt-token
-
-# CVE-2026-31812: quinn-proto unauthenticated remote DoS via QUIC transport parameter panic
-# Risk Assessment: LOW (devcontainer context)
-# - HIGH severity in quinn-proto v0.11.12 embedded in uv/uvx Rust binaries
-# - Affects QUIC transport parameter handling and may panic on malformed unauthenticated input
-# - uv/uvx in this image is used for package downloads from trusted registries, not as a QUIC server
-# - No user-facing QUIC endpoint is exposed by devcontainer workflows
-# - Fixed in quinn-proto v0.11.14; awaiting upstream uv release with patched dependency
-Expiration: 2026-05-15
-CVE-2026-31812
-
-# Tracking: https://github.com/vig-os/devcontainer
-# Upstream: https://github.com/aquasecurity/trivy/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Renovate PR CI gates expired or broken** ([#550](https://github.com/vig-os/devcontainer/issues/550))
   - Renovate changelog workflow now runs under `bash` so `set -euo pipefail` works inside the container
-  - Taplo lint hook uses `--no-default-schema-catalogs` after remote catalog fetch started failing
+  - Taplo lint hook no longer fetches remote schema catalogs (fetch started failing in taplo 0.10)
   - Renewed dependency-review allow-list exception for bats-file false positive (`GHSA-wvrr-2x4r-394v`)
+
+### Security
+
+- **Remediate nightly scan gate failures on :latest** ([#549](https://github.com/vig-os/devcontainer/issues/549))
+  - Rebased base image to latest `python:3.12-slim-bookworm` digest
+  - Patched `libgnutls30` to `3.7.9-2+deb12u7` for fixable GnuTLS CVEs
+  - Rewrote `.trivyignore` from scratch with fresh expirations for unfixable findings only
+
+### Changed
+
+- **Bump expected tool versions in image tests**
+  - `gh` 2.92 → 2.93, `just` 1.50 → 1.51, `cargo-binstall` 1.18 → 1.19 to match latest upstream releases
 
 ## [0.3.4](https://github.com/vig-os/devcontainer/releases/tag/0.3.4) - 2026-04-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- **Renovate PR CI gates expired or broken** ([#550](https://github.com/vig-os/devcontainer/issues/550))
+  - Renovate changelog workflow now runs under `bash` so `set -euo pipefail` works inside the container
+  - Taplo lint hook uses `--no-default-schema-catalogs` after remote catalog fetch started failing
+  - Renewed dependency-review allow-list exception for bats-file false positive (`GHSA-wvrr-2x4r-394v`)
+
 ## [0.3.4](https://github.com/vig-os/devcontainer/releases/tag/0.3.4) - 2026-04-29
 
 ### Added

--- a/Containerfile
+++ b/Containerfile
@@ -1,7 +1,7 @@
 # Use Python 3.12 as base image (pinned to digest for supply chain integrity)
 # Dependabot (docker ecosystem) will propose digest updates automatically
 # Updated to bookworm (stable) for better security patch cadence
-FROM python:3.12-slim-bookworm@sha256:d97792894a6a4162cae14da44542a83c75e56c77a27b92d58f3f83b7bc961292
+FROM python:3.12-slim-bookworm@sha256:93ab4b7fa528b25124c97bcc755415e60eb671a86b4dbe0328df2fe2d1c1193d
 
 # Add metadata
 # By default, we build the dev version unless specified as an argument
@@ -49,10 +49,9 @@ ENV DEBIAN_FRONTEND=noninteractive
 #     <package>=<version> \  # CVE-XXXX-XXXXX
 #     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# CVE-2026-28390, CVE-2026-31790 (OpenSSL; bookworm-security ahead of base digest)
+# CVE-2026-33845, CVE-2026-33846, CVE-2026-3833, CVE-2026-42009, CVE-2026-42010 (GnuTLS; bookworm-security)
 RUN apt-get update && apt-get install -y --no-install-recommends --only-upgrade \
-    libssl3=3.0.19-1~deb12u2 \
-    openssl=3.0.19-1~deb12u2 \
+    libgnutls30=3.7.9-2+deb12u7 \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Install minimal system dependencies

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -11,8 +11,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Renovate PR CI gates expired or broken** ([#550](https://github.com/vig-os/devcontainer/issues/550))
   - Renovate changelog workflow now runs under `bash` so `set -euo pipefail` works inside the container
-  - Taplo lint hook uses `--no-default-schema-catalogs` after remote catalog fetch started failing
+  - Taplo lint hook no longer fetches remote schema catalogs (fetch started failing in taplo 0.10)
   - Renewed dependency-review allow-list exception for bats-file false positive (`GHSA-wvrr-2x4r-394v`)
+
+### Security
+
+- **Remediate nightly scan gate failures on :latest** ([#549](https://github.com/vig-os/devcontainer/issues/549))
+  - Rebased base image to latest `python:3.12-slim-bookworm` digest
+  - Patched `libgnutls30` to `3.7.9-2+deb12u7` for fixable GnuTLS CVEs
+  - Rewrote `.trivyignore` from scratch with fresh expirations for unfixable findings only
+
+### Changed
+
+- **Bump expected tool versions in image tests**
+  - `gh` 2.92 → 2.93, `just` 1.50 → 1.51, `cargo-binstall` 1.18 → 1.19 to match latest upstream releases
 
 ## [0.3.4](https://github.com/vig-os/devcontainer/releases/tag/0.3.4) - 2026-04-29
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- **Renovate PR CI gates expired or broken** ([#550](https://github.com/vig-os/devcontainer/issues/550))
+  - Renovate changelog workflow now runs under `bash` so `set -euo pipefail` works inside the container
+  - Taplo lint hook uses `--no-default-schema-catalogs` after remote catalog fetch started failing
+  - Renewed dependency-review allow-list exception for bats-file false positive (`GHSA-wvrr-2x4r-394v`)
+
 ## [0.3.4](https://github.com/vig-os/devcontainer/releases/tag/0.3.4) - 2026-04-29
 
 ### Added

--- a/assets/workspace/.github/workflows/renovate-changelog.yml
+++ b/assets/workspace/.github/workflows/renovate-changelog.yml
@@ -69,6 +69,7 @@ jobs:
 
       - name: Update CHANGELOG.md from Renovate PR metadata
         id: update
+        shell: bash
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_TITLE: ${{ github.event.pull_request.title }}

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -19,17 +19,17 @@ import pytest
 EXPECTED_VERSIONS = {
     "git": "2.",  # Major version check (from apt package)
     "curl": "8.",  # Major version check (from apt package)
-    "gh": "2.92.",  # Minor version check (GitHub CLI, manually installed from latest release)
+    "gh": "2.93.",  # Minor version check (GitHub CLI, manually installed from latest release)
     "uv": "0.11.",  # Minor version check (manually installed from latest release)
     "python": "3.12",  # Python (from base image)
     "pre_commit": "4.5.",  # Minor version check (installed via uv pip)
     "ruff": "0.15.",  # Minor version check (installed via uv pip)
     "bandit": "1.9.",  # Minor version check (installed via uv pip)
     "pip_licenses": "5.",  # Major version check (installed via uv pip)
-    "just": "1.50.",  # Minor version check (manually installed from latest release)
+    "just": "1.51.",  # Minor version check (manually installed from latest release)
     "hadolint": "2.14.",  # Minor version check (manually installed from pinned release)
     "taplo": "0.10.",  # Minor version check (manually installed from latest release)
-    "cargo-binstall": "1.18.",  # Minor version check (installed from latest release),
+    "cargo-binstall": "1.19.",  # Minor version check (installed from latest release),
     "typstyle": "0.14.",  # Minor version check (installed from latest release)
     "vig_utils": "0.1.",  # Minor version check (installed via uv pip)
     "tmux": "3.3",  # Major.minor version check (from apt package)


### PR DESCRIPTION
## Summary

Fixes three shared CI gate failures blocking all 16 Renovate PRs.

- Renovate changelog workflow: add `shell: bash` so `set -euo pipefail` works inside the container
- Taplo lint: switch to `--no-default-schema-catalogs` after remote catalog fetch started failing
- Dependency review: renew `GHSA-wvrr-2x4r-394v` exception to 2026-09-01

Refs: #550