### PR TITLE
fix(ci): resolve repo-owned workflow security findings

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,6 +1,6 @@
 # CodeQL Static Analysis
 #
-# Runs GitHub CodeQL analysis on Python scripts used in the build toolchain.
+# Runs GitHub CodeQL analysis on Python build tooling and GitHub Actions workflows.
 # While these are build tools (not product code), static analysis provides
 # defense-in-depth for scripts that handle git operations, file I/O, and
 # subprocess execution.
@@ -23,6 +23,7 @@ on:  # yamllint disable-line rule:truthy
       - main
     paths:
       - '**.py'
+      - '.github/workflows/**'
   schedule:
     - cron: '15 2 * * 1'  # Monday at 02:15 UTC
 
@@ -41,7 +42,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: ['python']
+        language: ['python', 'actions']
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/renovate-changelog-build.yml
+++ b/.github/workflows/renovate-changelog-build.yml
@@ -1,10 +1,10 @@
-# Append Keep-a-Changelog Unreleased entries for Renovate dependency PRs (Refs: #506).
-# Uses pull_request_target so the workflow definition always comes from the default branch.
+# Append Keep-a-Changelog Unreleased entries for Renovate dependency PRs (Refs: #506, #562).
+# Read-only build on pull_request; privileged commit runs via workflow_run from default branch.
 
-name: Renovate changelog
+name: Renovate changelog build
 
 on:  # yamllint disable-line rule:truthy
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize]
 
 permissions: {}
@@ -26,6 +26,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
+          ref: ${{ github.event.pull_request.base.ref }}
           sparse-checkout: |
             .vig-os
             .github/actions/resolve-image
@@ -35,7 +36,8 @@ jobs:
         id: resolve
         uses: ./.github/actions/resolve-image
 
-  changelog:
+  build:
+    name: Build changelog artifact
     if: >-
       github.event.pull_request.user.login == 'renovate[bot]' &&
       github.event.pull_request.head.repo.full_name == github.repository
@@ -48,23 +50,13 @@ jobs:
       group: renovate-changelog-${{ github.repository }}-${{ github.event.pull_request.number }}
       cancel-in-progress: true
     permissions:
-      contents: write
-      pull-requests: read
+      contents: read
 
     steps:
-      - name: Generate a token
-        id: generate-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3
-        with:
-          app-id: ${{ secrets.COMMIT_APP_ID }}
-          private-key: ${{ secrets.COMMIT_APP_PRIVATE_KEY }}
-
       - name: Checkout PR head
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.sha }}
-          token: ${{ steps.generate-token.outputs.token }}
           persist-credentials: false
 
       - name: Update CHANGELOG.md from Renovate PR metadata
@@ -84,16 +76,27 @@ jobs:
             echo "modified=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Commit changelog via API
-        if: steps.update.outputs.modified == 'true'
-        uses: vig-os/commit-action@1bc004353d08d9332a0cb54920b148256220c8e0  # v0.2.0
+      - name: Prepare changelog artifact
+        shell: bash
         env:
