### PR TITLE
feat(nix): build the devcontainer image with buildLayeredImage (non-publishing)

### DIFF
--- a/.github/workflows/nix-image.yml
+++ b/.github/workflows/nix-image.yml
@@ -1,0 +1,95 @@
+# Nix-built devcontainer image (discovery phase, non-publishing)
+#
+# Builds the devcontainer image with Nix (`dockerTools.buildLayeredImage`, NOT a
+# Dockerfile `FROM`) and runs the portable testinfra suite (#635) against it.
+#
+# This workflow is intentionally NON-BLOCKING and NON-PUBLISHING (T2.1, #634):
+#   - It is a standalone workflow, not part of the required CI gate.
+#   - The build+test job is guarded with `continue-on-error: true`, so the
+#     FHS/bootstrap gaps the discovery phase is meant to surface (uv-pip tools,
+#     cargo tools, network-populated venv / pre-commit cache, version-pin
+#     differences vs. the Debian build) can never fail CI.
+#   - The image is loaded into the runner's local podman only; it is never
+#     pushed to any registry. Publishing is #639.
+#
+# Evaluator choice: upstream CppNix via cachix/install-nix-action, matching
+# nix-cachix.yml. The flake bakes CppNix (`pkgs.nix`) into the image closure so
+# `nix`/`direnv` are live inside the container.
+#
+# Triggers:
+#   - Push to the migration epic branch when the flake or this workflow changes.
+#   - workflow_dispatch (so it can be triggered later from the default branch).
+
+name: Nix Image (discovery)
+
+on:  # yamllint disable-line rule:truthy
+  push:
+    branches:
+      - 'feature/625-nix-claude-migration'
+    paths:
+      - 'flake.nix'
+      - 'flake.lock'
+      - '.github/workflows/nix-image.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-test:
+    name: Build Nix image & run portable testinfra
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    # Non-blocking: discovery phase. Remaining FHS/bootstrap gaps must not fail
+    # the wider CI while the image story is being iterated toward green.
+    continue-on-error: true
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+
+      - name: Install Nix (upstream CppNix)
+        uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3  # v31.10.6
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+            accept-flake-config = true
+
+      - name: Configure Cachix (pull-only substituter)
+        uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71  # v17
+        with:
+          name: ${{ vars.CACHIX_CACHE }}
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
+      - name: Build the devcontainer image with Nix
+        run: |
+          set -euo pipefail
+          # buildLayeredImage emits a gzipped OCI tarball at ./result.
+          nix build .#devcontainerImage --print-build-logs
+          # Stage it where the test-image composite action expects a tar file.
+          cp -L result /tmp/nix-devcontainer-image.tar.gz
+          ls -lL /tmp/nix-devcontainer-image.tar.gz
+
+      - name: Record image size
+        run: |
+          set -euo pipefail
+          echo "Compressed tarball size:"
+          du -h /tmp/nix-devcontainer-image.tar.gz
+
+      # Reuse the shared composite action: it loads the tar into podman, retags
+      # it to ghcr.io/vig-os/devcontainer:nix-image (local only, never pushed),
+      # and runs tests/test_image.py via TEST_CONTAINER_TAG.
+      - name: Load image and run portable testinfra
+        id: testinfra
+        uses: ./.github/actions/test-image
+        with:
+          image-tag: 'nix-image'
+          image-source: 'tar'
+          tar-file: '/tmp/nix-devcontainer-image.tar.gz'
+          skip-container-check: 'true'
+
+      - name: Report testinfra result
+        if: always()
+        run: |
+          echo "Portable testinfra result code: ${{ steps.testinfra.outputs.test-result }}"
+          echo "Discovery phase: non-zero is expected while FHS/bootstrap gaps remain."

--- a/.gitignore
+++ b/.gitignore
@@ -152,6 +152,9 @@ activemq-data/
 
 # Nix / direnv
 .direnv/
+# Nix build output symlinks (e.g. `nix build` -> ./result)
+/result
+/result-*
 
 # Environments
 .env

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added reusable flake outputs `lib.mkProjectShell`, `overlays.default`, and a `packages.devcontainerImage` stub for the later image build
   - Added a non-blocking `Nix Cachix` workflow (with `workflow_dispatch`) that builds the dev-shell and pushes its closure to the `vig-os` Cachix cache
   - Added a per-tool `nix develop -c <tool> --version` parity test driven from the flake SSoT to guard against future dev-shell/image drift
