### PR TITLE
feat(home): vigos.claude + wave-3 modules (waves 2/3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **CLAUDE.md hierarchy templates** ([#828](https://github.com/vig-os/devcontainer/issues/828))
   - docs/home/claude-md/: user-global, workspace-root, and workspace layer templates + the directory-layout convention that makes the cascade work. Guidelines, not enforcement.
 
+- **vigos.claude module + container secrets path** ([#823](https://github.com/vig-os/devcontainer/issues/823), absorbs [#546](https://github.com/vig-os/devcontainer/issues/546))
+  - ~/.claude policy per the ADR: settings.json seeded copy-if-absent (org seed pre-authorizes nothing, includeCoAuthoredBy=false), managed vigos.md fragment (checksum-overwrite + .bak), @vigos.md import line seeded into the user-owned CLAUDE.md, DISABLE_AUTOUPDATER via sessionVariables, optional workspace-CLAUDE.md management (empty by default).
+  - Devcontainer scaffold mounts ~/.config/vigos/secrets read-only and exports the files as env vars at shell startup — the slim token path replacing setup-claude.sh forwarding.
+
 ### Changed
 
 #### Modules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - ~/.claude policy per the ADR: settings.json seeded copy-if-absent (org seed pre-authorizes nothing, includeCoAuthoredBy=false), managed vigos.md fragment (checksum-overwrite + .bak), @vigos.md import line seeded into the user-owned CLAUDE.md, DISABLE_AUTOUPDATER via sessionVariables, optional workspace-CLAUDE.md management (empty by default).
   - Devcontainer scaffold mounts ~/.config/vigos/secrets read-only and exports the files as env vars at shell startup — the slim token path replacing setup-claude.sh forwarding.
 
+- **vigos.sesh, vigos.ghdash, vigos.editor modules** ([#824](https://github.com/vig-os/devcontainer/issues/824))
+  - sesh project sessions with a parameterized standard tmux layout (sessions + layout.windows options, no hardcoded paths), gh-dash with scoped lean sections via repoFilters, neovim with the claudecode.nvim bridge (plain programs.neovim, no nixvim input).
+
 ### Changed
 
 #### Modules

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -43,6 +43,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **CLAUDE.md hierarchy templates** ([#828](https://github.com/vig-os/devcontainer/issues/828))
   - docs/home/claude-md/: user-global, workspace-root, and workspace layer templates + the directory-layout convention that makes the cascade work. Guidelines, not enforcement.
 
+- **vigos.claude module + container secrets path** ([#823](https://github.com/vig-os/devcontainer/issues/823), absorbs [#546](https://github.com/vig-os/devcontainer/issues/546))
+  - ~/.claude policy per the ADR: settings.json seeded copy-if-absent (org seed pre-authorizes nothing, includeCoAuthoredBy=false), managed vigos.md fragment (checksum-overwrite + .bak), @vigos.md import line seeded into the user-owned CLAUDE.md, DISABLE_AUTOUPDATER via sessionVariables, optional workspace-CLAUDE.md management (empty by default).
+  - Devcontainer scaffold mounts ~/.config/vigos/secrets read-only and exports the files as env vars at shell startup — the slim token path replacing setup-claude.sh forwarding.
+
 ### Changed
 
 #### Modules

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -47,6 +47,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - ~/.claude policy per the ADR: settings.json seeded copy-if-absent (org seed pre-authorizes nothing, includeCoAuthoredBy=false), managed vigos.md fragment (checksum-overwrite + .bak), @vigos.md import line seeded into the user-owned CLAUDE.md, DISABLE_AUTOUPDATER via sessionVariables, optional workspace-CLAUDE.md management (empty by default).
   - Devcontainer scaffold mounts ~/.config/vigos/secrets read-only and exports the files as env vars at shell startup — the slim token path replacing setup-claude.sh forwarding.
 
+- **vigos.sesh, vigos.ghdash, vigos.editor modules** ([#824](https://github.com/vig-os/devcontainer/issues/824))
+  - sesh project sessions with a parameterized standard tmux layout (sessions + layout.windows options, no hardcoded paths), gh-dash with scoped lean sections via repoFilters, neovim with the claudecode.nvim bridge (plain programs.neovim, no nixvim input).
+
 ### Changed
 
 #### Modules

--- a/assets/workspace/.devcontainer/docker-compose.yml
+++ b/assets/workspace/.devcontainer/docker-compose.yml
@@ -8,6 +8,10 @@ services:
       # Container socket for container builds (Docker-out-of-Docker)
       # Path is set by initialize.sh in .env, falls back to Docker default
       - "${CONTAINER_SOCKET_PATH:-/var/run/docker.sock}:/var/run/docker.sock"
+      # Resident per-user credentials (vig-os/devcontainer#546, #823): the
+      # canonical host secrets dir, read-only. post-create.sh exports each
+      # file as an env var in the container shell when the dir is non-empty.
+      - "${HOME}/.config/vigos/secrets:/root/.config/vigos/secrets:ro"
     environment:
       # PRE_COMMIT_HOME, UV_PROJECT_ENVIRONMENT, VIRTUAL_ENV are set in the image (flake.nix)
       # Tell Podman/Docker to use the mounted socket (for container builds)

--- a/assets/workspace/.devcontainer/scripts/post-create.sh
+++ b/assets/workspace/.devcontainer/scripts/post-create.sh
@@ -48,3 +48,22 @@ fi
 # Add your custom setup commands here to install any dependencies or tools needed for your project
 
 echo "Post-create setup complete"
+
+# --- vigOS resident credentials (vig-os/devcontainer#546, #823) ------------
+# Export ~/.config/vigos/secrets/<NAME> files (mounted ro from the host) as
+# env vars at shell startup. Same semantics as vigos.shell.secretsEnv.
+if [ -d /root/.config/vigos/secrets ] && ! grep -q VIGOS_SECRETS_LOADED /root/.bashrc 2>/dev/null; then
+  cat >> /root/.bashrc <<'VIGOS_SECRETS'
+if [ -z "${VIGOS_SECRETS_LOADED:-}" ] && [ -d "$HOME/.config/vigos/secrets" ]; then
+  for _vigos_secret in "$HOME/.config/vigos/secrets"/*; do
+    [ -f "$_vigos_secret" ] || continue
+    _vigos_name="$(basename "$_vigos_secret")"
+    if printf '%s' "$_vigos_name" | grep -Eq '^[A-Z_][A-Z0-9_]*$'; then
+      export "$_vigos_name=$(cat "$_vigos_secret")"
+    fi
+  done
+  unset _vigos_secret _vigos_name
+  export VIGOS_SECRETS_LOADED=1
+fi
+VIGOS_SECRETS
+fi

--- a/flake.nix
+++ b/flake.nix
@@ -128,6 +128,7 @@
         full = {
           vigos = {
             packages.enable = true;
+            claude.enable = true;
             shell.enable = true;
             multiplexer.enable = true;
             cli.enable = true;
@@ -1122,6 +1123,7 @@
         cli = ./nix/home/cli.nix;
         direnv = ./nix/home/direnv.nix;
         git = ./nix/home/git.nix;
+        claude = ./nix/home/claude.nix;
       };
       homeModules = self.homeManagerModules;
 

--- a/flake.nix
+++ b/flake.nix
@@ -129,6 +129,9 @@
           vigos = {
             packages.enable = true;
             claude.enable = true;
+            sesh.enable = true;
+            ghdash.enable = true;
+            editor.enable = true;
             shell.enable = true;
             multiplexer.enable = true;
             cli.enable = true;
@@ -1124,6 +1127,9 @@
         direnv = ./nix/home/direnv.nix;
         git = ./nix/home/git.nix;
         claude = ./nix/home/claude.nix;
+        sesh = ./nix/home/sesh.nix;
+        ghdash = ./nix/home/ghdash.nix;
+        editor = ./nix/home/editor.nix;
       };
       homeModules = self.homeManagerModules;
 

--- a/nix/devtools.nix
+++ b/nix/devtools.nix
@@ -57,6 +57,9 @@ with pkgs;
   starship
   charm-freeze # freeze (charmbracelet terminal screenshots)
   expect
-  neovim # nvim
+  # lowPrio: when vigos.editor also installs a configured (wrapped) neovim
+  # in the same profile, the bare editor yields instead of colliding in
+  # buildEnv. Refs #824.
+  (pkgs.lib.lowPrio neovim) # nvim
   claude-code # claude
 ]

--- a/nix/home/claude.nix
+++ b/nix/home/claude.nix
@@ -1,0 +1,89 @@
+# vigos.claude — Claude Code conventions (#823, ADR Axis 5).
+#
+# Policy implemented here, in order of strictness:
+#   never managed:  ~/.claude.json, settings.local.json (mutable runtime state)
+#   seeded:         settings.json — copy-if-absent, then user-owned (Claude
+#                   rewrites it; org seed updates are announced in the
+#                   changelog, re-seed = delete + re-activate)
+#   managed (copy): ~/.claude/vigos.md org fragment — checksum-overwrite with
+#                   a .bak of local edits. No symlinks of ANY kind under
+#                   ~/.claude/ (store symlinks break Claude's sandbox and
+#                   atomic writes; out-of-store needs a local checkout).
+# The user-owned ~/.claude/CLAUDE.md gets a single `@vigos.md` import line
+# seeded (created if missing, appended once if absent — Claude Code itself
+# writes to this file via the memory feature, so it is never overwritten).
+# Packages: none — claude-code, nodejs, uv ship via vigos.packages/devTools.
+# Org defaults pre-authorize nothing (no permission modes in the seed).
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.vigos.claude;
+  settingsFormat = pkgs.formats.json { };
+  seedFile = settingsFormat.generate "vigos-claude-settings-seed.json" cfg.settingsSeed;
+  fragment = ./claude/vigos.md;
+in
+{
+  options.vigos.claude = {
+    enable = lib.mkEnableOption "the vigOS Claude Code conventions (~/.claude seeding + org fragment)";
+    settingsSeed = lib.mkOption {
+      inherit (settingsFormat) type;
+      default = {
+        includeCoAuthoredBy = false;
+      };
+      description = ''
+        Initial content for ~/.claude/settings.json, written only when the
+        file does not exist (user-owned afterwards). The default enforces the
+        org's no-AI-attribution rule and nothing else.
+      '';
+    };
+    claudeMd.workspaceFiles = lib.mkOption {
+      type = lib.types.attrsOf lib.types.path;
+      default = { };
+      example = lib.literalExpression ''{ "Documents/CLAUDE.md" = ./workspace-root.md; }'';
+      description = ''
+        Optional workspace-level CLAUDE.md files to manage, keyed by path
+        relative to the home directory (templates: docs/home/claude-md/).
+        Empty by default — guidelines, not enforcement.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home = {
+      # Nix owns claude-code updates; the native self-updater stays off. Set
+      # here (not in the user-editable seed) so the promise survives edits.
+      sessionVariables.DISABLE_AUTOUPDATER = lib.mkDefault "1";
+
+      file = lib.mapAttrs (_name: source: { inherit source; }) cfg.claudeMd.workspaceFiles;
+
+      activation.vigosClaude = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+        claudeDir="$HOME/.claude"
+        run mkdir -p "$claudeDir"
+
+        # settings.json: seed once, never touch again.
+        if [ ! -e "$claudeDir/settings.json" ]; then
+          run install -m 0644 ${seedFile} "$claudeDir/settings.json"
+        fi
+
+        # vigos.md fragment: checksum-overwrite, .bak of local edits.
+        if ! cmp -s ${fragment} "$claudeDir/vigos.md" 2>/dev/null; then
+          if [ -e "$claudeDir/vigos.md" ]; then
+            run cp "$claudeDir/vigos.md" "$claudeDir/vigos.md.bak"
+          fi
+          run install -m 0644 ${fragment} "$claudeDir/vigos.md"
+        fi
+
+        # CLAUDE.md: user-owned; ensure the @vigos.md import line exists once.
+        if [ ! -e "$claudeDir/CLAUDE.md" ]; then
+          run sh -c 'printf "@vigos.md\n" > "$1"' _ "$claudeDir/CLAUDE.md"
+        elif ! grep -q "^@vigos\.md$" "$claudeDir/CLAUDE.md"; then
+          run sh -c 'printf "\n@vigos.md\n" >> "$1"' _ "$claudeDir/CLAUDE.md"
+        fi
+      '';
+    };
+  };
+}

--- a/nix/home/claude/vigos.md
+++ b/nix/home/claude/vigos.md
@@ -1,0 +1,13 @@
+# vigOS org practices (managed fragment)
+
+<!-- Managed by vigos.claude: org updates overwrite this file (a .bak of
+     local edits is kept). Put personal rules in ~/.claude/CLAUDE.md. -->
+
+- Never name an AI in git history: no AI Co-Authored-By trailers, never an
+  AI as author or committer. Repos enforce this with hooks.
+- Conventional Commits with a final `Refs: #<issue>` line (`chore` may omit
+  when no issue applies). Pre-commit hooks are mandatory; never `--no-verify`.
+- Traceability: issue → branch → PR; minimal diffs; no out-of-scope drive-bys.
+- Run the repo's full local hook suite green before any push.
+- Autonomous / skip-permissions agent runs happen inside the devcontainer,
+  not on hosts (org working agreement).

--- a/nix/home/default.nix
+++ b/nix/home/default.nix
@@ -10,5 +10,8 @@
     ./direnv.nix
     ./git.nix
     ./claude.nix
+    ./sesh.nix
+    ./ghdash.nix
+    ./editor.nix
   ];
 }

--- a/nix/home/default.nix
+++ b/nix/home/default.nix
@@ -9,5 +9,6 @@
     ./cli.nix
     ./direnv.nix
     ./git.nix
+    ./claude.nix
   ];
 }

--- a/nix/home/editor.nix
+++ b/nix/home/editor.nix
@@ -1,0 +1,29 @@
+# vigos.editor — neovim with the Claude Code bridge (#824). Deliberately
+# small (plain programs.neovim + nixpkgs vimPlugins; no nixvim input per the
+# ADR): the org default is "nvim works and talks to Claude"; a richer
+# editor stack stays personal.
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+{
+  options.vigos.editor.enable = lib.mkEnableOption "neovim with the claudecode.nvim bridge";
+
+  config = lib.mkIf config.vigos.editor.enable {
+    programs.neovim = {
+      enable = lib.mkDefault true;
+      defaultEditor = lib.mkDefault true;
+      viAlias = lib.mkDefault true;
+      vimAlias = lib.mkDefault true;
+      plugins = [ pkgs.vimPlugins.claudecode-nvim ];
+      extraLuaConfig = lib.mkAfter ''
+        -- claudecode.nvim: :ClaudeCode toggles a Claude terminal; visual
+        -- selections go over with :ClaudeCodeSend.
+        require("claudecode").setup({})
+        vim.opt.number = true
+      '';
+    };
+  };
+}

--- a/nix/home/ghdash.nix
+++ b/nix/home/ghdash.nix
@@ -1,0 +1,56 @@
+# vigos.ghdash — gh-dash PR/issue dashboard (#824). Parameterized port: the
+# hardcoded personal repo filters became `repoFilters`; the CPU-tuning
+# lessons (lean scoped sections, capped closed lists) are the defaults.
+# Reuses the gh login; the gh-dash package rides this module (not devTools).
+{
+  config,
+  lib,
+  ...
+}:
+let
+  cfg = config.vigos.ghdash;
+
+  scope = if cfg.repoFilters == [ ] then "involves:@me" else lib.concatStringsSep " " cfg.repoFilters;
+
+  sections = [
+    {
+      title = "Involved";
+      filters = "is:open involves:@me ${scope}";
+    }
+    {
+      title = "Open";
+      filters = "is:open ${scope}";
+    }
+    {
+      title = "Recently closed";
+      filters = "is:closed ${scope} sort:updated-desc";
+      limit = 10;
+    }
+  ];
+in
+{
+  options.vigos.ghdash = {
+    enable = lib.mkEnableOption "the gh-dash PR/issue dashboard";
+    repoFilters = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      example = [ "repo:vig-os/devcontainer" ];
+      description = ''
+        GitHub search scope for the generated sections (e.g. repo:/org:
+        qualifiers). Empty = everything involving you. Scoping to the repos
+        you work in keeps each idle dashboard cheap.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    programs.gh-dash = {
+      enable = lib.mkDefault true;
+      settings = {
+        prSections = lib.mkDefault sections;
+        issuesSections = lib.mkDefault sections;
+        defaults.refetchIntervalMinutes = lib.mkDefault 10;
+      };
+    };
+  };
+}

--- a/nix/home/git.nix
+++ b/nix/home/git.nix
@@ -43,7 +43,6 @@ in
       git = lib.mkMerge [
         {
           enable = lib.mkDefault true;
-          delta.enable = lib.mkDefault true;
         }
         (lib.mkIf (cfg.userName != null) { userName = lib.mkDefault cfg.userName; })
         (lib.mkIf (cfg.userEmail != null) { userEmail = lib.mkDefault cfg.userEmail; })
@@ -55,6 +54,11 @@ in
           };
         })
       ];
+
+      delta = {
+        enable = lib.mkDefault true;
+        enableGitIntegration = lib.mkDefault true;
+      };
 
       gh = {
         enable = lib.mkDefault true;

--- a/nix/home/sesh.nix
+++ b/nix/home/sesh.nix
@@ -1,0 +1,155 @@
+# vigos.sesh — one-keypress project sessions with a standard tmux layout
+# (#824). Parameterized port of the maintainer's proven setup: the hardcoded
+# project list became the `sessions` option, the window set became
+# `layout.windows` with devTools-only defaults.
+#
+# Packages: sesh and the two generated scripts ship from here — sesh is NOT
+# in devTools, so this does not duplicate vigos.packages.
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.vigos.sesh;
+
+  windowFlags = w: "-n ${lib.escapeShellArg w.name} -c \"$PWD\"";
+
+  # Build the standard layout: window 1 hosts the first entry (its command
+  # runs in place with a shell fallback so the window survives quitting the
+  # TUI); the rest are created detached, commands typed via send-keys against
+  # captured window ids (stable even if names collide or auto-rename).
+  seshLayout = pkgs.writeShellApplication {
+    name = "sesh-layout";
+    runtimeInputs = [ pkgs.tmux ];
+    text = ''
+      sess=$(tmux display-message -p '#S')
+
+      # Idempotent guard: re-running (or a restored session that already has
+      # the first window's name) must not duplicate windows.
+      if tmux list-windows -t "$sess" -F '#{window_name}' | grep -qx ${lib.escapeShellArg (lib.head cfg.layout.windows).name}; then
+        tmux select-window -t "$sess:${(lib.head cfg.layout.windows).name}" || true
+        exit 0
+      fi
+
+      tmux rename-window -t "$sess:1" ${lib.escapeShellArg (lib.head cfg.layout.windows).name}
+      ${lib.concatMapStringsSep "\n" (
+        w:
+        if w.command != null then
+          ''
+            wid=$(tmux new-window -d -P -F '#{window_id}' -t "$sess:" ${windowFlags w})
+            tmux send-keys -t "$wid" ${lib.escapeShellArg w.command} Enter
+          ''
+        else
+          ''tmux new-window -d -t "$sess:" ${windowFlags w}''
+      ) (lib.tail cfg.layout.windows)}
+      tmux select-window -t "$sess:1"
+      ${lib.optionalString ((lib.head cfg.layout.windows).command != null) ''
+        ${(lib.head cfg.layout.windows).command} || true
+      ''}
+      exec "''${SHELL:-bash}"
+    '';
+  };
+
+  # Curated-seeds picker: fzf over the sessions list (plus live tmux
+  # sessions), in sesh.toml order. Bind it where you like — tmux gets a
+  # popup bind below; a desktop key is personal-config territory.
+  seshPicker = pkgs.writeShellApplication {
+    name = "sesh-picker";
+    runtimeInputs = with pkgs; [
+      sesh
+      fzf
+      zoxide
+      tmux
+    ];
+    text = ''
+      selected=$(sesh list -c -d -H -i | fzf --ansi --no-sort --prompt='project> ' --height=100%) || exit 0
+      [ -z "$selected" ] && exit 0
+      exec sesh connect "$selected"
+    '';
+  };
+
+  windowModule = lib.types.submodule {
+    options = {
+      name = lib.mkOption {
+        type = lib.types.str;
+        description = "tmux window name.";
+      };
+      command = lib.mkOption {
+        type = lib.types.nullOr lib.types.str;
+        default = null;
+        description = "Command launched in the window (null = plain shell).";
+      };
+    };
+  };
+
+  sessionModule = lib.types.submodule {
+    options = {
+      name = lib.mkOption {
+        type = lib.types.str;
+        example = "vigOS · devcontainer";
+        description = "Picker label; use a 'Group · project' prefix to cluster the list.";
+      };
+      path = lib.mkOption {
+        type = lib.types.str;
+        description = "Project directory the session starts in.";
+      };
+    };
+  };
+
+  sessionToml = s: ''
+    [[session]]
+    name = "${s.name}"
+    path = "${s.path}"
+  '';
+in
+{
+  options.vigos.sesh = {
+    enable = lib.mkEnableOption "sesh project sessions with the standard tmux layout";
+    sessions = lib.mkOption {
+      type = lib.types.listOf sessionModule;
+      default = [ ];
+      description = "Curated project seeds shown by sesh-picker, in order.";
+    };
+    layout.windows = lib.mkOption {
+      type = lib.types.listOf windowModule;
+      default = [
+        {
+          name = "edit";
+          command = "nvim .";
+        }
+        {
+          name = "git";
+          command = "lazygit";
+        }
+        { name = "shell"; }
+        # A plain shell on purpose: no agent session/API call fires on
+        # connect — type `claude` when wanted (worktrees for parallel runs).
+        { name = "claude"; }
+      ];
+      description = "Standard window set for every new session; the first entry owns window 1.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home = {
+      packages = [
+        pkgs.sesh
+        seshLayout
+        seshPicker
+      ];
+      file.".config/sesh/sesh.toml".text = ''
+        [default_session]
+        startup_command = "sesh-layout"
+
+        ${lib.concatMapStringsSep "\n" sessionToml cfg.sessions}
+      '';
+    };
+
+    # prefix+o pops the picker inside tmux (merges with vigos.multiplexer).
+    programs.tmux.extraConfig = lib.mkAfter ''
+      bind o display-popup -E "sesh-picker"
+    '';
+  };
+}

--- a/tests/test_flake_checks.py
+++ b/tests/test_flake_checks.py
@@ -218,7 +218,16 @@ def test_toolchain_modules_are_exposed() -> None:
         assert info["isImportable"], f"{output}.default is not importable"
 
 
-HM_MODULES = {"default", "packages", "shell", "multiplexer", "cli", "direnv", "git"}
+HM_MODULES = {
+    "default",
+    "packages",
+    "shell",
+    "multiplexer",
+    "cli",
+    "direnv",
+    "git",
+    "claude",
+}
 HM_SYSTEMS = ("x86_64-linux", "aarch64-linux", "aarch64-darwin", "x86_64-darwin")
 
 
@@ -410,6 +419,39 @@ def test_personal_template_is_exposed() -> None:
         pytest.fail("Failed to read templates.personal:\n" + result.stderr)
     info = json.loads(result.stdout)
     assert info["hasPath"] and info["hasDescription"]
+
+
+def test_claude_module_policy() -> None:
+    """vigos.claude must honor the ADR Axis-5 policy (#823).
+
+    DISABLE_AUTOUPDATER set via sessionVariables (Nix owns updates), the
+    workspace-CLAUDE.md management option present but empty by default, and
+    no home-level skills directory managed.
+    """
+    result = subprocess.run(
+        [
+            "nix",
+            "eval",
+            "--json",
+            f'{REPO_ROOT}#homeConfigurations."ci-full-x86_64-linux".config',
+            "--apply",
+            "c: { "
+            "autoupdater = c.home.sessionVariables.DISABLE_AUTOUPDATER or null; "
+            "workspaceFiles = c.vigos.claude.claudeMd.workspaceFiles; "
+            "enabled = c.vigos.claude.enable; "
+            "}",
+        ],
+        capture_output=True,
+        text=True,
+        env=_nix_env(),
+        timeout=600,
+    )
+    if result.returncode != 0:
+        pytest.fail("claude policy eval failed:\n" + result.stderr)
+    cfg = json.loads(result.stdout)
+    assert cfg["enabled"] is True
+    assert cfg["autoupdater"] == "1"
+    assert cfg["workspaceFiles"] == {}
 
 
 def test_flake_check_succeeds() -> None:

--- a/tests/test_flake_checks.py
+++ b/tests/test_flake_checks.py
@@ -469,7 +469,7 @@ def test_wave3_full_profile_config() -> None:
             "c: { "
             "ghdash = c.programs.gh-dash.enable; "
             "neovim = c.programs.neovim.enable; "
-            "seshToml = c.home.file ? \".config/sesh/sesh.toml\"; "
+            'seshToml = c.home.file ? ".config/sesh/sesh.toml"; '
             "seshSessions = c.vigos.sesh.sessions; "
             "}",
         ],

--- a/tests/test_flake_checks.py
+++ b/tests/test_flake_checks.py
@@ -227,6 +227,9 @@ HM_MODULES = {
     "direnv",
     "git",
     "claude",
+    "sesh",
+    "ghdash",
+    "editor",
 }
 HM_SYSTEMS = ("x86_64-linux", "aarch64-linux", "aarch64-darwin", "x86_64-darwin")
 
@@ -452,6 +455,36 @@ def test_claude_module_policy() -> None:
     assert cfg["enabled"] is True
     assert cfg["autoupdater"] == "1"
     assert cfg["workspaceFiles"] == {}
+
+
+def test_wave3_full_profile_config() -> None:
+    """Wave-3 modules must materialize in the full ci profile (#824)."""
+    result = subprocess.run(
+        [
+            "nix",
+            "eval",
+            "--json",
+            f'{REPO_ROOT}#homeConfigurations."ci-full-x86_64-linux".config',
+            "--apply",
+            "c: { "
+            "ghdash = c.programs.gh-dash.enable; "
+            "neovim = c.programs.neovim.enable; "
+            "seshToml = c.home.file ? \".config/sesh/sesh.toml\"; "
+            "seshSessions = c.vigos.sesh.sessions; "
+            "}",
+        ],
+        capture_output=True,
+        text=True,
+        env=_nix_env(),
+        timeout=600,
+    )
+    if result.returncode != 0:
+        pytest.fail("wave-3 profile eval failed:\n" + result.stderr)
+    cfg = json.loads(result.stdout)
+    assert cfg["ghdash"] is True
+    assert cfg["neovim"] is True
+    assert cfg["seshToml"] is True, "sesh.toml must be generated"
+    assert cfg["seshSessions"] == [], "sesh sessions must default empty"
 
 
 def test_flake_check_succeeds() -> None:


### PR DESCRIPTION
## Summary

Waves 2 and 3 of epic #814, continuing on the same master branch right after #833 merged. Two module groups complete the `vigos.*` surface:

- **`vigos.claude`** (#823) — the ADR Axis-5 `~/.claude` policy implemented: `settings.json` seeded copy-if-absent (the seed pre-authorizes nothing; `includeCoAuthoredBy=false` per the org rule), a managed `~/.claude/vigos.md` org fragment (checksum-overwrite with `.bak` of local edits), a single `@vigos.md` import line seeded into the user-owned `CLAUDE.md` (never overwritten — Claude writes there via the memory feature), **no symlinks of any kind under `~/.claude/`**, `DISABLE_AUTOUPDATER` via `home.sessionVariables`, and the off-by-default workspace-CLAUDE.md management option. The devcontainer scaffold now mounts `~/.config/vigos/secrets` read-only and exports the files as env vars at shell startup — **the slim token path #546 asks for** (compose scaffolding only; the image is untouched per ADR Axis 4).
- **`vigos.sesh` / `vigos.ghdash` / `vigos.editor`** (#824) — the parameterization-heavy ports: sesh project sessions with the standard tmux layout as options (`sessions`, `layout.windows` — no hardcoded paths; picker on tmux `prefix+o`), gh-dash with lean scoped sections from `repoFilters` (the CPU-tuning lessons as defaults), and neovim with the `claudecode.nvim` bridge via plain `programs.neovim` (no nixvim input, per the ADR). The bare devTools neovim went `lowPrio` so a configured editor wins buildEnv within one profile.

Also in this diff: the wave-1 delta wiring moved to the renamed `programs.delta.*` options (HM deprecation).

## Ledger

| Sub-issue | Work | PR → master branch | Status |
|---|---|---|---|
| #823 B2 | vigos.claude + container secrets path (absorbs #546) | #844 | ✅ TDD |
| #824 B3 | vigos.sesh, vigos.ghdash, vigos.editor | #845 | ✅ TDD |

## Evidence

- `pytest tests/test_flake_checks.py`: **13/13** (new: claude Axis-5 policy assertions, wave-3 full-profile assertions).
- `nix-fast-build .#checks.x86_64-linux` green incl. `hm-full` with all nine modules enabled; `ci-full-aarch64-darwin` evaluates.
- Sandbox pre-commit/deadnix/statix checks green (they caught: a statix grouped-attr rejection, an unused lambda arg, a ruff-format quoting nit, and the neovim buildEnv collision — all fixed pre-merge).
- Home Matrix re-runs on this PR (paths match) and rebuilds darwin/arm closures with the full module set.

## Changelog (added under `Unreleased`)

- **vigos.claude module + container secrets path** (#823, absorbs #546)
  - `~/.claude` policy per the ADR: seeded settings, managed fragment + `.bak`, `@vigos.md` import line, `DISABLE_AUTOUPDATER` via sessionVariables, optional workspace-CLAUDE.md management.
  - Devcontainer scaffold mounts `~/.config/vigos/secrets` read-only and exports the files as env vars — replacing setup-claude.sh forwarding.
- **vigos.sesh, vigos.ghdash, vigos.editor modules** (#824)
  - sesh sessions + parameterized standard layout, gh-dash scoped sections, neovim + claudecode.nvim bridge.

## Follow-ups (not this PR)

- B1 acceptance completion in the personal config (#822), then extending the dogfood to waves 2/3.
- Home Matrix promotion to required; first module-bearing release tag.

Refs: #814