### PR TITLE
fix(security): accept piscina CVE-2026-55388 bundled in cursor-agent

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -17,6 +17,18 @@
 Expiration: 2026-09-01
 CVE-2026-42504
 
+# CVE-2026-55388: piscina Prototype Pollution gadget -> RCE in cursor-agent CLI
+# Risk Assessment: LOW (devcontainer context)
+# - HIGH severity in piscina 4.9.0 bundled in the cursor-agent CLI
+#   (/root/.local/share/cursor-agent/.../node_modules/piscina); fixed upstream in piscina 4.9.3+
+# - cursor-agent is installed unpinned from cursor.com/install; we do not control its bundled
+#   deps and the fix can only arrive via a future cursor-agent build
+# - Gadget requires attacker-controlled piscina options (inherited options.filename); not an
+#   attacker-reachable surface in devcontainer/CI use
+# - Tracking: https://github.com/vig-os/devcontainer/issues/602, #512
+Expiration: 2026-09-01
+CVE-2026-55388
+
 # jwt-token: Trivy secret scan false positive
 # Risk Assessment: N/A (not a vulnerability)
 # - JWT-like string in typos crate test fixtures under /opt/pre-commit-cache


### PR DESCRIPTION
## Summary

The nightly security scan ([run 27817416422](https://github.com/vig-os/devcontainer/actions/runs/27817416422)) flagged one **fixable HIGH** vulnerability in `ghcr.io/vig-os/devcontainer:latest` and opened #602:

| Package | CVE | Severity | Installed | Fixed | Where |
|---------|-----|----------|-----------|-------|-------|
| `piscina` | CVE-2026-55388 | HIGH | 4.9.0 | 4.9.3+ | bundled in cursor-agent CLI |

`piscina` (prototype-pollution gadget → RCE via inherited `options.filename`) is **bundled inside the cursor-agent CLI**, installed unpinned from `cursor.com/install` (`Containerfile`). We do not control cursor-agent's bundled dependency versions; the fix can only arrive via a future cursor-agent build, and stripping/pinning piscina would break its worker pool. The gadget is not an attacker-reachable surface in devcontainer/CI use.

This mirrors the existing accepted entry **CVE-2026-42504** (Go stdlib HIGH bundled in the `gh` binary) — the documented IEC 62304 risk-acceptance path (layer 4 in `docs/CONTAINER_SECURITY.md`).

## Change

- Add `CVE-2026-55388` to `.trivyignore` with risk assessment + expiration **2026-09-01**.

## Verification

- `uv run check-expirations .trivyignore` → exit 0 (81 entries).
- Local Trivy gate re-scan against `:latest` with the updated `.trivyignore` → exit 0; piscina finding suppressed, no remaining fixable HIGH/CRITICAL.

## Note

The nightly scan reads `.trivyignore` from the default branch (`main`), so this only clears #602's nightly gate once it reaches `main` via the normal release/promote cycle.

Refs: #602