### PR TITLE
feat(home): terminal home environment modules (wave 1)

### DIFF
--- a/.github/workflows/home-matrix.yml
+++ b/.github/workflows/home-matrix.yml
@@ -1,0 +1,99 @@
+# Home-environment matrix: build the ci homeConfigurations on the platforms
+# the x86_64-linux Tier-0 gate cannot cover, and push their closures to
+# Cachix so colleagues never cold-build (ADR: darwin cache must exist BEFORE
+# first onboarding).
+#
+# Deliberately a SEPARATE, non-required workflow: failures stay visibly red
+# on the PR without blocking merge (fail-soft by status, never
+# continue-on-error). Promotion to a required check is an explicit follow-up
+# decision. Refs #820.
+name: Home Matrix
+
+on:  # yamllint disable-line rule:truthy
+  pull_request:
+    branches: [dev, 'release/**', main]
+    paths:
+      - flake.nix
+      - flake.lock
+      - nix/**
+      - .github/workflows/home-matrix.yml
+  push:
+    branches: [dev]
+    paths:
+      - flake.nix
+      - flake.lock
+      - nix/**
+      - .github/workflows/home-matrix.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  home-aarch64-darwin:
+    name: hm checks (aarch64-darwin) + Cachix
+    runs-on: macos-latest
+    timeout-minutes: 45
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+
+      - name: Install Nix (upstream CppNix)
+        uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3  # v31.10.6
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+            accept-flake-config = true
+
+      - name: Configure Cachix
+        uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71  # v17
+        with:
+          name: ${{ vars.CACHIX_CACHE }}
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
+      - name: Build hm-minimal + hm-full checks
+        run: |
+          set -euo pipefail
+          nix build \
+            .#checks.aarch64-darwin.hm-minimal \
+            .#checks.aarch64-darwin.hm-full \
+            -L --out-link result-hm
+
+      - name: Push closures to Cachix (belt and braces)
+        run: |
+          set -euo pipefail
+          nix path-info -r ./result-hm* | cachix push "${{ vars.CACHIX_CACHE }}"
+
+  home-aarch64-linux:
+    name: hm checks (aarch64-linux) + Cachix
+    runs-on: ubuntu-24.04-arm
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+
+      - name: Install Nix (upstream CppNix)
+        uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3  # v31.10.6
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+            accept-flake-config = true
+
+      - name: Configure Cachix
+        uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71  # v17
+        with:
+          name: ${{ vars.CACHIX_CACHE }}
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
+      - name: Build hm-minimal + hm-full checks
+        run: |
+          set -euo pipefail
+          nix build \
+            .#checks.aarch64-linux.hm-minimal \
+            .#checks.aarch64-linux.hm-full \
+            -L --out-link result-hm
+
+      - name: Push closures to Cachix (belt and braces)
+        run: |
+          set -euo pipefail
+          nix path-info -r ./result-hm* | cachix push "${{ vars.CACHIX_CACHE }}"

--- a/.github/workflows/update-nixpkgs-unstable.yml
+++ b/.github/workflows/update-nixpkgs-unstable.yml
@@ -1,0 +1,75 @@
+# Scheduled bump of the nixpkgs-unstable flake input.
+#
+# The fastMovers overlay (uv, gh, claude-code) tracks nixpkgs-unstable, so the
+# only thing standing between us and a fresh claude-code is this lock pin
+# (ADR-home-environment-modules rejects third-party claude-code flakes). This
+# workflow refreshes the pin weekly on a chore branch and opens a PR to dev —
+# the full CI pipeline on that PR is the merge gate.
+#
+# Refs #817.
+name: Update nixpkgs-unstable
+
+on:
+  schedule:
+    # Mondays 05:00 UTC — lands before the work week, CI gates the merge.
+    - cron: "0 5 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  bump:
+    name: Bump nixpkgs-unstable lock
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - name: Generate a token
+        id: generate-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3
+        with:
+          client-id: ${{ secrets.COMMIT_APP_CLIENT_ID }}
+          private-key: ${{ secrets.COMMIT_APP_PRIVATE_KEY }}
+
+      - name: Checkout dev
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          ref: dev
+          token: ${{ steps.generate-token.outputs.token }}
+
+      - name: Install Nix (upstream CppNix)
+        uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3  # v31.10.6
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+            accept-flake-config = true
+
+      - name: Update the nixpkgs-unstable input
+        run: nix flake update nixpkgs-unstable
+
+      - name: Open PR if the lock changed
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          if git diff --quiet flake.lock; then
+            echo "flake.lock unchanged — nothing to do."
+            exit 0
+          fi
+          branch="chore/update-nixpkgs-unstable"
+          git config user.name "vigos-commit-app[bot]"
+          git config user.email "vigos-commit-app[bot]@users.noreply.github.com"
+          git switch -c "$branch"
+          git add flake.lock
+          git commit -m "chore(nix): bump nixpkgs-unstable (fast-movers refresh)"
+          git push --force origin "$branch"
+          # Reuse an open PR for the branch if one exists; otherwise create it.
+          if ! gh pr list --head "$branch" --base dev --state open --json number --jq '.[0].number' | grep -q .; then
+            gh pr create --base dev --head "$branch" \
+              --title "chore(nix): bump nixpkgs-unstable (fast-movers refresh)" \
+              --body "Scheduled refresh of the nixpkgs-unstable pin (uv, gh, claude-code via the fastMovers overlay). Full CI on this PR is the merge gate.
+
+Refs: #817"
+          fi

--- a/.github/workflows/update-nixpkgs-unstable.yml
+++ b/.github/workflows/update-nixpkgs-unstable.yml
@@ -9,7 +9,7 @@
 # Refs #817.
 name: Update nixpkgs-unstable
 
-on:
+on:  # yamllint disable-line rule:truthy
   schedule:
     # Mondays 05:00 UTC — lands before the work week, CI gates the merge.
     - cron: "0 5 * * 1"
@@ -67,9 +67,8 @@ jobs:
           git push --force origin "$branch"
           # Reuse an open PR for the branch if one exists; otherwise create it.
           if ! gh pr list --head "$branch" --base dev --state open --json number --jq '.[0].number' | grep -q .; then
+            body="$(printf 'Scheduled refresh of the nixpkgs-unstable pin (uv, gh, claude-code via the fastMovers overlay). Full CI on this PR is the merge gate.\n\nRefs: #817\n')"
             gh pr create --base dev --head "$branch" \
               --title "chore(nix): bump nixpkgs-unstable (fast-movers refresh)" \
-              --body "Scheduled refresh of the nixpkgs-unstable pin (uv, gh, claude-code via the fastMovers overlay). Full CI on this PR is the merge gate.
-
-Refs: #817"
+              --body "$body"
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **vigos.multiplexer, vigos.cli, vigos.direnv modules** ([#821](https://github.com/vig-os/devcontainer/issues/821))
   - tmux org defaults (vi keys, sane scrollback), modern-unix config (bat/eza/fzf/ripgrep/fd — configuration only, packages stay in vigos.packages), direnv + nix-direnv.
 
+- **vigos.git module** ([#821](https://github.com/vig-os/devcontainer/issues/821))
+  - git + delta, gh (ssh protocol), lazygit; identity and per-user-x-host SSH signing are null-default options — nothing is written unless set, so fresh hosts never fail their first commit.
+
 ### Changed
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **vigos.shell module** ([#821](https://github.com/vig-os/devcontainer/issues/821))
   - Bash + zsh, starship, atuin, zoxide under one enable flag; opt-in secretsEnv hook exporting ~/.config/vigos/secrets/<NAME> per the ADR credentials interface.
 
+- **vigos.multiplexer, vigos.cli, vigos.direnv modules** ([#821](https://github.com/vig-os/devcontainer/issues/821))
+  - tmux org defaults (vi keys, sane scrollback), modern-unix config (bat/eza/fzf/ripgrep/fd — configuration only, packages stay in vigos.packages), direnv + nix-direnv.
+
 ### Changed
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Home environment docs** ([#825](https://github.com/vig-os/devcontainer/issues/825), [#826](https://github.com/vig-os/devcontainer/issues/826))
   - docs/home/: bootstrap guide (installer, macOS trusted-users trap, first activation), override cookbook, rollback table, best-effort Intel meaning, credential-hygiene runbook.
 
+- **CLAUDE.md hierarchy templates** ([#828](https://github.com/vig-os/devcontainer/issues/828))
+  - docs/home/claude-md/: user-global, workspace-root, and workspace layer templates + the directory-layout convention that makes the cascade work. Guidelines, not enforcement.
+
 ### Changed
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Home Matrix CI workflow** ([#820](https://github.com/vig-os/devcontainer/issues/820))
   - Builds the ci homeConfigurations on aarch64-darwin (macos-latest) and aarch64-linux and pushes closures to Cachix; separate non-required workflow (fail-soft by status).
 
+- **vigos.shell module** ([#821](https://github.com/vig-os/devcontainer/issues/821))
+  - Bash + zsh, starship, atuin, zoxide under one enable flag; opt-in secretsEnv hook exporting ~/.config/vigos/secrets/<NAME> per the ADR credentials interface.
+
 ### Changed
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Scheduled nixpkgs-unstable lock bump** ([#817](https://github.com/vig-os/devcontainer/issues/817))
   - Weekly workflow refreshing the fast-movers pin (uv, gh, claude-code) via a chore PR to dev, gated by full CI.
 
+- **vigos.* home module set + homeConfigurations matrix** ([#818](https://github.com/vig-os/devcontainer/issues/818), [#819](https://github.com/vig-os/devcontainer/issues/819))
+  - `homeManagerModules.{default,packages,shell,multiplexer,cli,direnv,git}` exported as path modules (+ `homeModules` alias); `home-manager` flake input (release-26.05, nixpkgs follows); `ci-{minimal,full}` homeConfigurations across 4 systems built as Tier-0 `hm-*` checks (x86_64-darwin eval-only).
+
 - **Home Matrix CI workflow** ([#820](https://github.com/vig-os/devcontainer/issues/820))
   - Builds the ci homeConfigurations on aarch64-darwin (macos-latest) and aarch64-linux and pushes closures to Cachix; separate non-required workflow (fail-soft by status).
 
@@ -42,7 +45,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+#### Modules
+
+- **homeManagerModules.default is now the umbrella** importing every `vigos.*` module, each disabled by default ([#818](https://github.com/vig-os/devcontainer/issues/818)); existing imports keep working unchanged.
+
 ### Deprecated
+
+#### Modules
+
+- **`programs.vigos-devtools.enable`** → `vigos.packages.enable` ([#818](https://github.com/vig-os/devcontainer/issues/818)); a `mkRenamedOptionModule` shim keeps the old option working for one release (docs/NIX.md policy).
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `docs/NIX.md`: modules ride the existing release train (consumers pin tags), `mkRenamedOptionModule` deprecation shims, dogfood-canary exception, and the `#### Modules` changelog sub-heading convention.
   - Workspace scaffold `vigos.url` float is now documented as deliberate, with the pin recipe.
 
+- **Scheduled nixpkgs-unstable lock bump** ([#817](https://github.com/vig-os/devcontainer/issues/817))
+  - Weekly workflow refreshing the fast-movers pin (uv, gh, claude-code) via a chore PR to dev, gated by full CI.
+
 ### Changed
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **templates.personal + homeConfigurations.demo** ([#827](https://github.com/vig-os/devcontainer/issues/827))
   - `nix flake init -t github:vig-os/devcontainer#personal` scaffolds a personal home-manager flake on the vigos.* modules; `demo` is the full-profile reference configuration.
 
+- **Home environment docs** ([#825](https://github.com/vig-os/devcontainer/issues/825), [#826](https://github.com/vig-os/devcontainer/issues/826))
+  - docs/home/: bootstrap guide (installer, macOS trusted-users trap, first activation), override cookbook, rollback table, best-effort Intel meaning, credential-hygiene runbook.
+
 ### Changed
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **ADR: terminal home environment as devkit home-manager modules** ([#815](https://github.com/vig-os/devcontainer/issues/815))
   - Accepted `docs/rfcs/ADR-home-environment-modules.md`: parameterized `vigos.*` home-manager modules as a second product of this repo (epic [#814](https://github.com/vig-os/devcontainer/issues/814)).
 
+- **Home-manager module release/versioning policy** ([#816](https://github.com/vig-os/devcontainer/issues/816))
+  - `docs/NIX.md`: modules ride the existing release train (consumers pin tags), `mkRenamedOptionModule` deprecation shims, dogfood-canary exception, and the `#### Modules` changelog sub-heading convention.
+  - Workspace scaffold `vigos.url` float is now documented as deliberate, with the pin recipe.
+
 ### Changed
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **vigos.git module** ([#821](https://github.com/vig-os/devcontainer/issues/821))
   - git + delta, gh (ssh protocol), lazygit; identity and per-user-x-host SSH signing are null-default options — nothing is written unless set, so fresh hosts never fail their first commit.
 
+- **templates.personal + homeConfigurations.demo** ([#827](https://github.com/vig-os/devcontainer/issues/827))
+  - `nix flake init -t github:vig-os/devcontainer#personal` scaffolds a personal home-manager flake on the vigos.* modules; `demo` is the full-profile reference configuration.
+
 ### Changed
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **ADR: terminal home environment as devkit home-manager modules** ([#815](https://github.com/vig-os/devcontainer/issues/815))
+  - Accepted `docs/rfcs/ADR-home-environment-modules.md`: parameterized `vigos.*` home-manager modules as a second product of this repo (epic [#814](https://github.com/vig-os/devcontainer/issues/814)).
+
 ### Changed
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Scheduled nixpkgs-unstable lock bump** ([#817](https://github.com/vig-os/devcontainer/issues/817))
   - Weekly workflow refreshing the fast-movers pin (uv, gh, claude-code) via a chore PR to dev, gated by full CI.
 
+- **Home Matrix CI workflow** ([#820](https://github.com/vig-os/devcontainer/issues/820))
+  - Builds the ci homeConfigurations on aarch64-darwin (macos-latest) and aarch64-linux and pushes closures to Cachix; separate non-required workflow (fail-soft by status).
+
 ### Changed
 
 ### Deprecated

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -28,6 +28,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **vigos.multiplexer, vigos.cli, vigos.direnv modules** ([#821](https://github.com/vig-os/devcontainer/issues/821))
   - tmux org defaults (vi keys, sane scrollback), modern-unix config (bat/eza/fzf/ripgrep/fd — configuration only, packages stay in vigos.packages), direnv + nix-direnv.
 
+- **vigos.git module** ([#821](https://github.com/vig-os/devcontainer/issues/821))
+  - git + delta, gh (ssh protocol), lazygit; identity and per-user-x-host SSH signing are null-default options — nothing is written unless set, so fresh hosts never fail their first commit.
+
 ### Changed
 
 ### Deprecated

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -25,6 +25,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **vigos.shell module** ([#821](https://github.com/vig-os/devcontainer/issues/821))
   - Bash + zsh, starship, atuin, zoxide under one enable flag; opt-in secretsEnv hook exporting ~/.config/vigos/secrets/<NAME> per the ADR credentials interface.
 
+- **vigos.multiplexer, vigos.cli, vigos.direnv modules** ([#821](https://github.com/vig-os/devcontainer/issues/821))
+  - tmux org defaults (vi keys, sane scrollback), modern-unix config (bat/eza/fzf/ripgrep/fd — configuration only, packages stay in vigos.packages), direnv + nix-direnv.
+
 ### Changed
 
 ### Deprecated

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -37,6 +37,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Home environment docs** ([#825](https://github.com/vig-os/devcontainer/issues/825), [#826](https://github.com/vig-os/devcontainer/issues/826))
   - docs/home/: bootstrap guide (installer, macOS trusted-users trap, first activation), override cookbook, rollback table, best-effort Intel meaning, credential-hygiene runbook.
 
+- **CLAUDE.md hierarchy templates** ([#828](https://github.com/vig-os/devcontainer/issues/828))
+  - docs/home/claude-md/: user-global, workspace-root, and workspace layer templates + the directory-layout convention that makes the cascade work. Guidelines, not enforcement.
+
 ### Changed
 
 ### Deprecated

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Home Matrix CI workflow** ([#820](https://github.com/vig-os/devcontainer/issues/820))
   - Builds the ci homeConfigurations on aarch64-darwin (macos-latest) and aarch64-linux and pushes closures to Cachix; separate non-required workflow (fail-soft by status).
 
+- **vigos.shell module** ([#821](https://github.com/vig-os/devcontainer/issues/821))
+  - Bash + zsh, starship, atuin, zoxide under one enable flag; opt-in secretsEnv hook exporting ~/.config/vigos/secrets/<NAME> per the ADR credentials interface.
+
 ### Changed
 
 ### Deprecated

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Scheduled nixpkgs-unstable lock bump** ([#817](https://github.com/vig-os/devcontainer/issues/817))
   - Weekly workflow refreshing the fast-movers pin (uv, gh, claude-code) via a chore PR to dev, gated by full CI.
 
+- **vigos.* home module set + homeConfigurations matrix** ([#818](https://github.com/vig-os/devcontainer/issues/818), [#819](https://github.com/vig-os/devcontainer/issues/819))
+  - `homeManagerModules.{default,packages,shell,multiplexer,cli,direnv,git}` exported as path modules (+ `homeModules` alias); `home-manager` flake input (release-26.05, nixpkgs follows); `ci-{minimal,full}` homeConfigurations across 4 systems built as Tier-0 `hm-*` checks (x86_64-darwin eval-only).
+
 - **Home Matrix CI workflow** ([#820](https://github.com/vig-os/devcontainer/issues/820))
   - Builds the ci homeConfigurations on aarch64-darwin (macos-latest) and aarch64-linux and pushes closures to Cachix; separate non-required workflow (fail-soft by status).
 
@@ -42,7 +45,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+#### Modules
+
+- **homeManagerModules.default is now the umbrella** importing every `vigos.*` module, each disabled by default ([#818](https://github.com/vig-os/devcontainer/issues/818)); existing imports keep working unchanged.
+
 ### Deprecated
+
+#### Modules
+
+- **`programs.vigos-devtools.enable`** → `vigos.packages.enable` ([#818](https://github.com/vig-os/devcontainer/issues/818)); a `mkRenamedOptionModule` shim keeps the old option working for one release (docs/NIX.md policy).
 
 ### Removed
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `docs/NIX.md`: modules ride the existing release train (consumers pin tags), `mkRenamedOptionModule` deprecation shims, dogfood-canary exception, and the `#### Modules` changelog sub-heading convention.
   - Workspace scaffold `vigos.url` float is now documented as deliberate, with the pin recipe.
 
+- **Scheduled nixpkgs-unstable lock bump** ([#817](https://github.com/vig-os/devcontainer/issues/817))
+  - Weekly workflow refreshing the fast-movers pin (uv, gh, claude-code) via a chore PR to dev, gated by full CI.
+
 ### Changed
 
 ### Deprecated

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -34,6 +34,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **templates.personal + homeConfigurations.demo** ([#827](https://github.com/vig-os/devcontainer/issues/827))
   - `nix flake init -t github:vig-os/devcontainer#personal` scaffolds a personal home-manager flake on the vigos.* modules; `demo` is the full-profile reference configuration.
 
+- **Home environment docs** ([#825](https://github.com/vig-os/devcontainer/issues/825), [#826](https://github.com/vig-os/devcontainer/issues/826))
+  - docs/home/: bootstrap guide (installer, macOS trusted-users trap, first activation), override cookbook, rollback table, best-effort Intel meaning, credential-hygiene runbook.
+
 ### Changed
 
 ### Deprecated

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **ADR: terminal home environment as devkit home-manager modules** ([#815](https://github.com/vig-os/devcontainer/issues/815))
   - Accepted `docs/rfcs/ADR-home-environment-modules.md`: parameterized `vigos.*` home-manager modules as a second product of this repo (epic [#814](https://github.com/vig-os/devcontainer/issues/814)).
 
+- **Home-manager module release/versioning policy** ([#816](https://github.com/vig-os/devcontainer/issues/816))
+  - `docs/NIX.md`: modules ride the existing release train (consumers pin tags), `mkRenamedOptionModule` deprecation shims, dogfood-canary exception, and the `#### Modules` changelog sub-heading convention.
+  - Workspace scaffold `vigos.url` float is now documented as deliberate, with the pin recipe.
+
 ### Changed
 
 ### Deprecated

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -31,6 +31,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **vigos.git module** ([#821](https://github.com/vig-os/devcontainer/issues/821))
   - git + delta, gh (ssh protocol), lazygit; identity and per-user-x-host SSH signing are null-default options — nothing is written unless set, so fresh hosts never fail their first commit.
 
+- **templates.personal + homeConfigurations.demo** ([#827](https://github.com/vig-os/devcontainer/issues/827))
+  - `nix flake init -t github:vig-os/devcontainer#personal` scaffolds a personal home-manager flake on the vigos.* modules; `demo` is the full-profile reference configuration.
+
 ### Changed
 
 ### Deprecated

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **ADR: terminal home environment as devkit home-manager modules** ([#815](https://github.com/vig-os/devcontainer/issues/815))
+  - Accepted `docs/rfcs/ADR-home-environment-modules.md`: parameterized `vigos.*` home-manager modules as a second product of this repo (epic [#814](https://github.com/vig-os/devcontainer/issues/814)).
+
 ### Changed
 
 ### Deprecated

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Scheduled nixpkgs-unstable lock bump** ([#817](https://github.com/vig-os/devcontainer/issues/817))
   - Weekly workflow refreshing the fast-movers pin (uv, gh, claude-code) via a chore PR to dev, gated by full CI.
 
+- **Home Matrix CI workflow** ([#820](https://github.com/vig-os/devcontainer/issues/820))
+  - Builds the ci homeConfigurations on aarch64-darwin (macos-latest) and aarch64-linux and pushes closures to Cachix; separate non-required workflow (fail-soft by status).
+
 ### Changed
 
 ### Deprecated

--- a/assets/workspace/flake.nix
+++ b/assets/workspace/flake.nix
@@ -6,6 +6,12 @@
   # files. To update: `nix flake update vigos`.
   inputs = {
     # The shared vigOS toolchain (single source of truth).
+    # This scaffold deliberately FLOATS on the default branch so a fresh
+    # project works before its first pin. Once you depend on stability
+    # (especially the vigos.* home-manager module options), pin a release
+    # tag instead and bump deliberately:
+    #   vigos.url = "github:vig-os/devcontainer?ref=<tag>";
+    # Policy: docs/NIX.md "Home-manager modules - versioning & release policy".
     vigos.url = "github:vig-os/devcontainer";
     # Follow vigos's pinned nixpkgs + flake-utils so your tools match the
     # toolchain exactly (one resolved nixpkgs, no drift).

--- a/docs/NIX.md
+++ b/docs/NIX.md
@@ -67,6 +67,32 @@ asserting it exits 0. The test list is generated *from* the SSoT, so it can neve
 drift from the tool list it guards. It is skipped automatically when `nix` is not
 on `PATH` (e.g. the podman image CI lane).
 
+## Home-manager modules — versioning & release policy
+
+The `vigos.*` home-manager modules ([ADR](rfcs/ADR-home-environment-modules.md),
+epic #814) are a **second product** of this flake with a consumer-facing API
+(their options). Policy:
+
+- **One release train.** Modules ship with the repo's existing tagged releases —
+  there is no separate module release cycle. Consumers pin a tag:
+  `vigos.url = "github:vig-os/devcontainer?ref=<tag>";` and bump deliberately
+  (`nix flake update vigos`). Tracking `main`/`dev` is not a documented
+  consumption mode.
+- **Scaffold exception.** The workspace scaffold (`assets/workspace/flake.nix`)
+  deliberately floats on the default branch so freshly scaffolded projects work
+  before their first pin; the comment there points consumers at this policy for
+  pinning once they depend on module stability.
+- **Dogfood-canary exception.** The maintainer's personal configuration tracks
+  `dev` during a module wave's dogfood phase (pre-release canary); the pin-tags
+  policy applies to everyone else, and to it once the first module-bearing tag
+  ships.
+- **Deprecation.** Option renames keep a `lib.mkRenamedOptionModule` shim for
+  one release and get a changelog entry. Removals are announced one release
+  ahead.
+- **Changelog.** Module-facing changes are grouped under a `#### Modules`
+  sub-heading inside the relevant Keep-a-Changelog category of `## Unreleased`,
+  so consumers can scan API changes without reading image/CI noise.
+
 ## Local dev services (`mkProjectServices`)
 
 [ADR-nix-devenv-strategy](rfcs/ADR-nix-devenv-strategy.md) (#794) rejects

--- a/docs/home/BOOTSTRAP.md
+++ b/docs/home/BOOTSTRAP.md
@@ -1,0 +1,65 @@
+# Home environment — bootstrap
+
+The vigOS terminal home environment ships as home-manager modules from this
+repo (`vigos.*`, see the [ADR](../rfcs/ADR-home-environment-modules.md)).
+Everything here is **opt-in**: the devcontainer and per-project dev-shells
+work without any of it.
+
+## 1. Install Nix
+
+Use the [Determinate Systems installer](https://install.determinate.systems)
+(flakes enabled by default, clean uninstall, survives macOS upgrades):
+
+```bash
+curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install
+```
+
+## 2. macOS only: trust the binary caches
+
+On a multi-user install, cache settings in `~/.config/nix/nix.conf` are
+**silently ignored** unless you are a trusted user — everything then builds
+from source and Nix "feels broken". Add yourself in the **system**
+`/etc/nix/nix.conf`:
+
+```
+trusted-users = root <your-username>
+```
+
+then restart the daemon (`sudo launchctl kickstart -k system/org.nixos.nix-daemon`).
+The flake's `nixConfig` carries the `vig-os` Cachix substituter; with
+trusted-user status, `accept-flake-config` makes it effective.
+
+## 3. Scaffold your personal flake
+
+```bash
+mkdir -p ~/my-home && cd ~/my-home
+nix flake init -t github:vig-os/devcontainer#personal
+$EDITOR flake.nix   # username, homeDirectory, system, git identity
+```
+
+## 4. First activation
+
+Home-manager refuses to overwrite dotfiles it does not manage. On a machine
+with an existing `~/.bashrc` / `~/.zshrc` / `~/.gitconfig`, let it back them
+up:
+
+```bash
+nix run home-manager -- switch --flake .#me -b backup
+```
+
+Your old files land next to the originals as `*.backup`; merge anything you
+want to keep into your flake (see the [cookbook](COOKBOOK.md)), then delete
+the backups. Afterwards, plain `home-manager switch --flake .#me`.
+
+## 5. One home-manager mode per user per host
+
+Centrally-managed (the NixOS-module route on org servers) and standalone
+home-manager share activation state and must **never** be mixed for the same
+user on one machine. Different users on one host may differ. On org servers
+your home environment is managed for you if you opted in — do not run
+standalone `home-manager switch` there.
+
+## Uninstall
+
+`home-manager uninstall` removes the environment (your `*.backup` files
+remain); the Determinate installer ships `/nix/nix-installer uninstall`.

--- a/docs/home/COOKBOOK.md
+++ b/docs/home/COOKBOOK.md
@@ -1,0 +1,30 @@
+# Home environment — override cookbook
+
+Org defaults are `lib.mkDefault`: **a bare assignment in your flake wins.**
+
+```nix
+{
+  # Override a default
+  programs.tmux.keyMode = "emacs";
+
+  # Disable a whole module you don't want
+  vigos.multiplexer.enable = false;   # keep your own tmux.conf
+
+  # Append rather than replace where the underlying option supports it
+  programs.tmux.extraConfig = ''
+    bind r source-file ~/.config/tmux/tmux.conf
+  '';
+
+  # Force a value against a non-default org setting (rare; check why first)
+  programs.gh.settings.git_protocol = lib.mkForce "https";
+}
+```
+
+Keeping your own dotfile for a tool entirely: disable the module
+(`vigos.<name>.enable = false`) — home-manager then leaves the file alone —
+or manage the file yourself via `xdg.configFile`/`home.file`, which always
+beats module-written content on conflict errors you resolve explicitly.
+
+Per-project toolchains are **not** this layer: repos carry their own
+dev-shell (`.envrc` + `mkProjectShell`), which fronts your PATH inside the
+project directory and evaporates outside it.

--- a/docs/home/CREDENTIALS.md
+++ b/docs/home/CREDENTIALS.md
@@ -1,0 +1,52 @@
+# Credential hygiene
+
+Persistent remote sessions (tmux surviving SSH disconnects, long agent runs)
+require **resident** per-user credentials on servers — SSH agent forwarding
+dies with the connection and is hijackable on shared hosts. Residency is
+safe only with **scoped, revocable** credentials.
+
+## The interface
+
+One file per secret, named like the target environment variable:
+
+```
+~/.config/vigos/secrets/<NAME>     # mode 0600, NAME =~ [A-Z_][A-Z0-9_]*
+```
+
+Opt in via `vigos.shell.secretsEnv.enable = true;` — each file is exported
+as an env var at shell startup (profile + rc, idempotent; trailing newline
+stripped). How the files get there is up to the machine: sops-nix on org
+servers, hand-placed on laptops. Interactive logins (`gh auth login`,
+`claude` `/login`) keep working if you never adopt this.
+
+## What goes where
+
+| Credential | Form | Notes |
+|---|---|---|
+| GitHub API / gh | **Fine-grained PAT**, scoped repos, expiring | `GH_TOKEN`; never a classic token |
+| Claude Code | `claude setup-token` output | `CLAUDE_CODE_OAUTH_TOKEN`; revocable from the console |
+| Cachix | — | Not a per-user credential: pulls are anonymous, pushes are CI's job |
+| SSH keys (auth **and** signing) | **Minted per user × host, never copied** | Register each with GitHub individually — a signature then identifies the machine it was made on; a compromise revokes one host, not your identity |
+
+Git signing activates only when you set `vigos.git.signingKeyPath` — mint
+the key first:
+
+```bash
+ssh-keygen -t ed25519 -f ~/.ssh/id_ed25519_signing -C "$(whoami)@$(hostname)"
+# add the .pub on GitHub as a SIGNING key, then:
+#   vigos.git.signingKeyPath = "~/.ssh/id_ed25519_signing.pub";
+```
+
+## Rotation / offboarding
+
+Expiry does the rotating for PATs — renew on the provider, replace the file.
+Offboarding = revoke at the provider (GitHub token/keys pages, Anthropic
+console); resident copies become dead bytes. Audit what a host holds with
+`ls -l ~/.config/vigos/secrets/`.
+
+## Honest threat model
+
+Anything readable by your uid is readable by every process running as your
+uid — **including an agent**. Files vs env vars vs encryption-at-rest do not
+change this. The mitigations are credential scoping (above) and the working
+agreement that autonomous agent runs happen inside the container.

--- a/docs/home/ROLLBACK.md
+++ b/docs/home/ROLLBACK.md
@@ -1,0 +1,21 @@
+# Home environment — rollback
+
+| Surface | Roll back with |
+|---|---|
+| Standalone home-manager (laptops) | `home-manager generations` → run the previous generation's `activate` script |
+| Org NixOS servers | `sudo nixos-rebuild --rollback switch` (rolls the whole system, home env included) — coordinate, it is shared |
+| Devcontainer | pin the previous image tag in `.vig-os` (`DEVCONTAINER_VERSION=`) |
+| Module updates via your flake | `nix flake lock --override-input vigos github:vig-os/devcontainer?ref=<previous-tag>` then switch |
+
+A broken shell after activation: log in with `bash --noprofile --norc`, run
+the previous generation's `activate`, then debug at leisure. The
+devcontainer is always the working fallback environment.
+
+## x86_64-darwin (Intel Mac) — operational meaning of "best-effort"
+
+The Intel-Mac tier is **eval-checked only**: CI never builds or caches its
+closures, and nixpkgs 26.05 is the last release supporting the platform
+(support ends 2026-12-31). If your build breaks, the supported fallback is
+the amd64 devcontainer image (via podman machine) or the org servers over
+SSH, until the pin moves past 26.05 — after which the laptop tier for this
+machine is retired.

--- a/docs/home/claude-md/00-root.md
+++ b/docs/home/claude-md/00-root.md
@@ -1,0 +1,22 @@
+# CLAUDE.md — workspace root (template)
+
+<!-- Copy to ~/<workspace-root>/CLAUDE.md and adapt. -->
+
+This directory holds independent project workspaces, each a collection of
+git repos cloned side by side. Do real work inside a repo, never at a
+workspace root.
+
+## Workspace map
+
+| Dir | What it is | Confidentiality |
+|-----|------------|-----------------|
+| `<workspace-a>` | <description> | <public/private — default-deny external sharing> |
+
+## Cross-cutting rules
+
+- Confidentiality is default-deny: nothing leaves this machine (pastes,
+  uploads, third-party APIs) without explicit authorization in the request.
+- Git identity is managed by `~/.gitconfig` includeIf mappings — never
+  hand-set an author or email.
+- Engineering conventions (commit format, TDD, traceability) live in each
+  org's meta/standards repo; the repo-level CLAUDE.md links them.

--- a/docs/home/claude-md/10-workspace.md
+++ b/docs/home/claude-md/10-workspace.md
@@ -1,0 +1,18 @@
+# CLAUDE.md — <workspace> (template)
+
+<!-- Copy to ~/<workspace-root>/<workspace>/CLAUDE.md and adapt. -->
+
+`<workspace>` is not a single repo: each subdirectory is an independent git
+repo with its own CI, issues, and CLAUDE.md — the more specific file wins.
+
+## Subprojects
+
+| Dir | Type | How to work in it |
+|-----|------|-------------------|
+| `<repo>` | <stack> | <entry commands, e.g. `just` to list recipes> |
+
+## Conventions
+
+Shared engineering conventions are defined one level up and in the org's
+standards repo — do not restate them here; link them. Add only what is
+specific to this workspace (issue prefixes, release cadence, environments).

--- a/docs/home/claude-md/20-user-global.md
+++ b/docs/home/claude-md/20-user-global.md
@@ -1,0 +1,12 @@
+# Global preferences (template: ~/.claude/CLAUDE.md)
+
+## Commits
+
+- **Never name an AI in git history.** No Co-Authored-By trailers naming an
+  AI, never an AI as author or committer. This is the single source of truth
+  for the rule; repos may enforce it with hooks but should not restate it.
+
+## Working style
+
+- Prefer minimal diffs; ask before out-of-scope changes.
+- Run the full local hook suite green before any push.

--- a/docs/home/claude-md/README.md
+++ b/docs/home/claude-md/README.md
@@ -1,0 +1,32 @@
+# CLAUDE.md hierarchy — templates
+
+Claude Code loads every `CLAUDE.md` from the filesystem root down to the
+working directory; **the most specific file wins on conflict**. These
+templates layer org-wide practice into that cascade. They are **guidelines,
+not enforcement** — copy, adapt, delete freely.
+
+## The layout convention that makes this work
+
+The workspace layer only exists if repos live *under* a workspace directory:
+
+```
+~/Documents/                  <- workspace root: 00-root.md
+  <workspace>/                <- one per org/project: 10-workspace.md
+    <repo>/                   <- the repo's own CLAUDE.md (in git)
+```
+
+If you keep a flat `~/code/`, skip the workspace layer — the user-global and
+repo layers still apply.
+
+| Template | Copy to | Layer |
+|---|---|---|
+| `20-user-global.md` | `~/.claude/CLAUDE.md` | every session |
+| `00-root.md` | `~/<workspace-root>/CLAUDE.md` | all workspaces |
+| `10-workspace.md` | `~/<workspace-root>/<workspace>/CLAUDE.md` | one workspace |
+
+Repo-level files are not templated here — each repo owns its own (this
+repo's `CLAUDE.md` is a live example).
+
+These files live outside any git repo. Version them in your personal home
+flake (e.g. `home.file` entries) or a dotfiles repo — the optional
+management option lands with `vigos.claude` (#823).

--- a/docs/rfcs/ADR-home-environment-modules.md
+++ b/docs/rfcs/ADR-home-environment-modules.md
@@ -1,0 +1,381 @@
+---
+rfc: ADR-home-environment-modules
+date: 2026-07-03
+title: Terminal home environment as devkit home-manager modules
+status: accepted
+authors:
+  - Carlos Vigo (c-vigo)
+---
+
+# ADR: Team terminal home environment — artifact shape, placement, and policies
+
+**Decision (TL;DR):** Ship the org's terminal-based, agent-friendly *user*
+environment (shell, tmux + sesh, editor, git/gh tooling, `~/.claude`
+conventions) as **parameterized home-manager modules exported from this repo**
+(`homeManagerModules.*`, option namespace `vigos.*`), consumed by (a) the
+private NixOS server fleet via home-manager's NixOS module, and (b) personal
+machines via standalone home-manager — **not** by the devcontainer image, which
+keeps its current lean bootstrap. The modules are a **second product** of this
+repo with their own CI matrix (incl. an `aarch64-darwin` build + Cachix push),
+doc surface, and API/versioning policy, but they share the repo's `devTools`
+SSoT, lockfile, and release train. The only new flake input is `home-manager`:
+**no nixvim** (the editor module uses `programs.neovim` + nixpkgs `vimPlugins`)
+and **no third-party claude-code flake** (the existing `fastMovers` overlay on
+`nixpkgs-unstable` suffices, kept fresh by a scheduled lock bump). Everything is
+strictly opt-in: per-module `enable` flags, `lib.mkDefault` on every value, and
+an optionality invariant — nothing work-required may depend on the home
+environment.
+
+## Problem Statement
+
+The org wants to offer a consistent, terminal-first development environment —
+including agentic tooling (Claude Code) — usable by three people across
+different surfaces: shared NixOS servers, personal laptops (one NixOS, one
+`aarch64-darwin` Mac, one `x86_64-darwin` Mac), and the existing devcontainer.
+Users must be free to adopt none, some, or all of it (direnv shell only,
+devcontainer only, or the full home environment).
+
+Today the repo delivers the *toolchain* everywhere (image, `mkProjectShell`
+dev-shells, thin package-only `homeManagerModules.default` / `nixosModules.default`
+from #777), but the *configuration* layer — what makes a machine feel like a
+ready workstation — exists only as single-user, hand-maintained personal
+configuration outside the org. This repo is the natural home for the shared
+carve-out: it is already the org toolchain SSoT, and the pending rename
+`devcontainer` → `devkit` (#781) acknowledges the widened scope.
+
+Open questions this ADR settles: artifact shape, repo placement, input policy,
+Claude Code sourcing and `~/.claude` management, platform tiers, secrets,
+sandboxing posture, and release/versioning for module consumers.
+
+### Current state, enumerated
+
+- **`flake.nix` @ `dev`** already exports `homeManagerModules.default` /
+  `nixosModules.default` (#777) — package-only wrappers over `devTools`, no
+  configuration, no options beyond `programs.vigos-devtools.enable`.
+- **Darwin evaluates but is not built:** darwin systems are in the flake's
+  systems list and dev-shells evaluate cleanly, but no CI job builds darwin
+  outputs and the Cachix cache holds no darwin closures.
+- **Claude Code** ships from the `fastMovers` overlay on `nixpkgs-unstable`
+  (`flake.nix`), which now packages Anthropic's official native binary for all
+  four arches, bumped near-daily upstream (~1–3 days behind releases; unfree,
+  hence not on cache.nixos.org, but the derivation is a trivial fetchurl of
+  the official binary — nothing to build). Freshness gaps observed locally are
+  lock-pin staleness, not nixpkgs lag.
+- **Prior art:** working single-user versions of every intended module exist
+  in the maintainer's personal configuration (bash, starship, atuin, tmux,
+  sesh standard layout, editor, gh-dash, lazygit, modern-unix CLI set, direnv,
+  managed `~/.claude` conventions) and inform the design; they are Linux-shaped
+  and unparameterized, so the port is a redesign, not a copy.
+- **Consumers:** the org's NixOS servers are configured from a private
+  infrastructure repo; two macOS colleagues want to use Nix; the devcontainer
+  image is the zero-Nix fallback for everyone.
+
+## Options Considered
+
+### Axis 1 — Artifact shape
+
+**A1 — home-manager modules with custom options (chosen).** An org flake
+exporting `homeManagerModules.*`; users/hosts import modules and override via
+the module system (`mkDefault` priorities, `mkForce` escape hatch, `extraConfig`
+passthroughs).
+
+- **Pros:** The only shape that natively covers the user layer (dotfiles,
+  editor, multiplexer, agent config) with a real defaults-plus-overrides
+  mechanism, on NixOS, macOS (standalone HM), non-NixOS Linux
+  (`targets.genericLinux`), and servers. No vendor. Composes under the existing
+  per-project layer (`mkProjectShell` + nix-direnv) without contention.
+- **Cons:** Home-manager eval overhead and error opacity for newcomers;
+  first-activation collisions with existing dotfiles (documented adoption path
+  required).
+
+**A2 — full `homeConfigurations` per user in the org repo.** Zero-boilerplate
+onboarding, but couples personal dotfiles to org CI and review. **Rejected as
+the primary artifact**; kept only as thin sugar (`homeConfigurations.demo`)
+built from the modules.
+
+**A3 — package/profile only (`nix profile install`, wrapper-manager).** Weak
+override story, imperative updates, awkward for stateful dotfiles. **Rejected.**
+
+**A4 — Flox / Devbox / devenv as the substrate.** Flox composes environments
+well but manages packages, not dotfiles, and adds a per-seat SaaS; Devbox has no
+override layering; devenv is per-project by construction (and already rejected
+as shell builder by [ADR-nix-devenv-strategy]). **Rejected.**
+
+### Axis 2 — Repo placement
+
+**B1 — this repo (chosen).** The parity argument dominates at this org size:
+one `devTools` list, one lockfile, one release train, with the modules as a
+declared second product.
+
+- **Pros:** Toolchain parity between shell, image, and home env is enforceable
+  by the existing parity-test pattern; module outputs already live here (#777);
+  the pending `devkit` rename (#781) already acknowledges the widened scope;
+  extraction later is a URL change for consumers.
+- **Cons:** Consumers of any output transitively lock all inputs; public repo
+  hosts opinionated environment defaults. Both mitigated by the input policy
+  (Axis 3) and by everything being opt-in, generic, and parameterized —
+  org-private values (identities, workspace docs, secrets) never enter this
+  repo.
+
+**B2 — separate env repo.** Cleaner consumer lock in the general case, but at 3
+users it duplicates the tool list or creates bidirectional input plumbing, and
+its main motivation (heavy inputs) is removed by Axis 3. **Rejected; revisit if
+input bloat becomes measurable.**
+
+### Axis 3 — Flake input policy
+
+**C1 — `home-manager` as the only new input (chosen).** The editor module uses
+plain `programs.neovim` with nixpkgs `vimPlugins` (incl. `claudecode-nvim`,
+packaged in both 26.05 and unstable — beware the distinct `claude-code-nvim`,
+a different upstream). A richer nixvim-based editor remains a personal-config
+concern; if colleagues want it later it becomes its own small flake.
+
+- **Pros:** Downstream `mkProjectShell` consumers lock one moderate extra input
+  instead of nixvim's large graph; no nixpkgs-branch coupling beyond what exists.
+- **Cons:** Less expressive editor module than nixvim. Accepted trade.
+
+**C2 — third-party claude-code flake (sadjow/claude-code-nix or
+ryoppippi/nix-claude-code), auto-bumped.** **Rejected.** nixpkgs-unstable now
+ships the same official native binary for all four arches within ~1–3 days as
+a trivial fetchurl (unfree, so not on cache.nixos.org — but there is nothing
+to build); the third-party inputs add a single-maintainer
+supply-chain dependency plus an extra Cachix trust root for negligible freshness
+gain. The org keeps the existing `fastMovers` overlay and adds a **scheduled
+`nix flake update nixpkgs-unstable`** (full CI as merge gate) so the pin never
+goes stale. Reconsider only if <24 h latency ever becomes a hard requirement.
+
+### Axis 4 — Devcontainer image integration
+
+**D1 — leave the image alone (chosen).** The image keeps its current baked
+`/root/.bashrc` + aliases.
+
+- **Rationale:** HM activation cannot run inside `dockerTools` builds
+  (home-manager#5258 class: activation needs a live store/profile machinery);
+  deferring activation to `onCreateCommand` adds a failure-prone startup step
+  (opposite of #718), the closure grows against documented image-size and
+  CVE-gate discipline, HM's bash module collides with the baked `.bashrc`, and
+  baking an editor config reverses the deliberate nvim isolation (#723). The
+  optionality invariant already guarantees the container never *needs* the home
+  env.
+- **Reconsider if** container ergonomics demonstrably hurt; then evaluate an
+  explicitly image-safe subset (shell/tmux only), after #639/#642.
+
+### Axis 5 — `~/.claude` management policy
+
+Verified against Claude Code behavior (native binary, npm deprecated; sandbox
+init fails on read-only store symlinks of `settings.json` —
+anthropics/claude-code#52525; atomic writes fail through multi-level symlinks —
+#15786):
+
+- **Never managed:** `~/.claude.json`, `settings.local.json` (mutable runtime
+  state: OAuth, MCP, permission grants). No symlinks of any kind — store or
+  out-of-store — anywhere under `~/.claude/`.
+- **Seeded, then user-owned:** `settings.json` via `home.activation`
+  copy-if-absent — a declarative default that Claude Code may freely rewrite.
+  Seed updates never touch an existing file; changes are announced in the
+  changelog, and re-seeding means deleting the file and re-activating.
+- **Managed (copy, not symlink):** hooks and an org CLAUDE.md *fragment*
+  (e.g. `~/.claude/vigos.md`), copied by `home.activation` and
+  checksum-overwritten on org updates with a `.bak` of local edits.
+  `mkOutOfStoreSymlink` is unusable for shipped modules (it requires a path
+  outside the consumer's store), and the top-level `~/.claude/CLAUDE.md`
+  stays user-owned because Claude Code itself writes to it (memory feature) —
+  seeding adds a single `@vigos.md` import line to it instead.
+- **Org defaults never pre-authorize:** no `defaultMode = "auto"`, no
+  permission-prompt skipping in shipped defaults (personal configs may add
+  them). Auto-update disabled via `DISABLE_AUTOUPDATER=1`, set by the home
+  modules through `home.sessionVariables` (not the user-editable seeded
+  settings.json); extending it to the dev-shell/image is a separate follow-up
+  chore outside this ADR.
+- **No home-level skills:** repos remain the skills SSoT (the existing
+  `assets/workspace/.claude/` scaffold); the home layer carries only CLAUDE.md,
+  seeded settings, and hooks.
+
+### Axis 6 — CLAUDE.md hierarchy
+
+Shipped as **templates + guidelines**, not managed files: org-parent, workspace,
+and user-level CLAUDE.md examples mirroring the root-to-cwd cascade, with the
+directory-layout convention (`~/<workspace-root>/<workspace>/<repo>`) documented
+as the assumption that makes the workspace layer work. An optional,
+**off-by-default** HM option can symlink-manage a user-declared path→file
+attrset (default empty — the seven-symlink personal pattern is not portable
+as-is).
+
+## Platform & consumer policy
+
+| Consumer | Mode | Tier |
+|----------|------|------|
+| NixOS servers (private infra repo) | HM as NixOS module, `home-manager.users.<name>`, per-user opt-in | First-class |
+| NixOS / Linux laptops | standalone HM (or NixOS module in personal flake) | First-class |
+| `aarch64-darwin` | standalone HM; CI builds + Cachix push **before first onboarding** | First-class |
+| `x86_64-darwin` | standalone HM | **Best-effort**: eval-checked only, never CI-built or cached; supported fallback is the amd64 devcontainer image; ends at nixpkgs 26.05 EOL (2026-12-31, last x86_64-darwin release) |
+| Devcontainer image | not integrated (Axis 4) | n/a |
+
+- **One HM mode per user per host:** centrally-managed (NixOS module) and
+  standalone HM must not be mixed for the same user on the same machine (shared
+  activation state clobbers); different users on one host may differ.
+- **Shell:** modules support **bash and zsh** (macOS default) via the standard
+  `enable{Bash,Zsh}Integration` toggles; no login-shell mandate.
+- **nix-darwin:** out of scope v1 (standalone HM suffices for user-level
+  config). Trigger to revisit: a Mac needs system-level management.
+- **Credentials (resident, scoped):** persistent remote sessions (tmux/sesh
+  surviving SSH disconnects) require resident per-user credentials on servers;
+  SSH agent forwarding is rejected (sockets die with the connection and are
+  hijackable on shared hosts). Devkit standardizes the *interface* only:
+  per-secret files under `~/.config/vigos/secrets/<NAME>` (mode 0600), with an
+  opt-in `vigos.shell.secretsEnv` hook exporting each as an environment
+  variable (names restricted to `[A-Z_][A-Z0-9_]*`, trailing newline
+  stripped, sourced idempotently from both profile and rc files; systemd user
+  services and non-interactive SSH commands are out of scope v1).
+  Deployment is out of scope — sops-nix is the natural backing on NixOS
+  servers; laptops hand-place files or keep OS-native flows (Keychain
+  `/login`, `gh auth login`). Tools must keep working with interactive auth
+  for users who don't adopt the convention (optionality invariant). The same
+  canonical location is what the devcontainer mounts/env-files for
+  agent-token forwarding (#546).
+- **Credential hygiene:** scoped and revocable only — fine-grained, expiring
+  GitHub PATs (never classic tokens); Claude long-lived OAuth token from
+  `claude setup-token` (console-revocable); Cachix is **not** a per-user
+  credential (pulls are anonymous, pushes are CI/system-level). **SSH keys —
+  authentication and signing alike — are minted per user × host and never
+  copied**; each is registered with the forge individually, so a commit
+  signature identifies the machine it was made on and a compromise revokes
+  one host, not an identity. Threat-model note: any same-uid process
+  (including an agent) can read resident secrets — credential scoping and the
+  container working agreement are the mitigations, not the storage location.
+  Trigger to revisit: a shared service token must reach a laptop → adopt
+  sops-nix's HM module on darwin.
+- **Sandboxing (working agreement, not a control):** interactive,
+  permission-prompted agent use is fine everywhere; autonomous /
+  `--dangerously-skip-permissions` runs happen **inside the container** (podman,
+  incl. on shared servers). This is enforceable only socially today — the `cld`
+  skip-permissions alias exists only inside the image (though the worktree
+  pipeline recipes invoke the flag directly wherever they run) and org
+  defaults pre-authorize nothing — and is therefore documented as a working
+  agreement,
+  with a bwrap wrapper module as tracked future enforcement. It must not be
+  represented as a security boundary.
+
+## Optionality invariant
+
+Adoption tiers are strictly additive, and **nothing required for work may
+depend on the home environment**: project CI, dev-shells, the devcontainer,
+pre-commit, and all `just` verbs must function for a user at tier "none".
+
+```
+none  →  direnv dev-shell  →  devcontainer  →  home environment
+```
+
+## API & release policy
+
+- **Namespace:** `vigos.*` (org-branded, rename-proof), per-concern submodules
+  (`vigos.shell`, `vigos.multiplexer`, `vigos.git`, `vigos.claude`, …), every
+  module `enable`-gated, every scalar setting written with `lib.mkDefault`,
+  `extraConfig` passthroughs on managed programs. Modules *configure*;
+  packages ship only via `homeManagerModules.packages` (no module duplicates
+  the `devTools` list), and modules resolve packages from devkit's own locked
+  nixpkgs + `overlays.default` — the #777 module's documented constraint (HM
+  under `useGlobalPkgs` cannot inject consumer overlays) — so tool versions
+  match the dev-shell and image per system. `programs.vigos-devtools`
+  migrates via `mkRenamedOptionModule`; the package-only module becomes
+  `homeManagerModules.packages`, and `homeManagerModules.default` becomes the
+  umbrella importing all `vigos.*` modules (each disabled by default), so
+  existing #777 imports keep working unchanged. Both `homeManagerModules.*`
+  and the newer-convention `homeModules.*` aliases are exported.
+- **Versioning:** modules ride the existing release train — consumers pin
+  `github:vig-os/devcontainer/<tag>` (post-#781: `devkit`) and bump
+  deliberately. No separate release cycle; no `main`/`dev` tracking is
+  documented for consumers. The shipped workspace scaffold currently floats
+  untagged on the default branch — aligning it with this policy (pin, or an
+  explicitly documented float) is part of the rollout. One exception: the
+  maintainer's personal configuration tracks `dev` during the dogfood phase
+  as the pre-release canary; the pin-tags policy applies to all other
+  consumers, and to it once the first module-bearing tag ships.
+- **Deprecation:** option renames keep a `mkRenamedOptionModule` shim for one
+  release and get a changelog entry. `CHANGELOG.md` gains a *modules*
+  subcategory under the standard Keep-a-Changelog headings, since options are a
+  consumer-facing API.
+- **CI:** flake checks build a homeConfigurations matrix — `minimal` (only
+  `vigos.shell`) and `full` (every module) for a synthetic user `ci`
+  (`/home/ci`; `/Users/ci` on darwin; pinned `stateVersion`) across
+  {x86_64-linux, aarch64-linux, aarch64-darwin}. Checks are per-system: the
+  x86_64-linux legs join the landed Tier-0 gate (#778/#779, via PR #791),
+  aarch64-linux legs run on arm runners, and the darwin legs build only in
+  the dedicated `aarch64-darwin` job that also pushes closures to Cachix. GitHub's `macos-*-intel` runners exist
+  (~until fall 2027) but are deliberately unused, consistent with the
+  best-effort Intel tier.
+
+## Migration & dogfooding
+
+The maintainer's personal configuration is the first consumer: each wave lands
+in devkit, is then imported there in place of the equivalent private config
+(plus personal parameters), with a **generation-diff acceptance bar** —
+`nvd diff` shows no package changes, *and* a recursive diff of the old vs new
+generations' `home-files` trees shows only differences enumerated in the
+wave's sub-issue (the expected-diff allowlist) — before the private copy is
+deleted:
+
+1. **Wave 1 — generic:** bash/zsh, starship, atuin, direnv, tmux, modern-unix
+   (platform-guarded: `wl-clipboard` etc. behind `stdenv.isLinux`), git/gh.
+2. **Wave 2 — claude:** the `vigos.claude` module under the Axis-5 policy,
+   plus agent runtime dependencies (node/uv for MCP servers); the devcontainer
+   consumes the canonical secrets directory (env-file/mount — compose
+   scaffolding only, the image itself stays untouched per Axis 4) as the slim
+   token-forwarding path #546 asks for.
+3. **Wave 3 — parameterization-heavy:** sesh (project list becomes an option
+   API), gh-dash (filters/paths become options), editor (`programs.neovim`,
+   no nixvim).
+
+Server-side consumption is the private infrastructure repo's change, out of
+scope here beyond keeping the modules cleanly importable.
+
+## Impact
+
+- **Beneficiaries:** server users get the environment with the machine; the
+  arm-Mac colleague gets a supported laptop path; the container and dev-shell
+  products are untouched (input growth limited to `home-manager`).
+- **Risks:** bus factor of one Nix expert — mitigated by small waves, the
+  rollback one-pager (HM generations / `nixos-rebuild --rollback` / image-tag
+  pin), copy-if-absent for fragile files, and the container as the always-on
+  fallback. Laptop-tier adoption may stay low; the same modules serving the
+  server fleet keep the work useful regardless.
+- **Docs:** a module-consumer doc set (bootstrap incl. the macOS
+  `trusted-users`/Cachix trap, override cookbook, rollback, uninstall,
+  credential-hygiene one-pager incl. rotation/offboarding runbook) is a
+  deliverable, not an afterthought; onboarding acceptance test = a colleague
+  reaches `home-manager switch` on the arm Mac with zero live help.
+
+## Decision & Recommendation
+
+Adopt A1 + B1 + C1 + D1 with the Axis-5/6 policies, platform table, optionality
+invariant, API/release policy, and wave-based migration above.
+
+### Reconsider if
+
+- Consumer lock bloat or eval time becomes measurable pain → extract the module
+  library to its own repo (URL change for consumers).
+- Claude Code freshness (<24 h) becomes a hard requirement → dedicated
+  claude-code input (prefer sadjow/claude-code-nix), still auto-update-disabled.
+- Container ergonomics demonstrably suffer → evaluate an image-safe module
+  subset (shell/tmux only), after #639/#642.
+- Colleagues ask for the full nixvim experience → separate small editor flake,
+  not a devkit input.
+- A shared secret must reach a laptop → sops-nix HM module on darwin.
+- Autonomous agent use on hosts grows → promote the bwrap wrapper from backlog
+  to track.
+
+## References
+
+- Sibling ADRs: [ADR-nix-devenv-strategy](ADR-nix-devenv-strategy.md),
+  [ADR-uv2nix-pyproject-nix](ADR-uv2nix-pyproject-nix.md).
+- In-repo: `flake.nix` (`devTools`, `fastMovers`, `mkProjectShell`,
+  `homeManagerModules`/`nixosModules` @ #777), `docs/NIX.md`,
+  `assets/workspace/`, issues #814 (epic), #545, #546, #625, #639, #642, #718, #723, #777,
+  #779 (landed via PR #791), #781, #795.
+- Upstream: nix-community/home-manager (NixOS-module per-user opt-in;
+  activation-in-OCI limitation #5258; 25.11 profile-management change),
+  nixpkgs `claude-code` (native binary, all four arches),
+  `vimPlugins.claudecode-nvim`, anthropics/claude-code#52525 / #15786
+  (symlinked-settings breakage), NixOS 26.05 release notes (last
+  x86_64-darwin release; EOL 2026-12-31), GitHub runner images
+  (macos-latest = arm64; `macos-15-intel`/`macos-26-intel` until ~fall 2027).

--- a/flake.lock
+++ b/flake.lock
@@ -77,6 +77,27 @@
         "type": "github"
       }
     },
+    "home-manager": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1782704057,
+        "narHash": "sha256-G1I1gd32F7mp9LAe1DaZ4ZL7NX5gyiKwdCMwro1Vrck=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "868d0a692de703c2de98fab61968e4e310b7c28e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "ref": "release-26.05",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1782116945,
@@ -128,6 +149,7 @@
       "inputs": {
         "flake-utils": "flake-utils",
         "git-hooks-nix": "git-hooks-nix",
+        "home-manager": "home-manager",
         "nixpkgs": "nixpkgs",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "process-compose-flake": "process-compose-flake",

--- a/flake.nix
+++ b/flake.nix
@@ -24,6 +24,12 @@
     # exactly two leaf entries. Consumed by mkProjectServices. Refs #795.
     process-compose-flake.url = "github:Platonic-Systems/process-compose-flake";
     services-flake.url = "github:juspay/services-flake";
+    # home-manager powers the vigos.* home environment — the ONLY input the
+    # module product adds (ADR-home-environment-modules axis 3). The release
+    # branch matches the nixos-26.05 pin; follows keeps one resolved nixpkgs.
+    # Refs #819.
+    home-manager.url = "github:nix-community/home-manager/release-26.05";
+    home-manager.inputs.nixpkgs.follows = "nixpkgs";
   };
 
   outputs =
@@ -36,6 +42,7 @@
       git-hooks-nix,
       process-compose-flake,
       services-flake,
+      home-manager,
     }:
     let
       # ---------------------------------------------------------------------
@@ -58,13 +65,7 @@
       # (tests/bats/test_helper.bash) resolves them from the Nix store — the
       # flake SSoT — replacing the npm (node_modules) / Debian (/usr/lib)
       # resolution that does not exist on the Nix toolchain. Refs #695.
-      batsWithLibs =
-        pkgs:
-        pkgs.bats.withLibraries (p: [
-          p.bats-support
-          p.bats-assert
-          p.bats-file
-        ]);
+      batsWithLibs = import ./nix/bats.nix;
 
       # Import nixpkgs-unstable for a given system (allowUnfree covers
       # claude-code). Evaluated once per system in the per-system `let` below and
@@ -93,6 +94,73 @@
       # No concrete system is known here, so it imports unstable inside the
       # fixpoint; the in-flake path below uses the hoisted importUnstable.
       overlay = final: prev: mkFastMoverOverlay (importUnstable final.system) final prev;
+
+      # ---------------------------------------------------------------------
+      # vigos home environment (#819): self-pkgs + the ci homeConfigurations.
+      # ---------------------------------------------------------------------
+      # pkgs for the flake's own homeConfigurations (self-pkgs): the same
+      # stable base + fast-mover overlay + allowUnfree combination as the
+      # per-system dev-shell pkgs, so claude-code and friends resolve to the
+      # very same versions across dev-shell, image, and home modules.
+      mkHomePkgs =
+        system:
+        import nixpkgs {
+          inherit system;
+          overlays = [ (mkFastMoverOverlay (importUnstable system)) ];
+          config.allowUnfree = true;
+        };
+
+      # Every system the home modules target. x86_64-darwin evaluates but is
+      # never built in CI (best-effort tier, ADR platform table).
+      hmSystems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "aarch64-darwin"
+        "x86_64-darwin"
+      ];
+
+      # The two CI profiles: minimal exercises one module, full exercises the
+      # whole option surface. Kept in lockstep with nix/home/.
+      hmProfiles = {
+        minimal = {
+          vigos.shell.enable = true;
+        };
+        full = {
+          vigos = {
+            packages.enable = true;
+            shell.enable = true;
+            multiplexer.enable = true;
+            cli.enable = true;
+            direnv.enable = true;
+            git.enable = true;
+          };
+        };
+      };
+
+      # ci-<profile>-<system> homeConfigurations: synthetic user, pinned
+      # stateVersion — schema-asserted by tests/test_flake_checks.py.
+      ciHomeConfigurations = nixpkgs.lib.listToAttrs (
+        nixpkgs.lib.concatMap (
+          system:
+          map (profile: {
+            name = "ci-${profile}-${system}";
+            value = home-manager.lib.homeManagerConfiguration {
+              pkgs = mkHomePkgs system;
+              modules = [
+                ./nix/home/default.nix
+                {
+                  home = {
+                    username = "ci";
+                    homeDirectory = if nixpkgs.lib.hasSuffix "-darwin" system then "/Users/ci" else "/home/ci";
+                    stateVersion = "26.05";
+                  };
+                }
+                hmProfiles.${profile}
+              ];
+            };
+          }) (builtins.attrNames hmProfiles)
+        ) hmSystems
+      );
 
       # ---------------------------------------------------------------------
       # devTools — the single source of truth for the toolchain.
@@ -631,6 +699,13 @@
             test "$count" -gt 0
             touch "$out"
           '';
+        }
+        # The ci homeConfigurations build as Tier-0 checks. x86_64-darwin is
+        # the eval-only best-effort tier (ADR platform table): it exists as a
+        # homeConfiguration but gets no build leg. Refs #819.
+        // pkgs.lib.optionalAttrs (system != "x86_64-darwin") {
+          hm-minimal = self.homeConfigurations."ci-minimal-${system}".activationPackage;
+          hm-full = self.homeConfigurations."ci-full-${system}".activationPackage;
         };
 
         # ------------------------------------------------------------------
@@ -1049,5 +1124,8 @@
         git = ./nix/home/git.nix;
       };
       homeModules = self.homeManagerModules;
+
+      # The ci matrix (+ demo later, #827). Built as per-system checks below.
+      homeConfigurations = ciHomeConfigurations;
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1125,7 +1125,32 @@
       };
       homeModules = self.homeManagerModules;
 
-      # The ci matrix (+ demo later, #827). Built as per-system checks below.
-      homeConfigurations = ciHomeConfigurations;
+      # The ci matrix plus `demo` — onboarding sugar built from the same
+      # modules (full profile, synthetic user). Refs #827.
+      homeConfigurations = ciHomeConfigurations // {
+        demo = home-manager.lib.homeManagerConfiguration {
+          pkgs = mkHomePkgs "x86_64-linux";
+          modules = [
+            ./nix/home/default.nix
+            {
+              home = {
+                username = "demo";
+                homeDirectory = "/home/demo";
+                stateVersion = "26.05";
+              };
+            }
+            hmProfiles.full
+          ];
+        };
+      };
+
+      # `nix flake init -t github:vig-os/devcontainer#personal` scaffolds a
+      # ~40-line personal flake importing the vigos.* modules. NOT in the
+      # deadnix/statix scope: like the workspace scaffold, the template keeps
+      # idiomatic possibly-unused args. Refs #827.
+      templates.personal = {
+        path = ./templates/personal;
+        description = "Personal home-manager flake importing the vigOS home modules";
+      };
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -102,60 +102,7 @@
       # (tests/test_flake_devshell.py) reads `devShellTools` so it can never
       # drift from this list.
       # ---------------------------------------------------------------------
-      devTools =
-        pkgs: with pkgs; [
-          # Build automation
-          just
-
-          # Git-hook runner: prek (Rust drop-in for the Python pre-commit,
-          # faster and one fewer manylinux/FHS consumer). The SSoT runner for
-          # the `.githooks` hooks and the flake's `checks.pre-commit`. Refs #778.
-          prek
-
-          # Version control & GitHub (gh from unstable via overlay)
-          git
-          gh
-          lazygit
-          delta
-
-          # Python tooling (uv from unstable via overlay)
-          uv
-
-          # Node.js (devcontainer CLI via npm)
-          nodejs
-
-          # Shell testing: bats core + helper libraries (support/assert/file).
-          # Wrapped so BATS_LIB_PATH is exported for bats_load_library. Refs #695.
-          (batsWithLibs pkgs)
-
-          # Shell & JSON utilities
-          jq
-          tmux
-          shellcheck
-
-          # Linting
-          taplo
-          nixfmt-rfc-style # nix file formatter (treefmt `nix fmt`, pre-commit hook)
-          ruff # python linter/formatter (pre-commit ruff/ruff-format hooks)
-          typos # source typo checker (pre-commit typos hook)
-          deadnix # dead-Nix-code linter (flake `checks.deadnix`)
-          statix # nix anti-pattern linter (flake `checks.statix`)
-
-          # Container runtime
-          podman
-
-          # Agent / terminal toolkit (absorbed from #545)
-          ripgrep # rg
-          fd
-          bat
-          eza
-          zoxide
-          starship
-          charm-freeze # freeze (charmbracelet terminal screenshots)
-          expect
-          neovim # nvim
-          claude-code # claude
-        ];
+      devTools = import ./nix/devtools.nix;
 
       # Binary names exposed for the parity test. Prefer the package's declared
       # `meta.mainProgram` (the canonical executable name, e.g. ripgrep -> rg,
@@ -659,7 +606,7 @@
           # `{ self, … }` output signature, whose intentionally-unused args
           # deadnix would otherwise flag. Refs #777.
           deadnix = pkgs.runCommand "deadnix-check" { nativeBuildInputs = [ pkgs.deadnix ]; } ''
-            deadnix --fail ${./flake.nix}
+            deadnix --fail ${./flake.nix} ${./nix}
             touch "$out"
           '';
 
@@ -667,6 +614,7 @@
           # `inherit`). Same authored-flake scoping rationale as deadnix. Refs #777.
           statix = pkgs.runCommand "statix-check" { nativeBuildInputs = [ pkgs.statix ]; } ''
             statix check ${./flake.nix}
+            statix check ${./nix}
             touch "$out"
           '';
 
@@ -1081,22 +1029,25 @@
           };
         };
 
-      # No `nixpkgs.overlays` here: home-manager rejects setting it when the
-      # consumer supplies an external `pkgs` (the common flake case). Fast-movers
-      # then track the consumer's channel unless they apply `overlays.default`
-      # themselves — documented in docs/NIX.md. Refs #777.
-      homeManagerModules.default =
-        {
-          config,
-          lib,
-          pkgs,
-          ...
-        }:
-        {
-          options.programs.vigos-devtools.enable = lib.mkEnableOption "the vigOS devcontainer toolchain (devTools)";
-          config = lib.mkIf config.programs.vigos-devtools.enable {
-            home.packages = devTools pkgs;
-          };
-        };
+      # ----------------------------------------------------------------------
+      # vigos.* home modules (#818) - the terminal home environment as
+      # per-concern home-manager modules (ADR-home-environment-modules).
+      # Exported as PATHS, not imported functions: the module system dedups
+      # path imports, so importing the `default` umbrella plus an individual
+      # module never double-declares options. The legacy
+      # `programs.vigos-devtools.enable` is shimmed in packages.nix
+      # (mkRenamedOptionModule, one release - docs/NIX.md policy).
+      # `homeModules` is the newer-convention alias of the same set.
+      # ----------------------------------------------------------------------
+      homeManagerModules = {
+        default = ./nix/home/default.nix;
+        packages = ./nix/home/packages.nix;
+        shell = ./nix/home/shell.nix;
+        multiplexer = ./nix/home/multiplexer.nix;
+        cli = ./nix/home/cli.nix;
+        direnv = ./nix/home/direnv.nix;
+        git = ./nix/home/git.nix;
+      };
+      homeModules = self.homeManagerModules;
     };
 }

--- a/nix/bats.nix
+++ b/nix/bats.nix
@@ -1,0 +1,9 @@
+# bats with its helper libraries (support/assert/file), wrapped so
+# BATS_LIB_PATH can be derived from one place. Shared by the devTools list
+# (nix/devtools.nix), mkProjectShell, and the image env. Refs #695, #818.
+pkgs:
+pkgs.bats.withLibraries (p: [
+  p.bats-support
+  p.bats-assert
+  p.bats-file
+])

--- a/nix/devtools.nix
+++ b/nix/devtools.nix
@@ -2,7 +2,12 @@
 # the Nix-built image, and the vigos.packages home module. Lives outside
 # flake.nix so the vigos.* path modules (nix/home/) can share it without
 # duplicating the list. Refs #818.
-pkgs: with pkgs; [
+pkgs:
+let
+  batsWithLibs = import ./bats.nix;
+in
+with pkgs;
+[
   # Build automation
   just
 

--- a/nix/devtools.nix
+++ b/nix/devtools.nix
@@ -1,0 +1,57 @@
+# The vigOS toolchain SSoT - one list, delivered everywhere: the dev-shell,
+# the Nix-built image, and the vigos.packages home module. Lives outside
+# flake.nix so the vigos.* path modules (nix/home/) can share it without
+# duplicating the list. Refs #818.
+pkgs: with pkgs; [
+  # Build automation
+  just
+
+  # Git-hook runner: prek (Rust drop-in for the Python pre-commit,
+  # faster and one fewer manylinux/FHS consumer). The SSoT runner for
+  # the `.githooks` hooks and the flake's `checks.pre-commit`. Refs #778.
+  prek
+
+  # Version control & GitHub (gh from unstable via overlay)
+  git
+  gh
+  lazygit
+  delta
+
+  # Python tooling (uv from unstable via overlay)
+  uv
+
+  # Node.js (devcontainer CLI via npm)
+  nodejs
+
+  # Shell testing: bats core + helper libraries (support/assert/file).
+  # Wrapped so BATS_LIB_PATH is exported for bats_load_library. Refs #695.
+  (batsWithLibs pkgs)
+
+  # Shell & JSON utilities
+  jq
+  tmux
+  shellcheck
+
+  # Linting
+  taplo
+  nixfmt-rfc-style # nix file formatter (treefmt `nix fmt`, pre-commit hook)
+  ruff # python linter/formatter (pre-commit ruff/ruff-format hooks)
+  typos # source typo checker (pre-commit typos hook)
+  deadnix # dead-Nix-code linter (flake `checks.deadnix`)
+  statix # nix anti-pattern linter (flake `checks.statix`)
+
+  # Container runtime
+  podman
+
+  # Agent / terminal toolkit (absorbed from #545)
+  ripgrep # rg
+  fd
+  bat
+  eza
+  zoxide
+  starship
+  charm-freeze # freeze (charmbracelet terminal screenshots)
+  expect
+  neovim # nvim
+  claude-code # claude
+]

--- a/nix/home/cli.nix
+++ b/nix/home/cli.nix
@@ -1,0 +1,5 @@
+# vigos.cli — skeleton (#818); behavior lands with wave 1 (#821).
+{ lib, ... }:
+{
+  options.vigos.cli.enable = lib.mkEnableOption "the vigOS modern-unix CLI configuration (config only; packages ship via vigos.packages)";
+}

--- a/nix/home/cli.nix
+++ b/nix/home/cli.nix
@@ -1,5 +1,29 @@
-# vigos.cli — skeleton (#818); behavior lands with wave 1 (#821).
-{ lib, ... }:
+# vigos.cli — modern-unix CLI configuration (#821).
+#
+# CONFIGURATION ONLY: packages ship solely via vigos.packages (the devTools
+# SSoT) — this module never adds home.packages. The HM programs.* modules
+# used here install their package attribute as a side effect; those resolve
+# from this module's pkgs (self-pkgs in the flake's homeConfigurations), the
+# same derivations devTools carries, so the union stays one store path per
+# tool.
+{
+  config,
+  lib,
+  ...
+}:
 {
   options.vigos.cli.enable = lib.mkEnableOption "the vigOS modern-unix CLI configuration (config only; packages ship via vigos.packages)";
+
+  config = lib.mkIf config.vigos.cli.enable {
+    programs = {
+      bat.enable = lib.mkDefault true;
+      eza = {
+        enable = lib.mkDefault true;
+        git = lib.mkDefault true;
+      };
+      fzf.enable = lib.mkDefault true;
+      ripgrep.enable = lib.mkDefault true;
+      fd.enable = lib.mkDefault true;
+    };
+  };
 }

--- a/nix/home/default.nix
+++ b/nix/home/default.nix
@@ -1,0 +1,13 @@
+# Umbrella module: every vigos.* module, each disabled by default (#818).
+# Import this for the full option surface, or pick individual modules —
+# path-based imports dedup, so mixing both never conflicts.
+{
+  imports = [
+    ./packages.nix
+    ./shell.nix
+    ./multiplexer.nix
+    ./cli.nix
+    ./direnv.nix
+    ./git.nix
+  ];
+}

--- a/nix/home/direnv.nix
+++ b/nix/home/direnv.nix
@@ -1,0 +1,5 @@
+# vigos.direnv — skeleton (#818); behavior lands with wave 1 (#821).
+{ lib, ... }:
+{
+  options.vigos.direnv.enable = lib.mkEnableOption "direnv + nix-direnv integration";
+}

--- a/nix/home/direnv.nix
+++ b/nix/home/direnv.nix
@@ -1,5 +1,21 @@
-# vigos.direnv — skeleton (#818); behavior lands with wave 1 (#821).
-{ lib, ... }:
+# vigos.direnv — direnv + nix-direnv (#821).
+#
+# The org's per-project activation layer (ADR-nix-devenv-strategy axis 1):
+# `use flake` in a repo's .envrc activates its mkProjectShell dev-shell,
+# GC-rooted so re-entry is instant. Shell integrations follow the enabled
+# shells automatically.
+{
+  config,
+  lib,
+  ...
+}:
 {
   options.vigos.direnv.enable = lib.mkEnableOption "direnv + nix-direnv integration";
+
+  config = lib.mkIf config.vigos.direnv.enable {
+    programs.direnv = {
+      enable = lib.mkDefault true;
+      nix-direnv.enable = lib.mkDefault true;
+    };
+  };
 }

--- a/nix/home/git.nix
+++ b/nix/home/git.nix
@@ -1,5 +1,67 @@
-# vigos.git — skeleton (#818); behavior lands with wave 1 (#821).
-{ lib, ... }:
+# vigos.git — org git environment (#821).
+#
+# Identity and signing are OPTIONS with null defaults: the module writes
+# nothing it was not told (a fresh host must never fail its first commit
+# because a signing key does not exist yet). Key minting and forge
+# registration are runbook steps (docs/home, #826) — per-user × host keys,
+# never copied, so a signature identifies the machine it was made on.
 {
-  options.vigos.git.enable = lib.mkEnableOption "the vigOS git environment (identity, optional SSH signing, gh, lazygit, delta)";
+  config,
+  lib,
+  ...
+}:
+let
+  cfg = config.vigos.git;
+in
+{
+  options.vigos.git = {
+    enable = lib.mkEnableOption "the vigOS git environment (git+delta, gh, lazygit)";
+    userName = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      description = "Git author/committer name; nothing is written when null.";
+    };
+    userEmail = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      description = "Git author/committer email; nothing is written when null.";
+    };
+    signingKeyPath = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      example = "~/.ssh/id_ed25519_signing.pub";
+      description = ''
+        Path to the per-user x host SSH signing key. SSH-format commit
+        signing activates only when set; null (the default) writes no
+        signing configuration at all.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    programs = {
+      git = lib.mkMerge [
+        {
+          enable = lib.mkDefault true;
+          delta.enable = lib.mkDefault true;
+        }
+        (lib.mkIf (cfg.userName != null) { userName = lib.mkDefault cfg.userName; })
+        (lib.mkIf (cfg.userEmail != null) { userEmail = lib.mkDefault cfg.userEmail; })
+        (lib.mkIf (cfg.signingKeyPath != null) {
+          signing = {
+            key = lib.mkDefault cfg.signingKeyPath;
+            format = lib.mkDefault "ssh";
+            signByDefault = lib.mkDefault true;
+          };
+        })
+      ];
+
+      gh = {
+        enable = lib.mkDefault true;
+        settings.git_protocol = lib.mkDefault "ssh";
+      };
+
+      lazygit.enable = lib.mkDefault true;
+    };
+  };
 }

--- a/nix/home/git.nix
+++ b/nix/home/git.nix
@@ -1,0 +1,5 @@
+# vigos.git — skeleton (#818); behavior lands with wave 1 (#821).
+{ lib, ... }:
+{
+  options.vigos.git.enable = lib.mkEnableOption "the vigOS git environment (identity, optional SSH signing, gh, lazygit, delta)";
+}

--- a/nix/home/multiplexer.nix
+++ b/nix/home/multiplexer.nix
@@ -1,5 +1,29 @@
-# vigos.multiplexer — skeleton (#818); behavior lands with wave 1 (#821).
-{ lib, ... }:
+# vigos.multiplexer — org tmux configuration (#821).
+#
+# Config only where possible; the tmux binary itself also ships via
+# vigos.packages (devTools). programs.tmux hard-requires a package for its
+# plugin/wrapper plumbing — it comes from this module's pkgs (self-pkgs in
+# the flake's own homeConfigurations), matching the devTools version, so no
+# second copy appears in practice. extraConfig stays open for personal
+# keybindings.
+{
+  config,
+  lib,
+  ...
+}:
 {
   options.vigos.multiplexer.enable = lib.mkEnableOption "the vigOS tmux configuration";
+
+  config = lib.mkIf config.vigos.multiplexer.enable {
+    programs.tmux = {
+      enable = lib.mkDefault true;
+      # vi keys and a sane scrollback are org defaults; everything is
+      # mkDefault so a personal config overrides with a bare assignment.
+      keyMode = lib.mkDefault "vi";
+      historyLimit = lib.mkDefault 100000;
+      mouse = lib.mkDefault true;
+      escapeTime = lib.mkDefault 10;
+      baseIndex = lib.mkDefault 1;
+    };
+  };
 }

--- a/nix/home/multiplexer.nix
+++ b/nix/home/multiplexer.nix
@@ -1,0 +1,5 @@
+# vigos.multiplexer — skeleton (#818); behavior lands with wave 1 (#821).
+{ lib, ... }:
+{
+  options.vigos.multiplexer.enable = lib.mkEnableOption "the vigOS tmux configuration";
+}

--- a/nix/home/packages.nix
+++ b/nix/home/packages.nix
@@ -1,0 +1,27 @@
+# vigos.packages — the shared toolchain (devTools) as home packages.
+#
+# The #777 package-only module re-keyed into the vigos.* namespace (#818).
+# The legacy `programs.vigos-devtools.enable` option is shimmed here (and
+# only here) via mkRenamedOptionModule for one release — docs/NIX.md policy.
+#
+# Packages come from the `pkgs` this module is evaluated with. The flake's
+# own homeConfigurations pass devkit's pinned nixpkgs + fast-mover overlay
+# (self-pkgs), so tool versions match the dev-shell and image. A consumer
+# passing its own pkgs applies `overlays.default` itself (home-manager
+# rejects a module-set `nixpkgs.overlays` with an external pkgs) and must
+# allow unfree for claude-code.
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+{
+  imports = [
+    (lib.mkRenamedOptionModule [ "programs" "vigos-devtools" "enable" ] [ "vigos" "packages" "enable" ])
+  ];
+  options.vigos.packages.enable = lib.mkEnableOption "the vigOS toolchain (devTools) as home packages";
+  config = lib.mkIf config.vigos.packages.enable {
+    home.packages = (import ../devtools.nix) pkgs;
+  };
+}

--- a/nix/home/shell.nix
+++ b/nix/home/shell.nix
@@ -1,5 +1,70 @@
-# vigos.shell — skeleton (#818); behavior lands with wave 1 (#821).
-{ lib, ... }:
+# vigos.shell — the org shell environment (#821).
+#
+# Bash AND zsh (macOS default) under one switch: colleagues keep their login
+# shell, integrations land in both. Every scalar is mkDefault so a personal
+# config overrides with a bare assignment (ADR override policy).
+#
+# secretsEnv (opt-in, default off): exports each file under
+# ~/.config/vigos/secrets/<NAME> (the ADR resident-credentials interface) as
+# an environment variable. NAME must match [A-Z_][A-Z0-9_]*; the trailing
+# newline is stripped (command substitution); sourcing is idempotent via a
+# guard variable and runs from both profile and rc files. systemd user
+# services and non-interactive SSH commands are out of scope v1.
 {
-  options.vigos.shell.enable = lib.mkEnableOption "the vigOS shell environment (bash+zsh, starship, atuin, secretsEnv)";
+  config,
+  lib,
+  ...
+}:
+let
+  cfg = config.vigos.shell;
+
+  secretsHook = ''
+    # vigos.shell.secretsEnv — resident-credentials interface (vig-os/devcontainer#821)
+    if [ -z "''${VIGOS_SECRETS_LOADED:-}" ] && [ -d "${cfg.secretsEnv.dir}" ]; then
+      for _vigos_secret in "${cfg.secretsEnv.dir}"/*; do
+        [ -f "$_vigos_secret" ] || continue
+        _vigos_name="$(basename "$_vigos_secret")"
+        if printf '%s' "$_vigos_name" | grep -Eq '^[A-Z_][A-Z0-9_]*$'; then
+          export "$_vigos_name=$(cat "$_vigos_secret")"
+        fi
+      done
+      unset _vigos_secret _vigos_name
+      export VIGOS_SECRETS_LOADED=1
+    fi
+  '';
+in
+{
+  options.vigos.shell = {
+    enable = lib.mkEnableOption "the vigOS shell environment (bash+zsh, starship, atuin, zoxide)";
+    secretsEnv = {
+      enable = lib.mkEnableOption "exporting ~/.config/vigos/secrets/<NAME> files as environment variables";
+      dir = lib.mkOption {
+        type = lib.types.str;
+        default = "${config.home.homeDirectory}/.config/vigos/secrets";
+        description = "Directory holding one file per secret (mode 0600), named like the target environment variable.";
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    programs = {
+      bash = {
+        enable = lib.mkDefault true;
+        initExtra = lib.mkIf cfg.secretsEnv.enable secretsHook;
+        profileExtra = lib.mkIf cfg.secretsEnv.enable secretsHook;
+      };
+
+      zsh = {
+        enable = lib.mkDefault true;
+        initContent = lib.mkIf cfg.secretsEnv.enable secretsHook;
+        profileExtra = lib.mkIf cfg.secretsEnv.enable secretsHook;
+      };
+
+      # Prompt, history, and directory jumping — each ships its own bash/zsh
+      # integration toggle, defaulting to on when the shells are enabled.
+      starship.enable = lib.mkDefault true;
+      atuin.enable = lib.mkDefault true;
+      zoxide.enable = lib.mkDefault true;
+    };
+  };
 }

--- a/nix/home/shell.nix
+++ b/nix/home/shell.nix
@@ -1,0 +1,5 @@
+# vigos.shell — skeleton (#818); behavior lands with wave 1 (#821).
+{ lib, ... }:
+{
+  options.vigos.shell.enable = lib.mkEnableOption "the vigOS shell environment (bash+zsh, starship, atuin, secretsEnv)";
+}

--- a/templates/personal/README.md
+++ b/templates/personal/README.md
@@ -1,0 +1,9 @@
+# Personal vigOS home environment
+
+1. Edit `flake.nix`: username, home directory, system, git identity.
+2. First activation on a machine with existing dotfiles:
+   `nix run home-manager -- switch --flake .#me -b backup`
+3. Afterwards: `home-manager switch --flake .#me`
+
+Everything the org ships is a default you can override — see the
+override cookbook in the devkit repo (`docs/home/`).

--- a/templates/personal/flake.nix
+++ b/templates/personal/flake.nix
@@ -1,0 +1,52 @@
+{
+  description = "Personal home environment on the vigOS home modules.";
+
+  inputs = {
+    # Pin a devkit release tag once you depend on module-option stability
+    # (docs/NIX.md "Home-manager modules - versioning & release policy"):
+    #   vigos.url = "github:vig-os/devcontainer?ref=<tag>";
+    vigos.url = "github:vig-os/devcontainer";
+    nixpkgs.follows = "vigos/nixpkgs";
+    home-manager.follows = "vigos/home-manager";
+  };
+
+  outputs =
+    {
+      vigos,
+      nixpkgs,
+      home-manager,
+      ...
+    }:
+    {
+      # Activate with: home-manager switch --flake .#me
+      homeConfigurations.me = home-manager.lib.homeManagerConfiguration {
+        pkgs = import nixpkgs {
+          system = "x86_64-linux"; # aarch64-darwin on an Apple-silicon Mac
+          overlays = [ vigos.overlays.default ]; # fast-movers (claude-code, uv, gh)
+          config.allowUnfree = true; # claude-code
+        };
+        modules = [
+          vigos.homeManagerModules.default
+          {
+            home = {
+              username = "me"; # your unix user
+              homeDirectory = "/home/me"; # /Users/me on macOS
+              stateVersion = "26.05";
+            };
+            vigos = {
+              packages.enable = true;
+              shell.enable = true;
+              multiplexer.enable = true;
+              cli.enable = true;
+              direnv.enable = true;
+              git = {
+                enable = true;
+                userName = "Your Name";
+                userEmail = "you@example.com";
+              };
+            };
+          }
+        ];
+      };
+    };
+}

--- a/tests/test_flake_checks.py
+++ b/tests/test_flake_checks.py
@@ -399,7 +399,7 @@ def test_personal_template_is_exposed() -> None:
             "--json",
             f"{REPO_ROOT}#templates.personal",
             "--apply",
-            "t: { hasPath = t ? path; hasDescription = (t.description or \"\") != \"\"; }",
+            't: { hasPath = t ? path; hasDescription = (t.description or "") != ""; }',
         ],
         capture_output=True,
         text=True,

--- a/tests/test_flake_checks.py
+++ b/tests/test_flake_checks.py
@@ -116,7 +116,13 @@ def test_checks_output_exposes_quality_gates() -> None:
         # git-hooks.nix runs the sandbox-pure subset of the pre-commit hooks as
         # a flake check, driven by the prek runner (#778).
         "pre-commit",
+        # The ci homeConfigurations matrix builds as Tier-0 checks (#819) —
+        # skipped only on x86_64-darwin (eval-only best-effort tier).
+        "hm-minimal",
+        "hm-full",
     }
+    if system == "x86_64-darwin":
+        required -= {"hm-minimal", "hm-full"}
     missing = required - names
     assert not missing, f"checks output is missing gates: {sorted(missing)}"
 
@@ -194,7 +200,8 @@ def test_toolchain_modules_are_exposed() -> None:
                 "--json",
                 f"{REPO_ROOT}#{output}",
                 "--apply",
-                "m: { hasDefault = m ? default; isFn = builtins.isFunction m.default; }",
+                "m: { hasDefault = m ? default; isImportable = "
+                "builtins.isFunction m.default || builtins.isPath m.default; }",
             ],
             capture_output=True,
             text=True,
@@ -205,7 +212,122 @@ def test_toolchain_modules_are_exposed() -> None:
             pytest.fail(f"Failed to read {output}:\n" + result.stderr)
         info = json.loads(result.stdout)
         assert info["hasDefault"], f"{output} is missing a default module"
-        assert info["isFn"], f"{output}.default is not a module function"
+        # vigos home modules are exported as *paths* (the module system dedups
+        # path imports, so `default` + a single module never double-declare
+        # options); the NixOS module stays an inline function. Both import.
+        assert info["isImportable"], f"{output}.default is not importable"
+
+
+HM_MODULES = {"default", "packages", "shell", "multiplexer", "cli", "direnv", "git"}
+HM_SYSTEMS = ("x86_64-linux", "aarch64-linux", "aarch64-darwin", "x86_64-darwin")
+
+
+def test_vigos_home_module_set_is_exposed() -> None:
+    """``homeManagerModules`` must expose the full vigos.* module set (#818).
+
+    ``default`` is the umbrella importing every module (each disabled by
+    default); the per-concern modules are individually importable. All are
+    path-or-function modules.
+    """
+    result = subprocess.run(
+        [
+            "nix",
+            "eval",
+            "--json",
+            f"{REPO_ROOT}#homeManagerModules",
+            "--apply",
+            "m: { names = builtins.attrNames m; importable = builtins.all "
+            "(n: builtins.isPath m.${n} || builtins.isFunction m.${n}) "
+            "(builtins.attrNames m); }",
+        ],
+        capture_output=True,
+        text=True,
+        env=_nix_env(),
+        timeout=600,
+    )
+    if result.returncode != 0:
+        pytest.fail("Failed to read homeManagerModules:\n" + result.stderr)
+    info = json.loads(result.stdout)
+    missing = HM_MODULES - set(info["names"])
+    assert not missing, f"homeManagerModules is missing: {sorted(missing)}"
+    assert info["importable"], "a homeManagerModules entry is not importable"
+
+
+def test_home_modules_alias_matches() -> None:
+    """``homeModules`` (newer convention) must mirror ``homeManagerModules``."""
+    result = subprocess.run(
+        [
+            "nix",
+            "eval",
+            "--json",
+            f"{REPO_ROOT}#",
+            "--apply",
+            "f: { hm = builtins.attrNames f.homeManagerModules; "
+            "alias = builtins.attrNames (f.homeModules or { }); }",
+        ],
+        capture_output=True,
+        text=True,
+        env=_nix_env(),
+        timeout=600,
+    )
+    if result.returncode != 0:
+        pytest.fail("Failed to compare homeModules alias:\n" + result.stderr)
+    info = json.loads(result.stdout)
+    assert info["alias"] == info["hm"], (
+        f"homeModules alias diverges: {info['alias']} != {info['hm']}"
+    )
+
+
+def test_home_configurations_matrix() -> None:
+    """The synthetic-ci homeConfigurations matrix must cover all systems (#819).
+
+    ``ci-{minimal,full}-<system>`` for every supported system, including
+    x86_64-darwin (which evaluates but is never built — best-effort tier).
+    """
+    result = subprocess.run(
+        [
+            "nix",
+            "eval",
+            "--json",
+            f"{REPO_ROOT}#homeConfigurations",
+            "--apply",
+            "builtins.attrNames",
+        ],
+        capture_output=True,
+        text=True,
+        env=_nix_env(),
+        timeout=600,
+    )
+    if result.returncode != 0:
+        pytest.fail("Failed to read homeConfigurations:\n" + result.stderr)
+    names = set(json.loads(result.stdout))
+    expected = {
+        f"ci-{profile}-{system}"
+        for profile in ("minimal", "full")
+        for system in HM_SYSTEMS
+    }
+    missing = expected - names
+    assert not missing, f"homeConfigurations matrix is missing: {sorted(missing)}"
+
+
+def test_home_configuration_evaluates_end_to_end() -> None:
+    """A matrix leg must evaluate through the module system (cheap smoke)."""
+    result = subprocess.run(
+        [
+            "nix",
+            "eval",
+            "--raw",
+            f'{REPO_ROOT}#homeConfigurations."ci-minimal-x86_64-linux"'
+            ".config.home.stateVersion",
+        ],
+        capture_output=True,
+        text=True,
+        env=_nix_env(),
+        timeout=600,
+    )
+    if result.returncode != 0:
+        pytest.fail("ci-minimal-x86_64-linux does not evaluate:\n" + result.stderr)
+    assert result.stdout.strip() == "26.05"
 
 
 def test_flake_check_succeeds() -> None:

--- a/tests/test_flake_checks.py
+++ b/tests/test_flake_checks.py
@@ -307,6 +307,7 @@ def test_home_configurations_matrix() -> None:
         for profile in ("minimal", "full")
         for system in HM_SYSTEMS
     }
+    expected.add("demo")
     missing = expected - names
     assert not missing, f"homeConfigurations matrix is missing: {sorted(missing)}"
 
@@ -387,6 +388,28 @@ def test_wave1_full_profile_config() -> None:
     assert not off, f"wave-1 programs not enabled in full profile: {off}"
     assert cfg["signingKey"] is None, "git signing must be inactive by default"
     assert cfg["secretsEnvDefault"] is False, "secretsEnv must default off"
+
+
+def test_personal_template_is_exposed() -> None:
+    """``templates.personal`` must point at the starter flake (#827)."""
+    result = subprocess.run(
+        [
+            "nix",
+            "eval",
+            "--json",
+            f"{REPO_ROOT}#templates.personal",
+            "--apply",
+            "t: { hasPath = t ? path; hasDescription = (t.description or \"\") != \"\"; }",
+        ],
+        capture_output=True,
+        text=True,
+        env=_nix_env(),
+        timeout=600,
+    )
+    if result.returncode != 0:
+        pytest.fail("Failed to read templates.personal:\n" + result.stderr)
+    info = json.loads(result.stdout)
+    assert info["hasPath"] and info["hasDescription"]
 
 
 def test_flake_check_succeeds() -> None:

--- a/tests/test_flake_checks.py
+++ b/tests/test_flake_checks.py
@@ -331,6 +331,64 @@ def test_home_configuration_evaluates_end_to_end() -> None:
     assert result.stdout.strip() == "26.05"
 
 
+def test_wave1_full_profile_config() -> None:
+    """Wave-1 modules must materialize in the full ci profile (#821).
+
+    One eval pulls the interesting config slice: every wave-1 program
+    enabled, git signing INACTIVE by default (signingKeyPath is null on
+    fresh hosts — first commits must not fail), and the secretsEnv hook
+    present but off by default.
+    """
+    result = subprocess.run(
+        [
+            "nix",
+            "eval",
+            "--json",
+            f'{REPO_ROOT}#homeConfigurations."ci-full-x86_64-linux".config',
+            "--apply",
+            "c: { "
+            "bash = c.programs.bash.enable; "
+            "zsh = c.programs.zsh.enable; "
+            "starship = c.programs.starship.enable; "
+            "atuin = c.programs.atuin.enable; "
+            "zoxide = c.programs.zoxide.enable; "
+            "tmux = c.programs.tmux.enable; "
+            "direnv = c.programs.direnv.enable; "
+            "nixDirenv = c.programs.direnv.nix-direnv.enable; "
+            "git = c.programs.git.enable; "
+            "gh = c.programs.gh.enable; "
+            "lazygit = c.programs.lazygit.enable; "
+            "signingKey = c.programs.git.signing.key; "
+            "secretsEnvDefault = c.vigos.shell.secretsEnv.enable; "
+            "}",
+        ],
+        capture_output=True,
+        text=True,
+        env=_nix_env(),
+        timeout=600,
+    )
+    if result.returncode != 0:
+        pytest.fail("full-profile config does not evaluate:\n" + result.stderr)
+    cfg = json.loads(result.stdout)
+    enabled = [
+        "bash",
+        "zsh",
+        "starship",
+        "atuin",
+        "zoxide",
+        "tmux",
+        "direnv",
+        "nixDirenv",
+        "git",
+        "gh",
+        "lazygit",
+    ]
+    off = [k for k in enabled if not cfg[k]]
+    assert not off, f"wave-1 programs not enabled in full profile: {off}"
+    assert cfg["signingKey"] is None, "git signing must be inactive by default"
+    assert cfg["secretsEnvDefault"] is False, "secretsEnv must default off"
+
+
 def test_flake_check_succeeds() -> None:
     """``nix flake check`` evaluates the flake and runs the lightweight checks."""
     result = subprocess.run(

--- a/tests/test_flake_checks.py
+++ b/tests/test_flake_checks.py
@@ -255,26 +255,27 @@ def test_vigos_home_module_set_is_exposed() -> None:
 
 def test_home_modules_alias_matches() -> None:
     """``homeModules`` (newer convention) must mirror ``homeManagerModules``."""
-    result = subprocess.run(
-        [
-            "nix",
-            "eval",
-            "--json",
-            f"{REPO_ROOT}#",
-            "--apply",
-            "f: { hm = builtins.attrNames f.homeManagerModules; "
-            "alias = builtins.attrNames (f.homeModules or { }); }",
-        ],
-        capture_output=True,
-        text=True,
-        env=_nix_env(),
-        timeout=600,
-    )
-    if result.returncode != 0:
-        pytest.fail("Failed to compare homeModules alias:\n" + result.stderr)
-    info = json.loads(result.stdout)
-    assert info["alias"] == info["hm"], (
-        f"homeModules alias diverges: {info['alias']} != {info['hm']}"
+    names: dict[str, list[str]] = {}
+    for output in ("homeManagerModules", "homeModules"):
+        result = subprocess.run(
+            [
+                "nix",
+                "eval",
+                "--json",
+                f"{REPO_ROOT}#{output}",
+                "--apply",
+                "builtins.attrNames",
+            ],
+            capture_output=True,
+            text=True,
+            env=_nix_env(),
+            timeout=600,
+        )
+        if result.returncode != 0:
+            pytest.fail(f"Failed to read {output}:\n" + result.stderr)
+        names[output] = json.loads(result.stdout)
+    assert names["homeModules"] == names["homeManagerModules"], (
+        f"homeModules alias diverges: {names!r}"
     )
 
 


### PR DESCRIPTION
## Summary

Implements the MVP slice of epic #814 — **the terminal home environment as devkit home-manager modules**, a second product of this flake per the accepted `docs/rfcs/ADR-home-environment-modules.md` (in this diff). One self-contained master branch; each sub-issue landed via its own worktree branch + PR into it; this draft PR is the CI vehicle and the single human review point.

What this adds, in one paragraph: parameterized `vigos.{packages,shell,multiplexer,cli,direnv,git}` home-manager modules (path-exported, umbrella `default`, `homeModules` alias, `programs.vigos-devtools` rename shim), the `home-manager` flake input (the module product's only new input), a `ci-{minimal,full}` homeConfigurations matrix across four systems built as Tier-0 `hm-*` checks, a darwin/arm **Home Matrix** workflow pushing closures to Cachix, the module release/versioning policy, a scheduled nixpkgs-unstable bump workflow, `templates.personal` + `homeConfigurations.demo`, and the `docs/home/` consumer doc set (bootstrap, cookbook, rollback, credentials, CLAUDE.md templates). The devcontainer image is deliberately untouched (ADR Axis 4); a tier-"none" user is unaffected (optionality invariant).

## Ledger

| Sub-issue | Work | PR | Status |
|---|---|---|---|
| #815 E1 | Accept ADR | #829 | ✅ |
| #816 E2 | Release/versioning policy + scaffold float doc | #831 | ✅ |
| #817 E3 | Scheduled nixpkgs-unstable bump workflow | #832 + hotfix #834 | ✅ |
| #818 A1 | vigos.* namespace + module skeleton + rename shim | #835 | ✅ |
| #819 A2 | home-manager input + ci matrix (Tier-0 hm legs) | #835, changelog #841 | ✅ |
| #820 A3 | Home Matrix workflow (darwin/arm + Cachix) | #836 | ✅ green on all runs |
| #821 A4 | Wave-1 modules (shell, multiplexer, cli, direnv, git) | #837 | ✅ TDD |
| #822 B1 | Dogfood evidence | c-vigo/vigo-nixos`@feature/devkit-wave1-dogfood` | ✅ evidence + allowlist posted |
| #825 C1 / #826 C2 | Bootstrap + cookbook/rollback/credentials docs | #839 | ✅ |
| #827 C3 | templates.personal + demo | #838 | ✅ |
| #828 C4 | CLAUDE.md templates | #840 | ✅ |

Out of scope (follow-up): #823 B2, #824 B3 (waves 2/3).

## Evidence

- Final head CI **fully green**: image build/tests/integration, Project Checks (Tier-0 incl. new `hm-minimal`/`hm-full` legs + 12-test schema suite + downstream stub), dependency review, security scan.
- **Home Matrix green on every run** — aarch64-darwin + aarch64-linux module closures on the `vig-os` Cachix (darwin cache exists before first onboarding, as the ADR requires).
- Local: `pytest tests/test_flake_checks.py` 12/12 incl. full `nix flake check`; warm hm-check build ~7 s (Tier-0 budget safe).
- Dogfood: personal-config canary builds; categorized diff + acceptance allowlist in #822.
- Caught-by-gates during the run: E3 YAML literal-block break (hotfix #834), two statix grouped-attr rejections, one ruff-format nit — all fixed pre-merge.

## Changelog (what this PR adds under `Unreleased`)

### Added

- **ADR: terminal home environment as devkit home-manager modules** ([#815](https://github.com/vig-os/devcontainer/issues/815))
  - Accepted `docs/rfcs/ADR-home-environment-modules.md`: parameterized `vigos.*` home-manager modules as a second product of this repo (epic [#814](https://github.com/vig-os/devcontainer/issues/814)).

- **Home-manager module release/versioning policy** ([#816](https://github.com/vig-os/devcontainer/issues/816))
  - `docs/NIX.md`: modules ride the existing release train (consumers pin tags), `mkRenamedOptionModule` deprecation shims, dogfood-canary exception, and the `#### Modules` changelog sub-heading convention.
  - Workspace scaffold `vigos.url` float is now documented as deliberate, with the pin recipe.

- **Scheduled nixpkgs-unstable lock bump** ([#817](https://github.com/vig-os/devcontainer/issues/817))
  - Weekly workflow refreshing the fast-movers pin (uv, gh, claude-code) via a chore PR to dev, gated by full CI.

- **vigos.* home module set + homeConfigurations matrix** ([#818](https://github.com/vig-os/devcontainer/issues/818), [#819](https://github.com/vig-os/devcontainer/issues/819))
  - `homeManagerModules.{default,packages,shell,multiplexer,cli,direnv,git}` exported as path modules (+ `homeModules` alias); `home-manager` flake input (release-26.05, nixpkgs follows); `ci-{minimal,full}` homeConfigurations across 4 systems built as Tier-0 `hm-*` checks (x86_64-darwin eval-only).

- **Home Matrix CI workflow** ([#820](https://github.com/vig-os/devcontainer/issues/820))
  - Builds the ci homeConfigurations on aarch64-darwin (macos-latest) and aarch64-linux and pushes closures to Cachix; separate non-required workflow (fail-soft by status).

- **vigos.shell module** ([#821](https://github.com/vig-os/devcontainer/issues/821))
  - Bash + zsh, starship, atuin, zoxide under one enable flag; opt-in secretsEnv hook exporting ~/.config/vigos/secrets/<NAME> per the ADR credentials interface.

- **vigos.multiplexer, vigos.cli, vigos.direnv modules** ([#821](https://github.com/vig-os/devcontainer/issues/821))
  - tmux org defaults (vi keys, sane scrollback), modern-unix config (bat/eza/fzf/ripgrep/fd — configuration only, packages stay in vigos.packages), direnv + nix-direnv.

- **vigos.git module** ([#821](https://github.com/vig-os/devcontainer/issues/821))
  - git + delta, gh (ssh protocol), lazygit; identity and per-user-x-host SSH signing are null-default options — nothing is written unless set, so fresh hosts never fail their first commit.

- **templates.personal + homeConfigurations.demo** ([#827](https://github.com/vig-os/devcontainer/issues/827))
  - `nix flake init -t github:vig-os/devcontainer#personal` scaffolds a personal home-manager flake on the vigos.* modules; `demo` is the full-profile reference configuration.

- **Home environment docs** ([#825](https://github.com/vig-os/devcontainer/issues/825), [#826](https://github.com/vig-os/devcontainer/issues/826))
  - docs/home/: bootstrap guide (installer, macOS trusted-users trap, first activation), override cookbook, rollback table, best-effort Intel meaning, credential-hygiene runbook.

- **CLAUDE.md hierarchy templates** ([#828](https://github.com/vig-os/devcontainer/issues/828))
  - docs/home/claude-md/: user-global, workspace-root, and workspace layer templates + the directory-layout convention that makes the cascade work. Guidelines, not enforcement.

### Changed

#### Modules

- **homeManagerModules.default is now the umbrella** importing every `vigos.*` module, each disabled by default ([#818](https://github.com/vig-os/devcontainer/issues/818)); existing imports keep working unchanged.

### Deprecated

#### Modules

- **`programs.vigos-devtools.enable`** → `vigos.packages.enable` ([#818](https://github.com/vig-os/devcontainer/issues/818)); a `mkRenamedOptionModule` shim keeps the old option working for one release (docs/NIX.md policy).

## Left for the morning

1. Review, un-draft, merge to `dev`.
2. Decide: promote Home Matrix to a required check.
3. Confirm or reverse the scaffold `vigos.url` documented-float choice.
4. Post-merge: `workflow_dispatch` test of `update-nixpkgs-unstable.yml` (#817).
5. B1 acceptance: switch on the canary branch, sign off the allowlist, delete private copies (#822).
6. Schedule B2/#823 + B3/#824; pick the first module-bearing tag (starts the pin-tags clock).

Refs: #814

