### PR TITLE
fix(setup): point the workspace python interpreter at the workspace venv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,6 +145,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `derive-branch-summary` now handles `-h`/`--help` (prints usage, exits 0) instead of treating the flag as an issue title and failing; the worktree launcher probes availability with `--help`, so the bug blocked worktree creation entirely
 - **CONTRIBUTE prerequisites now document the direnv shell hook** ([#633](https://github.com/vig-os/devcontainer/issues/633))
   - The `direnv` prerequisite promised the dev-shell "loads automatically on `cd`" but never documented installing direnv's shell hook (`eval "$(direnv hook bash)"`), the step that behaviour depends on. Without the hook, `direnv allow` still succeeds yet the flake never activates on `cd` and host tooling (e.g. an old system Node) is used with no warning. Documented the hook in the prerequisites table and as a fast-path note, with `nix develop` as the hook-free fallback
+- **Workspace python interpreter pointed at the dead `/opt/venv` path** ([#706](https://github.com/vig-os/devcontainer/issues/706))
+  - The synced `.vscode/settings.json` rewrote `python.defaultInterpreterPath` to `/opt/venv/bin/python3`, which no longer exists on the Nix image, breaking the VS Code interpreter for downstream projects
+  - The interpreter now stays workspace-relative (`${workspaceFolder}/.venv/bin/python3`), matching the `uv`-created `.venv` in the opened project
 
 ### Security
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -145,6 +145,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `derive-branch-summary` now handles `-h`/`--help` (prints usage, exits 0) instead of treating the flag as an issue title and failing; the worktree launcher probes availability with `--help`, so the bug blocked worktree creation entirely
 - **CONTRIBUTE prerequisites now document the direnv shell hook** ([#633](https://github.com/vig-os/devcontainer/issues/633))
   - The `direnv` prerequisite promised the dev-shell "loads automatically on `cd`" but never documented installing direnv's shell hook (`eval "$(direnv hook bash)"`), the step that behaviour depends on. Without the hook, `direnv allow` still succeeds yet the flake never activates on `cd` and host tooling (e.g. an old system Node) is used with no warning. Documented the hook in the prerequisites table and as a fast-path note, with `nix develop` as the hook-free fallback
+- **Workspace python interpreter pointed at the dead `/opt/venv` path** ([#706](https://github.com/vig-os/devcontainer/issues/706))
+  - The synced `.vscode/settings.json` rewrote `python.defaultInterpreterPath` to `/opt/venv/bin/python3`, which no longer exists on the Nix image, breaking the VS Code interpreter for downstream projects
+  - The interpreter now stays workspace-relative (`${workspaceFolder}/.venv/bin/python3`), matching the `uv`-created `.venv` in the opened project
 
 ### Security
 

--- a/assets/workspace/.vscode/settings.json
+++ b/assets/workspace/.vscode/settings.json
@@ -4,7 +4,7 @@
     "Justfile": "just",
     "justfile.*": "just"
   },
-  "python.defaultInterpreterPath": "/opt/venv/bin/python3",
+  "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python3",
   "[python]": {
     "editor.defaultFormatter": "charliermarsh.ruff",
     "editor.formatOnSave": true,

--- a/scripts/manifest.toml
+++ b/scripts/manifest.toml
@@ -43,9 +43,6 @@ dest = ".devcontainer/CHANGELOG.md"
 
 [[entries]]
 src = ".vscode/settings.json"
-transforms = [
-  { type = "Sed", pattern = "\\$\\{workspaceFolder\\}/\\.venv/bin/python3", replace = "/opt/venv/bin/python3" },
-]
 
 [[entries]]
 src = ".github/agent-blocklist.toml"

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -66,9 +66,7 @@ class TestWorkspaceInterpreterPath:
         sync_manifest = _load_sync_manifest()
         sync_manifest.sync(project_root, tmp_path)
 
-        settings = json.loads(
-            (tmp_path / ".vscode" / "settings.json").read_text()
-        )
+        settings = json.loads((tmp_path / ".vscode" / "settings.json").read_text())
         interpreter = settings["python.defaultInterpreterPath"]
 
         assert interpreter == "${workspaceFolder}/.venv/bin/python3"

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -2,21 +2,32 @@
 
 from __future__ import annotations
 
+import importlib.util
+import json
 import sys
 from pathlib import Path
 
 scripts_dir = Path(__file__).parent.parent / "scripts"
-sys.path.insert(0, str(scripts_dir.parent))
+project_root = scripts_dir.parent
+sys.path.insert(0, str(project_root))
 
 
 def _load_transforms():
-    import importlib.util
-
     spec = importlib.util.spec_from_file_location(
         "transforms", scripts_dir / "transforms.py"
     )
     module = importlib.util.module_from_spec(spec)
     sys.modules["transforms"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_sync_manifest():
+    spec = importlib.util.spec_from_file_location(
+        "sync_manifest", scripts_dir / "sync_manifest.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["sync_manifest"] = module
     spec.loader.exec_module(module)
     return module
 
@@ -45,6 +56,23 @@ class TestTransformsModule:
         transforms.RemoveLines(pattern=r"remove me").apply(f)
 
         assert f.read_text() == "keep\nkeep\n"
+
+
+class TestWorkspaceInterpreterPath:
+    """The synced workspace settings must point at the workspace venv."""
+
+    def test_synced_settings_uses_workspace_relative_venv(self, tmp_path):
+        """Syncing must leave the python interpreter workspace-relative, never /opt/venv."""
+        sync_manifest = _load_sync_manifest()
+        sync_manifest.sync(project_root, tmp_path)
+
+        settings = json.loads(
+            (tmp_path / ".vscode" / "settings.json").read_text()
+        )
+        interpreter = settings["python.defaultInterpreterPath"]
+
+        assert interpreter == "${workspaceFolder}/.venv/bin/python3"
+        assert "/opt/venv" not in interpreter
 
 
 class TestRemovePrecommitHooks:


### PR DESCRIPTION
`/opt/venv` is the decommissioned Debian image path; the Nix image has no such directory. The `.vscode/settings.json` manifest entry rewrote `python.defaultInterpreterPath` to `/opt/venv/bin/python3`, shipping a broken VS Code interpreter to downstream projects.

This removes the Sed transform so the source's workspace-relative `${workspaceFolder}/.venv/bin/python3` passes through unchanged (VS Code resolves `${workspaceFolder}` to the opened project, where `uv` creates `.venv`), and regenerates the synced workspace asset.

Added a behavioral test that runs the real manifest sync and asserts the interpreter path is workspace-relative and never `/opt/venv`.

Closes #706