### PR TITLE
fix(image): bake writable on-PATH npm global prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`npm install -g` now lands CLIs on PATH in the Nix image** ([#728](https://github.com/vig-os/devcontainer/issues/728))
+  - npm's default global prefix was the read-only `nodejs` nix-store path, whose `bin/` is not on `PATH` — so `npm install -g <tool>` reported success but the binary was unresolvable (`command -v <tool>` failed). The image now bakes `NPM_CONFIG_PREFIX=/usr/local` (already on the baked `PATH`) and creates a writable `/usr/local/bin` in the bootstrap layer, so globally installed CLIs resolve on `PATH`
 - **`init-workspace --mode direnv` now produces a loadable `justfile`** ([#641](https://github.com/vig-os/devcontainer/issues/641))
   - The scaffolded root `justfile` hard-imported `.devcontainer/justfile.devc` and `.devcontainer/justfile.gh`, but `direnv` mode prunes `.devcontainer/` — so every `just` command (including init-workspace's own final `just sync`) failed to parse in a direnv-mode workspace. Made the two `.devcontainer/` imports optional (`import?`, matching `justfile.project`/`justfile.local`); the `sync` recipe lives in the preserved `justfile.project`, so `just sync` still works in all modes
 - **Worktree recipes read agent config from the `.claude/` SSoT** ([#627](https://github.com/vig-os/devcontainer/issues/627))

--- a/flake.nix
+++ b/flake.nix
@@ -432,6 +432,15 @@
                     mkdir -p "$out/opt/pre-commit-cache"
                     mkdir -p "$out/workspace"
 
+                    # Writable global-install prefix for npm. npm's default
+                    # prefix is the read-only nodejs nix-store path, whose bin/
+                    # is off PATH — so `npm install -g <tool>` reports success
+                    # but the binary lands where nothing can resolve it. Create
+                    # the FHS /usr/local/bin (already on the baked PATH) so the
+                    # prefix exists and is writable at runtime; NPM_CONFIG_PREFIX
+                    # (config.Env) points npm here. Refs #728.
+                    mkdir -p "$out/usr/local/bin"
+
                     # /tmp with the sticky bit. A bare layered image has no
                     # /tmp; tools that need a scratch/socket dir (tmux, uv,
                     # pytest) fail without it ("no suitable socket path"). An
@@ -480,6 +489,10 @@
                   "PRE_COMMIT_HOME=/opt/pre-commit-cache"
                   "UV_PROJECT_ENVIRONMENT=/root/assets/workspace/.venv"
                   "VIRTUAL_ENV=/root/assets/workspace/.venv"
+                  # Point npm's global prefix at the writable, on-PATH
+                  # /usr/local (its bin/ is baked by the bootstrap layer) so
+                  # `npm install -g` lands runnable CLIs on PATH. Refs #728.
+                  "NPM_CONFIG_PREFIX=/usr/local"
                   "UV_PYTHON_DOWNLOADS=never"
                   "UV_PYTHON=${python}/bin/python3.14"
                   "BATS_LIB_PATH=${batsWithLibs pkgs}/share/bats"

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -477,6 +477,53 @@ class TestDevelopmentTools:
         assert result.rc == 0, f"{name} command failed: {result.stderr}"
 
 
+class TestNodeEnvironment:
+    """Test the Node.js / npm environment (#728)."""
+
+    def test_npm_installed(self, host):
+        """npm runs (ships with the nixpkgs nodejs)."""
+        result = host.run("npm --version")
+        assert result.rc == 0, f"npm --version failed: {result.stderr}"
+
+    def test_npm_global_prefix_bin_on_path(self, host):
+        """npm's global prefix bin/ must be writable and on PATH (#728).
+
+        In a bare Nix-built image npm's default prefix is the read-only nodejs
+        nix-store path, whose bin/ is not on PATH: ``npm install -g`` reports
+        success but the binary lands somewhere nothing can resolve. The image
+        bakes ``NPM_CONFIG_PREFIX`` to a writable, on-PATH dir to fix this.
+        """
+        prefix = host.run("npm config get prefix")
+        assert prefix.rc == 0, f"npm config get prefix failed: {prefix.stderr}"
+        prefix_dir = prefix.stdout.strip()
+        assert prefix_dir, "npm reported an empty global prefix"
+
+        path = host.run("printenv PATH")
+        assert f"{prefix_dir}/bin" in path.stdout.split(":"), (
+            f"npm global bin {prefix_dir}/bin is not on PATH: {path.stdout.strip()}"
+        )
+
+        probe = f"{prefix_dir}/bin/.npm_prefix_write_probe"
+        result = host.run(f"touch {probe} && rm {probe}")
+        assert result.rc == 0, (
+            f"npm global bin {prefix_dir}/bin is not writable: {result.stderr}"
+        )
+
+    def test_npm_global_install_is_runnable(self, host):
+        """A global ``npm install -g`` lands on PATH and is runnable (#728).
+
+        Faithful reproduction of the reported bug: install a CLI globally and
+        confirm it resolves on PATH afterwards.
+        """
+        try:
+            install = host.run("npm install -g tsx")
+            assert install.rc == 0, f"npm install -g tsx failed: {install.stderr}"
+            assert_tool_on_path(host, "tsx")
+            assert_tool_runs(host, "tsx", "--version")
+        finally:
+            host.run("npm uninstall -g tsx")
+
+
 class TestEnvironmentVariables:
     """Test that environment variables are set correctly."""
 
@@ -493,6 +540,7 @@ class TestEnvironmentVariables:
             ("PRE_COMMIT_HOME", "/opt/pre-commit-cache"),
             ("UV_PROJECT_ENVIRONMENT", "/root/assets/workspace/.venv"),
             ("VIRTUAL_ENV", "/root/assets/workspace/.venv"),
+            ("NPM_CONFIG_PREFIX", "/usr/local"),
         ],
         ids=[
             "lang",
@@ -503,6 +551,7 @@ class TestEnvironmentVariables:
             "pre_commit_home",
             "uv_project_environment",
             "virtual_env",
+            "npm_config_prefix",
         ],
     )
     def test_env_vars_set(self, host, name, expected):

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -509,17 +509,21 @@ class TestNodeEnvironment:
             f"npm global bin {prefix_dir}/bin is not writable: {result.stderr}"
         )
 
-    def test_npm_global_install_is_runnable(self, host):
-        """A global ``npm install -g`` lands on PATH and is runnable (#728).
+    def test_npm_global_install_resolves_on_path(self, host):
+        """A global ``npm install -g`` lands a resolvable binary on PATH (#728).
 
         Faithful reproduction of the reported bug: install a CLI globally and
-        confirm it resolves on PATH afterwards.
+        confirm it resolves on PATH afterwards (previously the binary landed in
+        the read-only nodejs store path, off PATH, so ``command -v`` failed).
+
+        Scoped to #728: only that the binary is on PATH. Executing it relies on
+        the ``#!/usr/bin/env`` shebang interpreter, which #727 provides — this
+        test deliberately does not depend on that.
         """
         try:
             install = host.run("npm install -g tsx")
             assert install.rc == 0, f"npm install -g tsx failed: {install.stderr}"
             assert_tool_on_path(host, "tsx")
-            assert_tool_runs(host, "tsx", "--version")
         finally:
             host.run("npm uninstall -g tsx")
 


### PR DESCRIPTION
## Problem

In the Nix-built image, npm's global prefix defaults to the read-only `nodejs` nix-store path (`/nix/store/...-nodejs-slim-<ver>`), whose `bin/` is not on `PATH` (image `PATH` is `/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin`). So `npm install -g <tool>` reports success (exit 0, "changed N packages") but the binary lands in the store `bin/` where nothing on `PATH` can see it — e.g. `npm install -g tsx` then `command -v tsx` -> not found.

## Fix

- Bake `NPM_CONFIG_PREFIX=/usr/local` into the image `config.Env`. `/usr/local/bin` is already on the baked `PATH`.
- Create a writable `/usr/local/bin` in the `bootstrap` layer (the image has no FHS `/usr/local`), so the prefix exists and is writable at runtime (root, `HOME=/root`).

Now `npm install -g <tool>` lands the binary at `/usr/local/bin/<tool>`, which resolves on `PATH`.

## Tests (TDD)

Added `TestNodeEnvironment` in `tests/test_image.py`:
- `test_npm_installed`
- `test_npm_global_prefix_bin_on_path` — prefix `bin/` is on `PATH` and writable
- `test_npm_global_install_resolves_on_path` — `npm install -g tsx` then `command -v tsx` resolves

Plus `NPM_CONFIG_PREFIX=/usr/local` added to the `test_env_vars_set` parametrization.

Verified RED on the pre-fix image (3 fix-related tests fail: `command -v tsx` not found, `NPM_CONFIG_PREFIX` unset, prefix bin off PATH) and GREEN after the fix.

## Coordination with #727

The install test is deliberately scoped to PATH resolution (`command -v`), not execution. Executing an installed CLI relies on the `#!/usr/bin/env` shebang interpreter that #727 provides; this change stands alone and does not depend on it.

Closes #728