### PR TITLE
fix: address PR #670 review nit batch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1421,7 +1421,8 @@ jobs:
     needs: [validate, finalize, build-and-test, vulnix-gate, publish]
     runs-on: ubuntu-24.04
     timeout-minutes: 10
-    if: ${{ always() && (needs.validate.result == 'failure' || needs.finalize.result == 'failure' || needs.build-and-test.result == 'failure' || needs.vulnix-gate.result == 'failure' || needs.publish.result == 'failure') }}
+    # A cancelled required job is treated as not-green (same as failure): roll back rather than leave a partial release.
+    if: ${{ always() && (contains(fromJSON('["failure", "cancelled"]'), needs.validate.result) || contains(fromJSON('["failure", "cancelled"]'), needs.finalize.result) || contains(fromJSON('["failure", "cancelled"]'), needs.build-and-test.result) || contains(fromJSON('["failure", "cancelled"]'), needs.vulnix-gate.result) || contains(fromJSON('["failure", "cancelled"]'), needs.publish.result)) }}
     permissions:
       contents: read        # required by actions/checkout in rollback job
       issues: write          # create failure issue

--- a/.typos.toml
+++ b/.typos.toml
@@ -6,3 +6,5 @@
 ba = "ba"
 # CVE policy term (#637): a finding "unexcepted" = not in the exception register
 unexcepted = "unexcepted"
