### PR TITLE
ci(cachix): make image-closure Cachix push first-class and blocking

### DIFF
--- a/.github/actions/build-image/action.yml
+++ b/.github/actions/build-image/action.yml
@@ -13,6 +13,10 @@
 #   registry: Container registry URL (default: ghcr.io/vig-os/devcontainer)
 #   output-file: Path for the tar output
 #   cachix-cache / cachix-auth-token: passed to flake provisioning (setup-env)
+#   push-image-closure: when 'true', push the built image closure to Cachix as a
+#     BLOCKING step (trusted paths only — `dev`/release) so published images are
+#     cache-backed. Default false keeps per-PR CI pull-only; the step is also
+#     guarded on the auth token so fork PRs (no secret) never fail.
 #
 # Outputs:
 #   image-tag: Full image tag (e.g., ghcr.io/vig-os/devcontainer:1.0.0-amd64)
@@ -60,6 +64,14 @@ inputs:
     description: 'Cachix auth token (optional; pulls need no token)'
     required: false
     default: ''
+  push-image-closure:
+    description: >-
+      Push the built image closure to Cachix as a BLOCKING step (trusted paths
+      only: `dev` and releases) so published images are cache-backed. Default
+      false keeps per-PR CI pull-only. Only takes effect when a Cachix cache and
+      auth token are both provided (fork PRs lack the token and are never failed).
+    required: false
+    default: 'false'
 
 outputs:
   image-tag:
@@ -98,6 +110,27 @@ runs:
         nix build .#devcontainerImage --print-build-logs
         cp -L result "${{ inputs.output-file }}"
         ls -lL "${{ inputs.output-file }}"
+
+    # First-class, BLOCKING push of the built image closure to the vig-os Cachix
+    # cache so published images are cache-backed: consumers substitute the closure
+    # instead of rebuilding it from source. Mirrors the nix-cachix.yml dev-shell
+    # idiom (`nix path-info --recursive | cachix push`). NO continue-on-error — a
+    # push failure on a trusted path (dev/release) fails the build. Runs only when
+    # opted in (`push-image-closure`) AND a cache + auth token are present, so
+    # per-PR CI stays pull-only and fork PRs (no secret) never fail. setup-env
+    # already ran cachix-action, which installed `cachix` and configured auth.
+    - name: Push image closure to Cachix (blocking, trusted paths only)
+      if: >-
+        inputs.push-image-closure == 'true' &&
+        inputs.cachix-cache != '' &&
+        inputs.cachix-auth-token != ''
+      shell: bash
+      env:
+        CACHIX_CACHE: ${{ inputs.cachix-cache }}
+        CACHIX_AUTH_TOKEN: ${{ inputs.cachix-auth-token }}
+      run: |
+        set -euo pipefail
+        nix path-info --recursive ./result | cachix push "$CACHIX_CACHE"
 
     - name: Verify tar output was created
       shell: bash

--- a/.github/workflows/nix-image.yml
+++ b/.github/workflows/nix-image.yml
@@ -8,12 +8,16 @@
 #
 # The portable testinfra suite now passes on the Nix image, so the
 # build-and-test job GATES on it (#666); the FHS/bootstrap discovery gaps are
-# closed. The per-arch push and the multi-arch-index job stay
+# closed. The per-arch GHCR *tag* push and the multi-arch-index job stay
 # `continue-on-error` so a registry hiccup cannot fail the build/test gate.
 #   - It pushes ONLY the disposable `nix-dev*` discovery tags (per-arch +
 #     index). It never touches the versioned or `:latest` cutover tags — the
 #     publish-cutover is #639. These tags exist so `imagetools inspect` can prove
-#     the index shape and so the arm64 closure lands in Cachix.
+#     the index shape.
+#   - The per-arch image *closure* push to the `vig-os` Cachix cache is
+#     first-class and BLOCKING (#776): a push failure fails the build so the
+#     discovery images are guaranteed cache-backed (distinct from the GHCR tag
+#     push above, which stays non-blocking).
 #
 # Evaluator choice: upstream CppNix via cachix/install-nix-action, matching
 # nix-cachix.yml. The flake bakes CppNix (`pkgs.nix`) into the image closure so
