### PR TITLE
docs: add downstream SECURITY.md template and document accepted Scorecard findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Bump `urllib3` 2.7.0, `requests` 2.34.2, `idna` 3.18, `Pygments` 2.20.0 in the repo lockfile
   - Constrain workspace-template jupyter stack to patched versions (`notebook` 7.5.6, `jupyterlab` 4.5.7, `jupyter-server` 2.18.0, `mistune` 3.2.1)
 
+- **Add downstream SECURITY.md template and close smoke-test Scorecard gaps** ([#568](https://github.com/vig-os/devcontainer/issues/568))
+  - Add `assets/workspace/SECURITY.md` so generated and smoke-test repos ship a security policy (clears Scorecard `SecurityPolicyID` on the next release re-sync)
+  - Document `FuzzingID` and `CIIBestPracticesID` as accepted won't-fix posture in the template policy
+  - Document smoke-test-specific accepted findings (branch-protection, code-review, pinned `download-then-run`) in the `assets/smoke-test/` overlay, accepted because the deploy-validation repo runs fully unattended
+
 ### Changed
 
 - **Consolidate Renovate dependency updates** ([#550](https://github.com/vig-os/devcontainer/issues/550))

--- a/assets/smoke-test/README.md
+++ b/assets/smoke-test/README.md
@@ -51,6 +51,25 @@ from `vig-os/devcontainer` and runs an automated deploy-and-test cycle:
 
 This flow applies to both RC tags and final tags.
 
+## Accepted Scorecard findings
+
+This repository is an **unattended deploy-validation target**, so a few OpenSSF
+Scorecard checks are intentionally accepted as won't-fix here (they do not apply
+to real downstream projects, which should keep branch protection and review).
+The full security policy and project-general accepted findings live in
+[`SECURITY.md`](SECURITY.md); the smoke-test-specific ones are:
+
+- **BranchProtectionID** / **CodeReviewID**: the automated deploy/release PRs are
+  merged without human review by design. Requiring approving reviews would stall
+  the `chore/deploy-<tag>` auto-merge and defeat the purpose of the smoke test.
+- **PinnedDependenciesID** (`download-then-run`): the installer in
+  `.github/workflows/repository-dispatch.yml` is fetched by immutable release
+  tag, retried, and validated post-install. The `curl | bash` step cannot be
+  pinned by hash and is accepted.
+
+These are recorded as dismissed (won't-fix) code-scanning alerts with a comment
+referencing the upstream tracking issue. See `vig-os/devcontainer` #568.
+
 ## Audit trail and status
 
 There is no CHANGELOG in this repository.

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -52,6 +52,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Bump `urllib3` 2.7.0, `requests` 2.34.2, `idna` 3.18, `Pygments` 2.20.0 in the repo lockfile
   - Constrain workspace-template jupyter stack to patched versions (`notebook` 7.5.6, `jupyterlab` 4.5.7, `jupyter-server` 2.18.0, `mistune` 3.2.1)
 
+- **Add downstream SECURITY.md template and close smoke-test Scorecard gaps** ([#568](https://github.com/vig-os/devcontainer/issues/568))
+  - Add `assets/workspace/SECURITY.md` so generated and smoke-test repos ship a security policy (clears Scorecard `SecurityPolicyID` on the next release re-sync)
+  - Document `FuzzingID` and `CIIBestPracticesID` as accepted won't-fix posture in the template policy
+  - Document smoke-test-specific accepted findings (branch-protection, code-review, pinned `download-then-run`) in the `assets/smoke-test/` overlay, accepted because the deploy-validation repo runs fully unattended
+
 ### Changed
 
 - **Consolidate Renovate dependency updates** ([#550](https://github.com/vig-os/devcontainer/issues/550))

--- a/assets/workspace/SECURITY.md
+++ b/assets/workspace/SECURITY.md
@@ -1,0 +1,67 @@
+# Security Policy
+
+## Supported Versions
+
+| Version  | Supported |
+|----------|-----------|
+| latest   | Yes       |
+| < latest | No        |
+
+Only the latest released version receives security updates.
+Older versions are not maintained.
+
+## Reporting a Vulnerability
+
+**Do not open a public GitHub issue for security vulnerabilities.**
+
+To report a vulnerability, use
+[GitHub Private Vulnerability Reporting](https://github.com/{{GITHUB_REPOSITORY}}/security/advisories/new).
+
+When reporting, please include:
+
+- Description of the vulnerability
+- Steps to reproduce (or proof of concept)
+- Affected component (source code, CI workflow, dependency, etc.)
+- Potential impact assessment
+
+## Response Timeline
+
+| Stage              | Target           |
+|--------------------|------------------|
+| Acknowledgement    | 3 business days  |
+| Initial assessment | 7 business days  |
+| Fix or mitigation  | 30 calendar days |
+
+We will keep you informed of progress throughout.
+
+## Scope
+
+The following areas are in scope for security reports:
+
+- **Source code:** Application and library code under `src/`
+- **Supply chain:** GitHub Actions workflows and pinned dependencies
+- **Build tooling:** Project scripts and CI/CD configuration
+- **Secrets handling:** Accidental exposure of tokens, keys, or credentials
+- **Workflow permissions:** Overly broad permissions in CI/CD pipelines
+
+## Security Practices
+
+This repository follows these security practices:
+
+- All GitHub Actions are pinned to commit SHAs (not mutable tags)
+- Pre-commit hook repos are pinned to commit SHAs
+- Renovate monitors dependencies for updates and known vulnerabilities
+- Dependency review blocks pull requests that introduce vulnerable dependencies
+- Workflow permissions follow the principle of least privilege
+- Workflow inputs are bound to environment variables (not interpolated inline)
+- No `pull_request_target` triggers are used (prevents untrusted code execution)
+- OpenSSF Scorecard runs weekly to track security posture
+- CodeQL static analysis scans the project and GitHub Actions workflows
+
+### OpenSSF Scorecard accepted findings
+
+The following Scorecard checks are not applicable to this project and are
+accepted as won't-fix:
+
+- **FuzzingID** (medium): no fuzzing targets in the project or CI scripts
+- **CIIBestPracticesID** (low): not a CII Best Practices badge candidate; posture is tracked via Scorecard and CodeQL instead


### PR DESCRIPTION
## Description

Closes the downstream-only OpenSSF Scorecard gaps for `vig-os/devcontainer-smoke-test` that are not covered by #562/#563.

Adds a `SECURITY.md` policy to the workspace template so generated repos (and the smoke-test repo) ship a security policy, and documents the findings that are deliberately accepted as won't-fix. Branch-protection and code-review are accepted (not enforced) for the smoke-test repo because it is a fully unattended deploy-validation target — requiring human review would stall the automated `chore/deploy-<tag>` auto-merge.

## Type of Change

- [ ] `feat` -- New feature
- [ ] `fix` -- Bug fix
- [x] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [ ] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- `assets/workspace/SECURITY.md` (new): template security policy with `{{GITHUB_REPOSITORY}}` placeholder for the private-reporting advisory URL. Includes an accepted-findings section for `FuzzingID` and `CIIBestPracticesID`. Auto-included in the build-time placeholder manifest (`Containerfile`) so substitution happens at init time; propagates to downstream repos on the next release re-sync, clearing Scorecard `SecurityPolicyID`.
- `assets/smoke-test/README.md`: new "Accepted Scorecard findings" section documenting the smoke-test-only acceptances (branch-protection, code-review, pinned `download-then-run`) and the rationale (unattended deploy-validation repo).
- `CHANGELOG.md` (+ synced `assets/workspace/.devcontainer/CHANGELOG.md`): Security entry under `## Unreleased`.

## Changelog Entry

### Security

- **Add downstream SECURITY.md template and close smoke-test Scorecard gaps** ([#568](https://github.com/vig-os/devcontainer/issues/568))
  - Add `assets/workspace/SECURITY.md` so generated and smoke-test repos ship a security policy (clears Scorecard `SecurityPolicyID` on the next release re-sync)
  - Document `FuzzingID` and `CIIBestPracticesID` as accepted won't-fix posture in the template policy
  - Document smoke-test-specific accepted findings (branch-protection, code-review, pinned `download-then-run`) in the `assets/smoke-test/` overlay, accepted because the deploy-validation repo runs fully unattended

## Testing

- [ ] Tests pass locally (`just test`)
- [x] Manual testing performed (describe below)

### Manual Testing Details

- `pymarkdown` passed on all edited markdown via the repo hook (`uv run pre-commit run pymarkdown --files ...`); full pre-commit suite passed on commit.
- Verified the new `SECURITY.md` is picked up by the build-time placeholder manifest grep in `Containerfile` (`{{GITHUB_REPOSITORY}}` pattern).
- On `vig-os/devcontainer-smoke-test`, dismissed the accepted Scorecard alerts as won't-fix with #568 rationale and verified they no longer appear in the open alert list: `BranchProtectionID`, `CodeReviewID`, `PinnedDependenciesID`, `FuzzingID`, `CIIBestPracticesID`.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

Out-of-band actions on `vig-os/devcontainer-smoke-test` (cannot be done from this repo):

- The 5 accepted Scorecard alerts have already been dismissed as won't-fix (see Manual Testing Details).
- `SecurityPolicyID` will clear automatically once this `SECURITY.md` propagates on the next release re-sync.
- `release-extension.yml` (a `PRESERVE_FILES` entry, so it does not re-sync) needs the top-level `permissions: contents: read` block added directly in the smoke-test repo (refs #562 A4) — handled separately by a signed commit there.

This deviates from the issue's original "configure rulesets requiring review" criterion: enforcing review on the smoke-test would break its unattended deployment, so those findings are accepted/dismissed instead.

Refs: #568
