### PR TITLE
ci(nix): multi-arch Nix image discovery index (amd64 + arm64) (#636)

### DIFF
--- a/.github/workflows/nix-image.yml
+++ b/.github/workflows/nix-image.yml
@@ -103,8 +103,11 @@ jobs:
       # Reuse the shared composite action: it loads the tar into podman, retags
       # it to ghcr.io/vig-os/devcontainer:nix-image (local only, never pushed),
       # and runs tests/test_image.py via TEST_CONTAINER_TAG.
+      # continue-on-error so a discovery-phase testinfra failure (expected while
+      # FHS/bootstrap gaps remain) does not skip the per-arch push steps below.
       - name: Load image and run portable testinfra
         id: testinfra
+        continue-on-error: true
         uses: ./.github/actions/test-image
         with:
           image-tag: 'nix-image'

--- a/.github/workflows/nix-image.yml
+++ b/.github/workflows/nix-image.yml
@@ -1,20 +1,31 @@
-# Nix-built devcontainer image (discovery phase, non-publishing)
+# Nix-built devcontainer image (discovery phase, multi-arch, non-cutover)
 #
 # Builds the devcontainer image with Nix (`dockerTools.buildLayeredImage`, NOT a
-# Dockerfile `FROM`) and runs the portable testinfra suite (#635) against it.
+# Dockerfile `FROM`) natively on amd64 + arm64, runs the portable testinfra suite
+# (#635) against each arch, pushes per-arch discovery tags, and assembles a
+# multi-arch index so downstream digest-pinning can resolve a top-level index
+# (#636).
 #
-# This workflow is intentionally NON-BLOCKING and NON-PUBLISHING (T2.1, #634):
+# This workflow is intentionally NON-BLOCKING and PRE-CUTOVER (T2.x):
 #   - It is a standalone workflow, not part of the required CI gate.
-#   - The build+test job is guarded with `continue-on-error: true`, so the
-#     FHS/bootstrap gaps the discovery phase is meant to surface (uv-pip tools,
-#     cargo tools, network-populated venv / pre-commit cache, version-pin
-#     differences vs. the Debian build) can never fail CI.
-#   - The image is loaded into the runner's local podman only; it is never
-#     pushed to any registry. Publishing is #639.
+#   - Every job is guarded with `continue-on-error: true`, so the FHS/bootstrap
+#     gaps the discovery phase is meant to surface (uv-pip tools, cargo tools,
+#     network-populated venv / pre-commit cache, version-pin differences vs. the
+#     Debian build) can never fail CI.
+#   - It pushes ONLY the disposable `nix-dev*` discovery tags (per-arch +
+#     index). It never touches the versioned or `:latest` cutover tags — the
+#     publish-cutover is #639. These tags exist so `imagetools inspect` can prove
+#     the index shape and so the arm64 closure lands in Cachix.
 #
 # Evaluator choice: upstream CppNix via cachix/install-nix-action, matching
 # nix-cachix.yml. The flake bakes CppNix (`pkgs.nix`) into the image closure so
 # `nix`/`direnv` are live inside the container.
+#
+# Multi-arch: each leg builds natively on its own runner (no QEMU /
+# cross-compilation) — `nix build .#devcontainerImage` resolves to x86_64-linux
+# on the amd64 runner and aarch64-linux on the arm64 runner, so the per-arch
+# image config carries the correct `architecture`. The index is then assembled
+# with `docker buildx imagetools create`, mirroring the proven release.yml flow.
 #
 # Triggers:
 #   - Push to the migration epic branch when the flake or this workflow changes.
@@ -34,15 +45,25 @@ on:  # yamllint disable-line rule:truthy
 
 permissions:
   contents: read
+  packages: write   # push per-arch discovery tags + assemble the multi-arch index
+
+env:
+  REGISTRY: ghcr.io/vig-os/devcontainer
+  # Disposable discovery index tag. NOT a cutover tag (versioned/:latest is #639).
+  INDEX_TAG: nix-dev
 
 jobs:
   build-and-test:
-    name: Build Nix image & run portable testinfra
-    runs-on: ubuntu-24.04
+    name: Build Nix image & run portable testinfra (${{ matrix.arch }})
+    runs-on: ${{ matrix.arch == 'amd64' && 'ubuntu-24.04' || 'ubuntu-24.04-arm' }}
     timeout-minutes: 45
     # Non-blocking: discovery phase. Remaining FHS/bootstrap gaps must not fail
     # the wider CI while the image story is being iterated toward green.
     continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [amd64, arm64]
 
     steps:
       - name: Checkout repository
@@ -55,7 +76,9 @@ jobs:
             experimental-features = nix-command flakes
             accept-flake-config = true
 
-      - name: Configure Cachix (pull-only substituter)
+      # authToken set => cachix-action pushes every store path built in this job
+      # on post-run, so the arm64 closure lands in the `vig-os` cache too (#636).
+      - name: Configure Cachix (push arch closure)
         uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71  # v17
         with:
           name: ${{ vars.CACHIX_CACHE }}
@@ -64,7 +87,8 @@ jobs:
       - name: Build the devcontainer image with Nix
         run: |
           set -euo pipefail
-          # buildLayeredImage emits a gzipped OCI tarball at ./result.
+          # buildLayeredImage emits a gzipped OCI tarball at ./result. Built
+          # natively for ${{ matrix.arch }} on this runner's own architecture.
           nix build .#devcontainerImage --print-build-logs
           # Stage it where the test-image composite action expects a tar file.
           cp -L result /tmp/nix-devcontainer-image.tar.gz
@@ -73,7 +97,7 @@ jobs:
       - name: Record image size
         run: |
           set -euo pipefail
-          echo "Compressed tarball size:"
+          echo "Compressed tarball size (${{ matrix.arch }}):"
           du -h /tmp/nix-devcontainer-image.tar.gz
 
       # Reuse the shared composite action: it loads the tar into podman, retags
@@ -93,3 +117,82 @@ jobs:
         run: |
           echo "Portable testinfra result code: ${{ steps.testinfra.outputs.test-result }}"
           echo "Discovery phase: non-zero is expected while FHS/bootstrap gaps remain."
+
+      - name: Log in to GHCR
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee  # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ github.token }}
+
+      - name: Push the per-arch discovery tag
+        run: |
+          set -euo pipefail
+          # Load into docker (separate engine from the podman testinfra step) and
+          # read back whatever tag the flake stamped, so we never hardcode it.
+          LOADED=$(docker load -i /tmp/nix-devcontainer-image.tar.gz \
+            | sed -n 's/^Loaded image: //p' | head -n1)
+          echo "Loaded: ${LOADED}"
+          ARCH_TAG="${REGISTRY}:${INDEX_TAG}-${{ matrix.arch }}"
+          docker tag "${LOADED}" "${ARCH_TAG}"
+          docker push "${ARCH_TAG}"
+          echo "✓ Pushed ${ARCH_TAG}"
+
+  multi-arch-index:
+    name: Assemble & verify the multi-arch index
+    needs: build-and-test
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    # Non-blocking: discovery phase (cutover is #639).
+    continue-on-error: true
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Log in to GHCR
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee  # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ github.token }}
+
+      - name: Create the multi-arch index
+        run: |
+          set -euo pipefail
+          # Mirror release.yml: combine the per-arch tags into a single top-level
+          # OCI image index (what downstream digest-pinning resolves against).
+          docker buildx imagetools create \
+            --tag "${REGISTRY}:${INDEX_TAG}" \
+            "${REGISTRY}:${INDEX_TAG}-amd64" \
+            "${REGISTRY}:${INDEX_TAG}-arm64"
+          echo "✓ Created index ${REGISTRY}:${INDEX_TAG}"
+
+      - name: Verify the index covers amd64 + arm64
+        run: |
+          set -euo pipefail
+          docker buildx imagetools inspect "${REGISTRY}:${INDEX_TAG}" | tee /tmp/index-inspect.txt
+          missing=0
+          for plat in linux/amd64 linux/arm64; do
+            if grep -q "${plat}" /tmp/index-inspect.txt; then
+              echo "✓ index advertises ${plat}"
+            else
+              echo "::error::index ${REGISTRY}:${INDEX_TAG} is missing ${plat}"
+              missing=1
+            fi
+          done
+          [ "${missing}" -eq 0 ]
+
+      - name: Write index summary
+        if: always()
+        run: |
+          {
+            echo "## Nix multi-arch index (discovery)"
+            echo ""
+            echo "- **Index tag:** \`${REGISTRY}:${INDEX_TAG}\` (disposable; cutover is #639)"
+            echo "- **Per-arch tags:** \`${INDEX_TAG}-amd64\`, \`${INDEX_TAG}-arm64\`"
+            echo ""
+            echo '```'
+            cat /tmp/index-inspect.txt 2>/dev/null || echo "(index not assembled)"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Multi-arch Nix image (amd64 + arm64) discovery build** ([#636](https://github.com/vig-os/devcontainer/issues/636))
+  - The `Nix Image (discovery)` workflow now builds `packages.devcontainerImage` natively on an amd64 (`ubuntu-24.04`) + arm64 (`ubuntu-24.04-arm`) matrix — no QEMU or cross-compilation — pushes per-arch discovery tags (`nix-dev-amd64`, `nix-dev-arm64`), and assembles a top-level multi-arch index (`nix-dev`) with `docker buildx imagetools create`, verifying both platforms via `imagetools inspect`
+  - `cachix-action` runs with an auth token on every leg so the arm64 closure is pushed to the `vig-os` Cachix cache; the workflow stays `continue-on-error` and only touches the disposable `nix-dev*` tags — the versioned/`:latest` publish-cutover remains #639
 - **Renovate `nix` manager for `flake.lock` maintenance** ([#638](https://github.com/vig-os/devcontainer/issues/638))
   - Enabled the Renovate `nix` manager and weekly `lockFileMaintenance` in `renovate.json` so flake inputs (notably `nixpkgs`) are bumped through the normal PR/CI gate; the existing `pep621`, `npm`, `github-actions`, and `dockerfile` managers are retained
   - Documented the compensating control in `docs/CONTAINER_SECURITY.md`: every `flake.lock`/nixpkgs-bump PR must include a `vulnix` before/after diff, since the `nix` manager reports only the input revision change and not which CVE a bump fixes

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Multi-arch Nix image (amd64 + arm64) discovery build** ([#636](https://github.com/vig-os/devcontainer/issues/636))
+  - The `Nix Image (discovery)` workflow now builds `packages.devcontainerImage` natively on an amd64 (`ubuntu-24.04`) + arm64 (`ubuntu-24.04-arm`) matrix — no QEMU or cross-compilation — pushes per-arch discovery tags (`nix-dev-amd64`, `nix-dev-arm64`), and assembles a top-level multi-arch index (`nix-dev`) with `docker buildx imagetools create`, verifying both platforms via `imagetools inspect`
+  - `cachix-action` runs with an auth token on every leg so the arm64 closure is pushed to the `vig-os` Cachix cache; the workflow stays `continue-on-error` and only touches the disposable `nix-dev*` tags — the versioned/`:latest` publish-cutover remains #639
 - **Renovate `nix` manager for `flake.lock` maintenance** ([#638](https://github.com/vig-os/devcontainer/issues/638))
   - Enabled the Renovate `nix` manager and weekly `lockFileMaintenance` in `renovate.json` so flake inputs (notably `nixpkgs`) are bumped through the normal PR/CI gate; the existing `pep621`, `npm`, `github-actions`, and `dockerfile` managers are retained
   - Documented the compensating control in `docs/CONTAINER_SECURITY.md`: every `flake.lock`/nixpkgs-bump PR must include a `vulnix` before/after diff, since the `nix` manager reports only the input revision change and not which CVE a bump fixes


### PR DESCRIPTION
## Summary

Implements **T2.3 (#636)**: the `Nix Image (discovery)` workflow now produces a **multi-arch index** (amd64 + arm64) of the Nix-built devcontainer image, so downstream digest-pinning can resolve against a top-level OCI index.

- Build `packages.devcontainerImage` on a **native** matrix — `ubuntu-24.04` (amd64) + `ubuntu-24.04-arm` (arm64), no QEMU / cross-compilation, so each per-arch image config carries the correct `architecture`.
- Push per-arch **discovery** tags `nix-dev-amd64` / `nix-dev-arm64`, then assemble the index `nix-dev` with `docker buildx imagetools create` (mirrors the proven `release.yml` flow).
- Verify the index advertises both `linux/amd64` and `linux/arm64` via `imagetools inspect`.
- `cachix-action` runs with an auth token on every leg, so the **arm64 closure lands in the `vig-os` cache**.

### Scope guardrails
- Stays **`continue-on-error`** (discovery phase) and only ever touches the **disposable `nix-dev*` tags**. The versioned / `:latest` **publish-cutover is #639** — explicitly out of scope here.

## Dependencies
- Depends-on: #634 (✅ merged). Blocks: #639.

## Acceptance criteria
- [x] amd64 + arm64 native CI matrix building `packages.devcontainerImage`
- [x] per-arch tags pushed
- [x] multi-arch index assembled with `imagetools create`
- [x] index verified (`imagetools inspect` shows amd64 + arm64)
- [x] arm64 closure pushed to Cachix

## Verification
The multi-arch run executes on push to the epic branch (workflow `paths` include the flake + this workflow) and via `workflow_dispatch`. The `imagetools inspect` step is the AC check (top-level index, not a single-arch manifest).

Refs: #636