### PR TITLE
docs(readme): describe the Nix-built image, drop the Debian base claim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **README now describes the Nix-built image** ([#673](https://github.com/vig-os/devcontainer/issues/673))
+  - Replaced the stale `python:3.12-slim-trixie` Debian base-image claim with the actual build: a Nix flake assembled via `dockerTools.buildLayeredImage` (no Debian/Docker base), with CPython 3.14 and the toolchain from a pinned `nixpkgs`, bit-reproducible
 - **Make `just init` Nix-first** ([#671](https://github.com/vig-os/devcontainer/issues/671))
   - Rewrote `scripts/init.sh` from a multi-OS package installer into a Nix-first gate + bootstrapper: it requires Nix (and direnv, unless `--no-direnv`) and the dev-shell toolchain, then performs one-time, idempotent project bootstrap (`uv sync --frozen --all-extras`, git hooks path, commit-message template, `pre-commit install-hooks`) with advisory `podman info` / `gh auth status` checks. It no longer installs any tool — the toolchain is the flake's `devTools` — and short-circuits inside the built image (`IN_CONTAINER=true`)
   - Repointed `docs/generate.py` and the `CONTRIBUTE.md.j2` template: the per-OS "Requirements" table is now a "Prerequisites: Nix + direnv + a working host container runtime" section, with the toolchain sourced from `flake.nix`

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ For detailed command descriptions, run `just --list --unsorted` or `just --help`
 
 ## Image Details
 
-- **Base Image**: `python:3.12-slim-trixie`
+- **Build**: Nix flake via `dockerTools.buildLayeredImage` (no Debian/Docker base image); bit-reproducible
 - **Registry**: `ghcr.io/vig-os/devcontainer`
 - **Architecture**: Multi-platform support (AMD64, ARM64)
 - **License**: Apache
@@ -204,9 +204,9 @@ For detailed command descriptions, run `just --list --unsorted` or `just --help`
 
 ## Features
 
-### **Base Image**
+### **Build**
 
-- **python:3.12-slim-trixie** – Minimal Python base image (Debian Trixie) for lightweight and robust foundation
+- **Nix flake** – The image is assembled entirely by Nix via `dockerTools.buildLayeredImage` (no Debian/Docker base image). Python (CPython 3.14) and the whole toolchain come from a pinned `nixpkgs`, so the build is bit-reproducible
 
 ### **System Tools**
 
@@ -220,8 +220,7 @@ For detailed command descriptions, run `just --list --unsorted` or `just --help`
 
 ### **Python Environment**
 
-- **Python 3.12** - Latest stable Python version
-- **pip, setuptools, wheel** - Python packaging tools (included with base image)
+- **Python 3.14** - CPython from the pinned `nixpkgs`
 - **uv** - Fast Python package installer and resolver
 
 ### **Development Tools**

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -44,6 +44,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **README now describes the Nix-built image** ([#673](https://github.com/vig-os/devcontainer/issues/673))
+  - Replaced the stale `python:3.12-slim-trixie` Debian base-image claim with the actual build: a Nix flake assembled via `dockerTools.buildLayeredImage` (no Debian/Docker base), with CPython 3.14 and the toolchain from a pinned `nixpkgs`, bit-reproducible
 - **Make `just init` Nix-first** ([#671](https://github.com/vig-os/devcontainer/issues/671))
   - Rewrote `scripts/init.sh` from a multi-OS package installer into a Nix-first gate + bootstrapper: it requires Nix (and direnv, unless `--no-direnv`) and the dev-shell toolchain, then performs one-time, idempotent project bootstrap (`uv sync --frozen --all-extras`, git hooks path, commit-message template, `pre-commit install-hooks`) with advisory `podman info` / `gh auth status` checks. It no longer installs any tool — the toolchain is the flake's `devTools` — and short-circuits inside the built image (`IN_CONTAINER=true`)
   - Repointed `docs/generate.py` and the `CONTRIBUTE.md.j2` template: the per-OS "Requirements" table is now a "Prerequisites: Nix + direnv + a working host container runtime" section, with the toolchain sourced from `flake.nix`

--- a/docs/templates/README.md.j2
+++ b/docs/templates/README.md.j2
@@ -129,7 +129,7 @@ For detailed command descriptions, run `just --list --unsorted` or `just --help`
 
 ## Image Details
 
-- **Base Image**: `python:3.12-slim-trixie`
+- **Build**: Nix flake via `dockerTools.buildLayeredImage` (no Debian/Docker base image); bit-reproducible
 - **Registry**: `ghcr.io/vig-os/devcontainer`
 - **Architecture**: Multi-platform support (AMD64, ARM64)
 - **License**: Apache
@@ -138,9 +138,9 @@ For detailed command descriptions, run `just --list --unsorted` or `just --help`
 
 ## Features
 
-### **Base Image**
+### **Build**
 
-- **python:3.12-slim-trixie** – Minimal Python base image (Debian Trixie) for lightweight and robust foundation
+- **Nix flake** – The image is assembled entirely by Nix via `dockerTools.buildLayeredImage` (no Debian/Docker base image). Python (CPython 3.14) and the whole toolchain come from a pinned `nixpkgs`, so the build is bit-reproducible
 
 ### **System Tools**
 
@@ -154,8 +154,7 @@ For detailed command descriptions, run `just --list --unsorted` or `just --help`
 
 ### **Python Environment**
 
-- **Python 3.12** - Latest stable Python version
-- **pip, setuptools, wheel** - Python packaging tools (included with base image)
+- **Python 3.14** - CPython from the pinned `nixpkgs`
 - **uv** - Fast Python package installer and resolver
 
 ### **Development Tools**


### PR DESCRIPTION
## Summary

The shipped devcontainer image is now built entirely by Nix (`dockerTools.buildLayeredImage` in `flake.nix`; the Debian path was decommissioned in #642), but the README still advertised a `python:3.12-slim-trixie` Debian base image. This corrects the README to match reality.

## Changes

- Edited the source template `docs/templates/README.md.j2` (README.md is generated — `just docs` regenerates it):
  - "Image Details" -> replaced **Base Image: `python:3.12-slim-trixie`** with a **Build** line: Nix flake via `dockerTools.buildLayeredImage` (no Debian/Docker base image); bit-reproducible.
  - "Features" -> renamed **Base Image** section to **Build**, describing the Nix flake build, CPython 3.14, and the pinned `nixpkgs` toolchain.
  - "Python Environment" -> Python 3.12 -> Python 3.14 (CPython from pinned `nixpkgs`); dropped the "pip, setuptools, wheel (included with base image)" line, which no longer holds.
- Regenerated `README.md` via `just docs`.
- Added one CHANGELOG entry under Unreleased -> Changed.

Version facts read directly from `flake.nix` (`python = pkgs.python314`, `nixpkgs nixos-26.05`, deterministic timestamp). No invented numbers.

## Verification

- `grep -rniE "slim-trixie|debian.*base|python:3\.12" README.md docs/templates/README.md.j2` -> no stale claims (only the new "no Debian/Docker base image" phrasing matches `debian.*base`).
- `just docs` regenerated cleanly; `just lint` passed.

Closes #673