### PR TITLE
ci(release): gate publish on a hard vulnix CVE check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -804,9 +804,58 @@ jobs:
         run: |
           echo "✓ Build, tests, and security scan passed for ${{ matrix.arch }}"
 
+  vulnix-gate:
+    name: Vulnix CVE Gate
+    needs: [validate, finalize]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout release commit
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          ref: ${{ needs.finalize.outputs.finalize_sha }}
+
+      - name: Set up environment (Nix flake + uv for the gate)
+        uses: ./.github/actions/setup-env
+        with:
+          provision-via-flake: 'true'
+          sync-dependencies: 'true'
+          cachix-cache: ${{ vars.CACHIX_CACHE }}
+          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
+      - name: Validate .vulnixignore exception expirations
+        run: uv run check-expirations .vulnixignore
+
+      - name: Build the vulnix scan target (image package closure)
+        run: |
+          set -euo pipefail
+          nix build .#devcontainerImageEnv --print-build-logs
+
+      - name: Run vulnix (primary CVE scanner)
+        # Mirrors security-scan.yml: vulnix exit codes 0=clean, 1=only
+        # whitelisted (needs -s), 2=reportable advisories (the gate, not the
+        # scan, decides pass/fail). Any code > 2 means the scan itself failed —
+        # fail the job instead of masking the crash as an empty, clean result.
+        run: |
+          set -uo pipefail
+          nix run .#vulnix -- --closure ./result --json > vulnix-findings.json
+          rc=$?
+          [ "$rc" -le 2 ] || { echo "::error::vulnix scan failed (exit $rc)"; exit "$rc"; }
+
+      - name: Gate on unexcepted HIGH/CRITICAL vulnix findings
+        id: vulnix-gate
+        # BLOCKING (#639): fails on any HIGH/CRITICAL not covered by a
+        # non-expired entry in .vulnixignore. Reuses vig_utils.vulnix_gate (the
+        # same gate the nightly security-scan runs) so the publish job below
+        # cannot proceed on a CVE the nightly would have blocked.
+        run: uv run vulnix-gate vulnix-findings.json --register .vulnixignore
+
   publish:
     name: Publish Release
-    needs: [validate, finalize, build-and-test]
+    needs: [validate, finalize, build-and-test, vulnix-gate]
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     permissions:
@@ -1369,10 +1418,10 @@ jobs:
     name: Rollback on Failure
     # Rollback is intentionally scoped to pre-publish/publish failures.
     # Dispatch-only smoke-test failures happen after publish; automation does not delete tags or reset branches (forward-fix policy).
-    needs: [validate, finalize, build-and-test, publish]
+    needs: [validate, finalize, build-and-test, vulnix-gate, publish]
     runs-on: ubuntu-24.04
     timeout-minutes: 10
-    if: ${{ always() && (needs.validate.result == 'failure' || needs.finalize.result == 'failure' || needs.build-and-test.result == 'failure' || needs.publish.result == 'failure') }}
+    if: ${{ always() && (needs.validate.result == 'failure' || needs.finalize.result == 'failure' || needs.build-and-test.result == 'failure' || needs.vulnix-gate.result == 'failure' || needs.publish.result == 'failure') }}
     permissions:
       contents: read        # required by actions/checkout in rollback job
       issues: write          # create failure issue
@@ -1492,6 +1541,7 @@ jobs:
             if ('${{ needs.validate.result }}' !== 'success') failedJobs.push('validate');
             if ('${{ needs.finalize.result }}' !== 'success') failedJobs.push('finalize');
             if ('${{ needs.build-and-test.result }}' !== 'success') failedJobs.push('build-and-test');
