### PR TITLE
ci: pin pre-commit python to 3.14 for PEP 758 bare-except tuples

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,11 @@
 
 exclude: ^.github_data/|^docs/issues/|^docs/pull-requests/
 
+# Build python-language hooks with the project interpreter (3.14) so PEP 758
+# syntax (bare except tuples) never false-flags under an older parser. Refs #803.
+default_language_version:
+  python: python3.14
+
 repos:
   # General Pre-commit Hooks (Fixes formatting issues)
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/assets/workspace/.pre-commit-config.yaml
+++ b/assets/workspace/.pre-commit-config.yaml
@@ -3,6 +3,11 @@
 
 exclude: ^.github_data/|^docs/issues/|^docs/pull-requests/
 
+# Build python-language hooks with the project interpreter (3.14) so PEP 758
+# syntax (bare except tuples) never false-flags under an older parser. Refs #803.
+default_language_version:
+  python: python3.14
+
 repos:
   # General Pre-commit Hooks (Fixes formatting issues)
   - repo: https://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
## Summary

Fixes the recurring `SyntaxError: multiple exception types must be parenthesized` false-positive, and settles the underlying style question: **keep the PEP 758 unparenthesized `except X, Y:` form** (the forward Python standard) and fix the tooling instead of the code.

## Why not just parenthesize?

`except X, Y:` (no parens) is [PEP 758](https://peps.python.org/pep-0758/), valid on Python **3.14+** and permanently going forward (verified: `ruff format` strips added parens at both `target py314` and `py315`). The repo targets py314, so ruff *emits* this form — parenthesizing to `except (X, Y):` fights the formatter and would be reverted on every `ruff format`. `requires-python >=3.14` means consumers are 3.14+ anyway. So the syntax is correct and future-proof; only pre-3.14 *parsers* choke on it.

## Root cause + fix

The flake-provided `pre-commit` is itself a **Python-3.13** app, so it builds its `debug-statements` hook env with 3.13 → rejects the syntax on a bare local `pre-commit run`. CI is green because it runs pre-commit under the project's 3.14.

Fix — pin the hook interpreter:
```yaml
default_language_version:
  python: python3.14
```
Verified: after the pin, a bare flake `pre-commit run --all-files` is fully green (the `debug-statements` hook now builds its env with 3.14). No code changed; the two files using the syntax (`tests/conftest.py`, `packages/vig-utils/tests/test_claude_ssot.py`) stay as-is.

## Notes

- The mirrored downstream `assets/workspace/.pre-commit-config.yaml` gets the same pin via sync-manifest.
- Bump the pin alongside `requires-python` on future Python upgrades.
- Follow-up: record the "embrace PEP 758, don't parenthesize" convention in the org standards SSoT (`vig-os/meta/docs`).

Refs: #803