### PR TITLE
fix(image): patch OpenSSL CVE-2026-45447 for release Trivy gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Retain targeted `libgnutls30=3.7.9-2+deb12u7` upgrade (base ships `deb12u6`; fixable GnuTLS CVEs require `deb12u7`)
   - CI Trivy gate passes with zero fixable HIGH/CRITICAL OS findings after rebuild
 
+- **Patch fixable OpenSSL HIGH CVE blocking the 0.3.5 release** ([#580](https://github.com/vig-os/devcontainer/issues/580))
+  - Targeted `libssl3`/`openssl` upgrade to `3.0.20-1~deb12u2` (base ships `deb12u1`); clears `CVE-2026-45447` flagged by the release Trivy gate
+
 - **Refresh bundled gh and uv to clear Go and Rust CVEs** ([#564](https://github.com/vig-os/devcontainer/issues/564))
   - Fresh image build pulls latest `gh` v2.93.0 and `uv` v0.11.19, clearing all bundled-tool HIGH findings except one awaiting upstream
   - `uv`/`uvx` Rust crate CVEs (including `rustls-webpki` GHSA-82j2-j2ch-gfr8) no longer reported after rebuild

--- a/Containerfile
+++ b/Containerfile
@@ -59,6 +59,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends --only-upgrade 
     libgnutls30=3.7.9-2+deb12u7 \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
+# CVE-2026-45447 (OpenSSL PKCS#7/S-MIME; bookworm-security)
+RUN apt-get update && apt-get install -y --no-install-recommends --only-upgrade \
+    libssl3=3.0.20-1~deb12u2 \
+    openssl=3.0.20-1~deb12u2 \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
 # Install minimal system dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -52,6 +52,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Retain targeted `libgnutls30=3.7.9-2+deb12u7` upgrade (base ships `deb12u6`; fixable GnuTLS CVEs require `deb12u7`)
   - CI Trivy gate passes with zero fixable HIGH/CRITICAL OS findings after rebuild
 
+- **Patch fixable OpenSSL HIGH CVE blocking the 0.3.5 release** ([#580](https://github.com/vig-os/devcontainer/issues/580))
+  - Targeted `libssl3`/`openssl` upgrade to `3.0.20-1~deb12u2` (base ships `deb12u1`); clears `CVE-2026-45447` flagged by the release Trivy gate
+
 - **Refresh bundled gh and uv to clear Go and Rust CVEs** ([#564](https://github.com/vig-os/devcontainer/issues/564))
   - Fresh image build pulls latest `gh` v2.93.0 and `uv` v0.11.19, clearing all bundled-tool HIGH findings except one awaiting upstream
   - `uv`/`uvx` Rust crate CVEs (including `rustls-webpki` GHSA-82j2-j2ch-gfr8) no longer reported after rebuild


### PR DESCRIPTION
## Summary
- Add targeted `libssl3`/`openssl` upgrade to `3.0.20-1~deb12u2` in `Containerfile` to clear fixable HIGH `CVE-2026-45447` that blocked release 0.3.5-rc1
- Document the security fix under `## [0.3.5] - TBD` in `CHANGELOG.md`

## Root cause
Release workflow run failed in **Build and Test (amd64) → Scan image for vulnerabilities** because Trivy reported fixable HIGH findings in `libssl3`/`openssl` (`3.0.20-1~deb12u1`; fixed in `deb12u2`).

## Validation
- Local build succeeded
- `dpkg -l` confirms `libssl3` and `openssl` at `3.0.20-1~deb12u2`
- Trivy scan with `HIGH,CRITICAL`, `ignore-unfixed`, and `.trivyignore` passes (exit 0)

## Test plan
- [x] Local image build
- [x] Local Trivy gate
- [ ] CI on this PR
- [ ] Re-run Release workflow as candidate (`0.3.5-rc2`) after merge

Refs: #580