@@ -78,8 +82,9 @@ jobs:
             experimental-features = nix-command flakes
             accept-flake-config = true
 
-      # authToken set => cachix-action pushes every store path built in this job
-      # on post-run, so the arm64 closure lands in the `vig-os` cache too (#636).
+      # authToken set => cachix-action installs `cachix`, configures push auth,
+      # and adds the `vig-os` substituter for this job (the explicit blocking
+      # push below is the first-class guarantee; #776).
       - name: Configure Cachix (push arch closure)
         uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71  # v17
         with:
@@ -95,6 +100,21 @@ jobs:
           # Stage it where the test-image composite action expects a tar file.
           cp -L result /tmp/nix-devcontainer-image.tar.gz
           ls -lL /tmp/nix-devcontainer-image.tar.gz
+
+      # First-class, BLOCKING push of the per-arch image closure to the vig-os
+      # cache (#776): published/discovery images are cache-backed so consumers
+      # substitute the closure instead of rebuilding from source. NO
+      # continue-on-error — a push failure fails the discovery build. Runs on the
+      # trusted paths only (push to `dev`/epic + workflow_dispatch, which carry
+      # the auth token); guarded on the cache being set for safety.
+      - name: Push per-arch image closure to Cachix (blocking)
+        if: vars.CACHIX_CACHE != ''
+        env:
+          CACHIX_CACHE: ${{ vars.CACHIX_CACHE }}
+          CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
+        run: |
+          set -euo pipefail
+          nix path-info --recursive ./result | cachix push "$CACHIX_CACHE"
 
       - name: Record image size
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -766,6 +766,9 @@ jobs:
           cachix-cache: ${{ vars.CACHIX_CACHE }}
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
           output-file: /tmp/image.tar
+          # Trusted publish path: BLOCKING push of the image closure to Cachix so
+          # released images are cache-backed (consumers substitute, not rebuild).
+          push-image-closure: 'true'
 
       - name: Run image tests
         uses: ./.github/actions/test-image
@@ -833,6 +836,20 @@ jobs:
         run: |
           set -euo pipefail
           nix build .#devcontainerImageEnv --print-build-logs
