### PR TITLE
fix(vig-utils): fail loud on unscored CVEs in vulnix gate

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -75,12 +75,19 @@ jobs:
           nix build .#devcontainerImageEnv --print-build-logs
 
       - name: Run vulnix (primary CVE scanner)
+        # NOTE: no blanket `|| true`. vulnix exit codes: 0 = clean, 1 = only
+        # whitelisted (needs -s), 2 = reportable advisories found (the gate, not
+        # the scan, decides pass/fail). Any code > 2 (e.g. 3 usage error, 127
+        # not-found, 137 OOM-kill) means the scan itself failed — fail the job
+        # instead of masking the crash as an empty, clean-looking result.
         run: |
-          set -euo pipefail
-          # vulnix exits non-zero when advisories are found; the gate decides
-          # pass/fail, so don't let the scan itself fail the step.
-          nix run .#vulnix -- --closure ./result --json > vulnix-findings.json || true
-          nix run .#vulnix -- --closure ./result | tee vulnix-report.txt || true
+          set -uo pipefail
+          nix run .#vulnix -- --closure ./result --json > vulnix-findings.json
+          rc=$?
+          [ "$rc" -le 2 ] || { echo "::error::vulnix scan failed (exit $rc)"; exit "$rc"; }
+          nix run .#vulnix -- --closure ./result | tee vulnix-report.txt
+          rc=${PIPESTATUS[0]}
+          [ "$rc" -le 2 ] || { echo "::error::vulnix report failed (exit $rc)"; exit "$rc"; }
 
       - name: Gate on unexcepted HIGH/CRITICAL vulnix findings
         id: vulnix-gate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -171,6 +171,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Drop the piscina CVE ignore tied to `cursor-agent`** ([#628](https://github.com/vig-os/devcontainer/issues/628))
   - Removed the `CVE-2026-55388` (piscina) `.trivyignore` entry, which only existed for the now-removed `cursor-agent` CLI
+- **vulnix gate fails loud on unscored CVEs and scanner crashes** ([#755](https://github.com/vig-os/devcontainer/issues/755))
+  - `vulnix-gate` now blocks on a CVE with no CVSS v3 base score (unknown severity is failed loud, not silently skipped); only sub-threshold *scored* CVEs remain awareness-only
+  - The nightly `security-scan` step no longer wraps the vulnix scan in `|| true`: it tolerates only vulnix's scan-ran exit codes (≤ 2) and fails the job on any higher code, so a scanner crash can no longer masquerade as an empty, clean result
 
 ## [0.3.9](https://github.com/vig-os/devcontainer/releases/tag/0.3.9) - 2026-06-23
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -171,6 +171,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Drop the piscina CVE ignore tied to `cursor-agent`** ([#628](https://github.com/vig-os/devcontainer/issues/628))
   - Removed the `CVE-2026-55388` (piscina) `.trivyignore` entry, which only existed for the now-removed `cursor-agent` CLI
+- **vulnix gate fails loud on unscored CVEs and scanner crashes** ([#755](https://github.com/vig-os/devcontainer/issues/755))
+  - `vulnix-gate` now blocks on a CVE with no CVSS v3 base score (unknown severity is failed loud, not silently skipped); only sub-threshold *scored* CVEs remain awareness-only
+  - The nightly `security-scan` step no longer wraps the vulnix scan in `|| true`: it tolerates only vulnix's scan-ran exit codes (≤ 2) and fails the job on any higher code, so a scanner crash can no longer masquerade as an empty, clean result
 
 ## [0.3.9](https://github.com/vig-os/devcontainer/releases/tag/0.3.9) - 2026-06-23
 

--- a/packages/vig-utils/src/vig_utils/vulnix_gate.py
+++ b/packages/vig-utils/src/vig_utils/vulnix_gate.py
@@ -5,12 +5,13 @@
 target) and emits JSON findings. This gate fails (exit 1) when any HIGH/CRITICAL
 CVE — CVSS v3 base score >= threshold (default 7.0) — is *not* covered by a
 non-expired entry in the exception register (`.vulnixignore`, the same
-`Expiration: YYYY-MM-DD` format as `.trivyignore`).
+`Expiration: YYYY-MM-DD` format as `.trivyignore`). An *unscored* CVE (no CVSS
+v3 base score) is also gated — its unknown severity is failed loud rather than
+silently skipped.
 
 Register-entry expiry is enforced separately by `check-expirations` (pre-commit
 + CI); this gate additionally refuses to mask a finding with an already-expired
-exception. Sub-threshold and unscored CVEs are awareness-only and never gate,
-mirroring the Trivy `ignore-unfixed` posture.
+exception. Only sub-threshold *scored* CVEs are awareness-only and never gate.
 
 This is the objective go/no-go input for the publish-cutover (#637 → #639).
 
@@ -55,19 +56,21 @@ def blocking_findings(
     excepted: set[str],
     threshold: float = DEFAULT_THRESHOLD,
 ) -> list[dict]:
-    """Return the unexcepted HIGH/CRITICAL findings in vulnix JSON *items*.
+    """Return the unexcepted blocking findings in vulnix JSON *items*.
 
-    Each returned dict is ``{pname, version, cve, score}``. A CVE blocks only
-    when its CVSS v3 base score is known and ``>= threshold`` and it is not in
-    *excepted*; sub-threshold and unscored CVEs are skipped (awareness only).
+    Each returned dict is ``{pname, version, cve, score}`` (``score`` is ``None``
+    for unscored CVEs). A CVE blocks when it is not in *excepted* and either its
+    CVSS v3 base score is ``>= threshold`` or it is unscored: an unknown severity
+    is failed loud rather than silently skipped. Only sub-threshold scored CVEs
+    are awareness-only and never gate.
     """
     blocking: list[dict] = []
     for item in items:
         scores = item.get("cvssv3_basescore") or {}
         for cve in item.get("affected_by") or []:
             score = scores.get(cve)
-            if score is None or score < threshold:
-                continue  # unscored or sub-threshold: awareness only
+            if score is not None and score < threshold:
+                continue  # sub-threshold scored: awareness only
             if cve in excepted:
                 continue
             blocking.append(
@@ -130,13 +133,22 @@ def main(today: date | None = None) -> int:
 
     if blocking:
         print(
-            f"::error::{len(blocking)} unexcepted HIGH/CRITICAL vulnix finding(s) "
-            f"(CVSS >= {args.threshold}):",
+            f"::error::{len(blocking)} unexcepted HIGH/CRITICAL or unscored vulnix "
+            f"finding(s) (CVSS >= {args.threshold} or no score):",
             file=sys.stderr,
         )
-        for finding in sorted(blocking, key=lambda f: (-f["score"], f["cve"])):
+        # Unscored findings (score None) sort first: unknown severity is most urgent.
+        for finding in sorted(
+            blocking,
+            key=lambda f: (
+                -(f["score"] if f["score"] is not None else float("inf")),
+                f["cve"],
+            ),
+        ):
+            score = finding["score"]
+            severity = f"CVSS {score}" if score is not None else "unscored"
             print(
-                f"::error::  - {finding['cve']} (CVSS {finding['score']}) "
+                f"::error::  - {finding['cve']} ({severity}) "
                 f"in {finding['pname']} {finding['version']}",
                 file=sys.stderr,
             )

--- a/packages/vig-utils/tests/test_vulnix_gate.py
+++ b/packages/vig-utils/tests/test_vulnix_gate.py
@@ -97,9 +97,20 @@ class TestBlockingFindings:
         result = blocking_findings([HIGH], excepted={"CVE-2026-3805"})
         assert result == []
 
-    def test_low_and_unscored_are_not_blocking(self):
-        # < threshold and unknown-severity CVEs are awareness-only, never gate.
-        result = blocking_findings([LOW, UNSCORED], excepted=set())
+    def test_low_is_not_blocking(self):
+        # Sub-threshold CVEs are awareness-only and never gate.
+        result = blocking_findings([LOW], excepted=set())
+        assert result == []
+
+    def test_unscored_is_blocking(self):
+        # An unscored CVE has unknown severity: fail loud, do not silently skip.
+        result = blocking_findings([UNSCORED], excepted=set())
+        assert {f["cve"] for f in result} == {"CVE-2026-30892"}
+        assert result[0]["score"] is None
+
+    def test_excepted_unscored_is_not_blocking(self):
+        # A non-expired exception still covers an unscored CVE.
+        result = blocking_findings([UNSCORED], excepted={"CVE-2026-30892"})
         assert result == []
 
     def test_threshold_is_configurable(self):
@@ -124,7 +135,7 @@ class TestMain:
     def test_passes_when_no_blocking_findings(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
     ):
-        findings = self._write_findings(tmp_path, [LOW, UNSCORED])
+        findings = self._write_findings(tmp_path, [LOW])
         register = tmp_path / ".vulnixignore"
         register.write_text("# none\n", encoding="utf-8")
         code = self._run(
@@ -132,6 +143,18 @@ class TestMain:
         )
         assert code == 0
         assert "No unexcepted HIGH/CRITICAL" in capsys.readouterr().out
+
+    def test_fails_on_unscored(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ):
+        findings = self._write_findings(tmp_path, [UNSCORED])
+        register = tmp_path / ".vulnixignore"
+        register.write_text("# none\n", encoding="utf-8")
+        code = self._run(
+            [str(findings), "--register", str(register)], date(2026, 6, 23)
+        )
+        assert code == 1
+        assert "CVE-2026-30892" in capsys.readouterr().err
 
     def test_fails_on_unexcepted_high(
         self, tmp_path: Path, capsys: pytest.CaptureFixture[str]


### PR DESCRIPTION
## Summary

Fixes M2 from the PR #670 review: `vulnix-gate` silently skipped unscored CVEs and the nightly scan swallowed scanner crashes with `|| true`, so an unscored CRITICAL or a crashed scanner looked identical to a clean result.

### Changes

- **`vulnix_gate.py`** — `blocking_findings` now blocks a CVE with no CVSS v3 base score (`score is None`); only sub-threshold *scored* CVEs remain awareness-only. `main()` sorts unscored findings first (unknown severity = most urgent) and labels them `unscored` in the GitHub error annotations. An explicit non-expired `.vulnixignore` exception still covers an unscored CVE.
- **`.github/workflows/security-scan.yml`** — dropped the blanket `|| true` on the vulnix scan/report capture. It now tolerates only vulnix's scan-ran exit codes (`<= 2`: `0` clean, `1` whitelisted-only, `2` reportable advisories — the gate decides pass/fail) and fails the job on any higher code (`3` usage error, `127` not-found, `137` OOM-kill, etc.), so a scanner crash can no longer masquerade as an empty, clean scan.
- **`CHANGELOG.md`** — Security entry.

### Test evidence (TDD: RED -> GREEN)

RED (after writing the new specs, before the fix):

```
FAILED packages/vig-utils/tests/test_vulnix_gate.py::TestBlockingFindings::test_unscored_is_blocking
FAILED packages/vig-utils/tests/test_vulnix_gate.py::TestMain::test_fails_on_unscored
2 failed, 13 passed in 0.04s
```

GREEN (after the fix):

```
15 passed in 0.02s
```

New/updated tests assert an unscored CVE blocks (`blocking_findings` and the `main` CLI exit code), that a sub-threshold scored CVE still does not block, and that a non-expired exception still covers an unscored CVE.

`just precommit`: all hooks pass.

Closes #755
