### PR TITLE
feat(home): vigos.* namespace + home-manager input + ci matrix checks

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -77,6 +77,27 @@
         "type": "github"
       }
     },
+    "home-manager": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1782704057,
+        "narHash": "sha256-G1I1gd32F7mp9LAe1DaZ4ZL7NX5gyiKwdCMwro1Vrck=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "868d0a692de703c2de98fab61968e4e310b7c28e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "ref": "release-26.05",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1782116945,
@@ -128,6 +149,7 @@
       "inputs": {
         "flake-utils": "flake-utils",
         "git-hooks-nix": "git-hooks-nix",
+        "home-manager": "home-manager",
         "nixpkgs": "nixpkgs",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "process-compose-flake": "process-compose-flake",

--- a/flake.nix
+++ b/flake.nix
@@ -24,6 +24,12 @@
     # exactly two leaf entries. Consumed by mkProjectServices. Refs #795.
     process-compose-flake.url = "github:Platonic-Systems/process-compose-flake";
     services-flake.url = "github:juspay/services-flake";
+    # home-manager powers the vigos.* home environment — the ONLY input the
+    # module product adds (ADR-home-environment-modules axis 3). The release
+    # branch matches the nixos-26.05 pin; follows keeps one resolved nixpkgs.
+    # Refs #819.
+    home-manager.url = "github:nix-community/home-manager/release-26.05";
+    home-manager.inputs.nixpkgs.follows = "nixpkgs";
   };
 
   outputs =
@@ -36,6 +42,7 @@
       git-hooks-nix,
       process-compose-flake,
       services-flake,
+      home-manager,
     }:
     let
       # ---------------------------------------------------------------------
@@ -58,13 +65,7 @@
       # (tests/bats/test_helper.bash) resolves them from the Nix store — the
       # flake SSoT — replacing the npm (node_modules) / Debian (/usr/lib)
       # resolution that does not exist on the Nix toolchain. Refs #695.
-      batsWithLibs =
-        pkgs:
-        pkgs.bats.withLibraries (p: [
-          p.bats-support
-          p.bats-assert
-          p.bats-file
-        ]);
+      batsWithLibs = import ./nix/bats.nix;
 
       # Import nixpkgs-unstable for a given system (allowUnfree covers
       # claude-code). Evaluated once per system in the per-system `let` below and
@@ -93,6 +94,73 @@
       # No concrete system is known here, so it imports unstable inside the
       # fixpoint; the in-flake path below uses the hoisted importUnstable.
       overlay = final: prev: mkFastMoverOverlay (importUnstable final.system) final prev;
+
+      # ---------------------------------------------------------------------
+      # vigos home environment (#819): self-pkgs + the ci homeConfigurations.
+      # ---------------------------------------------------------------------
+      # pkgs for the flake's own homeConfigurations (self-pkgs): the same
+      # stable base + fast-mover overlay + allowUnfree combination as the
+      # per-system dev-shell pkgs, so claude-code and friends resolve to the
+      # very same versions across dev-shell, image, and home modules.
+      mkHomePkgs =
+        system:
+        import nixpkgs {
+          inherit system;
+          overlays = [ (mkFastMoverOverlay (importUnstable system)) ];
+          config.allowUnfree = true;
+        };
+
+      # Every system the home modules target. x86_64-darwin evaluates but is
+      # never built in CI (best-effort tier, ADR platform table).
+      hmSystems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "aarch64-darwin"
+        "x86_64-darwin"
+      ];
+
+      # The two CI profiles: minimal exercises one module, full exercises the
+      # whole option surface. Kept in lockstep with nix/home/.
+      hmProfiles = {
+        minimal = {
+          vigos.shell.enable = true;
+        };
+        full = {
+          vigos = {
+            packages.enable = true;
+            shell.enable = true;
+            multiplexer.enable = true;
+            cli.enable = true;
+            direnv.enable = true;
+            git.enable = true;
+          };
+        };
+      };
+
+      # ci-<profile>-<system> homeConfigurations: synthetic user, pinned
+      # stateVersion — schema-asserted by tests/test_flake_checks.py.
+      ciHomeConfigurations = nixpkgs.lib.listToAttrs (
+        nixpkgs.lib.concatMap (
+          system:
+          map (profile: {
+            name = "ci-${profile}-${system}";
+            value = home-manager.lib.homeManagerConfiguration {
+              pkgs = mkHomePkgs system;
+              modules = [
+                ./nix/home/default.nix
+                {
+                  home = {
+                    username = "ci";
+                    homeDirectory = if nixpkgs.lib.hasSuffix "-darwin" system then "/Users/ci" else "/home/ci";
+                    stateVersion = "26.05";
+                  };
+                }
+                hmProfiles.${profile}
+              ];
+            };
+          }) (builtins.attrNames hmProfiles)
+        ) hmSystems
+      );
 
       # ---------------------------------------------------------------------
       # devTools — the single source of truth for the toolchain.
