### PR TITLE
fix(ci): cap prepare-release draft-PR body under GitHub's 65536-char limit

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -303,12 +303,24 @@ jobs:
         run: |
           set -euo pipefail
 
-          PR_BODY="# Release $VERSION
+          # GitHub caps PR bodies at 65536 chars; a large frozen release
+          # changelog can overflow it (#810). Truncate at a line boundary and
+          # point to the full CHANGELOG.md on the release branch when it does.
+          MAX_BODY=65000
+          HEADER="# Release $VERSION
 
           This PR prepares release $VERSION for merge to main.
 
-          $CHANGELOG_CONTENT
           "
+          PR_BODY="${HEADER}${CHANGELOG_CONTENT}"$'\n'
+
+          if [ "${#PR_BODY}" -gt "$MAX_BODY" ]; then
+            NOTE=$(printf '\n\n_Changelog truncated to fit GitHub'"'"'s %s-char PR-body limit; see `CHANGELOG.md` on `%s` for the full entry._' "$MAX_BODY" "$RELEASE_BRANCH")
+            budget=$(( MAX_BODY - ${#HEADER} - ${#NOTE} ))
+            TRUNCATED="${CHANGELOG_CONTENT:0:budget}"
+            TRUNCATED="${TRUNCATED%$'\n'*}"
+            PR_BODY="${HEADER}${TRUNCATED}${NOTE}"
+          fi
 
           PR_URL=$(uv run retry --retries 3 --backoff 5 --max-backoff 60 -- \
             gh pr create \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,6 +170,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`prepare-release` no longer fails when the release changelog exceeds GitHub's PR-body limit** ([#810](https://github.com/vig-os/devcontainer/issues/810))
+  - The `Create draft PR to main` step passed the entire frozen changelog section as the PR body; GitHub caps PR bodies at 65,536 characters, so a large release (e.g. 0.4.0 at ~64k chars) overflowed with `GraphQL: Body is too long` and the release rolled back. The step now caps the body, truncating the changelog at a line boundary and pointing to the full `CHANGELOG.md` on the release branch when it would overflow; small releases still inline the whole changelog unchanged
 - **Scaffold justfile audit: worktree recipes reachable, compose docs de-stale'd** ([#806](https://github.com/vig-os/devcontainer/issues/806))
   - The scaffold root `justfile` now imports `.devcontainer/justfile.worktree` (`import?`, so direnv-mode workspaces still parse): the shipped `.claude` worktree skills invoke `just worktree-start`, but nothing imported the recipes, so they were unreachable in consumer repos
   - The shipped `.devcontainer/README.md` no longer documents the long-removed `docker-compose.override.yml(.example)` workflow; it now describes the real layering (`docker-compose.project.yaml` team-shared / `docker-compose.local.yaml` personal) that #799 deliberately kept

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -170,6 +170,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`prepare-release` no longer fails when the release changelog exceeds GitHub's PR-body limit** ([#810](https://github.com/vig-os/devcontainer/issues/810))
+  - The `Create draft PR to main` step passed the entire frozen changelog section as the PR body; GitHub caps PR bodies at 65,536 characters, so a large release (e.g. 0.4.0 at ~64k chars) overflowed with `GraphQL: Body is too long` and the release rolled back. The step now caps the body, truncating the changelog at a line boundary and pointing to the full `CHANGELOG.md` on the release branch when it would overflow; small releases still inline the whole changelog unchanged
 - **Scaffold justfile audit: worktree recipes reachable, compose docs de-stale'd** ([#806](https://github.com/vig-os/devcontainer/issues/806))
   - The scaffold root `justfile` now imports `.devcontainer/justfile.worktree` (`import?`, so direnv-mode workspaces still parse): the shipped `.claude` worktree skills invoke `just worktree-start`, but nothing imported the recipes, so they were unreachable in consumer repos
   - The shipped `.devcontainer/README.md` no longer documents the long-removed `docker-compose.override.yml(.example)` workflow; it now describes the real layering (`docker-compose.project.yaml` team-shared / `docker-compose.local.yaml` personal) that #799 deliberately kept


### PR DESCRIPTION
## Summary

Fixes the **Prepare Release** failure where the `Create draft PR to main` step aborts with:

```
pull request create failed: GraphQL: Body is too long (maximum is 65536 characters) (createPullRequest)
```

The step built the PR body from the **entire** frozen changelog section and passed it to `gh pr create --body`. GitHub caps PR bodies at 65,536 chars; the 0.4.0 section (~64k chars) overflowed, so the release aborted and rolled back ([run 28699283187](https://github.com/vig-os/devcontainer/actions/runs/28699283187)).

## Change

In the `Create draft PR to main` step, cap the assembled body at a 65,000-char budget. When it would overflow, truncate the changelog **at a line boundary** and append a pointer to the full `CHANGELOG.md` on the release branch. Small releases still inline the whole changelog unchanged. Also mirrors the CHANGELOG entry into `assets/workspace/.devcontainer/CHANGELOG.md` (sync-enforced).

## Verification

Inline-YAML shell isn't unit-testable (TDD skipped, noted in commit), so the capping logic was verified with a standalone harness:

- **Oversized input (~123k chars, multi-line):** output PR body = **64,941 chars ≤ 65,000**, truncation note present, cut lands on a clean line boundary (no partial bullet).
- **Real current 0.4.0 section (64,055 chars):** passes through **intact**, body 64,123 < 65,536, no truncation note, full content preserved.
- **Small input:** intact, correct blank-line separation between intro and changelog.

Repo gates green locally:
- `just precommit` — all hooks Passed (both `.` and `assets/workspace`).
- `just test-bats` — **267/267 pass**, including `prepare-release PR body omits persistent checklist and related sections` and `release workflow refreshes release PR body from changelog` (both guard the edited region).
- Targeted integration tests (`test_template_*release*`) — 2 passed.

Closes #810