### PR TITLE
fix(security): ignore fixed jq CVEs pending :latest rebuild

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -24,3 +24,15 @@ CVE-2026-42504
 # - Tracking: https://github.com/vig-os/devcontainer/issues/512
 Expiration: 2026-09-01
 jwt-token
+
+# CVE-2026-32316, CVE-2026-40164: jq DoS / potential arbitrary code execution
+# Risk Assessment: LOW (devcontainer context)
+# - HIGH severity in Debian jq/libjq1 1.6-2.1+deb12u1; fixed in 1.6-2.1+deb12u2
+# - :latest is frozen pending the Nix publish-cutover (#639); the Debian rebuild
+#   path was decommissioned (#642), so :latest cannot be rebuilt to pull deb12u2.
+#   Time-box the ignore until the Nix image ships.
+# - jq processes trusted local JSON in devcontainer workflows, not untrusted input
+# - Tracking: https://github.com/vig-os/devcontainer/issues/805, #512
+Expiration: 2026-09-01
+CVE-2026-32316
+CVE-2026-40164


### PR DESCRIPTION
## Summary

The nightly **Scheduled Security Scan** on `ghcr.io/vig-os/devcontainer:latest` now fails the fixable-HIGH gate on the Debian `jq`/`libjq1` stack:

| CVE | Severity | Installed | Fixed in |
|-----|----------|-----------|----------|
| CVE-2026-32316 | HIGH | 1.6-2.1+deb12u1 | 1.6-2.1+deb12u2 |
| CVE-2026-40164 | HIGH | 1.6-2.1+deb12u1 | 1.6-2.1+deb12u2 |

Failing run: https://github.com/vig-os/devcontainer/actions/runs/28699509481

## Why a `.trivyignore` entry (not a rebuild)

The fix exists upstream (`deb12u2`), but `:latest` is frozen pending the Nix publish-cutover (#639) and the Debian rebuild path was decommissioned (#642), so `:latest` cannot be rebuilt to pull `deb12u2`. This adds a **time-boxed** ignore (`Expiration: 2026-09-01`) until the Nix image ships, mirroring the existing gh-binary exception pattern. The `check-expirations` hook will force review/removal at expiry.

Risk is LOW in devcontainer context: `jq` processes trusted local JSON in devcontainer workflows, not untrusted input.

## Verification

- `uv run check-expirations .trivyignore .vulnixignore` → `Validated 39 exception(s)`
- `just precommit` → all hooks green (incl. `check-expirations`)
- `just test-vig-utils` → 513 passed

The next scheduled scan will pass the gate once merged and the image is remediated, allowing #805 to auto-close.

Closes #805