@@ -631,6 +699,13 @@
             test "$count" -gt 0
             touch "$out"
           '';
+        }
+        # The ci homeConfigurations build as Tier-0 checks. x86_64-darwin is
+        # the eval-only best-effort tier (ADR platform table): it exists as a
+        # homeConfiguration but gets no build leg. Refs #819.
+        // pkgs.lib.optionalAttrs (system != "x86_64-darwin") {
+          hm-minimal = self.homeConfigurations."ci-minimal-${system}".activationPackage;
+          hm-full = self.homeConfigurations."ci-full-${system}".activationPackage;
         };
 
         # ------------------------------------------------------------------
@@ -1049,5 +1124,8 @@
         git = ./nix/home/git.nix;
       };
       homeModules = self.homeManagerModules;
+
+      # The ci matrix (+ demo later, #827). Built as per-system checks below.
+      homeConfigurations = ciHomeConfigurations;
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -102,60 +102,7 @@
       # (tests/test_flake_devshell.py) reads `devShellTools` so it can never
       # drift from this list.
       # ---------------------------------------------------------------------
-      devTools =
-        pkgs: with pkgs; [
-          # Build automation
-          just
-
-          # Git-hook runner: prek (Rust drop-in for the Python pre-commit,
-          # faster and one fewer manylinux/FHS consumer). The SSoT runner for
-          # the `.githooks` hooks and the flake's `checks.pre-commit`. Refs #778.
-          prek
-
-          # Version control & GitHub (gh from unstable via overlay)
-          git
-          gh
-          lazygit
-          delta
-
-          # Python tooling (uv from unstable via overlay)
-          uv
-
-          # Node.js (devcontainer CLI via npm)
-          nodejs
-
-          # Shell testing: bats core + helper libraries (support/assert/file).
-          # Wrapped so BATS_LIB_PATH is exported for bats_load_library. Refs #695.
-          (batsWithLibs pkgs)
-
-          # Shell & JSON utilities
-          jq
-          tmux
-          shellcheck
-
-          # Linting
-          taplo
-          nixfmt-rfc-style # nix file formatter (treefmt `nix fmt`, pre-commit hook)
-          ruff # python linter/formatter (pre-commit ruff/ruff-format hooks)
-          typos # source typo checker (pre-commit typos hook)
-          deadnix # dead-Nix-code linter (flake `checks.deadnix`)
-          statix # nix anti-pattern linter (flake `checks.statix`)
-
-          # Container runtime
-          podman
-
-          # Agent / terminal toolkit (absorbed from #545)
-          ripgrep # rg
-          fd
-          bat
-          eza
-          zoxide
-          starship
-          charm-freeze # freeze (charmbracelet terminal screenshots)
-          expect
-          neovim # nvim
-          claude-code # claude
-        ];
+      devTools = import ./nix/devtools.nix;
 
       # Binary names exposed for the parity test. Prefer the package's declared
       # `meta.mainProgram` (the canonical executable name, e.g. ripgrep -> rg,
@@ -659,7 +606,7 @@
           # `{ self, … }` output signature, whose intentionally-unused args
           # deadnix would otherwise flag. Refs #777.
           deadnix = pkgs.runCommand "deadnix-check" { nativeBuildInputs = [ pkgs.deadnix ]; } ''
-            deadnix --fail ${./flake.nix}
+            deadnix --fail ${./flake.nix} ${./nix}
             touch "$out"
           '';
 
