### PR TITLE
fix(image): set empty build-users-group in baked nix.conf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **In-image on-demand `nix` local builds work (`build-users-group=`)** ([#749](https://github.com/vig-os/devcontainer/issues/749))
+  - The baked `/etc/nix/nix.conf` (#739) enabled `nix-command`/`flakes` but the in-image nix runs as root, single-user, daemonless with no `nixbld` group — so any on-demand `nix shell`/`nix develop` needing a local build (not a pure cache substitution, e.g. a `rust-overlay` toolchain) aborted with "the group 'nixbld' … does not exist". The bootstrap nix.conf now also sets an empty `build-users-group =`, the standard rootless/in-container setting, so root builds directly
+
 - **Dev-shell exposes `python3` + `pre-commit` (image parity), CI-safely** ([#729](https://github.com/vig-os/devcontainer/issues/729))
   - `mkProjectShell` now ships a bare `python3`/`pre-commit` on PATH so the downstream flake-input/direnv dev-shell matches the image. The earlier attempt was reverted because, on the FHS CI runner, the dev-shell→PATH forwarding leaked the Nix CPython, so `uv sync` built the project venv from it and pre-commit's manylinux `pymarkdown` (`pyjson5`) hook could not resolve `libstdc++`. Fixed at the right layer: `setup-env` now filters the Nix `python3-<ver>` (and `pre-commit`) out of the forwarded runner PATH so CI keeps building the venv from the downloaded managed CPython. No new `LD_LIBRARY_PATH`, so the #703 FHS leak-guard is unaffected. A `nix develop --ignore-environment` parity test (and the FHS leak-guard) now run in the Project Checks job
 - **FHS loader symlink is now architecture-aware** ([#736](https://github.com/vig-os/devcontainer/issues/736))

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -111,6 +111,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **In-image on-demand `nix` local builds work (`build-users-group=`)** ([#749](https://github.com/vig-os/devcontainer/issues/749))
+  - The baked `/etc/nix/nix.conf` (#739) enabled `nix-command`/`flakes` but the in-image nix runs as root, single-user, daemonless with no `nixbld` group — so any on-demand `nix shell`/`nix develop` needing a local build (not a pure cache substitution, e.g. a `rust-overlay` toolchain) aborted with "the group 'nixbld' … does not exist". The bootstrap nix.conf now also sets an empty `build-users-group =`, the standard rootless/in-container setting, so root builds directly
+
 - **Dev-shell exposes `python3` + `pre-commit` (image parity), CI-safely** ([#729](https://github.com/vig-os/devcontainer/issues/729))
   - `mkProjectShell` now ships a bare `python3`/`pre-commit` on PATH so the downstream flake-input/direnv dev-shell matches the image. The earlier attempt was reverted because, on the FHS CI runner, the dev-shell→PATH forwarding leaked the Nix CPython, so `uv sync` built the project venv from it and pre-commit's manylinux `pymarkdown` (`pyjson5`) hook could not resolve `libstdc++`. Fixed at the right layer: `setup-env` now filters the Nix `python3-<ver>` (and `pre-commit`) out of the forwarded runner PATH so CI keeps building the venv from the downloaded managed CPython. No new `LD_LIBRARY_PATH`, so the #703 FHS leak-guard is unaffected. A `nix develop --ignore-environment` parity test (and the FHS leak-guard) now run in the Project Checks job
 - **FHS loader symlink is now architecture-aware** ([#736](https://github.com/vig-os/devcontainer/issues/736))

--- a/flake.nix
+++ b/flake.nix
@@ -568,10 +568,20 @@
                     # it needs that input's store path threaded in here and is
                     # not a one-liner, so on-demand `nix shell` tracks the
                     # channel default for now. Refs #739.
+                    #
+                    # `build-users-group =` (empty): the in-image nix runs as
+                    # root, single-user, daemonless (no `nixbld` group, store
+                    # owned root:root). Without this, any on-demand `nix shell`/
+                    # `nix develop` that needs a LOCAL build (not a pure cache
+                    # substitution) aborts with "the group 'nixbld' ... does not
+                    # exist" — e.g. a rust-overlay toolchain. Empty disables the
+                    # build-user drop so root builds directly (standard rootless/
+                    # in-container setting). Refs #749.
                     mkdir -p "$out/etc/nix"
                     cat > "$out/etc/nix/nix.conf" <<'NIXCONF'
                     experimental-features = nix-command flakes
                     accept-flake-config = true
+                    build-users-group =
                     NIXCONF
                   '';
             in

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -947,6 +947,28 @@ class TestNixConfiguration:
             f"unexpected nix eval output: {result.stdout!r}"
         )
 
+    def test_nix_conf_disables_build_users_group(self, host):
+        """nix.conf sets an empty ``build-users-group`` (#749).
+
+        The in-image nix runs as root, single-user, daemonless with no
+        ``nixbld`` group, so any on-demand ``nix shell``/``nix develop`` that
+        needs a local build (not a pure cache substitution) would abort with
+        "the group 'nixbld' ... does not exist". An empty ``build-users-group``
+        makes root build directly.
+        """
+        content = host.file("/etc/nix/nix.conf").content_string
+        group_lines = [
+            line.strip()
+            for line in content.splitlines()
+            if line.strip().startswith("build-users-group")
+        ]
+        assert group_lines, "no build-users-group setting in /etc/nix/nix.conf"
+        # Must be empty (everything after '=' is blank) so root builds directly.
+        value = group_lines[0].split("=", 1)[1].strip()
+        assert value == "", (
+            f"build-users-group must be empty for single-user in-image nix, got {value!r}"
+        )
+
 
 class TestPlaceholders:
     """Test that placeholders are replaced correctly."""


### PR DESCRIPTION
Closes #749. Extends #739: the baked nix.conf enabled nix-command/flakes but the in-image root/single-user/daemonless nix has no `nixbld` group, so on-demand `nix shell`/`nix develop` needing a **local build** (not pure cache substitution — e.g. a rust-overlay toolchain) aborted. Adds `build-users-group =` (empty). Verified in-image: a local derivation build now succeeds. New `test_nix_conf_disables_build_users_group` asserts the setting.