### PR TITLE
docs: correct the Python version to 3.14 in the TESTING template

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -30,7 +30,7 @@ These tests run against a running container instance to verify the image itself
 (installed tools, versions, environment variables, file structure).
 
 - `TestSystemTools` - git, curl, openssh-client, gh, just
-- `TestPythonEnvironment` - Python 3.12, uv
+- `TestPythonEnvironment` - Python 3.14, uv
 - `TestDevelopmentTools` - pre-commit, ruff, just
 - `TestEnvironmentVariables` - environment variables
 - `TestFileStructure` - file structure

--- a/docs/templates/TESTING.md.j2
+++ b/docs/templates/TESTING.md.j2
@@ -30,7 +30,7 @@ These tests run against a running container instance to verify the image itself
 (installed tools, versions, environment variables, file structure).
 
 - `TestSystemTools` - git, curl, openssh-client, gh, just
-- `TestPythonEnvironment` - Python 3.12, uv
+- `TestPythonEnvironment` - Python 3.14, uv
 - `TestDevelopmentTools` - pre-commit, ruff, just
 - `TestEnvironmentVariables` - environment variables
 - `TestFileStructure` - file structure


### PR DESCRIPTION
The Nix image ships CPython 3.14, but the auto-generated TESTING.md (via docs/templates/TESTING.md.j2) still listed Python 3.12. Fixed the template and regenerated TESTING.md so the docs match the shipped interpreter (README was already correct).

Closes #709