+# version-check.sh duration placeholder (#759): 'Nd' = N days (cf. Nw/Nh/Nm)
+Nd = "Nd"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Review-nit batch: dry-run/scaffold-guard, summary cancel handling, help/message fixes** ([#759](https://github.com/vig-os/devcontainer/issues/759))
+  - `install.sh` `--dry-run` now derives the shown command from the real `CMD` array via `printf '%q'` (no hand-maintained duplicate string), and the automatic "initial project scaffold" commit is guarded so it only runs for a freshly scaffolded (empty) target instead of sweeping a pre-populated directory
+  - `release.yml` now treats a `cancelled` required job as not-green (it triggers rollback like a failure), so a cancellation can no longer leave a partial release un-rolled-back
+  - `version-check.sh` help text corrected (`And (days)` → `Nd (days)`), and `init.sh` now reports "Pre-commit hook environments installed" (the `install-hooks` step only fetches hook environments)
 - **Restore arm64 image-testing coverage post-merge** ([#760](https://github.com/vig-os/devcontainer/issues/760))
   - `nix-image.yml` (the only lane that builds + runs the portable testinfra suite natively on arm64) was push-filtered to the migration epic branch only, so once it merges the arm64 image would no longer be exercised on the integration branch — PR CI (`ci.yml`) builds and tests amd64 only. Added `dev` to the workflow's `push:` branch filter (keeping the existing `flake.nix`/`flake.lock`/workflow `paths:` guard) so the native amd64 + arm64 build/test matrix keeps running on `dev` post-merge
 - **release.yml publish retags the loaded Nix image tag** ([#752](https://github.com/vig-os/devcontainer/issues/752))
@@ -181,8 +185,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
-- **Per-CVE rationale and shorter expiry for `.vulnixignore` Class-2 excepts** ([#762](https://github.com/vig-os/devcontainer/issues/762))
-  - Replaced the single blanket Class-2 rationale and long uniform expiry (2026-09-23) over ~22 HIGH/CRITICAL CVEs with a per-CVE note (package, what pulls it into the runtime closure, honest reachability) and short, staggered expiries (openssl 2026-07-31, glibc 2026-08-15, the rest 2026-08-31) so each suppression is individually justified and re-reviewed near-term. Provenance was confirmed against the real image closure (`nix path-info -r .#devcontainerImageEnv` + `nix why-depends`); 2026 CVE specifics were not verified offline, so the notes state this plainly and the short expiries force re-review rather than asserting an all-clear
 - **Drop the piscina CVE ignore tied to `cursor-agent`** ([#628](https://github.com/vig-os/devcontainer/issues/628))
   - Removed the `CVE-2026-55388` (piscina) `.trivyignore` entry, which only existed for the now-removed `cursor-agent` CLI
 - **vulnix gate fails loud on unscored CVEs and scanner crashes** ([#755](https://github.com/vig-os/devcontainer/issues/755))

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -114,6 +114,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Review-nit batch: dry-run/scaffold-guard, summary cancel handling, help/message fixes** ([#759](https://github.com/vig-os/devcontainer/issues/759))
+  - `install.sh` `--dry-run` now derives the shown command from the real `CMD` array via `printf '%q'` (no hand-maintained duplicate string), and the automatic "initial project scaffold" commit is guarded so it only runs for a freshly scaffolded (empty) target instead of sweeping a pre-populated directory
+  - `release.yml` now treats a `cancelled` required job as not-green (it triggers rollback like a failure), so a cancellation can no longer leave a partial release un-rolled-back
+  - `version-check.sh` help text corrected (`And (days)` → `Nd (days)`), and `init.sh` now reports "Pre-commit hook environments installed" (the `install-hooks` step only fetches hook environments)
 - **Restore arm64 image-testing coverage post-merge** ([#760](https://github.com/vig-os/devcontainer/issues/760))
   - `nix-image.yml` (the only lane that builds + runs the portable testinfra suite natively on arm64) was push-filtered to the migration epic branch only, so once it merges the arm64 image would no longer be exercised on the integration branch — PR CI (`ci.yml`) builds and tests amd64 only. Added `dev` to the workflow's `push:` branch filter (keeping the existing `flake.nix`/`flake.lock`/workflow `paths:` guard) so the native amd64 + arm64 build/test matrix keeps running on `dev` post-merge
 - **release.yml publish retags the loaded Nix image tag** ([#752](https://github.com/vig-os/devcontainer/issues/752))
@@ -181,8 +185,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
-- **Per-CVE rationale and shorter expiry for `.vulnixignore` Class-2 excepts** ([#762](https://github.com/vig-os/devcontainer/issues/762))
-  - Replaced the single blanket Class-2 rationale and long uniform expiry (2026-09-23) over ~22 HIGH/CRITICAL CVEs with a per-CVE note (package, what pulls it into the runtime closure, honest reachability) and short, staggered expiries (openssl 2026-07-31, glibc 2026-08-15, the rest 2026-08-31) so each suppression is individually justified and re-reviewed near-term. Provenance was confirmed against the real image closure (`nix path-info -r .#devcontainerImageEnv` + `nix why-depends`); 2026 CVE specifics were not verified offline, so the notes state this plainly and the short expiries force re-review rather than asserting an all-clear
 - **Drop the piscina CVE ignore tied to `cursor-agent`** ([#628](https://github.com/vig-os/devcontainer/issues/628))
   - Removed the `CVE-2026-55388` (piscina) `.trivyignore` entry, which only existed for the now-removed `cursor-agent` CLI
 - **vulnix gate fails loud on unscored CVEs and scanner crashes** ([#755](https://github.com/vig-os/devcontainer/issues/755))

--- a/assets/workspace/.devcontainer/scripts/version-check.sh
+++ b/assets/workspace/.devcontainer/scripts/version-check.sh
@@ -14,7 +14,7 @@
 #   ./version-check.sh interval <dur>   # Set check interval
 #   ./version-check.sh config           # Display current configuration
 #
-# DURATIONS: And (days), Nw (weeks), Nh (hours), Nm (minutes)
+# DURATIONS: Nd (days), Nw (weeks), Nh (hours), Nm (minutes)
 #
 # CONFIGURATION:
 #   Stored in .devcontainer/.local/version-check.conf (gitignored)
@@ -359,7 +359,7 @@ cmd_mute() {
     local seconds
     seconds=$(parse_duration "$duration") || {
         echo "Invalid duration format: $duration"
-        echo "Use: And (days), Nw (weeks), Nh (hours), Nm (minutes)"
+        echo "Use: Nd (days), Nw (weeks), Nh (hours), Nm (minutes)"
         echo "Examples: 7d, 1w, 12h, 30m"
         return 1
     }
@@ -392,7 +392,7 @@ cmd_set_interval() {
     local seconds
     seconds=$(parse_duration "$duration") || {
         echo "Invalid duration format: $duration"
-        echo "Use: And (days), Nw (weeks), Nh (hours), Nm (minutes)"
+        echo "Use: Nd (days), Nw (weeks), Nh (hours), Nm (minutes)"
         return 1
     }
 

--- a/install.sh
+++ b/install.sh
@@ -477,18 +477,21 @@ fi
 
 if [ "$DRY_RUN" = true ]; then
     info "Would execute:"
-    printf "  %s" "$RUNTIME run --rm -e SHORT_NAME=\"$PROJECT_NAME\" -e ORG_NAME=\"$ORG_NAME\" -e GITHUB_REPOSITORY=\"$GITHUB_REPOSITORY\" -v \"$PROJECT_PATH\":/workspace \"$IMAGE\" /root/assets/init-workspace.sh --no-prompts"
-    if [ -n "$FORCE" ]; then
-        printf " %s" "--force"
-    fi
-    if [ -n "$SMOKE_TEST" ]; then
-        printf " %s" "--smoke-test"
-    fi
-    if [ -n "$MODE" ]; then
-        printf " %s %s" "--mode" "$MODE"
-    fi
-    printf "\n"
+    # Derive the shown command from the real CMD array (built above, including
+    # --force/--smoke-test/--mode) via printf '%q' so it is shell-safe and stays
+    # in sync with what would actually run — no hand-maintained duplicate string.
+    printf '  '
+    printf '%q ' "${CMD[@]}"
+    printf '\n'
     exit 0
+fi
+
+# Record whether the target was empty BEFORE the container scaffolds it. The git
+# step below only auto-commits a freshly scaffolded tree, so it never sweeps a
+# pre-populated directory into a misleading "initial scaffold" commit (#759).
+TARGET_WAS_EMPTY=false
+if [ -z "$(ls -A "$PROJECT_PATH" 2>/dev/null)" ]; then
+    TARGET_WAS_EMPTY=true
 fi
 
 # Check if terminal is interactive (needed for init-workspace.sh prompts)
@@ -569,13 +572,22 @@ setup_git_repo() {
         echo "Git repository initialized with 'main' branch"
     fi
 
-    # Create initial commit if repo has no commits (enables branch creation)
+    # Create initial commit if repo has no commits (enables branch creation).
+    # Only auto-commit when we scaffolded an empty target; never sweep a
+    # pre-populated directory into a misleading "initial scaffold" commit (#759).
     if ! git rev-parse HEAD >/dev/null 2>&1; then
-        echo "Creating initial commit..."
-        git add -A
-        git commit -m "chore: initial project scaffold" --allow-empty
-        created_repo=true
-        echo "Initial commit created"
+        if [ "${TARGET_WAS_EMPTY:-false}" = true ]; then
+            echo "Creating initial commit..."
+            git add -A
+            git commit -m "chore: initial project scaffold" --allow-empty
+            created_repo=true
+            echo "Initial commit created"
+        else
+            echo "Existing files detected; skipping the automatic scaffold commit."
+            echo "  Review and commit your files yourself, e.g.:"
+            echo "    git add -A && git commit -m 'chore: initial commit'"
+            created_repo=false
+        fi
     fi
 
     # Verify or create branches

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -212,9 +212,9 @@ if [ -f .gitmessage ] && git config commit.template .gitmessage; then
 fi
 
 if uv run pre-commit install-hooks; then
-    log_success "Pre-commit hooks installed"
+    log_success "Pre-commit hook environments installed"
 else
-    log_warning "Could not install pre-commit hooks"
+    log_warning "Could not install pre-commit hook environments"
 fi
 
 # ═══════════════════════════════════════════════════════════════════════════════

--- a/tests/bats/install.bats
+++ b/tests/bats/install.bats
@@ -71,17 +71,27 @@ setup() {
     assert_output --partial "init-workspace.sh"
 }
 
+@test "dry-run command is derived from the CMD array via printf %q" {
+    # The shown command must be rendered from the real CMD array, not a
+    # hand-maintained duplicate string (#759).
+    # shellcheck disable=SC2016
+    run grep "printf '%q" "$INSTALL_SH"
+    assert_success
+}
+
 @test "dry-run includes image registry in command" {
     run bash "$INSTALL_SH" --dry-run .
     assert_success
     assert_output --partial "ghcr.io/vig-os/devcontainer"
 }
 
-@test "dry-run output quotes project path and image for safe copy-paste" {
+@test "dry-run output is shell-quoted for safe copy-paste" {
     run bash "$INSTALL_SH" --dry-run .
     assert_success
-    assert_output --regexp '"[^"]+":/workspace'
-    assert_output --regexp '"ghcr.io/vig-os/devcontainer:[^"]+"'
+    # The command is rendered from the real CMD array via printf '%q', so each
+    # argument is shell-safe (quoted only when it contains special characters).
+    assert_output --regexp '[^ ]+:/workspace'
+    assert_output --regexp 'ghcr\.io/vig-os/devcontainer:[^ ]+'
 }
 
 # ── version flag ──────────────────────────────────────────────────────────────
@@ -117,7 +127,7 @@ setup() {
 @test "default org is vigOS" {
     run bash "$INSTALL_SH" --dry-run .
     assert_success
-    assert_output --partial 'ORG_NAME="vigOS"'
+    assert_output --partial 'ORG_NAME=vigOS'
 }
 
 @test "default GITHUB_REPOSITORY is OWNER/REPO when no git origin" {
@@ -125,20 +135,20 @@ setup() {
     test_dir="$(mktemp -d)"
     run bash "$INSTALL_SH" --dry-run "$test_dir"
     assert_success
-    assert_output --partial 'GITHUB_REPOSITORY="OWNER/REPO"'
+    assert_output --partial 'GITHUB_REPOSITORY=OWNER/REPO'
     rm -rf "$test_dir"
 }
 
 @test "custom --repo is passed to container" {
     run bash "$INSTALL_SH" --dry-run --repo vig-os/myapp .
     assert_success
-    assert_output --partial 'GITHUB_REPOSITORY="vig-os/myapp"'
+    assert_output --partial 'GITHUB_REPOSITORY=vig-os/myapp'
 }
 
 @test "custom org is passed to container" {
     run bash "$INSTALL_SH" --dry-run --org MyOrg .
     assert_success
-    assert_output --partial 'ORG_NAME="MyOrg"'
+    assert_output --partial 'ORG_NAME=MyOrg'
 }
 
 # ── name flag / sanitization ─────────────────────────────────────────────────
@@ -150,7 +160,7 @@ setup() {
 
     run bash "$INSTALL_SH" --dry-run "$test_dir/My-Awesome-Project"
     assert_success
-    assert_output --partial 'SHORT_NAME="my_awesome_project"'
+    assert_output --partial 'SHORT_NAME=my_awesome_project'
 
     rm -rf "$test_dir"
 }
@@ -158,7 +168,7 @@ setup() {
 @test "custom name overrides directory name" {
     run bash "$INSTALL_SH" --dry-run --name custom_name .
     assert_success
-    assert_output --partial 'SHORT_NAME="custom_name"'
+    assert_output --partial 'SHORT_NAME=custom_name'
 }
 
 # ── invalid path ──────────────────────────────────────────────────────────────
@@ -266,6 +276,15 @@ setup() {
 
 @test "install.sh creates initial commit if needed" {
     run grep 'git commit' "$INSTALL_SH"
+    assert_success
+}
+
+@test "install.sh guards the scaffold commit against a populated directory" {
+    # The automatic 'initial project scaffold' commit must only run for a
+    # freshly scaffolded (empty) target, gated by the TARGET_WAS_EMPTY flag,
+    # so it never sweeps a pre-populated directory into a misleading commit (#759).
+    # shellcheck disable=SC2016
+    run grep 'TARGET_WAS_EMPTY' "$INSTALL_SH"
     assert_success
 }
 

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -137,10 +137,10 @@ class TestInstallScriptIntegration:
             f"install.sh --dry-run --name failed:\n"
             f"stdout: {result.stdout}\nstderr: {result.stderr}"
         )
-        assert 'SHORT_NAME="install_test_project"' in result.stdout, (
+        assert "SHORT_NAME=install_test_project" in result.stdout, (
             "Expected sanitized name without trailing underscore in dry-run output"
         )
-        assert 'SHORT_NAME="install_test_project_"' not in result.stdout, (
+        assert "SHORT_NAME=install_test_project_" not in result.stdout, (
             "Sanitized name should not end with an underscore"
         )
 


### PR DESCRIPTION
## Summary

Batch of trivial review nits from the PR #670 review (parent #625). Closes #759.

Per-item outcome:

| # | Item | File | Change |
|---|------|------|--------|
| 1 | `version-check.sh` help typo | `assets/workspace/.devcontainer/scripts/version-check.sh` | `And (days)` → `Nd (days)` (3 occurrences: comment + 2 help echoes); `Nd` allowlisted in `.typos.toml` |
| 2 | `init.sh` misleading message | `scripts/init.sh` | `Pre-commit hooks installed` → `Pre-commit hook environments installed` (and matching warning); `install-hooks` only installs hook envs |
| 3 | Unparenthesized `except A, B:` | `tests/conftest.py`, `packages/vig-utils/tests/test_claude_ssot.py` | **Skipped (not a bug).** Repo targets Python 3.14 (`requires-python >=3.14`, ruff `target-version = py314`); under PEP 758 `except A, B:` is valid and `ruff format` *removes* the parens. Parenthesizing would fail the `ruff-format` CI check. The unparenthesized form already ships on the base branch. |
| 4 | `release.yml` cancel handling | `.github/workflows/release.yml` | The result-aggregation `rollback` job now treats a `cancelled` required job as not-green (rolls back like a failure), via `contains(fromJSON('["failure","cancelled"]'), needs.<job>.result)` |
| 5a | `install.sh` dry-run | `install.sh` | Dry-run command now derived from the real `CMD` array via `printf '%q'` (no hand-maintained duplicate string), so the shown command matches what executes |
| 5b | `install.sh` scaffold guard | `install.sh` | New `TARGET_WAS_EMPTY` flag captured before the container scaffolds; the auto `initial project scaffold` commit only runs for a freshly-scaffolded empty target, never sweeping a pre-populated directory |

## Tests (TDD)

- `tests/bats/install.bats`: updated dry-run assertions to the `%q`-derived format, added a guard test (`TARGET_WAS_EMPTY`) and a derive-from-CMD test (`printf '%q'`). Committed RED before the `install.sh` fix, then GREEN.
- `tests/test_install_script.py`: synced the dry-run name-sanitization assertion to the `%q` (unquoted) output.

## Verification

- `bats tests/bats/install.bats` — 55/55 pass
- `shellcheck install.sh version-check.sh init.sh` — clean
- `actionlint` / `yamllint` on `release.yml` — expression accepted; no new findings (pre-existing shellcheck warnings in unrelated `run:` blocks untouched)
- `ruff format --check` / `pre-commit` on all changed files — pass
- `PYTHONPATH= uv run pytest packages/vig-utils/tests/test_claude_ssot.py tests/test_utils.py` and the dry-run install test — pass

Note: 3 `test_image.py` testinfra failures observed locally are pre-existing/environmental (run against a stale prebuilt `podman://` image) and unrelated to these text-only changes.

Closes #759