### PR TITLE
feat(nix): nix-direnv onboarding fast path

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,17 @@
+# nix-direnv: GC-rooted, cached flake evaluation so re-entry is instant and the
+# dev-shell closure is not garbage-collected. Falls back to bare `use flake`
+# when the nix-direnv library is unavailable.
+#
+# Prefer a user-installed nix-direnv (sourced from ~/.config/direnv/direnvrc);
+# otherwise self-bootstrap the pinned library into .direnv/ on first allow.
+if ! has use_flake 2>/dev/null && ! declare -f use_flake >/dev/null 2>&1; then
+  nix_direnv_version="3.0.6"
+  nix_direnv_sha="sha256-RYcUJaRMf8oF5LznDrlCXbkOQrywm0HDv1VjYGaJGdM="
+  if ! source_url \
+    "https://raw.githubusercontent.com/nix-community/nix-direnv/${nix_direnv_version}/direnvrc" \
+    "${nix_direnv_sha}" 2>/dev/null; then
+    echo "direnv: nix-direnv unavailable; falling back to bare 'use flake'." >&2
+  fi
+fi
+
 use flake

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added reusable flake outputs `lib.mkProjectShell`, `overlays.default`, and a `packages.devcontainerImage` stub for the later image build
   - Added a non-blocking `Nix Cachix` workflow (with `workflow_dispatch`) that builds the dev-shell and pushes its closure to the `vig-os` Cachix cache
   - Added a per-tool `nix develop -c <tool> --version` parity test driven from the flake SSoT to guard against future dev-shell/image drift
