### PR TITLE
fix(promote-release): delete RC draft pre-releases by id and gate tag removal

### DIFF
--- a/.github/scripts/select-rc-draft-releases.sh
+++ b/.github/scripts/select-rc-draft-releases.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Select RC draft pre-releases to prune after promote-release.
+# Reads a GitHub "list releases" array on stdin and emits "<id>\t<tag_name>"
+# for every draft pre-release whose tag is X.Y.Z-rcN for the given base semver.
+# Seeding cleanup from the releases list (not from git tags) reclaims drafts
+# whose RC tag was already deleted in an earlier, partially-failed run.
+# shellcheck shell=bash
+set -euo pipefail
+
+if [ $# -ne 1 ]; then
+  echo "usage: select-rc-draft-releases.sh <base-version>" >&2
+  exit 2
+fi
+
+BASE="$1"
+if ! echo "$BASE" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+  echo "ERROR: invalid base version '$BASE'" >&2
+  exit 2
+fi
+
+jq -r --arg base "$BASE" '
+  ( "^" + ($base | gsub("\\.";"\\.")) + "-rc[0-9]+$" ) as $rc
+  | .[]
+  | select(.draft == true and .prerelease == true and (.tag_name | test($rc)))
+  | "\(.id)\t\(.tag_name)"
+'

--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -606,42 +606,61 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail
+          SELECT_SCRIPT="${GITHUB_WORKSPACE}/.github/scripts/select-rc-draft-releases.sh"
+          TMP=$(mktemp)
+          trap 'rm -f "$TMP"' EXIT
+
+          # Pass 1: delete RC draft pre-releases by release id. Seeding from the
+          # releases list (not git tags) reclaims drafts whose RC tag was already
+          # removed by an earlier partial run; deleting by id works for drafts,
+          # which `gh release delete <tag>` cannot resolve.
+          retry --retries 3 --backoff 5 --max-backoff 30 -- \
+            gh api --paginate "repos/${GITHUB_REPOSITORY}/releases" > "$TMP"
+          DELETE_FAILED=0
+          while IFS=$'\t' read -r rel_id tag; do
+            [ -z "$rel_id" ] && continue
+            echo "Deleting RC draft pre-release $tag (release id $rel_id)"
+            if ! retry --retries 3 --backoff 5 --max-backoff 30 -- \
+              gh api -X DELETE "repos/${GITHUB_REPOSITORY}/releases/${rel_id}"; then
+              echo "ERROR: failed to delete RC draft pre-release $tag (release id $rel_id)"
+              DELETE_FAILED=1
+            fi
+          done < <(jq -s 'add // []' "$TMP" | bash "$SELECT_SCRIPT" "$VERSION")
+
+          # Re-read releases after deletions so the tag pass and verification see
+          # the current state.
+          retry --retries 3 --backoff 5 --max-backoff 30 -- \
+            gh api --paginate "repos/${GITHUB_REPOSITORY}/releases" > "$TMP"
+          RELEASES_AFTER=$(jq -s 'add // []' "$TMP")
+
+          # Pass 2: delete leftover git RC tags for the base version, but keep any
+          # tag that still has a GitHub Release attached — a published pre-release,
+          # or a draft whose deletion failed above so it stays discoverable.
           TAGS=$(retry --retries 3 --backoff 5 --max-backoff 30 -- \
             git ls-remote --tags --refs "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "${VERSION}-rc*" \
             | awk '{print $2}' | sed 's#refs/tags/##' || true)
-          if [ -z "$TAGS" ]; then
-            echo "No remote RC tags matching ${VERSION}-rc*"
-            exit 0
-          fi
           while IFS= read -r tag; do
             [ -z "$tag" ] && continue
-            RAW=""
-            if ! RAW=$(retry --retries 2 --backoff 3 --max-backoff 10 -- \
-              gh api "repos/${GITHUB_REPOSITORY}/releases" --paginate 2>&1); then
-              echo "WARN: release lookup failed for tag $tag, skipping deletion"
+            HAS_RELEASE=$(printf '%s' "$RELEASES_AFTER" | jq -r --arg t "$tag" 'any(.[]; .tag_name == $t)')
+            if [ "$HAS_RELEASE" = "true" ]; then
+              echo "Keeping tag $tag (GitHub Release still attached)"
               continue
-            fi
-            RELEASE_JSON=$(printf '%s' "$RAW" | \
-              jq -s --arg tag "$tag" 'flatten | map(select(.tag_name == $tag)) | .[0] // empty' 2>/dev/null || true)
-            if printf '%s' "$RELEASE_JSON" | jq -e 'type == "object"' >/dev/null 2>&1; then
-              IS_DRAFT=$(printf '%s' "$RELEASE_JSON" | jq -r '.draft')
-              IS_PRERELEASE=$(printf '%s' "$RELEASE_JSON" | jq -r '.prerelease')
-              # Only prune RC draft pre-releases; never touch a published release.
-              if [ "$IS_DRAFT" = "true" ] && [ "$IS_PRERELEASE" = "true" ] && \
-                printf '%s' "$tag" | grep -qE "^${VERSION}-rc[0-9]+$"; then
-                echo "Deleting RC draft pre-release $tag (draft pre-release)"
-                retry --retries 3 --backoff 5 --max-backoff 30 -- \
-                  gh release delete "$tag" --yes \
-                  || echo "WARN: failed to delete RC draft pre-release $tag"
-                # Fall through to delete the now-orphaned tag below.
-              else
-                echo "Skipping tag $tag (published GitHub Release exists)"
-                continue
-              fi
             fi
             echo "Deleting remote tag $tag (no GitHub Release)"
             retry --retries 3 --backoff 5 --max-backoff 30 -- \
               gh api -X DELETE "repos/${GITHUB_REPOSITORY}/git/refs/tags/${tag}" \
               || echo "WARN: failed to delete tag $tag"
           done <<< "$TAGS"
+
+          # Verify: no RC draft pre-release for the base version may survive.
+          REMAINING=$(printf '%s' "$RELEASES_AFTER" | bash "$SELECT_SCRIPT" "$VERSION" || true)
+          if [ -n "$REMAINING" ]; then
+            echo "ERROR: RC draft pre-releases still present for $VERSION:"
+            printf '%s\n' "$REMAINING"
+            exit 1
+          fi
+          if [ "$DELETE_FAILED" -ne 0 ]; then
+            echo "ERROR: one or more RC draft pre-release deletions failed for $VERSION"
+            exit 1
+          fi
           echo "✓ RC draft pre-release and git RC tag cleanup complete for $VERSION"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Stop promote-release cleanup from orphaning RC draft pre-releases** ([#623](https://github.com/vig-os/devcontainer/issues/623))
+  - The cleanup step deleted RC draft pre-releases with `gh release delete <tag>`, which cannot resolve a draft, then deleted the git RC tag anyway — stranding the draft and making it undiscoverable on later runs (the loop was seeded from git tags)
+  - Cleanup now enumerates RC draft pre-releases from the releases list, deletes them by release id, removes a git RC tag only when no release is attached, and fails loudly if any RC draft survives — also reclaiming drafts whose tag was already removed by an earlier partial run
+
 ### Security
 
 ## [0.3.8](https://github.com/vig-os/devcontainer/releases/tag/0.3.8) - 2026-06-22

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Stop promote-release cleanup from orphaning RC draft pre-releases** ([#623](https://github.com/vig-os/devcontainer/issues/623))
+  - The cleanup step deleted RC draft pre-releases with `gh release delete <tag>`, which cannot resolve a draft, then deleted the git RC tag anyway — stranding the draft and making it undiscoverable on later runs (the loop was seeded from git tags)
+  - Cleanup now enumerates RC draft pre-releases from the releases list, deletes them by release id, removes a git RC tag only when no release is attached, and fails loudly if any RC draft survives — also reclaiming drafts whose tag was already removed by an earlier partial run
+
 ### Security
 
 ## [0.3.8](https://github.com/vig-os/devcontainer/releases/tag/0.3.8) - 2026-06-22

--- a/assets/workspace/.github/workflows/promote-release.yml
+++ b/assets/workspace/.github/workflows/promote-release.yml
@@ -403,42 +403,70 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail
+          TMP=$(mktemp)
+          trap 'rm -f "$TMP"' EXIT
+
+          # Emit "<id>\t<tag>" for every RC draft pre-release of the base version,
+          # read from the releases list cached in "$TMP". Drafts must be deleted by
+          # id (gh release delete <tag> cannot resolve a draft), and seeding from
+          # releases — not git tags — reclaims drafts whose RC tag was already
+          # removed by an earlier partial run.
+          select_rc_draft_releases() {
+            jq -r -s --arg base "$VERSION" '
+              ( "^" + ($base | gsub("\\.";"\\.")) + "-rc[0-9]+$" ) as $rc
+              | (add // [])[]
+              | select(.draft == true and .prerelease == true and (.tag_name | test($rc)))
+              | "\(.id)\t\(.tag_name)"
+            ' "$TMP"
+          }
+
+          # Pass 1: delete RC draft pre-releases by release id.
+          retry --retries 3 --backoff 5 --max-backoff 30 -- \
+            gh api --paginate "repos/${GITHUB_REPOSITORY}/releases" > "$TMP"
+          DELETE_FAILED=0
+          while IFS=$'\t' read -r rel_id tag; do
+            [ -z "$rel_id" ] && continue
+            echo "Deleting RC draft pre-release $tag (release id $rel_id)"
+            if ! retry --retries 3 --backoff 5 --max-backoff 30 -- \
+              gh api -X DELETE "repos/${GITHUB_REPOSITORY}/releases/${rel_id}"; then
+              echo "ERROR: failed to delete RC draft pre-release $tag (release id $rel_id)"
+              DELETE_FAILED=1
+            fi
+          done < <(select_rc_draft_releases)
+
+          # Re-read releases after deletions for the tag pass and verification.
+          retry --retries 3 --backoff 5 --max-backoff 30 -- \
+            gh api --paginate "repos/${GITHUB_REPOSITORY}/releases" > "$TMP"
+          RELEASES_AFTER=$(jq -s 'add // []' "$TMP")
+
+          # Pass 2: delete leftover git RC tags for the base version, but keep any
+          # tag that still has a GitHub Release attached — a published pre-release,
+          # or a draft whose deletion failed above so it stays discoverable.
           TAGS=$(retry --retries 3 --backoff 5 --max-backoff 30 -- \
             git ls-remote --tags --refs "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "${VERSION}-rc*" \
             | awk '{print $2}' | sed 's#refs/tags/##' || true)
-          if [ -z "$TAGS" ]; then
-            echo "No remote RC tags matching ${VERSION}-rc*"
-            exit 0
-          fi
           while IFS= read -r tag; do
             [ -z "$tag" ] && continue
-            RAW=""
-            if ! RAW=$(retry --retries 2 --backoff 3 --max-backoff 10 -- \
-              gh api "repos/${GITHUB_REPOSITORY}/releases" --paginate 2>&1); then
-              echo "WARN: release lookup failed for tag $tag, skipping deletion"
+            HAS_RELEASE=$(printf '%s' "$RELEASES_AFTER" | jq -r --arg t "$tag" 'any(.[]; .tag_name == $t)')
+            if [ "$HAS_RELEASE" = "true" ]; then
+              echo "Keeping tag $tag (GitHub Release still attached)"
               continue
-            fi
-            RELEASE_JSON=$(printf '%s' "$RAW" | \
-              jq -s --arg tag "$tag" 'flatten | map(select(.tag_name == $tag)) | .[0] // empty' 2>/dev/null || true)
-            if printf '%s' "$RELEASE_JSON" | jq -e 'type == "object"' >/dev/null 2>&1; then
-              IS_DRAFT=$(printf '%s' "$RELEASE_JSON" | jq -r '.draft')
-              IS_PRERELEASE=$(printf '%s' "$RELEASE_JSON" | jq -r '.prerelease')
-              # Only prune RC draft pre-releases; never touch a published release.
-              if [ "$IS_DRAFT" = "true" ] && [ "$IS_PRERELEASE" = "true" ] && \
-                printf '%s' "$tag" | grep -qE "^${VERSION}-rc[0-9]+$"; then
-                echo "Deleting RC draft pre-release $tag (draft pre-release)"
-                retry --retries 3 --backoff 5 --max-backoff 30 -- \
-                  gh release delete "$tag" --yes \
-                  || echo "WARN: failed to delete RC draft pre-release $tag"
-                # Fall through to delete the now-orphaned tag below.
-              else
-                echo "Skipping tag $tag (published GitHub Release exists)"
-                continue
-              fi
             fi
             echo "Deleting remote tag $tag (no GitHub Release)"
             retry --retries 3 --backoff 5 --max-backoff 30 -- \
               gh api -X DELETE "repos/${GITHUB_REPOSITORY}/git/refs/tags/${tag}" \
               || echo "WARN: failed to delete tag $tag"
           done <<< "$TAGS"
+
+          # Verify: no RC draft pre-release for the base version may survive.
+          REMAINING=$(select_rc_draft_releases || true)
+          if [ -n "$REMAINING" ]; then
+            echo "ERROR: RC draft pre-releases still present for $VERSION:"
+            printf '%s\n' "$REMAINING"
+            exit 1
+          fi
+          if [ "$DELETE_FAILED" -ne 0 ]; then
+            echo "ERROR: one or more RC draft pre-release deletions failed for $VERSION"
+            exit 1
+          fi
           echo "✓ RC draft pre-release and git RC tag cleanup complete for $VERSION"

--- a/tests/bats/fixtures/releases-list.json
+++ b/tests/bats/fixtures/releases-list.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": 1001,
+    "tag_name": "0.3.8-rc1",
+    "draft": true,
+    "prerelease": true
+  },
+  {
+    "id": 1002,
+    "tag_name": "0.3.8-rc2",
+    "draft": true,
+    "prerelease": true
+  },
+  {
+    "id": 1003,
+    "tag_name": "0.3.8-rc3",
+    "draft": false,
+    "prerelease": true
+  },
+  {
+    "id": 1004,
+    "tag_name": "0.3.8",
+    "draft": true,
+    "prerelease": false
+  },
+  {
+    "id": 1005,
+    "tag_name": "0.3.8",
+    "draft": false,
+    "prerelease": false
+  },
+  {
+    "id": 1006,
+    "tag_name": "0.3.7-rc1",
+    "draft": true,
+    "prerelease": true
+  },
+  {
+    "id": 1007,
+    "tag_name": "0.3.80-rc1",
+    "draft": true,
+    "prerelease": true
+  },
+  {
+    "id": 1008,
+    "tag_name": "0.3.8-rcx",
+    "draft": true,
+    "prerelease": true
+  }
+]

--- a/tests/bats/select-rc-draft-releases.bats
+++ b/tests/bats/select-rc-draft-releases.bats
@@ -1,0 +1,57 @@
+#!/usr/bin/env bats
+# BATS tests for RC draft pre-release selection used by promote-release cleanup (#623).
+
+setup() {
+  load test_helper
+  SCRIPT="${PROJECT_ROOT}/.github/scripts/select-rc-draft-releases.sh"
+  FIXTURE="${PROJECT_ROOT}/tests/bats/fixtures/releases-list.json"
+}
+
+@test "select-rc-draft-releases emits id and tag for every RC draft pre-release of the base" {
+  run bash "$SCRIPT" 0.3.8 <"$FIXTURE"
+  assert_success
+  assert_line "1001	0.3.8-rc1"
+  assert_line "1002	0.3.8-rc2"
+}
+
+@test "select-rc-draft-releases ignores published (non-draft) RC pre-releases" {
+  run bash "$SCRIPT" 0.3.8 <"$FIXTURE"
+  assert_success
+  refute_output --partial "1003"
+}
+
+@test "select-rc-draft-releases ignores draft final (non-prerelease) releases" {
+  run bash "$SCRIPT" 0.3.8 <"$FIXTURE"
+  assert_success
+  refute_output --partial "1004"
+  refute_output --partial "1005"
+}
+
+@test "select-rc-draft-releases ignores RC drafts of other base versions" {
+  run bash "$SCRIPT" 0.3.8 <"$FIXTURE"
+  assert_success
+  refute_output --partial "0.3.7-rc1"
+  refute_output --partial "0.3.80-rc1"
+}
+
+@test "select-rc-draft-releases ignores malformed rc suffixes" {
+  run bash "$SCRIPT" 0.3.8 <"$FIXTURE"
+  assert_success
+  refute_output --partial "0.3.8-rcx"
+}
+
+@test "select-rc-draft-releases emits nothing when no RC drafts match" {
+  run bash "$SCRIPT" 9.9.9 <"$FIXTURE"
+  assert_success
+  assert_output ""
+}
+
+@test "select-rc-draft-releases rejects an invalid base version" {
+  run bash "$SCRIPT" not-a-version <"$FIXTURE"
+  assert_failure
+}
+
+@test "select-rc-draft-releases requires exactly one argument" {
+  run bash "$SCRIPT"
+  assert_failure
+}

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -26,7 +26,7 @@ EXPECTED_VERSIONS = {
     "ruff": "0.15.",  # Minor version check (installed via uv pip)
     "bandit": "1.9.",  # Minor version check (installed via uv pip)
     "pip_licenses": "5.",  # Major version check (installed via uv pip)
-    "just": "1.53.",  # Minor version check (manually installed from latest release)
+    "just": "1.54.",  # Minor version check (manually installed from latest release)
     "hadolint": "2.14.",  # Minor version check (manually installed from pinned release)
     "taplo": "0.10.",  # Minor version check (manually installed from latest release)
     "cargo-binstall": "1.20.",  # Minor version check (installed from latest release)


### PR DESCRIPTION
## Description

`promote-release.yml` left RC **draft pre-releases** stranded in the smoke-test repo every release cycle (e.g. `0.3.7-rc1`, `0.3.8-rc1` are currently orphaned). The cleanup step (added in #601) identified each RC draft correctly but deleted it with `gh release delete <tag>`, which resolves the release via the *get-release-by-tag* API — an endpoint that never returns drafts. So the delete failed (`WARN: failed to delete RC draft pre-release …`), yet the code fell through and deleted the git RC tag anyway. Since the loop was seeded from `git ls-remote --tags`, the now-tagless draft became undiscoverable and survived every subsequent run.

Root cause confirmed from the `0.3.8` promote run log in the smoke-test repo:

```
Deleting RC draft pre-release 0.3.8-rc1 (draft pre-release)
WARN: failed to delete RC draft pre-release 0.3.8-rc1
Deleting remote tag 0.3.8-rc1 (no GitHub Release)
```

## Type of Change

- [ ] `feat` -- New feature
- [x] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [ ] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

Rework the cleanup step in **both** promote-release workflows:

- **`.github/scripts/select-rc-draft-releases.sh`** (new) — enumerates RC draft pre-releases for a base version from a GitHub releases list, emitting `<id>\t<tag>` for each `draft && prerelease` whose tag is `X.Y.Z-rcN`. Bats-tested.
- **`.github/workflows/promote-release.yml`** — cleanup now: (1) seeds from the releases list, not git tags, so drafts whose RC tag was already removed by an earlier partial run are reclaimed; (2) deletes each RC draft by **release id** (works for drafts); (3) deletes a git RC tag only when no GitHub Release is still attached (preserves published pre-releases and keeps a failed-delete draft discoverable); (4) verifies no RC draft survives and fails loudly otherwise. Uses the new helper.
- **`assets/workspace/.github/workflows/promote-release.yml`** — same fix; since consumer repos don't ship `.github/scripts`, the template inlines the equivalent jq filter.
- **`tests/bats/select-rc-draft-releases.bats`** + **`tests/bats/fixtures/releases-list.json`** (new) — 8 cases covering selection, draft/prerelease/base filtering, malformed suffixes, and arg validation.
- **`CHANGELOG.md`** / synced **`assets/workspace/.devcontainer/CHANGELOG.md`** — Fixed entry.

## Changelog Entry

### Fixed

- **Stop promote-release cleanup from orphaning RC draft pre-releases** ([#623](https://github.com/vig-os/devcontainer/issues/623))
  - The cleanup step deleted RC draft pre-releases with `gh release delete <tag>`, which cannot resolve a draft, then deleted the git RC tag anyway — stranding the draft and making it undiscoverable on later runs (the loop was seeded from git tags)
  - Cleanup now enumerates RC draft pre-releases from the releases list, deletes them by release id, removes a git RC tag only when no release is attached, and fails loudly if any RC draft survives — also reclaiming drafts whose tag was already removed by an earlier partial run

## Testing

- [x] Tests pass locally (`just test`)
- [ ] Manual testing performed (describe below)

### Manual Testing Details

- New bats suite passes (8/8); full bats suite green except the pre-existing `worktree.bats` tmux integration test (unrelated; `skip`ped in CI).
- Simulated the new selection + tag-retention logic against `tests/bats/fixtures/releases-list.json`: RC drafts of the base are selected by id; published pre-releases and other base versions are retained; `HAS_RELEASE` correctly keeps tags that still have a release and deletes orphans.
- shellcheck + yamllint clean on the changed files.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

The two already-orphaned drafts (`0.3.7-rc1`, `0.3.8-rc1`) in `vig-os/devcontainer-smoke-test` are not removed by this PR; the next final promote will reclaim them now that cleanup seeds from the releases list, or they can be deleted manually.

Refs: #623
