### PR TITLE
ci(nix): provision CI tooling via the flake dev-shell

### DIFF
--- a/.github/actions/build-image/action.yml
+++ b/.github/actions/build-image/action.yml
@@ -88,6 +88,14 @@ inputs:
     description: 'Docker Hub access token for authenticated pulls (optional; omit on forks)'
     required: false
     default: ''
+  cachix-cache:
+    description: 'Cachix binary cache name (passed to flake provisioning)'
+    required: false
+    default: ''
+  cachix-auth-token:
+    description: 'Cachix auth token (optional; pulls need no token)'
+    required: false
+    default: ''
 
 outputs:
   image-tag:
@@ -115,6 +123,11 @@ runs:
       uses: ./.github/actions/setup-env
       with:
         sync-dependencies: 'true'
+        # Provision the toolchain from the flake (SSoT). The Debian image build
+        # itself (buildx + Containerfile) is unchanged. Refs #632.
+        provision-via-flake: 'true'
+        cachix-cache: ${{ inputs.cachix-cache }}
+        cachix-auth-token: ${{ inputs.cachix-auth-token }}
 
     - name: Prepare build directory
       shell: bash

--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -7,6 +7,14 @@
 # - hadolint (for Containerfile linting in pre-commit)
 # - BATS + helper libraries (for shell script testing)
 #
+# Flake provisioning (provision-via-flake, Refs #632):
+# - When 'true', the toolchain comes from the Nix flake (the SSoT) via
+#   `nix develop` instead of the ad-hoc installs below: Nix + Cachix are
+#   installed, the dev-shell is built (a warm vig-os Cachix pull), and its
+#   tool bin dirs are prepended to PATH. Python/uv, just, hadolint, and taplo
+#   ad-hoc steps are skipped; podman, Node.js, BATS, and the devcontainer CLI
+#   keep their dedicated steps (not flake-provided or host-integration tools).
+#
 # IMPORTANT:
 # - This action does NOT checkout code, allowing callers to control ref, token,
 #   persist-credentials, and other checkout options.
@@ -100,6 +108,27 @@ inputs:
     description: 'Install BATS and helper libraries (support, assert, file) for shell testing'
     required: false
     default: 'false'
+  provision-via-flake:
+    description: >-
+      Provision the toolchain from the Nix flake (the toolchain SSoT) instead of
+      ad-hoc installs. When 'true', installs Nix + Cachix, builds the flake
+      dev-shell, and prepends its tools to PATH so every subsequent step runs as
+      if inside `nix develop`. Tools provided by the flake (Python/uv, just,
+      hadolint, taplo, Node.js) skip their ad-hoc install steps. podman is kept
+      on the apt path even under flake provisioning because rootless podman on
+      GitHub runners needs the host's setuid newuidmap/newgidmap and container
+      config; BATS and the devcontainer CLI are not in the flake and keep their
+      dedicated steps. Refs #632.
+    required: false
+    default: 'false'
+  cachix-cache:
+    description: 'Cachix binary cache name (used when provision-via-flake is true)'
+    required: false
+    default: ''
+  cachix-auth-token:
+    description: 'Cachix auth token for pushing (optional; pulls need no token)'
+    required: false
+    default: ''
 
 outputs:
   uv-version:
@@ -109,22 +138,68 @@ outputs:
 runs:
   using: composite
   steps:
