### PR TITLE
build(image): tag the discovery image nix-dev to match CI

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -423,7 +423,10 @@
               # (#635), which targets ghcr.io/vig-os/devcontainer:<tag>, runs
               # unchanged against the loaded image under a unique tag.
               name = "ghcr.io/vig-os/devcontainer";
-              tag = "nix-wt634";
+              # Disposable discovery tag, matching the CI workflow's
+              # INDEX_TAG (.github/workflows/nix-image.yml). The versioned
+              # / :latest cutover is handled separately (#639).
+              tag = "nix-dev";
 
               contents = imageTools ++ [ bootstrap ];
 


### PR DESCRIPTION
## Summary

`flake.nix` baked a stale, branch/issue-specific WIP tag `nix-wt634` into `dockerTools.buildLayeredImage`. This aligns the image tag with the disposable discovery tag the CI workflow already documents as `INDEX_TAG: nix-dev` (`.github/workflows/nix-image.yml`), so the flake and CI agree on one tag.

- Changed `tag = "nix-wt634"` -> `tag = "nix-dev"`, with a clarifying comment.
- Does **not** touch the versioned / `:latest` cutover tags, which are tracked separately in #639.

## Verification

- `grep -rn 'nix-wt' . --exclude-dir=.git --exclude-dir=docs` returns nothing.
- `nixfmt --check flake.nix` clean; `nix flake check --no-build` -> all checks passed.

Skip TDD: build constant, no behavioral surface. No CHANGELOG entry: internal build plumbing, not user-visible.

Closes #705