### PR TITLE
fix(image): refresh bundled gh and uv to clear Go and Rust CVEs

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -11,8 +11,9 @@
 # Risk Assessment: LOW (devcontainer context)
 # - HIGH severity in Go stdlib embedded in gh (GitHub CLI) binary
 # - Requires maliciously-crafted MIME headers; gh validates GitHub API responses only
-# - Fixed in Go 1.26.4; awaiting upstream gh release rebuilt with patched stdlib
-# - Tracking: https://github.com/vig-os/devcontainer/issues/512
+# - Latest gh v2.93.0 (2026-05-27) still embeds Go 1.26.3; fix requires Go 1.26.4 rebuild
+# - Fresh image build (gh 2.93.0, uv 0.11.19) cleared all other bundled-tool HIGH findings
+# - Tracking: https://github.com/vig-os/devcontainer/issues/512, #564
 Expiration: 2026-09-01
 CVE-2026-42504
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **Refresh bundled gh and uv to clear Go and Rust CVEs** ([#564](https://github.com/vig-os/devcontainer/issues/564))
+  - Fresh image build pulls latest `gh` v2.93.0 and `uv` v0.11.19, clearing all bundled-tool HIGH findings except one awaiting upstream
+  - `uv`/`uvx` Rust crate CVEs (including `rustls-webpki` GHSA-82j2-j2ch-gfr8) no longer reported after rebuild
+  - Remaining `gh` Go-stdlib HIGH (CVE-2026-42504) kept in `.trivyignore` until `gh` ships a Go 1.26.4 rebuild
+
 - **Update pytest to v9.0.3** ([#528](https://github.com/vig-os/devcontainer/issues/528))
   - Security patch for pytest dependency bump
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -19,6 +19,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **Refresh bundled gh and uv to clear Go and Rust CVEs** ([#564](https://github.com/vig-os/devcontainer/issues/564))
+  - Fresh image build pulls latest `gh` v2.93.0 and `uv` v0.11.19, clearing all bundled-tool HIGH findings except one awaiting upstream
+  - `uv`/`uvx` Rust crate CVEs (including `rustls-webpki` GHSA-82j2-j2ch-gfr8) no longer reported after rebuild
+  - Remaining `gh` Go-stdlib HIGH (CVE-2026-42504) kept in `.trivyignore` until `gh` ships a Go 1.26.4 rebuild
+
 - **Update pytest to v9.0.3** ([#528](https://github.com/vig-os/devcontainer/issues/528))
   - Security patch for pytest dependency bump
 


### PR DESCRIPTION
## Summary
- Verified a cache-busting image rebuild pulls latest bundled tools (`gh` v2.93.0, `uv` v0.11.19)
- Reconciled `.trivyignore` after Trivy scan: `uv`/`uvx` Rust HIGH findings cleared; only `gh` CVE-2026-42504 remains (awaiting upstream Go 1.26.4 rebuild)
- Added CHANGELOG security entry documenting scan results

## Scan results (local, Trivy v0.69.3)
| Target | Before (issue) | After rebuild |
|--------|----------------|---------------|
| `usr/local/bin/gh` | Multiple Go-stdlib HIGH CVEs | 1 HIGH (CVE-2026-42504, ignored) |
| `usr/local/bin/uv` | rustls-webpki GHSA-82j2-j2ch-gfr8 (HIGH) | Clean |
| `usr/local/bin/uvx` | Rust crate CVEs (medium/low) | Clean |

Gate (`HIGH,CRITICAL`, `--ignore-unfixed`, `.trivyignore`) passes locally.

## Test plan
- [x] `just build no_cache=1` — fresh image with latest gh/uv
- [x] Local Trivy gate scan passes
- [ ] CI `container-image` Trivy gate on PR

Closes #564

Refs: #512