### PR TITLE
fix(devshell): isolate neovim from host ~/.config/nvim via NVIM_APPNAME

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -190,10 +190,23 @@
               export LD_LIBRARY_PATH="''${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}${ldLibraryPath}"
             fi
           '';
+
+          # The dev-shell's `neovim` must not inherit the user's personal
+          # `~/.config/nvim`. nixvim (and other launchers like a LazyVim
+          # lockfile) emit a config at the standard XDG path that assumes a
+          # specific wrapper — e.g. nixvim's `init.lua` only finds its plugins
+          # when launched by its wrapper's `--cmd "set packpath^=…"`. A bare
+          # `nvim` auto-sources that config but lacks the packpath, so it crashes
+          # on startup (`module 'catppuccin' not found`). NVIM_APPNAME redirects
+          # config/data/state lookups to `~/.config/vigos-dev` (which does not
+          # exist), so the shell's nvim starts vanilla and isolated. Refs #723.
+          nvimIsolationHook = ''
+            export NVIM_APPNAME="vigos-dev"
+          '';
         in
         pkgs.mkShell {
           packages = (devTools pkgs) ++ extraPackages;
-          shellHook = ldLibraryPathHook + "\n" + shellHook;
+          shellHook = ldLibraryPathHook + "\n" + nvimIsolationHook + "\n" + shellHook;
 
           UV_PYTHON = "${python}/bin/python3.14";
           UV_PYTHON_DOWNLOADS = "never";


### PR DESCRIPTION
## Problem

The dev-shell ships plain upstream `neovim` (`flake.nix:116`). A user who manages their editor with **nixvim** (home-manager) has an `init.lua` at the standard `~/.config/nvim` XDG path that only resolves its plugins when launched by nixvim's wrapper (`--cmd "set packpath^=…vim-pack-dir"`). When direnv activates this dev-shell, the bare `neovim` shadows that wrapper, auto-sources the host `init.lua` without the packpath, and crashes on startup:

```
E5113: Lua chunk: ~/.config/nvim/init.lua:49: module 'catppuccin' not found
```

Same class of breakage for any launcher whose `~/.config/nvim` assumes a specific runtime (LazyVim lockfile, etc.).

## Change

Add an `nvimIsolationHook` to `mkProjectShell` that exports `NVIM_APPNAME="vigos-dev"`, composed like the existing `ldLibraryPathHook` so it applies regardless of any consumer-supplied `shellHook`. nvim then looks under `~/.config/vigos-dev` (which doesn't exist) and starts vanilla and isolated — `neovim` stays available in the shell without colliding with the user's config/data/state dirs.

## Verification

```
$ nix eval --raw .#devShells.x86_64-linux.default.shellHook
…
export NVIM_APPNAME="vigos-dev"
echo "devcontainer dev environment loaded (nix)"
```

Hook is injected between the LD hook and the consumer hook, as intended.

Closes #723. Sub-issue of #625.