@@ -667,6 +614,7 @@
           # `inherit`). Same authored-flake scoping rationale as deadnix. Refs #777.
           statix = pkgs.runCommand "statix-check" { nativeBuildInputs = [ pkgs.statix ]; } ''
             statix check ${./flake.nix}
+            statix check ${./nix}
             touch "$out"
           '';
 
@@ -1081,22 +1029,25 @@
           };
         };
 
-      # No `nixpkgs.overlays` here: home-manager rejects setting it when the
-      # consumer supplies an external `pkgs` (the common flake case). Fast-movers
-      # then track the consumer's channel unless they apply `overlays.default`
-      # themselves — documented in docs/NIX.md. Refs #777.
-      homeManagerModules.default =
-        {
-          config,
-          lib,
-          pkgs,
-          ...
-        }:
-        {
-          options.programs.vigos-devtools.enable = lib.mkEnableOption "the vigOS devcontainer toolchain (devTools)";
-          config = lib.mkIf config.programs.vigos-devtools.enable {
-            home.packages = devTools pkgs;
-          };
-        };
+      # ----------------------------------------------------------------------
+      # vigos.* home modules (#818) - the terminal home environment as
+      # per-concern home-manager modules (ADR-home-environment-modules).
+      # Exported as PATHS, not imported functions: the module system dedups
+      # path imports, so importing the `default` umbrella plus an individual
+      # module never double-declares options. The legacy
+      # `programs.vigos-devtools.enable` is shimmed in packages.nix
+      # (mkRenamedOptionModule, one release - docs/NIX.md policy).
+      # `homeModules` is the newer-convention alias of the same set.
+      # ----------------------------------------------------------------------
+      homeManagerModules = {
+        default = ./nix/home/default.nix;
+        packages = ./nix/home/packages.nix;
+        shell = ./nix/home/shell.nix;
+        multiplexer = ./nix/home/multiplexer.nix;
+        cli = ./nix/home/cli.nix;
+        direnv = ./nix/home/direnv.nix;
+        git = ./nix/home/git.nix;
+      };
+      homeModules = self.homeManagerModules;
     };
 }

--- a/nix/bats.nix
+++ b/nix/bats.nix
@@ -1,0 +1,9 @@
+# bats with its helper libraries (support/assert/file), wrapped so
+# BATS_LIB_PATH can be derived from one place. Shared by the devTools list
+# (nix/devtools.nix), mkProjectShell, and the image env. Refs #695, #818.
+pkgs:
+pkgs.bats.withLibraries (p: [
+  p.bats-support
+  p.bats-assert
+  p.bats-file
+])

--- a/nix/devtools.nix
+++ b/nix/devtools.nix
@@ -2,7 +2,12 @@
 # the Nix-built image, and the vigos.packages home module. Lives outside
 # flake.nix so the vigos.* path modules (nix/home/) can share it without
 # duplicating the list. Refs #818.
