### PR TITLE
ci(nix): let flake uv fetch the pinned CPython 3.14.6

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -177,6 +177,22 @@ runs:
         printf '%s' "$SHELL_PATH" | tr ':' '\n' \
           | grep '^/nix/store' >> "$GITHUB_PATH"
 
+        # Propagate the dev-shell's uv Python-download metadata URL to later
+        # steps. GITHUB_PATH only carries PATH, not env vars, so this var (set
+        # in the flake dev-shell, the SSoT) must be forwarded explicitly so
+        # `uv sync` can fetch the project's pinned CPython, which nixpkgs does
+        # not package and the nixpkgs uv cannot download on its own. Refs #632.
+        # The dev-shell's shellHook prints a banner to stdout, so capture the
+        # var on its own line and extract just that line (mirrors the PATH
+        # filtering above).
+        UV_DL_JSON_URL="$(nix develop --profile "$RUNNER_TEMP/dev-profile" \
+          --command bash -c 'printf "UV_PYTHON_DOWNLOADS_JSON_URL=%s\n" "${UV_PYTHON_DOWNLOADS_JSON_URL:-}"' \
+          | grep '^UV_PYTHON_DOWNLOADS_JSON_URL=' | tail -n1 | cut -d= -f2-)"
+        if [ -n "$UV_DL_JSON_URL" ]; then
+          echo "UV_PYTHON_DOWNLOADS_JSON_URL=$UV_DL_JSON_URL" >> "$GITHUB_ENV"
+          echo "Forwarded UV_PYTHON_DOWNLOADS_JSON_URL=$UV_DL_JSON_URL"
+        fi
+
         echo "Flake dev-shell provisioned; tools added to PATH:"
         printf '%s' "$SHELL_PATH" | tr ':' '\n' | grep '^/nix/store' | head -50
 

--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -171,11 +171,19 @@ runs:
 
         # Capture the dev-shell PATH and prepend its nix-store bin dirs to
         # GITHUB_PATH so all following steps resolve the flake's tools first.
+        #
+        # Exclude the flake's podman: rootless podman on GitHub runners relies
+        # on the host's setuid newuidmap/newgidmap and container config, which
+        # the nix-store podman does not see, so `podman info` fails. The host's
+        # preinstalled podman is kept on PATH by NOT shadowing it here (matches
+        # the apt-podman intent documented on the provision-via-flake input).
+        # Refs #632.
         SHELL_PATH="$(nix develop --profile "$RUNNER_TEMP/dev-profile" \
           --command bash -c 'printf "%s" "$PATH"')"
 
         printf '%s' "$SHELL_PATH" | tr ':' '\n' \
-          | grep '^/nix/store' >> "$GITHUB_PATH"
+          | grep '^/nix/store' \
+          | grep -v '/nix/store/[^/]*-podman[^/]*/bin' >> "$GITHUB_PATH"
 
         # Propagate the dev-shell's uv Python-download metadata URL to later
         # steps. GITHUB_PATH only carries PATH, not env vars, so this var (set

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The `setup-env` action gained a `provision-via-flake` mode that installs Nix (SHA-pinned `install-nix-action`) and the `vig-os` Cachix substituter, builds the flake dev-shell, and prepends its tools to `PATH`, replacing the ad-hoc installs of `uv`/Python, `just`, `hadolint`, and `taplo`
   - Enabled the mode in the CI build/test path (`build-image`, `test-image`, `test-integration`, `project-checks`) so jobs run inside the flake shell (the toolchain SSoT); `podman`, Node.js, BATS, and the devcontainer CLI keep their dedicated install paths
   - The Debian image is still built unchanged and the Docker `type=gha` build cache stays intact
+  - Set `UV_PYTHON_DOWNLOADS_JSON_URL` in the flake dev-shell so the nixpkgs `uv` (whose embedded Python-download list is stripped) can fetch the project's pinned CPython `3.14.6`, which nixpkgs does not package, letting `uv sync --frozen` succeed under flake provisioning
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Enabled the mode in the CI build/test path (`build-image`, `test-image`, `test-integration`, `project-checks`) so jobs run inside the flake shell (the toolchain SSoT); `podman`, Node.js, BATS, and the devcontainer CLI keep their dedicated install paths
   - The Debian image is still built unchanged and the Docker `type=gha` build cache stays intact
   - Set `UV_PYTHON_DOWNLOADS_JSON_URL` in the flake dev-shell so the nixpkgs `uv` (whose embedded Python-download list is stripped) can fetch the project's pinned CPython `3.14.6`, which nixpkgs does not package, letting `uv sync --frozen` succeed under flake provisioning
+  - Keep `podman` off the flake-provisioned `PATH` so the runner's rootless-configured host `podman` is used (the nix-store `podman` cannot reach the host's setuid `newuidmap`/`newgidmap`, so `podman info` failed)
 
 ### Deprecated
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The `setup-env` action gained a `provision-via-flake` mode that installs Nix (SHA-pinned `install-nix-action`) and the `vig-os` Cachix substituter, builds the flake dev-shell, and prepends its tools to `PATH`, replacing the ad-hoc installs of `uv`/Python, `just`, `hadolint`, and `taplo`
   - Enabled the mode in the CI build/test path (`build-image`, `test-image`, `test-integration`, `project-checks`) so jobs run inside the flake shell (the toolchain SSoT); `podman`, Node.js, BATS, and the devcontainer CLI keep their dedicated install paths
   - The Debian image is still built unchanged and the Docker `type=gha` build cache stays intact
