### PR TITLE
fix(scripts): Nix image scaffolds real writable files, not store symlinks (#664)

### DIFF
--- a/.github/workflows/nix-image.yml
+++ b/.github/workflows/nix-image.yml
@@ -141,6 +141,34 @@ jobs:
           docker push "${ARCH_TAG}"
           echo "✓ Pushed ${ARCH_TAG}"
 
+      # Regression guard (#664): a Nix image bakes the workspace template as
+      # read-only /nix/store symlinks, so the scaffold must produce REAL, writable
+      # files (not dangling symlinks on the host). The install/integration suite
+      # only covers the Debian image, so assert the Nix scaffold here.
+      - name: Assert the scaffold has no dangling store symlinks (#664)
+        if: matrix.arch == 'amd64'
+        run: |
+          set -euo pipefail
+          dest="$(mktemp -d)"
+          # `just sync` at the end may fail offline; the scaffold (rsync -L +
+          # chmod u+w) runs first, which is what we assert. Bound the run.
+          timeout 300 docker run --rm \
+            -e SHORT_NAME=ci -e ORG_NAME=ci -e GITHUB_REPOSITORY=ci/ci \
+            -v "${dest}":/workspace "${REGISTRY}:${INDEX_TAG}-amd64" \
+            /root/assets/init-workspace.sh --no-prompts --mode both || true
+          echo "Scaffolded top-level:"; ls -A "${dest}"
+          dangling="$(find "${dest}" -xtype l || true)"
+          if [ -n "${dangling}" ]; then
+            echo "::error::scaffold contains dangling symlinks (store-symlink bug regressed):"
+            echo "${dangling}"
+            exit 1
+          fi
+          if [ ! -f "${dest}/flake.nix" ] || [ -L "${dest}/flake.nix" ]; then
+            echo "::error::flake.nix missing or a symlink — expected a real file"
+            exit 1
+          fi
+          echo "✓ scaffold is real files with no dangling symlinks"
+
   multi-arch-index:
     name: Assemble & verify the multi-arch index
     needs: build-and-test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Nix image no longer scaffolds dangling, read-only symlinks into a new workspace** ([#664](https://github.com/vig-os/devcontainer/issues/664))
+  - The Nix-built image bakes the workspace template as read-only `/nix/store` symlinks (how `buildLayeredImage` represents the layer); `init-workspace.sh` now rsyncs with `--copy-links` and `chmod -R u+w "$WORKSPACE_DIR"`, so a scaffolded workspace gets real, writable files instead of symlinks that dangle on the host (and the placeholder `sed -i` no longer fails on read-only files). No-op on the Debian image
+  - Added a static bats guard (scaffold rsync uses `--copy-links`; workspace made writable) and a behavioural step in `nix-image.yml` that scaffolds via the real Nix image and asserts no dangling symlinks — the install/integration suite otherwise only exercises the Debian image
 - **`just wt-start` no longer aborts on its helper-CLI prerequisite check** ([#657](https://github.com/vig-os/devcontainer/issues/657))
   - `derive-branch-summary` now handles `-h`/`--help` (prints usage, exits 0) instead of treating the flag as an issue title and failing; the worktree launcher probes availability with `--help`, so the bug blocked worktree creation entirely
 

--- a/assets/init-workspace.sh
+++ b/assets/init-workspace.sh
@@ -282,12 +282,12 @@ echo "Copying files from $TEMPLATE_DIR to $WORKSPACE_DIR..."
 # Pre-commit cache is now at /opt/pre-commit-cache (not in assets/workspace)
 if [[ "$SMOKE_TEST" == "true" ]]; then
     # Smoke mode: clean deploy (--delete removes stale files), then overlay smoke-test assets
-    rsync -av --delete --exclude='.git' --exclude='.venv' --exclude='docs/issues/' --exclude='docs/pull-requests/' "$TEMPLATE_DIR/" "$WORKSPACE_DIR/"
+    rsync -avL --delete --exclude='.git' --exclude='.venv' --exclude='docs/issues/' --exclude='docs/pull-requests/' "$TEMPLATE_DIR/" "$WORKSPACE_DIR/"
 
     SMOKE_TEST_DIR="$SCRIPT_DIR/smoke-test"
     if [[ -d "$SMOKE_TEST_DIR" ]]; then
         echo "Deploying smoke-test-specific files..."
-        rsync -av "$SMOKE_TEST_DIR/" "$WORKSPACE_DIR/"
+        rsync -avL "$SMOKE_TEST_DIR/" "$WORKSPACE_DIR/"
     else
         echo "Warning: Smoke-test directory not found at $SMOKE_TEST_DIR" >&2
     fi
@@ -312,8 +312,15 @@ else
         fi
     done
 
-    rsync -av --exclude='.git' --exclude='.venv' "${EXCLUDE_ARGS[@]}" "$TEMPLATE_DIR/" "$WORKSPACE_DIR/"
+    rsync -avL --exclude='.git' --exclude='.venv' "${EXCLUDE_ARGS[@]}" "$TEMPLATE_DIR/" "$WORKSPACE_DIR/"
 fi
+
+# The Nix-built image stores the baked template as read-only symlinks into the
+# Nix store. The rsync `-L` (--copy-links) above dereferences them into real
+# files, but those inherit the store's read-only (0444) mode. Make the scaffold
+# user-writable so the placeholder substitution below — and the user's own edits
+# — work. No-op on the Debian image (its template files are already writable).
+chmod -R u+w "$WORKSPACE_DIR"
 
 # Prune the scaffold to the chosen delivery mode. Idempotent and safe: only
 # removes paths inside the new workspace.

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -80,6 +80,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Nix image no longer scaffolds dangling, read-only symlinks into a new workspace** ([#664](https://github.com/vig-os/devcontainer/issues/664))
+  - The Nix-built image bakes the workspace template as read-only `/nix/store` symlinks (how `buildLayeredImage` represents the layer); `init-workspace.sh` now rsyncs with `--copy-links` and `chmod -R u+w "$WORKSPACE_DIR"`, so a scaffolded workspace gets real, writable files instead of symlinks that dangle on the host (and the placeholder `sed -i` no longer fails on read-only files). No-op on the Debian image
+  - Added a static bats guard (scaffold rsync uses `--copy-links`; workspace made writable) and a behavioural step in `nix-image.yml` that scaffolds via the real Nix image and asserts no dangling symlinks — the install/integration suite otherwise only exercises the Debian image
 - **`just wt-start` no longer aborts on its helper-CLI prerequisite check** ([#657](https://github.com/vig-os/devcontainer/issues/657))
   - `derive-branch-summary` now handles `-h`/`--help` (prints usage, exits 0) instead of treating the flag as an issue title and failing; the worktree launcher probes availability with `--help`, so the bug blocked worktree creation entirely
 

--- a/tests/bats/init-workspace.bats
+++ b/tests/bats/init-workspace.bats
@@ -227,15 +227,35 @@ prune_mode() {
 }
 
 @test "init-workspace.sh smoke mode uses rsync --delete for clean deploy" {
-    run grep 'rsync -av --delete' "$INIT_WORKSPACE_SH"
+    run grep 'rsync -avL --delete' "$INIT_WORKSPACE_SH"
     assert_success
 }
 
 @test "init-workspace.sh smoke mode excludes synced docs directories from delete" {
-    run grep -A1 'rsync -av --delete' "$INIT_WORKSPACE_SH"
+    run grep -A1 'rsync -avL --delete' "$INIT_WORKSPACE_SH"
     assert_success
     assert_output --partial "--exclude='docs/issues/'"
     assert_output --partial "--exclude='docs/pull-requests/'"
+}
+
+# ── Nix-image scaffold: real, writable files (#664) ───────────────────────────
+# The Nix image bakes the template as read-only /nix/store symlinks. The scaffold
+# rsync must --copy-links (-L) so a new workspace gets real files (not dangling
+# symlinks on the host), and must restore writability (the store mode is 0444).
+
+@test "init-workspace.sh dereferences store symlinks when scaffolding (#664)" {
+    # Every template/asset rsync must copy referents, not symlinks.
+    run grep -nE 'rsync -avL' "$INIT_WORKSPACE_SH"
+    assert_success
+    # ...and none may scaffold with a plain `rsync -av ` (symlinks-as-symlinks).
+    run grep -nE 'rsync -av ' "$INIT_WORKSPACE_SH"
+    assert_failure
+}
+
+@test "init-workspace.sh makes the scaffold user-writable (#664)" {
+    # shellcheck disable=SC2016
+    run grep -E 'chmod -R u\+w "\$WORKSPACE_DIR"' "$INIT_WORKSPACE_SH"
+    assert_success
 }
 
 # ── parse-github-remote-lib (#509) ─────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes **#664** — a cutover-blocker found by locally testing the Nix-image install flow.

`dockerTools.buildLayeredImage` stores the baked workspace template as **read-only `/nix/store` symlinks**. `init-workspace.sh` scaffolded with `rsync -a` (symlinks-as-symlinks), so a real install produced **dangling, read-only symlinks** on the host (and the placeholder `sed -i` would fail on read-only files). **Latent because CI runs the install/integration tests against the Debian image only** — the Nix image just gets the testinfra suite.

### Fix (`assets/init-workspace.sh`)
- All three scaffold rsyncs now use **`--copy-links`** (`-avL`) to dereference the store symlinks into real files.
- **`chmod -R u+w "$WORKSPACE_DIR"`** right after the scaffold restores writability (the store mode is `0444`) — before the placeholder `sed -i`. No-op on the Debian image.

### Regression guards
- **Static bats** (`init-workspace.bats`, blocking in the integration suite): scaffold rsync uses `--copy-links`, no plain `rsync -av`, workspace made writable. Also updated two existing smoke-mode tests that pinned the old `rsync -av --delete` string.
- **Behavioural** (`nix-image.yml`, amd64): scaffolds via the **real Nix image** and asserts `find -xtype l` is empty and `flake.nix` is a real file.

## Verified locally (rebuilt image + scaffold)
- Before: `flake.nix -> /nix/store/…-devcontainer-bootstrap/…` (dangling on host).
- After: **0 dangling symlinks**; `flake.nix`/`.envrc`/`pyproject.toml` are real files with owner-write mode (`-rw-r--r--`); placeholder substitution applied (`name = "dummy"`); the #640 stub + #641 `--mode` prune intact. `shellcheck` clean.
- (The host showing root-owned files is a docker-rootful artifact; under the devcontainer's podman-rootless runtime the uid maps to the host user.)

## Dependencies
- Relates to #625 / #634 (Nix image) / #639 (unblocks the cutover).

Refs: #664