### PR TITLE
docs: address PR #575 review comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `@devcontainers/cli` 0.87.0 ([#538](https://github.com/vig-os/devcontainer/issues/538))
 
 - **Bump expected tool versions in image tests**
-  - `gh` 2.92 → 2.93, `just` 1.50 → 1.52, `cargo-binstall` 1.18 → 1.19 to match latest upstream releases
+  - `gh` 2.92 → 2.93, `just` 1.50 → 1.52, `cargo-binstall` 1.18 → 1.20 to match latest upstream releases
 
 - **Consolidate Renovate dependency updates (553–556)** ([#553](https://github.com/vig-os/devcontainer/issues/553), [#554](https://github.com/vig-os/devcontainer/issues/554), [#555](https://github.com/vig-os/devcontainer/issues/555), [#556](https://github.com/vig-os/devcontainer/issues/556))
   - Pin `pytest` to 9.0.3, bump `pytest-cov` to 7.1.0, `rich` to 15.0.0
@@ -34,7 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Renewed dependency-review allow-list exception for bats-file false positive (`GHSA-wvrr-2x4r-394v`)
 
 - **Image tests red on stale cargo-binstall pin** ([#557](https://github.com/vig-os/devcontainer/issues/557))
-  - Bump expected `cargo-binstall` 1.19 → 1.20 to match the latest upstream release the image installs
+  - Bump expected `cargo-binstall` to 1.20 to match the latest upstream release the image installs
 
 ### Security
 
@@ -57,9 +57,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Security patch for pytest dependency bump
 
 - **Remediate nightly scan gate failures on :latest** ([#549](https://github.com/vig-os/devcontainer/issues/549))
-  - Rebased base image to latest `python:3.12-slim-bookworm` digest
-  - Patched `libgnutls30` to `3.7.9-2+deb12u7` for fixable GnuTLS CVEs
-  - Rewrote `.trivyignore` from scratch with fresh expirations for unfixable findings only
+  - Patched `libgnutls30` to `3.7.9-2+deb12u7` for fixable GnuTLS CVEs (retained across the 3.14 base rebase; see #565)
 
 - **Resolve repo-owned workflow security findings** ([#562](https://github.com/vig-os/devcontainer/issues/562))
   - Split Renovate changelog automation into read-only `pull_request` build + privileged `workflow_run` commit, removing `pull_request_target` and PR-head checkout under elevated permissions (Scorecard `DangerousWorkflowID`)

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `@devcontainers/cli` 0.87.0 ([#538](https://github.com/vig-os/devcontainer/issues/538))
 
 - **Bump expected tool versions in image tests**
-  - `gh` 2.92 → 2.93, `just` 1.50 → 1.52, `cargo-binstall` 1.18 → 1.19 to match latest upstream releases
+  - `gh` 2.92 → 2.93, `just` 1.50 → 1.52, `cargo-binstall` 1.18 → 1.20 to match latest upstream releases
 
 - **Consolidate Renovate dependency updates (553–556)** ([#553](https://github.com/vig-os/devcontainer/issues/553), [#554](https://github.com/vig-os/devcontainer/issues/554), [#555](https://github.com/vig-os/devcontainer/issues/555), [#556](https://github.com/vig-os/devcontainer/issues/556))
   - Pin `pytest` to 9.0.3, bump `pytest-cov` to 7.1.0, `rich` to 15.0.0
@@ -34,7 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Renewed dependency-review allow-list exception for bats-file false positive (`GHSA-wvrr-2x4r-394v`)
 
 - **Image tests red on stale cargo-binstall pin** ([#557](https://github.com/vig-os/devcontainer/issues/557))
-  - Bump expected `cargo-binstall` 1.19 → 1.20 to match the latest upstream release the image installs
+  - Bump expected `cargo-binstall` to 1.20 to match the latest upstream release the image installs
 
 ### Security
 
@@ -57,9 +57,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Security patch for pytest dependency bump
 
 - **Remediate nightly scan gate failures on :latest** ([#549](https://github.com/vig-os/devcontainer/issues/549))
-  - Rebased base image to latest `python:3.12-slim-bookworm` digest
-  - Patched `libgnutls30` to `3.7.9-2+deb12u7` for fixable GnuTLS CVEs
-  - Rewrote `.trivyignore` from scratch with fresh expirations for unfixable findings only
+  - Patched `libgnutls30` to `3.7.9-2+deb12u7` for fixable GnuTLS CVEs (retained across the 3.14 base rebase; see #565)
 
 - **Resolve repo-owned workflow security findings** ([#562](https://github.com/vig-os/devcontainer/issues/562))
   - Split Renovate changelog automation into read-only `pull_request` build + privileged `workflow_run` commit, removing `pull_request_target` and PR-head checkout under elevated permissions (Scorecard `DangerousWorkflowID`)

--- a/packages/vig-utils/src/vig_utils/check_expirations.py
+++ b/packages/vig-utils/src/vig_utils/check_expirations.py
@@ -41,9 +41,16 @@ def parse_entries(path: Path) -> list[tuple[str, date]]:
 
             expiration_match = EXPIRATION_PATTERN.match(line)
             if expiration_match:
-                current_expiration = datetime.strptime(
-                    expiration_match.group(1), "%Y-%m-%d"
-                ).date()
+                try:
+                    current_expiration = datetime.strptime(
+                        expiration_match.group(1), "%Y-%m-%d"
+                    ).date()
+                except ValueError as exc:
+                    msg = (
+                        f"{path}:{line_num}: invalid expiration date "
+                        f"{expiration_match.group(1)!r}"
+                    )
+                    raise ValueError(msg) from exc
                 continue
 
             if current_expiration is None:

--- a/packages/vig-utils/tests/test_check_expirations.py
+++ b/packages/vig-utils/tests/test_check_expirations.py
@@ -69,6 +69,12 @@ class TestParseEntries:
         with pytest.raises(ValueError, match="no Expiration directive"):
             parse_entries(path)
 
+    def test_invalid_expiration_date_raises_with_context(self, tmp_path: Path):
+        path = tmp_path / "ignore.txt"
+        path.write_text("Expiration: 2026-13-45\nCVE-2010-4756\n", encoding="utf-8")
+        with pytest.raises(ValueError, match="invalid expiration date"):
+            parse_entries(path)
+
     def test_ignores_comments_and_blank_lines(self, tmp_path: Path):
         path = tmp_path / "ignore.txt"
         path.write_text(


### PR DESCRIPTION
## Summary

Addresses the non-blocking Copilot review comments on #575 plus a thorough changelog pass on the `0.3.5` block.

- Reconcile `cargo-binstall` version in both changelogs: the routine tool-bump entry now reads `1.18 → 1.20` and the #557 fix entry drops the conflicting from-version, matching the final pin in `tests/test_image.py` (`1.20.`).
- Consolidate the `#549` entry: drop the superseded `python:3.12-slim-bookworm` digest and `.trivyignore`-rewrite bullets (the release ships `3.14` per #565 and curates `.trivyignore` per #566); keep the durable `libgnutls30` patch.
- `check-expirations`: wrap `datetime.strptime` so a calendar-invalid `Expiration:` date (passes the regex, fails parsing) raises a `ValueError` with the `path:line` context the other parse errors carry. Added a regression test.

## Test plan

- [x] `uv run pytest tests/test_check_expirations.py` (14 passed)
- [x] `uvx ruff check` clean on the changed Python files
- [x] `check-expirations .trivyignore` validates 80 exceptions
- [ ] CI green on this PR

Refs: #557, #549, #566