### PR TITLE
fix(setup): ensure a containers policy.json so podman load works in the dev-shell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`just build` no longer fails on dev-shell-only podman hosts (missing containers `policy.json`)** ([#685](https://github.com/vig-os/devcontainer/issues/685))
+  - On a NixOS host that gets `podman` purely from the flake dev-shell (no `virtualisation.containers` module), no signature-verification `policy.json` exists at `/etc/containers/policy.json` or `~/.config/containers/policy.json`, so `podman load` (`just build`) failed even though `nix build` and the advisory `podman info` check (`just init`) were green
+  - `just init` now ensures the user-level `~/.config/containers/policy.json` with the standard permissive default (`{ "default": [ { "type": "insecureAcceptAnything" } ] }`, the same content `containers-common` / the NixOS module ship); the write is idempotent and never overwrites a system or user policy. Documented in `docs/NIX.md`
 - **`just init` no longer fails on NixOS hosts (uv downloaded a CPython NixOS cannot execute)** ([#683](https://github.com/vig-os/devcontainer/issues/683))
   - The flake dev-shell carried no Python and let the nixpkgs `uv` fetch a managed CPython — a generic, dynamically-linked ELF a NixOS host cannot execute out of the box (no FHS `ld-linux`) — so `uv sync` (`just init`) aborted on NixOS hosts while FHS hosts were unaffected
   - `mkProjectShell` now pins a Nix store CPython via `UV_PYTHON` and sets `UV_PYTHON_DOWNLOADS=never`, so the dev-shell builds the venv from a store interpreter (patched to the store loader) that runs on both NixOS and FHS hosts instead of a downloaded one

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -104,6 +104,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`just build` no longer fails on dev-shell-only podman hosts (missing containers `policy.json`)** ([#685](https://github.com/vig-os/devcontainer/issues/685))
+  - On a NixOS host that gets `podman` purely from the flake dev-shell (no `virtualisation.containers` module), no signature-verification `policy.json` exists at `/etc/containers/policy.json` or `~/.config/containers/policy.json`, so `podman load` (`just build`) failed even though `nix build` and the advisory `podman info` check (`just init`) were green
+  - `just init` now ensures the user-level `~/.config/containers/policy.json` with the standard permissive default (`{ "default": [ { "type": "insecureAcceptAnything" } ] }`, the same content `containers-common` / the NixOS module ship); the write is idempotent and never overwrites a system or user policy. Documented in `docs/NIX.md`
 - **`just init` no longer fails on NixOS hosts (uv downloaded a CPython NixOS cannot execute)** ([#683](https://github.com/vig-os/devcontainer/issues/683))
   - The flake dev-shell carried no Python and let the nixpkgs `uv` fetch a managed CPython — a generic, dynamically-linked ELF a NixOS host cannot execute out of the box (no FHS `ld-linux`) — so `uv sync` (`just init`) aborted on NixOS hosts while FHS hosts were unaffected
   - `mkProjectShell` now pins a Nix store CPython via `UV_PYTHON` and sets `UV_PYTHON_DOWNLOADS=never`, so the dev-shell builds the venv from a store interpreter (patched to the store loader) that runs on both NixOS and FHS hosts instead of a downloaded one

--- a/docs/NIX.md
+++ b/docs/NIX.md
@@ -96,6 +96,29 @@ template `.venv` scaffold, a sticky `/tmp`, and the `precommit`/`cc`/`cld`
 aliases. The image's interpreter is pinned via `UV_PYTHON=<nix python3.14>` and
 `UV_PYTHON_DOWNLOADS=never`.
 
+### Host container runtime (`policy.json`)
+
+`just build` ends in `podman load -i result`, and podman's containers/image
+library refuses to load any image unless a signature-verification `policy.json`
+exists at `~/.config/containers/policy.json` or `/etc/containers/policy.json`
+(this podman build has no `--signature-policy` flag and no env override). The
+flake dev-shell ships the **podman CLI** but not that host file: on NixOS the
+`virtualisation.containers` module normally installs `/etc/containers/policy.json`,
+so a host that gets podman purely from the dev-shell never receives one and
+`podman load` fails — even though `podman info` (the `just init` advisory check)
+is green.
+
+`just init` closes this gap: if neither lookup path has a policy, it writes the
+user-level default `~/.config/containers/policy.json` with the standard permissive
+content (the same `{ "default": [ { "type": "insecureAcceptAnything" } ] }` that
+`containers-common` / the NixOS module ship). The write is idempotent and never
+overwrites a system or user policy. To do it by hand:
+
+```bash
+mkdir -p ~/.config/containers
+printf '{ "default": [ { "type": "insecureAcceptAnything" } ] }\n' > ~/.config/containers/policy.json
+```
+
 ## Evaluator and pre-commit decisions
 
 These are decided inline in `flake.nix`; summarized here.

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -237,6 +237,26 @@ else
     fi
 fi
 
+# podman's containers/image library requires a signature-verification policy.json
+# for `podman load` (used by `just build`) — a check that `podman info` does NOT
+# perform. The NixOS `virtualisation.containers` module normally installs
+# /etc/containers/policy.json, but a host that gets podman purely from the flake
+# dev-shell never gets it, so `just build` fails at `podman load` even though
+# `podman info` is green. This podman build exposes no `--signature-policy` flag
+# and no env override, so the file must exist at one of the two lookup paths.
+# Ensure the user-level default (idempotent; never overwrites a system or user one).
+system_policy="/etc/containers/policy.json"
+user_policy="${HOME}/.config/containers/policy.json"
+if [ -f "$system_policy" ] || [ -f "$user_policy" ]; then
+    log_success "Containers signature policy present (podman load can run)"
+elif mkdir -p "$(dirname "$user_policy")" 2>/dev/null &&
+    printf '{ "default": [ { "type": "insecureAcceptAnything" } ] }\n' >"$user_policy"; then
+    log_success "Wrote a permissive containers policy to $user_policy (needed by podman load)"
+else
+    log_warning "No containers policy.json and could not create $user_policy."
+    log_info "Create it manually: printf '{ \"default\": [ { \"type\": \"insecureAcceptAnything\" } ] }\\n' > $user_policy"
+fi
+
 if gh auth status >/dev/null 2>&1; then
     log_success "GitHub CLI is authenticated"
 else

--- a/tests/bats/init.bats
+++ b/tests/bats/init.bats
@@ -143,6 +143,24 @@ setup() {
     assert_success
 }
 
+@test "init.sh ensures a containers signature policy for podman load" {
+    # `podman load` (just build) needs a policy.json that `podman info` does not;
+    # the dev-shell podman ships none, so init must handle it.
+    run grep 'policy.json' "$INIT_SH"
+    assert_success
+}
+
+@test "init.sh writes the permissive containers policy default" {
+    run grep 'insecureAcceptAnything' "$INIT_SH"
+    assert_success
+}
+
+@test "init.sh checks the system containers policy before writing a user one" {
+    # Idempotent / never-clobber: a system (or user) policy short-circuits the write.
+    run grep -F '/etc/containers/policy.json' "$INIT_SH"
+    assert_success
+}
+
 # ── legacy installer is gone ────────────────────────────────────────────────────
 
 @test "requirements.yaml has been retired" {


### PR DESCRIPTION
## Summary

On a NixOS host that gets `podman` from the **flake dev-shell** (the intended #625 onboarding path) rather than the `virtualisation.containers` NixOS module, `just build` failed at `podman load -i result` because no signature-verification `policy.json` existed at `~/.config/containers/policy.json` or `/etc/containers/policy.json`. `nix build` succeeded, but the image could not be loaded.

The onboarding gap: `scripts/init.sh`'s advisory host check uses `podman info`, which does **not** require `policy.json`, so `just init` reported the runtime green and the failure only surfaced later at `just build`.

## Root cause

podman's containers/image library requires a `policy.json` for `podman load`; this build exposes **no** `--signature-policy` flag and **no** env-var override, so the file must physically exist at one of the two lookup paths. The NixOS module normally installs `/etc/containers/policy.json`; a dev-shell-only host never receives it.

## Fix

`scripts/init.sh` (Host Checks) now **ensures the user-level `~/.config/containers/policy.json`** with the standard permissive default (`{ "default": [ { "type": "insecureAcceptAnything" } ] }`, the same content `containers-common` / the NixOS module ship) when neither lookup path has a policy. The write is:

- **idempotent** — re-running reports the policy as present, no rewrite;
- **non-destructive** — never overwrites a system or user policy;
- **out of `--check`** — `--check` exits before Host Checks, so it stays read-only.

Documented in `docs/NIX.md` (new *Host container runtime (`policy.json`)* subsection) and recorded in `CHANGELOG.md` (auto-synced to the workspace changelog).

## Testing

- `tests/bats/init.bats`: 3 new structural assertions (policy.json wired, permissive default, system-path short-circuit) — added RED, now green; full suite passes (29/29).
- Behavioral check (sandboxed `HOME`): first run writes valid JSON; second run is idempotent; an existing system policy short-circuits without creating a user file.
- `shellcheck scripts/init.sh` passes; `bash -n` parses clean.

Closes #685
