### PR TITLE
fix(ci): make the release Trivy image scan awareness-only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -800,14 +800,20 @@ jobs:
           image-tag: ${{ needs.validate.outputs.publish_version }}-${{ matrix.arch }}
           ref: ${{ needs.finalize.outputs.finalize_sha }}
 
-      - name: Scan image for vulnerabilities
+      - name: Scan image for vulnerabilities (defense in depth, awareness only)
+        # Non-blocking per the #637 posture: the Nix image's blocking CVE
+        # control is the vulnix-gate job + .vulnixignore (#639). Trivy sees
+        # language-ecosystem packages embedded in shipped binaries that vulnix
+        # cannot, so its table stays in the log as awareness signal — mirrors
+        # security-scan.yml and ci.yml (exit-code 0). Refs #849.
+        continue-on-error: true
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0
         with:
           version: 'v0.71.2'
           input: /tmp/image.tar
           format: 'table'
           severity: 'HIGH,CRITICAL'
-          exit-code: '1'
+          exit-code: '0'
           ignore-unfixed: true
           trivyignores: '.trivyignore'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,6 +182,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Release-lane Trivy scan aligned with the ratified awareness-only posture** ([#849](https://github.com/vig-os/devcontainer/issues/849))
+  - `release.yml`'s build-and-test Trivy step was the last Debian-era blocking scanner (`exit-code: 1` with only `.trivyignore`), failing the candidate on embedded language-ecosystem HIGHs already triaged into `.vulnixignore`. Per the #637 decision the Nix image's blocking CVE control is the vulnix-gate; the step is now non-blocking (`exit-code: 0`, `continue-on-error`) with its table kept in the log as awareness signal, mirroring `security-scan.yml` and `ci.yml`
 - **`setup-env` no longer flakes on a SIGPIPE race when listing the provisioned dev-shell PATH** ([#847](https://github.com/vig-os/devcontainer/issues/847))
   - The provisioning step's `grep '^/nix/store' | head -50` summary runs under the runner's `pipefail` shell; once the dev-shell PATH topped 50 nix-store entries, `head` exiting early could SIGPIPE `grep` (exit 2) and fail the step — a scheduling race that killed a release build-and-test leg. `sed -n '1,50p'` consumes the whole stream and prints the same summary
 - **Release lane fixed for the Nix stack: current runners + tolerated vulnix findings exit** ([#842](https://github.com/vig-os/devcontainer/issues/842))

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -182,6 +182,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Release-lane Trivy scan aligned with the ratified awareness-only posture** ([#849](https://github.com/vig-os/devcontainer/issues/849))
+  - `release.yml`'s build-and-test Trivy step was the last Debian-era blocking scanner (`exit-code: 1` with only `.trivyignore`), failing the candidate on embedded language-ecosystem HIGHs already triaged into `.vulnixignore`. Per the #637 decision the Nix image's blocking CVE control is the vulnix-gate; the step is now non-blocking (`exit-code: 0`, `continue-on-error`) with its table kept in the log as awareness signal, mirroring `security-scan.yml` and `ci.yml`
 - **`setup-env` no longer flakes on a SIGPIPE race when listing the provisioned dev-shell PATH** ([#847](https://github.com/vig-os/devcontainer/issues/847))
   - The provisioning step's `grep '^/nix/store' | head -50` summary runs under the runner's `pipefail` shell; once the dev-shell PATH topped 50 nix-store entries, `head` exiting early could SIGPIPE `grep` (exit 2) and fail the step — a scheduling race that killed a release build-and-test leg. `sed -n '1,50p'` consumes the whole stream and prints the same summary
 - **Release lane fixed for the Nix stack: current runners + tolerated vulnix findings exit** ([#842](https://github.com/vig-os/devcontainer/issues/842))


### PR DESCRIPTION
## Summary

Forward-fix for the third 0.4.0 candidate failure ([#849](https://github.com/vig-os/devcontainer/issues/849), diagnosis posted there). Again no tag consumed. Positive signal: everything the previous fixes touched now passes — validate, finalize, **vulnix-gate**, and the amd64 **image + integration tests** were green; the run died only at the Trivy step.

`release.yml`'s `Scan image for vulnerabilities` was the last Debian-era **blocking** Trivy scanner (`exit-code: '1'`, gated only by `.trivyignore`). It failed on ~14 HIGH / 0 CRITICAL findings in language-ecosystem packages embedded in shipped binaries — the same 2026-07 batch already triaged into `.vulnixignore`, which is why the blocking vulnix-gate passed. Under the ratified #637 posture the Nix image's blocking CVE control is the **vulnix-gate + `.vulnixignore`**; Trivy is defense-in-depth, awareness only:

- `security-scan.yml:145-154` — SBOM-mode scan, `exit-code: '0'`, `continue-on-error: true`
- `ci.yml:323,334` — `exit-code: '0'` (why the same image passed the release PR's Security Scan check)

This aligns the release lane: `exit-code: '0'` + `continue-on-error: true`, table output retained in the job log.

## Verification

- Same image content passed ci.yml's Security Scan and the nightly-shaped dispatch today; vulnix-gate green on this very run.
- `just precommit` (full suite, all files): green, exit 0.
- Changelog entry added to the open `## [0.4.0] - TBD` section.

Refs: #849