-          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
-          TARGET_BRANCH: refs/heads/${{ github.event.pull_request.head.ref }}
-          MAX_ATTEMPTS: "3"
-          COMMIT_MESSAGE: |-
-            docs(changelog): add unreleased entry for renovate PR ${{ github.event.pull_request.number }}
+          MODIFIED: ${{ steps.update.outputs.modified }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          set -euo pipefail
+          mkdir -p changelog-artifact
+          {
+            echo "MODIFIED=${MODIFIED}"
+            echo "PR_NUMBER=${PR_NUMBER}"
+            echo "HEAD_REF=${HEAD_REF}"
+          } > changelog-artifact/metadata.env
+          if [[ "${MODIFIED}" == "true" ]]; then
+            cp CHANGELOG.md changelog-artifact/
+          fi
 
-            Refs: #${{ github.event.pull_request.number }}
-          FILE_PATHS: CHANGELOG.md
+      - name: Upload changelog artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: renovate-changelog
+          path: changelog-artifact/
+          retention-days: 1

--- a/.github/workflows/renovate-changelog-commit.yml
+++ b/.github/workflows/renovate-changelog-commit.yml
@@ -1,0 +1,67 @@
+# Privileged commit for Renovate changelog updates (Refs: #506, #562).
+# Runs from default branch via workflow_run; never checks out PR-head code.
+
+name: Renovate changelog commit
+
+on:  # yamllint disable-line rule:truthy
+  workflow_run:
+    workflows: [Renovate changelog build]
+    types: [completed]
+
+permissions: {}
+
+jobs:
+  commit:
+    name: Commit changelog update
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.head_repository.full_name == github.repository
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    concurrency:
+      group: renovate-changelog-commit-${{ github.repository }}-${{ github.event.workflow_run.id }}
+      cancel-in-progress: false
+    permissions:
+      actions: read
+      contents: read
+
+    steps:
+      - name: Generate a token
+        id: generate-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3
+        with:
+          app-id: ${{ secrets.COMMIT_APP_ID }}
+          private-key: ${{ secrets.COMMIT_APP_PRIVATE_KEY }}
+
+      - name: Download changelog artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: renovate-changelog
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Read changelog metadata
+        id: metadata
+        shell: bash
+        run: |
+          set -euo pipefail
+          # shellcheck disable=SC1091
+          source metadata.env
+          echo "modified=${MODIFIED}" >> "$GITHUB_OUTPUT"
+          echo "pr_number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+          echo "head_ref=${HEAD_REF}" >> "$GITHUB_OUTPUT"
+
+      - name: Commit changelog via API
+        if: steps.metadata.outputs.modified == 'true'
+        uses: vig-os/commit-action@1bc004353d08d9332a0cb54920b148256220c8e0  # v0.2.0
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          TARGET_BRANCH: refs/heads/${{ steps.metadata.outputs.head_ref }}
+          MAX_ATTEMPTS: "3"
+          COMMIT_MESSAGE: |-
+            docs(changelog): add unreleased entry for renovate PR ${{ steps.metadata.outputs.pr_number }}
+
+            Refs: #${{ steps.metadata.outputs.pr_number }}
+          FILE_PATHS: CHANGELOG.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Patched `libgnutls30` to `3.7.9-2+deb12u7` for fixable GnuTLS CVEs
   - Rewrote `.trivyignore` from scratch with fresh expirations for unfixable findings only
 
+- **Resolve repo-owned workflow security findings** ([#562](https://github.com/vig-os/devcontainer/issues/562))
+  - Split Renovate changelog automation into read-only `pull_request` build + privileged `workflow_run` commit, removing `pull_request_target` and PR-head checkout under elevated permissions (Scorecard `DangerousWorkflowID`)
+  - Add GitHub Actions to CodeQL language matrix so stale `actions/missing-workflow-permissions` alerts auto-close on the next default-branch run
+  - Add explicit `permissions:` to workspace `release-extension.yml` template; downstream smoke-test updates flow through release re-sync
+  - Document accepted OpenSSF Scorecard posture (Fuzzing, CII) and verified branch-protection rulesets in `SECURITY.md`
+
 ### Changed
 
 - **Consolidate Renovate dependency updates** ([#550](https://github.com/vig-os/devcontainer/issues/550))

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -61,8 +61,17 @@ This repository follows these security practices:
 - Workflow inputs are bound to environment variables (not interpolated inline)
 - No `pull_request_target` triggers are used (prevents untrusted code execution)
 - OpenSSF Scorecard runs weekly to track security posture
-- CodeQL static analysis scans Python build tooling
-- Branch protection is enforced via GitHub Enterprise
+- CodeQL static analysis scans Python build tooling and GitHub Actions workflows
+- Branch protection is enforced via GitHub Enterprise rulesets (Main protection requires pull request review, code-owner approval, required status checks, non-fast-forward merges, and branch deletion protection)
+
+### OpenSSF Scorecard accepted findings
+
+The following Scorecard checks are not applicable to a devcontainer image repository and are accepted as won't-fix:
+
+- **FuzzingID** (medium): no fuzzing targets in container build tooling or CI scripts
+- **CIIBestPracticesID** (low): not a CII Best Practices badge candidate; posture is tracked via Scorecard and CodeQL instead
+
+**VulnerabilitiesID** (high) is a roll-up of container and dependency findings remediated separately (see `.trivyignore` and dependency review).
 
 ## Compliance
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -27,6 +27,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Patched `libgnutls30` to `3.7.9-2+deb12u7` for fixable GnuTLS CVEs
   - Rewrote `.trivyignore` from scratch with fresh expirations for unfixable findings only
 
+- **Resolve repo-owned workflow security findings** ([#562](https://github.com/vig-os/devcontainer/issues/562))
+  - Split Renovate changelog automation into read-only `pull_request` build + privileged `workflow_run` commit, removing `pull_request_target` and PR-head checkout under elevated permissions (Scorecard `DangerousWorkflowID`)
+  - Add GitHub Actions to CodeQL language matrix so stale `actions/missing-workflow-permissions` alerts auto-close on the next default-branch run
+  - Add explicit `permissions:` to workspace `release-extension.yml` template; downstream smoke-test updates flow through release re-sync
+  - Document accepted OpenSSF Scorecard posture (Fuzzing, CII) and verified branch-protection rulesets in `SECURITY.md`
+
 ### Changed
 
 - **Consolidate Renovate dependency updates** ([#550](https://github.com/vig-os/devcontainer/issues/550))

--- a/assets/workspace/.github/workflows/codeql.yml
+++ b/assets/workspace/.github/workflows/codeql.yml
@@ -1,6 +1,6 @@
 # CodeQL Static Analysis
 #
-# Runs GitHub CodeQL analysis on Python scripts used in the build toolchain.
+# Runs GitHub CodeQL analysis on Python build tooling and GitHub Actions workflows.
 # While these are build tools (not product code), static analysis provides
 # defense-in-depth for scripts that handle git operations, file I/O, and
 # subprocess execution.
@@ -23,6 +23,7 @@ on:  # yamllint disable-line rule:truthy
       - main
     paths:
       - '**.py'
+      - '.github/workflows/**'
   schedule:
     - cron: '15 2 * * 1'  # Monday at 02:15 UTC
 
@@ -41,7 +42,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: ['python']
+        language: ['python', 'actions']
 
     steps:
       - name: Checkout repository

--- a/assets/workspace/.github/workflows/release-extension.yml
+++ b/assets/workspace/.github/workflows/release-extension.yml
@@ -24,6 +24,9 @@ on:  # yamllint disable-line rule:truthy
         required: true
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   extension:
     name: Extension Hook (Default No-op)

--- a/assets/workspace/.github/workflows/renovate-changelog-build.yml
+++ b/assets/workspace/.github/workflows/renovate-changelog-build.yml
@@ -1,10 +1,10 @@
-# Append Keep-a-Changelog Unreleased entries for Renovate dependency PRs (Refs: #506).
-# Uses pull_request_target so the workflow definition always comes from the default branch.
+# Append Keep-a-Changelog Unreleased entries for Renovate dependency PRs (Refs: #506, #562).
+# Read-only build on pull_request; privileged commit runs via workflow_run from default branch.
 
-name: Renovate changelog
+name: Renovate changelog build
 
 on:  # yamllint disable-line rule:truthy
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize]
 
 permissions: {}
@@ -26,6 +26,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
+          ref: ${{ github.event.pull_request.base.ref }}
           sparse-checkout: |
             .vig-os
             .github/actions/resolve-image
@@ -35,7 +36,8 @@ jobs:
         id: resolve
         uses: ./.github/actions/resolve-image
 
-  changelog:
+  build:
+    name: Build changelog artifact
     if: >-
       github.event.pull_request.user.login == 'renovate[bot]' &&
       github.event.pull_request.head.repo.full_name == github.repository
@@ -48,23 +50,13 @@ jobs:
       group: renovate-changelog-${{ github.repository }}-${{ github.event.pull_request.number }}
       cancel-in-progress: true
     permissions:
-      contents: write
-      pull-requests: read
+      contents: read
 
     steps:
-      - name: Generate a token
-        id: generate-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3
-        with:
-          app-id: ${{ secrets.COMMIT_APP_ID }}
-          private-key: ${{ secrets.COMMIT_APP_PRIVATE_KEY }}
-
       - name: Checkout PR head
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.sha }}
-          token: ${{ steps.generate-token.outputs.token }}
           persist-credentials: false
 
       - name: Update CHANGELOG.md from Renovate PR metadata
@@ -84,16 +76,27 @@ jobs:
             echo "modified=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Commit changelog via API
-        if: steps.update.outputs.modified == 'true'
-        uses: vig-os/commit-action@1bc004353d08d9332a0cb54920b148256220c8e0  # v0.2.0
+      - name: Prepare changelog artifact
+        shell: bash
         env:
-          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
-          TARGET_BRANCH: refs/heads/${{ github.event.pull_request.head.ref }}
-          MAX_ATTEMPTS: "3"
-          COMMIT_MESSAGE: |-
-            docs(changelog): add unreleased entry for renovate PR ${{ github.event.pull_request.number }}
+          MODIFIED: ${{ steps.update.outputs.modified }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: |
+          set -euo pipefail
+          mkdir -p changelog-artifact
+          {
+            echo "MODIFIED=${MODIFIED}"
+            echo "PR_NUMBER=${PR_NUMBER}"
+            echo "HEAD_REF=${HEAD_REF}"
+          } > changelog-artifact/metadata.env
+          if [[ "${MODIFIED}" == "true" ]]; then
+            cp CHANGELOG.md changelog-artifact/
+          fi
 
-            Refs: #${{ github.event.pull_request.number }}
-          FILE_PATHS: CHANGELOG.md
+      - name: Upload changelog artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: renovate-changelog
+          path: changelog-artifact/
+          retention-days: 1

--- a/assets/workspace/.github/workflows/renovate-changelog-commit.yml
+++ b/assets/workspace/.github/workflows/renovate-changelog-commit.yml
@@ -1,0 +1,67 @@
+# Privileged commit for Renovate changelog updates (Refs: #506, #562).
+# Runs from default branch via workflow_run; never checks out PR-head code.
+
+name: Renovate changelog commit
+
+on:  # yamllint disable-line rule:truthy
+  workflow_run:
+    workflows: [Renovate changelog build]
+    types: [completed]
+
+permissions: {}
+
+jobs:
+  commit:
+    name: Commit changelog update
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.head_repository.full_name == github.repository
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    concurrency:
+      group: renovate-changelog-commit-${{ github.repository }}-${{ github.event.workflow_run.id }}
+      cancel-in-progress: false
+    permissions:
+      actions: read
+      contents: read
+
+    steps:
+      - name: Generate a token
+        id: generate-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3
+        with:
+          app-id: ${{ secrets.COMMIT_APP_ID }}
+          private-key: ${{ secrets.COMMIT_APP_PRIVATE_KEY }}
+
+      - name: Download changelog artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: renovate-changelog
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Read changelog metadata
+        id: metadata
+        shell: bash
+        run: |
+          set -euo pipefail
+          # shellcheck disable=SC1091
+          source metadata.env
+          echo "modified=${MODIFIED}" >> "$GITHUB_OUTPUT"
+          echo "pr_number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+          echo "head_ref=${HEAD_REF}" >> "$GITHUB_OUTPUT"
+
+      - name: Commit changelog via API
+        if: steps.metadata.outputs.modified == 'true'
+        uses: vig-os/commit-action@1bc004353d08d9332a0cb54920b148256220c8e0  # v0.2.0
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          TARGET_BRANCH: refs/heads/${{ steps.metadata.outputs.head_ref }}
+          MAX_ATTEMPTS: "3"
+          COMMIT_MESSAGE: |-
+            docs(changelog): add unreleased entry for renovate PR ${{ steps.metadata.outputs.pr_number }}
+
+            Refs: #${{ steps.metadata.outputs.pr_number }}
+          FILE_PATHS: CHANGELOG.md

--- a/scripts/manifest.toml
+++ b/scripts/manifest.toml
@@ -61,7 +61,10 @@ src = ".github/ISSUE_TEMPLATE/"
 src = ".github/actions/resolve-image/"
 
 [[entries]]
-src = ".github/workflows/renovate-changelog.yml"
+src = ".github/workflows/renovate-changelog-build.yml"
+
+[[entries]]
+src = ".github/workflows/renovate-changelog-commit.yml"
 
 [[entries]]
 src = ".github/workflows/scorecard.yml"


### PR DESCRIPTION
## Description

Resolves repo-owned Scorecard and CodeQL workflow findings tracked in #562. Splits Renovate changelog automation off the dangerous `pull_request_target` + PR-head-checkout pattern, adds CodeQL Actions scanning so stale permission alerts auto-close, hardens the workspace `release-extension.yml` template, and documents verified branch-protection rulesets plus accepted Scorecard posture.

## Type of Change

- [ ] `feat` -- New feature
- [x] `fix` -- Bug fix
- [x] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [x] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- **Renovate changelog refactor (A1)**
  - Replace `.github/workflows/renovate-changelog.yml` with `renovate-changelog-build.yml` (`pull_request`, read-only, uploads CHANGELOG artifact) and `renovate-changelog-commit.yml` (`workflow_run`, App-token commit, no PR-head checkout)
  - Mirror the same split under `assets/workspace/.github/workflows/`
  - Update `scripts/manifest.toml` sync entries for the two new workflow files
- **CodeQL Actions coverage (A2)**
  - Add `actions` to the CodeQL language matrix in root and workspace `codeql.yml`
  - Add `.github/workflows/**` to CodeQL push paths on `main` so default-branch runs re-scan workflows
- **Template permissions (A4)**
  - Add `permissions: contents: read` to `assets/workspace/.github/workflows/release-extension.yml`
- **Posture documentation (A3)**
  - Update `SECURITY.md` with verified Main protection ruleset requirements and accepted OpenSSF Scorecard findings (Fuzzing, CII)

## Changelog Entry

### Security

- **Resolve repo-owned workflow security findings** ([#562](https://github.com/vig-os/devcontainer/issues/562))
  - Split Renovate changelog automation into read-only `pull_request` build + privileged `workflow_run` commit, removing `pull_request_target` and PR-head checkout under elevated permissions (Scorecard `DangerousWorkflowID`)
  - Add GitHub Actions to CodeQL language matrix so stale `actions/missing-workflow-permissions` alerts auto-close on the next default-branch run
  - Add explicit `permissions:` to workspace `release-extension.yml` template; downstream smoke-test updates flow through release re-sync
  - Document accepted OpenSSF Scorecard posture (Fuzzing, CII) and verified branch-protection rulesets in `SECURITY.md`

## Testing

- [ ] Tests pass locally (`just test`)
- [x] Manual testing performed (describe below)

### Manual Testing Details

- yamllint, check-yaml, check-action-pins, and actionlint passed on changed workflow files
- pre-commit hooks passed on all four commits
- End-to-end Renovate changelog commit path requires merge to `main` (`workflow_run` runs default-branch workflow definition)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

- Alert #1748 (`DangerousWorkflowID`) should clear after Scorecard re-runs on `main` post-merge
- CodeQL alerts #453–456 should auto-close after the next default-branch CodeQL run with Actions enabled
- Main protection ruleset verified active: PR review (1 approval, code-owner required, thread resolution), required status checks, non-fast-forward, deletion block
- `FuzzingID` and `CIIBestPracticesID` documented as accepted won't-fix for a devcontainer image repo
- Smoke-test `release-extension.yml` is not patched directly; updates flow through this repo's release re-sync actions

Refs: #562
