### PR TITLE
chore(ci): set ruff target-version to py314

### DIFF
--- a/packages/vig-utils/tests/test_claude_ssot.py
+++ b/packages/vig-utils/tests/test_claude_ssot.py
@@ -50,7 +50,7 @@ def test_no_tracked_file_references_cursor_skills() -> None:
         path = REPO_ROOT / rel
         try:
             text = path.read_text(encoding="utf-8")
-        except (UnicodeDecodeError, FileNotFoundError):
+        except UnicodeDecodeError, FileNotFoundError:
             continue
         if ".cursor/skills/" in text:
             offenders.append(rel)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,8 +54,8 @@ vig-utils = { path = "packages/vig-utils", editable = true }
 # Black-compatible line length
 line-length = 88
 
-# Target Python 3.12
-target-version = "py312"
+# Target Python 3.14
+target-version = "py314"
 
 [tool.ruff.lint]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -169,7 +169,7 @@ def is_running_in_container() -> bool:
     try:
         with Path("/proc/1/cgroup").open() as f:
             return "docker" in f.read() or "podman" in f.read()
-    except (FileNotFoundError, PermissionError):
+    except FileNotFoundError, PermissionError:
         pass
     return False
 
@@ -1006,7 +1006,7 @@ def devcontainer_with_sidecar(initialized_workspace, sidecar_image, container_ta
                     parts = error_message.split("Command failed:")
                     if len(parts) > 1:
                         podman_command = parts[1].strip()
-        except (json.JSONDecodeError, KeyError):
+        except json.JSONDecodeError, KeyError:
             pass
 
         # Extract actual podman error from stderr


### PR DESCRIPTION
Align ruff `target-version` with the project's `requires-python = ">=3.14,<3.15"` so lint and formatting target the real runtime instead of the stale `py312` value.

Closes #708