### PR TITLE
ci: restore arm64 image-testing coverage post-merge

### DIFF
--- a/.github/workflows/nix-image.yml
+++ b/.github/workflows/nix-image.yml
@@ -26,7 +26,10 @@
 # with `docker buildx imagetools create`, mirroring the proven release.yml flow.
 #
 # Triggers:
-#   - Push to the migration epic branch when the flake or this workflow changes.
+#   - Push to the migration epic branch OR the integration branch (`dev`) when
+#     the flake or this workflow changes. `dev` keeps the native arm64 build+test
+#     lane alive post-merge — PR CI (ci.yml) builds/tests amd64 only, so without
+#     this the arm64 image coverage would be stranded once the epic merges (#760).
 #   - workflow_dispatch (so it can be triggered later from the default branch).
 
 name: Nix Image (discovery)
@@ -35,6 +38,7 @@ on:  # yamllint disable-line rule:truthy
   push:
     branches:
       - 'feature/625-nix-claude-migration'
+      - 'dev'
     paths:
       - 'flake.nix'
       - 'flake.lock'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Restore arm64 image-testing coverage post-merge** ([#760](https://github.com/vig-os/devcontainer/issues/760))
+  - `nix-image.yml` (the only lane that builds + runs the portable testinfra suite natively on arm64) was push-filtered to the migration epic branch only, so once it merges the arm64 image would no longer be exercised on the integration branch — PR CI (`ci.yml`) builds and tests amd64 only. Added `dev` to the workflow's `push:` branch filter (keeping the existing `flake.nix`/`flake.lock`/workflow `paths:` guard) so the native amd64 + arm64 build/test matrix keeps running on `dev` post-merge
 - **release.yml publish retags the loaded Nix image tag** ([#752](https://github.com/vig-os/devcontainer/issues/752))
 - **install.sh `--skip-pull` works under docker; ci.yml runs safety via `uv run`** ([#757](https://github.com/vig-os/devcontainer/issues/757))
   - `install.sh` checked for a present local image with the podman-only `$RUNTIME image exists`, which docker lacks, so `--skip-pull` always failed under docker; it now uses `$RUNTIME image inspect`, which works on both runtimes

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -110,6 +110,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Restore arm64 image-testing coverage post-merge** ([#760](https://github.com/vig-os/devcontainer/issues/760))
+  - `nix-image.yml` (the only lane that builds + runs the portable testinfra suite natively on arm64) was push-filtered to the migration epic branch only, so once it merges the arm64 image would no longer be exercised on the integration branch — PR CI (`ci.yml`) builds and tests amd64 only. Added `dev` to the workflow's `push:` branch filter (keeping the existing `flake.nix`/`flake.lock`/workflow `paths:` guard) so the native amd64 + arm64 build/test matrix keeps running on `dev` post-merge
 - **release.yml publish retags the loaded Nix image tag** ([#752](https://github.com/vig-os/devcontainer/issues/752))
 - **install.sh `--skip-pull` works under docker; ci.yml runs safety via `uv run`** ([#757](https://github.com/vig-os/devcontainer/issues/757))
   - `install.sh` checked for a present local image with the podman-only `$RUNTIME image exists`, which docker lacks, so `--skip-pull` always failed under docker; it now uses `$RUNTIME image inspect`, which works on both runtimes


### PR DESCRIPTION
## Summary

`nix-image.yml` is the only CI lane that builds the devcontainer image and runs the portable testinfra suite **natively on arm64** (amd64 + arm64 matrix, no QEMU). Its `push:` filter targeted the migration epic branch only, so once that epic merges to the integration branch (`dev`), arm64 image coverage is stranded — PR CI (`ci.yml`) `build-image`/`test-image` build and test amd64 only.

## Change

- `.github/workflows/nix-image.yml`: add `dev` to the `push:` `branches:` list (and update the trigger comment). The native amd64 + arm64 build/test matrix now keeps running on `dev` post-merge.
- The existing `paths:` guard (`flake.nix`, `flake.lock`, `.github/workflows/nix-image.yml`) is retained, so the heavy arm64 build fires **only** when the flake or this workflow changes — not on every push to `dev`.
- CHANGELOG `## Unreleased` → Fixed entry, mirrored into `assets/workspace/.devcontainer/CHANGELOG.md` (sync-manifest hook keeps the two identical).

## Verification

- `actionlint .github/workflows/nix-image.yml` → clean (exit 0). (`ci.yml` emits only pre-existing shellcheck info/style notices on untouched lines.)
- `yamllint` on both workflows → clean.
- `pre-commit run --files …` → all hooks pass (incl. `sync-manifest`, `yamllint`, `branch-name`, `check-action-pins`, `check agent identity`).
- TDD: skipped — workflow YAML / config-only change, not unit-testable.

Closes #760