### PR TITLE
test: fix statix dev-shell parity check (--help, no top-level --version) (#792)

### DIFF
--- a/tests/test_flake_devshell.py
+++ b/tests/test_flake_devshell.py
@@ -44,6 +44,10 @@ VERSION_FLAG_OVERRIDES: dict[str, list[str]] = {
     "expect": ["-v"],
     # tmux uses -V (uppercase) to print its version.
     "tmux": ["-V"],
+    # statix has no top-level version flag (`--version` exits 2 with "unexpected
+    # argument"); it is a subcommand CLI. `--help` exits 0 and proves the binary
+    # is runnable in the dev-shell, which is what this parity check asserts.
+    "statix": ["--help"],
 }
 
 pytestmark = pytest.mark.skipif(


### PR DESCRIPTION
## Summary

#777 added `statix` to the `devTools` SSoT, but `statix` has no top-level version
flag (`--version` exits 2 with "unexpected argument"; no `-V`) — it is a
subcommand CLI. So `tests/test_flake_devshell.py::test_each_tool_runs_in_devshell`
(which invokes each tool with a version flag) fails on `statix`.

Fix: add a `VERSION_FLAG_OVERRIDES` entry `statix: ["--help"]` (exits 0), matching
the existing `expect`/`tmux` overrides. The check only asserts the binary is
runnable in the dev-shell.

Not previously CI-gated — `project-checks` runs this file only with a `-k` filter
that excludes `test_each_tool_runs_in_devshell`, so the regression was latent.

Verified: `nix develop -c statix --help` exits 0.

Refs: #792