### PR TITLE
build(nix): resolve BATS helper libraries from the flake

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -10,8 +10,8 @@
 # - When 'true', the toolchain comes from the Nix flake (the SSoT) via
 #   `nix develop` instead of the ad-hoc installs below: Nix + Cachix are
 #   installed, the dev-shell is built (a warm vig-os Cachix pull), and its
-#   tool bin dirs are prepended to PATH. Python/uv, just, and taplo
-#   ad-hoc steps are skipped; podman, Node.js, BATS, and the devcontainer CLI
+#   tool bin dirs are prepended to PATH. Python/uv, just, taplo, and BATS
+#   ad-hoc steps are skipped; podman, Node.js, and the devcontainer CLI
 #   keep their dedicated steps (not flake-provided or host-integration tools).
 #
 # IMPORTANT:
@@ -108,11 +108,11 @@ inputs:
       ad-hoc installs. When 'true', installs Nix + Cachix, builds the flake
       dev-shell, and prepends its tools to PATH so every subsequent step runs as
       if inside `nix develop`. Tools provided by the flake (Python/uv, just,
-      taplo, Node.js) skip their ad-hoc install steps. podman is kept
+      taplo, Node.js, BATS) skip their ad-hoc install steps. podman is kept
       on the apt path even under flake provisioning because rootless podman on
       GitHub runners needs the host's setuid newuidmap/newgidmap and container
-      config; BATS and the devcontainer CLI are not in the flake and keep their
-      dedicated steps. Refs #632.
+      config; the devcontainer CLI is not in the flake and keeps its dedicated
+      step. Refs #632, #695.
     required: false
     default: 'false'
   cachix-cache:
@@ -370,11 +370,13 @@ runs:
         echo "devcontainer $(devcontainer --version)"
 
     # ── BATS (shell testing) ─────────────────────────────────────────
-    # Installs BATS core and helper libraries via the official action.
-    # Versions match package.json to keep local and CI environments in sync.
+    # Under flake provisioning BATS comes from the flake (the SSoT): the
+    # bats.withLibraries wrapper is on PATH and exports BATS_LIB_PATH, so these
+    # ad-hoc steps are skipped (mirrors just/taplo). The official action remains
+    # for non-flake callers, installing BATS core + helper libraries. Refs #695.
     - name: Setup BATS and libraries
       id: bats
-      if: inputs.install-bats == 'true'
+      if: inputs.provision-via-flake != 'true' && inputs.install-bats == 'true'
       uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43  # v4.0.0
       with:
         support-version: '0.3.0'
@@ -383,7 +385,7 @@ runs:
         detik-install: 'false'
 
     - name: Export BATS_LIB_PATH