-pkgs: with pkgs; [
+pkgs:
+let
+  batsWithLibs = import ./bats.nix;
+in
+with pkgs;
+[
   # Build automation
   just
 

--- a/nix/devtools.nix
+++ b/nix/devtools.nix
@@ -1,0 +1,57 @@
+# The vigOS toolchain SSoT - one list, delivered everywhere: the dev-shell,
+# the Nix-built image, and the vigos.packages home module. Lives outside
+# flake.nix so the vigos.* path modules (nix/home/) can share it without
+# duplicating the list. Refs #818.
+pkgs: with pkgs; [
+  # Build automation
+  just
+
+  # Git-hook runner: prek (Rust drop-in for the Python pre-commit,
+  # faster and one fewer manylinux/FHS consumer). The SSoT runner for
+  # the `.githooks` hooks and the flake's `checks.pre-commit`. Refs #778.
+  prek
+
+  # Version control & GitHub (gh from unstable via overlay)
+  git
+  gh
+  lazygit
+  delta
+
+  # Python tooling (uv from unstable via overlay)
+  uv
+
+  # Node.js (devcontainer CLI via npm)
+  nodejs
+
+  # Shell testing: bats core + helper libraries (support/assert/file).
+  # Wrapped so BATS_LIB_PATH is exported for bats_load_library. Refs #695.
+  (batsWithLibs pkgs)
+
+  # Shell & JSON utilities
+  jq
+  tmux
+  shellcheck
+
+  # Linting
+  taplo
+  nixfmt-rfc-style # nix file formatter (treefmt `nix fmt`, pre-commit hook)
+  ruff # python linter/formatter (pre-commit ruff/ruff-format hooks)
+  typos # source typo checker (pre-commit typos hook)
+  deadnix # dead-Nix-code linter (flake `checks.deadnix`)
+  statix # nix anti-pattern linter (flake `checks.statix`)
+
+  # Container runtime
+  podman
+
+  # Agent / terminal toolkit (absorbed from #545)
+  ripgrep # rg
+  fd
+  bat
+  eza
+  zoxide
+  starship
+  charm-freeze # freeze (charmbracelet terminal screenshots)
+  expect
+  neovim # nvim
+  claude-code # claude
+]

--- a/nix/home/cli.nix
+++ b/nix/home/cli.nix
@@ -1,0 +1,5 @@
+# vigos.cli — skeleton (#818); behavior lands with wave 1 (#821).
+{ lib, ... }:
+{
+  options.vigos.cli.enable = lib.mkEnableOption "the vigOS modern-unix CLI configuration (config only; packages ship via vigos.packages)";
+}

--- a/nix/home/default.nix
+++ b/nix/home/default.nix
@@ -1,0 +1,13 @@
+# Umbrella module: every vigos.* module, each disabled by default (#818).
+# Import this for the full option surface, or pick individual modules —
+# path-based imports dedup, so mixing both never conflicts.
+{
+  imports = [
+    ./packages.nix
+    ./shell.nix
+    ./multiplexer.nix
+    ./cli.nix
+    ./direnv.nix
+    ./git.nix
+  ];
+}

--- a/nix/home/direnv.nix
+++ b/nix/home/direnv.nix
@@ -1,0 +1,5 @@
+# vigos.direnv — skeleton (#818); behavior lands with wave 1 (#821).
+{ lib, ... }:
+{
+  options.vigos.direnv.enable = lib.mkEnableOption "direnv + nix-direnv integration";
+}

--- a/nix/home/git.nix
+++ b/nix/home/git.nix
@@ -1,0 +1,5 @@
+# vigos.git — skeleton (#818); behavior lands with wave 1 (#821).
+{ lib, ... }:
+{
+  options.vigos.git.enable = lib.mkEnableOption "the vigOS git environment (identity, optional SSH signing, gh, lazygit, delta)";
+}

--- a/nix/home/multiplexer.nix
+++ b/nix/home/multiplexer.nix
@@ -1,0 +1,5 @@
+# vigos.multiplexer — skeleton (#818); behavior lands with wave 1 (#821).
+{ lib, ... }:
+{
+  options.vigos.multiplexer.enable = lib.mkEnableOption "the vigOS tmux configuration";
+}

--- a/nix/home/packages.nix
+++ b/nix/home/packages.nix
@@ -1,0 +1,27 @@
+# vigos.packages — the shared toolchain (devTools) as home packages.
+#
+# The #777 package-only module re-keyed into the vigos.* namespace (#818).
+# The legacy `programs.vigos-devtools.enable` option is shimmed here (and
+# only here) via mkRenamedOptionModule for one release — docs/NIX.md policy.
+#
+# Packages come from the `pkgs` this module is evaluated with. The flake's
+# own homeConfigurations pass devkit's pinned nixpkgs + fast-mover overlay
+# (self-pkgs), so tool versions match the dev-shell and image. A consumer
+# passing its own pkgs applies `overlays.default` itself (home-manager
+# rejects a module-set `nixpkgs.overlays` with an external pkgs) and must
+# allow unfree for claude-code.
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+{
+  imports = [
+    (lib.mkRenamedOptionModule [ "programs" "vigos-devtools" "enable" ] [ "vigos" "packages" "enable" ])
+  ];
+  options.vigos.packages.enable = lib.mkEnableOption "the vigOS toolchain (devTools) as home packages";
+  config = lib.mkIf config.vigos.packages.enable {
+    home.packages = (import ../devtools.nix) pkgs;
+  };
+}

--- a/nix/home/shell.nix
+++ b/nix/home/shell.nix
@@ -1,0 +1,5 @@
+# vigos.shell — skeleton (#818); behavior lands with wave 1 (#821).
+{ lib, ... }:
+{
+  options.vigos.shell.enable = lib.mkEnableOption "the vigOS shell environment (bash+zsh, starship, atuin, secretsEnv)";
+}

--- a/tests/test_flake_checks.py
+++ b/tests/test_flake_checks.py
@@ -116,7 +116,13 @@ def test_checks_output_exposes_quality_gates() -> None:
         # git-hooks.nix runs the sandbox-pure subset of the pre-commit hooks as
         # a flake check, driven by the prek runner (#778).
         "pre-commit",
+        # The ci homeConfigurations matrix builds as Tier-0 checks (#819) —
+        # skipped only on x86_64-darwin (eval-only best-effort tier).
+        "hm-minimal",
+        "hm-full",
     }
+    if system == "x86_64-darwin":
+        required -= {"hm-minimal", "hm-full"}
     missing = required - names
     assert not missing, f"checks output is missing gates: {sorted(missing)}"
 
@@ -194,7 +200,8 @@ def test_toolchain_modules_are_exposed() -> None:
                 "--json",
                 f"{REPO_ROOT}#{output}",
                 "--apply",
-                "m: { hasDefault = m ? default; isFn = builtins.isFunction m.default; }",
+                "m: { hasDefault = m ? default; isImportable = "
+                "builtins.isFunction m.default || builtins.isPath m.default; }",
             ],
             capture_output=True,
             text=True,
