### PR TITLE
fix(ci): branch release/X.Y.Z from post-freeze dev SHA

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -238,10 +238,29 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.commit-app-token.outputs.token }}
           RELEASE_BRANCH: ${{ needs.validate.outputs.release_branch }}
+          PREPARE_START_SHA: ${{ steps.pre-state.outputs.prepare_start_sha }}
         run: |
           set -euo pipefail
-          DEV_SHA=$(uv run retry --retries 3 --backoff 5 --max-backoff 60 -- \
-            gh api "repos/${{ github.repository }}/git/ref/heads/dev" --jq '.object.sha')
+          # Wait for dev to advance past the pre-freeze SHA before branching (#617).
+          # The freeze commit-action updates dev's ref, but a REST ref read can
+          # briefly return the stale pre-freeze SHA (read-after-write lag); branching
+          # then would create release/X.Y.Z without the freeze. `retry` only retries
+          # on failure, so a stale-but-successful read slips through -- assert the SHA
+          # actually changed instead of trusting the first read.
+          DEV_SHA=""
+          for attempt in $(seq 1 8); do
+            DEV_SHA=$(uv run retry --retries 3 --backoff 5 --max-backoff 60 -- \
+              gh api "repos/${{ github.repository }}/git/ref/heads/dev" --jq '.object.sha')
+            if [ "$DEV_SHA" != "$PREPARE_START_SHA" ]; then
+              break
+            fi
+            echo "dev still at pre-freeze SHA $DEV_SHA (attempt $attempt/8); waiting for freeze to propagate..."
+            sleep 5
+          done
+          if [ "$DEV_SHA" = "$PREPARE_START_SHA" ]; then
+            echo "ERROR: dev did not advance past pre-freeze SHA $PREPARE_START_SHA; freeze commit not visible"
+            exit 1
+          fi
           echo "Creating branch $RELEASE_BRANCH from dev at $DEV_SHA..."
           uv run retry --retries 3 --backoff 5 --max-backoff 60 -- \
             gh api "repos/${{ github.repository }}/git/refs" \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Prevent prepare-release from branching `release/X.Y.Z` at the pre-freeze dev SHA** ([#617](https://github.com/vig-os/devcontainer/issues/617))
+  - The "Create release branch from dev" step now polls dev until it advances past the captured pre-freeze SHA before branching, and hard-fails if it never does, closing a read-after-write race that could create a release branch missing the `## [X.Y.Z] - TBD` freeze
+
 ### Security
 
 ## [0.3.8] - TBD

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Prevent prepare-release from branching `release/X.Y.Z` at the pre-freeze dev SHA** ([#617](https://github.com/vig-os/devcontainer/issues/617))
+  - The "Create release branch from dev" step now polls dev until it advances past the captured pre-freeze SHA before branching, and hard-fails if it never does, closing a read-after-write race that could create a release branch missing the `## [X.Y.Z] - TBD` freeze
+
 ### Security
 
 ## [0.3.8] - TBD

--- a/assets/workspace/.github/workflows/prepare-release.yml
+++ b/assets/workspace/.github/workflows/prepare-release.yml
@@ -236,10 +236,29 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.commit_app_token.outputs.token }}
           RELEASE_BRANCH: ${{ needs.validate.outputs.release_branch }}
+          PREPARE_START_SHA: ${{ steps.pre_state.outputs.prepare_start_sha }}
         run: |
           set -euo pipefail
-          DEV_SHA=$(retry --retries 3 --backoff 5 --max-backoff 60 -- \
-            gh api "repos/${{ github.repository }}/git/ref/heads/dev" --jq '.object.sha')
+          # Wait for dev to advance past the pre-freeze SHA before branching (#617).
+          # The freeze commit-action updates dev's ref, but a REST ref read can
+          # briefly return the stale pre-freeze SHA (read-after-write lag); branching
+          # then would create release/X.Y.Z without the freeze. `retry` only retries
+          # on failure, so a stale-but-successful read slips through -- assert the SHA
+          # actually changed instead of trusting the first read.
+          DEV_SHA=""
+          for attempt in $(seq 1 8); do
+            DEV_SHA=$(retry --retries 3 --backoff 5 --max-backoff 60 -- \
+              gh api "repos/${{ github.repository }}/git/ref/heads/dev" --jq '.object.sha')
+            if [ "$DEV_SHA" != "$PREPARE_START_SHA" ]; then
+              break
+            fi
+            echo "dev still at pre-freeze SHA $DEV_SHA (attempt $attempt/8); waiting for freeze to propagate..."
+            sleep 5
+          done
+          if [ "$DEV_SHA" = "$PREPARE_START_SHA" ]; then
+            echo "ERROR: dev did not advance past pre-freeze SHA $PREPARE_START_SHA; freeze commit not visible"
+            exit 1
+          fi
           retry --retries 3 --backoff 5 --max-backoff 60 -- \
             gh api "repos/${{ github.repository }}/git/refs" \
             -f ref="refs/heads/$RELEASE_BRANCH" \


### PR DESCRIPTION
## Description

Fixes a read-after-write race in `prepare-release` that can create the
`release/X.Y.Z` branch at the **pre-freeze** dev SHA, so the release branch lacks
`## [X.Y.Z] - TBD` and the downstream `Release` workflow fails validation
(`does not contain '## [X.Y.Z] - TBD'`). Surfaced on the 0.3.8 release.

## Type of Change

- [x] `ci` -- CI/CD pipeline changes (fix)

## Root cause

Within a successful `Prepare Release` run, the "Create release branch from dev"
step re-reads `dev`'s ref and branches from whatever it returns:

```bash
DEV_SHA=$(retry ... gh api ".../git/ref/heads/dev" --jq '.object.sha')
```

GitHub's REST ref read is not strongly consistent immediately after a write —
~1s after commit-action pushes the freeze, the read can still return the
pre-freeze SHA. `retry` only retries on **failure**, so a stale-but-successful
read passes through and the release branch is cut without the freeze. The failure
only surfaces two steps later in `Release`.

Evidence (run `27949666239`): capture pre-prepare dev SHA `a1e787c` (11:34:42) →
commit freeze `0a9334d` (11:34:44) → create branch re-read dev → **`a1e787c`**
(11:34:45) → `release/0.3.8` cut at the pre-freeze SHA.

## Changes

Poll `dev` until its SHA differs from the captured `prepare_start_sha` (with
backoff), and hard-fail if it never advances; branch from that confirmed
post-freeze SHA. Applied to both copies of the identical step:

- `.github/workflows/prepare-release.yml`
- `assets/workspace/.github/workflows/prepare-release.yml`

## Changelog Entry

### Fixed
- **Prevent prepare-release from branching `release/X.Y.Z` at the pre-freeze dev SHA** ([#617](https://github.com/vig-os/devcontainer/issues/617))
  - The "Create release branch from dev" step now polls dev until it advances past the captured pre-freeze SHA before branching, and hard-fails if it never does, closing a read-after-write race that could create a release branch missing the `## [X.Y.Z] - TBD` freeze

## Testing

- [x] `pre-commit run` passes (yamllint/shellcheck/generate-docs/etc.).
- Logic traced against the failing 0.3.8 run; the guard would have looped until
  dev showed `0a9334d` (or failed loudly) instead of branching at `a1e787c`.

## Notes

Separate root cause from #612 (smoke-test dispatch idempotency) — this is the
devcontainer's own release branch-creation step. The already-stale `release/0.3.8`
still needs a one-off recovery (fast-forward to dev + re-run Release); this PR
prevents recurrence.

Refs: #617
