### PR TITLE
fix(smoke-test): seed Unreleased entry so prepare-release can run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Smoke-test `prepare-release` failed on empty Unreleased section** ([#597](https://github.com/vig-os/devcontainer/issues/597))
+  - The smoke-test fixture has no hand-authored changelog entries, so each release freeze left `## Unreleased` empty and the downstream `prepare-release` gate rejected it ("Unreleased section has no entries")
+  - The deploy step in `repository-dispatch.yml` now seeds a deploy entry into `## Unreleased` when it is empty, so the smoke-test release pipeline can always proceed
 - **`sync-main-to-dev` could silently drop the fresh `## Unreleased` scaffold** ([#590](https://github.com/vig-os/devcontainer/issues/590))
   - `prepare-release` no longer strips `## Unreleased` from the release branch, so `main` keeps an empty `## Unreleased` above the dated release (matching `dev`)
   - With the section present on both branches it is stable common context in the `main`↔`dev` merge base, so the sync merge preserves it cleanly instead of resolving in `main`'s favour and dropping it

--- a/assets/smoke-test/.github/workflows/repository-dispatch.yml
+++ b/assets/smoke-test/.github/workflows/repository-dispatch.yml
@@ -253,6 +253,41 @@ jobs:
             exit 1
           fi
 
+      - name: Seed CHANGELOG Unreleased entry for release validation
+        env:
+          TAG: ${{ needs.validate.outputs.tag }}
+        run: |
+          set -euo pipefail
+          # The smoke-test repo is a fixture: it has no hand-authored changelog
+          # entries, but each release freeze resets Unreleased to empty and the
+          # downstream prepare-release gate requires Unreleased to have content.
+          # Seed a deploy entry so the release pipeline can always proceed.
+          if awk '
+            /^## Unreleased$/ {in_unreleased=1; next}
+            /^## \[/ && in_unreleased {exit 1}
+            in_unreleased && /^[[:space:]]*-[[:space:]]/ {found=1}
+            END {exit(found ? 0 : 1)}
+          ' CHANGELOG.md; then
+            echo "Unreleased already has entries; nothing to seed."
+            exit 0
+          fi
+          tmp="$(mktemp)"
+          awk -v tag="$TAG" '
+            { print }
+            /^## Unreleased$/ {in_unreleased=1; next}
+            in_unreleased && /^### Changed$/ {
+              print ""
+              print "- **Smoke-test deploy of " tag "** -- automated devcontainer release-pipeline validation; no functional changes"
+              in_unreleased=0
+            }
+          ' CHANGELOG.md > "$tmp"
+          mv "$tmp" CHANGELOG.md
+          if ! grep -q "Smoke-test deploy of ${TAG}" CHANGELOG.md; then
+            echo "ERROR: failed to seed Unreleased entry (no '### Changed' under '## Unreleased'?)"
+            exit 1
+          fi
+          echo "✓ Seeded Unreleased entry for ${TAG}"
+
       - name: Prepare deploy branch and metadata
         id: prepare_branch
         env:

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -33,6 +33,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Smoke-test `prepare-release` failed on empty Unreleased section** ([#597](https://github.com/vig-os/devcontainer/issues/597))
+  - The smoke-test fixture has no hand-authored changelog entries, so each release freeze left `## Unreleased` empty and the downstream `prepare-release` gate rejected it ("Unreleased section has no entries")
+  - The deploy step in `repository-dispatch.yml` now seeds a deploy entry into `## Unreleased` when it is empty, so the smoke-test release pipeline can always proceed
 - **`sync-main-to-dev` could silently drop the fresh `## Unreleased` scaffold** ([#590](https://github.com/vig-os/devcontainer/issues/590))
   - `prepare-release` no longer strips `## Unreleased` from the release branch, so `main` keeps an empty `## Unreleased` above the dated release (matching `dev`)
   - With the section present on both branches it is stable common context in the `main`↔`dev` merge base, so the sync merge preserves it cleanly instead of resolving in `main`'s favour and dropping it


### PR DESCRIPTION
## Summary

Fixes #597 in the `0.3.6` release. The `0.3.6-rc1` candidate built and published fine, but the downstream smoke-test failed at `prepare-release` (`Unreleased section has no entries`). The smoke-test fixture has no hand-authored changelog entries, so each release freeze resets `## Unreleased` to empty and the gate can never pass on a no-op deploy.

This adds a **"Seed CHANGELOG Unreleased entry"** step to the deploy job in the smoke-test source template (`assets/smoke-test/.github/workflows/repository-dispatch.yml`): when `## Unreleased` is empty it seeds a deploy bullet under `### Changed`; existing entries are left untouched (idempotent guard).

**Targeted at `release/0.3.6`** so the fix ships with 0.3.6 and the candidate can be re-cut/re-validated. The consumer-side mirror of this fix (the smoke-test repo's own deployed copy) is tracked in vig-os/devcontainer-smoke-test#157 / PR #158.

## Why not a template/root parity change too?

The investigation in #597 initially suspected the workspace template's inline-awk Unreleased check had diverged from the root's `prepare-changelog validate`. It hasn't meaningfully: the template's `validate` job runs on a bare `ubuntu-24.04` (no devcontainer image, so `prepare-changelog` is unavailable), and the inline awk is functionally equivalent. The real bug is the empty-Unreleased fixture, which this PR fixes.

## Changes

- `assets/smoke-test/.github/workflows/repository-dispatch.yml`: seed Unreleased entry before opening the deploy PR
- `CHANGELOG.md` (+ mirror): Fixed entry under `## [0.3.6]`

## Verification

Seeding awk validated against an empty-Unreleased fixture: seeds correctly, leaves dated sections untouched, and the result passes the prepare-release gate. End-to-end requires the consumer PR (#158) to reach the smoke-test repo's `main`, since `repository_dispatch` runs from the default branch.

Refs: #597
