### PR TITLE
test(image): offline skip-guard for network-dependent tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Offline skip-guard for network-dependent image tests** ([#761](https://github.com/vig-os/devcontainer/issues/761))
+  - The image tests that fetch over the network — `test_uv_venv_workflow` (`uv add`/`uv sync` from PyPI) and `test_npm_global_install_resolves_on_path` (`npm install -g tsx` from the npm registry) — now `pytest.skip(...)` when the host cannot reach the relevant registry instead of failing on an offline/air-gapped runner. A reusable `_host_can_reach(host, hostname)` probe (generalizing the existing `_pypi_reachable` PyPI check) backs the guards; online runs still execute the tests unchanged
 - **Applied the still-relevant Renovate dependency updates** ([#625](https://github.com/vig-os/devcontainer/issues/625))
   - Folded the open Renovate PRs that still apply post-migration onto the epic: `actions/cache` → v6.1.0 (the v6 service, superseding the v5.x bumps), `actions/attest`/`actions/attest-build-provenance` → v4.1.1, `actions/setup-python` and `taiki-e/install-action` (just) digest refreshes, and `pandas` 3.0.3 → 3.0.4 in the workspace template. Stale ones were dropped: the `python:3.14-slim-bookworm` Docker digest (the `Containerfile` is gone) and the `ruff` pip pin (sourced from the flake now, #697); the `uv` 0.11.23 → 0.11.25 bump is deferred to the flake↔setup-env version sync (#720)
 - **`SECURITY.md` describes the Nix image security posture** ([#642](https://github.com/vig-os/devcontainer/issues/642))

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -55,6 +55,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Offline skip-guard for network-dependent image tests** ([#761](https://github.com/vig-os/devcontainer/issues/761))
+  - The image tests that fetch over the network — `test_uv_venv_workflow` (`uv add`/`uv sync` from PyPI) and `test_npm_global_install_resolves_on_path` (`npm install -g tsx` from the npm registry) — now `pytest.skip(...)` when the host cannot reach the relevant registry instead of failing on an offline/air-gapped runner. A reusable `_host_can_reach(host, hostname)` probe (generalizing the existing `_pypi_reachable` PyPI check) backs the guards; online runs still execute the tests unchanged
 - **Applied the still-relevant Renovate dependency updates** ([#625](https://github.com/vig-os/devcontainer/issues/625))
   - Folded the open Renovate PRs that still apply post-migration onto the epic: `actions/cache` → v6.1.0 (the v6 service, superseding the v5.x bumps), `actions/attest`/`actions/attest-build-provenance` → v4.1.1, `actions/setup-python` and `taiki-e/install-action` (just) digest refreshes, and `pandas` 3.0.3 → 3.0.4 in the workspace template. Stale ones were dropped: the `python:3.14-slim-bookworm` Docker digest (the `Containerfile` is gone) and the `ruff` pip pin (sourced from the flake now, #697); the `uv` 0.11.23 → 0.11.25 bump is deferred to the flake↔setup-env version sync (#720)
 - **`SECURITY.md` describes the Nix image security posture** ([#642](https://github.com/vig-os/devcontainer/issues/642))

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -279,6 +279,21 @@ class TestFhsShims:
             host.run(f"rm -f {script}")
 
 
+def _host_can_reach(host, hostname, port=443):
+    """Best-effort probe: can the image open a TCP connection to host:port?
+
+    Network-dependent image tests (PyPI wheel fetches, ``uv add``/``uv sync``,
+    ``npm install -g``) bake no warm cache, so on an offline/air-gapped runner
+    (e.g. a hermetic build sandbox) they must skip rather than fail. This single
+    socket probe backs every such guard. Refs #761.
+    """
+    probe = (
+        "import socket,sys; socket.setdefaulttimeout(5); "
+        f"socket.create_connection(('{hostname}', {port})); sys.exit(0)"
+    )
+    return host.run(f'python3 -c "{probe}"').rc == 0
+
+
 def _pypi_reachable(host):
     """Best-effort probe: can the image reach PyPI to fetch a wheel?
 
@@ -287,13 +302,7 @@ def _pypi_reachable(host):
     suite runs offline (e.g. a hermetic build sandbox) those tests skip rather
     than fail. Refs #736.
     """
-    return (
-        host.run(
-            'python3 -c "import socket,sys; socket.setdefaulttimeout(5); '
-            "socket.create_connection(('pypi.org', 443)); sys.exit(0)\""
-        ).rc
-        == 0
-    )
+    return _host_can_reach(host, "pypi.org")
 
 
 class TestManylinuxRuntime:
@@ -519,6 +528,8 @@ class TestPythonEnvironment:
 
     def test_uv_venv_workflow(self, host):
         """Test that uv sync creates venv and manages project dependencies correctly."""
+        if not _pypi_reachable(host):
+            pytest.skip("PyPI unreachable; uv add/sync cannot fetch packages offline")
         # Use /tmp for test project to avoid conflicts
         test_dir = "/tmp/uv_test_project"
         pyproject_path = f"{test_dir}/pyproject.toml"
@@ -766,6 +777,8 @@ class TestNodeEnvironment:
         the ``#!/usr/bin/env`` shebang interpreter, which #727 provides — this
         test deliberately does not depend on that.
         """
+        if not _host_can_reach(host, "registry.npmjs.org"):
+            pytest.skip("npm registry unreachable; cannot npm install -g offline")
         try:
             install = host.run("npm install -g tsx")
             assert install.rc == 0, f"npm install -g tsx failed: {install.stderr}"


### PR DESCRIPTION
## Summary

Closes #761.

Network-dependent image tests failed (rather than skipping) on an offline/air-gapped runner because the image bakes no warm cache. This adds an offline skip-guard to the two tests that actually hit the network:

- `TestPythonEnvironment.test_uv_venv_workflow` — runs `uv add` / `uv sync` against PyPI.
- `TestNodeEnvironment.test_npm_global_install_resolves_on_path` — runs `npm install -g tsx` against the npm registry.

Both now `pytest.skip(...)` when the relevant registry is unreachable; online runs execute them unchanged.

## Approach

Reused the existing connectivity idiom (`_pypi_reachable`, used by the manylinux wheel tests) rather than inventing a new one. Generalized its socket probe into a small reusable helper `_host_can_reach(host, hostname, port=443)`, and rewrote `_pypi_reachable` as a thin wrapper over it (DRY — no third copy of the probe). The npm guard probes `registry.npmjs.org`.

Scope kept tight: the new `.#devShellTools` parity test (#754) is **not** guarded (it uses local `nix eval` + `command -v`, no network), and the manylinux test keeps its existing `_pypi_reachable` guard untouched.

## Verification

- `pytest --collect-only tests/test_image.py` → 109 tests collected, no errors.
- Simulated an offline host (probe returns non-zero rc) and confirmed both guarded tests raise `Skipped` with the expected messages; an online fake host returns reachable. Online behaviour is otherwise unchanged.
- `ruff check` + `ruff format --check` clean on the changed file.
- Full image suite not run locally (requires a built image).

## Changelog

`### Changed` entry added under `## Unreleased` in both `CHANGELOG.md` and `assets/workspace/.devcontainer/CHANGELOG.md` (kept identical for the sync-manifest hook).