### PR TITLE
ci(renovate): add nix manager and lockFileMaintenance for flake.lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Renovate `nix` manager for `flake.lock` maintenance** ([#638](https://github.com/vig-os/devcontainer/issues/638))
+  - Enabled the Renovate `nix` manager and weekly `lockFileMaintenance` in `renovate.json` so flake inputs (notably `nixpkgs`) are bumped through the normal PR/CI gate; the existing `pep621`, `npm`, `github-actions`, and `dockerfile` managers are retained
+  - Documented the compensating control in `docs/CONTAINER_SECURITY.md`: every `flake.lock`/nixpkgs-bump PR must include a `vulnix` before/after diff, since the `nix` manager reports only the input revision change and not which CVE a bump fixes
 - **De-duplicate the flake into the toolchain SSoT** ([#631](https://github.com/vig-os/devcontainer/issues/631))
   - Factored a single `devTools` list in `flake.nix` as the source of truth shared by the dev-shell now and the image later, absorbing the agent-CLI toolkit (`rg`, `fd`, `bat`, `eza`, `delta`, `lazygit`, `zoxide`, `starship`, `freeze`, `expect`, `nvim`) plus `claude` ([#545](https://github.com/vig-os/devcontainer/issues/545))
   - Pinned `nixpkgs` to `nixos-25.05` and added a `nixpkgs-unstable` input overlaid only for fast-movers (`uv`, `gh`, `claude-code`); refreshed `flake.lock`

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Renovate `nix` manager for `flake.lock` maintenance** ([#638](https://github.com/vig-os/devcontainer/issues/638))
+  - Enabled the Renovate `nix` manager and weekly `lockFileMaintenance` in `renovate.json` so flake inputs (notably `nixpkgs`) are bumped through the normal PR/CI gate; the existing `pep621`, `npm`, `github-actions`, and `dockerfile` managers are retained
+  - Documented the compensating control in `docs/CONTAINER_SECURITY.md`: every `flake.lock`/nixpkgs-bump PR must include a `vulnix` before/after diff, since the `nix` manager reports only the input revision change and not which CVE a bump fixes
 - **De-duplicate the flake into the toolchain SSoT** ([#631](https://github.com/vig-os/devcontainer/issues/631))
   - Factored a single `devTools` list in `flake.nix` as the source of truth shared by the dev-shell now and the image later, absorbing the agent-CLI toolkit (`rg`, `fd`, `bat`, `eza`, `delta`, `lazygit`, `zoxide`, `starship`, `freeze`, `expect`, `nvim`) plus `claude` ([#545](https://github.com/vig-os/devcontainer/issues/545))
   - Pinned `nixpkgs` to `nixos-25.05` and added a `nixpkgs-unstable` input overlaid only for fast-movers (`uv`, `gh`, `claude-code`); refreshed `flake.lock`

--- a/docs/CONTAINER_SECURITY.md
+++ b/docs/CONTAINER_SECURITY.md
@@ -89,6 +89,28 @@ have no available Debian patch; the nightly gate only fails on fixable
 HIGH/CRITICAL findings. Re-scan after each base-image digest bump and drop
 entries when Debian ships fixes. Tracking: #566, #512, #521.
 
+### 5. Nix flake input maintenance (toolchain)
+
+The developer toolchain comes from the Nix flake (`flake.nix` / `flake.lock`),
+not from `apt`. Renovate keeps `flake.lock` current through two mechanisms in
+`renovate.json`:
+
+- The **`nix` manager** detects flake inputs and proposes pinned-input updates.
+- **`lockFileMaintenance`** (enabled, scheduled weekly) refreshes the locked
+  revisions of all inputs (notably `nixpkgs`) so security fixes land through the
+  normal PR/CI gate rather than a manual `nix flake update`.
+
+**Compensating control — `vulnix` before/after diff.** A `nixpkgs` revision bump
+does not declare *which* CVE it fixes (the `nix` manager reports only the
+old → new git revision). To keep the audit trail, each `flake.lock` /
+nixpkgs-bump PR must include a `vulnix` scan diff of the dev shell taken
+**before and after** the bump, showing which advisories the new revision clears
+(or introduces). This mirrors the CVE-comment rule for targeted `apt` upgrades:
+no change to the security surface lands without a recorded, auditable reason.
+
+The `vulnix` scanner setup itself is tracked separately (#637); this layer
+documents the required PR evidence regardless of how the scan is wired.
+
 ## Why not `apt-get upgrade`?
 
 Running `apt-get upgrade` (or `dist-upgrade`) in the Containerfile has several

--- a/renovate.json
+++ b/renovate.json
@@ -3,13 +3,23 @@
   "extends": [
     "github>vig-os/devcontainer//assets/workspace/.github/renovate-default"
   ],
-  "enabledManagers": ["github-actions", "pep621", "npm", "dockerfile"],
+  "enabledManagers": ["github-actions", "pep621", "npm", "dockerfile", "nix"],
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["before 9am on monday"]
+  },
   "packageRules": [
     {
       "description": "Dockerfile / Containerfile",
       "matchManagers": ["dockerfile"],
       "semanticCommitType": "build",
       "semanticCommitScope": "docker"
+    },
+    {
+      "description": "Nix flake.lock — bump flake inputs through the normal PR/CI gate",
+      "matchManagers": ["nix"],
+      "semanticCommitType": "build",
+      "semanticCommitScope": "nix"
     }
   ]
 }


### PR DESCRIPTION
Adds the Renovate `nix` manager + `lockFileMaintenance` so `flake.lock` inputs are bumped through the normal PR/CI gate.

- `renovate.json`: enable `nix` manager + `lockFileMaintenance`; retain `github-actions`/`pep621`/`npm`/`dockerfile`
- `docs/CONTAINER_SECURITY.md`: document the vulnix before/after-diff compensating control (xref #637)
- Changelog entry

Refs: #638