### PR TITLE
style: fix the duplicated word in the just clean recipe

### DIFF
--- a/justfile
+++ b/justfile
@@ -248,7 +248,7 @@ clean version="dev":
 [group('build')]
 clean-test-containers:
     #!/usr/bin/env bash
-    echo "Cleaning Cleaning up lingering test containers..."
+    echo "Cleaning up lingering test containers..."
     FMT=$(printf '\x7b\x7b.ID\x7d\x7d')
     DEVCONTAINERS=$(podman ps -a --filter "name=workspace-devcontainer" --format "$FMT" 2>/dev/null)
     SIDECARS=$(podman ps -a --filter "name=test-sidecar" --format "$FMT" 2>/dev/null)


### PR DESCRIPTION
Purely cosmetic, non-functional cleanup for #710.

## Changes
- **justfile** (`clean-test-containers` recipe): removed the duplicated word so the echo reads `Cleaning up lingering test containers...` instead of `Cleaning Cleaning up ...`.

## Left alone (deliberately)
- `assets/workspace/.devcontainer/scripts/post-create.sh`: comments are generic and not Debian-specific; nothing is factually wrong post-Nix.
- `tests/test_image.py`: the `EXPECTED_VERSIONS` block carries Debian-era comments ("from apt package", "Containerfile", install-method notes), but that whole block (values + comments) is being rewritten by the active Nix-migration work, so touching the comment text here would overlap with another PR. Per the "when in doubt, skip" guidance, left untouched.

Skip TDD: cosmetic/comment-only, no behavioral surface.
Skip CHANGELOG: no user-visible impact (echo wording only).

Closes #710