@@ -205,7 +212,122 @@ def test_toolchain_modules_are_exposed() -> None:
             pytest.fail(f"Failed to read {output}:\n" + result.stderr)
         info = json.loads(result.stdout)
         assert info["hasDefault"], f"{output} is missing a default module"
-        assert info["isFn"], f"{output}.default is not a module function"
+        # vigos home modules are exported as *paths* (the module system dedups
+        # path imports, so `default` + a single module never double-declare
+        # options); the NixOS module stays an inline function. Both import.
+        assert info["isImportable"], f"{output}.default is not importable"
+
+
+HM_MODULES = {"default", "packages", "shell", "multiplexer", "cli", "direnv", "git"}
+HM_SYSTEMS = ("x86_64-linux", "aarch64-linux", "aarch64-darwin", "x86_64-darwin")
+
+
+def test_vigos_home_module_set_is_exposed() -> None:
+    """``homeManagerModules`` must expose the full vigos.* module set (#818).
+
+    ``default`` is the umbrella importing every module (each disabled by
+    default); the per-concern modules are individually importable. All are
+    path-or-function modules.
+    """
+    result = subprocess.run(
+        [
+            "nix",
+            "eval",
+            "--json",
+            f"{REPO_ROOT}#homeManagerModules",
+            "--apply",
+            "m: { names = builtins.attrNames m; importable = builtins.all "
+            "(n: builtins.isPath m.${n} || builtins.isFunction m.${n}) "
+            "(builtins.attrNames m); }",
+        ],
+        capture_output=True,
+        text=True,
+        env=_nix_env(),
+        timeout=600,
+    )
+    if result.returncode != 0:
+        pytest.fail("Failed to read homeManagerModules:\n" + result.stderr)
+    info = json.loads(result.stdout)
+    missing = HM_MODULES - set(info["names"])
+    assert not missing, f"homeManagerModules is missing: {sorted(missing)}"
+    assert info["importable"], "a homeManagerModules entry is not importable"
+
+
+def test_home_modules_alias_matches() -> None:
+    """``homeModules`` (newer convention) must mirror ``homeManagerModules``."""
+    result = subprocess.run(
+        [
+            "nix",
+            "eval",
+            "--json",
+            f"{REPO_ROOT}#",
+            "--apply",
+            "f: { hm = builtins.attrNames f.homeManagerModules; "
+            "alias = builtins.attrNames (f.homeModules or { }); }",
+        ],
+        capture_output=True,
+        text=True,
+        env=_nix_env(),
+        timeout=600,
+    )
+    if result.returncode != 0:
+        pytest.fail("Failed to compare homeModules alias:\n" + result.stderr)
+    info = json.loads(result.stdout)
+    assert info["alias"] == info["hm"], (
+        f"homeModules alias diverges: {info['alias']} != {info['hm']}"
+    )
+
+
+def test_home_configurations_matrix() -> None:
+    """The synthetic-ci homeConfigurations matrix must cover all systems (#819).
+
+    ``ci-{minimal,full}-<system>`` for every supported system, including
+    x86_64-darwin (which evaluates but is never built — best-effort tier).
+    """
+    result = subprocess.run(
+        [
+            "nix",
+            "eval",
+            "--json",
+            f"{REPO_ROOT}#homeConfigurations",
+            "--apply",
+            "builtins.attrNames",
+        ],
+        capture_output=True,
+        text=True,
+        env=_nix_env(),
+        timeout=600,
+    )
+    if result.returncode != 0:
+        pytest.fail("Failed to read homeConfigurations:\n" + result.stderr)
+    names = set(json.loads(result.stdout))
+    expected = {
+        f"ci-{profile}-{system}"
+        for profile in ("minimal", "full")
+        for system in HM_SYSTEMS
+    }
+    missing = expected - names
+    assert not missing, f"homeConfigurations matrix is missing: {sorted(missing)}"
+
+
+def test_home_configuration_evaluates_end_to_end() -> None:
+    """A matrix leg must evaluate through the module system (cheap smoke)."""
+    result = subprocess.run(
+        [
+            "nix",
+            "eval",
+            "--raw",
+            f'{REPO_ROOT}#homeConfigurations."ci-minimal-x86_64-linux"'
+            ".config.home.stateVersion",
+        ],
+        capture_output=True,
+        text=True,
+        env=_nix_env(),
+        timeout=600,
+    )
+    if result.returncode != 0:
+        pytest.fail("ci-minimal-x86_64-linux does not evaluate:\n" + result.stderr)
+    assert result.stdout.strip() == "26.05"
 
 
 def test_flake_check_succeeds() -> None:

