### PR TITLE
fix: skip-pull image check under docker and run safety via uv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,7 +240,7 @@ jobs:
       - name: Run Safety (dependency vulnerability check)
         id: safety
         run: |
-          safety check --json > safety-report.json || true
+          uv run safety check --json > safety-report.json || true
           echo "Safety scan completed"
 
       - name: Upload security reports as artifacts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **release.yml publish retags the loaded Nix image tag** ([#752](https://github.com/vig-os/devcontainer/issues/752))
+- **install.sh `--skip-pull` works under docker; ci.yml runs safety via `uv run`** ([#757](https://github.com/vig-os/devcontainer/issues/757))
+  - `install.sh` checked for a present local image with the podman-only `$RUNTIME image exists`, which docker lacks, so `--skip-pull` always failed under docker; it now uses `$RUNTIME image inspect`, which works on both runtimes
+  - The CI `safety` dependency scan was invoked bare instead of via `uv run`, so it ran outside the uv env (unlike the adjacent `uv run bandit`); it now runs via `uv run safety`
 - **Dev-shell exposes `python3` + `pre-commit` (image parity), CI-safely** ([#729](https://github.com/vig-os/devcontainer/issues/729))
   - `mkProjectShell` now ships a bare `python3`/`pre-commit` on PATH so the downstream flake-input/direnv dev-shell matches the image. `setup-env` filters the Nix `python3-<ver>` (and `pre-commit`) out of the forwarded CI runner PATH so `uv` keeps building the project venv from the downloaded managed CPython. No new `LD_LIBRARY_PATH`, so the #703 FHS leak-guard is intact. A `nix develop --ignore-environment` parity test (and the FHS leak-guard) now run in the Project Checks job
 - **Nix image runs pre-compiled PyPI (manylinux) wheels at runtime (arch-aware FHS loader + baked `LD_LIBRARY_PATH`)** ([#736](https://github.com/vig-os/devcontainer/issues/736))

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -109,6 +109,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **release.yml publish retags the loaded Nix image tag** ([#752](https://github.com/vig-os/devcontainer/issues/752))
+- **install.sh `--skip-pull` works under docker; ci.yml runs safety via `uv run`** ([#757](https://github.com/vig-os/devcontainer/issues/757))
+  - `install.sh` checked for a present local image with the podman-only `$RUNTIME image exists`, which docker lacks, so `--skip-pull` always failed under docker; it now uses `$RUNTIME image inspect`, which works on both runtimes
+  - The CI `safety` dependency scan was invoked bare instead of via `uv run`, so it ran outside the uv env (unlike the adjacent `uv run bandit`); it now runs via `uv run safety`
 - **Dev-shell exposes `python3` + `pre-commit` (image parity), CI-safely** ([#729](https://github.com/vig-os/devcontainer/issues/729))
   - `mkProjectShell` now ships a bare `python3`/`pre-commit` on PATH so the downstream flake-input/direnv dev-shell matches the image. `setup-env` filters the Nix `python3-<ver>` (and `pre-commit`) out of the forwarded CI runner PATH so `uv` keeps building the project venv from the downloaded managed CPython. No new `LD_LIBRARY_PATH`, so the #703 FHS leak-guard is intact. A `nix develop --ignore-environment` parity test (and the FHS leak-guard) now run in the Project Checks job
 - **Nix image runs pre-compiled PyPI (manylinux) wheels at runtime (arch-aware FHS loader + baked `LD_LIBRARY_PATH`)** ([#736](https://github.com/vig-os/devcontainer/issues/736))

--- a/install.sh
+++ b/install.sh
@@ -517,7 +517,7 @@ if [ "$SKIP_PULL" = false ]; then
     fi
 else
     # Verify image exists locally when skipping pull
-    if ! $RUNTIME image exists "$IMAGE" 2>/dev/null; then
+    if ! $RUNTIME image inspect "$IMAGE" >/dev/null 2>&1; then
         err "Image $IMAGE not found locally (--skip-pull was specified)"
         exit 1
     fi

--- a/tests/bats/install.bats
+++ b/tests/bats/install.bats
@@ -318,6 +318,18 @@ setup() {
     assert_success
 }
 
+@test "install.sh checks local image with docker-compatible 'image inspect'" {
+    # shellcheck disable=SC2016
+    run grep '\$RUNTIME image inspect "\$IMAGE"' "$INSTALL_SH"
+    assert_success
+}
+
+@test "install.sh does not use podman-only '\$RUNTIME image exists'" {
+    # shellcheck disable=SC2016
+    run grep '\$RUNTIME image exists' "$INSTALL_SH"
+    assert_failure
+}
+
 # ── error handling ────────────────────────────────────────────────────────────
 
 @test "install.sh validates container runtime availability" {


### PR DESCRIPTION
## Summary

Fixes two script bugs flagged in the PR #670 review (M4).

**Bug 1 — `install.sh` `--skip-pull` under docker.** The local-image check used the podman-only `$RUNTIME image exists`, which docker lacks; with the error hidden by `2>/dev/null`, `--skip-pull` always failed under docker.

```diff
-    if ! $RUNTIME image exists "$IMAGE" 2>/dev/null; then
+    if ! $RUNTIME image inspect "$IMAGE" >/dev/null 2>&1; then
```

`image inspect` works on both docker and podman.

**Bug 2 — `ci.yml` bare `safety`.** The `safety` dependency scan was invoked bare instead of via `uv run`, so it ran outside the uv env where it is installed (unlike the adjacent `uv run bandit`).

```diff
-          safety check --json > safety-report.json || true
+          uv run safety check --json > safety-report.json || true
```

`|| true` is kept to match the bandit idiom — this is a non-blocking security scan whose report is uploaded as an artifact; failing the job on scanner noise is out of scope (and switching `check` → `scan` would change auth/behavior, also out of scope; #756 owns broader ci.yml job consistency).

## Tests

- Added two grep-based bats assertions to `tests/bats/install.bats` (RED → GREEN) confirming the docker-compatible `image inspect` form is used and the podman-only `$RUNTIME image exists` form is gone.
- `tests/bats/install.bats` passes; `shellcheck`, `check-yaml`, and `yamllint` pre-commit hooks pass on the touched files.
- Note: uv-based pre-commit hooks fail in this worktree due to an env interpreter pin mismatch (available Python 3.14.4 vs project `==3.14.6`), unrelated to this diff.

Closes #757