### PR TITLE
fix(prepare-release): stop stripping Unreleased so sync cannot drop it

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -4,16 +4,17 @@
 # 1. Validate: Check inputs and prerequisites
 # 2. Prepare:
 #    a. Freeze CHANGELOG on dev (Unreleased → [X.Y.Z] - TBD + fresh empty Unreleased)
-#    b. Fork release branch from the freeze commit
-#    c. Strip empty Unreleased section from release branch
-#    d. Create draft PR to main
+#    b. Fork release branch from the freeze commit (keeps the empty Unreleased)
+#    c. Create draft PR to main
 #
 # CHANGELOG flow:
 #   dev:     ## Unreleased (empty) + ## [X.Y.Z] - TBD (with content)
-#   release: ## [X.Y.Z] - TBD (with content, no Unreleased)
+#   release: ## Unreleased (empty) + ## [X.Y.Z] - TBD (with content)
 #
-# This ensures dev never loses ## Unreleased, and both branches share
-# the [X.Y.Z] section as a common ancestor for clean merges later.
+# The empty ## Unreleased is never stripped, so it is present on both dev and
+# release/main and is stable common context in the freeze commit that becomes
+# the main↔dev merge base. Finalization only edits the [X.Y.Z] line; the sync
+# merge keeps ## Unreleased instead of silently dropping it (#590).
 
 name: Prepare Release
 
@@ -259,41 +260,11 @@ jobs:
             gh api "repos/${{ github.repository }}/git/ref/heads/$RELEASE_BRANCH" --jq '.object.sha'
           echo "✓ Release branch ref verified as resolvable"
 