--- a/tests/test_flake_checks.py
+++ b/tests/test_flake_checks.py
@@ -255,26 +255,27 @@ def test_vigos_home_module_set_is_exposed() -> None:
 
 def test_home_modules_alias_matches() -> None:
     """``homeModules`` (newer convention) must mirror ``homeManagerModules``."""
-    result = subprocess.run(
-        [
-            "nix",
-            "eval",
-            "--json",
-            f"{REPO_ROOT}#",
-            "--apply",
-            "f: { hm = builtins.attrNames f.homeManagerModules; "
-            "alias = builtins.attrNames (f.homeModules or { }); }",
-        ],
-        capture_output=True,
-        text=True,
-        env=_nix_env(),
-        timeout=600,
-    )
-    if result.returncode != 0:
-        pytest.fail("Failed to compare homeModules alias:\n" + result.stderr)
-    info = json.loads(result.stdout)
-    assert info["alias"] == info["hm"], (
-        f"homeModules alias diverges: {info['alias']} != {info['hm']}"
+    names: dict[str, list[str]] = {}
+    for output in ("homeManagerModules", "homeModules"):
+        result = subprocess.run(
+            [
+                "nix",
+                "eval",
+                "--json",
+                f"{REPO_ROOT}#{output}",
+                "--apply",
+                "builtins.attrNames",
+            ],
+            capture_output=True,
+            text=True,
+            env=_nix_env(),
+            timeout=600,
+        )
+        if result.returncode != 0:
+            pytest.fail(f"Failed to read {output}:\n" + result.stderr)
+        names[output] = json.loads(result.stdout)
+    assert names["homeModules"] == names["homeManagerModules"], (
+        f"homeModules alias diverges: {names!r}"
     )
 
 


### PR DESCRIPTION
Lands A1 (#818) and A2 (#819) for epic #814: vigos.* path-module set with rename shim and umbrella, devTools relocated to nix/devtools.nix (SSoT shared with the modules), home-manager input, ci-{minimal,full} homeConfigurations across 4 systems, hm-minimal/hm-full Tier-0 checks (x86_64-darwin eval-only). Local evidence: full x86_64-linux Tier-0 green incl. new legs (hm builds: 7s warm); schema pytest 9/9.

Refs: #818, #819