+- **Build the devcontainer image with Nix (`buildLayeredImage`, non-publishing)** ([#634](https://github.com/vig-os/devcontainer/issues/634))
+  - Fleshed out `packages.devcontainerImage` from a stub into a real, bit-reproducible image assembled by `dockerTools.buildLayeredImage` (not a Dockerfile `FROM`); a `--rebuild` verifies the closure hash is identical
+  - Baked the in-container Nix evaluator (upstream CppNix, `pkgs.nix`) plus `direnv`/`nix-direnv` into the closure so `nix`/`direnv` are live inside the container; documented the CppNix-vs-Lix and `pre-commit`-vs-`prek` decisions in the flake
+  - Reproduced the Debian bootstrap layers in Nix: locale via `glibcLocales` + `LOCALE_ARCHIVE` (no `locale-gen`), `/root/assets`, pre-commit cache dir, template `.venv` scaffold (`UV_PYTHON_DOWNLOADS=never`, `UV_PYTHON=<nix python3.14>`), the `precommit`/`cc`/`cld` aliases, and `IS_SANDBOX=1`
+  - Added `fakeNss` (root uid-0 user database) and a sticky `/tmp` to close the first FHS gaps surfaced by the portable testinfra (fixing `ssh`, `whoami`, and `tmux`)
+  - Added a non-publishing `Nix Image (discovery)` workflow (with `workflow_dispatch`) that builds the image and runs the portable testinfra under `continue-on-error: true`
 
 ### Changed
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -15,6 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added reusable flake outputs `lib.mkProjectShell`, `overlays.default`, and a `packages.devcontainerImage` stub for the later image build
   - Added a non-blocking `Nix Cachix` workflow (with `workflow_dispatch`) that builds the dev-shell and pushes its closure to the `vig-os` Cachix cache
   - Added a per-tool `nix develop -c <tool> --version` parity test driven from the flake SSoT to guard against future dev-shell/image drift
+- **Build the devcontainer image with Nix (`buildLayeredImage`, non-publishing)** ([#634](https://github.com/vig-os/devcontainer/issues/634))
+  - Fleshed out `packages.devcontainerImage` from a stub into a real, bit-reproducible image assembled by `dockerTools.buildLayeredImage` (not a Dockerfile `FROM`); a `--rebuild` verifies the closure hash is identical
+  - Baked the in-container Nix evaluator (upstream CppNix, `pkgs.nix`) plus `direnv`/`nix-direnv` into the closure so `nix`/`direnv` are live inside the container; documented the CppNix-vs-Lix and `pre-commit`-vs-`prek` decisions in the flake
+  - Reproduced the Debian bootstrap layers in Nix: locale via `glibcLocales` + `LOCALE_ARCHIVE` (no `locale-gen`), `/root/assets`, pre-commit cache dir, template `.venv` scaffold (`UV_PYTHON_DOWNLOADS=never`, `UV_PYTHON=<nix python3.14>`), the `precommit`/`cc`/`cld` aliases, and `IS_SANDBOX=1`
+  - Added `fakeNss` (root uid-0 user database) and a sticky `/tmp` to close the first FHS gaps surfaced by the portable testinfra (fixing `ssh`, `whoami`, and `tmux`)
+  - Added a non-publishing `Nix Image (discovery)` workflow (with `workflow_dispatch`) that builds the image and runs the portable testinfra under `continue-on-error: true`
 
 ### Changed
 

--- a/flake.nix
+++ b/flake.nix
@@ -145,19 +145,153 @@
         devShellTools = devShellToolNames pkgs;
 
         packages = {
-          # Stub for the Nix-built devcontainer image. The real image is built
-          # in T2.1 (#634); this placeholder keeps the output present and
-          # buildable so downstream wiring (#632) can reference it early.
-          devcontainerImage = pkgs.runCommand "devcontainer-image-stub" { } ''
-            mkdir -p "$out"
-            cat > "$out/README" <<'EOF'
-            devcontainerImage is a placeholder stub.
+          # -----------------------------------------------------------------
+          # devcontainerImage — Nix-built devcontainer image (T2.1, #634).
+          #
+          # Assembled entirely by Nix via `dockerTools.buildLayeredImage` (NOT
+          # a Dockerfile `FROM`) so the build is bit-reproducible — the epic's
+          # "identical image digest on rebuild" criterion can hold. The Nix
+          # package manager (CppNix, `pkgs.nix`) is part of the closure so
+          # `nix`/`direnv` are live inside the container, identical to the
+          # direnv path; `nix2container` stays reserved for production images.
+          #
+          # Evaluator decision (#634): ship upstream CppNix (`pkgs.nix`) as the
+          # in-container evaluator. It is the channel default, needs no overlay,
+          # and the flake is installer-agnostic, so swapping to `pkgs.lix` later
+          # is a one-line change. `pkgs.lix` is left out for now to keep the
+          # closure smaller.
+          #
+          # pre-commit vs prek (#40): this image bakes upstream `pre-commit`
+          # (matches the Debian build and the pinned pyproject version).
+          # Migrating the cache layer to `prek` is deferred to #40; both are in
+          # nixpkgs, so it is a drop-in swap once that issue lands.
+          devcontainerImage =
+            let
+              python = pkgs.python314;
 
-            The real Nix-built devcontainer image is delivered in T2.1 (#634).
-            The toolchain it will bake is the `devTools` list in flake.nix
-            (this repo's SSoT), shared with the dev-shell.
-            EOF
-          '';
+              # The toolchain SSoT plus the runtime substrate a bare layered
+              # image lacks (an FHS base distro would provide these; here we add
+              # them explicitly — this is the discovery surface for FHS gaps).
+              imageTools =
+                (devTools pkgs)
+                ++ (with pkgs; [
+                  # Nix package manager in the closure (CppNix).
+                  nix
+                  direnv
+                  nix-direnv
+
+                  # Locale support without locale-gen.
+                  glibcLocales
+
+                  # Python + uv-managed venv bootstrap.
+                  python
+                  pre-commit
+
+                  # Base runtime substrate (no FHS base distro to inherit).
+                  bashInteractive
+                  coreutils-full
+                  findutils
+                  gnugrep
+                  gnused
+                  gawk
+                  gnutar
+                  gzip
+                  which
+                  cacert
+                  curl
+                  openssh
+                  nano
+                  rsync
+
+                  # /etc/passwd + /etc/group with a root (uid 0) entry. A bare
+                  # layered image has no FHS user database, so anything that
+                  # resolves the current uid (ssh, tmux, git) fails with
+                  # "No user exists for uid 0". fakeNss provides the minimal
+                  # nss files an FHS base distro would have supplied.
+                  dockerTools.fakeNss
+                ]);
+
+              # Bake the workspace assets, pre-commit cache dir and template
+              # .venv scaffold as a normal image layer. UV_PYTHON pins the Nix
+              # interpreter and UV_PYTHON_DOWNLOADS=never forbids uv from
+              # fetching a managed CPython (absent in the sandbox anyway). The
+              # venv/pre-commit population needs network, so it is best-effort
+              # here and the directories are created unconditionally.
+              bootstrap =
+                pkgs.runCommand "devcontainer-bootstrap"
+                  {
+                    nativeBuildInputs = [
+                      pkgs.coreutils
+                      pkgs.findutils
+                    ];
+                  }
+                  ''
+                    mkdir -p "$out/root/assets"
+                    cp -r ${./assets}/. "$out/root/assets/"
+                    chmod -R u+w "$out/root/assets"
+                    find "$out/root/assets" -type f -name "*.sh" -exec chmod +x {} \;
+
+                    # /root/.bashrc with carried aliases: precommit (Debian
+                    # build) plus cc/cld (#545).
+                    cat > "$out/root/.bashrc" <<'BASHRC'
+                    alias precommit="pre-commit run"
+                    alias cc="claude"
+                    alias cld="claude --dangerously-skip-permissions"
+                    BASHRC
+
+                    mkdir -p "$out/opt/pre-commit-cache"
+                    mkdir -p "$out/workspace"
+
+                    # /tmp with the sticky bit. A bare layered image has no
+                    # /tmp; tools that need a scratch/socket dir (tmux, uv,
+                    # pytest) fail without it ("no suitable socket path"). An
+                    # FHS base distro would have supplied it.
+                    mkdir -p "$out/tmp"
+                    chmod 1777 "$out/tmp"
+                  '';
+            in
+            pkgs.dockerTools.buildLayeredImage {
+              # Name matches the published repo so the portable testinfra
+              # (#635), which targets ghcr.io/vig-os/devcontainer:<tag>, runs
+              # unchanged against the loaded image under a unique tag.
+              name = "ghcr.io/vig-os/devcontainer";
+              tag = "nix-wt634";
+
+              contents = imageTools ++ [ bootstrap ];
+
+              # Deterministic epoch timestamp keeps the digest reproducible.
+              created = "1970-01-01T00:00:00Z";
+
+              config = {
+                Cmd = [ "${pkgs.bashInteractive}/bin/bash" ];
+                WorkingDir = "/workspace";
+                Env = [
+                  "LANG=en_US.UTF-8"
+                  "LANGUAGE=en_US:en"
+                  "LC_ALL=en_US.UTF-8"
+                  "LOCALE_ARCHIVE=${pkgs.glibcLocales}/lib/locale/locale-archive"
+                  "PYTHONUNBUFFERED=1"
+                  "IN_CONTAINER=true"
+                  # #545: the container is the trust boundary; bypass the uid-0
+                  # check for `claude --dangerously-skip-permissions`.
+                  "IS_SANDBOX=1"
+                  "PRE_COMMIT_HOME=/opt/pre-commit-cache"
+                  "UV_PROJECT_ENVIRONMENT=/root/assets/workspace/.venv"
+                  "VIRTUAL_ENV=/root/assets/workspace/.venv"
+                  "UV_PYTHON_DOWNLOADS=never"
+                  "UV_PYTHON=${python}/bin/python3.14"
+                  "SSL_CERT_FILE=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
+                  "NIX_SSL_CERT_FILE=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
+                  "HOME=/root"
+                ];
+                Labels = {
+                  "org.opencontainers.image.title" = "vigOS development environment";
+                  "org.opencontainers.image.source" =
+                    "https://github.com/vig-os/devcontainer";
+                  "org.opencontainers.image.licenses" = "MIT";
+                };
+              };
+            };
         };
       }
     )


### PR DESCRIPTION
## Summary

Fleshes out `packages.devcontainerImage` (T2.1, #634) from a stub into a real, **Nix-built, bit-reproducible** devcontainer image assembled by `dockerTools.buildLayeredImage` (not a Dockerfile `FROM`). Non-publishing discovery phase: the image is loaded into local podman only and the CI job is `continue-on-error`.

## Evaluator decision

**Upstream CppNix (`pkgs.nix`)** is baked into the image closure as the in-container evaluator (matching `nix-cachix.yml`), alongside `direnv` + `nix-direnv`, so `nix`/`direnv` are live inside the container. `pkgs.lix` is deferred (smaller closure; the flake is installer-agnostic so swapping is a one-line change). `pre-commit` (not `prek`) is baked, matching the Debian build; `prek` migration is deferred to #40. Both decisions are documented inline in `flake.nix`.

## Image size

- Compressed tarball: **660 MB**
- Uncompressed in podman: **2.05 GB**

This is **larger** than the Debian `:slim` image. The bulk is the full closures of `podman` (+ crun/conmon/netavark/criu/systemd-minimal), `nix` itself, `neovim`, `nodejs`, `python3.14` + `python3.12`, and `glibcLocales`. Trimming (e.g. dropping locale variants, slimming podman) is follow-up work, not discovery scope. Flagged per the acceptance criteria.

## Reproducibility

Confirmed: `nix build --rebuild` re-verifies the output and yields the **identical** store path (`9by7yxg5…-devcontainer.tar.gz`) and tarball sha256 — `dockerTools.buildLayeredImage` + a fixed `created` epoch are deterministic.

## Bootstrap layers reproduced (mirroring the Debian `Containerfile`)

- Locale via `glibcLocales` + `LOCALE_ARCHIVE` (no `locale-gen`)
- `/root/assets` (copied + shell scripts made executable)
- pre-commit cache dir at `/opt/pre-commit-cache` (`PRE_COMMIT_HOME`)
- template `.venv` env vars: `UV_PROJECT_ENVIRONMENT`, `VIRTUAL_ENV`, `UV_PYTHON_DOWNLOADS=never`, `UV_PYTHON=<nix python3.14>`
- `.bashrc` aliases `precommit`, plus `cc`/`cld` and `IS_SANDBOX=1` (from #545)

## Testinfra results (portable suite from #635 / T2.2)

Ran `tests/test_image.py` against the loaded image (`TEST_CONTAINER_TAG`): **29 passed, 34 failed** (up from 27 passed after FHS fixes).

**FHS gaps closed this PR:**
- `fakeNss` → root uid-0 user database (fixed `ssh -V`, `whoami`, `id`)
- sticky `/tmp` → fixed `tmux` (`no suitable socket path`)

**Remaining failures (all out of T2.1 scope, behind `continue-on-error`):**
- **Network-dependent bootstrap** (sandbox blocks network at build): empty pre-commit cache, `uv` venv workflow, and the uv-pip-installed tools `ruff`, `bandit`, `pip-licenses`, the pinned `pre-commit` version, and `vig-utils` (+ its 12 modules and 5 shell wrappers). The venv scaffold is baked but population needs network.
- **Tools not yet in `devTools`** (belong to #631 expansion / cargo path): `cargo-binstall`, `typstyle`, `just-lsp`.
- **Version-pin differences** vs. the Debian build (nixpkgs `nixos-25.05` pins): `gh` 2.94 vs 2.95, `just` 1.40 vs 1.54, `hadolint` 2.12 vs 2.14, `taplo` 0.9 vs 0.10. These are presence-vs-version assertions, not FHS gaps.

## CI

New standalone `.github/workflows/nix-image.yml` (separate file to avoid conflicts with the sibling T1.2 CI work): installs CppNix, builds the image, records size, loads it into the runner's podman via the shared `test-image` action, and runs the portable testinfra under **`continue-on-error: true`**. Triggers on epic-branch pushes touching the flake/workflow, plus **`workflow_dispatch`**.

## Remaining work (follow-ups, not this PR)

- Populate the template `.venv` + pre-commit cache (needs build-time network or a vendored approach) — closes most of the remaining failures.
- Add `cargo-binstall`/`typstyle`/`just-lsp` and reconcile version pins via #631.
- Image-size trimming.

Refs: #634