### PR TITLE
feat(home): wave-1 modules (shell, multiplexer, cli, direnv, git)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **vigos.multiplexer, vigos.cli, vigos.direnv modules** ([#821](https://github.com/vig-os/devcontainer/issues/821))
   - tmux org defaults (vi keys, sane scrollback), modern-unix config (bat/eza/fzf/ripgrep/fd — configuration only, packages stay in vigos.packages), direnv + nix-direnv.
 
+- **vigos.git module** ([#821](https://github.com/vig-os/devcontainer/issues/821))
+  - git + delta, gh (ssh protocol), lazygit; identity and per-user-x-host SSH signing are null-default options — nothing is written unless set, so fresh hosts never fail their first commit.
+
 ### Changed
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **vigos.shell module** ([#821](https://github.com/vig-os/devcontainer/issues/821))
   - Bash + zsh, starship, atuin, zoxide under one enable flag; opt-in secretsEnv hook exporting ~/.config/vigos/secrets/<NAME> per the ADR credentials interface.
 
+- **vigos.multiplexer, vigos.cli, vigos.direnv modules** ([#821](https://github.com/vig-os/devcontainer/issues/821))
+  - tmux org defaults (vi keys, sane scrollback), modern-unix config (bat/eza/fzf/ripgrep/fd — configuration only, packages stay in vigos.packages), direnv + nix-direnv.
+
 ### Changed
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Home Matrix CI workflow** ([#820](https://github.com/vig-os/devcontainer/issues/820))
   - Builds the ci homeConfigurations on aarch64-darwin (macos-latest) and aarch64-linux and pushes closures to Cachix; separate non-required workflow (fail-soft by status).
 
+- **vigos.shell module** ([#821](https://github.com/vig-os/devcontainer/issues/821))
+  - Bash + zsh, starship, atuin, zoxide under one enable flag; opt-in secretsEnv hook exporting ~/.config/vigos/secrets/<NAME> per the ADR credentials interface.
+
 ### Changed
 
 ### Deprecated

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -28,6 +28,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **vigos.multiplexer, vigos.cli, vigos.direnv modules** ([#821](https://github.com/vig-os/devcontainer/issues/821))
   - tmux org defaults (vi keys, sane scrollback), modern-unix config (bat/eza/fzf/ripgrep/fd — configuration only, packages stay in vigos.packages), direnv + nix-direnv.
 
+- **vigos.git module** ([#821](https://github.com/vig-os/devcontainer/issues/821))
+  - git + delta, gh (ssh protocol), lazygit; identity and per-user-x-host SSH signing are null-default options — nothing is written unless set, so fresh hosts never fail their first commit.
+
 ### Changed
 
 ### Deprecated

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -25,6 +25,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **vigos.shell module** ([#821](https://github.com/vig-os/devcontainer/issues/821))
   - Bash + zsh, starship, atuin, zoxide under one enable flag; opt-in secretsEnv hook exporting ~/.config/vigos/secrets/<NAME> per the ADR credentials interface.
 
+- **vigos.multiplexer, vigos.cli, vigos.direnv modules** ([#821](https://github.com/vig-os/devcontainer/issues/821))
+  - tmux org defaults (vi keys, sane scrollback), modern-unix config (bat/eza/fzf/ripgrep/fd — configuration only, packages stay in vigos.packages), direnv + nix-direnv.
+
 ### Changed
 
 ### Deprecated

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Home Matrix CI workflow** ([#820](https://github.com/vig-os/devcontainer/issues/820))
   - Builds the ci homeConfigurations on aarch64-darwin (macos-latest) and aarch64-linux and pushes closures to Cachix; separate non-required workflow (fail-soft by status).
 
+- **vigos.shell module** ([#821](https://github.com/vig-os/devcontainer/issues/821))
+  - Bash + zsh, starship, atuin, zoxide under one enable flag; opt-in secretsEnv hook exporting ~/.config/vigos/secrets/<NAME> per the ADR credentials interface.
+
 ### Changed
 
 ### Deprecated

--- a/nix/home/cli.nix
+++ b/nix/home/cli.nix
@@ -1,5 +1,29 @@
-# vigos.cli — skeleton (#818); behavior lands with wave 1 (#821).
-{ lib, ... }:
+# vigos.cli — modern-unix CLI configuration (#821).
+#
+# CONFIGURATION ONLY: packages ship solely via vigos.packages (the devTools
+# SSoT) — this module never adds home.packages. The HM programs.* modules
+# used here install their package attribute as a side effect; those resolve
+# from this module's pkgs (self-pkgs in the flake's homeConfigurations), the
+# same derivations devTools carries, so the union stays one store path per
+# tool.
+{
+  config,
+  lib,
+  ...
+}:
 {
   options.vigos.cli.enable = lib.mkEnableOption "the vigOS modern-unix CLI configuration (config only; packages ship via vigos.packages)";
+
+  config = lib.mkIf config.vigos.cli.enable {
+    programs = {
+      bat.enable = lib.mkDefault true;
+      eza = {
+        enable = lib.mkDefault true;
+        git = lib.mkDefault true;
+      };
+      fzf.enable = lib.mkDefault true;
+      ripgrep.enable = lib.mkDefault true;
+      fd.enable = lib.mkDefault true;
+    };
+  };
 }

--- a/nix/home/direnv.nix
+++ b/nix/home/direnv.nix
@@ -1,5 +1,21 @@
-# vigos.direnv — skeleton (#818); behavior lands with wave 1 (#821).
-{ lib, ... }:
+# vigos.direnv — direnv + nix-direnv (#821).
+#
+# The org's per-project activation layer (ADR-nix-devenv-strategy axis 1):
+# `use flake` in a repo's .envrc activates its mkProjectShell dev-shell,
+# GC-rooted so re-entry is instant. Shell integrations follow the enabled
+# shells automatically.
+{
+  config,
+  lib,
+  ...
+}:
 {
   options.vigos.direnv.enable = lib.mkEnableOption "direnv + nix-direnv integration";
+
+  config = lib.mkIf config.vigos.direnv.enable {
+    programs.direnv = {
+      enable = lib.mkDefault true;
+      nix-direnv.enable = lib.mkDefault true;
+    };
+  };
 }

--- a/nix/home/git.nix
+++ b/nix/home/git.nix
@@ -1,5 +1,67 @@
-# vigos.git — skeleton (#818); behavior lands with wave 1 (#821).
-{ lib, ... }:
+# vigos.git — org git environment (#821).
+#
+# Identity and signing are OPTIONS with null defaults: the module writes
+# nothing it was not told (a fresh host must never fail its first commit
+# because a signing key does not exist yet). Key minting and forge
+# registration are runbook steps (docs/home, #826) — per-user × host keys,
+# never copied, so a signature identifies the machine it was made on.
 {
-  options.vigos.git.enable = lib.mkEnableOption "the vigOS git environment (identity, optional SSH signing, gh, lazygit, delta)";
+  config,
+  lib,
+  ...
+}:
+let
+  cfg = config.vigos.git;
+in
+{
+  options.vigos.git = {
+    enable = lib.mkEnableOption "the vigOS git environment (git+delta, gh, lazygit)";
+    userName = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      description = "Git author/committer name; nothing is written when null.";
+    };
+    userEmail = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      description = "Git author/committer email; nothing is written when null.";
+    };
+    signingKeyPath = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      example = "~/.ssh/id_ed25519_signing.pub";
+      description = ''
+        Path to the per-user x host SSH signing key. SSH-format commit
+        signing activates only when set; null (the default) writes no
+        signing configuration at all.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    programs = {
+      git = lib.mkMerge [
+        {
+          enable = lib.mkDefault true;
+          delta.enable = lib.mkDefault true;
+        }
+        (lib.mkIf (cfg.userName != null) { userName = lib.mkDefault cfg.userName; })
+        (lib.mkIf (cfg.userEmail != null) { userEmail = lib.mkDefault cfg.userEmail; })
+        (lib.mkIf (cfg.signingKeyPath != null) {
+          signing = {
+            key = lib.mkDefault cfg.signingKeyPath;
+            format = lib.mkDefault "ssh";
+            signByDefault = lib.mkDefault true;
+          };
+        })
+      ];
+
+      gh = {
+        enable = lib.mkDefault true;
+        settings.git_protocol = lib.mkDefault "ssh";
+      };
+
+      lazygit.enable = lib.mkDefault true;
+    };
+  };
 }

--- a/nix/home/multiplexer.nix
+++ b/nix/home/multiplexer.nix
@@ -1,5 +1,29 @@
-# vigos.multiplexer — skeleton (#818); behavior lands with wave 1 (#821).
-{ lib, ... }:
+# vigos.multiplexer — org tmux configuration (#821).
+#
+# Config only where possible; the tmux binary itself also ships via
+# vigos.packages (devTools). programs.tmux hard-requires a package for its
+# plugin/wrapper plumbing — it comes from this module's pkgs (self-pkgs in
+# the flake's own homeConfigurations), matching the devTools version, so no
+# second copy appears in practice. extraConfig stays open for personal
+# keybindings.
+{
+  config,
+  lib,
+  ...
+}:
 {
   options.vigos.multiplexer.enable = lib.mkEnableOption "the vigOS tmux configuration";
+
+  config = lib.mkIf config.vigos.multiplexer.enable {
+    programs.tmux = {
+      enable = lib.mkDefault true;
+      # vi keys and a sane scrollback are org defaults; everything is
+      # mkDefault so a personal config overrides with a bare assignment.
+      keyMode = lib.mkDefault "vi";
+      historyLimit = lib.mkDefault 100000;
+      mouse = lib.mkDefault true;
+      escapeTime = lib.mkDefault 10;
+      baseIndex = lib.mkDefault 1;
+    };
+  };
 }

--- a/nix/home/shell.nix
+++ b/nix/home/shell.nix
@@ -1,5 +1,70 @@
-# vigos.shell — skeleton (#818); behavior lands with wave 1 (#821).
-{ lib, ... }:
+# vigos.shell — the org shell environment (#821).
+#
+# Bash AND zsh (macOS default) under one switch: colleagues keep their login
+# shell, integrations land in both. Every scalar is mkDefault so a personal
+# config overrides with a bare assignment (ADR override policy).
+#
+# secretsEnv (opt-in, default off): exports each file under
+# ~/.config/vigos/secrets/<NAME> (the ADR resident-credentials interface) as
+# an environment variable. NAME must match [A-Z_][A-Z0-9_]*; the trailing
+# newline is stripped (command substitution); sourcing is idempotent via a
+# guard variable and runs from both profile and rc files. systemd user
+# services and non-interactive SSH commands are out of scope v1.
 {
-  options.vigos.shell.enable = lib.mkEnableOption "the vigOS shell environment (bash+zsh, starship, atuin, secretsEnv)";
+  config,
+  lib,
+  ...
+}:
+let
+  cfg = config.vigos.shell;
+
+  secretsHook = ''
+    # vigos.shell.secretsEnv — resident-credentials interface (vig-os/devcontainer#821)
+    if [ -z "''${VIGOS_SECRETS_LOADED:-}" ] && [ -d "${cfg.secretsEnv.dir}" ]; then
+      for _vigos_secret in "${cfg.secretsEnv.dir}"/*; do
+        [ -f "$_vigos_secret" ] || continue
+        _vigos_name="$(basename "$_vigos_secret")"
+        if printf '%s' "$_vigos_name" | grep -Eq '^[A-Z_][A-Z0-9_]*$'; then
+          export "$_vigos_name=$(cat "$_vigos_secret")"
+        fi
+      done
+      unset _vigos_secret _vigos_name
+      export VIGOS_SECRETS_LOADED=1
+    fi
+  '';
+in
+{
+  options.vigos.shell = {
+    enable = lib.mkEnableOption "the vigOS shell environment (bash+zsh, starship, atuin, zoxide)";
+    secretsEnv = {
+      enable = lib.mkEnableOption "exporting ~/.config/vigos/secrets/<NAME> files as environment variables";
+      dir = lib.mkOption {
+        type = lib.types.str;
+        default = "${config.home.homeDirectory}/.config/vigos/secrets";
+        description = "Directory holding one file per secret (mode 0600), named like the target environment variable.";
+      };
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    programs = {
+      bash = {
+        enable = lib.mkDefault true;
+        initExtra = lib.mkIf cfg.secretsEnv.enable secretsHook;
+        profileExtra = lib.mkIf cfg.secretsEnv.enable secretsHook;
+      };
+
+      zsh = {
+        enable = lib.mkDefault true;
+        initContent = lib.mkIf cfg.secretsEnv.enable secretsHook;
+        profileExtra = lib.mkIf cfg.secretsEnv.enable secretsHook;
+      };
+
+      # Prompt, history, and directory jumping — each ships its own bash/zsh
+      # integration toggle, defaulting to on when the shells are enabled.
+      starship.enable = lib.mkDefault true;
+      atuin.enable = lib.mkDefault true;
+      zoxide.enable = lib.mkDefault true;
+    };
+  };
 }

--- a/tests/test_flake_checks.py
+++ b/tests/test_flake_checks.py
@@ -331,6 +331,64 @@ def test_home_configuration_evaluates_end_to_end() -> None:
     assert result.stdout.strip() == "26.05"
 
 
+def test_wave1_full_profile_config() -> None:
+    """Wave-1 modules must materialize in the full ci profile (#821).
+
+    One eval pulls the interesting config slice: every wave-1 program
+    enabled, git signing INACTIVE by default (signingKeyPath is null on
+    fresh hosts — first commits must not fail), and the secretsEnv hook
+    present but off by default.
+    """
+    result = subprocess.run(
+        [
+            "nix",
+            "eval",
+            "--json",
+            f'{REPO_ROOT}#homeConfigurations."ci-full-x86_64-linux".config',
+            "--apply",
+            "c: { "
+            "bash = c.programs.bash.enable; "
+            "zsh = c.programs.zsh.enable; "
+            "starship = c.programs.starship.enable; "
+            "atuin = c.programs.atuin.enable; "
+            "zoxide = c.programs.zoxide.enable; "
+            "tmux = c.programs.tmux.enable; "
+            "direnv = c.programs.direnv.enable; "
+            "nixDirenv = c.programs.direnv.nix-direnv.enable; "
+            "git = c.programs.git.enable; "
+            "gh = c.programs.gh.enable; "
+            "lazygit = c.programs.lazygit.enable; "
+            "signingKey = c.programs.git.signing.key; "
+            "secretsEnvDefault = c.vigos.shell.secretsEnv.enable; "
+            "}",
+        ],
+        capture_output=True,
+        text=True,
+        env=_nix_env(),
+        timeout=600,
+    )
+    if result.returncode != 0:
+        pytest.fail("full-profile config does not evaluate:\n" + result.stderr)
+    cfg = json.loads(result.stdout)
+    enabled = [
+        "bash",
+        "zsh",
+        "starship",
+        "atuin",
+        "zoxide",
+        "tmux",
+        "direnv",
+        "nixDirenv",
+        "git",
+        "gh",
+        "lazygit",
+    ]
+    off = [k for k in enabled if not cfg[k]]
+    assert not off, f"wave-1 programs not enabled in full profile: {off}"
+    assert cfg["signingKey"] is None, "git signing must be inactive by default"
+    assert cfg["secretsEnvDefault"] is False, "secretsEnv must default off"
+
+
 def test_flake_check_succeeds() -> None:
     """``nix flake check`` evaluates the flake and runs the lightweight checks."""
     result = subprocess.run(


### PR DESCRIPTION
Lands A4 (#821) for epic #814. TDD: red behavior test → shell → multiplexer/cli/direnv → git. Local evidence: full Tier-0 green (incl. hm legs), schema pytest 10/10, darwin full-profile eval OK.

Refs: #821