### PR TITLE
docs: resync security-gate docs to the blocking vulnix gate

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -141,7 +141,7 @@ jobs:
             echo "- **Scan target:** flake \`devcontainerImageEnv\` (image package closure)"
             echo "- **Primary scanner:** vulnix (nixpkgs-native)"
             echo "- **Date (UTC):** $(date -u +%Y-%m-%dT%H:%M:%SZ)"
-            echo "- **Gate:** ${{ steps.vulnix-gate.outcome }} (non-blocking during discovery; blocking at #639)"
+            echo "- **Gate:** ${{ steps.vulnix-gate.outcome }} (blocking: fails on unexcepted HIGH/CRITICAL findings)"
             echo ""
             echo "vulnix over-reports CVEs already patched in nixpkgs; triage findings"
             echo "into \`.vulnixignore\` and advance the nixpkgs rev before #639."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Resync security-gate docs to reflect the blocking vulnix gate** ([#758](https://github.com/vig-os/devcontainer/issues/758))
+  - `docs/NIX.md`, `docs/CONTAINER_SECURITY.md`, and the `security-scan.yml` summary string still described the nightly `vulnix` CVE gate as non-blocking / in a discovery phase, with a stale `builder: debian|nix` selector reference; the gate is now **blocking** (#639) and the build pipeline is Nix-only post-Debian-decommission (#642), so the wording is corrected to match
 - **Offline skip-guard for network-dependent image tests** ([#761](https://github.com/vig-os/devcontainer/issues/761))
   - The image tests that fetch over the network — `test_uv_venv_workflow` (`uv add`/`uv sync` from PyPI) and `test_npm_global_install_resolves_on_path` (`npm install -g tsx` from the npm registry) — now `pytest.skip(...)` when the host cannot reach the relevant registry instead of failing on an offline/air-gapped runner. A reusable `_host_can_reach(host, hostname)` probe (generalizing the existing `_pypi_reachable` PyPI check) backs the guards; online runs still execute the tests unchanged
 - **Applied the still-relevant Renovate dependency updates** ([#625](https://github.com/vig-os/devcontainer/issues/625))

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -55,6 +55,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Resync security-gate docs to reflect the blocking vulnix gate** ([#758](https://github.com/vig-os/devcontainer/issues/758))
+  - `docs/NIX.md`, `docs/CONTAINER_SECURITY.md`, and the `security-scan.yml` summary string still described the nightly `vulnix` CVE gate as non-blocking / in a discovery phase, with a stale `builder: debian|nix` selector reference; the gate is now **blocking** (#639) and the build pipeline is Nix-only post-Debian-decommission (#642), so the wording is corrected to match
 - **Offline skip-guard for network-dependent image tests** ([#761](https://github.com/vig-os/devcontainer/issues/761))
   - The image tests that fetch over the network — `test_uv_venv_workflow` (`uv add`/`uv sync` from PyPI) and `test_npm_global_install_resolves_on_path` (`npm install -g tsx` from the npm registry) — now `pytest.skip(...)` when the host cannot reach the relevant registry instead of failing on an offline/air-gapped runner. A reusable `_host_can_reach(host, hostname)` probe (generalizing the existing `_pypi_reachable` PyPI check) backs the guards; online runs still execute the tests unchanged
 - **Applied the still-relevant Renovate dependency updates** ([#625](https://github.com/vig-os/devcontainer/issues/625))

--- a/docs/CONTAINER_SECURITY.md
+++ b/docs/CONTAINER_SECURITY.md
@@ -55,9 +55,8 @@ instead.
 > advance the `nixpkgs` rev (layer 1); genuinely-not-applicable findings are
 > accepted in `.vulnixignore` with a rationale (layer 5).
 
-During the discovery phase the gate is **non-blocking** (`continue-on-error`).
-The publish-cutover (#639) flips it to blocking and wires SARIF upload and a
-deduplicated issue.
+The gate is **blocking** (#639): any unexcepted HIGH/CRITICAL finding fails the
+nightly scan.
 
 ### 3. CycloneDX SBOM + Trivy SBOM-mode scan (defence in depth)
 

--- a/docs/NIX.md
+++ b/docs/NIX.md
@@ -207,11 +207,11 @@ against the `.vulnixignore` exception register.
 
 ## Publish cutover
 
-The Nix image build is currently in the **discovery phase**: the workflows are
-non-publishing (`continue-on-error`) and touch only disposable discovery tags. The
-publish-cutover — flipping the versioned/`:latest` publish to the Nix builder and
-making the `vulnix` gate blocking — is tracked in **issue #639** (the release
-pipeline exposes a `builder: debian|nix` selector for the deliberate cutover run).
+The build pipeline is Nix-only (the Debian path was decommissioned in #642), and
+the nightly `vulnix` gate is **blocking** — any unexcepted HIGH/CRITICAL finding
+fails the scan. The remaining step is the deliberate Nix release that flips the
+versioned/`:latest` publish, tracked in **issue #639**; the nightly `vulnix` gate
+is the go/no-go signal for it.
 
 ## See also
 


### PR DESCRIPTION
## Summary

The nightly `vulnix` CVE gate is now **blocking** (#639) and the build pipeline
is Nix-only after the Debian decommission (#642), but the docs and one workflow
summary string still described it as non-blocking / in a discovery phase and
referenced the removed `builder: debian|nix` selector. This resyncs the wording
(M5 from the PR #670 review).

### Changes

- **`docs/NIX.md`** — rewrote the "Publish cutover" paragraph: dropped the
  discovery-phase / `continue-on-error` framing and the stale `builder:
  debian|nix` selector reference; states the build is Nix-only and the `vulnix`
  gate is blocking, with #639 now just the deliberate publish release.
- **`docs/CONTAINER_SECURITY.md`** — flipped the "non-blocking
  (`continue-on-error`)" sentence to **blocking**. Debian-decommission line left
  untouched.
- **`.github/workflows/security-scan.yml`** — aligned the step-summary `Gate:`
  string with the now-blocking gate (text only; gate logic unchanged from #755).
- **CHANGELOG.md** + **assets/workspace/.devcontainer/CHANGELOG.md** — mirrored
  `## Unreleased` → Changed entry (sync-manifest passes; files identical).

### Verification

- `grep -rn "non-blocking|discovery|builder:"` over the three target files: the
  workflow has zero hits; the only remaining `docs/NIX.md` hit (line 83,
  "per-arch discovery tags") is the literal image-tag name, a separate
  image-publish concern, not the security gate. All other repo hits are in
  `docs/issues/` and `docs/pull-requests/` historical archives, or unrelated
  meanings (skill pipeline, release-gate run discovery).
- `pre-commit` on the changed files: all hooks **Passed** (yamllint, pymarkdown,
  sync-manifest, check-action-pins, agent-identity).

Closes #758
