### PR TITLE
chore(deps): apply applicable Renovate action/dep updates

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -217,13 +217,13 @@ runs:
     # project interpreter via `uv sync` / `uv run`.
     - name: "Set up Python from pyproject"
       if: inputs.provision-via-flake != 'true' && inputs.install-python == 'true' && hashFiles('pyproject.toml') != ''
-      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
       with:
         python-version-file: "pyproject.toml"
 
     - name: "Set up Python fallback"
       if: inputs.provision-via-flake != 'true' && inputs.install-python == 'true' && hashFiles('pyproject.toml') == ''
-      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1  # v6
       with:
         python-version: ${{ inputs.python-version }}
 
@@ -325,7 +325,7 @@ runs:
     # Skipped under flake provisioning: just comes from the flake dev-shell.
     - name: Install just
       if: inputs.provision-via-flake != 'true' && inputs.install-just == 'true'
-      uses: taiki-e/install-action@ab08a3b50948bd57d91bd2980f025da7e0a88231  # just
+      uses: taiki-e/install-action@9cfa436698ecd30b7b47d715cbb8241e4624245a  # just
       with:
         tool: just
 

--- a/.github/actions/test-project/action.yml
+++ b/.github/actions/test-project/action.yml
@@ -64,7 +64,7 @@ runs:
 
     - name: Cache pre-commit hooks
       if: inputs.suite == 'all' || inputs.suite == 'lint'
-      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
       with:
         path: ~/.cache/pre-commit
         key: pre-commit-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1072,7 +1072,7 @@ jobs:
       - name: Attest build provenance (attempt 1)
         id: attest_provenance
         continue-on-error: true
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32  # v4.1.0
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373  # v4.1.1
         with:
           subject-name: ghcr.io/vig-os/devcontainer
           subject-digest: ${{ steps.digest.outputs.digest }}
@@ -1084,7 +1084,7 @@ jobs:
 
       - name: Attest build provenance (retry)
         if: steps.attest_provenance.outcome == 'failure'
-        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32  # v4.1.0
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373  # v4.1.1
         with:
           subject-name: ghcr.io/vig-os/devcontainer
           subject-digest: ${{ steps.digest.outputs.digest }}
@@ -1093,7 +1093,7 @@ jobs:
       - name: Attest SBOM (attempt 1)
         id: attest_sbom
         continue-on-error: true
-        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26  # v4.1.0
+        uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763  # v4.1.1
         with:
           subject-name: ghcr.io/vig-os/devcontainer
           subject-digest: ${{ steps.digest.outputs.digest }}
@@ -1106,7 +1106,7 @@ jobs:
 
       - name: Attest SBOM (retry)
         if: steps.attest_sbom.outcome == 'failure'
-        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26  # v4.1.0
+        uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763  # v4.1.1
         with:
           subject-name: ghcr.io/vig-os/devcontainer
           subject-digest: ${{ steps.digest.outputs.digest }}

--- a/.github/workflows/sync-issues.yml
+++ b/.github/workflows/sync-issues.yml
@@ -95,7 +95,7 @@ jobs:
 
       - name: Restore sync state (last synced timestamp)
         id: restore-state
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: .sync-state
           key: sync-issues-state-${{ github.repository }}
@@ -151,7 +151,7 @@ jobs:
 
       - name: Save sync state
         if: always()