-      if: inputs.install-bats == 'true'
+      if: inputs.provision-via-flake != 'true' && inputs.install-bats == 'true'
       shell: bash
       run: |
         # The bats-core/bats-action installs libraries to standard system paths

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **BATS suite no longer fails locally on the Nix toolchain (helper libraries unresolved)** ([#695](https://github.com/vig-os/devcontainer/issues/695))
+  - `tests/bats/test_helper.bash` resolved the BATS helper libraries (`bats-support`/`-assert`/`-file`) from `node_modules` (npm) or the now-removed Debian `/usr/lib` path; on the Nix toolchain neither exists locally, so every `.bats` file errored in `setup()` (`Could not find library 'bats-support'`) and all 246 tests failed
+  - Added `bats` wrapped with its helper libraries to the flake `devTools` SSoT and exported `BATS_LIB_PATH` in the dev-shell and image, so `bats_load_library` resolves the helpers from the Nix store; simplified `test_helper.bash` to that single path, switched `just test-bats` to the flake-provided `bats`, and removed the now-unused `bats*` npm dependencies. CI provisions BATS from the flake under `provision-via-flake` (the ad-hoc `bats-action` steps now run only for non-flake callers)
 - **Host-executed scripts no longer fail on NixOS (non-portable `#!/bin/bash` shebang)** ([#687](https://github.com/vig-os/devcontainer/issues/687))
   - `install.sh`, `assets/workspace/.devcontainer/scripts/initialize.sh`, and `assets/workspace/.devcontainer/scripts/version-check.sh` hardcoded `#!/bin/bash`, which has no `/bin/bash` on NixOS and similar hosts, so they failed to execute (and `just test` aborted). Switched all three to the portable `#!/usr/bin/env bash` (already used by `scripts/init.sh`), which resolves `bash` via `PATH`
 - **`allowed-signers` integration test no longer rejects valid ECDSA / security-key SSH keys** ([#688](https://github.com/vig-os/devcontainer/issues/688))

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -104,6 +104,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **BATS suite no longer fails locally on the Nix toolchain (helper libraries unresolved)** ([#695](https://github.com/vig-os/devcontainer/issues/695))
+  - `tests/bats/test_helper.bash` resolved the BATS helper libraries (`bats-support`/`-assert`/`-file`) from `node_modules` (npm) or the now-removed Debian `/usr/lib` path; on the Nix toolchain neither exists locally, so every `.bats` file errored in `setup()` (`Could not find library 'bats-support'`) and all 246 tests failed
+  - Added `bats` wrapped with its helper libraries to the flake `devTools` SSoT and exported `BATS_LIB_PATH` in the dev-shell and image, so `bats_load_library` resolves the helpers from the Nix store; simplified `test_helper.bash` to that single path, switched `just test-bats` to the flake-provided `bats`, and removed the now-unused `bats*` npm dependencies. CI provisions BATS from the flake under `provision-via-flake` (the ad-hoc `bats-action` steps now run only for non-flake callers)
 - **Host-executed scripts no longer fail on NixOS (non-portable `#!/bin/bash` shebang)** ([#687](https://github.com/vig-os/devcontainer/issues/687))
   - `install.sh`, `assets/workspace/.devcontainer/scripts/initialize.sh`, and `assets/workspace/.devcontainer/scripts/version-check.sh` hardcoded `#!/bin/bash`, which has no `/bin/bash` on NixOS and similar hosts, so they failed to execute (and `just test` aborted). Switched all three to the portable `#!/usr/bin/env bash` (already used by `scripts/init.sh`), which resolves `bash` via `PATH`
 - **`allowed-signers` integration test no longer rejects valid ECDSA / security-key SSH keys** ([#688](https://github.com/vig-os/devcontainer/issues/688))

--- a/flake.nix
+++ b/flake.nix
@@ -32,6 +32,19 @@
         "claude-code"
       ];
 
+      # bats + helper libraries as one wrapped package. The wrapper exports a
+      # BATS_LIB_PATH covering bats-support/-assert/-file so `bats_load_library`
+      # (tests/bats/test_helper.bash) resolves them from the Nix store — the
+      # flake SSoT — replacing the npm (node_modules) / Debian (/usr/lib)
+      # resolution that does not exist on the Nix toolchain. Refs #695.
+      batsWithLibs =
+        pkgs:
+        pkgs.bats.withLibraries (p: [
+          p.bats-support
+          p.bats-assert
+          p.bats-file
+        ]);
+
       overlay =
         final: prev:
         let
@@ -69,8 +82,12 @@
           # Python tooling (uv from unstable via overlay)
           uv
 
-          # Node.js (bats, devcontainer CLI via npm)
+          # Node.js (devcontainer CLI via npm)
           nodejs
+
+          # Shell testing: bats core + helper libraries (support/assert/file).
+          # Wrapped so BATS_LIB_PATH is exported for bats_load_library. Refs #695.
+          (batsWithLibs pkgs)
 
           # Shell & JSON utilities
           jq
@@ -150,6 +167,11 @@
 
           UV_PYTHON = "${python}/bin/python3.14";
           UV_PYTHON_DOWNLOADS = "never";
+
+          # Resolve the bats helper libraries from the Nix store. The wrapper
+          # also sets this when `bats` runs, but exporting it in the dev-shell
+          # makes the path visible (and works for a bare `bats` too). Refs #695.
+          BATS_LIB_PATH = "${batsWithLibs pkgs}/share/bats";
 
           # For CI only: the pin above means downloads never happen in the
           # dev-shell, but CI forwards this URL (NOT UV_PYTHON) so its FHS runner
@@ -406,6 +428,7 @@
                   "VIRTUAL_ENV=/root/assets/workspace/.venv"
                   "UV_PYTHON_DOWNLOADS=never"
                   "UV_PYTHON=${python}/bin/python3.14"
+                  "BATS_LIB_PATH=${batsWithLibs pkgs}/share/bats"
                   "SSL_CERT_FILE=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
                   "NIX_SSL_CERT_FILE=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
                   "HOME=/root"

--- a/justfile
+++ b/justfile
@@ -157,13 +157,15 @@ test-vig-utils:
 [group('test')]
 test-bats:
     #!/usr/bin/env bash
+    # bats and its helper libraries come from the flake (the toolchain SSoT);
+    # the wrapper exports BATS_LIB_PATH so test_helper.bash resolves them. #695.
     # Use GNU parallel if available for faster test execution
     if command -v parallel >/dev/null 2>&1; then
         echo "Running BATS tests in parallel..."
-        find tests/bats -name '*.bats' -print0 | parallel -0 -j+0 npx bats {}
+        find tests/bats -name '*.bats' -print0 | parallel -0 -j+0 bats {}
     else
         echo "Running BATS tests sequentially (install 'parallel' for faster execution)..."
-        npx bats tests/bats/
+        bats tests/bats/
     fi
 
 # Validate tracked Renovate configs with renovate-config-validator --strict

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,11 +6,7 @@
     "": {
       "name": "devcontainer-ci-deps",
       "dependencies": {
-        "@devcontainers/cli": "0.87.0",
-        "bats": "1.13.0",
-        "bats-assert": "github:bats-core/bats-assert#v2.2.4",
-        "bats-file": "github:bats-core/bats-file#v0.4.0",
-        "bats-support": "github:bats-core/bats-support#v0.3.0"
+        "@devcontainers/cli": "0.87.0"
       }
     },
     "node_modules/@devcontainers/cli": {
@@ -24,36 +20,6 @@
       "engines": {
         "node": ">=20.0.0"
       }
-    },
-    "node_modules/bats": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/bats/-/bats-1.13.0.tgz",
-      "integrity": "sha512-giSYKGTOcPZyJDbfbTtzAedLcNWdjCLbXYU3/MwPnjyvDXzu6Dgw8d2M+8jHhZXSmsCMSQqCp+YBsJ603UO4vQ==",
-      "license": "MIT",
-      "bin": {
-        "bats": "bin/bats"
-      }
-    },
-    "node_modules/bats-assert": {
-      "version": "2.2.4",
-      "resolved": "git+ssh://git@github.com/bats-core/bats-assert.git#f1e9280eaae8f86cbe278a687e6ba755bc802c1a",
-      "integrity": "sha512-EcaY4Z+Tbz1c7pnC1SrVSq0epr7tLwFpz6qt7KUW9K8uSw8V12DTfH9d2HxZWvBEATaCuMsZ7KoZMFiSQPRoXw==",
-      "license": "CC0-1.0",
-      "peerDependencies": {
-        "bats": "0.4 || ^1",
-        "bats-support": "^0.3"
-      }
-    },
-    "node_modules/bats-file": {
-      "version": "0.2.0",
-      "resolved": "git+ssh://git@github.com/bats-core/bats-file.git#13ad5e2ffcc360281432db3d43a306f7b3667d60",
-      "peerDependencies": {
-        "bats-support": "git+https://github.com/bats-core/bats-support.git#v0.3.0"
-      }
-    },
-    "node_modules/bats-support": {
-      "version": "0.3.0",
-      "resolved": "git+ssh://git@github.com/bats-core/bats-support.git#24a72e14349690bcbf7c151b9d2d1cdd32d36eb1"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,10 +3,6 @@
   "private": true,
   "description": "CI-only npm dependencies tracked by Dependabot",
   "dependencies": {
-    "@devcontainers/cli": "0.87.0",
-    "bats": "1.13.0",
-    "bats-support": "github:bats-core/bats-support#v0.3.0",
-    "bats-assert": "github:bats-core/bats-assert#v2.2.4",
-    "bats-file": "github:bats-core/bats-file#v0.4.0"
+    "@devcontainers/cli": "0.87.0"
   }
 }

--- a/tests/bats/test_helper.bash
+++ b/tests/bats/test_helper.bash
@@ -3,29 +3,17 @@
 # Usage (in every .bats file):
 #   setup() { load test_helper; }
 #
-# Library resolution order:
-#   1. node_modules/ (local dev via npx bats)
-#   2. /usr/lib/ (CI via bats-core/bats-action)
-#   3. bats_load_library (fallback, uses BATS_LIB_PATH)
+# bats and its helper libraries (bats-support/-assert/-file) come from the Nix
+# flake (the toolchain SSoT). The `bats.withLibraries` wrapper and the
+# dev-shell/image both export BATS_LIB_PATH, so `bats_load_library` resolves the
+# helpers from the Nix store — no node_modules (npm) or /usr/lib (Debian)
+# needed. Refs #695.
 
 # Resolve project root (two levels up from tests/bats/)
 PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 export PROJECT_ROOT
 
-# Load BATS helper libraries
-if [ -d "${PROJECT_ROOT}/node_modules/bats-support" ]; then
-    # Development mode: load from local node_modules
-    load "${PROJECT_ROOT}/node_modules/bats-support/load"
-    load "${PROJECT_ROOT}/node_modules/bats-assert/load"
-    load "${PROJECT_ROOT}/node_modules/bats-file/load"
-elif [ -d "/usr/lib/bats-support" ]; then
-    # CI mode: load from system paths (BATS_LIB_PATH)
-    load "/usr/lib/bats-support/load"
-    load "/usr/lib/bats-assert/load"
-    load "/usr/lib/bats-file/load"
-else
-    # Fallback: try using bats_load_library (available in BATS core)
-    bats_load_library bats-support
-    bats_load_library bats-assert
-    bats_load_library bats-file
-fi
+# Load BATS helper libraries via BATS_LIB_PATH (provided by the flake).
+bats_load_library bats-support
+bats_load_library bats-assert
+bats_load_library bats-file

--- a/tests/test_flake_devshell.py
+++ b/tests/test_flake_devshell.py
@@ -177,6 +177,38 @@ def test_devshell_tools_is_superset_of_agent_toolkit(
     assert not missing, f"devTools is missing agent-toolkit tools: {sorted(missing)}"
 
 
+def test_devshell_provides_bats(dev_shell_tools: list[str]) -> None:
+    """The flake must provide BATS so shell tests run without npm (#695).
+
+    The BATS helper libraries (bats-support/-assert/-file) were resolved from
+    ``node_modules`` (npm) or the now-removed Debian ``/usr/lib`` path. On the
+    Nix toolchain neither exists locally, so the suite must come from the flake
+    SSoT: ``bats.withLibraries`` puts ``bats`` on PATH and exports a
+    ``BATS_LIB_PATH`` covering the helper libraries.
+    """
+    assert "bats" in dev_shell_tools, (
+        "devTools must provide 'bats' (via bats.withLibraries) so the BATS "
+        "suite resolves its helper libraries from the flake, not node_modules"
+    )
+
+
+def test_devshell_bats_lib_path_resolves_helpers(dev_shell_env: dict[str, str]) -> None:
+    """BATS_LIB_PATH in the dev-shell must expose the three helper libraries.
+
+    ``bats_load_library bats-support`` (test_helper.bash) only works when
+    ``BATS_LIB_PATH`` points at a directory containing the helper libraries.
+    The ``bats.withLibraries`` wrapper exports it; assert the libraries are
+    actually reachable through it. Refs #695.
+    """
+    lib_path = dev_shell_env.get("BATS_LIB_PATH", "")
+    assert lib_path, "BATS_LIB_PATH must be set in the dev-shell"
+    roots = [Path(p) for p in lib_path.split(":") if p]
+    for lib in ("bats-support", "bats-assert", "bats-file"):
+        assert any((root / lib).is_dir() for root in roots), (
+            f"{lib} not found under any BATS_LIB_PATH entry: {lib_path}"
+        )
+
+
 def test_each_tool_runs_in_devshell(dev_shell_tools: list[str]) -> None:
     """Every tool in ``devTools`` is runnable inside ``nix develop``."""
     failures: list[str] = []


### PR DESCRIPTION
## Description

On the Nix toolchain the local BATS suite failed completely — 246 tests, 246
failures — every `.bats` file erroring in `setup()` with
`Could not find library 'bats-support'`. `tests/bats/test_helper.bash` resolved
the helper libraries (`bats-support`/`-assert`/`-file`) from `node_modules`
(npm) or the now-removed Debian `/usr/lib` path; on the Nix dev-shell neither
exists, `BATS_LIB_PATH` was unset, and `just test-bats` ran `npx bats`, which
fetches only `bats-core` (not the helpers).

This PR makes BATS come from the flake (the toolchain SSoT): `bats` wrapped with
its helper libraries is added to `devTools`, and `BATS_LIB_PATH` is exported in
the dev-shell and image so `bats_load_library` resolves the helpers from the Nix
store. Consumers are switched to the flake `bats` and the unused `bats*` npm
dependencies are removed.

## Type of Change

- [ ] `feat` -- New feature
- [ ] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [ ] `ci` -- CI/CD pipeline changes
- [x] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- **`flake.nix`** — add `batsWithLibs` (bats wrapped with `bats-support`,
  `bats-assert`, `bats-file`) to the `devTools` SSoT; export `BATS_LIB_PATH` in
  the dev-shell (`mkProjectShell`) and the image env.
- **`tests/bats/test_helper.bash`** — resolve the helpers via
  `bats_load_library` (`BATS_LIB_PATH` from the flake); drop the `node_modules`
  and `/usr/lib` branches.
- **`justfile`** — `test-bats` invokes the flake `bats` instead of `npx bats`.
- **`package.json` / `package-lock.json`** — remove the now-unused `bats`,
  `bats-support`, `bats-assert`, `bats-file` dependencies (keeps
  `@devcontainers/cli`).
- **`.github/actions/setup-env/action.yml`** — skip the ad-hoc `bats-action`
  and `BATS_LIB_PATH` export under `provision-via-flake` (the flake provides
  bats); the action remains for non-flake callers. Updated the related comments.
- **`tests/test_flake_devshell.py`** — add parity tests asserting the flake
  provides `bats` and that `BATS_LIB_PATH` exposes the three helper libraries.
- **`CHANGELOG.md`** (+ synced `.devcontainer` copy) — Fixed entry.

## Changelog Entry

### Fixed

- **BATS suite no longer fails locally on the Nix toolchain (helper libraries unresolved)** ([#695](https://github.com/vig-os/devcontainer/issues/695))
  - `tests/bats/test_helper.bash` resolved the BATS helper libraries (`bats-support`/`-assert`/`-file`) from `node_modules` (npm) or the now-removed Debian `/usr/lib` path; on the Nix toolchain neither exists locally, so every `.bats` file errored in `setup()` (`Could not find library 'bats-support'`) and all 246 tests failed
  - Added `bats` wrapped with its helper libraries to the flake `devTools` SSoT and exported `BATS_LIB_PATH` in the dev-shell and image, so `bats_load_library` resolves the helpers from the Nix store; simplified `test_helper.bash` to that single path, switched `just test-bats` to the flake-provided `bats`, and removed the now-unused `bats*` npm dependencies. CI provisions BATS from the flake under `provision-via-flake` (the ad-hoc `bats-action` steps now run only for non-flake callers)

## Testing

- [x] Tests pass locally (`just test`)
- [x] Manual testing performed (describe below)

### Manual Testing Details

- `nix develop --command just test-bats` with `node_modules` removed: **246/246
  pass** via the flake `bats` (previously 246/246 failed).
- `uv run pytest tests/test_flake_devshell.py`: **6 passed** (includes the new
  bats parity tests and `bats --version` running inside `nix develop`).
- `shellcheck -x tests/bats/test_helper.bash`: clean.
- `nixfmt flake.nix`: clean; `nix eval` of `devShells`, `packages.devcontainerImage`,
  and `checks` all evaluate.
- `jq empty package.json package-lock.json` and `yamllint` on the action: clean.

> Note: pre-commit's `ruff`/`typos` hooks cannot execute on the NixOS host
> (manylinux binaries, no `nix-ld`), so those file hooks were not run locally;
> `ruff check`/`ruff format --check` were verified via the Nix-native `ruff`.
> CI re-runs the full pre-commit suite.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

Sub-issue of the Nix migration epic #625; PR targets the epic branch
`feature/625-nix-claude-migration`. The remaining `npx bats` references in
`docs/issues/` and `docs/pull-requests/` are archived issue/PR records and were
intentionally left unchanged.

Refs: #695
