### PR TITLE
chore(flake): cheap hardening/hygiene batch (darwin guard, single eval, uv URL, renovate, nixfmt glob)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Flake cheap-fix batch: darwin-guarded image outputs, single nixpkgs-unstable eval, uv downloads URL derived from version, Renovate wheel-hash rule, nixfmt over all `*.nix`** ([#774](https://github.com/vig-os/devcontainer/issues/774))
+  - The Linux-only `packages` (`devcontainerImage` plus its `devcontainerImageEnv`/`vulnix` scan targets) are now exposed only on `*-linux` systems, so `nix flake check --all-systems` no longer aborts during the darwin `dockerTools` evaluation; the dev-shell stays cross-platform
+  - `nixpkgs-unstable` is imported once per system and threaded into the fast-mover overlay, instead of being re-imported inside the overlay fixpoint on each application
+  - `UV_PYTHON_DOWNLOADS_JSON_URL` is derived from `pkgs.uv.version` rather than a literal version pin, so it can no longer drift from the overlaid (floating) `uv`
+  - Added a Renovate custom regex manager that tracks the `pip-licenses` wheel version pinned in `flake.nix` (the sha256/URL hash path is refreshed by hand when the bump PR lands)
+  - The flake `checks.format` gate now runs `nixfmt --check` over every `*.nix` in the repo (source filtered to `.nix` files), not just `flake.nix`
 - **Resync security-gate docs to reflect the blocking vulnix gate** ([#758](https://github.com/vig-os/devcontainer/issues/758))
   - `docs/NIX.md`, `docs/CONTAINER_SECURITY.md`, and the `security-scan.yml` summary string still described the nightly `vulnix` CVE gate as non-blocking / in a discovery phase, with a stale `builder: debian|nix` selector reference; the gate is now **blocking** (#639) and the build pipeline is Nix-only post-Debian-decommission (#642), so the wording is corrected to match
 - **Offline skip-guard for network-dependent image tests** ([#761](https://github.com/vig-os/devcontainer/issues/761))

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -55,6 +55,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Flake cheap-fix batch: darwin-guarded image outputs, single nixpkgs-unstable eval, uv downloads URL derived from version, Renovate wheel-hash rule, nixfmt over all `*.nix`** ([#774](https://github.com/vig-os/devcontainer/issues/774))
+  - The Linux-only `packages` (`devcontainerImage` plus its `devcontainerImageEnv`/`vulnix` scan targets) are now exposed only on `*-linux` systems, so `nix flake check --all-systems` no longer aborts during the darwin `dockerTools` evaluation; the dev-shell stays cross-platform
+  - `nixpkgs-unstable` is imported once per system and threaded into the fast-mover overlay, instead of being re-imported inside the overlay fixpoint on each application
+  - `UV_PYTHON_DOWNLOADS_JSON_URL` is derived from `pkgs.uv.version` rather than a literal version pin, so it can no longer drift from the overlaid (floating) `uv`
+  - Added a Renovate custom regex manager that tracks the `pip-licenses` wheel version pinned in `flake.nix` (the sha256/URL hash path is refreshed by hand when the bump PR lands)
+  - The flake `checks.format` gate now runs `nixfmt --check` over every `*.nix` in the repo (source filtered to `.nix` files), not just `flake.nix`
 - **Resync security-gate docs to reflect the blocking vulnix gate** ([#758](https://github.com/vig-os/devcontainer/issues/758))
   - `docs/NIX.md`, `docs/CONTAINER_SECURITY.md`, and the `security-scan.yml` summary string still described the nightly `vulnix` CVE gate as non-blocking / in a discovery phase, with a stale `builder: debian|nix` selector reference; the gate is now **blocking** (#639) and the build pipeline is Nix-only post-Debian-decommission (#642), so the wording is corrected to match
 - **Offline skip-guard for network-dependent image tests** ([#761](https://github.com/vig-os/devcontainer/issues/761))

--- a/flake.nix
+++ b/flake.nix
@@ -45,20 +45,33 @@
           p.bats-file
         ]);
 
-      overlay =
-        final: prev:
-        let
-          unstable = import nixpkgs-unstable {
-            inherit (final) system;
-            config.allowUnfree = true;
-          };
-        in
+      # Import nixpkgs-unstable for a given system (allowUnfree covers
+      # claude-code). Evaluated once per system in the per-system `let` below and
+      # threaded into the overlay, rather than re-imported inside the overlay
+      # fixpoint on each application. Refs #774.
+      importUnstable =
+        system:
+        import nixpkgs-unstable {
+          inherit system;
+          config.allowUnfree = true;
+        };
+
+      # Build the fast-mover overlay from an already-imported `unstable` pkgs set,
+      # so the unstable import is hoisted out of the overlay closure (see
+      # importUnstable above).
+      mkFastMoverOverlay =
+        unstable: final: prev:
         builtins.listToAttrs (
           map (name: {
             inherit name;
             value = unstable.${name};
           }) fastMovers
         );
+
+      # System-independent overlay for downstream consumers (overlays.default).
+      # No concrete system is known here, so it imports unstable inside the
+      # fixpoint; the in-flake path below uses the hoisted importUnstable.
+      overlay = final: prev: mkFastMoverOverlay (importUnstable final.system) final prev;
 
       # ---------------------------------------------------------------------
       # devTools — the single source of truth for the toolchain.
@@ -135,16 +148,6 @@
       #     inherit pkgs;
       #     extraPackages = [ pkgs.foo ];
       #   };
-      # ---------------------------------------------------------------------
-      # uv's Python-download metadata, pinned to the uv release we provision.
-      # The nixpkgs build of uv ships with its embedded Python-download list
-      # stripped, so it cannot fetch a managed CPython on its own. CI provisions
-      # FROM this dev-shell on an FHS runner and forwards this URL (see the
-      # setup-env action) so the runner's uv can download a managed CPython for
-      # `uv sync` / pre-commit — a Nix-store interpreter cannot load pre-commit's
-      # manylinux-wheel C extensions outside `nix develop`. Refs #632, #666, #683.
-      uvPythonDownloadsJsonUrl = "https://raw.githubusercontent.com/astral-sh/uv/0.11.23/crates/uv-python/download-metadata.json";
-
       mkProjectShell =
         {
           pkgs,
@@ -152,6 +155,17 @@
           shellHook ? ''echo "devcontainer dev environment loaded (nix)"'',
         }:
         let
+          # uv's Python-download metadata, pinned to the uv release we provision.
+          # The nixpkgs build of uv ships with its embedded Python-download list
+          # stripped, so it cannot fetch a managed CPython on its own. CI
+          # provisions FROM this dev-shell on an FHS runner and forwards this URL
+          # (see the setup-env action) so the runner's uv can download a managed
+          # CPython for `uv sync` / pre-commit — a Nix-store interpreter cannot
+          # load pre-commit's manylinux-wheel C extensions outside `nix develop`.
+          # Derived from `pkgs.uv.version` so it tracks the overlaid (floating)
+          # uv and cannot drift from a literal pin. Refs #632, #666, #683, #774.
+          uvPythonDownloadsJsonUrl = "https://raw.githubusercontent.com/astral-sh/uv/${pkgs.uv.version}/crates/uv-python/download-metadata.json";
+
           # CPython matching `requires-python` (>=3.14,<3.15). The dev-shell
           # carries no Python on PATH (the project venv is uv-managed). Pin a
           # Nix store CPython via UV_PYTHON and forbid downloads
@@ -243,9 +257,11 @@
     flake-utils.lib.eachDefaultSystem (
       system:
       let
+        # Imported once per system and reused by the overlay below.
+        unstable = importUnstable system;
         pkgs = import nixpkgs {
           inherit system;
-          overlays = [ overlay ];
+          overlays = [ (mkFastMoverOverlay unstable) ];
           config.allowUnfree = true;
         };
 
@@ -379,10 +395,19 @@
         # dev-shell builds, and devShellTools evaluates. Refs #674.
         checks = {
           # Every *.nix file is nixfmt-clean (the `nix fmt` idempotency gate).
-          format = pkgs.runCommand "nixfmt-check" { nativeBuildInputs = [ pkgs.nixfmt-rfc-style ]; } ''
-            nixfmt --check ${./flake.nix}
-            touch "$out"
-          '';
+          # Source filtered to `.nix` files so the check only depends on (and
+          # reruns for) those, while still covering every *.nix in the repo —
+          # not just flake.nix. Refs #674, #774.
+          format =
+            pkgs.runCommand "nixfmt-check"
+              {
+                nativeBuildInputs = [ pkgs.nixfmt-rfc-style ];
+                src = pkgs.lib.sources.sourceFilesBySuffices ./. [ ".nix" ];
+              }
+              ''
+                find "$src" -name '*.nix' -exec nixfmt --check {} +
+                touch "$out"
+              '';
 
           # The dev-shell evaluates and its closure builds.
           devShell = self.devShells.${system}.default;
@@ -394,7 +419,12 @@
             touch "$out"
           '';
         };
-
+      }
+      # The image and its scan targets are Linux-only (dockerTools.* fails to
+      # even evaluate on darwin), so expose `packages` only on *-linux systems.
+      # Without this guard `nix flake check --all-systems` aborts during the
+      # darwin eval. The dev-shell stays cross-platform. Refs #774.
+      // pkgs.lib.optionalAttrs (pkgs.lib.hasSuffix "-linux" system) {
         packages = {
           # -----------------------------------------------------------------
           # devcontainerImage — Nix-built devcontainer image (T2.1, #634).

--- a/renovate.json
+++ b/renovate.json
@@ -3,15 +3,35 @@
   "extends": [
     "github>vig-os/devcontainer//assets/workspace/.github/renovate-default"
   ],
-  "enabledManagers": ["github-actions", "pep621", "npm", "nix"],
+  "enabledManagers": ["github-actions", "pep621", "npm", "nix", "custom.regex"],
   "lockFileMaintenance": {
     "enabled": true,
     "schedule": ["before 9am on monday"]
   },
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Track the pip-licenses wheel pinned in flake.nix (version lives in the pythonhosted wheel URL). Renovate proposes the version bump; the sha256 + URL hash path are refreshed by hand when the PR lands.",
+      "managerFilePatterns": ["/^flake\\.nix$/"],
+      "matchStrings": [
+        "pip_licenses-(?<currentValue>[0-9]+(?:\\.[0-9]+)*)-py3-none-any\\.whl"
+      ],
+      "depNameTemplate": "pip-licenses",
+      "packageNameTemplate": "pip-licenses",
+      "datasourceTemplate": "pypi"
+    }
+  ],
   "packageRules": [
     {
       "description": "Nix flake.lock — bump flake inputs through the normal PR/CI gate",
       "matchManagers": ["nix"],
+      "semanticCommitType": "build",
+      "semanticCommitScope": "nix"
+    },
+    {
+      "description": "pip-licenses wheel (custom regex manager) — build/nix scope, matching the flake.nix pin it lives in",
+      "matchManagers": ["custom.regex"],
+      "matchDepNames": ["pip-licenses"],
       "semanticCommitType": "build",
       "semanticCommitScope": "nix"
     }


### PR DESCRIPTION
## Summary

PR #670 roadmap thread A — the batched "cheap fixes" the reviewer flagged, all in `flake.nix` plus the Renovate config. Lands on the migration branch.

| # | Item | Where | Change |
|---|------|-------|--------|
| 1 | darwin guard | `flake.nix` (per-system return) | `packages` (image + `devcontainerImageEnv`/`vulnix` scan targets) now wrapped in `lib.optionalAttrs (lib.hasSuffix "-linux" system)` so `nix flake check --all-systems` no longer aborts on the darwin `dockerTools` eval; dev-shell stays cross-platform |
| 2 | hoist unstable import | `flake.nix` overlay | `import nixpkgs-unstable` factored into `importUnstable`, evaluated once per system and threaded into `mkFastMoverOverlay` instead of re-imported inside the overlay fixpoint |
| 3 | uv URL drift | `flake.nix` `mkProjectShell` | `uvPythonDownloadsJsonUrl` now derived from `pkgs.uv.version` (was a literal `0.11.23` while the overlaid uv floats — actually `0.11.19`, i.e. already drifted) |
| 4 | Renovate wheel rule | `renovate.json` | Added a `customManagers` regex tracking the `pip-licenses` wheel version pinned in `flake.nix` (datasource pypi), enabled `custom.regex`, plus a matching `packageRule` |
| 5 | nixfmt glob | `flake.nix` `checks.format` | flake check now runs `nixfmt --check` over every `*.nix` (source filtered to `.nix`), not just `flake.nix`. The pre-commit hook already globbed `\.nix$`, so it was unchanged |

## Verification

- `nix flake check` (x86_64-linux): **all checks passed** — including the new `checks.format` building `nixfmt-check` over all 3 tracked `*.nix`.
- `nix flake check --all-systems`: **all checks passed** — `checks.{aarch64,x86_64}-darwin` now evaluate cleanly; `packages.*-darwin` is absent (guard works), `packages.x86_64-linux` still exposes `devcontainerImage`/`devcontainerImageEnv`/`vulnix`.
- `just test-renovate` (renovate-config-validator --strict): **Config validated successfully against 3 file(s)**.
- `nixfmt --check` over all `*.nix`: clean (no other files needed reformatting).
- pre-commit: `nixfmt`, `sync-manifest` (CHANGELOG mirror), `check-json` all Passed; full commit ran the standard hook suite (no `--no-verify`).

Derived uv URL confirmed: `https://raw.githubusercontent.com/astral-sh/uv/0.11.19/crates/uv-python/download-metadata.json` (matches `pkgs.uv.version`).

Closes #774