+            if ('${{ needs.vulnix-gate.result }}' !== 'success') failedJobs.push('vulnix-gate');
             if ('${{ needs.publish.result }}' !== 'success') failedJobs.push('publish');
 
             const rollbackBranch = '${{ steps.rollback-branch.outcome }}';

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,6 +180,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **vulnix gate fails loud on unscored CVEs and scanner crashes** ([#755](https://github.com/vig-os/devcontainer/issues/755))
   - `vulnix-gate` now blocks on a CVE with no CVSS v3 base score (unknown severity is failed loud, not silently skipped); only sub-threshold *scored* CVEs remain awareness-only
   - The nightly `security-scan` step no longer wraps the vulnix scan in `|| true`: it tolerates only vulnix's scan-ran exit codes (≤ 2) and fails the job on any higher code, so a scanner crash can no longer masquerade as an empty, clean result
+- **Hard vulnix CVE gate on the release publish path** ([#753](https://github.com/vig-os/devcontainer/issues/753))
+  - The release workflow now runs a `vulnix-gate` job (the same `vulnix-gate` / `.vulnixignore` check as the nightly `security-scan`, built from the finalized release commit's image closure) that the `publish` job `needs:`, so a release can no longer ship an image carrying an unexcepted HIGH/CRITICAL CVE that nightly vulnix would have blocked. Previously the only CVE gate on the publish path was the per-arch Trivy step, which is largely dark on a Nix image. Wired into the rollback trigger alongside the other pre-publish jobs (Refs [#639](https://github.com/vig-os/devcontainer/issues/639))
 
 ## [0.3.9](https://github.com/vig-os/devcontainer/releases/tag/0.3.9) - 2026-06-23
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -180,6 +180,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **vulnix gate fails loud on unscored CVEs and scanner crashes** ([#755](https://github.com/vig-os/devcontainer/issues/755))
   - `vulnix-gate` now blocks on a CVE with no CVSS v3 base score (unknown severity is failed loud, not silently skipped); only sub-threshold *scored* CVEs remain awareness-only
   - The nightly `security-scan` step no longer wraps the vulnix scan in `|| true`: it tolerates only vulnix's scan-ran exit codes (≤ 2) and fails the job on any higher code, so a scanner crash can no longer masquerade as an empty, clean result
+- **Hard vulnix CVE gate on the release publish path** ([#753](https://github.com/vig-os/devcontainer/issues/753))
+  - The release workflow now runs a `vulnix-gate` job (the same `vulnix-gate` / `.vulnixignore` check as the nightly `security-scan`, built from the finalized release commit's image closure) that the `publish` job `needs:`, so a release can no longer ship an image carrying an unexcepted HIGH/CRITICAL CVE that nightly vulnix would have blocked. Previously the only CVE gate on the publish path was the per-arch Trivy step, which is largely dark on a Nix image. Wired into the rollback trigger alongside the other pre-publish jobs (Refs [#639](https://github.com/vig-os/devcontainer/issues/639))
 
 ## [0.3.9](https://github.com/vig-os/devcontainer/releases/tag/0.3.9) - 2026-06-23
 


### PR DESCRIPTION
## Summary

Closes #753. Refs #639.

Wires a **hard vulnix CVE gate onto the release publish path** (PR #670 review comment B2). Previously `vulnix-gate` lived only in the nightly `security-scan.yml`; the `publish` job in `release.yml` had no link to it, so the only CVE gate on the publish path was the per-arch Trivy step — which the repo documents as "largely dark" on a Nix image. A HIGH/CRITICAL CVE that nightly vulnix would have blocked could still ship in a release.

## Changes (`.github/workflows/release.yml` only)

- **New `vulnix-gate` job** (`needs: [validate, finalize]`): provisions the Nix flake + uv via the existing `./.github/actions/setup-env` (`provision-via-flake`) — the same provisioning `build-and-test` uses — checks out the finalized release commit, builds the image package closure (`.#devcontainerImageEnv`), runs vulnix, and **reuses `vig_utils.vulnix_gate`** (`uv run vulnix-gate … --register .vulnixignore`) plus `check-expirations` — the identical gate logic the nightly `security-scan` runs (no logic duplication). The vulnix run mirrors `security-scan.yml:84-90` exit-code handling.
- **`publish` now `needs: [validate, finalize, build-and-test, vulnix-gate]`** — publish cannot run unless the gate passed.
- **`rollback`** extended to include `vulnix-gate` in `needs:`, its failure condition, and the failed-jobs report — so a gate failure after `finalize` committed the changelog finalization still triggers the branch rollback (consistent with `build-and-test`).

`security-scan.yml` was **not** touched (owned by #755).

## Job-graph edges added

```
+  vulnix-gate:  needs: [validate, finalize]
   publish:      needs: [validate, finalize, build-and-test] -> [validate, finalize, build-and-test, vulnix-gate]
   rollback:     needs: [..., publish]  -> [..., vulnix-gate, publish]
                 if: (... build-and-test.result == 'failure' || publish.result == 'failure')
                  -> (... build-and-test.result == 'failure' || vulnix-gate.result == 'failure' || publish.result == 'failure')
```

## Verification

- **TDD skipped:** workflow YAML is not unit-testable (noted per repo rules).
- `actionlint .github/workflows/release.yml` — **no workflow errors** (the shellcheck SC2086/SC2129 info/style notes are all pre-existing in the `validate` job, none in the added job).
- `yamllint .github/workflows/release.yml` — **clean** (exit 0).
- `pre-commit run` on the changed files — **all hooks pass**, including `yamllint`, `check-yaml`, `check-action-pins` (checkout SHA-pinned), `sync-manifest` (both CHANGELOG copies identical), `pymarkdown`, and `check agent identity`.

## Changelog

Added an `## Unreleased` → Security entry, mirrored identically into `assets/workspace/.devcontainer/CHANGELOG.md` (sync-manifest verified).