### PR TITLE
fix(nix): pin a Nix store CPython for uv in the dev-shell

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -179,23 +179,21 @@ runs:
           | grep '^/nix/store' \
           | grep -v '/nix/store/[^/]*-podman[^/]*/bin' >> "$GITHUB_PATH"
 
-        # Propagate the dev-shell's uv interpreter pin (UV_PYTHON + the
-        # downloads policy) to later steps. GITHUB_PATH only carries PATH, not
-        # env vars, so these vars (set in the flake dev-shell, the SSoT) must be
-        # forwarded explicitly so `uv sync` builds the venv from the pinned Nix
-        # store CPython instead of downloading a managed one — which nixpkgs
-        # does not package, the nixpkgs uv cannot fetch, and a NixOS host cannot
-        # execute. Refs #632, #683. The dev-shell's shellHook prints a banner to
-        # stdout, so read the variables from `env` output by exact key match.
-        DEVSHELL_ENV="$(nix develop --profile "$RUNNER_TEMP/dev-profile" \
-          --command env)"
-        for var in UV_PYTHON UV_PYTHON_DOWNLOADS; do
-          value="$(printf '%s\n' "$DEVSHELL_ENV" | grep "^$var=" | tail -n1 | cut -d= -f2-)"
-          if [ -n "$value" ]; then
-            echo "$var=$value" >> "$GITHUB_ENV"
-            echo "Forwarded $var=$value"
-          fi
-        done
+        # Propagate the dev-shell's uv Python-download metadata URL to later
+        # steps. GITHUB_PATH only carries PATH, not env vars, so this var (set
+        # in the flake dev-shell, the SSoT) must be forwarded explicitly so
+        # `uv sync` can fetch the project's pinned CPython, which nixpkgs does
+        # not package and the nixpkgs uv cannot download on its own. Refs #632.
+        # The dev-shell's shellHook prints a banner to stdout, so capture the
+        # var on its own line and extract just that line (mirrors the PATH
+        # filtering above).
+        UV_DL_JSON_URL="$(nix develop --profile "$RUNNER_TEMP/dev-profile" \
+          --command bash -c 'printf "UV_PYTHON_DOWNLOADS_JSON_URL=%s\n" "${UV_PYTHON_DOWNLOADS_JSON_URL:-}"' \
+          | grep '^UV_PYTHON_DOWNLOADS_JSON_URL=' | tail -n1 | cut -d= -f2-)"
+        if [ -n "$UV_DL_JSON_URL" ]; then
+          echo "UV_PYTHON_DOWNLOADS_JSON_URL=$UV_DL_JSON_URL" >> "$GITHUB_ENV"
+          echo "Forwarded UV_PYTHON_DOWNLOADS_JSON_URL=$UV_DL_JSON_URL"
+        fi
 
         echo "Flake dev-shell provisioned; tools added to PATH:"
         printf '%s' "$SHELL_PATH" | tr ':' '\n' | grep '^/nix/store' | head -50

--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -179,21 +179,23 @@ runs:
           | grep '^/nix/store' \
           | grep -v '/nix/store/[^/]*-podman[^/]*/bin' >> "$GITHUB_PATH"
 