+- **nix-direnv onboarding fast path** ([#633](https://github.com/vig-os/devcontainer/issues/633))
+  - Switched `.envrc` from bare `use flake` to nix-direnv: the dev-shell evaluation is now GC-rooted and cached under `.direnv/`, so re-entering the directory is instant and the closure is never garbage-collected; nix-direnv self-bootstraps on first `direnv allow` and falls back to bare `use flake` when unavailable
+  - Documented the clone → `direnv allow` onboarding flow, the `vig-os` Cachix substituter (binary fetch instead of from-source build on first allow), and enabling the `nix-command`/`flakes` experimental features in `CONTRIBUTE.md` ([#255](https://github.com/vig-os/devcontainer/issues/255))
 
 ### Changed
 

--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -86,6 +86,51 @@ brew install podman just git openssh gh jq tmux node hadolint taplo parallel
 - Run `./scripts/init.sh` to check dependencies and get OS-specific installation commands.
 - Ensure Docker is installed if you plan to use it instead of Podman.
 
+## Nix dev shell (fast path)
+
+The repository ships a Nix flake (`flake.nix`) whose `devTools` list is the single
+source of truth for the toolchain. With [Nix](https://nixos.org/download) and
+[direnv](https://direnv.net/) installed you get the full dev environment on
+`cd` into the clone — no manual dependency install. On a warm
+[Cachix](https://www.cachix.org/) cache this is a binary fetch, not a from-source
+build, so the first `direnv allow` completes in seconds.
+
+1. **Enable the flakes experimental features.** Add to `~/.config/nix/nix.conf`
+   (or `/etc/nix/nix.conf`):
+
+   ```conf
+   experimental-features = nix-command flakes
+   ```
+
+2. **Add the `vig-os` Cachix substituter** so the dev-shell closure is fetched
+   from the binary cache instead of built locally. Add to the same `nix.conf`:
+
+   ```conf
+   substituters = https://cache.nixos.org https://vig-os.cachix.org
+   trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= vig-os.cachix.org-1:yoOYRi3bvnM6ThxO0joLt7vtzhTfkq3r6jykeUMg7Bk=
+   ```
+
+   Pulling from the public `vig-os` cache needs no token. (If you have the Cachix
+   CLI: `cachix use vig-os` writes the same lines for you.)
+
+3. **Clone and allow direnv:**
+
+   ```bash
+   git clone git@github.com:vig-os/devcontainer.git
+   cd devcontainer
+   direnv allow        # first allow fetches the closure from Cachix (seconds on a warm cache)
+   ```
+
+   The committed `.envrc` uses
+   [nix-direnv](https://github.com/nix-community/nix-direnv): the dev-shell
+   evaluation is cached and GC-rooted (under `.direnv/`, which is gitignored), so
+   re-entering the directory is instant and the closure is never garbage-collected.
+   nix-direnv is self-bootstrapped by `.envrc` on first allow; if you already
+   source it from `~/.config/direnv/direnvrc`, that installation is used instead.
+
+This Nix dev shell is an alternative to the devcontainer image below; use whichever
+fits your workflow.
+
 ## Setup
 
 Clone this repository and prepare it for container development:

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added reusable flake outputs `lib.mkProjectShell`, `overlays.default`, and a `packages.devcontainerImage` stub for the later image build
   - Added a non-blocking `Nix Cachix` workflow (with `workflow_dispatch`) that builds the dev-shell and pushes its closure to the `vig-os` Cachix cache
   - Added a per-tool `nix develop -c <tool> --version` parity test driven from the flake SSoT to guard against future dev-shell/image drift
+- **nix-direnv onboarding fast path** ([#633](https://github.com/vig-os/devcontainer/issues/633))
+  - Switched `.envrc` from bare `use flake` to nix-direnv: the dev-shell evaluation is now GC-rooted and cached under `.direnv/`, so re-entering the directory is instant and the closure is never garbage-collected; nix-direnv self-bootstraps on first `direnv allow` and falls back to bare `use flake` when unavailable
+  - Documented the clone → `direnv allow` onboarding flow, the `vig-os` Cachix substituter (binary fetch instead of from-source build on first allow), and enabling the `nix-command`/`flakes` experimental features in `CONTRIBUTE.md` ([#255](https://github.com/vig-os/devcontainer/issues/255))
 
 ### Changed
 

--- a/docs/templates/CONTRIBUTE.md.j2
+++ b/docs/templates/CONTRIBUTE.md.j2
@@ -28,6 +28,51 @@ This guide explains how to develop, build, test, and release the vigOS developme
 - Run `./scripts/init.sh` to check dependencies and get OS-specific installation commands.
 - Ensure Docker is installed if you plan to use it instead of Podman.
 
+## Nix dev shell (fast path)
+
+The repository ships a Nix flake (`flake.nix`) whose `devTools` list is the single
+source of truth for the toolchain. With [Nix](https://nixos.org/download) and
+[direnv](https://direnv.net/) installed you get the full dev environment on
+`cd` into the clone — no manual dependency install. On a warm
+[Cachix](https://www.cachix.org/) cache this is a binary fetch, not a from-source
+build, so the first `direnv allow` completes in seconds.
+
+1. **Enable the flakes experimental features.** Add to `~/.config/nix/nix.conf`
+   (or `/etc/nix/nix.conf`):
+
+   ```conf
+   experimental-features = nix-command flakes
+   ```
+
+2. **Add the `vig-os` Cachix substituter** so the dev-shell closure is fetched
+   from the binary cache instead of built locally. Add to the same `nix.conf`:
+
+   ```conf
+   substituters = https://cache.nixos.org https://vig-os.cachix.org
+   trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= vig-os.cachix.org-1:yoOYRi3bvnM6ThxO0joLt7vtzhTfkq3r6jykeUMg7Bk=
+   ```
+
+   Pulling from the public `vig-os` cache needs no token. (If you have the Cachix
+   CLI: `cachix use vig-os` writes the same lines for you.)
+
+3. **Clone and allow direnv:**
+
+   ```bash
+   git clone git@github.com:vig-os/devcontainer.git
+   cd devcontainer
+   direnv allow        # first allow fetches the closure from Cachix (seconds on a warm cache)
+   ```
+
+   The committed `.envrc` uses
+   [nix-direnv](https://github.com/nix-community/nix-direnv): the dev-shell
+   evaluation is cached and GC-rooted (under `.direnv/`, which is gitignored), so
+   re-entering the directory is instant and the closure is never garbage-collected.
+   nix-direnv is self-bootstrapped by `.envrc` on first allow; if you already
+   source it from `~/.config/direnv/direnvrc`, that installation is used instead.
+
+This Nix dev shell is an alternative to the devcontainer image below; use whichever
+fits your workflow.
+
 ## Setup
 
 Clone this repository and prepare it for container development:


### PR DESCRIPTION
## Summary

Implements T1.3 (#633): switch the non-container onboarding fast path to **nix-direnv**.

- **`.envrc`** — replaced bare `use flake` with nix-direnv. The dev-shell evaluation is now GC-rooted and cached under `.direnv/` (already gitignored), so re-entering the directory is instant and the closure is never garbage-collected. `.envrc` self-bootstraps the pinned nix-direnv `3.0.6` library (SRI-verified) on first `direnv allow`, uses a user-installed copy from `~/.config/direnv/direnvrc` when present, and falls back to bare `use flake` if neither is available.
- **`docs/templates/CONTRIBUTE.md.j2`** — new "Nix dev shell (fast path)" onboarding section documenting clone → `direnv allow`, the `vig-os` Cachix substituter (so the first allow is a binary fetch, not a from-source build), and enabling the `nix-command`/`flakes` experimental features. Regenerated `CONTRIBUTE.md` with `just docs`. This folds in #255.
- **`CHANGELOG.md`** — `## Unreleased` → Added entry.

Edits are localized to the onboarding/direnv section to keep a trivial merge with T3.2 (#638), which also touches `CONTRIBUTE.md`.

## Verification

- `just precommit` — green (all hooks pass).
- `just docs` — clean / idempotent (no diff on re-run).
- nix-direnv validated on host (direnv 2.32.1, nix 2.34.7): `direnv allow` loads the flake dev shell and creates the GC root `.direnv/flake-profile -> /nix/store/...-nix-shell-env`, confirming nix-direnv (not bare `use flake`) is active. Host `nix.conf` already carries the `vig-os` Cachix substituter, so the closure is fetched from the public cache rather than built from source.

## Acceptance criteria

A clean clone + `direnv allow` on a warm Cachix cache yields a working shell in seconds (documented in CONTRIBUTE.md; the substituter avoids a from-source build on first allow). Verified the GC-rooting mechanism works locally.

Refs: #633 (folds in #255)