### PR TITLE
fix(setup): drop the duplicate sync-manifest pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -219,13 +219,3 @@ repos:
           "--refs-optional-types", "chore",
           "--blocked-patterns", ".github/agent-blocklist.toml",
         ]
-
-  # Sync manifest
-  - repo: local
-    hooks:
-      - id: sync-manifest
-        name: sync manifest
-        entry: uv run python scripts/sync_manifest.py sync assets/workspace/
-        language: system
-        files: ^scripts/manifest\.toml$
-        pass_filenames: false


### PR DESCRIPTION
Kept the broad always-run sync-manifest hook (no `files:` filter, so it runs whenever any synced source file changes). Removed the duplicate `sync-manifest` block whose narrow `files: ^scripts/manifest\.toml$` filter would miss drift in other synced sources (CHANGELOG.md, .vscode/settings.json, .pre-commit-config.yaml, etc.).

Closes #707