-        # Propagate the dev-shell's uv Python-download metadata URL to later
-        # steps. GITHUB_PATH only carries PATH, not env vars, so this var (set
-        # in the flake dev-shell, the SSoT) must be forwarded explicitly so
-        # `uv sync` can fetch the project's pinned CPython, which nixpkgs does
-        # not package and the nixpkgs uv cannot download on its own. Refs #632.
-        # The dev-shell's shellHook prints a banner to stdout, so capture the
-        # var on its own line and extract just that line (mirrors the PATH
-        # filtering above).
-        UV_DL_JSON_URL="$(nix develop --profile "$RUNNER_TEMP/dev-profile" \
-          --command bash -c 'printf "UV_PYTHON_DOWNLOADS_JSON_URL=%s\n" "${UV_PYTHON_DOWNLOADS_JSON_URL:-}"' \
-          | grep '^UV_PYTHON_DOWNLOADS_JSON_URL=' | tail -n1 | cut -d= -f2-)"
-        if [ -n "$UV_DL_JSON_URL" ]; then
-          echo "UV_PYTHON_DOWNLOADS_JSON_URL=$UV_DL_JSON_URL" >> "$GITHUB_ENV"
-          echo "Forwarded UV_PYTHON_DOWNLOADS_JSON_URL=$UV_DL_JSON_URL"
-        fi
+        # Propagate the dev-shell's uv interpreter pin (UV_PYTHON + the
+        # downloads policy) to later steps. GITHUB_PATH only carries PATH, not
+        # env vars, so these vars (set in the flake dev-shell, the SSoT) must be
+        # forwarded explicitly so `uv sync` builds the venv from the pinned Nix
+        # store CPython instead of downloading a managed one — which nixpkgs
+        # does not package, the nixpkgs uv cannot fetch, and a NixOS host cannot
+        # execute. Refs #632, #683. The dev-shell's shellHook prints a banner to
+        # stdout, so read the variables from `env` output by exact key match.
+        DEVSHELL_ENV="$(nix develop --profile "$RUNNER_TEMP/dev-profile" \
+          --command env)"
+        for var in UV_PYTHON UV_PYTHON_DOWNLOADS; do
+          value="$(printf '%s\n' "$DEVSHELL_ENV" | grep "^$var=" | tail -n1 | cut -d= -f2-)"
+          if [ -n "$value" ]; then
+            echo "$var=$value" >> "$GITHUB_ENV"
+            echo "Forwarded $var=$value"
+          fi
+        done
 
         echo "Flake dev-shell provisioned; tools added to PATH:"
         printf '%s' "$SHELL_PATH" | tr ':' '\n' | grep '^/nix/store' | head -50

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,7 +82,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Provision CI build/test tooling from the flake dev-shell** ([#632](https://github.com/vig-os/devcontainer/issues/632))
   - The `setup-env` action gained a `provision-via-flake` mode that installs Nix (SHA-pinned `install-nix-action`) and the `vig-os` Cachix substituter, builds the flake dev-shell, and prepends its tools to `PATH`, replacing the ad-hoc installs of `uv`/Python, `just`, `hadolint`, and `taplo`
   - Enabled the mode in the CI build/test path (`build-image`, `test-image`, `test-integration`, `project-checks`) so jobs run inside the flake shell (the toolchain SSoT); `podman`, Node.js, BATS, and the devcontainer CLI keep their dedicated install paths
-  - Set `UV_PYTHON_DOWNLOADS_JSON_URL` in the flake dev-shell so the nixpkgs `uv` (whose embedded Python-download list is stripped) can fetch the project's pinned CPython `3.14.6`, which nixpkgs does not package, letting `uv sync --frozen` succeed under flake provisioning
+  - Pinned the project interpreter for the flake-provisioned `uv` so `uv sync --frozen` succeeds under flake provisioning: the dev-shell exports `UV_PYTHON` (a Nix store CPython, which nixpkgs does not package as a managed download) with `UV_PYTHON_DOWNLOADS=never`, and the `setup-env` action forwards both to later CI steps
   - Keep `podman` off the flake-provisioned `PATH` so the runner's rootless-configured host `podman` is used (the nix-store `podman` cannot reach the host's setuid `newuidmap`/`newgidmap`, so `podman info` failed)
 
 ### Deprecated
@@ -104,6 +104,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`just init` no longer fails on NixOS hosts (uv downloaded a CPython NixOS cannot execute)** ([#683](https://github.com/vig-os/devcontainer/issues/683))
+  - The flake dev-shell carried no Python and let the nixpkgs `uv` fetch a managed CPython — a generic, dynamically-linked ELF a NixOS host cannot execute out of the box (no FHS `ld-linux`) — so `uv sync` (`just init`) aborted on NixOS hosts while FHS hosts were unaffected
+  - `mkProjectShell` now pins a Nix store CPython via `UV_PYTHON` and sets `UV_PYTHON_DOWNLOADS=never` (mirroring the image path), so the venv is built from a store interpreter patched to the store loader that runs on both NixOS and FHS hosts; the CI `setup-env` flake-provision step forwards both vars in place of the retired `UV_PYTHON_DOWNLOADS_JSON_URL`
+  - Added dev-shell tests asserting `UV_PYTHON_DOWNLOADS=never` and `UV_PYTHON` pinned to a runnable Nix store CPython 3.14
 - **Nix image no longer scaffolds dangling, read-only symlinks into a new workspace** ([#664](https://github.com/vig-os/devcontainer/issues/664))
   - The Nix-built image bakes the workspace template as read-only `/nix/store` symlinks (how `buildLayeredImage` represents the layer); `init-workspace.sh` now rsyncs with `--copy-links` and `chmod -R u+w "$WORKSPACE_DIR"`, so a scaffolded workspace gets real, writable files instead of symlinks that dangle on the host (and the placeholder `sed -i` no longer fails on read-only files). No-op on the Debian image
   - Added a static bats guard (scaffold rsync uses `--copy-links`; workspace made writable) and a behavioural step in `nix-image.yml` that scaffolds via the real Nix image and asserts no dangling symlinks — the install/integration suite otherwise only exercises the Debian image

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,7 +82,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Provision CI build/test tooling from the flake dev-shell** ([#632](https://github.com/vig-os/devcontainer/issues/632))
   - The `setup-env` action gained a `provision-via-flake` mode that installs Nix (SHA-pinned `install-nix-action`) and the `vig-os` Cachix substituter, builds the flake dev-shell, and prepends its tools to `PATH`, replacing the ad-hoc installs of `uv`/Python, `just`, `hadolint`, and `taplo`
   - Enabled the mode in the CI build/test path (`build-image`, `test-image`, `test-integration`, `project-checks`) so jobs run inside the flake shell (the toolchain SSoT); `podman`, Node.js, BATS, and the devcontainer CLI keep their dedicated install paths
-  - Pinned the project interpreter for the flake-provisioned `uv` so `uv sync --frozen` succeeds under flake provisioning: the dev-shell exports `UV_PYTHON` (a Nix store CPython, which nixpkgs does not package as a managed download) with `UV_PYTHON_DOWNLOADS=never`, and the `setup-env` action forwards both to later CI steps
+  - Set `UV_PYTHON_DOWNLOADS_JSON_URL` in the flake dev-shell so the nixpkgs `uv` (whose embedded Python-download list is stripped) can fetch the project's pinned CPython `3.14.6`, which nixpkgs does not package, letting `uv sync --frozen` succeed under flake provisioning
   - Keep `podman` off the flake-provisioned `PATH` so the runner's rootless-configured host `podman` is used (the nix-store `podman` cannot reach the host's setuid `newuidmap`/`newgidmap`, so `podman info` failed)
 
 ### Deprecated
@@ -106,7 +106,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`just init` no longer fails on NixOS hosts (uv downloaded a CPython NixOS cannot execute)** ([#683](https://github.com/vig-os/devcontainer/issues/683))
   - The flake dev-shell carried no Python and let the nixpkgs `uv` fetch a managed CPython — a generic, dynamically-linked ELF a NixOS host cannot execute out of the box (no FHS `ld-linux`) — so `uv sync` (`just init`) aborted on NixOS hosts while FHS hosts were unaffected
-  - `mkProjectShell` now pins a Nix store CPython via `UV_PYTHON` and sets `UV_PYTHON_DOWNLOADS=never` (mirroring the image path), so the venv is built from a store interpreter patched to the store loader that runs on both NixOS and FHS hosts; the CI `setup-env` flake-provision step forwards both vars in place of the retired `UV_PYTHON_DOWNLOADS_JSON_URL`
+  - `mkProjectShell` now pins a Nix store CPython via `UV_PYTHON` and sets `UV_PYTHON_DOWNLOADS=never`, so the dev-shell builds the venv from a store interpreter (patched to the store loader) that runs on both NixOS and FHS hosts instead of a downloaded one
+  - CI keeps its managed-download path (`UV_PYTHON_DOWNLOADS_JSON_URL`) and does **not** receive `UV_PYTHON`: the `provision-via-flake` jobs run outside `nix develop` on an FHS runner, where a Nix store interpreter cannot load pre-commit's manylinux-wheel C extensions (`libstdc++.so.6`)
   - Added dev-shell tests asserting `UV_PYTHON_DOWNLOADS=never` and `UV_PYTHON` pinned to a runnable Nix store CPython 3.14
 - **Nix image no longer scaffolds dangling, read-only symlinks into a new workspace** ([#664](https://github.com/vig-os/devcontainer/issues/664))
   - The Nix-built image bakes the workspace template as read-only `/nix/store` symlinks (how `buildLayeredImage` represents the layer); `init-workspace.sh` now rsyncs with `--copy-links` and `chmod -R u+w "$WORKSPACE_DIR"`, so a scaffolded workspace gets real, writable files instead of symlinks that dangle on the host (and the placeholder `sed -i` no longer fails on read-only files). No-op on the Debian image

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -82,7 +82,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Provision CI build/test tooling from the flake dev-shell** ([#632](https://github.com/vig-os/devcontainer/issues/632))
   - The `setup-env` action gained a `provision-via-flake` mode that installs Nix (SHA-pinned `install-nix-action`) and the `vig-os` Cachix substituter, builds the flake dev-shell, and prepends its tools to `PATH`, replacing the ad-hoc installs of `uv`/Python, `just`, `hadolint`, and `taplo`
   - Enabled the mode in the CI build/test path (`build-image`, `test-image`, `test-integration`, `project-checks`) so jobs run inside the flake shell (the toolchain SSoT); `podman`, Node.js, BATS, and the devcontainer CLI keep their dedicated install paths
-  - Set `UV_PYTHON_DOWNLOADS_JSON_URL` in the flake dev-shell so the nixpkgs `uv` (whose embedded Python-download list is stripped) can fetch the project's pinned CPython `3.14.6`, which nixpkgs does not package, letting `uv sync --frozen` succeed under flake provisioning
+  - Pinned the project interpreter for the flake-provisioned `uv` so `uv sync --frozen` succeeds under flake provisioning: the dev-shell exports `UV_PYTHON` (a Nix store CPython, which nixpkgs does not package as a managed download) with `UV_PYTHON_DOWNLOADS=never`, and the `setup-env` action forwards both to later CI steps
   - Keep `podman` off the flake-provisioned `PATH` so the runner's rootless-configured host `podman` is used (the nix-store `podman` cannot reach the host's setuid `newuidmap`/`newgidmap`, so `podman info` failed)
 
 ### Deprecated
@@ -104,6 +104,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`just init` no longer fails on NixOS hosts (uv downloaded a CPython NixOS cannot execute)** ([#683](https://github.com/vig-os/devcontainer/issues/683))
+  - The flake dev-shell carried no Python and let the nixpkgs `uv` fetch a managed CPython — a generic, dynamically-linked ELF a NixOS host cannot execute out of the box (no FHS `ld-linux`) — so `uv sync` (`just init`) aborted on NixOS hosts while FHS hosts were unaffected
+  - `mkProjectShell` now pins a Nix store CPython via `UV_PYTHON` and sets `UV_PYTHON_DOWNLOADS=never` (mirroring the image path), so the venv is built from a store interpreter patched to the store loader that runs on both NixOS and FHS hosts; the CI `setup-env` flake-provision step forwards both vars in place of the retired `UV_PYTHON_DOWNLOADS_JSON_URL`
+  - Added dev-shell tests asserting `UV_PYTHON_DOWNLOADS=never` and `UV_PYTHON` pinned to a runnable Nix store CPython 3.14
 - **Nix image no longer scaffolds dangling, read-only symlinks into a new workspace** ([#664](https://github.com/vig-os/devcontainer/issues/664))
   - The Nix-built image bakes the workspace template as read-only `/nix/store` symlinks (how `buildLayeredImage` represents the layer); `init-workspace.sh` now rsyncs with `--copy-links` and `chmod -R u+w "$WORKSPACE_DIR"`, so a scaffolded workspace gets real, writable files instead of symlinks that dangle on the host (and the placeholder `sed -i` no longer fails on read-only files). No-op on the Debian image
   - Added a static bats guard (scaffold rsync uses `--copy-links`; workspace made writable) and a behavioural step in `nix-image.yml` that scaffolds via the real Nix image and asserts no dangling symlinks — the install/integration suite otherwise only exercises the Debian image

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -82,7 +82,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Provision CI build/test tooling from the flake dev-shell** ([#632](https://github.com/vig-os/devcontainer/issues/632))
   - The `setup-env` action gained a `provision-via-flake` mode that installs Nix (SHA-pinned `install-nix-action`) and the `vig-os` Cachix substituter, builds the flake dev-shell, and prepends its tools to `PATH`, replacing the ad-hoc installs of `uv`/Python, `just`, `hadolint`, and `taplo`
   - Enabled the mode in the CI build/test path (`build-image`, `test-image`, `test-integration`, `project-checks`) so jobs run inside the flake shell (the toolchain SSoT); `podman`, Node.js, BATS, and the devcontainer CLI keep their dedicated install paths
-  - Pinned the project interpreter for the flake-provisioned `uv` so `uv sync --frozen` succeeds under flake provisioning: the dev-shell exports `UV_PYTHON` (a Nix store CPython, which nixpkgs does not package as a managed download) with `UV_PYTHON_DOWNLOADS=never`, and the `setup-env` action forwards both to later CI steps
+  - Set `UV_PYTHON_DOWNLOADS_JSON_URL` in the flake dev-shell so the nixpkgs `uv` (whose embedded Python-download list is stripped) can fetch the project's pinned CPython `3.14.6`, which nixpkgs does not package, letting `uv sync --frozen` succeed under flake provisioning
   - Keep `podman` off the flake-provisioned `PATH` so the runner's rootless-configured host `podman` is used (the nix-store `podman` cannot reach the host's setuid `newuidmap`/`newgidmap`, so `podman info` failed)
 
 ### Deprecated
@@ -106,7 +106,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`just init` no longer fails on NixOS hosts (uv downloaded a CPython NixOS cannot execute)** ([#683](https://github.com/vig-os/devcontainer/issues/683))
   - The flake dev-shell carried no Python and let the nixpkgs `uv` fetch a managed CPython — a generic, dynamically-linked ELF a NixOS host cannot execute out of the box (no FHS `ld-linux`) — so `uv sync` (`just init`) aborted on NixOS hosts while FHS hosts were unaffected
-  - `mkProjectShell` now pins a Nix store CPython via `UV_PYTHON` and sets `UV_PYTHON_DOWNLOADS=never` (mirroring the image path), so the venv is built from a store interpreter patched to the store loader that runs on both NixOS and FHS hosts; the CI `setup-env` flake-provision step forwards both vars in place of the retired `UV_PYTHON_DOWNLOADS_JSON_URL`
+  - `mkProjectShell` now pins a Nix store CPython via `UV_PYTHON` and sets `UV_PYTHON_DOWNLOADS=never`, so the dev-shell builds the venv from a store interpreter (patched to the store loader) that runs on both NixOS and FHS hosts instead of a downloaded one
+  - CI keeps its managed-download path (`UV_PYTHON_DOWNLOADS_JSON_URL`) and does **not** receive `UV_PYTHON`: the `provision-via-flake` jobs run outside `nix develop` on an FHS runner, where a Nix store interpreter cannot load pre-commit's manylinux-wheel C extensions (`libstdc++.so.6`)
   - Added dev-shell tests asserting `UV_PYTHON_DOWNLOADS=never` and `UV_PYTHON` pinned to a runnable Nix store CPython 3.14
 - **Nix image no longer scaffolds dangling, read-only symlinks into a new workspace** ([#664](https://github.com/vig-os/devcontainer/issues/664))
   - The Nix-built image bakes the workspace template as read-only `/nix/store` symlinks (how `buildLayeredImage` represents the layer); `init-workspace.sh` now rsyncs with `--copy-links` and `chmod -R u+w "$WORKSPACE_DIR"`, so a scaffolded workspace gets real, writable files instead of symlinks that dangle on the host (and the placeholder `sed -i` no longer fails on read-only files). No-op on the Debian image

--- a/docs/NIX.md
+++ b/docs/NIX.md
@@ -56,10 +56,19 @@ The dev-shell carries no Python on `PATH` (the project venv is uv-managed), so
 pins a Nix store CPython via `UV_PYTHON` and forbids downloads with
 `UV_PYTHON_DOWNLOADS=never`. This avoids letting the nixpkgs `uv` fetch a managed
 CPython: that download is a generic, dynamically-linked ELF a NixOS host cannot
-execute out of the box (no FHS `ld-linux`), so `uv sync` aborted there (#683). A
-store interpreter is patched to the store loader and runs on both NixOS and FHS
-hosts. The **image** path uses the same two variables, baking the interpreter and
-toolchain from nixpkgs.
+execute out of the box (no FHS `ld-linux`), so `uv sync` (`just init`) aborted
+there (#683). A store interpreter is patched to the store loader and runs in the
+dev-shell on both NixOS and FHS hosts. The **image** path uses the same two
+variables, baking the interpreter and toolchain from nixpkgs.
+
+**CI is the exception.** The `provision-via-flake` jobs (#632) run *outside*
+`nix develop` — they only prepend the dev-shell's tool `PATH` — on an FHS runner,
+where a Nix store interpreter cannot load pre-commit's manylinux-wheel C
+extensions (`libstdc++.so.6`). So the dev-shell also keeps
+`UV_PYTHON_DOWNLOADS_JSON_URL` set (pinned to the provisioned `uv` release), and
+the `setup-env` action forwards **that URL only** — not `UV_PYTHON` — so the
+runner's stripped nixpkgs `uv` downloads a managed CPython instead. Locally the
+pin wins and no download happens; the URL matters only on the CI runner.
 
 ## The Nix-built image
 

--- a/docs/NIX.md
+++ b/docs/NIX.md
@@ -49,15 +49,17 @@ list — `uv`, `gh`, and `claude-code` — with their `nixpkgs-unstable` builds.
 These ship frequently and we want the latest version in both shell and image;
 everything else stays on the pinned stable channel for reproducibility.
 
-### uv and managed CPython
+### uv and the project interpreter
 
-The dev-shell carries no Python on `PATH` (the project venv is uv-managed). The
-nixpkgs build of `uv` ships with its embedded Python-download metadata stripped,
-so `uv sync` cannot fetch a managed CPython on its own. `mkProjectShell` therefore
-sets `UV_PYTHON_DOWNLOADS_JSON_URL` to upstream's `download-metadata.json` pinned
-to the provisioned `uv` version, restoring that capability without un-pinning
-nixpkgs. The **image** does not use this: it bakes the interpreter and toolchain
-from nixpkgs and sets `UV_PYTHON_DOWNLOADS=never`.
+The dev-shell carries no Python on `PATH` (the project venv is uv-managed), so
+`uv sync` must be told which interpreter to build the venv from. `mkProjectShell`
+pins a Nix store CPython via `UV_PYTHON` and forbids downloads with
+`UV_PYTHON_DOWNLOADS=never`. This avoids letting the nixpkgs `uv` fetch a managed
+CPython: that download is a generic, dynamically-linked ELF a NixOS host cannot
+execute out of the box (no FHS `ld-linux`), so `uv sync` aborted there (#683). A
+store interpreter is patched to the store loader and runs on both NixOS and FHS
+hosts. The **image** path uses the same two variables, baking the interpreter and
+toolchain from nixpkgs.
 
 ## The Nix-built image
 

--- a/flake.nix
+++ b/flake.nix
@@ -116,6 +116,16 @@
       #     inherit pkgs;
       #     extraPackages = [ pkgs.foo ];
       #   };
+      # ---------------------------------------------------------------------
+      # uv's Python-download metadata, pinned to the uv release we provision.
+      # The nixpkgs build of uv ships with its embedded Python-download list
+      # stripped, so it cannot fetch a managed CPython on its own. CI provisions
+      # FROM this dev-shell on an FHS runner and forwards this URL (see the
+      # setup-env action) so the runner's uv can download a managed CPython for
+      # `uv sync` / pre-commit — a Nix-store interpreter cannot load pre-commit's
+      # manylinux-wheel C extensions outside `nix develop`. Refs #632, #666, #683.
+      uvPythonDownloadsJsonUrl = "https://raw.githubusercontent.com/astral-sh/uv/0.11.23/crates/uv-python/download-metadata.json";
+
       mkProjectShell =
         {
           pkgs,
@@ -124,16 +134,14 @@
         }:
         let
           # CPython matching `requires-python` (>=3.14,<3.15). The dev-shell
-          # carries no Python on PATH (the project venv is uv-managed), so
-          # `uv sync` must be told which interpreter to build the venv from. We
-          # pin a Nix store CPython via UV_PYTHON and forbid downloads
-          # (UV_PYTHON_DOWNLOADS=never) rather than let the nixpkgs uv fetch a
-          # managed CPython: that download is a generic, dynamically-linked ELF
-          # a NixOS host cannot execute out of the box (no FHS ld-linux), so
-          # `uv sync` aborted there (#683). A store interpreter is patched to
-          # the store loader and runs on both NixOS and FHS hosts. This mirrors
-          # the IMAGE path, which bakes pythonEnv and sets the same two vars.
-          # Refs #632, #666, #683.
+          # carries no Python on PATH (the project venv is uv-managed). Pin a
+          # Nix store CPython via UV_PYTHON and forbid downloads
+          # (UV_PYTHON_DOWNLOADS=never): the nixpkgs uv would otherwise fetch a
+          # generic, dynamically-linked managed CPython a NixOS host cannot
+          # execute out of the box (no FHS ld-linux), so `uv sync` (`just init`)
+          # aborted there (#683). A store interpreter is patched to the store
+          # loader and runs in the dev-shell on both NixOS and FHS hosts. The
+          # IMAGE path sets the same two vars (baking pythonEnv). Refs #666, #683.
           python = pkgs.python314;
         in
         pkgs.mkShell {
@@ -142,6 +150,12 @@
 
           UV_PYTHON = "${python}/bin/python3.14";
           UV_PYTHON_DOWNLOADS = "never";
+
+          # For CI only: the pin above means downloads never happen in the
+          # dev-shell, but CI forwards this URL (NOT UV_PYTHON) so its FHS runner
+          # downloads a managed CPython for pre-commit's manylinux-wheel hooks,
+          # which a Nix-store interpreter cannot load there. Refs #632, #683.
+          UV_PYTHON_DOWNLOADS_JSON_URL = uvPythonDownloadsJsonUrl;
         };
     in
     flake-utils.lib.eachDefaultSystem (

--- a/flake.nix
+++ b/flake.nix
@@ -116,33 +116,32 @@
       #     inherit pkgs;
       #     extraPackages = [ pkgs.foo ];
       #   };
-      # ---------------------------------------------------------------------
-      # uv's Python-download metadata, pinned to the uv release we provision.
-      #
-      # The nixpkgs build of uv ships with its embedded Python-download list
-      # stripped (Nix is expected to supply interpreters), so `uv sync` cannot
-      # fetch a managed CPython on its own — it reports "No interpreter found
-      # ... in managed installations or search path". The dev-shell carries no
-      # Python on PATH (the project venv is uv-managed), so uv must fetch a
-      # CPython matching `requires-python` (>=3.14,<3.15). Pointing uv at
-      # upstream's download-metadata.json (pinned to the provisioned uv version)
-      # restores that capability without un-pinning nixpkgs. The IMAGE does not
-      # use this: it bakes the interpreter (pythonEnv) + the toolchain from
-      # nixpkgs and sets UV_PYTHON_DOWNLOADS=never. Refs #632, #666.
-      uvPythonDownloadsJsonUrl = "https://raw.githubusercontent.com/astral-sh/uv/0.11.23/crates/uv-python/download-metadata.json";
-
       mkProjectShell =
         {
           pkgs,
           extraPackages ? [ ],
           shellHook ? ''echo "devcontainer dev environment loaded (nix)"'',
         }:
+        let
+          # CPython matching `requires-python` (>=3.14,<3.15). The dev-shell
+          # carries no Python on PATH (the project venv is uv-managed), so
+          # `uv sync` must be told which interpreter to build the venv from. We
+          # pin a Nix store CPython via UV_PYTHON and forbid downloads
+          # (UV_PYTHON_DOWNLOADS=never) rather than let the nixpkgs uv fetch a
+          # managed CPython: that download is a generic, dynamically-linked ELF
+          # a NixOS host cannot execute out of the box (no FHS ld-linux), so
+          # `uv sync` aborted there (#683). A store interpreter is patched to
+          # the store loader and runs on both NixOS and FHS hosts. This mirrors
+          # the IMAGE path, which bakes pythonEnv and sets the same two vars.
+          # Refs #632, #666, #683.
+          python = pkgs.python314;
+        in
         pkgs.mkShell {
           packages = (devTools pkgs) ++ extraPackages;
           inherit shellHook;
 
-          # Let the nixpkgs uv resolve managed Python downloads (see note above).
-          UV_PYTHON_DOWNLOADS_JSON_URL = uvPythonDownloadsJsonUrl;
+          UV_PYTHON = "${python}/bin/python3.14";
+          UV_PYTHON_DOWNLOADS = "never";
         };
     in
     flake-utils.lib.eachDefaultSystem (

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -188,8 +188,9 @@ cd "$PROJECT_ROOT"
 
 print_section "Project Bootstrap"
 
-# Materialize the project venv from the lockfile. uv resolves the pinned CPython
-# via the flake's UV_PYTHON_DOWNLOADS_JSON_URL; no interpreter is hardcoded here.
+# Materialize the project venv from the lockfile. uv builds it from the
+# interpreter the flake dev-shell pins via UV_PYTHON (UV_PYTHON_DOWNLOADS=never);
+# no interpreter is hardcoded here.
 log_info "Syncing the project environment from the lockfile..."
 if uv sync --frozen --all-extras; then
     log_success "Project dependencies installed"

--- a/tests/test_flake_devshell.py
+++ b/tests/test_flake_devshell.py
@@ -72,6 +72,73 @@ def current_system() -> str:
 
 
 @pytest.fixture(scope="session")
+def dev_shell_env() -> dict[str, str]:
+    """Environment variables exported by the Nix dev-shell.
+
+    Runs ``nix develop -c env`` once and parses the result so the UV-bootstrap
+    assertions below share a single (slow) shell instantiation.
+    """
+    result = subprocess.run(
+        ["nix", "develop", str(REPO_ROOT), "-c", "env"],
+        capture_output=True,
+        text=True,
+        env=_nix_env(),
+        timeout=900,
+    )
+    if result.returncode != 0:
+        pytest.fail("Failed to capture the dev-shell environment:\n" + result.stderr)
+    env: dict[str, str] = {}
+    for line in result.stdout.splitlines():
+        key, sep, value = line.partition("=")
+        if sep:
+            env[key] = value
+    return env
+
+
+def test_devshell_disables_uv_python_downloads(dev_shell_env: dict[str, str]) -> None:
+    """The dev-shell must forbid uv from downloading a managed CPython (#683).
+
+    On a NixOS host a downloaded generic CPython is a dynamically-linked ELF the
+    host cannot execute out of the box, so ``uv sync`` (``just init``) aborts.
+    ``UV_PYTHON_DOWNLOADS=never`` forces uv to resolve a Nix store interpreter
+    instead, mirroring the image path.
+    """
+    assert dev_shell_env.get("UV_PYTHON_DOWNLOADS") == "never", (
+        "UV_PYTHON_DOWNLOADS must be 'never' so uv never fetches a generic "
+        f"CPython; got {dev_shell_env.get('UV_PYTHON_DOWNLOADS')!r}"
+    )
+
+
+def test_devshell_uv_python_pins_nix_store_interpreter(
+    dev_shell_env: dict[str, str],
+) -> None:
+    """UV_PYTHON must point at a runnable Nix store CPython 3.14 (#683).
+
+    A store interpreter is patched to the store's loader, so it runs on both
+    NixOS and FHS hosts — the cross-host fix for the failed ``uv sync``.
+    """
+    uv_python = dev_shell_env.get("UV_PYTHON")
+    assert uv_python, "UV_PYTHON must be set in the dev-shell"
+    assert uv_python.startswith("/nix/store/"), (
+        f"UV_PYTHON must be a Nix store interpreter, not {uv_python!r}"
+    )
+    interpreter = Path(uv_python)
+    assert interpreter.is_file() and os.access(interpreter, os.X_OK), (
+        f"UV_PYTHON does not point at an executable file: {uv_python}"
+    )
+    proc = subprocess.run(
+        [uv_python, "--version"],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert proc.returncode == 0 and "3.14" in proc.stdout, (
+        f"UV_PYTHON did not report Python 3.14: rc={proc.returncode} "
+        f"stdout={proc.stdout!r} stderr={proc.stderr!r}"
+    )
+
+
+@pytest.fixture(scope="session")
 def dev_shell_tools(current_system: str) -> list[str]:
     """Binary names of every tool in the flake's ``devTools`` SSoT."""
     result = subprocess.run(


### PR DESCRIPTION
## Description

On a **NixOS host**, onboarding via `direnv allow` + `just init` failed during the `uv sync` bootstrap. The flake dev-shell carried no Python on `PATH` and let the nixpkgs `uv` fetch a *managed* CPython matching `requires-python`. That download is a generic, dynamically-linked ELF a NixOS host cannot execute out of the box (no FHS `ld-linux`, see https://nix.dev/permalink/stub-ld), so `uv sync` aborted and `just init` exited non-zero. FHS hosts were unaffected.

This pins a Nix store CPython for `uv` in the **dev-shell** (`mkProjectShell`), so the venv is built from a store interpreter that runs on NixOS and FHS hosts alike. CI is deliberately left on its managed-download path (see below).

## Type of Change

- [x] `fix` -- Bug fix

## Changes Made

- **`flake.nix` (`mkProjectShell`):** set `UV_PYTHON=${pkgs.python314}/bin/python3.14` and `UV_PYTHON_DOWNLOADS=never` so the dev-shell never downloads a generic managed CPython. `UV_PYTHON_DOWNLOADS_JSON_URL` is retained (see CI note).
- **CI is the exception — `setup-env` is unchanged:** the `provision-via-flake` jobs run *outside* `nix develop` on an FHS runner, where a Nix store interpreter cannot load pre-commit's manylinux-wheel C extensions (`libstdc++.so.6`). So the action keeps forwarding `UV_PYTHON_DOWNLOADS_JSON_URL` **only** (not `UV_PYTHON`), and the runner downloads a managed CPython as before. (An earlier revision forwarded `UV_PYTHON` and broke the `pymarkdown` hook with a `libstdc++` `ImportError`; that was reverted.)
- **`scripts/init.sh`:** updated the bootstrap comment to describe the pinned interpreter.
- **`docs/NIX.md`, `CHANGELOG.md`:** documented the dev-shell-pin / CI-download split.

## Changelog Entry

### Fixed

- **`just init` no longer fails on NixOS hosts (uv downloaded a CPython NixOS cannot execute)** ([#683](https://github.com/vig-os/devcontainer/issues/683))
  - The flake dev-shell carried no Python and let the nixpkgs `uv` fetch a managed CPython — a generic, dynamically-linked ELF a NixOS host cannot execute out of the box (no FHS `ld-linux`) — so `uv sync` (`just init`) aborted on NixOS hosts while FHS hosts were unaffected
  - `mkProjectShell` now pins a Nix store CPython via `UV_PYTHON` and sets `UV_PYTHON_DOWNLOADS=never`, so the dev-shell builds the venv from a store interpreter (patched to the store loader) that runs on both NixOS and FHS hosts instead of a downloaded one
  - CI keeps its managed-download path (`UV_PYTHON_DOWNLOADS_JSON_URL`) and does **not** receive `UV_PYTHON`: the `provision-via-flake` jobs run outside `nix develop` on an FHS runner, where a Nix store interpreter cannot load pre-commit's manylinux-wheel C extensions (`libstdc++.so.6`)
  - Added dev-shell tests asserting `UV_PYTHON_DOWNLOADS=never` and `UV_PYTHON` pinned to a runnable Nix store CPython 3.14

## Testing

- [x] Tests pass locally (`tests/test_flake_devshell.py` + `tests/test_flake_checks.py` → 7 passed, incl. `nix flake check`)
- [x] Manual testing performed: verified on a real **NixOS host** — `just init` now completes and materializes the venv from the lockfile
- [x] Full CI (`test-suite=all`) green on the PR head branch

## Acceptance Criteria

- [x] `just init` materializes the venv on a NixOS host (no generic CPython download)
- [x] Onboarding remains working on FHS hosts (no regression; CI green)
- [x] No generic dynamically-linked CPython is downloaded by `uv sync` in the dev-shell
- [x] TDD compliance (RED test committed first)

Refs: #683