-      - name: Strip empty Unreleased section for release branch
-        run: |
-          set -euo pipefail
-          python3 -c "
-          import re
-          from pathlib import Path
-          content = Path('CHANGELOG.md').read_text()
-          content = re.sub(
-              r'## Unreleased\s*\n(?:### \w+\s*\n\s*)*\n*(?=## \[)',
-              '',
-              content,
-          )
-          Path('CHANGELOG.md').write_text(content)
-          "
-          echo "✓ Stripped empty Unreleased section from CHANGELOG"
-
-      - name: Sync workspace manifest after release changelog strip
-        run: |
-          set -euo pipefail
-          uv run python scripts/sync_manifest.py sync assets/workspace/
-          echo "✓ Synced workspace manifest after release changelog strip"
-
-      - name: Commit stripped CHANGELOG to release branch via API
-        uses: vig-os/commit-action@1bc004353d08d9332a0cb54920b148256220c8e0  # v0.2.0
-        env:
-          GH_TOKEN: ${{ steps.commit-app-token.outputs.token }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
-          TARGET_BRANCH: refs/heads/${{ needs.validate.outputs.release_branch }}
-          MAX_ATTEMPTS: "3"
-          COMMIT_MESSAGE: |-
-            chore: prepare release ${{ needs.validate.outputs.version }}
-
-            Strip empty Unreleased section from release branch.
-            Release date TBD (set during finalization).
-          FILE_PATHS: CHANGELOG.md,assets/workspace/.devcontainer/CHANGELOG.md
+      # The release branch keeps the empty ## Unreleased section (no stripping).
+      # main therefore retains ## Unreleased above the dated release, matching
+      # dev, so the section is stable common context in the eventual main↔dev
+      # sync merge and can never be silently dropped (#590). Keep a Changelog
+      # endorses an always-present Unreleased section.
 
       - name: Create draft PR to main
         id: pr
@@ -425,7 +396,7 @@ jobs:
           echo ""
           echo "CHANGELOG state:"
           echo "  dev:     ## Unreleased (empty) + ## [$VERSION] - TBD"
-          echo "  release: ## [$VERSION] - TBD (no Unreleased)"
+          echo "  release: ## Unreleased (empty) + ## [$VERSION] - TBD"
           echo ""
           echo "Next steps:"
           echo "  1. Test release: git checkout $RELEASE_BRANCH"

--- a/.github/workflows/sync-main-to-dev.yml
+++ b/.github/workflows/sync-main-to-dev.yml
@@ -16,8 +16,11 @@
 # - COMMIT_APP_* for git/ref operations (least-privilege commit identity)
 # - RELEASE_APP_* for PR/label operations that require pull-request scopes
 #
-# With the new CHANGELOG flow, dev already has ## Unreleased (created during
-# prepare-release), so no CHANGELOG reset is needed here.
+# No CHANGELOG reset is needed here. prepare-release never strips ## Unreleased
+# from the release branch, so main and dev both carry it and it is stable common
+# context in the merge base. main only edits the [X.Y.Z] line at finalization;
+# the merge therefore preserves ## Unreleased instead of silently dropping it
+# (#590).
 #
 # Triggers: push to main · workflow_dispatch
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`sync-main-to-dev` could silently drop the fresh `## Unreleased` scaffold** ([#590](https://github.com/vig-os/devcontainer/issues/590))
+  - `prepare-release` no longer strips `## Unreleased` from the release branch, so `main` keeps an empty `## Unreleased` above the dated release (matching `dev`)
+  - With the section present on both branches it is stable common context in the `main`↔`dev` merge base, so the sync merge preserves it cleanly instead of resolving in `main`'s favour and dropping it
+  - Applied to both the canonical workflow and the workspace template so adopters (e.g. `part-registry`) inherit the fix
 - **`devcontainer-upgrade` / install URL 404s** ([#591](https://github.com/vig-os/devcontainer/issues/591))
   - Replace the unhosted `vig-os.github.io/devcontainer/install.sh` Pages URL with the canonical `raw.githubusercontent.com/vig-os/devcontainer/main/install.sh` already used in `README.md`
   - Pipe the installer to `bash` instead of `sh` (the script has a `#!/bin/bash` shebang and uses bashisms), matching the canonical form

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`sync-main-to-dev` could silently drop the fresh `## Unreleased` scaffold** ([#590](https://github.com/vig-os/devcontainer/issues/590))
+  - `prepare-release` no longer strips `## Unreleased` from the release branch, so `main` keeps an empty `## Unreleased` above the dated release (matching `dev`)
+  - With the section present on both branches it is stable common context in the `main`↔`dev` merge base, so the sync merge preserves it cleanly instead of resolving in `main`'s favour and dropping it
+  - Applied to both the canonical workflow and the workspace template so adopters (e.g. `part-registry`) inherit the fix
 - **`devcontainer-upgrade` / install URL 404s** ([#591](https://github.com/vig-os/devcontainer/issues/591))
   - Replace the unhosted `vig-os.github.io/devcontainer/install.sh` Pages URL with the canonical `raw.githubusercontent.com/vig-os/devcontainer/main/install.sh` already used in `README.md`
   - Pipe the installer to `bash` instead of `sh` (the script has a `#!/bin/bash` shebang and uses bashisms), matching the canonical form

--- a/assets/workspace/.github/workflows/prepare-release.yml
+++ b/assets/workspace/.github/workflows/prepare-release.yml
@@ -258,34 +258,11 @@ jobs:
             gh api "repos/${{ github.repository }}/git/ref/heads/$RELEASE_BRANCH" --jq '.object.sha'
           echo "✓ Release branch ref verified as resolvable"
 
-      - name: Strip empty Unreleased section for release branch
-        run: |
-          set -euo pipefail
-          python3 -c "
-          import re
-          from pathlib import Path
-          content = Path('CHANGELOG.md').read_text()
-          content = re.sub(
-              r'## Unreleased\s*\n(?:### \w+\s*\n\s*)*\n*(?=## \[)',
-              '',
-              content,
-          )
-          Path('CHANGELOG.md').write_text(content)
-          "
-
-      - name: Commit stripped CHANGELOG to release branch via API
-        uses: vig-os/commit-action@1bc004353d08d9332a0cb54920b148256220c8e0  # v0.2.0
-        env:
-          GH_TOKEN: ${{ steps.commit_app_token.outputs.token }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
-          TARGET_BRANCH: refs/heads/${{ needs.validate.outputs.release_branch }}
-          MAX_ATTEMPTS: "3"
-          COMMIT_MESSAGE: |-
-            chore: prepare release ${{ needs.validate.outputs.version }}
-
-            Strip empty Unreleased section from release branch.
-            Release date TBD (set during finalization).
-          FILE_PATHS: CHANGELOG.md
+      # The release branch keeps the empty ## Unreleased section (no stripping).
+      # main therefore retains ## Unreleased above the dated release, matching
+      # dev, so the section is stable common context in the eventual main/dev
+      # sync merge and can never be silently dropped (#590). Keep a Changelog
+      # endorses an always-present Unreleased section.
 
       - name: Create draft PR to main
         id: pr

--- a/assets/workspace/.github/workflows/sync-main-to-dev.yml
+++ b/assets/workspace/.github/workflows/sync-main-to-dev.yml
@@ -19,8 +19,11 @@
 # NOTE: This workspace workflow is intentionally decoupled from upstream
 # `.github/workflows/sync-main-to-dev.yml` and maintained separately.
 #
-# With the new CHANGELOG flow, dev already has ## Unreleased (created during
-# prepare-release), so no CHANGELOG reset is needed here.
+# No CHANGELOG reset is needed here. prepare-release never strips ## Unreleased
+# from the release branch, so main and dev both carry it and it is stable common
+# context in the merge base. main only edits the [X.Y.Z] line at finalization;
+# the merge therefore preserves ## Unreleased instead of silently dropping it
+# (#590).
 #
 # Triggers: push to main · workflow_dispatch
 


### PR DESCRIPTION
## Summary

Fixes #590. `sync-main-to-dev` could **silently drop** `dev`'s fresh `## Unreleased` scaffold: the sync branch is cut from `main` (which had no `## Unreleased`, because `prepare-release` stripped it from the release branch) and merged into `dev` (which has it). The 3-way merge then resolves *cleanly* in `main`'s favour and deletes the scaffold — no conflict, green auto-merge, invisible loss until the next structure PR has nowhere to add an entry (observed every release in `part-registry`).

## Fix

Stop stripping `## Unreleased` from the release branch. `main` now keeps an empty `## Unreleased` above the dated release, **matching `dev`**, so the section is stable common context in the freeze commit that becomes the `main`↔`dev` merge base. Finalization only edits the `## [X.Y.Z]` line, so the sync merge preserves `## Unreleased` cleanly. [Keep a Changelog](https://keepachangelog.com/) endorses an always-present `Unreleased` section.

This is the minimal change — just remove the strip step — applied to **both** the canonical workflow and the workspace template so adopters (e.g. `part-registry`) inherit it.

### Why not re-add Unreleased on `dev` after the fork?
An earlier approach froze without `Unreleased` and re-added it to `dev` post-fork, keeping `main` free of `Unreleased`. Empirically that made the `main→dev` sync **conflict every release** (finalize edits the `[X.Y.Z]` line adjacent to the re-inserted scaffold) — i.e. the same manual chore #590 complains about. Keeping the section on both sides is the only way to get a *clean* conflict-free merge.

## Changes
- `.github/workflows/prepare-release.yml` + `assets/workspace/.github/workflows/prepare-release.yml`: drop the "Strip empty Unreleased section" step (and its release-branch commit); refresh the flow header/summary comments.
- `.github/workflows/sync-main-to-dev.yml` + workspace copy: refresh the stale comment to document the new invariant.
- `CHANGELOG.md` (+ mirrored workspace copy): `Fixed` entry.

## Verification
Simulated the full freeze → fork → finalize → `main→dev` sync cycle with the real `prepare-changelog` tooling, across **two consecutive releases**, with and without ongoing `dev` work:

```
cycle 0.2.0: sync merge rc=0 clean -> ## Unreleased PRESERVED
cycle 0.3.0: sync merge rc=0 clean -> ## Unreleased PRESERVED
```

The pre-fix flow reproduces the silent drop (`clean -> DROPPED`) for contrast. `just test-pytest` for `vig-utils` (481 passed) and `yamllint` on all four workflows are green.