### PR TITLE
fix(ci): avoid SIGPIPE race in setup-env dev-shell PATH summary

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -164,7 +164,9 @@ runs:
         fi
 
         echo "Flake dev-shell provisioned; tools added to PATH:"
-        printf '%s' "$SHELL_PATH" | tr ':' '\n' | grep '^/nix/store' | head -50
+        # sed, not head: head exiting early SIGPIPEs grep (exit 2) under the
+        # runner's pipefail shell once the list tops 50 entries (#847).
+        printf '%s' "$SHELL_PATH" | tr ':' '\n' | grep '^/nix/store' | sed -n '1,50p'
 
     # ── retry() shell helper ───────────────────────────────────────────
     - name: Export retry helper function

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,6 +182,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`setup-env` no longer flakes on a SIGPIPE race when listing the provisioned dev-shell PATH** ([#847](https://github.com/vig-os/devcontainer/issues/847))
+  - The provisioning step's `grep '^/nix/store' | head -50` summary runs under the runner's `pipefail` shell; once the dev-shell PATH topped 50 nix-store entries, `head` exiting early could SIGPIPE `grep` (exit 2) and fail the step — a scheduling race that killed a release build-and-test leg. `sed -n '1,50p'` consumes the whole stream and prints the same summary
 - **Release lane fixed for the Nix stack: current runners + tolerated vulnix findings exit** ([#842](https://github.com/vig-os/devcontainer/issues/842))
   - `release.yml`'s build-and-test matrix still pinned Debian-era `ubuntu-22.04`/`ubuntu-22.04-arm` runners, whose podman 3.4.4 breaks rootless volume UID mapping — `init-workspace.sh`'s in-container rsync failed to chmod the `/workspace` scaffold (`Operation not permitted`), killing the integration tests that pass everywhere else on `ubuntu-24.04` (podman 4.9.3). The matrix now uses the same `ubuntu-24.04`/`ubuntu-24.04-arm` expression as `nix-image.yml`
   - The release `Run vulnix` step missed `security-scan.yml`'s `|| rc=$?` capture, so under the runner's `bash -e` a normal exit 2 (findings present, to be judged against `.vulnixignore`) aborted the step before the vulnix-gate ran. The step now uses the nightly's capture/retry pattern (crashes with exit > 2 or invalid JSON still fail loudly)

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -182,6 +182,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`setup-env` no longer flakes on a SIGPIPE race when listing the provisioned dev-shell PATH** ([#847](https://github.com/vig-os/devcontainer/issues/847))
+  - The provisioning step's `grep '^/nix/store' | head -50` summary runs under the runner's `pipefail` shell; once the dev-shell PATH topped 50 nix-store entries, `head` exiting early could SIGPIPE `grep` (exit 2) and fail the step — a scheduling race that killed a release build-and-test leg. `sed -n '1,50p'` consumes the whole stream and prints the same summary
 - **Release lane fixed for the Nix stack: current runners + tolerated vulnix findings exit** ([#842](https://github.com/vig-os/devcontainer/issues/842))
   - `release.yml`'s build-and-test matrix still pinned Debian-era `ubuntu-22.04`/`ubuntu-22.04-arm` runners, whose podman 3.4.4 breaks rootless volume UID mapping — `init-workspace.sh`'s in-container rsync failed to chmod the `/workspace` scaffold (`Operation not permitted`), killing the integration tests that pass everywhere else on `ubuntu-24.04` (podman 4.9.3). The matrix now uses the same `ubuntu-24.04`/`ubuntu-24.04-arm` expression as `nix-image.yml`
   - The release `Run vulnix` step missed `security-scan.yml`'s `|| rc=$?` capture, so under the runner's `bash -e` a normal exit 2 (findings present, to be judged against `.vulnixignore`) aborted the step before the vulnix-gate ran. The step now uses the nightly's capture/retry pattern (crashes with exit > 2 or invalid JSON still fail loudly)


### PR DESCRIPTION
## Summary

Forward-fix for the second 0.4.0 candidate failure ([#847](https://github.com/vig-os/devcontainer/issues/847), diagnosis posted there). Again no tag consumed — publish was skipped.

The `setup-env` provisioning step ends with `printf … | grep '^/nix/store' | head -50` under the runner's `bash -e -o pipefail` shell. With the dev-shell PATH now exceeding 50 nix-store entries, `head` exiting early can SIGPIPE `grep` (exit 2) and fail the step — the log shows `grep: write error: Broken pipe` at the exact failure timestamp on the arm64 build-and-test leg. It's a scheduling race: the same line has run green across every workflow for weeks and passed on five other legs today.

Fix: `sed -n '1,50p'` instead of `head -50` — consumes the whole stream (no early pipe close), prints the same first 50 lines.

Positive signal from the failed run: the #842/#843 fixes are validated — `Vulnix CVE Gate` **passed** on this run (previously the step died on vulnix's exit 2), and amd64 was only cancelled by fail-fast.

## Verification

- Race mechanics confirmed from the job log (`grep: write error: Broken pipe` + `Process completed with exit code 2` at 18:42:21, inside the test-image action's setup-env sub-step).
- `just precommit` (full suite, all files): green, exit 0.
- Changelog entry added to the open `## [0.4.0] - TBD` section.

Refs: #847