+    # ── Nix flake provisioning (toolchain SSoT) ─────────────────────────
+    # When provision-via-flake is true, install Nix + Cachix and build the
+    # flake dev-shell, then prepend its tool bin dirs to GITHUB_PATH so every
+    # subsequent step runs as if inside `nix develop`. The ad-hoc tool installs
+    # below (Python/uv, just, hadolint, taplo, Node.js) are gated off in this
+    # mode. The Nix installer is SHA-pinned to match nix-cachix.yml and the
+    # vig-os Cachix substituter makes the dev-shell a fast binary-cache pull.
+    # Refs #632.
+    - name: Install Nix (upstream CppNix)
+      if: inputs.provision-via-flake == 'true'
+      uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3  # v31.10.6
+      with:
+        extra_nix_config: |
+          experimental-features = nix-command flakes
+          accept-flake-config = true
+
+    - name: Configure Cachix
+      if: inputs.provision-via-flake == 'true' && inputs.cachix-cache != ''
+      uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71  # v17
+      with:
+        name: ${{ inputs.cachix-cache }}
+        authToken: ${{ inputs.cachix-auth-token }}
+
+    - name: Build flake dev-shell and enter it
+      if: inputs.provision-via-flake == 'true'
+      shell: bash
+      run: |
+        set -euo pipefail
+        # Build the dev-shell into a gcroot profile (warm Cachix pull).
+        nix develop --profile "$RUNNER_TEMP/dev-profile" --command true
+
+        # Capture the dev-shell PATH and prepend its nix-store bin dirs to
+        # GITHUB_PATH so all following steps resolve the flake's tools first.
+        SHELL_PATH="$(nix develop --profile "$RUNNER_TEMP/dev-profile" \
+          --command bash -c 'printf "%s" "$PATH"')"
+
+        printf '%s' "$SHELL_PATH" | tr ':' '\n' \
+          | grep '^/nix/store' >> "$GITHUB_PATH"
+
+        echo "Flake dev-shell provisioned; tools added to PATH:"
+        printf '%s' "$SHELL_PATH" | tr ':' '\n' | grep '^/nix/store' | head -50
+
     # ── Python ───────────────────────────────────────────────────────────
+    # Skipped under flake provisioning: uv (from the flake) manages the
+    # project interpreter via `uv sync` / `uv run`.
     - name: "Set up Python from pyproject"
-      if: inputs.install-python == 'true' && hashFiles('pyproject.toml') != ''
+      if: inputs.provision-via-flake != 'true' && inputs.install-python == 'true' && hashFiles('pyproject.toml') != ''
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
       with:
         python-version-file: "pyproject.toml"
 
     - name: "Set up Python fallback"
-      if: inputs.install-python == 'true' && hashFiles('pyproject.toml') == ''
+      if: inputs.provision-via-flake != 'true' && inputs.install-python == 'true' && hashFiles('pyproject.toml') == ''
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
       with:
         python-version: ${{ inputs.python-version }}
 
     # ── uv ─────────────────────────────────────────────────────────────
+    # Skipped under flake provisioning: uv comes from the flake dev-shell.
     - name: Install uv
       id: setup-uv
+      if: inputs.provision-via-flake != 'true'
       continue-on-error: true
       uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
       with:
@@ -215,15 +290,17 @@ runs:
         node-version: ${{ inputs.node-version }}
 
     # ── Just (task runner) ──────────────────────────────────────────────
+    # Skipped under flake provisioning: just comes from the flake dev-shell.
     - name: Install just
-      if: inputs.install-just == 'true'
+      if: inputs.provision-via-flake != 'true' && inputs.install-just == 'true'
       uses: taiki-e/install-action@ab08a3b50948bd57d91bd2980f025da7e0a88231  # just
       with:
         tool: just
 
     # ── hadolint (Containerfile linter) ───────────────────────────────────
+    # Skipped under flake provisioning: hadolint comes from the flake dev-shell.
     - name: Install hadolint
-      if: inputs.install-hadolint == 'true'
+      if: inputs.provision-via-flake != 'true' && inputs.install-hadolint == 'true'
       shell: bash
       run: |
         set -euo pipefail
@@ -256,8 +333,9 @@ runs:
         hadolint --version
 
     # ── taplo (TOML linter/formatter) ──────────────────────────────────
+    # Skipped under flake provisioning: taplo comes from the flake dev-shell.
     - name: Install taplo
-      if: inputs.install-taplo == 'true'
+      if: inputs.provision-via-flake != 'true' && inputs.install-taplo == 'true'
       shell: bash
       run: |
         set -euo pipefail

--- a/.github/actions/test-image/action.yml
+++ b/.github/actions/test-image/action.yml
@@ -58,6 +58,14 @@ inputs:
     description: 'Git ref to checkout (e.g., commit SHA, branch, tag)'
     required: false
     default: ''
+  cachix-cache:
+    description: 'Cachix binary cache name (passed to flake provisioning)'
+    required: false
+    default: ''
+  cachix-auth-token:
+    description: 'Cachix auth token (optional; pulls need no token)'
+    required: false
+    default: ''
 
 outputs:
   test-result:
@@ -76,7 +84,12 @@ runs:
       uses: ./.github/actions/setup-env
       with:
         sync-dependencies: 'true'
+        # podman stays on the apt path (rootless host integration). uv and the
+        # rest of the toolchain come from the flake (SSoT). Refs #632.
         install-podman: 'true'
