### PR TITLE
fix(ci): cap release.yml PR-body writes under GitHub's 65536-char limit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -623,13 +623,27 @@ jobs:
             exit 1
           fi
 
-          cat > /tmp/release-pr-body.md <<EOF
-          # [Release $VERSION](https://github.com/${GITHUB_REPOSITORY}/releases/tag/$VERSION) - $RELEASE_DATE
+          # GitHub caps PR bodies at 65536 chars; a large finalized release
+          # changelog can overflow it (#810). Truncate at a line boundary and
+          # point to the full CHANGELOG.md on the release branch when it does.
+          MAX_BODY=65000
+          RELEASE_BRANCH="release/$VERSION"
+          HEADER="# [Release $VERSION](https://github.com/${GITHUB_REPOSITORY}/releases/tag/$VERSION) - $RELEASE_DATE
 
           This PR prepares release $VERSION for merge to main.
 
-          $CHANGELOG_CONTENT
-          EOF
+          "
+          PR_BODY="${HEADER}${CHANGELOG_CONTENT}"$'\n'
+
+          if [ "${#PR_BODY}" -gt "$MAX_BODY" ]; then
+            NOTE=$(printf '\n\n_Changelog truncated to fit GitHub'"'"'s %s-char PR-body limit; see `CHANGELOG.md` on `%s` for the full entry._' "$MAX_BODY" "$RELEASE_BRANCH")
+            budget=$(( MAX_BODY - ${#HEADER} - ${#NOTE} ))
+            TRUNCATED="${CHANGELOG_CONTENT:0:budget}"
+            TRUNCATED="${TRUNCATED%$'\n'*}"
+            PR_BODY="${HEADER}${TRUNCATED}${NOTE}"
+          fi
+
+          printf '%s' "$PR_BODY" > /tmp/release-pr-body.md
 
           retry --retries 3 --backoff 5 --max-backoff 30 -- \
             gh pr edit "$PR_NUMBER" --body-file /tmp/release-pr-body.md
@@ -1536,13 +1550,27 @@ jobs:
             exit 1
           fi
 
-          {
-            echo "# Release $VERSION"
-            echo ""
-            echo "This PR prepares release $VERSION for merge to main."
-            echo ""
-            echo "$CHANGELOG_CONTENT"
-          } > /tmp/release-pr-body.md
+          # GitHub caps PR bodies at 65536 chars; a large release changelog
+          # can overflow it (#810). Truncate at a line boundary and point to
+          # the full CHANGELOG.md on the release branch when it does.
+          MAX_BODY=65000
+          RELEASE_BRANCH="release/$VERSION"
+          HEADER="# Release $VERSION
+
+          This PR prepares release $VERSION for merge to main.
+
+          "
+          PR_BODY="${HEADER}${CHANGELOG_CONTENT}"$'\n'
+
+          if [ "${#PR_BODY}" -gt "$MAX_BODY" ]; then
+            NOTE=$(printf '\n\n_Changelog truncated to fit GitHub'"'"'s %s-char PR-body limit; see `CHANGELOG.md` on `%s` for the full entry._' "$MAX_BODY" "$RELEASE_BRANCH")
+            budget=$(( MAX_BODY - ${#HEADER} - ${#NOTE} ))
+            TRUNCATED="${CHANGELOG_CONTENT:0:budget}"
+            TRUNCATED="${TRUNCATED%$'\n'*}"
+            PR_BODY="${HEADER}${TRUNCATED}${NOTE}"
+          fi
+
+          printf '%s' "$PR_BODY" > /tmp/release-pr-body.md
 
           retry --retries 3 --backoff 5 --max-backoff 30 -- \
             gh pr edit "$PR_NUMBER" --body-file /tmp/release-pr-body.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,8 +182,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **`prepare-release` no longer fails when the release changelog exceeds GitHub's PR-body limit** ([#810](https://github.com/vig-os/devcontainer/issues/810))
+- **Release pipeline no longer fails when the release changelog exceeds GitHub's PR-body limit** ([#810](https://github.com/vig-os/devcontainer/issues/810))
   - The `Create draft PR to main` step passed the entire frozen changelog section as the PR body; GitHub caps PR bodies at 65,536 characters, so a large release (e.g. 0.4.0 at ~64k chars) overflowed with `GraphQL: Body is too long` and the release rolled back. The step now caps the body, truncating the changelog at a line boundary and pointing to the full `CHANGELOG.md` on the release branch when it would overflow; small releases still inline the whole changelog unchanged
+  - The same uncapped rebuild existed in `release.yml`: the finalize-path `Refresh release PR body from finalized changelog` step (which would have crashed the final release run mid-finalize and triggered rollback) and the rollback-path `Restore release PR body` step. Both now apply the same cap
 - **Scaffold justfile audit: worktree recipes reachable, compose docs de-stale'd** ([#806](https://github.com/vig-os/devcontainer/issues/806))
   - The scaffold root `justfile` now imports `.devcontainer/justfile.worktree` (`import?`, so direnv-mode workspaces still parse): the shipped `.claude` worktree skills invoke `just worktree-start`, but nothing imported the recipes, so they were unreachable in consumer repos
   - The shipped `.devcontainer/README.md` no longer documents the long-removed `docker-compose.override.yml(.example)` workflow; it now describes the real layering (`docker-compose.project.yaml` team-shared / `docker-compose.local.yaml` personal) that #799 deliberately kept

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -182,8 +182,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **`prepare-release` no longer fails when the release changelog exceeds GitHub's PR-body limit** ([#810](https://github.com/vig-os/devcontainer/issues/810))
+- **Release pipeline no longer fails when the release changelog exceeds GitHub's PR-body limit** ([#810](https://github.com/vig-os/devcontainer/issues/810))
   - The `Create draft PR to main` step passed the entire frozen changelog section as the PR body; GitHub caps PR bodies at 65,536 characters, so a large release (e.g. 0.4.0 at ~64k chars) overflowed with `GraphQL: Body is too long` and the release rolled back. The step now caps the body, truncating the changelog at a line boundary and pointing to the full `CHANGELOG.md` on the release branch when it would overflow; small releases still inline the whole changelog unchanged
+  - The same uncapped rebuild existed in `release.yml`: the finalize-path `Refresh release PR body from finalized changelog` step (which would have crashed the final release run mid-finalize and triggered rollback) and the rollback-path `Restore release PR body` step. Both now apply the same cap
 - **Scaffold justfile audit: worktree recipes reachable, compose docs de-stale'd** ([#806](https://github.com/vig-os/devcontainer/issues/806))
   - The scaffold root `justfile` now imports `.devcontainer/justfile.worktree` (`import?`, so direnv-mode workspaces still parse): the shipped `.claude` worktree skills invoke `just worktree-start`, but nothing imported the recipes, so they were unreachable in consumer repos
   - The shipped `.devcontainer/README.md` no longer documents the long-removed `docker-compose.override.yml(.example)` workflow; it now describes the real layering (`docker-compose.project.yaml` team-shared / `docker-compose.local.yaml` personal) that #799 deliberately kept


### PR DESCRIPTION
## Summary

#812 capped the PR body only in `prepare-release.yml`. Two more sites in `release.yml` rebuild the release-PR body from the full changelog section uncapped:

- **Finalize path** — `Refresh release PR body from finalized changelog` (blocking). The 0.4.0 section measures ~66.8k chars > GitHub's 65,536 limit, so the first `finalize-release 0.4.0` run would have crashed mid-finalize on `GraphQL: Body is too long` and triggered rollback.
- **Rollback path** — `Restore release PR body from pre-finalization CHANGELOG` (`continue-on-error`; overflow would leave the body unrestored).

Both steps now apply the same cap as #812: 65,000-char budget, truncation at a line boundary, and a note pointing to the full `CHANGELOG.md` on the release branch. Small releases inline the whole changelog unchanged.

Lands on `release/0.4.0` (before the RC dispatch) so the candidate tests the exact tree that ships; reaches `dev`/`main` via the promote merge + sync-back. Changelog entry added to the open `## [0.4.0] - TBD` section (the #810 entry, extended).

Follow-up candidate (not this PR): the cap logic now exists in three inline copies (`prepare-release.yml` + 2× `release.yml`) — worth extracting into a shared `.github/scripts/` helper next cycle.

## Verification

- Standalone harness replicating the de-indented step script, run against the **real 0.4.0 changelog section**: 66,794-char section → 64,869-char body, truncated at a line boundary, ending with the truncation note; sub-threshold input passes through byte-identical.
- YAML de-indentation of the new `HEADER` strings asserted via `yaml.safe_load` (no indent leak into the string literals).
- `just precommit` (full suite, all files): green, exit 0.
- `uv run pytest -k release` (10 passed) and `tests/test_workflow_cachix.py` (4 passed).

Refs: #810