-        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: .sync-state
           key: sync-issues-state-${{ github.repository }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Applied the still-relevant Renovate dependency updates** ([#625](https://github.com/vig-os/devcontainer/issues/625))
+  - Folded the open Renovate PRs that still apply post-migration onto the epic: `actions/cache` → v6.1.0 (the v6 service, superseding the v5.x bumps), `actions/attest`/`actions/attest-build-provenance` → v4.1.1, `actions/setup-python` and `taiki-e/install-action` (just) digest refreshes, and `pandas` 3.0.3 → 3.0.4 in the workspace template. Stale ones were dropped: the `python:3.14-slim-bookworm` Docker digest (the `Containerfile` is gone) and the `ruff` pip pin (sourced from the flake now, #697); the `uv` 0.11.23 → 0.11.25 bump is deferred to the flake↔setup-env version sync (#720)
 - **`SECURITY.md` describes the Nix image security posture** ([#642](https://github.com/vig-os/devcontainer/issues/642))
   - Replaced the stale Debian/`Containerfile` base-image pin, the "Trivy in CI/release" line, the 78 Debian LOW-CVE `.trivyignore` note, and the nine legacy BATS-npm GHSA exceptions (the framework now ships from the flake) with the current `vulnix` + CycloneDX SBOM scanning model and the `.vulnixignore`/`.trivyignore` dual register, mirroring `docs/CONTAINER_SECURITY.md`
 - **README now describes the Nix-built image** ([#673](https://github.com/vig-os/devcontainer/issues/673))

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -53,6 +53,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Applied the still-relevant Renovate dependency updates** ([#625](https://github.com/vig-os/devcontainer/issues/625))
+  - Folded the open Renovate PRs that still apply post-migration onto the epic: `actions/cache` → v6.1.0 (the v6 service, superseding the v5.x bumps), `actions/attest`/`actions/attest-build-provenance` → v4.1.1, `actions/setup-python` and `taiki-e/install-action` (just) digest refreshes, and `pandas` 3.0.3 → 3.0.4 in the workspace template. Stale ones were dropped: the `python:3.14-slim-bookworm` Docker digest (the `Containerfile` is gone) and the `ruff` pip pin (sourced from the flake now, #697); the `uv` 0.11.23 → 0.11.25 bump is deferred to the flake↔setup-env version sync (#720)
 - **`SECURITY.md` describes the Nix image security posture** ([#642](https://github.com/vig-os/devcontainer/issues/642))
   - Replaced the stale Debian/`Containerfile` base-image pin, the "Trivy in CI/release" line, the 78 Debian LOW-CVE `.trivyignore` note, and the nine legacy BATS-npm GHSA exceptions (the framework now ships from the flake) with the current `vulnix` + CycloneDX SBOM scanning model and the `.vulnixignore`/`.trivyignore` dual register, mirroring `docs/CONTAINER_SECURITY.md`
 - **README now describes the Nix-built image** ([#673](https://github.com/vig-os/devcontainer/issues/673))

--- a/assets/workspace/.github/workflows/sync-issues.yml
+++ b/assets/workspace/.github/workflows/sync-issues.yml
@@ -91,7 +91,7 @@ jobs:
 
       - name: Restore sync state (last synced timestamp)
         id: restore-state
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: .sync-state
           key: sync-issues-state-${{ github.repository }}
@@ -147,7 +147,7 @@ jobs:
 
       - name: Save sync state
         if: always()
-        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9  # v6.1.0
         with:
           path: .sync-state
           key: sync-issues-state-${{ github.repository }}

--- a/assets/workspace/pyproject.toml
+++ b/assets/workspace/pyproject.toml
@@ -15,7 +15,7 @@ dev = [
 science = [
   "numpy==2.5.0",
   "scipy==1.18.0",
-  "pandas==3.0.3",
+  "pandas==3.0.4",
   "matplotlib==3.11.0",
 ]
 all = ["{{SHORT_NAME}}[dev,science]"]


### PR DESCRIPTION
Folds the open Renovate PRs that still apply after the Nix migration onto the epic via one branch (no new issue).

**Applied:** `actions/cache` → v6.1.0 (#732, supersedes #731's v5.x); `actions/attest`/`attest-build-provenance` → v4.1.1 (#731); `actions/setup-python` (#722) + `taiki-e/install-action` (just) (#725) digests; `pandas` 3.0.3→3.0.4 in the workspace template (#726, partial).

**Dropped as stale:** python:3.14-slim Docker digest (#721 — `Containerfile` removed); `ruff` pip pin (#726 — flake-sourced per #697). **Deferred:** `uv` 0.11.23→0.11.25 (#731) to the flake↔setup-env sync (#720).

Refs #625