### PR TITLE
docs: document local image build loop and agent-models customization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Docs: local Nix image build/iterate loop + downstream `agent-models.toml` customization** ([#717](https://github.com/vig-os/devcontainer/issues/717))
+  - `docs/NIX.md` gained a "Building and iterating the image locally" section: when to build locally vs. pull the published image, the `just build` → `just test-image` iterate loop, and that `just build` tags `<repo>:dev` (the tag the default `test`/`test-image`/`test-integration` recipes use and auto-build)
+  - `docs/SKILL_PIPELINE.md` gained a "Customizing models downstream" note under **Model Selection** explaining how a consuming project overrides the `[models]` tiers and `[skill-tiers]` assignments in its own committed `.claude/agent-models.toml` — no recipe edits needed
 - **Flake polish: treefmt-nix, deadnix/statix gates, NixOS/home-manager modules, `nix run .#install`** ([#777](https://github.com/vig-os/devcontainer/issues/777))
   - `nix fmt` now runs [`treefmt`](https://github.com/numtide/treefmt-nix) across every supported language in one pass (`nixfmt-rfc-style` for `*.nix`, `ruff format` for `*.py`, `taplo` for `*.toml`), wrapping the same formatters the pre-commit hooks already run so the editor, hooks, and CI agree on one formatting
   - Added `checks.deadnix` and `checks.statix` (dead-Nix-code + anti-pattern linters), scoped to the authored `flake.nix`; `deadnix` and `statix` also join `devTools`

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Docs: local Nix image build/iterate loop + downstream `agent-models.toml` customization** ([#717](https://github.com/vig-os/devcontainer/issues/717))
+  - `docs/NIX.md` gained a "Building and iterating the image locally" section: when to build locally vs. pull the published image, the `just build` → `just test-image` iterate loop, and that `just build` tags `<repo>:dev` (the tag the default `test`/`test-image`/`test-integration` recipes use and auto-build)
+  - `docs/SKILL_PIPELINE.md` gained a "Customizing models downstream" note under **Model Selection** explaining how a consuming project overrides the `[models]` tiers and `[skill-tiers]` assignments in its own committed `.claude/agent-models.toml` — no recipe edits needed
 - **Flake polish: treefmt-nix, deadnix/statix gates, NixOS/home-manager modules, `nix run .#install`** ([#777](https://github.com/vig-os/devcontainer/issues/777))
   - `nix fmt` now runs [`treefmt`](https://github.com/numtide/treefmt-nix) across every supported language in one pass (`nixfmt-rfc-style` for `*.nix`, `ruff format` for `*.py`, `taplo` for `*.toml`), wrapping the same formatters the pre-commit hooks already run so the editor, hooks, and CI agree on one formatting
   - Added `checks.deadnix` and `checks.statix` (dead-Nix-code + anti-pattern linters), scoped to the authored `flake.nix`; `deadnix` and `statix` also join `devTools`

--- a/docs/NIX.md
+++ b/docs/NIX.md
@@ -124,6 +124,26 @@ template `.venv` scaffold, a sticky `/tmp`, and the `precommit`/`cc`/`cld`
 aliases. The image's interpreter is pinned via `UV_PYTHON=<nix python3.14>` and
 `UV_PYTHON_DOWNLOADS=never`.
 
+### Building and iterating the image locally
+
+Most contributors never build the image. `nix develop`/direnv gives the dev-shell
+fast path for day-to-day work, and CI publishes the image to GHCR — so `just test`
+pulls the published `dev` tag rather than building. Build locally only when you
+are changing the **image itself** (its `imageTools`/`bootstrap` contents, baked
+workspace assets, or the `flake.nix` image wiring) and want to test before pushing:
+
+```bash
+just build          # nix build .#devcontainerImage → podman load → tag <repo>:dev
+just test-image     # run tests/test_image.py against the freshly loaded dev tag
+```
+
+`just build` tags the loaded image `<repo>:dev`; `just test-image`, `just
+test-integration`, and `just test` all default to that `dev` tag (and
+auto-`just build` it if it is missing). The iterate loop for image changes is
+therefore: edit `flake.nix` → `just build` → `just test-image` → repeat. `nix
+build` is content-addressed, so an unchanged closure rebuilds instantly and the
+`no_cache` argument is a no-op.
+
 ### Host container runtime (`policy.json`)
 
 `just build` ends in `podman load -i result`, and podman's containers/image

--- a/docs/SKILL_PIPELINE.md
+++ b/docs/SKILL_PIPELINE.md
@@ -267,6 +267,23 @@ Agent models are read from `.claude/agent-models.toml`. The worktree recipes use
 - **`autonomous` tier** for the main `claude` session (design, code, reasoning).
 - **`lightweight` tier** for the one-shot branch-naming call.
 
+#### Customizing models downstream
+
+`agent-models.toml` ships in every scaffolded workspace (from
+`assets/workspace/.claude/agent-models.toml`) and is the single source of truth
+read by `justfile.worktree` and `derive-branch-summary` — no recipe edits are
+needed to change model assignments. A downstream project overrides the defaults
+by editing its own committed copy under `.claude/`:
+
+- **Remap a tier** in `[models]` — point a tier at a different `claude` CLI model
+  alias, e.g. `autonomous = "sonnet"` to run agent sessions on a cheaper model.
+- **Reassign a skill category** in `[skill-tiers]` — move a category to a
+  different tier, e.g. `review = "autonomous"` to give code review the strongest
+  model, or `orchestration = "standard"` to economize on planning.
+
+Aliases resolve to the latest model in each family, so pins stay current. The
+next worktree or delegated skill run picks up the edited toml automatically.
+
 ## Typical Interactive Workflow
 
 ```

--- a/docs/templates/SKILL_PIPELINE.md.j2
+++ b/docs/templates/SKILL_PIPELINE.md.j2
@@ -196,6 +196,23 @@ Agent models are read from `.claude/agent-models.toml`. The worktree recipes use
 - **`autonomous` tier** for the main `claude` session (design, code, reasoning).
 - **`lightweight` tier** for the one-shot branch-naming call.
 
+#### Customizing models downstream
+
+`agent-models.toml` ships in every scaffolded workspace (from
+`assets/workspace/.claude/agent-models.toml`) and is the single source of truth
+read by `justfile.worktree` and `derive-branch-summary` — no recipe edits are
+needed to change model assignments. A downstream project overrides the defaults
+by editing its own committed copy under `.claude/`:
+
+- **Remap a tier** in `[models]` — point a tier at a different `claude` CLI model
+  alias, e.g. `autonomous = "sonnet"` to run agent sessions on a cheaper model.
+- **Reassign a skill category** in `[skill-tiers]` — move a category to a
+  different tier, e.g. `review = "autonomous"` to give code review the strongest
+  model, or `orchestration = "standard"` to economize on planning.
+
+Aliases resolve to the latest model in each family, so pins stay current. The
+next worktree or delegated skill run picks up the edited toml automatically.
+
 ## Typical Interactive Workflow
 
 ```


### PR DESCRIPTION
## Summary

Closes the two documentation gaps from the Nix migration follow-up: local image build/iterate loop and downstream `agent-models.toml` customization.

- **`docs/NIX.md`** — new "Building and iterating the image locally" section: when to build locally vs. pull the published image, the `just build` → `just test-image` iterate loop, and that `just build` tags `<repo>:dev` (the tag the default `test`/`test-image`/`test-integration` recipes use and auto-build).
- **`docs/templates/SKILL_PIPELINE.md.j2`** — new "Customizing models downstream" note under **Model Selection**: how a consuming project overrides the `[models]` tiers and `[skill-tiers]` assignments in its own committed `.claude/agent-models.toml`, no recipe edits needed. Regenerated `docs/SKILL_PIPELINE.md` via `just docs`.
- **`CHANGELOG.md`** (+ synced workspace mirror) — entry under `## Unreleased` → Added.

Docs-only change; no code or behavior touched.

Refs: #717