### PR TITLE
fix(release): retag the loaded Nix image tag in publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -949,9 +949,12 @@ jobs:
             fi
 
             echo "Loading $arch image..."
-            docker load < "$ARTIFACT_PATH/image.tar"
-
-            SOURCE_IMAGE_TAG="$REPO:$BUILD_VERSION-$arch"
+            # Read back whatever tag the flake stamped (e.g. `nix-dev`) rather
+            # than assuming `$BUILD_VERSION-$arch`; the Nix image is saved
+            # verbatim and never carries the versioned tag.
+            SOURCE_IMAGE_TAG="$(docker load < "$ARTIFACT_PATH/image.tar" \
+              | sed -n 's/^Loaded image: //p' | head -n1)"
+            echo "Loaded: $SOURCE_IMAGE_TAG"
             IMAGE_TAG="$REPO:$PUBLISH_VERSION-$arch"
             docker tag "$SOURCE_IMAGE_TAG" "$IMAGE_TAG"
             echo "Pushing $arch image: $IMAGE_TAG"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **release.yml publish retags the loaded Nix image tag** ([#752](https://github.com/vig-os/devcontainer/issues/752))
 - **Dev-shell exposes `python3` + `pre-commit` (image parity), CI-safely** ([#729](https://github.com/vig-os/devcontainer/issues/729))
   - `mkProjectShell` now ships a bare `python3`/`pre-commit` on PATH so the downstream flake-input/direnv dev-shell matches the image. `setup-env` filters the Nix `python3-<ver>` (and `pre-commit`) out of the forwarded CI runner PATH so `uv` keeps building the project venv from the downloaded managed CPython. No new `LD_LIBRARY_PATH`, so the #703 FHS leak-guard is intact. A `nix develop --ignore-environment` parity test (and the FHS leak-guard) now run in the Project Checks job
 - **Nix image runs pre-compiled PyPI (manylinux) wheels at runtime (arch-aware FHS loader + baked `LD_LIBRARY_PATH`)** ([#736](https://github.com/vig-os/devcontainer/issues/736))

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -108,6 +108,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **release.yml publish retags the loaded Nix image tag** ([#752](https://github.com/vig-os/devcontainer/issues/752))
 - **Dev-shell exposes `python3` + `pre-commit` (image parity), CI-safely** ([#729](https://github.com/vig-os/devcontainer/issues/729))
   - `mkProjectShell` now ships a bare `python3`/`pre-commit` on PATH so the downstream flake-input/direnv dev-shell matches the image. `setup-env` filters the Nix `python3-<ver>` (and `pre-commit`) out of the forwarded CI runner PATH so `uv` keeps building the project venv from the downloaded managed CPython. No new `LD_LIBRARY_PATH`, so the #703 FHS leak-guard is intact. A `nix develop --ignore-environment` parity test (and the FHS leak-guard) now run in the Project Checks job
 - **Nix image runs pre-compiled PyPI (manylinux) wheels at runtime (arch-aware FHS loader + baked `LD_LIBRARY_PATH`)** ([#736](https://github.com/vig-os/devcontainer/issues/736))


### PR DESCRIPTION
## Summary

Fixes B1 from the PR #670 review: the `release.yml` `publish` job retagged from `$REPO:$BUILD_VERSION-$arch`, a tag the Nix image never carries. The flake bakes `tag = "nix-dev"` and `build-image/action.yml` saves the tar verbatim without retagging, so `docker tag "$SOURCE_IMAGE_TAG" …` failed with "No such image".

## Change

In the publish job's "Load and push images" step, capture the tag reported by `docker load` (`sed -n 's/^Loaded image: //p' | head -n1`) and retag from it — reusing the exact pattern already in `nix-image.yml:152-156`. Minimal diff, contained to the publish step; `build-image/action.yml` left untouched.

`BUILD_VERSION` is retained (still used to build `ARTIFACT_PATH`).

## Verification

- This is a workflow-YAML change, not unit-testable — TDD skipped per repo guidance.
- `pre-commit` (`check-yaml`, `yamllint`) pass on the changed files. Other hooks fail on a pre-existing, unrelated environment issue (uv resolves Python 3.14.4 but the project pins `==3.14.6`).
- `actionlint` (via `nix run nixpkgs#actionlint`) reports no findings in the edited range (lines 930-960).

Closes #752