### PR TITLE
docs(claude): clear residual cursor-agent references in pipeline docs (#627)

### DIFF
--- a/.claude/skills/solve-and-pr/SKILL.md
+++ b/.claude/skills/solve-and-pr/SKILL.md
@@ -29,7 +29,7 @@ This command:
 - Resolves or creates the linked branch
 - Sets up the environment (`uv sync`, `pre-commit install`)
 - Captures the local gh user as the reviewer (`gh api user --jq '.login'`)
-- Launches a tmux session running `cursor-agent` with `--yolo` mode
+- Launches a tmux session running `claude --dangerously-skip-permissions`
 - Passes `/worktree-solve-and-pr` as the initial prompt
 
 ### 3. Report back to the user

--- a/assets/workspace/.claude/skills/solve-and-pr/SKILL.md
+++ b/assets/workspace/.claude/skills/solve-and-pr/SKILL.md
@@ -29,7 +29,7 @@ This command:
 - Resolves or creates the linked branch
 - Sets up the environment (`uv sync`, `pre-commit install`)
 - Captures the local gh user as the reviewer (`gh api user --jq '.login'`)
-- Launches a tmux session running `cursor-agent` with `--yolo` mode
+- Launches a tmux session running `claude --dangerously-skip-permissions`
 - Passes `/worktree-solve-and-pr` as the initial prompt
 
 ### 3. Report back to the user

--- a/docs/SKILL_PIPELINE.md
+++ b/docs/SKILL_PIPELINE.md
@@ -257,15 +257,14 @@ The autonomous pipeline doesn't run inside your current editor session. It runs 
    - Creates and links the branch via `gh issue develop`.
    - Assigns the issue to `@me`.
 4. **Worktree setup** — `git worktree add`, then inside the worktree: `uv sync`, `pre-commit install`, copies `.env` from the main worktree.
-5. **Trust** — adds the worktree path to `~/.cursor/cli-config.json` `trustedDirectories`.
-6. **Launch** — starts `tmux new-session` running `agent chat --model <autonomous-model> --yolo "<prompt>"`.
+5. **Launch** — starts `tmux new-session` running `claude --dangerously-skip-permissions "<prompt>"`.
 
-The `--yolo` flag means the agent auto-approves all shell commands — appropriate because there's no human at this terminal.
+The `--dangerously-skip-permissions` flag means the agent auto-approves all shell commands — appropriate because there's no human at this terminal (the container is the trust boundary; `IS_SANDBOX=1` is set in the image).
 
 ### Model Selection
 
 Agent models are read from `.claude/agent-models.toml`. The worktree recipes use:
-- **`autonomous` tier** for the main `agent chat` session (design, code, reasoning).
+- **`autonomous` tier** for the main `claude` session (design, code, reasoning).
 - **`lightweight` tier** for the one-shot branch-naming call.
 
 ## Typical Interactive Workflow

--- a/docs/templates/SKILL_PIPELINE.md.j2
+++ b/docs/templates/SKILL_PIPELINE.md.j2
@@ -186,15 +186,14 @@ The autonomous pipeline doesn't run inside your current editor session. It runs 
    - Creates and links the branch via `gh issue develop`.
    - Assigns the issue to `@me`.
 4. **Worktree setup** — `git worktree add`, then inside the worktree: `uv sync`, `pre-commit install`, copies `.env` from the main worktree.
-5. **Trust** — adds the worktree path to `~/.cursor/cli-config.json` `trustedDirectories`.
-6. **Launch** — starts `tmux new-session` running `agent chat --model <autonomous-model> --yolo "<prompt>"`.
+5. **Launch** — starts `tmux new-session` running `claude --dangerously-skip-permissions "<prompt>"`.
 
-The `--yolo` flag means the agent auto-approves all shell commands — appropriate because there's no human at this terminal.
+The `--dangerously-skip-permissions` flag means the agent auto-approves all shell commands — appropriate because there's no human at this terminal (the container is the trust boundary; `IS_SANDBOX=1` is set in the image).
 
 ### Model Selection
 
 Agent models are read from `.claude/agent-models.toml`. The worktree recipes use:
-- **`autonomous` tier** for the main `agent chat` session (design, code, reasoning).
+- **`autonomous` tier** for the main `claude` session (design, code, reasoning).
 - **`lightweight` tier** for the one-shot branch-naming call.
 
 ## Typical Interactive Workflow


### PR DESCRIPTION
## Summary

Completes the Cursor→Claude migration's doc cleanup (a #627 lag found while verifying the epic #625 acceptance criterion `grep -ri cursor` → only CHANGELOG + the intentional blocklist).

The worktree pipeline launches `claude --dangerously-skip-permissions` since #627, but two docs still described `cursor-agent` / `agent chat --yolo` and a `~/.cursor/cli-config.json` trust step:
- `.claude/skills/solve-and-pr/SKILL.md` — `cursor-agent --yolo` → `claude --dangerously-skip-permissions`.
- `docs/templates/SKILL_PIPELINE.md.j2` (+ regenerated `docs/SKILL_PIPELINE.md`) — dropped the cursor trust step, updated the launch + model-tier wording to `claude`.

After this, `grep -ri cursor` returns only CHANGELOG history, `docs/issues` archives, and the intentional commit-msg blocklist + its tests.

Refs: #627, #625