### PR TITLE
fix(promote-release): prune RC draft pre-releases in cleanup

### DIFF
--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -7,7 +7,8 @@
 # 2. promote: GHCR :latest manifest, publish (undraft) GitHub Release
 # 3. merge: merge release/X.Y.Z PR to main (triggers sync-main-to-dev)
 # 4. cleanup (best-effort): delete GHCR RC images and matching RC cosign signatures for this
-#    base version; delete matching git RC tags that have no GitHub Release. GHCR deletes use
+#    base version; delete RC draft pre-releases, then matching git RC tags that have no
+#    (remaining) GitHub Release. GHCR deletes use
 #    GITHUB_TOKEN with repo Admin on the package (Manage Actions access); git RC tag deletes
 #    still use RELEASE_APP. Cleanup step fails loudly on leftover RC tags; job uses
 #    continue-on-error so promote still completes. See docs/RELEASE_CYCLE.md.
@@ -598,7 +599,7 @@ jobs:
 
           echo "✓ GHCR prune pass complete for base version $VERSION (no RC tags remain)"
 
-      - name: Delete git RC tags without GitHub Release
+      - name: Delete RC draft pre-releases and git RC tags
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           VERSION: ${{ needs.validate.outputs.version }}
@@ -620,15 +621,27 @@ jobs:
               echo "WARN: release lookup failed for tag $tag, skipping deletion"
               continue
             fi
-            if printf '%s' "$RAW" | \
-              jq -s --arg tag "$tag" 'flatten | map(select(.tag_name == $tag)) | .[0] // empty' 2>/dev/null | \
-              jq -e 'type == "object"' >/dev/null 2>&1; then
-              echo "Skipping tag $tag (GitHub Release exists)"
-              continue
+            RELEASE_JSON=$(printf '%s' "$RAW" | \
+              jq -s --arg tag "$tag" 'flatten | map(select(.tag_name == $tag)) | .[0] // empty' 2>/dev/null || true)
+            if printf '%s' "$RELEASE_JSON" | jq -e 'type == "object"' >/dev/null 2>&1; then
+              IS_DRAFT=$(printf '%s' "$RELEASE_JSON" | jq -r '.draft')
+              IS_PRERELEASE=$(printf '%s' "$RELEASE_JSON" | jq -r '.prerelease')
+              # Only prune RC draft pre-releases; never touch a published release.
+              if [ "$IS_DRAFT" = "true" ] && [ "$IS_PRERELEASE" = "true" ] && \
+                printf '%s' "$tag" | grep -qE "^${VERSION}-rc[0-9]+$"; then
+                echo "Deleting RC draft pre-release $tag (draft pre-release)"
+                retry --retries 3 --backoff 5 --max-backoff 30 -- \
+                  gh release delete "$tag" --yes \
+                  || echo "WARN: failed to delete RC draft pre-release $tag"
+                # Fall through to delete the now-orphaned tag below.
+              else
+                echo "Skipping tag $tag (published GitHub Release exists)"
+                continue
+              fi
             fi
             echo "Deleting remote tag $tag (no GitHub Release)"
             retry --retries 3 --backoff 5 --max-backoff 30 -- \
               gh api -X DELETE "repos/${GITHUB_REPOSITORY}/git/refs/tags/${tag}" \
               || echo "WARN: failed to delete tag $tag"
           done <<< "$TAGS"
