### PR TITLE
fix(vigutils): handle --help in derive-branch-summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`just wt-start` no longer aborts on its helper-CLI prerequisite check** ([#657](https://github.com/vig-os/devcontainer/issues/657))
+  - `derive-branch-summary` now handles `-h`/`--help` (prints usage, exits 0) instead of treating the flag as an issue title and failing; the worktree launcher probes availability with `--help`, so the bug blocked worktree creation entirely
+
 ### Security
 
 - **Drop the piscina CVE ignore tied to `cursor-agent`** ([#628](https://github.com/vig-os/devcontainer/issues/628))

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -62,6 +62,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`just wt-start` no longer aborts on its helper-CLI prerequisite check** ([#657](https://github.com/vig-os/devcontainer/issues/657))
+  - `derive-branch-summary` now handles `-h`/`--help` (prints usage, exits 0) instead of treating the flag as an issue title and failing; the worktree launcher probes availability with `--help`, so the bug blocked worktree creation entirely
+
 ### Security
 
 - **Drop the piscina CVE ignore tied to `cursor-agent`** ([#628](https://github.com/vig-os/devcontainer/issues/628))

--- a/packages/vig-utils/src/vig_utils/shell/derive-branch-summary.sh
+++ b/packages/vig-utils/src/vig_utils/shell/derive-branch-summary.sh
@@ -13,6 +13,18 @@
 #      DERIVE_BRANCH_TIMEOUT — timeout in seconds (default: 30). Use 2 for tests.
 set -euo pipefail
 
+case "${1:-}" in
+-h | --help)
+    cat <<'USAGE'
+Usage: derive-branch-summary <TITLE> [NAMING_RULE] [MODEL_TIER]
+  TITLE        issue title
+  NAMING_RULE  path to the branch-naming skill (default: .claude/skills/branch-naming/SKILL.md)
+  MODEL_TIER   agent-models.toml tier (default: lightweight; use standard for retry)
+USAGE
+    exit 0
+    ;;
+esac
+
 TITLE="${1:?Usage: derive-branch-summary.sh <TITLE> [NAMING_RULE] [MODEL_TIER]}"
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 NAMING_RULE="${2:-${REPO_ROOT}/.claude/skills/branch-naming/SKILL.md}"

--- a/packages/vig-utils/tests/test_shell_entrypoints.py
+++ b/packages/vig-utils/tests/test_shell_entrypoints.py
@@ -158,3 +158,11 @@ def test_derive_branch_summary_accepts_optional_model_tier_arg() -> None:
 
     assert result.returncode == 0
     assert result.stdout.strip() == "retry-summary"
+
+
+@pytest.mark.parametrize("flag", ["-h", "--help"])
+def test_derive_branch_summary_help_exits_zero(flag: str) -> None:
+    result = _run(["derive-branch-summary", flag])
+
+    assert result.returncode == 0, result.stderr
+    assert "Usage" in result.stdout


### PR DESCRIPTION
## What

Make `derive-branch-summary` handle `-h`/`--help` by printing usage and exiting 0, instead of
treating the flag as an issue title and failing with exit 1.

## Why

`just wt-start <issue>` guards helper-CLI availability with `uv run derive-branch-summary --help`.
Because the script did `TITLE="${1:?...}"`, `--help` was taken as the title, the agent path
failed, and the guard aborted the launcher — so no worktree could be created. (`resolve-branch`
tolerates `--help` only by accident: it ignores args and reads stdin.)

## How

- `test(vigutils)`: parametrized test asserting `-h`/`--help` exit 0 with usage on stdout (RED first).
- `fix(vigutils)`: add an `-h|--help` case to `derive-branch-summary.sh` (print usage, exit 0).
- Full `test_shell_entrypoints.py` suite stays green (19 passed); real titles still derive normally.

Closes #657.