### PR TITLE
fix(workspace): stop direnv --force from clobbering populated consumer repos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`install.sh --mode direnv --force` no longer clobbers a populated consumer repo** ([#738](https://github.com/vig-os/devcontainer/issues/738))
+  - Re-initializing an existing project in `direnv` mode deployed the full workspace template over it: the scaffold `rsync` overwrote a real `pyproject.toml` with the generic template one, and copied the template `.devcontainer/` before the mode prune deleted the directory wholesale — destroying tracked files (`devcontainer.json`, project compose files, …). `pyproject.toml` is now in the never-overwrite `PRESERVE_FILES` class, and `direnv` mode excludes `.devcontainer/` from the copy and skips the prune when a populated `.devcontainer/` predates the (re)scaffold, so real project files survive untouched. `--force` still deploys the Nix/direnv stub (`flake.nix`, `.envrc`, `.vig-os`) onto repos that lack it
+  - `install.sh` no longer prints a misleading `User configuration script not found … copy-host-user-conf.sh` warning in `direnv` mode, which scaffolds no `.devcontainer/` and therefore has no host-user-conf step to run
 - **`/usr/bin/env` now exists in the Nix-built image** ([#727](https://github.com/vig-os/devcontainer/issues/727))
   - The bare `dockerTools.buildLayeredImage` had no `/usr/bin` at all, so the ubiquitous `#!/usr/bin/env <interp>` shebang failed with `/usr/bin/env: bad interpreter: No such file or directory` — breaking essentially every Node/Python/Ruby CLI (e.g. `node_modules/.bin/tsc`) for image-mode consumers. Added `dockerTools.usrBinEnv` (the FHS shim symlinking `/usr/bin/env` to coreutils `env`) to the image package set, alongside the existing `fakeNss` shim
 - **`npm install -g` now lands CLIs on PATH in the Nix image** ([#728](https://github.com/vig-os/devcontainer/issues/728))

--- a/assets/init-workspace.sh
+++ b/assets/init-workspace.sh
@@ -46,6 +46,9 @@ PRESERVE_FILES=(
     # dev-env upgrade must never clobber it — same class as justfile.project.
     "flake.nix"
     ".envrc"
+    # The consumer owns its project manifest (#738): a (re)scaffold must never
+    # overwrite an existing pyproject.toml with the generic template one.
+    "pyproject.toml"
 )
 
 # Get script directory for manifest location
@@ -275,6 +278,14 @@ if [[ "$FORCE" == "true" ]]; then
     fi
 fi
 
+# Record whether the consumer already had a populated .devcontainer/ before the
+# scaffold (#738). In direnv mode we must neither overwrite nor delete it.
+DEVCONTAINER_PREEXISTED=false
+if [[ -d "$WORKSPACE_DIR/.devcontainer" ]] \
+    && [[ -n "$(ls -A "$WORKSPACE_DIR/.devcontainer" 2>/dev/null)" ]]; then
+    DEVCONTAINER_PREEXISTED=true
+fi
+
 # Copy template contents to workspace
 echo "Initializing workspace from template..."
 echo "Copying files from $TEMPLATE_DIR to $WORKSPACE_DIR..."
@@ -314,6 +325,13 @@ else
         fi
     done
 
+    # direnv mode wants no .devcontainer/ at all, so never copy the template one
+    # over a populated consumer .devcontainer/ (#738). Excluding it from the copy
+    # (rather than copying-then-pruning) keeps a real .devcontainer/ intact.
+    if [[ "$MODE" == "direnv" ]]; then
+        EXCLUDE_ARGS+=("--exclude=.devcontainer")
+    fi
+
     rsync -avL --exclude='.git' --exclude='.venv' "${EXCLUDE_ARGS[@]}" "$TEMPLATE_DIR/" "$WORKSPACE_DIR/"
 fi
 
@@ -335,8 +353,14 @@ case "$MODE" in
         rm -f "$WORKSPACE_DIR/flake.nix" "$WORKSPACE_DIR/.envrc"
         ;;
     direnv)
-        echo "Pruning to 'direnv' mode: removing .devcontainer/..."
-        rm -rf "$WORKSPACE_DIR/.devcontainer"
+        # Only drop a .devcontainer/ that this scaffold created; never delete a
+        # populated consumer .devcontainer/ that predates the (re)scaffold (#738).
+        if [[ "$DEVCONTAINER_PREEXISTED" == "true" ]]; then
+            echo "direnv mode: preserving existing .devcontainer/ (#738)"
+        else
+            echo "Pruning to 'direnv' mode: removing .devcontainer/..."
+            rm -rf "$WORKSPACE_DIR/.devcontainer"
+        fi
         ;;
     both)
         : # keep everything

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -107,6 +107,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`install.sh --mode direnv --force` no longer clobbers a populated consumer repo** ([#738](https://github.com/vig-os/devcontainer/issues/738))
+  - Re-initializing an existing project in `direnv` mode deployed the full workspace template over it: the scaffold `rsync` overwrote a real `pyproject.toml` with the generic template one, and copied the template `.devcontainer/` before the mode prune deleted the directory wholesale — destroying tracked files (`devcontainer.json`, project compose files, …). `pyproject.toml` is now in the never-overwrite `PRESERVE_FILES` class, and `direnv` mode excludes `.devcontainer/` from the copy and skips the prune when a populated `.devcontainer/` predates the (re)scaffold, so real project files survive untouched. `--force` still deploys the Nix/direnv stub (`flake.nix`, `.envrc`, `.vig-os`) onto repos that lack it
+  - `install.sh` no longer prints a misleading `User configuration script not found … copy-host-user-conf.sh` warning in `direnv` mode, which scaffolds no `.devcontainer/` and therefore has no host-user-conf step to run
 - **`/usr/bin/env` now exists in the Nix-built image** ([#727](https://github.com/vig-os/devcontainer/issues/727))
   - The bare `dockerTools.buildLayeredImage` had no `/usr/bin` at all, so the ubiquitous `#!/usr/bin/env <interp>` shebang failed with `/usr/bin/env: bad interpreter: No such file or directory` — breaking essentially every Node/Python/Ruby CLI (e.g. `node_modules/.bin/tsc`) for image-mode consumers. Added `dockerTools.usrBinEnv` (the FHS shim symlinking `/usr/bin/env` to coreutils `env`) to the image package set, alongside the existing `fakeNss` shim
 - **`npm install -g` now lands CLIs on PATH in the Nix image** ([#728](https://github.com/vig-os/devcontainer/issues/728))

--- a/install.sh
+++ b/install.sh
@@ -540,8 +540,15 @@ echo ""
 info "Running post-initialization setup..."
 
 # 1. Copy host user configuration (git, ssh, gh) into .devcontainer/.conf/
-# Non-fatal: warnings about missing SSH keys or GH CLI are expected on CI/fresh machines
-run_user_conf "$PROJECT_PATH" || true
+# Non-fatal: warnings about missing SSH keys or GH CLI are expected on CI/fresh machines.
+# direnv mode scaffolds no .devcontainer/, so the host-user-conf step (a
+# devcontainer-only concern) does not apply — skip it rather than emit a
+# misleading "script not found" warning (#738).
+if [ "$MODE" = "direnv" ]; then
+    info "direnv mode: skipping host user-conf copy (no .devcontainer/)"
+else
+    run_user_conf "$PROJECT_PATH" || true
+fi
 
 # 2. Git repository setup (init, initial commit, dev branch)
 # Runs on the host (not in container) so that SSH agent is available for commit signing

--- a/tests/bats/init-workspace.bats
+++ b/tests/bats/init-workspace.bats
@@ -235,6 +235,40 @@ _scaffold() {
     assert_output --partial "Invalid --mode"
 }
 
+# ── direnv (re)scaffold must not clobber a populated consumer repo (#738) ──────
+# `install.sh --mode direnv --force` on an existing project deployed the full
+# template over it: overwrote a real pyproject.toml and deleted a populated
+# .devcontainer/. direnv mode must only ADD the Nix/direnv stub.
+
+@test "init-workspace --mode=direnv --force preserves a populated pyproject.toml (#738)" {
+    ws="$BATS_TEST_TMPDIR/e2e-direnv-keep-pyproject"
+    mkdir -p "$ws"
+    printf '# SENTINEL-738 real consumer pyproject\n[project]\nname = "real_consumer"\n' \
+        >"$ws/pyproject.toml"
+    run _scaffold direnv "$ws"
+    assert_success
+    run grep -q 'SENTINEL-738 real consumer pyproject' "$ws/pyproject.toml"
+    assert_success
+    # ...and the Nix/direnv stub was still added.
+    run test -f "$ws/flake.nix"
+    assert_success
+    run test -f "$ws/.envrc"
+    assert_success
+}
+
+@test "init-workspace --mode=direnv --force preserves a populated .devcontainer/ (#738)" {
+    ws="$BATS_TEST_TMPDIR/e2e-direnv-keep-devcontainer"
+    mkdir -p "$ws/.devcontainer"
+    printf '{ "name": "SENTINEL-738 real devcontainer" }\n' \
+        >"$ws/.devcontainer/devcontainer.json"
+    run _scaffold direnv "$ws"
+    assert_success
+    run test -f "$ws/.devcontainer/devcontainer.json"
+    assert_success
+    run grep -q 'SENTINEL-738 real devcontainer' "$ws/.devcontainer/devcontainer.json"
+    assert_success
+}
+
 # ── script structure ──────────────────────────────────────────────────────────
 
 @test "init-workspace.sh is executable" {


### PR DESCRIPTION
## Summary

`install.sh --mode direnv --version <v> --skip-pull --podman --force <repo>` on an already-populated consumer repo was destructive: in `direnv` mode the scaffold `rsync` deployed the full workspace template over the project — overwriting a real `pyproject.toml`, and copying the template `.devcontainer/` before the mode prune (`rm -rf .devcontainer`) deleted the directory wholesale, destroying tracked files (`devcontainer.json`, project compose files, …).

Closes #738.

## Changes

- **`assets/init-workspace.sh`**
  - Add `pyproject.toml` to the never-overwrite `PRESERVE_FILES` class, so an existing project manifest is never overwritten by the generic template one (any mode).
  - In `direnv` mode, exclude `.devcontainer/` from the scaffold `rsync` and skip the prune when a populated `.devcontainer/` predates the (re)scaffold (`DEVCONTAINER_PREEXISTED`). A real devcontainer survives untouched; fresh repos still get no `.devcontainer/`.
  - `--force` semantics for the Nix/direnv stub (`flake.nix`, `.envrc`, `.vig-os`) are unchanged — they are still deployed onto repos that lack them.
- **`install.sh`**
  - Skip the host-user-conf copy in `direnv` mode (no `.devcontainer/` exists there) instead of emitting a misleading `User configuration script not found … copy-host-user-conf.sh` warning.

## Tests

- New regression tests in `tests/bats/init-workspace.bats` (`#738`): `--mode direnv --force` on a populated workspace preserves a real `pyproject.toml` (sentinel content) and a populated `.devcontainer/devcontainer.json`, while still adding `flake.nix` + `.envrc`. Written test-first (RED → GREEN).
- Full `init-workspace.bats` (47) and `install.bats` (51) suites pass; `shellcheck` clean on both scripts.

### Manual verification (scratch dir)

```
BEFORE: pyproject.toml = "# SENTINEL real uv-workspace pyproject" ; .devcontainer/devcontainer.json present
RUN:    bash assets/init-workspace.sh --force --no-prompts --mode direnv  (TEMPLATE_DIR/WORKSPACE_DIR overridden, just stubbed)
        -> "direnv mode: preserving existing .devcontainer/ (#738)"
AFTER:  pyproject.toml sentinel INTACT ; .devcontainer/devcontainer.json INTACT ; flake.nix + .envrc + .vig-os added
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)