### PR TITLE
test(image): bump expected cargo-binstall to 1.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Taplo lint hook no longer fetches remote schema catalogs (fetch started failing in taplo 0.10)
   - Renewed dependency-review allow-list exception for bats-file false positive (`GHSA-wvrr-2x4r-394v`)
 
+- **Image tests red on stale cargo-binstall pin** ([#557](https://github.com/vig-os/devcontainer/issues/557))
+  - Bump expected `cargo-binstall` 1.19 → 1.20 to match the latest upstream release the image installs
+
 ### Security
 
 - **Update pytest to v9.0.3** ([#528](https://github.com/vig-os/devcontainer/issues/528))

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Taplo lint hook no longer fetches remote schema catalogs (fetch started failing in taplo 0.10)
   - Renewed dependency-review allow-list exception for bats-file false positive (`GHSA-wvrr-2x4r-394v`)
 
+- **Image tests red on stale cargo-binstall pin** ([#557](https://github.com/vig-os/devcontainer/issues/557))
+  - Bump expected `cargo-binstall` 1.19 → 1.20 to match the latest upstream release the image installs
+
 ### Security
 
 - **Update pytest to v9.0.3** ([#528](https://github.com/vig-os/devcontainer/issues/528))

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -29,7 +29,7 @@ EXPECTED_VERSIONS = {
     "just": "1.51.",  # Minor version check (manually installed from latest release)
     "hadolint": "2.14.",  # Minor version check (manually installed from pinned release)
     "taplo": "0.10.",  # Minor version check (manually installed from latest release)
-    "cargo-binstall": "1.19.",  # Minor version check (installed from latest release),
+    "cargo-binstall": "1.20.",  # Minor version check (installed from latest release)
     "typstyle": "0.14.",  # Minor version check (installed from latest release)
     "vig_utils": "0.1.",  # Minor version check (installed via uv pip)
     "tmux": "3.3",  # Major.minor version check (from apt package)


### PR DESCRIPTION
## Summary

- Bump `EXPECTED_VERSIONS["cargo-binstall"]` from `1.19.` to `1.20.` after upstream released `1.20.0`
- Restore pin-based version gate (reverts semver-weakening approach); breaking on drift is intentional
- Record the bump in `CHANGELOG.md` (and mirrored workspace copy)

Fixes the `Image Tests` / `Test Summary` failures on Renovate PRs #553-556 caused by a stale test pin, not by the dependency updates themselves.

Follow-up for centralized version management: #559

Refs: #557

## Test plan

- [ ] CI `Image Tests` passes on a fresh build (installs `cargo-binstall` 1.20.0)
- [ ] `test_typstyle` still passes (pin unchanged at `0.14.`)
- [ ] Renovate PRs #553-556 go green on Image Tests after rebasing onto `dev`