+        provision-via-flake: 'true'
+        cachix-cache: ${{ inputs.cachix-cache }}
+        cachix-auth-token: ${{ inputs.cachix-auth-token }}
 
     - name: Load image from tar
       if: inputs.image-source == 'tar'

--- a/.github/actions/test-integration/action.yml
+++ b/.github/actions/test-integration/action.yml
@@ -36,6 +36,14 @@ inputs:
     description: 'Git ref to checkout (e.g., commit SHA, branch, tag)'
     required: false
     default: ''
+  cachix-cache:
+    description: 'Cachix binary cache name (passed to flake provisioning)'
+    required: false
+    default: ''
+  cachix-auth-token:
+    description: 'Cachix auth token (optional; pulls need no token)'
+    required: false
+    default: ''
 
 outputs:
   test-result:
@@ -54,8 +62,14 @@ runs:
       uses: ./.github/actions/setup-env
       with:
         sync-dependencies: 'true'
+        # podman and the devcontainer CLI keep their dedicated install paths
+        # (host integration / npm-global); uv and the rest come from the flake
+        # (SSoT). Refs #632.
         install-podman: 'true'
         install-devcontainer-cli: 'true'
+        provision-via-flake: 'true'
+        cachix-cache: ${{ inputs.cachix-cache }}
+        cachix-auth-token: ${{ inputs.cachix-auth-token }}
 
     - name: Load image from tar
       shell: bash

--- a/.github/actions/test-project/action.yml
+++ b/.github/actions/test-project/action.yml
@@ -35,6 +35,16 @@ inputs:
     required: false
     default: '-v -s --tb=short'
 
+  cachix-cache:
+    description: 'Cachix binary cache name (passed to flake provisioning)'
+    required: false
+    default: ''
+
+  cachix-auth-token:
+    description: 'Cachix auth token (optional; pulls need no token)'
+    required: false
+    default: ''
+
 runs:
   using: composite
   steps:
@@ -48,6 +58,10 @@ runs:
         install-hadolint: 'true'
         install-taplo: 'true'
         install-bats: 'true'
+        # Provision the toolchain from the flake (SSoT). Refs #632.
+        provision-via-flake: 'true'
+        cachix-cache: ${{ inputs.cachix-cache }}
+        cachix-auth-token: ${{ inputs.cachix-auth-token }}
 
     - name: Cache pre-commit hooks
       if: inputs.suite == 'all' || inputs.suite == 'lint'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,8 @@ jobs:
           vcs-ref: ${{ steps.version.outputs.vcs_ref }}
           dockerhub-username: ${{ secrets.DOCKERHUB_USERNAME }}
           dockerhub-token: ${{ secrets.DOCKERHUB_TOKEN }}
+          cachix-cache: ${{ vars.CACHIX_CACHE }}
+          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
           output-type: tar
           output-file: /tmp/image.tar
 
@@ -125,6 +127,8 @@ jobs:
         with:
           image-tag: ${{ needs.build-image.outputs.version }}-amd64
           image-source: tar
+          cachix-cache: ${{ vars.CACHIX_CACHE }}
+          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
   test-integration:
     name: Integration Tests
@@ -150,6 +154,8 @@ jobs:
         uses: ./.github/actions/test-integration
         with:
           image-tag: ${{ needs.build-image.outputs.version }}-amd64
+          cachix-cache: ${{ vars.CACHIX_CACHE }}
+          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
       - name: Upload test artifacts on failure
         if: failure()
@@ -177,6 +183,9 @@ jobs:
 
       - name: Run project checks
         uses: ./.github/actions/test-project
+        with:
+          cachix-cache: ${{ vars.CACHIX_CACHE }}
+          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
   python-security:
     name: Python Security Scan

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Replace dpkg `host.package(...).is_installed` checks (git, curl, openssh-client, nano, tmux, rsync) with path-agnostic `--version`/`-V` runs
   - Resolve `gh`, `just`, `hadolint`, `taplo` and cargo-installed tools via PATH (`command -v`) instead of hardcoded `/usr/local/bin` / `/root/.cargo/bin` / `/root/.local/bin` locations
   - Drop the `DEBIAN_FRONTEND` environment assertion and the apt-sourced version-prefix checks (git, curl, tmux, rsync) from `EXPECTED_VERSIONS`
