### PR TITLE
build(nix): stage the publish-cutover + advance nixpkgs to 26.05 (#639)

### DIFF
--- a/.github/actions/build-image/action.yml
+++ b/.github/actions/build-image/action.yml
@@ -68,6 +68,10 @@ inputs:
     description: 'Container registry URL'
     required: false
     default: 'ghcr.io/vig-os/devcontainer'
+  builder:
+    description: 'Image builder: "debian" (Containerfile) or "nix" (flake devcontainerImage). Default debian keeps the cutover paused (#639).'
+    required: false
+    default: 'debian'
   output-type:
     description: 'Output type: "tar" (save to file) or "registry" (push to registry)'
     required: false
@@ -162,8 +166,8 @@ runs:
           org.opencontainers.image.vendor=vigOS
           org.opencontainers.image.licenses=MIT
 
-    - name: Build image (tar output)
-      if: inputs.output-type == 'tar'
+    - name: Build image (tar output, Debian/Containerfile)
+      if: inputs.output-type == 'tar' && inputs.builder != 'nix'
       uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf  # v7.2.0
       with:
         context: ./build
@@ -179,6 +183,21 @@ runs:
           IMAGE_TAG=${{ inputs.version }}
         cache-from: type=gha
         cache-to: type=gha,mode=max
+
+    # Nix build path (#639 cutover). Native per-arch: `nix build .#devcontainerImage`
+    # resolves to the runner's own architecture, mirroring nix-image.yml. Nix is
+    # already provisioned by the setup-env step above (provision-via-flake). The
+    # flake stamps its own OCI labels; the docker metadata-action labels are not
+    # applied to the Nix image. Inert unless builder=nix (default debian).
+    - name: Build image (tar output, Nix flake)
+      if: inputs.output-type == 'tar' && inputs.builder == 'nix'
+      shell: bash
+      run: |
+        set -euo pipefail
+        nix build .#devcontainerImage --print-build-logs
+        # buildLayeredImage emits a gzipped OCI tar; docker load handles gzip.
+        cp -L result "${{ inputs.output-file }}"
+        ls -lL "${{ inputs.output-file }}"
 
     - name: Verify tar output was created
       if: inputs.output-type == 'tar'
@@ -212,8 +231,8 @@ runs:
       shell: bash
       run: echo "tar-file=${{ inputs.output-file }}" >> $GITHUB_OUTPUT
 
-    - name: Build image (registry output)
-      if: inputs.output-type == 'registry'
+    - name: Build image (registry output, Debian/Containerfile)
+      if: inputs.output-type == 'registry' && inputs.builder != 'nix'
       uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf  # v7.2.0
       with:
         context: ./build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,11 @@ on:  # yamllint disable-line rule:truthy
         required: false
         default: 'candidate'
         type: string
+      builder:
+        description: 'Image builder: debian (Containerfile) or nix (flake). Default debian keeps the publish-cutover paused (#639); set nix to cut over.'
+        required: false
+        default: 'debian'
+        type: string
       dry-run:
         description: 'Validate without making changes'
         required: false
@@ -759,6 +764,9 @@ jobs:
         with:
           version: ${{ needs.validate.outputs.publish_version }}
           arch: ${{ matrix.arch }}
+          # debian by default; set the workflow `builder` input to `nix` to cut
+          # the published image over to the Nix build (#639). Paused by default.
+          builder: ${{ inputs.builder }}
           release-date: ${{ needs.validate.outputs.release_date }}
           release-url: ${{ needs.validate.outputs.release_url }}
           build-timestamp: ${{ needs.validate.outputs.build_timestamp }}

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -210,10 +210,11 @@ jobs:
   # vulnix (nixpkgs-native) becomes the PRIMARY CVE signal here, scanning the
   # image's package closure (flake `devcontainerImageEnv`); Trivy stays on for a
   # CycloneDX SBOM + an SBOM-mode vuln view (defense in depth). The vulnix-gate
-  # step is NON-BLOCKING for now (discovery): vulnix over-reports because it does
-  # not see nixpkgs' backported patches, so findings are triaged into
-  # .vulnixignore (and the nixpkgs rev advanced) before #639 flips this gate to
-  # blocking and wires SARIF upload + a deduplicated issue, like scan-latest.
+  # step is BLOCKING (#639): the nixpkgs baseline was advanced to 26.05 and the
+  # residual findings triaged into .vulnixignore (see docs/security/
+  # nix-cutover-scan-overlap.md), so any new unexcepted HIGH/CRITICAL fails the
+  # scan. SARIF upload + a deduplicated issue (like scan-latest) land with the
+  # actual publish-cutover.
   scan-nix-image:
     name: Scan Nix image (vulnix + SBOM)
     runs-on: ubuntu-24.04
@@ -261,9 +262,9 @@ jobs:
 
       - name: Gate on unexcepted HIGH/CRITICAL vulnix findings
         id: vulnix-gate
-        # Discovery phase: non-blocking. #639 removes continue-on-error to make
-        # this the publish-cutover gate.
-        continue-on-error: true
+        # BLOCKING (#639): fails the nightly scan on any HIGH/CRITICAL not covered
+        # by a non-expired entry in .vulnixignore. This is the go/no-go gate for
+        # the publish-cutover.
         run: uv run vulnix-gate vulnix-findings.json --register .vulnixignore
 
       - name: Build the Nix image for SBOM generation

--- a/.vulnixignore
+++ b/.vulnixignore
@@ -20,6 +20,64 @@
 # Each accepted entry should record WHY (patched-in-nixpkgs / not-exploitable /
 # awaiting-upstream) per docs/CONTAINER_SECURITY.md.
 #
-# This register starts empty: the discovery-phase vulnix job is non-blocking
-# (continue-on-error), so its findings are triaged here before #639 flips the
-# gate to blocking. Tracking: https://github.com/vig-os/devcontainer/issues/637
+# Tracking: https://github.com/vig-os/devcontainer/issues/637
+
+# ============================================================================
+# Triage for the nixos-26.05 baseline (#639 publish-cutover prep), 2026-06-23.
+#
+# Bumping the pinned channel nixos-25.05 -> nixos-26.05 (the "advance the rev"
+# lever) cut the vulnix HIGH/CRITICAL surface from 83 to 27 unique CVEs. The
+# residual splits into two classes, triaged below. The actual publish stays
+# paused pending review of these entries (especially the CRITICALs).
+# ============================================================================
+
+# --- Class 1: not applicable (vulnix CPE mismatch — the CVE is a DIFFERENT
+#     product that shares a name). Definitive false positives; yearly re-check
+#     in case the NVD CPE data is corrected. ---
+Expiration: 2027-06-23
+# shellcheck 0.11.0 — CVE-2021-28794 is an RCE in the *VS Code ShellCheck
+# extension* (vscode-shellcheck), not the ShellCheck binary shipped here.
+CVE-2021-28794
+# git 2.54.0 — Jenkins *Git plugin* advisories (XSS/CSRF/permission checks),
+# not the git VCS. vulnix matches the "git" CPE against the wrong product.
+CVE-2022-30947
+CVE-2022-36882
+CVE-2022-36883
+
+# --- Class 2: recent CVEs vulnix matches by version against the current-stable
+#     nixpkgs (26.05). Low exploitability in an interactive, single-user dev
+#     container (no untrusted network services or inputs); the primary
+#     remediation is advancing the pinned nixpkgs rev as fixes land (Renovate
+#     `nix` manager + lockFileMaintenance, #638). Short expiry forces re-review
+#     each quarter as the pin advances. ---
+Expiration: 2026-09-23
+# glibc 2.42
+CVE-2025-15281
+CVE-2026-4046
+CVE-2026-4437
+CVE-2026-5435
+CVE-2026-5450
+CVE-2026-5928
+# openssl 3.6.2
+CVE-2026-7383
+CVE-2026-9076
+CVE-2026-34180
+CVE-2026-34181
+CVE-2026-34182
+CVE-2026-34183
+CVE-2026-42764
+CVE-2026-42765
+CVE-2026-45445
+CVE-2026-45447
+# perl 5.42.0
+CVE-2026-4176
+# zlib 1.3.2
+CVE-2026-27820
+# sqlite 3.51.2
+CVE-2026-11822
+CVE-2026-11824
+# ldns 1.9.0
+CVE-2026-10846
+# libmicrohttpd 1.0.2
+CVE-2025-59777
+CVE-2025-62689

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Stage the Nix publish-cutover; advance the nixpkgs baseline to 26.05** ([#639](https://github.com/vig-os/devcontainer/issues/639))
+  - Bumped the pinned channel `nixos-25.05` → `nixos-26.05` (the "advance the rev" CVE lever), cutting the vulnix HIGH/CRITICAL surface 83 → 27 and Trivy HIGH 244 → 14 on the image; triaged the residual 27 into `.vulnixignore` (4 CPE-mismatch false positives — VS Code/Jenkins, not the binaries; 23 recent CVEs accepted as low-risk in an interactive dev container with a 3-month re-review)
+  - Made the nightly `vulnix-gate` **blocking** (the #639 go/no-go gate) now that it is legitimately green, and archived the `vulnix`-vs-Trivy scan overlap in `docs/security/nix-cutover-scan-overlap.md` (zero overlap — disjoint surfaces, no finding class lost in the Debian→Nix switch)
+  - Added a `builder: debian|nix` selector to the `build-image` action and a matching `release.yml` input (**default `debian`**), so the release pipeline can build the Nix multi-arch image while the actual `:latest` publish stays paused — the cutover is the deliberate `release.yml -f builder=nix` run
 - **Make `.claude/` the single source of truth for agent rules and skills** ([#626](https://github.com/vig-os/devcontainer/issues/626))
   - Moved the 30 agent skills from `.cursor/skills/` to `.claude/skills/` and rewrote the 29 `.claude/commands/*.md` wrappers to point at the new paths
   - Split the seven `.cursor/rules/*.mdc`: static principles (coding principles, commit messages, changelog, single source of truth) are now consolidated in `CLAUDE.md`; workflow rules (`branch-naming`, `tdd`, `subagent-delegation`) became on-demand `.claude/skills/`

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -37,6 +37,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Stage the Nix publish-cutover; advance the nixpkgs baseline to 26.05** ([#639](https://github.com/vig-os/devcontainer/issues/639))
+  - Bumped the pinned channel `nixos-25.05` → `nixos-26.05` (the "advance the rev" CVE lever), cutting the vulnix HIGH/CRITICAL surface 83 → 27 and Trivy HIGH 244 → 14 on the image; triaged the residual 27 into `.vulnixignore` (4 CPE-mismatch false positives — VS Code/Jenkins, not the binaries; 23 recent CVEs accepted as low-risk in an interactive dev container with a 3-month re-review)
+  - Made the nightly `vulnix-gate` **blocking** (the #639 go/no-go gate) now that it is legitimately green, and archived the `vulnix`-vs-Trivy scan overlap in `docs/security/nix-cutover-scan-overlap.md` (zero overlap — disjoint surfaces, no finding class lost in the Debian→Nix switch)
+  - Added a `builder: debian|nix` selector to the `build-image` action and a matching `release.yml` input (**default `debian`**), so the release pipeline can build the Nix multi-arch image while the actual `:latest` publish stays paused — the cutover is the deliberate `release.yml -f builder=nix` run
 - **Make `.claude/` the single source of truth for agent rules and skills** ([#626](https://github.com/vig-os/devcontainer/issues/626))
   - Moved the 30 agent skills from `.cursor/skills/` to `.claude/skills/` and rewrote the 29 `.claude/commands/*.md` wrappers to point at the new paths
   - Split the seven `.cursor/rules/*.mdc`: static principles (coding principles, commit messages, changelog, single source of truth) are now consolidated in `CLAUDE.md`; workflow rules (`branch-naming`, `tdd`, `subagent-delegation`) became on-demand `.claude/skills/`

--- a/docs/security/nix-cutover-scan-overlap.md
+++ b/docs/security/nix-cutover-scan-overlap.md
@@ -1,0 +1,64 @@
+# Nix cutover — vulnix vs Trivy scan overlap
+
+Go/no-go evidence for the publish-cutover (#639) and the confidence check from
+#637: comparing the two CVE scanners over a one-cycle overlap so we can confirm
+no class of finding silently disappears when the published image moves from the
+Debian/apt build (Trivy OS-package scan) to the Nix build (vulnix).
+
+## Method
+
+- **Baseline:** `nixos-26.05` (rev `34268251`, 2026-06-22), bumped from the
+  year-old `nixos-25.05` as the primary CVE lever (see `CONTAINER_SECURITY.md`).
+- **vulnix** (primary gate) scans the image package closure —
+  `nix build .#devcontainerImageEnv` then `vulnix --closure`. Matches the Nix
+  store derivations by name + upstream version against NVD.
+- **Trivy** (defence in depth) scans the built image —
+  `trivy image --input <devcontainerImage tar>`. Detects bundled binaries and
+  language dependencies (e.g. Go stdlib inside `gh`/`podman`/`runc`) and flags
+  their CVEs.
+- Snapshot date: **2026-06-23**. HIGH/CRITICAL = CVSS v3 ≥ 7.0.
+
+## Results (26.05 baseline)
+
+| Scanner | HIGH/CRITICAL (unique) | Disposition |
+|---------|------------------------|-------------|
+| **vulnix** | 27 | All triaged in `.vulnixignore` (gate green) |
+| **Trivy** | 14 | Awareness / defence-in-depth (non-gating) |
+| **Overlap (both)** | **0** | — |
+
+- The bump cut the surface for **both** scanners: vulnix **83 → 27** unique
+  HIGH/CRITICAL, Trivy HIGH **244 → 14**.
+- **Zero overlap.** The two scanners flag completely disjoint CVE sets because
+  they examine different surfaces: vulnix sees Nix-store packages (glibc,
+  openssl, perl, …); Trivy sees vendored/bundled components inside binaries (Go
+  stdlib, npm/Go modules). Neither is redundant — together they widen coverage,
+  and **no class of finding disappears** in the Debian→Nix scanner switch
+  (Trivy's OS-package surface is replaced by vulnix's store surface; Trivy's
+  bundled-binary surface is retained).
+
+## vulnix residual (27, all excepted in `.vulnixignore`)
+
+- **Not applicable — CPE mismatch (4):** `shellcheck` CVE-2021-28794 (the VS Code
+  *extension*, not the binary) and three `git` CVEs that are *Jenkins Git-plugin*
+  advisories.
+- **Accepted recent CVEs (23):** `glibc`, `openssl`, `perl`, `zlib`, `sqlite`,
+  `ldns`, `libmicrohttpd` — version-matched against current-stable nixpkgs; low
+  exploitability in an interactive single-user dev container; remediation is
+  advancing the pinned `nixpkgs` rev as fixes land (#638). 3-month re-review.
+
+## Trivy residual (14 HIGH, non-gating)
+
+Bundled-binary CVEs (predominantly Go stdlib inside Go-based tools). Not gated by
+`vulnix-gate` (Trivy is the SBOM / defence-in-depth view); they shrink as the
+pinned `nixpkgs` rev advances. The nightly `scan-nix-image` job keeps emitting
+the CycloneDX SBOM + this comparison so the set is tracked each cycle.
+
+## Verdict
+
+- **vulnix gate: GREEN** after the 26.05 bump + triage (`vulnix-gate` exits 0).
+- **Confidence check: satisfied** — disjoint surfaces documented; no finding
+  class lost in the scanner switch.
+- **Publish remains PAUSED.** This batch stages the cutover (gate green +
+  blocking, release pipeline able to build the Nix image) but does not run a
+  release / promote `:latest`. That deliberate trigger — and a final review of
+  the CRITICAL acceptances above — is left to a maintainer.

--- a/flake.lock
+++ b/flake.lock
@@ -20,16 +20,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1767313136,
-        "narHash": "sha256-16KkgfdYqjaeRGBaYsNrhPRRENs0qzkQVUooNHtoy2w=",
+        "lastModified": 1782116945,
+        "narHash": "sha256-G3tw/IXmaH6IQ2upZvhuN9sG8CkuX+BLuJDpE8hz0Ds=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ac62194c3917d5f474c1a844b6fd6da2db95077d",
+        "rev": "34268251cf5547d39063f2c5ea9a196246f7f3a6",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-25.05",
+        "ref": "nixos-26.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
 
   inputs = {
     # Pinned stable channel: the controlled version document (flake.lock).
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-26.05";
     # Secondary channel, overlaid only for fast-moving tools (uv, gh, claude).
     nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     flake-utils.url = "github:numtide/flake-utils";


### PR DESCRIPTION
## Summary

**T4.1 (#639) prepped to the go/no-go gate — the irreversible publish is intentionally PAUSED.** Per the agreed plan, this lands everything reversible and stops before flipping the published `:latest`.

### What changed
1. **Advanced the nixpkgs baseline `nixos-25.05` → `nixos-26.05`** (`flake.nix`/`flake.lock`) — the legitimate "advance the rev" CVE lever. A year of security backports cuts the surface for **both** scanners: vulnix HIGH/CRITICAL **83 → 27**, Trivy HIGH **244 → 14**. (`nix flake update` *within* 25.05 was a no-op — only a release-branch bump moves the surface.) Image + dev-shell + scan-env all build cleanly.
2. **Triaged the residual 27** into `.vulnixignore` → `vulnix-gate` is **green**: 4 clear CPE-mismatch FPs (`shellcheck`=VS Code ext, `git`=Jenkins plugin; yearly re-check) + 23 recent CVEs accepted as low-risk in an interactive dev container (3-month re-review; lever = advance the pin, #638).
3. **Made the nightly vulnix gate blocking** (`security-scan.yml`) now that it's legitimately green.
4. **Staged the release pipeline** — added a `builder: debian|nix` selector to the `build-image` action + a matching `release.yml` input, **default `debian`** so nothing changes until the deliberate cutover.
5. **Archived the vulnix-vs-Trivy overlap** (`docs/security/nix-cutover-scan-overlap.md`) — **zero overlap**, disjoint surfaces, no finding class lost in the Debian→Nix switch.

### ⏸️ Paused / for maintainer review
- **No release is run; `:latest` is unchanged.** Merging this publishes nothing. The cutover is the deliberate **`gh workflow run release.yml -f builder=nix ...`** run, then promote.
- Please review the **CRITICAL acceptances** in `.vulnixignore` (glibc/perl/zlib 9.8) before the cutover.
- At the actual cutover, confirm the release-time Trivy gate behaviour on the Nix image (it may need to consult `.vulnixignore`/`vulnix-gate`).

## Verified locally
- `nix build .#devcontainerImage` / `.#devcontainerImageEnv` build on 26.05; dev-shell evaluates.
- `vulnix-gate /tmp/vulnix-locked.json --register .vulnixignore` → **exit 0** (27 exceptions).
- `check-expirations .trivyignore .vulnixignore` → validated (107 exceptions).

## Dependencies
- Depends-on: #636, #637 (✅ merged). Blocks: #640.

Refs: #639