-          echo "✓ Git RC tag cleanup complete for $VERSION"
+          echo "✓ RC draft pre-release and git RC tag cleanup complete for $VERSION"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Prune RC draft pre-releases in promote cleanup** ([#600](https://github.com/vig-os/devcontainer/issues/600))
+  - Cleanup now deletes `X.Y.Z-rcN` draft pre-releases (and their now-orphaned tags); guarded to never touch published releases
+
 ### Security
 
 ## [0.3.6](https://github.com/vig-os/devcontainer/releases/tag/0.3.6) - 2026-06-19

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Prune RC draft pre-releases in promote cleanup** ([#600](https://github.com/vig-os/devcontainer/issues/600))
+  - Cleanup now deletes `X.Y.Z-rcN` draft pre-releases (and their now-orphaned tags); guarded to never touch published releases
+
 ### Security
 
 ## [0.3.6](https://github.com/vig-os/devcontainer/releases/tag/0.3.6) - 2026-06-19

--- a/assets/workspace/.github/workflows/promote-release.yml
+++ b/assets/workspace/.github/workflows/promote-release.yml
@@ -3,7 +3,8 @@
 # 1. validate: semver, draft GitHub Release for X.Y.Z, release PR approved and CI green
 # 2. promote: publish (undraft) GitHub Release
 # 3. merge: merge release/X.Y.Z PR to main (triggers sync-main-to-dev)
-# 4. cleanup (best-effort): delete remote git RC tags matching X.Y.Z-rc* with no GitHub Release
+# 4. cleanup (best-effort): delete RC draft pre-releases for X.Y.Z, then remote git RC tags
+#    matching X.Y.Z-rc* with no (remaining) GitHub Release
 #
 # See docs/DOWNSTREAM_RELEASE.md. No GHCR/cosign/smoke-test gate (project-specific).
 name: Promote Release
@@ -395,7 +396,7 @@ jobs:
           client-id: ${{ secrets.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
-      - name: Delete git RC tags without GitHub Release
+      - name: Delete RC draft pre-releases and git RC tags
         env:
           GH_TOKEN: ${{ steps.release_app_token.outputs.token }}
           VERSION: ${{ needs.validate.outputs.version }}
@@ -417,15 +418,27 @@ jobs:
               echo "WARN: release lookup failed for tag $tag, skipping deletion"
               continue
             fi
-            if printf '%s' "$RAW" | \
-              jq -s --arg tag "$tag" 'flatten | map(select(.tag_name == $tag)) | .[0] // empty' 2>/dev/null | \
-              jq -e 'type == "object"' >/dev/null 2>&1; then
-              echo "Skipping tag $tag (GitHub Release exists)"
-              continue
+            RELEASE_JSON=$(printf '%s' "$RAW" | \
+              jq -s --arg tag "$tag" 'flatten | map(select(.tag_name == $tag)) | .[0] // empty' 2>/dev/null || true)
+            if printf '%s' "$RELEASE_JSON" | jq -e 'type == "object"' >/dev/null 2>&1; then
+              IS_DRAFT=$(printf '%s' "$RELEASE_JSON" | jq -r '.draft')
+              IS_PRERELEASE=$(printf '%s' "$RELEASE_JSON" | jq -r '.prerelease')
+              # Only prune RC draft pre-releases; never touch a published release.
+              if [ "$IS_DRAFT" = "true" ] && [ "$IS_PRERELEASE" = "true" ] && \
+                printf '%s' "$tag" | grep -qE "^${VERSION}-rc[0-9]+$"; then
+                echo "Deleting RC draft pre-release $tag (draft pre-release)"
+                retry --retries 3 --backoff 5 --max-backoff 30 -- \
+                  gh release delete "$tag" --yes \
+                  || echo "WARN: failed to delete RC draft pre-release $tag"
+                # Fall through to delete the now-orphaned tag below.
+              else
+                echo "Skipping tag $tag (published GitHub Release exists)"
+                continue
+              fi
             fi
             echo "Deleting remote tag $tag (no GitHub Release)"
             retry --retries 3 --backoff 5 --max-backoff 30 -- \
               gh api -X DELETE "repos/${GITHUB_REPOSITORY}/git/refs/tags/${tag}" \
               || echo "WARN: failed to delete tag $tag"
           done <<< "$TAGS"
-          echo "✓ Git RC tag cleanup complete for $VERSION"
+          echo "✓ RC draft pre-release and git RC tag cleanup complete for $VERSION"


### PR DESCRIPTION
## Description

Closes #600. The `promote-release.yml` cleanup job pruned RC GHCR images/signatures and git RC tags, but **skipped any tag with a GitHub Release attached**. Adopters that dispatch candidates with `create-release=true` (the smoke-test repo) publish `X.Y.Z-rcN` **draft pre-releases**, so every release cycle stranded a draft pre-release **and** its tag indefinitely.

## Type of Change

- [x] `fix` -- Bug fix

## Changes Made

In the cleanup step of both promote-release workflows, change the per-tag decision from *"release exists → skip"* to:

- If the matched release is `draft == true && prerelease == true` and the tag matches `^${VERSION}-rc[0-9]+$` → delete it via `gh release delete "$tag" --yes`, then **fall through** to the existing tag-deletion (`gh api -X DELETE .../git/refs/tags/${tag}`).
- Otherwise (published / non-prerelease / non-matching) → skip, untouched.
- No release → delete the tag (unchanged).

Strictly guarded so a published release can never be deleted. Reuses the existing `retry` wrapper, `jq` matching, logging style, and tag-deletion call — no new step.

Files:
- `assets/workspace/.github/workflows/promote-release.yml` — adopter-facing SSoT (what smoke-test consumes)
- `.github/workflows/promote-release.yml` — root, mirrored for parity (root's candidate path doesn't create RC drafts today)

## Changelog Entry

### Fixed
- **Prune RC draft pre-releases in promote cleanup** ([#600](https://github.com/vig-os/devcontainer/issues/600))
  - Cleanup now deletes `X.Y.Z-rcN` draft pre-releases (and their now-orphaned tags); guarded to never touch published releases

## Testing

- [x] Tests pass locally (pre-commit + YAML parse clean)
- [x] Manual testing performed (describe below)

### Manual Testing Details

The cleanup logic is shell embedded inline in workflow YAML (GitHub API calls), so it is not unit-testable without a refactor the issue does not ask for. Validated by:

- YAML parses for both files; all pre-commit hooks pass.
- Simulated the decision logic across five cases — RC draft prerelease → delete; published prerelease → skip; published final → skip; stray `-rcfoo` draft → skip (regex guard); no release → delete tag — all correct.

End-to-end verification is the **next release run** in `vig-os/devcontainer-smoke-test` (dispatches candidates with `create-release=true`): confirm the `X.Y.Z-rcN` draft pre-release + tag are pruned and the published `X.Y.Z` release is untouched.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective (N/A — inline workflow shell; verified via simulation + next release run)