+- **Provision CI build/test tooling from the flake dev-shell** ([#632](https://github.com/vig-os/devcontainer/issues/632))
+  - The `setup-env` action gained a `provision-via-flake` mode that installs Nix (SHA-pinned `install-nix-action`) and the `vig-os` Cachix substituter, builds the flake dev-shell, and prepends its tools to `PATH`, replacing the ad-hoc installs of `uv`/Python, `just`, `hadolint`, and `taplo`
+  - Enabled the mode in the CI build/test path (`build-image`, `test-image`, `test-integration`, `project-checks`) so jobs run inside the flake shell (the toolchain SSoT); `podman`, Node.js, BATS, and the devcontainer CLI keep their dedicated install paths
+  - The Debian image is still built unchanged and the Docker `type=gha` build cache stays intact
 
 ### Deprecated
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -33,6 +33,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Replace dpkg `host.package(...).is_installed` checks (git, curl, openssh-client, nano, tmux, rsync) with path-agnostic `--version`/`-V` runs
   - Resolve `gh`, `just`, `hadolint`, `taplo` and cargo-installed tools via PATH (`command -v`) instead of hardcoded `/usr/local/bin` / `/root/.cargo/bin` / `/root/.local/bin` locations
   - Drop the `DEBIAN_FRONTEND` environment assertion and the apt-sourced version-prefix checks (git, curl, tmux, rsync) from `EXPECTED_VERSIONS`
+- **Provision CI build/test tooling from the flake dev-shell** ([#632](https://github.com/vig-os/devcontainer/issues/632))
+  - The `setup-env` action gained a `provision-via-flake` mode that installs Nix (SHA-pinned `install-nix-action`) and the `vig-os` Cachix substituter, builds the flake dev-shell, and prepends its tools to `PATH`, replacing the ad-hoc installs of `uv`/Python, `just`, `hadolint`, and `taplo`
+  - Enabled the mode in the CI build/test path (`build-image`, `test-image`, `test-integration`, `project-checks`) so jobs run inside the flake shell (the toolchain SSoT); `podman`, Node.js, BATS, and the devcontainer CLI keep their dedicated install paths
+  - The Debian image is still built unchanged and the Docker `type=gha` build cache stays intact
 
 ### Deprecated
 


### PR DESCRIPTION
## Summary

CI now provisions its build/test toolchain from the Nix flake (the toolchain SSoT, #631) via `nix develop`, proving the `vig-os` Cachix binary cache under real CI load before any image risk (T2.1/#634) is taken.

- **`setup-env` action** gains a `provision-via-flake` mode: installs Nix (SHA-pinned `cachix/install-nix-action`, matching `nix-cachix.yml`) and the `vig-os` Cachix substituter, builds the flake dev-shell, and prepends its nix-store bin dirs to `GITHUB_PATH` so every subsequent step runs as if inside `nix develop`.
- The ad-hoc installs of **uv/Python, just, hadolint, taplo** are gated off in this mode (they come from the flake).
- **podman, Node.js, BATS, and the devcontainer CLI** keep their dedicated install steps — podman needs the runner's setuid `newuidmap`/`newgidmap` and host container config for rootless mode; BATS/devcontainer-CLI are not in the flake.
- Mode enabled across the CI build/test path: `build-image`, `test-image`, `test-integration`, `project-checks`. The cache name (`vars.CACHIX_CACHE`) and token (`secrets.CACHIX_AUTH_TOKEN`) are threaded from `ci.yml` through each action into `setup-env`.

### Out of scope (unchanged)
- The **Debian image is still built unchanged** (buildx + Containerfile); the Nix-built image is T2.1/#634.
- The Docker **`type=gha` build cache** stays intact in parallel.

## Verification

Local (host Nix 2.34.7):
- `nix flake metadata` resolves the flake.
- `nix develop ... --command` builds the dev-shell and reports the gated tools: `uv 0.11.19`, `just 1.40.0`, `hadolint 2.12.0`, `taplo 0.9.3`, `node v22.20.0`, `jq 1.7.1`, `gh 2.94.0`.
- Reproduced the action's PATH-extraction logic: it isolates the 46 `/nix/store/*/bin` dirs from the dev-shell `$PATH` (just/uv/hadolint/taplo/node/git/gh all present) — exactly what gets appended to `GITHUB_PATH`.
- `just precommit` green (ruff, yamllint, taplo, shellcheck, hadolint, pymarkdown, **check-action-pins**, sync-manifest, agent-identity, branch-name).

Full CI build-time cold-vs-warm Cachix comparison (issue test note) will come from this PR's own CI run.

Refs: #632
