### PR TITLE
fix(image): pin multi-arch index digest to unbreak arm64 release build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Image tests red on stale cargo-binstall pin** ([#557](https://github.com/vig-os/devcontainer/issues/557))
   - Bump expected `cargo-binstall` to 1.20 to match the latest upstream release the image installs
 
+- **arm64 release build failed with "exec format error"** ([#578](https://github.com/vig-os/devcontainer/issues/578))
+  - Restore the multi-arch index digest for `python:3.14-slim-bookworm` (`sha256:a9bee155…`); the previous bump pinned the amd64-only child manifest, so the arm64 build pulled an amd64 image and the first `RUN` died with `exec /bin/sh: exec format error`
+  - Document in `Containerfile` that manual base-image pins must use the index digest, never a per-platform child manifest
+
 ### Security
 
 - **Accept Debian won't-fix LOW CVEs in .trivyignore** ([#566](https://github.com/vig-os/devcontainer/issues/566))
@@ -44,8 +48,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Security tab LOW count drops after the next release refreshes `:latest`
 
 - **Bump base image digest and clear fixable OS-package CVEs** ([#565](https://github.com/vig-os/devcontainer/issues/565))
-  - Pin `python:3.14-slim-bookworm` to latest upstream digest (`sha256:ec58d916…`)
-  - Retain targeted `libgnutls30=3.7.9-2+deb12u7` upgrade (new base ships `deb12u6`; fixable GnuTLS CVEs require `deb12u7`)
+  - Keep `python:3.14-slim-bookworm` pinned to its multi-arch index digest (`sha256:a9bee155…`)
+  - Retain targeted `libgnutls30=3.7.9-2+deb12u7` upgrade (base ships `deb12u6`; fixable GnuTLS CVEs require `deb12u7`)
   - CI Trivy gate passes with zero fixable HIGH/CRITICAL OS findings after rebuild
 
 - **Refresh bundled gh and uv to clear Go and Rust CVEs** ([#564](https://github.com/vig-os/devcontainer/issues/564))

--- a/Containerfile
+++ b/Containerfile
@@ -1,7 +1,12 @@
 # Use Python 3.14 as base image (pinned to digest for supply chain integrity)
 # Renovate (dockerfile manager) will propose digest updates automatically
 # Updated to bookworm (stable) for better security patch cadence
-FROM python:3.14-slim-bookworm@sha256:ec58d916f9e24a6035cab2bdf07f6206c4cc092a16613c60597534711332d9d6
+#
+# IMPORTANT: this MUST be the multi-arch *index* digest (the top-level
+# `Digest:` from `docker buildx imagetools inspect python:3.14-slim-bookworm`),
+# never a per-platform child manifest. Pinning a single-arch (amd64) child
+# manifest breaks the arm64 release build with "exec format error" (see #578).
+FROM python:3.14-slim-bookworm@sha256:a9bee15510a364124aa24692899d269835683b883de42f7ebec8c293cf679ccb
 
 # Add metadata
 # By default, we build the dev version unless specified as an argument

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -36,6 +36,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Image tests red on stale cargo-binstall pin** ([#557](https://github.com/vig-os/devcontainer/issues/557))
   - Bump expected `cargo-binstall` to 1.20 to match the latest upstream release the image installs
 
+- **arm64 release build failed with "exec format error"** ([#578](https://github.com/vig-os/devcontainer/issues/578))
+  - Restore the multi-arch index digest for `python:3.14-slim-bookworm` (`sha256:a9bee155…`); the previous bump pinned the amd64-only child manifest, so the arm64 build pulled an amd64 image and the first `RUN` died with `exec /bin/sh: exec format error`
+  - Document in `Containerfile` that manual base-image pins must use the index digest, never a per-platform child manifest
+
 ### Security
 
 - **Accept Debian won't-fix LOW CVEs in .trivyignore** ([#566](https://github.com/vig-os/devcontainer/issues/566))
@@ -44,8 +48,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Security tab LOW count drops after the next release refreshes `:latest`
 
 - **Bump base image digest and clear fixable OS-package CVEs** ([#565](https://github.com/vig-os/devcontainer/issues/565))
-  - Pin `python:3.14-slim-bookworm` to latest upstream digest (`sha256:ec58d916…`)
-  - Retain targeted `libgnutls30=3.7.9-2+deb12u7` upgrade (new base ships `deb12u6`; fixable GnuTLS CVEs require `deb12u7`)
+  - Keep `python:3.14-slim-bookworm` pinned to its multi-arch index digest (`sha256:a9bee155…`)
+  - Retain targeted `libgnutls30=3.7.9-2+deb12u7` upgrade (base ships `deb12u6`; fixable GnuTLS CVEs require `deb12u7`)
   - CI Trivy gate passes with zero fixable HIGH/CRITICAL OS findings after rebuild
 
 - **Refresh bundled gh and uv to clear Go and Rust CVEs** ([#564](https://github.com/vig-os/devcontainer/issues/564))


### PR DESCRIPTION
## Summary

The 0.3.5-rc1 release failed on the arm64 build leg. The GitHub annotation blamed `libgnutls30`, but the real cause was the base-image pin: commit `40a7d1e` set `Containerfile` line 4 to the **amd64-only child manifest** digest (`sha256:ec58d916…`) instead of the **multi-arch index** digest. On `ubuntu-22.04-arm`, Docker pulled the amd64 image and the first shell `RUN` died with `exec /bin/sh: exec format error` (exit 255).

- Restore the multi-arch index digest `sha256:a9bee155…` (verified `oci.image.index.v1+json`, contains `linux/amd64` + `linux/arm64/v8`).
- No CVE regression: the live `python:3.14-slim-bookworm` index digest is unchanged from the pre-bump value, and fixable GnuTLS CVEs are still covered by the retained `libgnutls30=3.7.9-2+deb12u7` upgrade.
- Correct the misleading `#565` CHANGELOG entry and add a `#578` Fixed entry (root + workspace template).
- Add an inline `Containerfile` note: manual base-image pins must use the index digest, never a per-platform child manifest.

## Test plan

- [ ] CI matrix builds both `amd64` and `arm64` legs successfully.
- [ ] Publish 0.3.5-rc2 to validate the fix end-to-end, then re-run the final release.

Refs: #578