### PR TITLE
fix(image): arm64-aware FHS loader + renameable baked .venv prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **FHS loader symlink is now architecture-aware** ([#736](https://github.com/vig-os/devcontainer/issues/736))
+  - The manylinux FHS loader was hardcoded to `/lib64/ld-linux-x86-64.so.2`, which does not exist on `aarch64` (the loader is `/lib/ld-linux-aarch64.so.1`), so the arm64 image build failed the `test_fhs_loader_exists` portable testinfra check. The loader name and FHS dir are now derived from the build platform, and the test asserts the arch-appropriate path
+- **Baked `.venv` prompt is now renameable by consumer `post-create.sh`** ([#735](https://github.com/vig-os/devcontainer/issues/735))
+  - `python -m venv` writes `VIRTUAL_ENV_PROMPT` unquoted, but the consumer `post-create.sh` rewrites the double-quoted form, so its prompt rename no-opped and the integration `test_venv_prompt_name` check failed. The bootstrap now normalizes the activate prompt assignment to the quoted `"template-project"` the template targets
 - **Nix image now bakes the template `/root/assets/workspace/.venv`** ([#735](https://github.com/vig-os/devcontainer/issues/735))
   - The image advertised `UV_PROJECT_ENVIRONMENT`/`VIRTUAL_ENV` at `/root/assets/workspace/.venv` but never created it (the Debian image did). The published 0.3.x consumer `post-create.sh` runs `sed -i .../.venv/bin/activate` as its first venv step and aborted under `set -euo pipefail` (`exit 2`) when the file was missing — so git setup, gh auth, pre-commit install, and `just sync` never ran. The flake bootstrap layer now pre-creates the venv from the baked CPython (hermetic, network-free, no packages — `just sync` populates it), so `.venv/bin/activate` exists and matches the advertised env vars
 - **Nix image now runs pre-compiled PyPI (manylinux) wheels at runtime** ([#736](https://github.com/vig-os/devcontainer/issues/736))

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -109,6 +109,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **FHS loader symlink is now architecture-aware** ([#736](https://github.com/vig-os/devcontainer/issues/736))
+  - The manylinux FHS loader was hardcoded to `/lib64/ld-linux-x86-64.so.2`, which does not exist on `aarch64` (the loader is `/lib/ld-linux-aarch64.so.1`), so the arm64 image build failed the `test_fhs_loader_exists` portable testinfra check. The loader name and FHS dir are now derived from the build platform, and the test asserts the arch-appropriate path
+- **Baked `.venv` prompt is now renameable by consumer `post-create.sh`** ([#735](https://github.com/vig-os/devcontainer/issues/735))
+  - `python -m venv` writes `VIRTUAL_ENV_PROMPT` unquoted, but the consumer `post-create.sh` rewrites the double-quoted form, so its prompt rename no-opped and the integration `test_venv_prompt_name` check failed. The bootstrap now normalizes the activate prompt assignment to the quoted `"template-project"` the template targets
 - **Nix image now bakes the template `/root/assets/workspace/.venv`** ([#735](https://github.com/vig-os/devcontainer/issues/735))
   - The image advertised `UV_PROJECT_ENVIRONMENT`/`VIRTUAL_ENV` at `/root/assets/workspace/.venv` but never created it (the Debian image did). The published 0.3.x consumer `post-create.sh` runs `sed -i .../.venv/bin/activate` as its first venv step and aborted under `set -euo pipefail` (`exit 2`) when the file was missing — so git setup, gh auth, pre-commit install, and `just sync` never ran. The flake bootstrap layer now pre-creates the venv from the baked CPython (hermetic, network-free, no packages — `just sync` populates it), so `.venv/bin/activate` exists and matches the advertised env vars
 - **Nix image now runs pre-compiled PyPI (manylinux) wheels at runtime** ([#736](https://github.com/vig-os/devcontainer/issues/736))

--- a/flake.nix
+++ b/flake.nix
@@ -418,6 +418,17 @@
                 pkgs.zlib
               ];
 
+              # The FHS loader name/dir manylinux wheels hardcode are
+              # arch-specific: x86_64 -> /lib64/ld-linux-x86-64.so.2,
+              # aarch64 -> /lib/ld-linux-aarch64.so.1. Derive from the build
+              # platform so the multi-arch image is correct on both. Refs #736.
+              fhsLoaderName =
+                if pkgs.stdenv.hostPlatform.isAarch64 then
+                  "ld-linux-aarch64.so.1"
+                else
+                  "ld-linux-x86-64.so.2";
+              fhsLoaderDir = if pkgs.stdenv.hostPlatform.isAarch64 then "lib" else "lib64";
+
               # Bake the workspace assets, pre-commit cache dir and template
               # .venv scaffold as a normal image layer. UV_PYTHON pins the Nix
               # interpreter and UV_PYTHON_DOWNLOADS=never forbids uv from
@@ -471,6 +482,15 @@
                     find "$venvdir/bin" -maxdepth 1 -type f \
                       -exec sed -i "s|$out||g" {} +
                     sed -i "s|$out||g" "$venvdir/pyvenv.cfg"
+                    # `python -m venv` writes VIRTUAL_ENV_PROMPT unquoted
+                    # (VIRTUAL_ENV_PROMPT=.venv), but the consumer post-create.sh
+                    # rewrites the *double-quoted* form
+                    # (VIRTUAL_ENV_PROMPT="..." -> the project short name). Without
+                    # quotes that sed no-ops and the prompt is never renamed.
+                    # Normalize to the quoted "template-project" the template
+                    # expects so the rename applies. Refs #735.
+                    sed -i -E 's/^([[:space:]]*VIRTUAL_ENV_PROMPT=).*/\1"template-project"/' \
+                      "$venvdir/bin/activate"
 
                     mkdir -p "$out/opt/pre-commit-cache"
                     mkdir -p "$out/workspace"
@@ -508,17 +528,20 @@
                     chmod 1777 "$out/tmp"
 
                     # FHS dynamic loader for runtime-installed manylinux wheels.
-                    # A bare Nix layered image has no /lib64/ld-linux-x86-64.so.2
-                    # — the interpreter every manylinux x86_64 wheel hardcodes as
-                    # its PT_INTERP — so PyPI-pinned standalone tools (e.g.
-                    # pre-commit's ruff/typos) abort with "cannot execute:
-                    # required file not found". Symlink the Nix glibc loader
-                    # there; being newer it runs the old-glibc wheels (glibc is
+                    # A bare Nix layered image lacks the loader every manylinux
+                    # wheel hardcodes as its PT_INTERP, so PyPI-pinned standalone
+                    # tools (e.g. pre-commit's ruff/typos) abort with "cannot
+                    # execute: required file not found". Symlink the Nix glibc
+                    # loader there; being newer it runs old-glibc wheels (glibc is
                     # backward compatible). Paired with LD_LIBRARY_PATH
-                    # (config.Env) for the C++/z runtime the wheels need. #736.
-                    mkdir -p "$out/lib64"
-                    ln -s ${pkgs.glibc}/lib/ld-linux-x86-64.so.2 \
-                      "$out/lib64/ld-linux-x86-64.so.2"
+                    # (config.Env) for the C++/z runtime the wheels need. The
+                    # loader name and FHS dir are ARCH-SPECIFIC — x86_64 wheels
+                    # want /lib64/ld-linux-x86-64.so.2, aarch64 wheels want
+                    # /lib/ld-linux-aarch64.so.1 — so derive both from the build
+                    # platform (the image builds natively per arch). Refs #736.
+                    mkdir -p "$out/${fhsLoaderDir}"
+                    ln -s ${pkgs.glibc}/lib/${fhsLoaderName} \
+                      "$out/${fhsLoaderDir}/${fhsLoaderName}"
                     # /etc/nix/nix.conf enabling the experimental features the
                     # modern Nix CLI needs. The image bakes CppNix but shipped
                     # no nix.conf, so `nix-command`/`flakes` were off by default

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -221,15 +221,23 @@ class TestManylinuxRuntime:
     """
 
     def test_fhs_loader_exists(self, host):
-        """The FHS loader manylinux x86_64 wheels exec must exist.
+        """The FHS loader manylinux wheels exec must exist (arch-specific).
 
-        Unconditional (needs no network): a missing
-        ``/lib64/ld-linux-x86-64.so.2`` is the root cause of ``cannot execute:
-        required file not found`` for any PyPI-pinned standalone tool. Refs #736.
+        Unconditional (needs no network): a missing loader is the root cause of
+        ``cannot execute: required file not found`` for any PyPI-pinned
+        standalone tool. The path is arch-specific (the image builds natively
+        per arch): x86_64 -> ``/lib64/ld-linux-x86-64.so.2``,
+        aarch64 -> ``/lib/ld-linux-aarch64.so.1``. Refs #736.
         """
-        loader = host.file("/lib64/ld-linux-x86-64.so.2")
+        arch = host.system_info.arch
+        loader_path = (
+            "/lib/ld-linux-aarch64.so.1"
+            if arch in ("aarch64", "arm64")
+            else "/lib64/ld-linux-x86-64.so.2"
+        )
+        loader = host.file(loader_path)
         assert loader.exists, (
-            "/lib64/ld-linux-x86-64.so.2 missing; manylinux wheel executables "
+            f"{loader_path} missing; manylinux wheel executables "
             "(e.g. PyPI-pinned pre-commit ruff/typos) cannot exec"
         )
 


### PR DESCRIPTION
Fixes two regressions the merged #736/#735 introduced, caught by PR #670's arm64 testinfra and integration jobs:

- **#736**: the FHS loader symlink was hardcoded to `/lib64/ld-linux-x86-64.so.2` — missing on aarch64 (`/lib/ld-linux-aarch64.so.1`), failing `test_fhs_loader_exists` on the arm64 image. Now arch-derived; test is arch-aware.
- **#735**: `python -m venv` writes `VIRTUAL_ENV_PROMPT` unquoted, but consumer `post-create.sh` seds the double-quoted form, so the prompt rename no-opped and `test_venv_prompt_name` failed. Bootstrap now normalizes the prompt to the quoted `template-project`.

Refs: #736, #735