### PR TITLE
fix(setup): use portable env-bash shebang in host scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Host-executed scripts no longer fail on NixOS (non-portable `#!/bin/bash` shebang)** ([#687](https://github.com/vig-os/devcontainer/issues/687))
+  - `install.sh`, `assets/workspace/.devcontainer/scripts/initialize.sh`, and `assets/workspace/.devcontainer/scripts/version-check.sh` hardcoded `#!/bin/bash`, which has no `/bin/bash` on NixOS and similar hosts, so they failed to execute (and `just test` aborted). Switched all three to the portable `#!/usr/bin/env bash` (already used by `scripts/init.sh`), which resolves `bash` via `PATH`
 - **`just build` no longer fails on dev-shell-only podman hosts (missing containers `policy.json`)** ([#685](https://github.com/vig-os/devcontainer/issues/685))
   - On a NixOS host that gets `podman` purely from the flake dev-shell (no `virtualisation.containers` module), no signature-verification `policy.json` exists at `/etc/containers/policy.json` or `~/.config/containers/policy.json`, so `podman load` (`just build`) failed even though `nix build` and the advisory `podman info` check (`just init`) were green
   - `just init` now ensures the user-level `~/.config/containers/policy.json` with the standard permissive default (`{ "default": [ { "type": "insecureAcceptAnything" } ] }`, the same content `containers-common` / the NixOS module ship); the write is idempotent and never overwrites a system or user policy. Documented in `docs/NIX.md`

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -104,6 +104,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Host-executed scripts no longer fail on NixOS (non-portable `#!/bin/bash` shebang)** ([#687](https://github.com/vig-os/devcontainer/issues/687))
+  - `install.sh`, `assets/workspace/.devcontainer/scripts/initialize.sh`, and `assets/workspace/.devcontainer/scripts/version-check.sh` hardcoded `#!/bin/bash`, which has no `/bin/bash` on NixOS and similar hosts, so they failed to execute (and `just test` aborted). Switched all three to the portable `#!/usr/bin/env bash` (already used by `scripts/init.sh`), which resolves `bash` via `PATH`
 - **`just build` no longer fails on dev-shell-only podman hosts (missing containers `policy.json`)** ([#685](https://github.com/vig-os/devcontainer/issues/685))
   - On a NixOS host that gets `podman` purely from the flake dev-shell (no `virtualisation.containers` module), no signature-verification `policy.json` exists at `/etc/containers/policy.json` or `~/.config/containers/policy.json`, so `podman load` (`just build`) failed even though `nix build` and the advisory `podman info` check (`just init`) were green
   - `just init` now ensures the user-level `~/.config/containers/policy.json` with the standard permissive default (`{ "default": [ { "type": "insecureAcceptAnything" } ] }`, the same content `containers-common` / the NixOS module ship); the write is idempotent and never overwrites a system or user policy. Documented in `docs/NIX.md`

--- a/assets/workspace/.devcontainer/scripts/initialize.sh
+++ b/assets/workspace/.devcontainer/scripts/initialize.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Initialize script - runs on host before container starts
 # This script is called from initializeCommand in devcontainer.json

--- a/assets/workspace/.devcontainer/scripts/version-check.sh
+++ b/assets/workspace/.devcontainer/scripts/version-check.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 ###############################################################################
 # version-check.sh - Devcontainer Update Checker
 #

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # vigOS devcontainer quick install script
 #
 # Usage:

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -385,3 +385,42 @@ class TestInstallScriptIntegration:
         assert result.returncode == 0, "Failed to check git status"
         # Should be empty (no uncommitted changes)
         assert not result.stdout.strip(), f"Found uncommitted changes:\n{result.stdout}"
+
+
+class TestHostScriptShebangPortability:
+    """Assert host-executed scripts use a portable shebang.
+
+    These scripts run on the *host* (not inside the container), so they must
+    not hardcode ``#!/bin/bash``: NixOS and other distros that follow the
+    Filesystem Hierarchy Standard loosely have no ``/bin/bash``, which makes
+    them fail to execute. The portable form ``#!/usr/bin/env bash`` resolves
+    ``bash`` via ``PATH`` and works everywhere. Refs #687.
+
+    This is a pure content check — it needs no built container image — so it
+    runs in any pytest invocation that collects this module.
+    """
+
+    # Host-executed scripts that must carry the portable shebang. Scoped to
+    # the three scripts in issue #687; the broader in-container sweep is out
+    # of scope.
+    HOST_SCRIPTS = (
+        "install.sh",
+        "assets/workspace/.devcontainer/scripts/initialize.sh",
+        "assets/workspace/.devcontainer/scripts/version-check.sh",
+    )
+
+    PORTABLE_SHEBANG = "#!/usr/bin/env bash"
+
+    @pytest.mark.parametrize("rel_path", HOST_SCRIPTS)
+    def test_host_script_uses_portable_shebang(self, rel_path):
+        """Each host-executed script must start with #!/usr/bin/env bash."""
+        project_root = Path(__file__).resolve().parents[1]
+        script = project_root / rel_path
+        assert script.exists(), f"Expected host script not found: {rel_path}"
+
+        first_line = script.read_text().splitlines()[0]
+        assert first_line == self.PORTABLE_SHEBANG, (
+            f"{rel_path} must use the portable shebang "
+            f"'{self.PORTABLE_SHEBANG}' (NixOS has no /bin/bash), "
+            f"but found: {first_line!r}"
+        )


### PR DESCRIPTION
## Summary

Three **host-executed** scripts hardcoded a non-portable `#!/bin/bash` shebang. On NixOS (and other hosts that do not provide `/bin/bash`), the kernel cannot resolve the interpreter, so the scripts fail to execute — which is why `just test` aborts on NixOS hosts. Switched all three to the portable `#!/usr/bin/env bash` form already used by `scripts/init.sh`, which resolves `bash` via `PATH`.

## Root cause

A `#!/bin/bash` shebang requires `bash` to live at the absolute path `/bin/bash`. NixOS does not populate `/bin` with FHS binaries (only `/bin/sh` exists), so any host-side script with that shebang is not directly executable. `#!/usr/bin/env bash` defers interpreter lookup to `PATH`, working on both FHS and NixOS hosts.

## Files changed (shebang only)

- `install.sh`
- `assets/workspace/.devcontainer/scripts/initialize.sh`
- `assets/workspace/.devcontainer/scripts/version-check.sh`

The in-container script consistency sweep is intentionally **out of scope** (per the issue).

## Tests

Added a reproducible portability test (`TestHostScriptShebangPortability` in `tests/test_install_script.py`) that parametrizes over the three host scripts and asserts each starts with `#!/usr/bin/env bash`. It is a pure content check (no container image needed). Confirmed RED before the fix (3 failures) and GREEN after (3 passed). The issue's original three failing tests are environment-specific (only reproduce on a NixOS host with no `/bin/bash`) and so are not reproducible in CI; this new test covers the regression deterministically.

Closes #687