+  - Set `UV_PYTHON_DOWNLOADS_JSON_URL` in the flake dev-shell so the nixpkgs `uv` (whose embedded Python-download list is stripped) can fetch the project's pinned CPython `3.14.6`, which nixpkgs does not package, letting `uv sync --frozen` succeed under flake provisioning
 
 ### Deprecated
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -44,6 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Enabled the mode in the CI build/test path (`build-image`, `test-image`, `test-integration`, `project-checks`) so jobs run inside the flake shell (the toolchain SSoT); `podman`, Node.js, BATS, and the devcontainer CLI keep their dedicated install paths
   - The Debian image is still built unchanged and the Docker `type=gha` build cache stays intact
   - Set `UV_PYTHON_DOWNLOADS_JSON_URL` in the flake dev-shell so the nixpkgs `uv` (whose embedded Python-download list is stripped) can fetch the project's pinned CPython `3.14.6`, which nixpkgs does not package, letting `uv sync --frozen` succeed under flake provisioning
+  - Keep `podman` off the flake-provisioned `PATH` so the runner's rootless-configured host `podman` is used (the nix-store `podman` cannot reach the host's setuid `newuidmap`/`newgidmap`, so `podman info` failed)
 
 ### Deprecated
 

--- a/flake.nix
+++ b/flake.nix
@@ -118,6 +118,20 @@
       #     extraPackages = [ pkgs.foo ];
       #   };
       # ---------------------------------------------------------------------
+      # uv's Python-download metadata, pinned to the uv release we provision.
+      #
+      # The nixpkgs build of uv ships with its embedded Python-download list
+      # stripped (Nix is expected to supply interpreters), so `uv sync` cannot
+      # fetch a managed CPython on its own — it reports "No interpreter found
+      # ... in managed installations or search path". Our projects pin an exact
+      # patch (requires-python == 3.14.6) that nixpkgs does not package (stable
+      # has 3.14.0, unstable 3.14.4), so the interpreter must come from uv's
+      # managed download. Pointing uv at upstream's download-metadata.json
+      # (pinned to the same uv version installed on the non-flake CI path)
+      # restores that capability without un-pinning nixpkgs. Refs #632.
+      uvPythonDownloadsJsonUrl =
+        "https://raw.githubusercontent.com/astral-sh/uv/0.11.23/crates/uv-python/download-metadata.json";
+
       mkProjectShell =
         {
           pkgs,
@@ -127,6 +141,9 @@
         pkgs.mkShell {
           packages = (devTools pkgs) ++ extraPackages;
           inherit shellHook;
+
+          # Let the nixpkgs uv resolve managed Python downloads (see note above).
+          UV_PYTHON_DOWNLOADS_JSON_URL = uvPythonDownloadsJsonUrl;
         };
     in
     flake-utils.lib.eachDefaultSystem (


### PR DESCRIPTION
## Summary

Follow-up fix for #632 (T1.2). PR #653 enabled flake-provisioned CI but its `Build Container Image` and `Project Checks` jobs failed. PR #653 was already squash-merged into the epic at the broken state, so this lands as a new PR against `feature/625-nix-claude-migration`.

Three coordinated fixes, one root chain:

### 1. uv could not provide CPython 3.14.6

`uv sync --frozen --all-extras` failed with `No interpreter found for Python 3.14.6`. Causes:

- The project pins an **exact** patch (`requires-python == 3.14.6`, also in `uv.lock`). nixpkgs does not package it — `nixos-25.05` has `python314 == 3.14.0`, `nixpkgs-unstable` has `3.14.4`; a Nix interpreter is rejected by `uv --frozen` as incompatible.
- The **nixpkgs build of `uv`** ships with its embedded Python-download list stripped, so it cannot fetch a managed CPython on its own.

**Fix:** set `UV_PYTHON_DOWNLOADS_JSON_URL` in the flake dev-shell (`mkProjectShell` in `flake.nix`, the toolchain SSoT) to upstream uv's `download-metadata.json`, pinned to the same uv release the non-flake CI path installs (`0.11.23`). This restores managed downloads without un-pinning nixpkgs. `UV_PYTHON_DOWNLOADS` keeps its default.

### 2. The variable did not reach CI steps

`GITHUB_PATH` only carries PATH, not env vars, so the dev-shell variable never reached the `uv sync` step. **Fix:** forward `UV_PYTHON_DOWNLOADS_JSON_URL` from the dev-shell to `GITHUB_ENV` in the `provision-via-flake` setup step.

### 3. The flake's podman shadowed the host podman

With (1)+(2) fixed, build/image/integration jobs went green but `Project Checks` still failed: a BATS dry-run test (`tests/bats/install.bats`) errored because `install.sh` runs `podman info` and the flake's nix-store podman cannot reach the runner's setuid `newuidmap`/`newgidmap`. **Fix:** exclude the flake podman bin from the `provision-via-flake` PATH export so the runner's rootless-configured host podman is used (matches the documented intent on the `provision-via-flake` input). The flake's `devTools` (and the parity test) are unchanged.

### Validation

- `nix develop -c uv sync --frozen --all-extras` succeeds; dev-shell and venv both report **Python 3.14.6**.
- `pre-commit run --all-files` green; flake parity test passes; `nix flake check` passes.
- Full CI on this branch is **green**: Build Container Image, Project Checks, Image Tests, Integration Tests, Security Scan, Python Security Scan, Test Summary.

Refs: #632
