### PR TITLE
fix(image): add /usr/bin/env to the Nix-built image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`/usr/bin/env` now exists in the Nix-built image** ([#727](https://github.com/vig-os/devcontainer/issues/727))
+  - The bare `dockerTools.buildLayeredImage` had no `/usr/bin` at all, so the ubiquitous `#!/usr/bin/env <interp>` shebang failed with `/usr/bin/env: bad interpreter: No such file or directory` — breaking essentially every Node/Python/Ruby CLI (e.g. `node_modules/.bin/tsc`) for image-mode consumers. Added `dockerTools.usrBinEnv` (the FHS shim symlinking `/usr/bin/env` to coreutils `env`) to the image package set, alongside the existing `fakeNss` shim
 - **`init-workspace --mode direnv` now produces a loadable `justfile`** ([#641](https://github.com/vig-os/devcontainer/issues/641))
   - The scaffolded root `justfile` hard-imported `.devcontainer/justfile.devc` and `.devcontainer/justfile.gh`, but `direnv` mode prunes `.devcontainer/` — so every `just` command (including init-workspace's own final `just sync`) failed to parse in a direnv-mode workspace. Made the two `.devcontainer/` imports optional (`import?`, matching `justfile.project`/`justfile.local`); the `sync` recipe lives in the preserved `justfile.project`, so `just sync` still works in all modes
 - **Worktree recipes read agent config from the `.claude/` SSoT** ([#627](https://github.com/vig-os/devcontainer/issues/627))

--- a/flake.nix
+++ b/flake.nix
@@ -325,6 +325,14 @@
             # "No user exists for uid 0". fakeNss provides the minimal
             # nss files an FHS base distro would have supplied.
             dockerTools.fakeNss
+
+            # /usr/bin/env -> coreutils env. A bare layered image has no
+            # /usr/bin at all, so the ubiquitous `#!/usr/bin/env <interp>`
+            # shebang fails with "/usr/bin/env: bad interpreter" — breaking
+            # essentially every Node/Python/Ruby CLI (e.g.
+            # node_modules/.bin/tsc) for image-mode consumers. usrBinEnv is
+            # the minimal shim an FHS base distro would have supplied. #727.
+            dockerTools.usrBinEnv
           ]);
       in
       {

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -150,6 +150,46 @@ def test_image_oci_config_declares_path(container_image):
     )
 
 
+class TestFhsShims:
+    """Test the minimal FHS shims a bare layered image needs (#727)."""
+
+    def test_usr_bin_env_exists(self, host):
+        """``/usr/bin/env`` must exist (the universal shebang interpreter).
+
+        A bare ``buildLayeredImage`` has no ``/usr/bin`` at all, so the
+        ubiquitous ``#!/usr/bin/env <interp>`` shebang fails with
+        ``/usr/bin/env: bad interpreter`` — breaking essentially every
+        Node/Python/Ruby CLI (e.g. ``node_modules/.bin/tsc``) for image-mode
+        consumers. An FHS base distro would have supplied it. Refs #727.
+        """
+        env = host.file("/usr/bin/env")
+        assert env.exists, "/usr/bin/env not found (universal shebang interpreter)"
+
+    def test_usr_bin_env_shebang_runs(self, host):
+        """A ``#!/usr/bin/env <interp>`` script must execute via ``/usr/bin/env``.
+
+        Mirrors how a ``node_modules/.bin`` CLI is launched: the kernel reads the
+        shebang and execs ``/usr/bin/env <interp>``. Uses ``bash`` (always in the
+        image) as the interpreter so the test asserts the ``/usr/bin/env``
+        resolution path itself, not the presence of any one language runtime.
+        """
+        script = "/tmp/usr_bin_env_shebang_test"
+        host.run(f"rm -f {script}")
+        try:
+            result = host.run(
+                f"printf '#!/usr/bin/env bash\\necho shebang-ok\\n' > {script} "
+                f"&& chmod +x {script} && {script}"
+            )
+            assert result.rc == 0, (
+                f"#!/usr/bin/env bash script failed to run: {result.stderr}"
+            )
+            assert "shebang-ok" in result.stdout, (
+                f"unexpected shebang script output: {result.stdout!r}"
+            )
+        finally:
+            host.run(f"rm -f {script}")
+
+
 class TestSystemTools:
     """Test that system tools are installed with correct versions."""
 


### PR DESCRIPTION
## Summary

The Nix-built image (`flake.nix` `packages.devcontainerImage`, `dockerTools.buildLayeredImage`) had **no `/usr/bin/env`** — `/usr/bin` did not exist at all. `env` lived only at `/bin/env`. The universal `#!/usr/bin/env <interp>` shebang therefore failed inside the image:

```
sh: .../node_modules/.bin/tsc: /usr/bin/env: bad interpreter: No such file or directory
```

This broke essentially every Node/Python/Ruby CLI for image-mode consumers.

## Fix

Added `pkgs.dockerTools.usrBinEnv` to the image package set (`imageTools`), right next to the existing `dockerTools.fakeNss` shim. `usrBinEnv` is the idiomatic nixpkgs FHS shim that symlinks `/usr/bin/env` to coreutils `env` — the minimal piece an FHS base distro would have supplied. Minimal, one-line diff consistent with how the flake already assembles its FHS shims.

## Verification

Direct check in the rebuilt `:dev` image:

```
$ podman run --rm ghcr.io/vig-os/devcontainer:dev bash -lc \
    'ls -l /usr/bin/env && printf "#!/usr/bin/env node\nconsole.log(1)\n" > /tmp/t && chmod +x /tmp/t && /tmp/t'
lrwxrwxrwx 1 root root 66 Jan  1  1980 /usr/bin/env -> /nix/store/...-coreutils-9.11/bin/env
1
```

Both a `#!/usr/bin/env node` and a `#!/usr/bin/env bash` shebang script now execute.

## Tests (TDD)

Added `TestFhsShims` to `tests/test_image.py`:
- `test_usr_bin_env_exists` — asserts `/usr/bin/env` exists.
- `test_usr_bin_env_shebang_runs` — asserts a `#!/usr/bin/env bash` script runs via `/usr/bin/env`.

Both committed as a failing test first (RED, confirmed `126 == 0` / `bad interpreter`), then the fix. Full image suite after the fix: **66 passed**.

Closes #727