+
+      # First-class, BLOCKING push of the scan-target closure to Cachix (#776) so
+      # the CVE-scan closure is cache-backed too (nightly + re-runs substitute it
+      # instead of rebuilding). setup-env (provision-via-flake) already ran
+      # cachix-action, installing `cachix` and configuring push auth. Guarded on
+      # the cache being set; the release path always carries the auth token.
+      - name: Push scan-target closure to Cachix (blocking)
+        if: vars.CACHIX_CACHE != ''
+        env:
+          CACHIX_CACHE: ${{ vars.CACHIX_CACHE }}
+          CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
+        run: |
+          set -euo pipefail
+          nix path-info --recursive ./result | cachix push "$CACHIX_CACHE"
 
       - name: Run vulnix (primary CVE scanner)
         # Mirrors security-scan.yml: vulnix exit codes 0=clean, 1=only

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Image-closure Cachix push is now first-class and blocking on the trusted paths** ([#776](https://github.com/vig-os/devcontainer/issues/776))
+  - Published images are now guaranteed **cache-backed**: on the trusted paths (push to `dev` and releases) the built image closure is pushed to the `vig-os` Cachix cache as a **blocking** step (`nix path-info --recursive ./result | cachix push`), so consumers substitute the exact pinned closure instead of rebuilding it from source. Previously the image closure only reached the cache incidentally (a non-blocking, discovery-only side effect of `cachix-action`)
+  - `.github/actions/build-image` gained an opt-in `push-image-closure` input (default `false`) that performs the blocking push, guarded on a non-empty auth token — so per-PR CI stays **pull-only** and fork PRs (which lack `CACHIX_AUTH_TOKEN`) never fail. The release `build-and-test` job opts in; the `Nix Image (discovery)` workflow pushes each per-arch image closure on `dev` as the same blocking step (distinct from the still-non-blocking GHCR discovery *tag* push)
+  - The release CVE gate (`vulnix-gate`) now also pushes the `devcontainerImageEnv` scan-target closure, so the vulnix scan surface is cache-backed too. Documented the guarantee in `docs/NIX.md` and `docs/CONTAINER_SECURITY.md`
 - **Flake cheap-fix batch: darwin-guarded image outputs, single nixpkgs-unstable eval, uv downloads URL derived from version, Renovate wheel-hash rule, nixfmt over all `*.nix`** ([#774](https://github.com/vig-os/devcontainer/issues/774))
   - The Linux-only `packages` (`devcontainerImage` plus its `devcontainerImageEnv`/`vulnix` scan targets) are now exposed only on `*-linux` systems, so `nix flake check --all-systems` no longer aborts during the darwin `dockerTools` evaluation; the dev-shell stays cross-platform
   - `nixpkgs-unstable` is imported once per system and threaded into the fast-mover overlay, instead of being re-imported inside the overlay fixpoint on each application

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -55,6 +55,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Image-closure Cachix push is now first-class and blocking on the trusted paths** ([#776](https://github.com/vig-os/devcontainer/issues/776))
+  - Published images are now guaranteed **cache-backed**: on the trusted paths (push to `dev` and releases) the built image closure is pushed to the `vig-os` Cachix cache as a **blocking** step (`nix path-info --recursive ./result | cachix push`), so consumers substitute the exact pinned closure instead of rebuilding it from source. Previously the image closure only reached the cache incidentally (a non-blocking, discovery-only side effect of `cachix-action`)
+  - `.github/actions/build-image` gained an opt-in `push-image-closure` input (default `false`) that performs the blocking push, guarded on a non-empty auth token — so per-PR CI stays **pull-only** and fork PRs (which lack `CACHIX_AUTH_TOKEN`) never fail. The release `build-and-test` job opts in; the `Nix Image (discovery)` workflow pushes each per-arch image closure on `dev` as the same blocking step (distinct from the still-non-blocking GHCR discovery *tag* push)
+  - The release CVE gate (`vulnix-gate`) now also pushes the `devcontainerImageEnv` scan-target closure, so the vulnix scan surface is cache-backed too. Documented the guarantee in `docs/NIX.md` and `docs/CONTAINER_SECURITY.md`
 - **Flake cheap-fix batch: darwin-guarded image outputs, single nixpkgs-unstable eval, uv downloads URL derived from version, Renovate wheel-hash rule, nixfmt over all `*.nix`** ([#774](https://github.com/vig-os/devcontainer/issues/774))
   - The Linux-only `packages` (`devcontainerImage` plus its `devcontainerImageEnv`/`vulnix` scan targets) are now exposed only on `*-linux` systems, so `nix flake check --all-systems` no longer aborts during the darwin `dockerTools` evaluation; the dev-shell stays cross-platform
   - `nixpkgs-unstable` is imported once per system and threaded into the fast-mover overlay, instead of being re-imported inside the overlay fixpoint on each application

--- a/docs/CONTAINER_SECURITY.md
+++ b/docs/CONTAINER_SECURITY.md
@@ -11,7 +11,12 @@ place. The Debian/`apt` build path has been decommissioned (#642).
 
 1. **Reproducibility first** – Every build from the same commit and the same
    `flake.lock` produces a byte-identical image closure. There is no
-   non-deterministic upgrade step (no `apt-get upgrade`) in the build path.
+   non-deterministic upgrade step (no `apt-get upgrade`) in the build path. On
+   the trusted paths (push to `dev` and releases) that closure is pushed to the
+   `vig-os` Cachix cache as a **blocking** step (#776), so published images are
+   guaranteed cache-backed: consumers substitute the exact, pinned closure
+   instead of rebuilding it from source. Per-PR CI stays pull-only. See
+   [`docs/NIX.md`](NIX.md#image-closures-are-cache-backed-too-blocking-push).
 2. **Defence in depth** – Multiple scanners and levers detect and remediate CVEs
    at different speeds and over different surfaces so no single mechanism is a
    bottleneck.

--- a/docs/NIX.md
+++ b/docs/NIX.md
@@ -184,6 +184,25 @@ self-bootstraps the pinned library on first allow, or uses your
 to bare `use flake` when unavailable. The full fast path lives in
 [`CONTRIBUTE.md`](../CONTRIBUTE.md).
 
+### Image closures are cache-backed too (blocking push)
+
+The cache is not just for the dev-shell. On the trusted paths the **image**
+closure is pushed to `vig-os` Cachix as a **first-class, blocking** step (#776),
+so published images are guaranteed cache-backed and consumers substitute the
+closure instead of rebuilding it from source:
+
+- `.github/actions/build-image` pushes the built `devcontainerImage` closure when
+  its `push-image-closure` input is `true` (`nix path-info --recursive ./result |
+  cachix push`). The release workflow (`build-and-test`) opts in, so every
+  released image is cache-backed. The push is **blocking** (no
+  `continue-on-error`) and guarded on a non-empty auth token, so per-PR CI stays
+  **pull-only** and fork PRs (which lack the secret) never fail.
+- The `Nix Image (discovery)` workflow pushes each per-arch image closure on
+  `dev` as the same blocking step (distinct from the non-blocking GHCR discovery
+  *tag* push).
+- The release CVE gate also pushes the `devcontainerImageEnv` scan-target closure,
+  so the vulnix scan surface is cache-backed as well.
+
 ## How `nixpkgs` bumps flow (Renovate + vulnix)
 
 The pinned `nixpkgs` revision in `flake.lock` defines the image's entire CVE

--- a/tests/test_workflow_cachix.py
+++ b/tests/test_workflow_cachix.py
@@ -1,0 +1,103 @@
+"""Workflow-shape tests for the first-class, blocking image-closure Cachix push.
+
+Issue #776 makes the *image* closure push to the ``vig-os`` Cachix cache
+first-class and **blocking** on the trusted paths (push to ``dev`` and release),
+so published images are guaranteed cache-backed and consumers substitute the
+closure instead of rebuilding it from source.
+
+These are pure YAML-shape assertions (no ``nix``/``podman`` needed): they parse
+the composite action and the workflows and assert the closure-push step exists,
+is *not* ``continue-on-error`` on the trusted paths, and is opt-in (so per-PR CI
+stays pull-only).
+
+Refs: #776
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+# Repository root (tests/ -> repo root).
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+BUILD_IMAGE_ACTION = REPO_ROOT / ".github" / "actions" / "build-image" / "action.yml"
+NIX_IMAGE_WF = REPO_ROOT / ".github" / "workflows" / "nix-image.yml"
+RELEASE_WF = REPO_ROOT / ".github" / "workflows" / "release.yml"
+
+
+def _load(path: Path) -> dict:
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def _is_closure_push(step: dict) -> bool:
+    """A step that pushes a built store closure to Cachix (the #776 idiom)."""
+    run = step.get("run", "")
+    return "cachix push" in run and "path-info --recursive" in run
+
+
+def _steps_of_job(workflow: dict, job: str) -> list[dict]:
+    return workflow["jobs"][job]["steps"]
+
+
+def test_build_image_action_has_opt_in_closure_push() -> None:
+    """The build-image composite gained a guarded, blocking closure-push step."""
+    action = _load(BUILD_IMAGE_ACTION)
+
+    # Opt-in input keeps per-PR CI pull-only (default false).
+    assert "push-image-closure" in action["inputs"], (
+        "build-image must expose a push-image-closure input"
+    )
+    assert action["inputs"]["push-image-closure"]["default"] in ("false", False)
+
+    push_steps = [s for s in action["runs"]["steps"] if _is_closure_push(s)]
+    assert len(push_steps) == 1, "expected exactly one closure-push step"
+    step = push_steps[0]
+
+    # Blocking: a push failure on a trusted path fails the build.
+    assert step.get("continue-on-error") is not True, (
+        "the image-closure push must be blocking (no continue-on-error)"
+    )
+
+    # Gated on the opt-in flag *and* on the auth token so fork PRs never fail.
+    guard = step.get("if", "")
+    assert "push-image-closure" in guard
+    assert "cachix-auth-token" in guard
+
+
+def test_nix_image_discovery_push_is_blocking() -> None:
+    """The dev discovery workflow pushes the image closure as a blocking step."""
+    wf = _load(NIX_IMAGE_WF)
+    push_steps = [s for s in _steps_of_job(wf, "build-and-test") if _is_closure_push(s)]
+    assert push_steps, "nix-image.yml build-and-test must push the image closure"
+    for step in push_steps:
+        assert step.get("continue-on-error") is not True, (
+            "the discovery image-closure push must be blocking"
+        )
+
+
+def test_release_build_and_test_opts_into_closure_push() -> None:
+    """Release build-and-test tells build-image to push (cache-back published images)."""
+    wf = _load(RELEASE_WF)
+    build_steps = [
+        s
+        for s in _steps_of_job(wf, "build-and-test")
+        if "build-image" in str(s.get("uses", ""))
+    ]
+    assert build_steps, "release build-and-test must call the build-image action"
+    for step in build_steps:
+        assert step.get("with", {}).get("push-image-closure") in ("true", True), (
+            "release build-and-test must set push-image-closure: 'true'"
+        )
+
+
+def test_release_vulnix_gate_pushes_scan_target_closure() -> None:
+    """The release CVE gate pushes the scan-target closure so scans are cache-backed."""
+    wf = _load(RELEASE_WF)
+    push_steps = [s for s in _steps_of_job(wf, "vulnix-gate") if _is_closure_push(s)]
+    assert push_steps, "vulnix-gate must push the devcontainerImageEnv closure"
+    for step in push_steps:
+        assert step.get("continue-on-error") is not True, (
+            "the scan-target closure push must be blocking"
+        )


### PR DESCRIPTION
## Summary

Makes the devcontainer **image** closure push to the `vig-os` Cachix cache
**first-class and blocking** on the trusted paths (push to `dev` and releases),
so published images are guaranteed cache-backed and consumers substitute the
pinned closure instead of rebuilding it from source. Previously the image
closure only reached the cache incidentally (a non-blocking, discovery-only side
effect of `cachix-action`).

## Changes

- **`.github/actions/build-image/action.yml`** — new opt-in `push-image-closure`
  input (default `false`) plus a blocking `nix path-info --recursive ./result |
  cachix push` step, guarded on the flag **and** a non-empty auth token, so
  per-PR CI stays pull-only and fork PRs (no secret) never fail.
- **`.github/workflows/release.yml`** — `build-and-test` opts in
  (`push-image-closure: 'true'`) so released images are cache-backed; the
  `vulnix-gate` now also pushes the `devcontainerImageEnv` scan-target closure.
- **`.github/workflows/nix-image.yml`** — the discovery build pushes each per-arch
  image closure as a blocking step (distinct from the still-non-blocking GHCR
  discovery *tag* push).
- **`docs/NIX.md`, `docs/CONTAINER_SECURITY.md`, `CHANGELOG.md`** — document the
  cache-backed-published-image guarantee.
- **`tests/test_workflow_cachix.py`** — YAML-shape tests asserting the closure
  push exists, is blocking (no `continue-on-error`) on the trusted paths, and is
  opt-in (so per-PR CI stays pull-only). TDD: added RED first, then GREEN.

## Push-gating decision

Gated the new **explicit** push on an opt-in `push-image-closure` input (plus a
token-presence guard), rather than on token presence alone. Token-presence alone
would make internal-branch PR CI push on every run (internal PRs carry the
secret), violating "keep per-PR CI pull-only"; the explicit flag gives precise
control — only the trusted callers opt in. The token guard is belt-and-suspenders
so a trusted path without a token (or a fork) never fails.

## Verification

- `pytest tests/test_workflow_cachix.py` — 4 passed.
- `pre-commit` ran on every commit (yamllint, ruff, pymarkdown, action-pin check,
  agent-identity guard, manifest sync) — all passed.
- Could **not** execute the actual workflows (no runner/Cachix token here); the
  guarantee is asserted structurally by the new tests and by yamllint/action-pin
  checks. `actionlint` is not wired into this repo's pre-commit, so it was not run.

Refs: #776