### PR TITLE
fix(devshell): expose python3 + pre-commit on dev-shell PATH (CI-safe)

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -172,12 +172,26 @@ runs:
         # preinstalled podman is kept on PATH by NOT shadowing it here (matches
         # the apt-podman intent documented on the provision-via-flake input).
         # Refs #632.
+        #
+        # Exclude the flake's bare CPython (and pre-commit): the dev-shell now
+        # ships `python3`/`pre-commit` on PATH for dev-shell<->image parity
+        # (#729), but CI must keep building the project venv from a DOWNLOADED
+        # manylinux-compatible CPython (the UV_PYTHON_DOWNLOADS_JSON_URL path
+        # below) so pre-commit's manylinux hooks (pymarkdown -> pyjson5) resolve
+        # the runner's system libstdc++. If the Nix `python3.14` were on the
+        # runner PATH, `uv sync` would select it (it satisfies requires-python),
+        # rebuild the venv on the Nix loader, and reintroduce the #698/#703
+        # `libstdc++` ImportError that forced the #729 revert. The interpreter
+        # drv is `python3-<ver>` (library pkgs are `python3.14-<pkg>` and are
+        # unaffected); the `pre-commit-` exclusion is belt-and-suspenders (CI
+        # uses `uv run pre-commit`, never the bare flake one). Refs #729.
         SHELL_PATH="$(nix develop --profile "$RUNNER_TEMP/dev-profile" \
           --command bash -c 'printf "%s" "$PATH"')"
 
         printf '%s' "$SHELL_PATH" | tr ':' '\n' \
           | grep '^/nix/store' \
-          | grep -v '/nix/store/[^/]*-podman[^/]*/bin' >> "$GITHUB_PATH"
+          | grep -v '/nix/store/[^/]*-podman[^/]*/bin' \
+          | grep -Ev '/nix/store/[^/]*-(python3-[0-9]|pre-commit-)[^/]*/bin' >> "$GITHUB_PATH"
 
         # Propagate the dev-shell's uv Python-download metadata URL to later
         # steps. GITHUB_PATH only carries PATH, not env vars, so this var (set

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,6 +191,16 @@ jobs:
       - name: Check flake quality gates
         run: nix flake check --accept-flake-config
 
+      # Guard the dev-shell <-> image parity: the dev-shell must expose
+      # `python3`/`pre-commit` (#729) and must NOT leak the Nix C++ runtime onto
+      # an FHS host's LD_LIBRARY_PATH (#703). These drive `nix develop` directly
+      # (not covered by `test-project`'s pytest scope), so run them explicitly
+      # here where Nix + the dev profile are warm. Refs #729, #703.
+      - name: Check dev-shell python/pre-commit parity + FHS leak-guard
+        run: |
+          uv run pytest tests/test_flake_devshell.py \
+            -k "exposes_python3_and_precommit or no_nix_cxx_runtime_leak" -v
+
       # Validate the scaffolded downstream stub (assets/workspace/flake.nix)
       # against THIS toolchain, not the published vigos, so a change to the flake
       # API (lib.mkProjectShell / overlays.default) can't silently break a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Dev-shell exposes `python3` + `pre-commit` (image parity), CI-safely** ([#729](https://github.com/vig-os/devcontainer/issues/729))
