### PR TITLE
feat(nix): de-duplicate the flake into the toolchain SSoT

### DIFF
--- a/.github/workflows/nix-cachix.yml
+++ b/.github/workflows/nix-cachix.yml
@@ -1,0 +1,67 @@
+# Nix dev-shell cache warming (Cachix)
+#
+# Builds the flake dev-shell and pushes its closure to the `vig-os` Cachix
+# binary cache so later tracks (#633, T2.x) and contributors get a warm cache.
+#
+# This workflow is intentionally NON-BLOCKING: it is a standalone workflow that
+# is not part of the required CI gate, and the build/push step is guarded with
+# `continue-on-error: true`. It can never fail the existing CI.
+#
+# Evaluator choice: upstream CppNix via cachix/install-nix-action. The flake is
+# installer-agnostic — swapping to the Lix or Determinate installer needs no
+# flake changes.
+#
+# Triggers:
+#   - Push to the migration epic / main branches (warm the cache on merge)
+#   - workflow_dispatch (manually warm from any branch, incl. feature branches)
+
+name: Nix Cachix
+
+on:  # yamllint disable-line rule:truthy
+  push:
+    branches:
+      - main
+      - dev
+      - 'feature/625-nix-claude-migration'
+    paths:
+      - 'flake.nix'
+      - 'flake.lock'
+      - '.github/workflows/nix-cachix.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  push-devshell:
+    name: Build & push dev-shell to Cachix
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    # Non-blocking: this job is not a required check and never fails CI.
+    continue-on-error: true
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+
+      - name: Install Nix (upstream CppNix)
+        uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3  # v31.10.6
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+            accept-flake-config = true
+
+      - name: Configure Cachix
+        uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71  # v17
+        with:
+          name: ${{ vars.CACHIX_CACHE }}
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
+      - name: Build dev-shell and push closure to Cachix
+        run: |
+          set -euo pipefail
+          # Build the dev-shell derivation and its full closure.
+          nix develop --profile dev-profile --command true
+          # Push the dev-shell closure (and its build-time deps) to the cache.
+          nix path-info --recursive ./dev-profile \
+            | cachix push "${{ vars.CACHIX_CACHE }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **De-duplicate the flake into the toolchain SSoT** ([#631](https://github.com/vig-os/devcontainer/issues/631))
+  - Factored a single `devTools` list in `flake.nix` as the source of truth shared by the dev-shell now and the image later, absorbing the agent-CLI toolkit (`rg`, `fd`, `bat`, `eza`, `delta`, `lazygit`, `zoxide`, `starship`, `freeze`, `expect`, `nvim`) plus `claude` ([#545](https://github.com/vig-os/devcontainer/issues/545))
+  - Pinned `nixpkgs` to `nixos-25.05` and added a `nixpkgs-unstable` input overlaid only for fast-movers (`uv`, `gh`, `claude-code`); refreshed `flake.lock`
+  - Added reusable flake outputs `lib.mkProjectShell`, `overlays.default`, and a `packages.devcontainerImage` stub for the later image build
+  - Added a non-blocking `Nix Cachix` workflow (with `workflow_dispatch`) that builds the dev-shell and pushes its closure to the `vig-os` Cachix cache
+  - Added a per-tool `nix develop -c <tool> --version` parity test driven from the flake SSoT to guard against future dev-shell/image drift
+
 ### Changed
 
 - **Make `.claude/` the single source of truth for agent rules and skills** ([#626](https://github.com/vig-os/devcontainer/issues/626))

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# Project: eXoma Devcontainer
+# Project: vigOS Devcontainer
 
 ## Custom Commands
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **De-duplicate the flake into the toolchain SSoT** ([#631](https://github.com/vig-os/devcontainer/issues/631))
+  - Factored a single `devTools` list in `flake.nix` as the source of truth shared by the dev-shell now and the image later, absorbing the agent-CLI toolkit (`rg`, `fd`, `bat`, `eza`, `delta`, `lazygit`, `zoxide`, `starship`, `freeze`, `expect`, `nvim`) plus `claude` ([#545](https://github.com/vig-os/devcontainer/issues/545))
+  - Pinned `nixpkgs` to `nixos-25.05` and added a `nixpkgs-unstable` input overlaid only for fast-movers (`uv`, `gh`, `claude-code`); refreshed `flake.lock`
+  - Added reusable flake outputs `lib.mkProjectShell`, `overlays.default`, and a `packages.devcontainerImage` stub for the later image build
+  - Added a non-blocking `Nix Cachix` workflow (with `workflow_dispatch`) that builds the dev-shell and pushes its closure to the `vig-os` Cachix cache
+  - Added a per-tool `nix develop -c <tool> --version` parity test driven from the flake SSoT to guard against future dev-shell/image drift
+
 ### Changed
 
 - **Make `.claude/` the single source of truth for agent rules and skills** ([#626](https://github.com/vig-os/devcontainer/issues/626))

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,27 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1772736753,
-        "narHash": "sha256-au/m3+EuBLoSzWUCb64a/MZq6QUtOV8oC0D9tY2scPQ=",
+        "lastModified": 1767313136,
+        "narHash": "sha256-16KkgfdYqjaeRGBaYsNrhPRRENs0qzkQVUooNHtoy2w=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "917fec990948658ef1ccd07cef2a1ef060786846",
+        "rev": "ac62194c3917d5f474c1a844b6fd6da2db95077d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-25.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1781607440,
+        "narHash": "sha256-rxO+uc/KFbSJp+pgyXRuAX6QlG9hJdnt0BXpEQRXY+U=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "3e41b24abd260e8f71dbe2f5737d24122f972158",
         "type": "github"
       },
       "original": {
@@ -37,7 +53,8 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-unstable": "nixpkgs-unstable"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,49 +1,169 @@
 {
-  description = "eXoma devcontainer – host development environment";
+  description = "eXoma devcontainer – toolchain SSoT (dev-shell + image basis)";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    # Pinned stable channel: the controlled version document (flake.lock).
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
+    # Secondary channel, overlaid only for fast-moving tools (uv, gh, claude).
+    nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     flake-utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = { self, nixpkgs, flake-utils }:
-    flake-utils.lib.eachDefaultSystem (system:
+  outputs =
+    {
+      self,
+      nixpkgs,
+      nixpkgs-unstable,
+      flake-utils,
+    }:
+    let
+      # ---------------------------------------------------------------------
+      # Overlay: pull fast-movers from nixpkgs-unstable.
+      #
+      # The stable channel (nixos-25.05) lags on tools that ship frequently and
+      # whose latest version we want in both the dev-shell and the image. We
+      # overlay only those few packages from unstable; everything else stays on
+      # the pinned stable channel for reproducibility.
+      # ---------------------------------------------------------------------
+      fastMovers = [
+        "uv"
+        "gh"
+        # claude (claude-code) is an agent CLI that moves very fast; track unstable.
+        "claude-code"
+      ];
+
+      overlay =
+        final: prev:
+        let
+          unstable = import nixpkgs-unstable {
+            inherit (final) system;
+            config.allowUnfree = true;
+          };
+        in
+        builtins.listToAttrs (
+          map (name: {
+            inherit name;
+            value = unstable.${name};
+          }) fastMovers
+        );
+
+      # ---------------------------------------------------------------------
+      # devTools — the single source of truth for the toolchain.
+      #
+      # This list is the shared basis for the dev-shell now and the image later
+      # (#634). Adding a tool here adds it everywhere; the per-tool parity test
+      # (tests/test_flake_devshell.py) reads `devShellTools` so it can never
+      # drift from this list.
+      # ---------------------------------------------------------------------
+      devTools =
+        pkgs:
+        with pkgs;
+        [
+          # Build automation
+          just
+
+          # Version control & GitHub (gh from unstable via overlay)
+          git
+          gh
+          lazygit
+          delta
+
+          # Python tooling (uv from unstable via overlay)
+          uv
+
+          # Node.js (bats, devcontainer CLI via npm)
+          nodejs
+
+          # Shell & JSON utilities
+          jq
+          tmux
+          shellcheck
+
+          # Linting
+          hadolint
+          taplo
+
+          # Container runtime
+          podman
+
+          # Agent / terminal toolkit (absorbed from #545)
+          ripgrep # rg
+          fd
+          bat
+          eza
+          zoxide
+          starship
+          charm-freeze # freeze (charmbracelet terminal screenshots)
+          expect
+          neovim # nvim
+          claude-code # claude
+        ];
+
+      # Binary names exposed for the parity test. Prefer the package's declared
+      # `meta.mainProgram` (the canonical executable name, e.g. ripgrep -> rg,
+      # neovim -> nvim, claude-code -> claude); fall back to the pname.
+      devShellToolNames =
+        pkgs:
+        map (
+          drv: drv.meta.mainProgram or drv.pname or (builtins.parseDrvName drv.name).name
+        ) (devTools pkgs);
+
+      # ---------------------------------------------------------------------
+      # mkProjectShell — reusable dev-shell builder for downstream repos.
+      #
+      # Consumers can build a shell with the shared toolchain plus their own
+      # extra packages:
+      #   devShells.default = inputs.devcontainer.lib.mkProjectShell {
+      #     inherit pkgs;
+      #     extraPackages = [ pkgs.foo ];
+      #   };
+      # ---------------------------------------------------------------------
+      mkProjectShell =
+        {
+          pkgs,
+          extraPackages ? [ ],
+          shellHook ? ''echo "devcontainer dev environment loaded (nix)"'',
+        }:
+        pkgs.mkShell {
+          packages = (devTools pkgs) ++ extraPackages;
+          inherit shellHook;
+        };
+    in
+    flake-utils.lib.eachDefaultSystem (
+      system:
       let
-        pkgs = nixpkgs.legacyPackages.${system};
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [ overlay ];
+          config.allowUnfree = true;
+        };
       in
       {
-        devShells.default = pkgs.mkShell {
-          packages = with pkgs; [
-            # Build automation
-            just
+        devShells.default = mkProjectShell { inherit pkgs; };
 
-            # Version control & GitHub
-            git
-            gh
+        # Binary names of every tool in devTools — read by the parity test.
+        devShellTools = devShellToolNames pkgs;
 
-            # Python tooling
-            uv
+        packages = {
+          # Stub for the Nix-built devcontainer image. The real image is built
+          # in T2.1 (#634); this placeholder keeps the output present and
+          # buildable so downstream wiring (#632) can reference it early.
+          devcontainerImage = pkgs.runCommand "devcontainer-image-stub" { } ''
+            mkdir -p "$out"
+            cat > "$out/README" <<'EOF'
+            devcontainerImage is a placeholder stub.
 
-            # Node.js (bats, devcontainer CLI via npm)
-            nodejs
-
-            # Shell & JSON utilities
-            jq
-            tmux
-            shellcheck
-
-            # Linting
-            hadolint
-            taplo
-
-            # Container runtime
-            podman
-          ];
-
-          shellHook = ''
-            echo "devcontainer dev environment loaded (nix)"
+            The real Nix-built devcontainer image is delivered in T2.1 (#634).
+            The toolchain it will bake is the `devTools` list in flake.nix
+            (this repo's SSoT), shared with the dev-shell.
+            EOF
           '';
         };
       }
-    );
+    )
+    // {
+      # System-independent reusable outputs.
+      lib = { inherit mkProjectShell devTools; };
+      overlays.default = overlay;
+    };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "eXoma devcontainer – toolchain SSoT (dev-shell + image basis)";
+  description = "vigOS devcontainer – toolchain SSoT (dev-shell + image basis)";
 
   inputs = {
     # Pinned stable channel: the controlled version document (flake.lock).

--- a/tests/test_flake_devshell.py
+++ b/tests/test_flake_devshell.py
@@ -33,6 +33,8 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 VERSION_FLAG_OVERRIDES: dict[str, list[str]] = {
     # expect is a Tcl interpreter; it has no --version. `-v` prints the version.
     "expect": ["-v"],
+    # tmux uses -V (uppercase) to print its version.
+    "tmux": ["-V"],
 }
 
 pytestmark = pytest.mark.skipif(
@@ -55,10 +57,25 @@ def _nix_env() -> dict[str, str]:
 
 
 @pytest.fixture(scope="session")
-def dev_shell_tools() -> list[str]:
+def current_system() -> str:
+    """The Nix system double for the host (e.g. x86_64-linux)."""
+    result = subprocess.run(
+        ["nix", "eval", "--raw", "--impure", "--expr", "builtins.currentSystem"],
+        capture_output=True,
+        text=True,
+        env=_nix_env(),
+        timeout=120,
+    )
+    if result.returncode != 0:
+        pytest.fail("Failed to resolve builtins.currentSystem:\n" + result.stderr)
+    return result.stdout.strip()
+
+
+@pytest.fixture(scope="session")
+def dev_shell_tools(current_system: str) -> list[str]:
     """Binary names of every tool in the flake's ``devTools`` SSoT."""
     result = subprocess.run(
-        ["nix", "eval", "--json", f"{REPO_ROOT}#devShellTools"],
+        ["nix", "eval", "--json", f"{REPO_ROOT}#devShellTools.{current_system}"],
         capture_output=True,
         text=True,
         env=_nix_env(),

--- a/tests/test_flake_devshell.py
+++ b/tests/test_flake_devshell.py
@@ -1,0 +1,114 @@
+"""Dev-shell / image toolchain parity tests for the Nix flake.
+
+These tests are the TDD anchor for the toolchain SSoT (issue #631). The flake
+exposes a single ``devTools`` list; this module reads the per-tool *binary
+names* straight from the flake (``nix eval .#devShellTools``) so the test can
+never drift from the list it is meant to guard.
+
+For every tool in that SSoT it runs ``nix develop -c <bin> <version-flag>`` and
+asserts the command exits 0 inside the dev-shell. This guards against
+dev-shell / image drift (the ``EXPECTED_VERSIONS`` problem #27 calls out).
+
+The suite is skipped automatically when ``nix`` is not on PATH (e.g. inside the
+podman image CI lane) so it never breaks unrelated jobs.
+
+Refs: #631
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+# Repository root (two levels up: tests/ -> repo root).
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Tools whose executable name differs from a plain `<tool> --version` call.
+# Default version flag is `--version`; override here when a tool differs.
+VERSION_FLAG_OVERRIDES: dict[str, list[str]] = {
+    # expect is a Tcl interpreter; it has no --version. `-v` prints the version.
+    "expect": ["-v"],
+}
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("nix") is None,
+    reason="nix is not installed; dev-shell parity tests require Nix",
+)
+
+
+def _nix_env() -> dict[str, str]:
+    """Environment for nix invocations with flakes enabled and the public cache."""
+    env = os.environ.copy()
+    env.setdefault(
+        "NIX_CONFIG",
+        "experimental-features = nix-command flakes\n"
+        "extra-substituters = https://vig-os.cachix.org\n"
+        "extra-trusted-public-keys = "
+        "vig-os.cachix.org-1:yoOYRi3bvnM6ThxO0joLt7vtzhTfkq3r6jykeUMg7Bk=",
+    )
+    return env
+
+
+@pytest.fixture(scope="session")
+def dev_shell_tools() -> list[str]:
+    """Binary names of every tool in the flake's ``devTools`` SSoT."""
+    result = subprocess.run(
+        ["nix", "eval", "--json", f"{REPO_ROOT}#devShellTools"],
+        capture_output=True,
+        text=True,
+        env=_nix_env(),
+        timeout=900,
+    )
+    if result.returncode != 0:
+        pytest.fail("Failed to read devShellTools from the flake:\n" + result.stderr)
+    tools = json.loads(result.stdout)
+    assert isinstance(tools, list) and tools, "devShellTools must be a non-empty list"
+    return tools
+
+
+def test_devshell_tools_is_superset_of_agent_toolkit(
+    dev_shell_tools: list[str],
+) -> None:
+    """The SSoT must absorb issue #545's agent-CLI toolkit plus claude."""
+    required = {
+        "rg",
+        "fd",
+        "bat",
+        "eza",
+        "delta",
+        "lazygit",
+        "zoxide",
+        "starship",
+        "freeze",
+        "expect",
+        "nvim",
+        "claude",
+    }
+    missing = required - set(dev_shell_tools)
+    assert not missing, f"devTools is missing agent-toolkit tools: {sorted(missing)}"
+
+
+def test_each_tool_runs_in_devshell(dev_shell_tools: list[str]) -> None:
+    """Every tool in ``devTools`` is runnable inside ``nix develop``."""
+    failures: list[str] = []
+    for tool in dev_shell_tools:
+        flag = VERSION_FLAG_OVERRIDES.get(tool, ["--version"])
+        cmd = ["nix", "develop", str(REPO_ROOT), "-c", tool, *flag]
+        proc = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            env=_nix_env(),
+            timeout=900,
+        )
+        if proc.returncode != 0:
+            failures.append(
+                f"{tool} ({' '.join(flag)}) exited {proc.returncode}: "
+                f"{proc.stderr.strip()[:200]}"
+            )
+    assert not failures, "Tools failed inside nix develop:\n" + "\n".join(failures)


### PR DESCRIPTION
## Summary

Implements **T1.1 (#631)** — collapses the flake dev-shell and the (future) image tool list into a single `devTools` source of truth and lays the reusable flake outputs the rest of the Nix track depends on.

### What changed
- **Single `devTools` SSoT** in `flake.nix` — shared basis for the dev-shell now and the image later (#634). Absorbs the #545 agent-CLI toolkit (`rg`, `fd`, `bat`, `eza`, `delta`, `lazygit`, `zoxide`, `starship`, `freeze`, `expect`, `nvim`) plus `claude`, on top of the existing toolchain (`just`, `git`, `gh`, `uv`, `nodejs`, `jq`, `tmux`, `shellcheck`, `hadolint`, `taplo`, `podman`).
- **Channel switch** — `nixpkgs` pinned to `nixos-25.05`; new `nixpkgs-unstable` input overlaid **only** for fast-movers `uv`, `gh`, `claude-code`. `flake.lock` refreshed.
- **Reusable outputs** — `lib.mkProjectShell` (downstream repos build the shared shell + extra packages), `overlays.default` (the fast-mover overlay), and a `packages.devcontainerImage` **stub** (placeholder; real image is T2.1/#634).
- **Cachix CI** — new non-blocking `nix-cachix.yml` workflow that builds the dev-shell and pushes its closure to the `vig-os` cache.
- **TDD parity test** — `tests/test_flake_devshell.py` reads the binary names straight from the flake (`nix eval .#devShellTools.<system>`) and runs `nix develop -c <tool> <version-flag>` for each, so it can never drift from `devTools`.

### How `claude` is provided
`claude` is the **`claude-code`** package from nixpkgs (binary `claude`, via `meta.mainProgram`). It is a fast-mover, so it is sourced from `nixpkgs-unstable` through `overlays.default` (unstable `2.1.x` vs stable `1.0.85`). No custom fetch/overlay-from-scratch needed — it is packaged cleanly in nixpkgs.

> Note: nixpkgs `freeze` is an EDR-bypass payload toolkit (optiv/Freeze), **not** the charmbracelet terminal-screenshot tool #545 intended. Used **`charm-freeze`** (binary `freeze`) instead.

### Evaluator choice + rationale
**Upstream CppNix** via `cachix/install-nix-action` (SHA-pinned `v31.10.6`). It is the most broadly supported installer, pairs natively with `cachix/cachix-action`, and needs no extra infra. The flake is **installer-agnostic** — swapping to the Lix `lix-installer` or the Determinate installer requires **zero flake changes**, so this decision is cheaply reversible.

### Cachix wiring
- `cachix/install-nix-action@…v31.10.6` (flakes enabled) → `cachix/cachix-action@…v17` with `name: ${{ vars.CACHIX_CACHE }}` and `authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}` (token never printed/hardcoded).
- Builds `nix develop --profile dev-profile` and pushes `nix path-info -r ./dev-profile | cachix push`.
- **Non-blocking:** standalone workflow (not a required check) + `continue-on-error: true` → existing CI is unaffected.
- Adds **`workflow_dispatch`** plus a push trigger on the epic branch for on-branch validation.
- Actions are SHA-pinned per `check-action-pins` policy.

### Verification (local, against the public `vig-os` cache)
- `nix flake check` → **all checks passed** (`devShellTools` shows only a benign "unknown flake output" warning).
- `tests/test_flake_devshell.py` → **2 passed** — every one of the 23 tools runs inside `nix develop` (incl. `claude --version`, `nvim --version`, `rg --version`, `freeze --version`, `tmux -V`, `expect -v`).
- `just precommit` → **all hooks pass** (incl. `check-action-pins`, agent-identity, yamllint).

### TDD trail
- `test(nix):` failing parity test committed first (RED).
- `feat(nix):` flake SSoT + outputs making it pass (GREEN).
- `ci(nix):` non-blocking Cachix workflow.

Refs: #631
