### PR TITLE
build(image): bump base image digest for OS CVE remediation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **Bump base image digest and clear fixable OS-package CVEs** ([#565](https://github.com/vig-os/devcontainer/issues/565))
+  - Pin `python:3.14-slim-bookworm` to latest upstream digest (`sha256:ec58d916…`)
+  - Retain targeted `libgnutls30=3.7.9-2+deb12u7` upgrade (new base ships `deb12u6`; fixable GnuTLS CVEs require `deb12u7`)
+  - CI Trivy gate passes with zero fixable HIGH/CRITICAL OS findings after rebuild
+
 - **Refresh bundled gh and uv to clear Go and Rust CVEs** ([#564](https://github.com/vig-os/devcontainer/issues/564))
   - Fresh image build pulls latest `gh` v2.93.0 and `uv` v0.11.19, clearing all bundled-tool HIGH findings except one awaiting upstream
   - `uv`/`uvx` Rust crate CVEs (including `rustls-webpki` GHSA-82j2-j2ch-gfr8) no longer reported after rebuild

--- a/Containerfile
+++ b/Containerfile
@@ -1,7 +1,7 @@
 # Use Python 3.14 as base image (pinned to digest for supply chain integrity)
-# Dependabot (docker ecosystem) will propose digest updates automatically
+# Renovate (dockerfile manager) will propose digest updates automatically
 # Updated to bookworm (stable) for better security patch cadence
-FROM python:3.14-slim-bookworm@sha256:a9bee15510a364124aa24692899d269835683b883de42f7ebec8c293cf679ccb
+FROM python:3.14-slim-bookworm@sha256:ec58d916f9e24a6035cab2bdf07f6206c4cc092a16613c60597534711332d9d6
 
 # Add metadata
 # By default, we build the dev version unless specified as an argument
@@ -36,8 +36,8 @@ ENV DEBIAN_FRONTEND=noninteractive
 # upgrade silently changes packages between builds, defeating that guarantee.
 #
 # Instead we rely on:
-#   1. Dependabot proposing base-image digest updates (covers most CVEs).
-#   2. Weekly Trivy scans (.github/workflows/security-scan.yml) for visibility.
+#   1. Renovate proposing base-image digest updates (covers most CVEs).
+#   2. Nightly Trivy scans (.github/workflows/security-scan.yml) for visibility.
 #   3. Targeted --only-upgrade for HIGH/CRITICAL CVEs that cannot wait for a
 #      new base image rebuild. Each entry must reference a CVE.
 #

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -19,6 +19,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **Bump base image digest and clear fixable OS-package CVEs** ([#565](https://github.com/vig-os/devcontainer/issues/565))
+  - Pin `python:3.14-slim-bookworm` to latest upstream digest (`sha256:ec58d916…`)
+  - Retain targeted `libgnutls30=3.7.9-2+deb12u7` upgrade (new base ships `deb12u6`; fixable GnuTLS CVEs require `deb12u7`)
+  - CI Trivy gate passes with zero fixable HIGH/CRITICAL OS findings after rebuild
+
 - **Refresh bundled gh and uv to clear Go and Rust CVEs** ([#564](https://github.com/vig-os/devcontainer/issues/564))
   - Fresh image build pulls latest `gh` v2.93.0 and `uv` v0.11.19, clearing all bundled-tool HIGH findings except one awaiting upstream
   - `uv`/`uvx` Rust crate CVEs (including `rustls-webpki` GHSA-82j2-j2ch-gfr8) no longer reported after rebuild

--- a/docs/CONTAINER_SECURITY.md
+++ b/docs/CONTAINER_SECURITY.md
@@ -22,27 +22,29 @@ The `FROM` line in the Containerfile pins the base image to an immutable
 SHA-256 digest:
 
 ```dockerfile
-FROM python:3.12-slim-bookworm@sha256:<digest>
+FROM python:3.14-slim-bookworm@sha256:<digest>
 ```
 
-Dependabot (configured for the `docker` ecosystem) monitors the upstream image
-and opens a pull request whenever a new digest is published. Because the
-upstream maintainers rebuild the image to include Debian security patches, most
-CVEs are resolved simply by merging the Dependabot PR.
+Renovate (configured with the `dockerfile` manager in `renovate.json`) monitors
+the upstream image and opens a pull request whenever a new digest is published.
+Because the upstream maintainers rebuild the image to include Debian security
+patches, most CVEs are resolved simply by merging the Renovate PR.
 
 **Typical remediation time:** 1–7 days after the upstream image is rebuilt.
 
-### 2. Weekly Trivy scan (detection)
+### 2. Nightly Trivy scan (detection)
 
-The scheduled workflow (`.github/workflows/security-scan.yml`) builds the
-image every Monday and runs a full Trivy vulnerability scan. Results are:
+The scheduled workflow (`.github/workflows/security-scan.yml`) pulls the
+published `:latest` image nightly (05:00 UTC) and runs a full Trivy vulnerability
+scan. Results are:
 
 - Printed as a table in the workflow log.
 - Uploaded as a SARIF report to the GitHub Security tab.
 - Accompanied by a CycloneDX SBOM artifact.
 
-This scan is **non-blocking** (exit-code 0) and serves as an early-warning
-system for newly published CVEs.
+This scan is **non-blocking** for the full report (exit-code 0) and serves as
+an early-warning system for newly published CVEs. A separate gate step fails
+on fixable HIGH/CRITICAL findings (`ignore-unfixed: true`).
 
 ### 3. Targeted package upgrades (escape hatch)
 
@@ -111,7 +113,7 @@ New CVE detected by Trivy
            (with risk   No ──┤──── Yes
            assessment)  │         │
                         ▼         ▼
-                   Add targeted   Wait for Dependabot
+                   Add targeted   Wait for Renovate
                    --only-upgrade   digest update PR
                    to Containerfile
 ```
@@ -120,4 +122,4 @@ New CVE detected by Trivy
 
 - [Containerfile](../Containerfile) – Build definition with inline comments
 - [.trivyignore](../.trivyignore) – Accepted low-risk CVEs
-- [security-scan.yml](../.github/workflows/security-scan.yml) – Weekly scan workflow
+- [security-scan.yml](../.github/workflows/security-scan.yml) – Nightly scan workflow


### PR DESCRIPTION
## Description

Bump the pinned `python:3.14-slim-bookworm` base image digest to the latest upstream release and refresh container security documentation. The digest bump clears fixable HIGH/CRITICAL OS-package CVEs (curl, rsync, libssh2, libexpat, krb5, glibc, etc.); the existing targeted `libgnutls30=3.7.9-2+deb12u7` upgrade is retained because the new base still ships `deb12u6`.

## Type of Change

- [ ] `feat` -- New feature
- [ ] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [ ] `ci` -- CI/CD pipeline changes
- [x] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- **`Containerfile`**
  - Bump base digest to `sha256:ec58d916f9e24a6035cab2bdf07f6206c4cc092a16613c60597534711332d9d6`
  - Update inline security comments (Dependabot → Renovate, weekly → nightly scan)
  - Retain existing `libgnutls30=3.7.9-2+deb12u7` targeted upgrade
- **`docs/CONTAINER_SECURITY.md`**
  - Correct stale policy facts: Renovate (not Dependabot), Python 3.14, nightly scan schedule, gate behaviour
- **`CHANGELOG.md`** and **`assets/workspace/.devcontainer/CHANGELOG.md`**
  - Add Unreleased Security entry for #565

## Changelog Entry

### Security

- **Bump base image digest and clear fixable OS-package CVEs** ([#565](https://github.com/vig-os/devcontainer/issues/565))
  - Pin `python:3.14-slim-bookworm` to latest upstream digest (`sha256:ec58d916…`)
  - Retain targeted `libgnutls30=3.7.9-2+deb12u7` upgrade (new base ships `deb12u6`; fixable GnuTLS CVEs require `deb12u7`)
  - CI Trivy gate passes with zero fixable HIGH/CRITICAL OS findings after rebuild

## Testing

- [x] Tests pass locally (`just test`)
- [x] Manual testing performed (describe below)

### Manual Testing Details

- `just build` — image builds successfully with new digest
- Trivy gate (`HIGH,CRITICAL`, `ignore-unfixed`, `.trivyignore`) — pass (zero fixable findings)
- `just test-image` — 67/67 pass
- `hadolint Containerfile` — pass
- Full `just test` — 270 pytest + BATS pass except one pre-existing flaky `worktree.bats` Cursor Agent prompt test (unrelated to this change)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

No additional targeted `--only-upgrade` entries were needed beyond the existing GnuTLS pin; the digest bump alone cleared all other fixable HIGH/CRITICAL OS CVEs. Remaining unfixed findings (perl, zlib) are `fix_deferred`/`will_not_fix` and do not gate CI.

Refs: #565
