### PR TITLE
build(image): remove cursor-agent install from the image

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -17,18 +17,6 @@
 Expiration: 2026-09-01
 CVE-2026-42504
 
-# CVE-2026-55388: piscina Prototype Pollution gadget -> RCE in cursor-agent CLI
-# Risk Assessment: LOW (devcontainer context)
-# - HIGH severity in piscina 4.9.0 bundled in the cursor-agent CLI
-#   (/root/.local/share/cursor-agent/.../node_modules/piscina); fixed upstream in piscina 4.9.3+
-# - cursor-agent is installed unpinned from cursor.com/install; we do not control its bundled
-#   deps and the fix can only arrive via a future cursor-agent build
-# - Gadget requires attacker-controlled piscina options (inherited options.filename); not an
-#   attacker-reachable surface in devcontainer/CI use
-# - Tracking: https://github.com/vig-os/devcontainer/issues/602, #512
-Expiration: 2026-09-01
-CVE-2026-55388
-
 # jwt-token: Trivy secret scan false positive
 # Risk Assessment: N/A (not a vulnerability)
 # - JWT-like string in typos crate test fixtures under /opt/pre-commit-cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,9 +27,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- **Remove the `cursor-agent` CLI install from the image** ([#628](https://github.com/vig-os/devcontainer/issues/628))
+  - Dropped the unpinned `curl … cursor.com/install` build step and its `/root/.local/bin` PATH entry, leaving an all-nixpkgs toolchain ahead of the Nix migration
+  - Removed the coupled `test_cursor_agent_installed` image test
+
 ### Fixed
 
 ### Security
+
+- **Drop the piscina CVE ignore tied to `cursor-agent`** ([#628](https://github.com/vig-os/devcontainer/issues/628))
+  - Removed the `CVE-2026-55388` (piscina) `.trivyignore` entry, which only existed for the now-removed `cursor-agent` CLI
 
 ## [0.3.9](https://github.com/vig-os/devcontainer/releases/tag/0.3.9) - 2026-06-23
 

--- a/Containerfile
+++ b/Containerfile
@@ -163,24 +163,6 @@ RUN set -eux; \
     rm -f "taplo-linux-${ARCH}"; \
     taplo --version;
 
-# Install cursor-agent CLI (installs to ~/.local/bin)
-ENV PATH="/root/.local/bin:${PATH}"
-RUN set -eux; \
-    INSTALLER="/tmp/cursor-install.sh"; \
-    for attempt in 1 2 3; do \
-        if curl -fsSL https://cursor.com/install -o "${INSTALLER}" \
-            && bash "${INSTALLER}" \
-            && agent --version; then \
-            rm -f "${INSTALLER}"; \
-            exit 0; \
-        fi; \
-        rm -f "${INSTALLER}"; \
-        echo "cursor-agent install attempt ${attempt} failed, retrying in 10s..."; \
-        sleep 10; \
-    done; \
-    echo "WARNING: cursor-agent install failed after 3 attempts (external CDN issue); skipping"; \
-    echo "Install manually: curl -fsSL https://cursor.com/install | bash";
-
 # Install latest cargo-binstall from release archive with minisign signature verification
 # cargo-binstall uses minisign for signing releases. Each release has an ephemeral key.
 ENV PATH="/root/.cargo/bin:${PATH}"

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -27,9 +27,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- **Remove the `cursor-agent` CLI install from the image** ([#628](https://github.com/vig-os/devcontainer/issues/628))
+  - Dropped the unpinned `curl … cursor.com/install` build step and its `/root/.local/bin` PATH entry, leaving an all-nixpkgs toolchain ahead of the Nix migration
+  - Removed the coupled `test_cursor_agent_installed` image test
+
 ### Fixed
 
 ### Security
+
+- **Drop the piscina CVE ignore tied to `cursor-agent`** ([#628](https://github.com/vig-os/devcontainer/issues/628))
+  - Removed the `CVE-2026-55388` (piscina) `.trivyignore` entry, which only existed for the now-removed `cursor-agent` CLI
 
 ## [0.3.9](https://github.com/vig-os/devcontainer/releases/tag/0.3.9) - 2026-06-23
 

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -203,12 +203,6 @@ class TestSystemTools:
             f"Expected taplo {expected}, got: {result.stdout}"
         )
 
-    def test_cursor_agent_installed(self, host):
-        """Test that cursor-agent CLI (agent) is installed."""
-        result = host.run("agent --version")
-        if result.rc != 0:
-            pytest.skip("cursor-agent not available (external CDN issue)")
-
     def test_cargo_binstall(self, host):
         """Test that cargo-binstall is installed and right version."""
         result = host.run("cargo-binstall -V")


### PR DESCRIPTION
Removes the unpinned `cursor-agent` CLI install from the devcontainer image and the CVE ignore tied to it.

- Delete the cursor-agent install block from `Containerfile` and `build/Containerfile` (+ dead PATH note)
- Drop `CVE-2026-55388` (piscina, bundled in cursor-agent) from `.trivyignore`
- Remove the now-invalid `test_cursor_agent_installed` image test (atomically coupled to the install removal; pre-empts that one bullet of C5 #630)
- Changelog entry

Verification deferred to CI (image suite): build + image tests + Trivy security scan. Local build was not completed in-worktree.

Refs: #628