+  - `mkProjectShell` now ships a bare `python3`/`pre-commit` on PATH so the downstream flake-input/direnv dev-shell matches the image. The earlier attempt was reverted because, on the FHS CI runner, the dev-shell→PATH forwarding leaked the Nix CPython, so `uv sync` built the project venv from it and pre-commit's manylinux `pymarkdown` (`pyjson5`) hook could not resolve `libstdc++`. Fixed at the right layer: `setup-env` now filters the Nix `python3-<ver>` (and `pre-commit`) out of the forwarded runner PATH so CI keeps building the venv from the downloaded managed CPython. No new `LD_LIBRARY_PATH`, so the #703 FHS leak-guard is unaffected. A `nix develop --ignore-environment` parity test (and the FHS leak-guard) now run in the Project Checks job
 - **FHS loader symlink is now architecture-aware** ([#736](https://github.com/vig-os/devcontainer/issues/736))
   - The manylinux FHS loader was hardcoded to `/lib64/ld-linux-x86-64.so.2`, which does not exist on `aarch64` (the loader is `/lib/ld-linux-aarch64.so.1`), so the arm64 image build failed the `test_fhs_loader_exists` portable testinfra check. The loader name and FHS dir are now derived from the build platform, and the test asserts the arch-appropriate path
 - **Baked `.venv` prompt is now renameable by consumer `post-create.sh`** ([#735](https://github.com/vig-os/devcontainer/issues/735))

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -109,6 +109,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Dev-shell exposes `python3` + `pre-commit` (image parity), CI-safely** ([#729](https://github.com/vig-os/devcontainer/issues/729))
+  - `mkProjectShell` now ships a bare `python3`/`pre-commit` on PATH so the downstream flake-input/direnv dev-shell matches the image. The earlier attempt was reverted because, on the FHS CI runner, the dev-shell→PATH forwarding leaked the Nix CPython, so `uv sync` built the project venv from it and pre-commit's manylinux `pymarkdown` (`pyjson5`) hook could not resolve `libstdc++`. Fixed at the right layer: `setup-env` now filters the Nix `python3-<ver>` (and `pre-commit`) out of the forwarded runner PATH so CI keeps building the venv from the downloaded managed CPython. No new `LD_LIBRARY_PATH`, so the #703 FHS leak-guard is unaffected. A `nix develop --ignore-environment` parity test (and the FHS leak-guard) now run in the Project Checks job
 - **FHS loader symlink is now architecture-aware** ([#736](https://github.com/vig-os/devcontainer/issues/736))
   - The manylinux FHS loader was hardcoded to `/lib64/ld-linux-x86-64.so.2`, which does not exist on `aarch64` (the loader is `/lib/ld-linux-aarch64.so.1`), so the arm64 image build failed the `test_fhs_loader_exists` portable testinfra check. The loader name and FHS dir are now derived from the build platform, and the test asserts the arch-appropriate path
 - **Baked `.venv` prompt is now renameable by consumer `post-create.sh`** ([#735](https://github.com/vig-os/devcontainer/issues/735))

--- a/flake.nix
+++ b/flake.nix
@@ -205,7 +205,24 @@
           '';
         in
         pkgs.mkShell {
-          packages = (devTools pkgs) ++ extraPackages;
+          # The toolchain SSoT, plus a bare Python interpreter and pre-commit so
+          # the downstream dev-shell matches the image's PATH (`python`/`python3`
+          # + `pre-commit`). These are not in `devTools`: the image already
+          # provides them via `pythonEnv` + `pre-commit` in `imageTools`, and a
+          # bare interpreter in the SSoT would collide with `pythonEnv` there.
+          # Safe for CI despite the FHS pymarkdown/manylinux constraint: the
+          # dev-shell pins `UV_PYTHON` (below) to this same store CPython, and
+          # the CI PATH-forwarding (setup-env) filters this interpreter out so
+          # `uv` still builds the runner venv from a downloaded managed CPython.
+          # No new LD_LIBRARY_PATH, so the #703 FHS leak-guard is unaffected.
+          # Refs #729.
+          packages =
+            (devTools pkgs)
+            ++ [
+              python
+              pkgs.pre-commit
+            ]
+            ++ extraPackages;
           shellHook = ldLibraryPathHook + "\n" + nvimIsolationHook + "\n" + shellHook;
 
           UV_PYTHON = "${python}/bin/python3.14";

--- a/tests/test_flake_devshell.py
+++ b/tests/test_flake_devshell.py
@@ -349,6 +349,51 @@ def test_devshell_bats_lib_path_resolves_helpers(dev_shell_env: dict[str, str]) 
         )
 
 
+@pytest.mark.parametrize("binary", ["python3", "pre-commit"])
+def test_devshell_exposes_python3_and_precommit(binary: str) -> None:
+    """The dev-shell must put ``python3`` and ``pre-commit`` on PATH (#729).
+
+    The image (``imageTools``) ships a Python interpreter (``pythonEnv``) and
+    ``pre-commit``, but ``mkProjectShell`` carried neither: the downstream
+    flake-input / direnv dev-shell could reach Python only via ``uv run`` and
+    had no ``pre-commit`` at all — a dev-shell ↔ image parity gap.
+
+    The check runs under ``nix develop --ignore-environment`` so it asserts the
+    dev-shell's *own* PATH contribution and is not satisfied by a host
+    ``python3``/``pre-commit`` leaking through the inherited environment (the
+    exact way the gap hid until #729). These two binaries are intentionally not
+    in the ``devTools`` SSoT (a bare interpreter there would collide with the
+    image's ``pythonEnv``), so they are asserted explicitly here rather than
+    through ``devShellTools``.
+    """
+    cmd = [
+        "nix",
+        "develop",
+        "--ignore-environment",
+        "--keep",
+        "HOME",
+        str(REPO_ROOT),
+        "-c",
+        "bash",
+        "-c",
+        f"command -v {binary}",
+    ]
+    proc = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        env=_nix_env(),
+        timeout=900,
+    )
+    # `command -v` exits 0 iff the binary is on PATH; rely on the exit code
+    # (the shellHook's banner pollutes stdout, so it is not a presence signal).
+    assert proc.returncode == 0, (
+        f"{binary} must be on the dev-shell's own PATH (#729): "
+        f"rc={proc.returncode} stdout={proc.stdout.strip()!r} "
+        f"stderr={proc.stderr.strip()[:200]}"
+    )
+
+
 def test_each_tool_runs_in_devshell(dev_shell_tools: list[str]) -> None:
     """Every tool in ``devTools`` is runnable inside ``nix develop``."""
     failures: list[str] = []


### PR DESCRIPTION
Resolves #729 (the host-safe re-implementation after the 8f778f5 revert).

**Root cause of the revert:** the dev-shell→runner PATH forwarding (`setup-env`) leaked the Nix `python3.14`, so CI's `uv sync` selected it instead of the downloaded managed CPython → pre-commit ran under the Nix interpreter → manylinux `pyjson5` couldn't resolve `libstdc++` on FHS (#698 rescue is `/etc/NIXOS`-gated, #703).

**Fix:** re-expose `python3`/`pre-commit` in `mkProjectShell`, and filter the Nix `python3-<ver>`/`pre-commit` out of the forwarded runner PATH (mirrors the existing podman exclusion) so CI keeps building the venv from the managed CPython. No new `LD_LIBRARY_PATH` → #703 leak-guard unaffected. Parity test + FHS leak-guard now run in Project Checks.

Closes #729