### PR TITLE
feat(home): vigos.claude — ~/.claude policy + container secrets path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **CLAUDE.md hierarchy templates** ([#828](https://github.com/vig-os/devcontainer/issues/828))
   - docs/home/claude-md/: user-global, workspace-root, and workspace layer templates + the directory-layout convention that makes the cascade work. Guidelines, not enforcement.
 
+- **vigos.claude module + container secrets path** ([#823](https://github.com/vig-os/devcontainer/issues/823), absorbs [#546](https://github.com/vig-os/devcontainer/issues/546))
+  - ~/.claude policy per the ADR: settings.json seeded copy-if-absent (org seed pre-authorizes nothing, includeCoAuthoredBy=false), managed vigos.md fragment (checksum-overwrite + .bak), @vigos.md import line seeded into the user-owned CLAUDE.md, DISABLE_AUTOUPDATER via sessionVariables, optional workspace-CLAUDE.md management (empty by default).
+  - Devcontainer scaffold mounts ~/.config/vigos/secrets read-only and exports the files as env vars at shell startup — the slim token path replacing setup-claude.sh forwarding.
+
 ### Changed
 
 #### Modules

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -43,6 +43,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **CLAUDE.md hierarchy templates** ([#828](https://github.com/vig-os/devcontainer/issues/828))
   - docs/home/claude-md/: user-global, workspace-root, and workspace layer templates + the directory-layout convention that makes the cascade work. Guidelines, not enforcement.
 
+- **vigos.claude module + container secrets path** ([#823](https://github.com/vig-os/devcontainer/issues/823), absorbs [#546](https://github.com/vig-os/devcontainer/issues/546))
+  - ~/.claude policy per the ADR: settings.json seeded copy-if-absent (org seed pre-authorizes nothing, includeCoAuthoredBy=false), managed vigos.md fragment (checksum-overwrite + .bak), @vigos.md import line seeded into the user-owned CLAUDE.md, DISABLE_AUTOUPDATER via sessionVariables, optional workspace-CLAUDE.md management (empty by default).
+  - Devcontainer scaffold mounts ~/.config/vigos/secrets read-only and exports the files as env vars at shell startup — the slim token path replacing setup-claude.sh forwarding.
+
 ### Changed
 
 #### Modules

--- a/assets/workspace/.devcontainer/docker-compose.yml
+++ b/assets/workspace/.devcontainer/docker-compose.yml
@@ -8,6 +8,10 @@ services:
       # Container socket for container builds (Docker-out-of-Docker)
       # Path is set by initialize.sh in .env, falls back to Docker default
       - "${CONTAINER_SOCKET_PATH:-/var/run/docker.sock}:/var/run/docker.sock"
+      # Resident per-user credentials (vig-os/devcontainer#546, #823): the
+      # canonical host secrets dir, read-only. post-create.sh exports each
+      # file as an env var in the container shell when the dir is non-empty.
+      - "${HOME}/.config/vigos/secrets:/root/.config/vigos/secrets:ro"
     environment:
       # PRE_COMMIT_HOME, UV_PROJECT_ENVIRONMENT, VIRTUAL_ENV are set in the image (flake.nix)
       # Tell Podman/Docker to use the mounted socket (for container builds)

--- a/assets/workspace/.devcontainer/scripts/post-create.sh
+++ b/assets/workspace/.devcontainer/scripts/post-create.sh
@@ -48,3 +48,22 @@ fi
 # Add your custom setup commands here to install any dependencies or tools needed for your project
 
 echo "Post-create setup complete"
+
+# --- vigOS resident credentials (vig-os/devcontainer#546, #823) ------------
+# Export ~/.config/vigos/secrets/<NAME> files (mounted ro from the host) as
+# env vars at shell startup. Same semantics as vigos.shell.secretsEnv.
+if [ -d /root/.config/vigos/secrets ] && ! grep -q VIGOS_SECRETS_LOADED /root/.bashrc 2>/dev/null; then
+  cat >> /root/.bashrc <<'VIGOS_SECRETS'
+if [ -z "${VIGOS_SECRETS_LOADED:-}" ] && [ -d "$HOME/.config/vigos/secrets" ]; then
+  for _vigos_secret in "$HOME/.config/vigos/secrets"/*; do
+    [ -f "$_vigos_secret" ] || continue
+    _vigos_name="$(basename "$_vigos_secret")"
+    if printf '%s' "$_vigos_name" | grep -Eq '^[A-Z_][A-Z0-9_]*$'; then
+      export "$_vigos_name=$(cat "$_vigos_secret")"
+    fi
+  done
+  unset _vigos_secret _vigos_name
+  export VIGOS_SECRETS_LOADED=1
+fi
+VIGOS_SECRETS
+fi

--- a/flake.nix
+++ b/flake.nix
@@ -128,6 +128,7 @@
         full = {
           vigos = {
             packages.enable = true;
+            claude.enable = true;
             shell.enable = true;
             multiplexer.enable = true;
             cli.enable = true;
@@ -1122,6 +1123,7 @@
         cli = ./nix/home/cli.nix;
         direnv = ./nix/home/direnv.nix;
         git = ./nix/home/git.nix;
+        claude = ./nix/home/claude.nix;
       };
       homeModules = self.homeManagerModules;
 

--- a/nix/home/claude.nix
+++ b/nix/home/claude.nix
@@ -1,0 +1,89 @@
+# vigos.claude — Claude Code conventions (#823, ADR Axis 5).
+#
+# Policy implemented here, in order of strictness:
+#   never managed:  ~/.claude.json, settings.local.json (mutable runtime state)
+#   seeded:         settings.json — copy-if-absent, then user-owned (Claude
+#                   rewrites it; org seed updates are announced in the
+#                   changelog, re-seed = delete + re-activate)
+#   managed (copy): ~/.claude/vigos.md org fragment — checksum-overwrite with
+#                   a .bak of local edits. No symlinks of ANY kind under
+#                   ~/.claude/ (store symlinks break Claude's sandbox and
+#                   atomic writes; out-of-store needs a local checkout).
+# The user-owned ~/.claude/CLAUDE.md gets a single `@vigos.md` import line
+# seeded (created if missing, appended once if absent — Claude Code itself
+# writes to this file via the memory feature, so it is never overwritten).
+# Packages: none — claude-code, nodejs, uv ship via vigos.packages/devTools.
+# Org defaults pre-authorize nothing (no permission modes in the seed).
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.vigos.claude;
+  settingsFormat = pkgs.formats.json { };
+  seedFile = settingsFormat.generate "vigos-claude-settings-seed.json" cfg.settingsSeed;
+  fragment = ./claude/vigos.md;
+in
+{
+  options.vigos.claude = {
+    enable = lib.mkEnableOption "the vigOS Claude Code conventions (~/.claude seeding + org fragment)";
+    settingsSeed = lib.mkOption {
+      inherit (settingsFormat) type;
+      default = {
+        includeCoAuthoredBy = false;
+      };
+      description = ''
+        Initial content for ~/.claude/settings.json, written only when the
+        file does not exist (user-owned afterwards). The default enforces the
+        org's no-AI-attribution rule and nothing else.
+      '';
+    };
+    claudeMd.workspaceFiles = lib.mkOption {
+      type = lib.types.attrsOf lib.types.path;
+      default = { };
+      example = lib.literalExpression ''{ "Documents/CLAUDE.md" = ./workspace-root.md; }'';
+      description = ''
+        Optional workspace-level CLAUDE.md files to manage, keyed by path
+        relative to the home directory (templates: docs/home/claude-md/).
+        Empty by default — guidelines, not enforcement.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home = {
+      # Nix owns claude-code updates; the native self-updater stays off. Set
+      # here (not in the user-editable seed) so the promise survives edits.
+      sessionVariables.DISABLE_AUTOUPDATER = lib.mkDefault "1";
+
+      file = lib.mapAttrs (_name: source: { inherit source; }) cfg.claudeMd.workspaceFiles;
+
+      activation.vigosClaude = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+        claudeDir="$HOME/.claude"
+        run mkdir -p "$claudeDir"
+
+        # settings.json: seed once, never touch again.
+        if [ ! -e "$claudeDir/settings.json" ]; then
+          run install -m 0644 ${seedFile} "$claudeDir/settings.json"
+        fi
+
+        # vigos.md fragment: checksum-overwrite, .bak of local edits.
+        if ! cmp -s ${fragment} "$claudeDir/vigos.md" 2>/dev/null; then
+          if [ -e "$claudeDir/vigos.md" ]; then
+            run cp "$claudeDir/vigos.md" "$claudeDir/vigos.md.bak"
+          fi
+          run install -m 0644 ${fragment} "$claudeDir/vigos.md"
+        fi
+
+        # CLAUDE.md: user-owned; ensure the @vigos.md import line exists once.
+        if [ ! -e "$claudeDir/CLAUDE.md" ]; then
+          run sh -c 'printf "@vigos.md\n" > "$1"' _ "$claudeDir/CLAUDE.md"
+        elif ! grep -q "^@vigos\.md$" "$claudeDir/CLAUDE.md"; then
+          run sh -c 'printf "\n@vigos.md\n" >> "$1"' _ "$claudeDir/CLAUDE.md"
+        fi
+      '';
+    };
+  };
+}

--- a/nix/home/claude/vigos.md
+++ b/nix/home/claude/vigos.md
@@ -1,0 +1,13 @@
+# vigOS org practices (managed fragment)
+
+<!-- Managed by vigos.claude: org updates overwrite this file (a .bak of
+     local edits is kept). Put personal rules in ~/.claude/CLAUDE.md. -->
+
+- Never name an AI in git history: no AI Co-Authored-By trailers, never an
+  AI as author or committer. Repos enforce this with hooks.
+- Conventional Commits with a final `Refs: #<issue>` line (`chore` may omit
+  when no issue applies). Pre-commit hooks are mandatory; never `--no-verify`.
+- Traceability: issue → branch → PR; minimal diffs; no out-of-scope drive-bys.
+- Run the repo's full local hook suite green before any push.
+- Autonomous / skip-permissions agent runs happen inside the devcontainer,
+  not on hosts (org working agreement).

--- a/nix/home/default.nix
+++ b/nix/home/default.nix
@@ -9,5 +9,6 @@
     ./cli.nix
     ./direnv.nix
     ./git.nix
+    ./claude.nix
   ];
 }

--- a/nix/home/git.nix
+++ b/nix/home/git.nix
@@ -43,7 +43,6 @@ in
       git = lib.mkMerge [
         {
           enable = lib.mkDefault true;
-          delta.enable = lib.mkDefault true;
         }
         (lib.mkIf (cfg.userName != null) { userName = lib.mkDefault cfg.userName; })
         (lib.mkIf (cfg.userEmail != null) { userEmail = lib.mkDefault cfg.userEmail; })
@@ -55,6 +54,11 @@ in
           };
         })
       ];
+
+      delta = {
+        enable = lib.mkDefault true;
+        enableGitIntegration = lib.mkDefault true;
+      };
 
       gh = {
         enable = lib.mkDefault true;

--- a/tests/test_flake_checks.py
+++ b/tests/test_flake_checks.py
@@ -218,7 +218,16 @@ def test_toolchain_modules_are_exposed() -> None:
         assert info["isImportable"], f"{output}.default is not importable"
 
 
-HM_MODULES = {"default", "packages", "shell", "multiplexer", "cli", "direnv", "git"}
+HM_MODULES = {
+    "default",
+    "packages",
+    "shell",
+    "multiplexer",
+    "cli",
+    "direnv",
+    "git",
+    "claude",
+}
 HM_SYSTEMS = ("x86_64-linux", "aarch64-linux", "aarch64-darwin", "x86_64-darwin")
 
 
@@ -410,6 +419,39 @@ def test_personal_template_is_exposed() -> None:
         pytest.fail("Failed to read templates.personal:\n" + result.stderr)
     info = json.loads(result.stdout)
     assert info["hasPath"] and info["hasDescription"]
+
+
+def test_claude_module_policy() -> None:
+    """vigos.claude must honor the ADR Axis-5 policy (#823).
+
+    DISABLE_AUTOUPDATER set via sessionVariables (Nix owns updates), the
+    workspace-CLAUDE.md management option present but empty by default, and
+    no home-level skills directory managed.
+    """
+    result = subprocess.run(
+        [
+            "nix",
+            "eval",
+            "--json",
+            f'{REPO_ROOT}#homeConfigurations."ci-full-x86_64-linux".config',
+            "--apply",
+            "c: { "
+            "autoupdater = c.home.sessionVariables.DISABLE_AUTOUPDATER or null; "
+            "workspaceFiles = c.vigos.claude.claudeMd.workspaceFiles; "
+            "enabled = c.vigos.claude.enable; "
+            "}",
+        ],
+        capture_output=True,
+        text=True,
+        env=_nix_env(),
+        timeout=600,
+    )
+    if result.returncode != 0:
+        pytest.fail("claude policy eval failed:\n" + result.stderr)
+    cfg = json.loads(result.stdout)
+    assert cfg["enabled"] is True
+    assert cfg["autoupdater"] == "1"
+    assert cfg["workspaceFiles"] == {}
 
 
 def test_flake_check_succeeds() -> None:


### PR DESCRIPTION
Lands B2 (#823) for epic #814; absorbs #546's slim token path (compose scaffolding only, image untouched).

Refs: #823, #546