### PR TITLE
fix(ci): anchor changelog PR-body extraction to line-start headings

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -212,7 +212,11 @@ jobs:
           VERSION: ${{ needs.validate.outputs.version }}
         run: |
           set -euo pipefail
-          CHANGELOG_CONTENT=$(sed -n "/## \[$VERSION\]/,/## \[/p" CHANGELOG.md | sed '$d')
+          # Anchor the range patterns to start-of-line so only real column-0
+          # version headings delimit the section. An unanchored "## [" also
+          # matches inline backtick-quoted headings inside bullets (e.g.
+          # `## [X.Y.Z] - TBD`), which truncated the PR body early (#620).
+          CHANGELOG_CONTENT=$(sed -n "/^## \[$VERSION\]/,/^## \[/p" CHANGELOG.md | sed '$d')
           {
             echo "changelog<<CHANGELOGEOF"
             echo "$CHANGELOG_CONTENT"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `prepare-changelog finalize` is now a no-op when the version heading is already dated, instead of erroring
   - `prepare-changelog prepare` folds an existing same-version heading back into a single `## [X.Y.Z] - TBD` section instead of stacking a duplicate
   - New `prepare-changelog reset-version <version>` command reverts a dated heading back to `- TBD` (idempotent); the smoke-test dispatch template runs it at dispatch start and scopes its deploy-seed check to the `Unreleased` section
+- **Fix release PR body truncation when changelog bullets quote a version heading** ([#620](https://github.com/vig-os/devcontainer/issues/620))
+  - The "Extract CHANGELOG content for PR body" step now anchors its `sed` range to start-of-line headings, so an inline backtick-quoted heading inside a bullet no longer ends the range early
 
 ## [0.3.7](https://github.com/vig-os/devcontainer/releases/tag/0.3.7) - 2026-06-22
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -29,6 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `prepare-changelog finalize` is now a no-op when the version heading is already dated, instead of erroring
   - `prepare-changelog prepare` folds an existing same-version heading back into a single `## [X.Y.Z] - TBD` section instead of stacking a duplicate
   - New `prepare-changelog reset-version <version>` command reverts a dated heading back to `- TBD` (idempotent); the smoke-test dispatch template runs it at dispatch start and scopes its deploy-seed check to the `Unreleased` section
+- **Fix release PR body truncation when changelog bullets quote a version heading** ([#620](https://github.com/vig-os/devcontainer/issues/620))
+  - The "Extract CHANGELOG content for PR body" step now anchors its `sed` range to start-of-line headings, so an inline backtick-quoted heading inside a bullet no longer ends the range early
 
 ## [0.3.7](https://github.com/vig-os/devcontainer/releases/tag/0.3.7) - 2026-06-22
 

--- a/assets/workspace/.github/workflows/prepare-release.yml
+++ b/assets/workspace/.github/workflows/prepare-release.yml
@@ -210,7 +210,11 @@ jobs:
           VERSION: ${{ needs.validate.outputs.version }}
         run: |
           set -euo pipefail
-          CHANGELOG_CONTENT=$(sed -n "/## \[$VERSION\]/,/## \[/p" CHANGELOG.md | sed '$d')
+          # Anchor the range patterns to start-of-line so only real column-0
+          # version headings delimit the section. An unanchored "## [" also
+          # matches inline backtick-quoted headings inside bullets (e.g.
+          # `## [X.Y.Z] - TBD`), which truncated the PR body early (#620).
+          CHANGELOG_CONTENT=$(sed -n "/^## \[$VERSION\]/,/^## \[/p" CHANGELOG.md | sed '$d')
           {
             echo "changelog<<CHANGELOGEOF"
             echo "$CHANGELOG_CONTENT"


### PR DESCRIPTION
## Description

Fixes a latent bug in `prepare-release`'s "Extract CHANGELOG content for PR body"
step that truncated the release PR body (observed on #619) when a `## [X.Y.Z]`
section contains the literal `## [` inside a bullet (e.g. a changelog entry that
quotes `` `## [X.Y.Z] - TBD` ``).

Targeted at **`release/0.3.8`** so it ships with this release.

## Type of Change

- [x] `ci` -- CI/CD pipeline changes (fix)

## Root cause

```bash
CHANGELOG_CONTENT=$(sed -n "/## \[$VERSION\]/,/## \[/p" CHANGELOG.md | sed '$d')
```

The range-end pattern `/## \[/` is unanchored, so it matches the first line
containing `## [` anywhere — including inline backtick-quoted headings inside
bullets — closing the range early and dropping the rest of the section.

## Change

Anchor both range patterns to start-of-line:

```bash
sed -n "/^## \[$VERSION\]/,/^## \[/p" CHANGELOG.md | sed '$d'
```

Applied to both copies:
- `.github/workflows/prepare-release.yml`
- `assets/workspace/.github/workflows/prepare-release.yml`

## Testing

- [x] `pre-commit run` passes.
- Verified against the real `release/0.3.8` CHANGELOG: the old pattern stops after
  the first #617 bullet; the anchored pattern extracts the full `[0.3.8]` section
  (both #617 and #612), ending at the blank line before `## [0.3.7]`.

## Notes

The release→main→dev sync will carry this back to `dev`; no separate dev PR needed.
PR #619's body was already corrected manually.

Refs: #620
