### PR TITLE
docs(nix): add consolidated docs/NIX.md reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Consolidated `docs/NIX.md` Nix reference** ([#255](https://github.com/vig-os/devcontainer/issues/255))
+  - Added a single onboarding/architecture doc for the flake: the `devTools` toolchain SSoT and the dev-shell ↔ image parity guard, the stable/unstable channel split + fast-mover overlay, the Nix-built (`buildLayeredImage`) reproducible multi-arch image, the CppNix-vs-Lix and `pre-commit`-vs-`prek` decisions, the `vig-os` Cachix `direnv allow` flow, how `nixpkgs` bumps flow (Renovate `nix` manager + `vulnix` before/after), and the #639 publish-cutover — cross-linking `CONTRIBUTE.md`, `docs/NIX2CONTAINER.md`, and `docs/CONTAINER_SECURITY.md`
 - **Install/init delivery-mode picker (`--mode devcontainer|direnv|both`)** ([#641](https://github.com/vig-os/devcontainer/issues/641))
   - `install.sh` gained a `--mode devcontainer|direnv|both` flag (accepts both `--mode X` and `--mode=X`), validated up front and passed through to `init-workspace.sh`. Empty means "let init-workspace decide": the one-line install runs non-interactively and defaults to `both` (unchanged behaviour)
   - `init-workspace.sh` gained the same `--mode` flag plus an interactive prompt when the mode is unset and prompts are enabled (default selection `both`); under `--no-prompts`/`--smoke-test` with no `--mode` it defaults to `both`. After the rsync scaffold it prunes to the chosen mode: `devcontainer` removes the `flake.nix` + `.envrc` stub, `direnv` removes the `.devcontainer/` scaffold, and `both` keeps everything (prune is idempotent and scoped to the new workspace)

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Consolidated `docs/NIX.md` Nix reference** ([#255](https://github.com/vig-os/devcontainer/issues/255))
+  - Added a single onboarding/architecture doc for the flake: the `devTools` toolchain SSoT and the dev-shell ↔ image parity guard, the stable/unstable channel split + fast-mover overlay, the Nix-built (`buildLayeredImage`) reproducible multi-arch image, the CppNix-vs-Lix and `pre-commit`-vs-`prek` decisions, the `vig-os` Cachix `direnv allow` flow, how `nixpkgs` bumps flow (Renovate `nix` manager + `vulnix` before/after), and the #639 publish-cutover — cross-linking `CONTRIBUTE.md`, `docs/NIX2CONTAINER.md`, and `docs/CONTAINER_SECURITY.md`
 - **Install/init delivery-mode picker (`--mode devcontainer|direnv|both`)** ([#641](https://github.com/vig-os/devcontainer/issues/641))
   - `install.sh` gained a `--mode devcontainer|direnv|both` flag (accepts both `--mode X` and `--mode=X`), validated up front and passed through to `init-workspace.sh`. Empty means "let init-workspace decide": the one-line install runs non-interactively and defaults to `both` (unchanged behaviour)
   - `init-workspace.sh` gained the same `--mode` flag plus an interactive prompt when the mode is unset and prompts are enabled (default selection `both`); under `--no-prompts`/`--smoke-test` with no `--mode` it defaults to `both`. After the rsync scaffold it prunes to the chosen mode: `devcontainer` removes the `flake.nix` + `.envrc` stub, `direnv` removes the `.devcontainer/` scaffold, and `both` keeps everything (prune is idempotent and scoped to the new workspace)

--- a/docs/NIX.md
+++ b/docs/NIX.md
@@ -1,0 +1,167 @@
+# Nix in the vigOS devcontainer
+
+This repository is **Nix-first**: the Nix flake (`flake.nix`) is the single source
+of truth for the development toolchain *and* the basis of the built devcontainer
+image, so the dev-shell and the image can never drift. This document is the
+consolidated reference for how the flake is structured and why. For day-one
+onboarding (clone → `direnv allow`) see the fast path in
+[`CONTRIBUTE.md`](../CONTRIBUTE.md); for the downstream production-image pattern
+see [`docs/NIX2CONTAINER.md`](NIX2CONTAINER.md).
+
+## The flake as the toolchain SSoT
+
+The flake exposes one list, `devTools`, that enumerates every CLI in the
+environment (`just`, `git`, `gh`, `uv`, `nodejs`, `jq`, `tmux`, `ripgrep`, `fd`,
+`bat`, `eza`, `delta`, `lazygit`, `zoxide`, `starship`, `neovim`, `claude-code`,
+`podman`, `hadolint`, `taplo`, `shellcheck`, …). Adding a tool there adds it
+everywhere — the dev-shell now and the image's `imageTools` set.
+
+- **`devShells.default`** is built from `devTools` via `mkProjectShell`, so
+  `nix develop` (or `direnv`) gives you exactly that toolchain.
+- **`mkProjectShell`** is also a reusable `lib` output: downstream repos build
+  their own shell as `devTools ++ extraPackages` (see the scaffolded
+  `assets/workspace/flake.nix`).
+- **`overlays.default`** and **`lib.{mkProjectShell,devTools}`** are exported as
+  system-independent outputs so consumers can follow the same pinned `nixpkgs`.
+
+### Dev-shell ↔ image parity guard
+
+Because both the dev-shell and the image are assembled from `devTools`, a single
+test keeps them honest. `tests/test_flake_devshell.py` reads the binary names
+straight from the flake (`nix eval .#devShellTools`, derived from each package's
+`meta.mainProgram`) and runs `nix develop -c <bin> --version` for every tool,
+asserting it exits 0. The test list is generated *from* the SSoT, so it can never
+drift from the tool list it guards. It is skipped automatically when `nix` is not
+on `PATH` (e.g. the podman image CI lane).
+
+## Stable / unstable channel split and the fast-mover overlay
+
+The flake pins two inputs:
+
+- **`nixpkgs`** → `github:NixOS/nixpkgs/nixos-26.05` — the controlled, pinned
+  stable channel (the "version document", anchored by `flake.lock`). Everything
+  comes from here unless explicitly overridden.
+- **`nixpkgs-unstable`** → `github:NixOS/nixpkgs/nixpkgs-unstable` — overlaid
+  **only** for a small set of fast-moving tools.
+
+The `overlay` (also exported as `overlays.default`) replaces just the `fastMovers`
+list — `uv`, `gh`, and `claude-code` — with their `nixpkgs-unstable` builds.
+These ship frequently and we want the latest version in both shell and image;
+everything else stays on the pinned stable channel for reproducibility.
+
+### uv and managed CPython
+
+The dev-shell carries no Python on `PATH` (the project venv is uv-managed). The
+nixpkgs build of `uv` ships with its embedded Python-download metadata stripped,
+so `uv sync` cannot fetch a managed CPython on its own. `mkProjectShell` therefore
+sets `UV_PYTHON_DOWNLOADS_JSON_URL` to upstream's `download-metadata.json` pinned
+to the provisioned `uv` version, restoring that capability without un-pinning
+nixpkgs. The **image** does not use this: it bakes the interpreter and toolchain
+from nixpkgs and sets `UV_PYTHON_DOWNLOADS=never`.
+
+## The Nix-built image
+
+`packages.devcontainerImage` is assembled entirely by Nix via
+**`dockerTools.buildLayeredImage`** — not a Dockerfile `FROM`. Key properties:
+
+- **Bit-reproducible.** Every build from the same commit and `flake.lock`
+  produces a byte-identical image closure (the epic's "identical image digest on
+  rebuild" criterion). A deterministic `created = "1970-01-01T00:00:00Z"` epoch
+  keeps the digest stable; there is no non-deterministic upgrade step.
+- **Multi-arch.** The image builds natively on an amd64 + arm64 matrix (no QEMU,
+  no cross-compilation); per-arch discovery tags are assembled into a multi-arch
+  index.
+- **Contents = `imageTools`.** That is `devTools` plus the runtime substrate a
+  bare layered image lacks (an FHS base distro would otherwise supply it): the
+  Nix evaluator (`nix`, `direnv`, `nix-direnv`), `glibcLocales` for locale
+  support, the project Python env (`vig-utils` + `pip-licenses` baked via
+  `python314.withPackages`), `pre-commit`/`ruff`/`bandit`, Rust/just tooling
+  (`cargo-binstall`, `just-lsp`, `typstyle`), core GNU utilities, `cacert`,
+  `openssh`, and `dockerTools.fakeNss` (a root uid-0 user database, without which
+  `ssh`/`tmux`/`git` fail with "No user exists for uid 0").
+
+A `bootstrap` layer bakes the workspace assets, the pre-commit cache dir, the
+template `.venv` scaffold, a sticky `/tmp`, and the `precommit`/`cc`/`cld`
+aliases. The image's interpreter is pinned via `UV_PYTHON=<nix python3.14>` and
+`UV_PYTHON_DOWNLOADS=never`.
+
+## Evaluator and pre-commit decisions
+
+These are decided inline in `flake.nix`; summarized here.
+
+- **CppNix vs Lix (#634).** The image ships upstream **CppNix** (`pkgs.nix`) as
+  the in-container evaluator. It is the channel default, needs no overlay, and the
+  flake is installer-agnostic, so swapping to `pkgs.lix` later is a one-line
+  change. `pkgs.lix` is left out for now to keep the closure smaller.
+- **`pre-commit` vs `prek` (#40).** The image bakes upstream **`pre-commit`** to
+  match the prior Debian build and the pinned `pyproject` version. Migrating the
+  cache layer to `prek` is deferred to #40; both are in nixpkgs, so it is a
+  drop-in swap once that issue lands.
+
+## Cachix and the `direnv allow` onboarding flow
+
+The dev-shell closure is published to the public **`vig-os`** Cachix binary
+cache, so the first `direnv allow` is a binary fetch (seconds) rather than a
+from-source build. To use it, enable flakes and add the substituter to your Nix
+config (`~/.config/nix/nix.conf` or `/etc/nix/nix.conf`):
+
+```conf
+experimental-features = nix-command flakes
+substituters = https://cache.nixos.org https://vig-os.cachix.org
+trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= vig-os.cachix.org-1:yoOYRi3bvnM6ThxO0joLt7vtzhTfkq3r6jykeUMg7Bk=
+```
+
+Pulling from the public `vig-os` cache needs no token (`cachix use vig-os` writes
+the same lines). Then:
+
+```bash
+git clone git@github.com:vig-os/devcontainer.git
+cd devcontainer
+direnv allow        # first allow fetches the closure from Cachix
+```
+
+The committed `.envrc` uses [nix-direnv](https://github.com/nix-community/nix-direnv):
+the dev-shell evaluation is cached and GC-rooted under `.direnv/` (gitignored), so
+re-entry is instant and the closure is never garbage-collected. nix-direnv
+self-bootstraps the pinned library on first allow, or uses your
+`~/.config/direnv/direnvrc` installation if you already source it; it falls back
+to bare `use flake` when unavailable. The full fast path lives in
+[`CONTRIBUTE.md`](../CONTRIBUTE.md).
+
+## How `nixpkgs` bumps flow (Renovate + vulnix)
+
+The pinned `nixpkgs` revision in `flake.lock` defines the image's entire CVE
+surface, so advancing the pin is the **primary CVE-remediation lever** (see
+[`docs/CONTAINER_SECURITY.md`](CONTAINER_SECURITY.md) for the full strategy).
+Renovate keeps the pin current through `renovate.json`:
+
+- The **`nix` manager** detects flake inputs and proposes pinned-input updates
+  (committed as `build(nix): …`).
+- **`lockFileMaintenance`** (enabled, scheduled weekly) refreshes the locked
+  revisions of all inputs so upstream security fixes land through the normal
+  PR/CI gate rather than a manual `nix flake update`.
+
+**vulnix before/after requirement.** A `nixpkgs`-rev bump does not declare *which*
+CVE it fixes — the `nix` manager reports only the old → new revision. To preserve
+the audit trail, each `flake.lock` / `nixpkgs`-bump PR should include a `vulnix`
+scan diff taken **before and after** the bump, showing which advisories the new
+revision clears (or introduces). The nightly `vulnix` scan runs against the
+`devcontainerImageEnv` closure; HIGH/CRITICAL findings are gated by `vulnix-gate`
+against the `.vulnixignore` exception register.
+
+## Publish cutover
+
+The Nix image build is currently in the **discovery phase**: the workflows are
+non-publishing (`continue-on-error`) and touch only disposable discovery tags. The
+publish-cutover — flipping the versioned/`:latest` publish to the Nix builder and
+making the `vulnix` gate blocking — is tracked in **issue #639** (the release
+pipeline exposes a `builder: debian|nix` selector for the deliberate cutover run).
+
+## See also
+
+- [`CONTRIBUTE.md`](../CONTRIBUTE.md) — onboarding fast path (clone → `direnv allow`).
+- [`docs/NIX2CONTAINER.md`](NIX2CONTAINER.md) — the downstream production-image
+  pattern with `nix2container` (distinct from this image's `buildLayeredImage`).
+- [`docs/CONTAINER_SECURITY.md`](CONTAINER_SECURITY.md) — the full CVE-patching
+  strategy (pinned `nixpkgs`, `vulnix`, SBOM/Trivy, exception registers).
+- [`flake.nix`](../flake.nix) — the authoritative source for all of the above.


### PR DESCRIPTION
## Summary

Adds `docs/NIX.md`, a single consolidated onboarding/architecture reference for
the Nix flake. Until now the flake's design rationale lived only as inline
comments in `flake.nix` plus the downstream-focused `docs/NIX2CONTAINER.md`;
there was no single doc covering the flake as the toolchain SSoT.

All content is sourced by reading `flake.nix`, `.envrc`, `CONTRIBUTE.md`,
`renovate.json`, `tests/test_flake_devshell.py`, `docs/NIX2CONTAINER.md`, and
`docs/CONTAINER_SECURITY.md` — nothing invented.

## Sections

- The flake as the toolchain SSoT (`devTools`) + dev-shell ↔ image parity guard (`tests/test_flake_devshell.py`)
- Stable/unstable channel split (`nixos-26.05` + `nixpkgs-unstable`) and the fast-mover overlay (`uv`, `gh`, `claude-code`); uv/managed-CPython note
- The Nix-built image (`dockerTools.buildLayeredImage`): bit-reproducibility, multi-arch, `imageTools` contents
- Evaluator decision (CppNix vs Lix) and `pre-commit` vs `prek` (summarizing the flake's inline rationale)
- Cachix (`vig-os`) substituter + `direnv allow` onboarding flow
- How `nixpkgs` bumps flow (Renovate `nix` manager + `lockFileMaintenance` + the `vulnix` before/after requirement)
- Publish-cutover pointer (#639)
- Cross-links to `CONTRIBUTE.md`, `docs/NIX2CONTAINER.md`, `docs/CONTAINER_SECURITY.md`, `flake.nix`

## Notes

- `docs/NIX.md` is authored directly (not a generated file); the `generate-docs` hook does not target it.
- No template edits — chose the conflict-free option (the CONTRIBUTE.md fast path already covers onboarding), avoiding overlap with the sibling template PR.
- CHANGELOG: one new `### Added` bullet; the `sync-manifest` hook mirrored it to `assets/workspace/.devcontainer/CHANGELOG.md`.
- pymarkdown + all pre-commit hooks pass.

Closes #255