### PR TITLE
fix(setup): pin the scaffolded .vig-os to the requested install version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,6 +182,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`install.sh --version` now pins the scaffolded `.vig-os` to the requested version** ([#852](https://github.com/vig-os/devcontainer/issues/852))
+  - The Nix image bakes the release it was built from into the scaffolded `.vig-os` (correct for finals, where the repo pin is bumped at finalize — but stale for release candidates), and `install.sh` never wrote its `--version` into the scaffold. An RC install therefore pinned the previous release: the 0.4.0-rc1 smoke test scaffolded the new prek-era workspace pinned to the Debian 0.3.9 image and its CI lint failed with `prek: command not found`. `install.sh` now forwards an explicit `--version` as `VIG_OS_VERSION` and `init-workspace.sh` pins it in `.vig-os` post-scaffold; plain `latest` installs keep the baked pin
 - **Release-lane Trivy scan aligned with the ratified awareness-only posture** ([#849](https://github.com/vig-os/devcontainer/issues/849))
   - `release.yml`'s build-and-test Trivy step was the last Debian-era blocking scanner (`exit-code: 1` with only `.trivyignore`), failing the candidate on embedded language-ecosystem HIGHs already triaged into `.vulnixignore`. Per the #637 decision the Nix image's blocking CVE control is the vulnix-gate; the step is now non-blocking (`exit-code: 0`, `continue-on-error`) with its table kept in the log as awareness signal, mirroring `security-scan.yml` and `ci.yml`
 - **`setup-env` no longer flakes on a SIGPIPE race when listing the provisioned dev-shell PATH** ([#847](https://github.com/vig-os/devcontainer/issues/847))

--- a/assets/init-workspace.sh
+++ b/assets/init-workspace.sh
@@ -17,6 +17,8 @@
 #   SHORT_NAME           - Project short name (required)
 #   ORG_NAME             - Organization name (optional, defaults to "vigOS/devc")
 #   GITHUB_REPOSITORY    - owner/repo for Renovate preset extends (optional if origin is github.com)
+#   VIG_OS_VERSION       - Override the DEVCONTAINER_VERSION pinned in the scaffolded
+#                          .vig-os (optional; install.sh forwards its --version, #852)
 
 set -euo pipefail
 
@@ -366,6 +368,20 @@ case "$MODE" in
         : # keep everything
         ;;
 esac
+
+# Pin the explicitly requested devcontainer version (#852). The image bakes
+# the release it was built from into the scaffolded .vig-os (flake bootstrap),
+# which is correct for finals but stale for release candidates: the repo-root
+# pin only advances at finalize. install.sh forwards its --version here so the
+# scaffold pins the image actually installed.
+if [[ -n "${VIG_OS_VERSION:-}" && -f "$WORKSPACE_DIR/.vig-os" ]]; then
+    if [[ ! "$VIG_OS_VERSION" =~ ^[A-Za-z0-9._-]+$ ]]; then
+        echo "Error: invalid VIG_OS_VERSION: $VIG_OS_VERSION" >&2
+        exit 1
+    fi
+    echo "Pinning DEVCONTAINER_VERSION=${VIG_OS_VERSION} in .vig-os..."
+    sed -i "s/^DEVCONTAINER_VERSION=.*/DEVCONTAINER_VERSION=${VIG_OS_VERSION}/" "$WORKSPACE_DIR/.vig-os"
+fi
 
 resolve_github_repository
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -182,6 +182,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`install.sh --version` now pins the scaffolded `.vig-os` to the requested version** ([#852](https://github.com/vig-os/devcontainer/issues/852))
+  - The Nix image bakes the release it was built from into the scaffolded `.vig-os` (correct for finals, where the repo pin is bumped at finalize — but stale for release candidates), and `install.sh` never wrote its `--version` into the scaffold. An RC install therefore pinned the previous release: the 0.4.0-rc1 smoke test scaffolded the new prek-era workspace pinned to the Debian 0.3.9 image and its CI lint failed with `prek: command not found`. `install.sh` now forwards an explicit `--version` as `VIG_OS_VERSION` and `init-workspace.sh` pins it in `.vig-os` post-scaffold; plain `latest` installs keep the baked pin
 - **Release-lane Trivy scan aligned with the ratified awareness-only posture** ([#849](https://github.com/vig-os/devcontainer/issues/849))
   - `release.yml`'s build-and-test Trivy step was the last Debian-era blocking scanner (`exit-code: 1` with only `.trivyignore`), failing the candidate on embedded language-ecosystem HIGHs already triaged into `.vulnixignore`. Per the #637 decision the Nix image's blocking CVE control is the vulnix-gate; the step is now non-blocking (`exit-code: 0`, `continue-on-error`) with its table kept in the log as awareness signal, mirroring `security-scan.yml` and `ci.yml`
 - **`setup-env` no longer flakes on a SIGPIPE race when listing the provisioned dev-shell PATH** ([#847](https://github.com/vig-os/devcontainer/issues/847))

--- a/install.sh
+++ b/install.sh
@@ -450,6 +450,17 @@ info "Using $RUNTIME with image $IMAGE"
 info "Target directory: $PROJECT_PATH"
 info "Project name: $PROJECT_NAME"
 
+# Forward an explicitly requested version so init-workspace pins it in the
+# scaffolded .vig-os (#852). The image's baked pin is the release the image
+# was built from, which is stale for release candidates (the repo pin only
+# advances at finalize). "latest" is not a concrete tag: keep the baked pin.
+# (The ${arr[@]+...} idiom keeps empty-array expansion safe under set -u on
+# bash 3.2, e.g. macOS.)
+declare -a VERSION_ENV=()
+if [ "$VERSION" != "latest" ]; then
+    VERSION_ENV=(-e "VIG_OS_VERSION=$VERSION")
+fi
+
 # Build the command using an array for safe execution
 # Use --rm to cleanup container after run; no -it since we use --no-prompts (non-interactive)
 # Pass SHORT_NAME and ORG_NAME as environment variables to the container
@@ -458,6 +469,7 @@ declare -a CMD=(
     -e "SHORT_NAME=$PROJECT_NAME"
     -e "ORG_NAME=$ORG_NAME"
     -e "GITHUB_REPOSITORY=$GITHUB_REPOSITORY"
+    ${VERSION_ENV[@]+"${VERSION_ENV[@]}"}
     -v "$PROJECT_PATH:/workspace"
     "$IMAGE"
     /root/assets/init-workspace.sh --no-prompts

--- a/tests/bats/init-workspace.bats
+++ b/tests/bats/init-workspace.bats
@@ -506,3 +506,21 @@ _scaffold() {
     run grep -F "$pattern" "$INIT_WORKSPACE_SH"
     assert_success
 }
+
+# ── .vig-os version-pin override (#852) ───────────────────────────────────────
+# The image bakes the release it was built from into the scaffolded .vig-os
+# (flake bootstrap), which is correct for finals but stale for release
+# candidates: the repo-root pin only advances at finalize. install.sh forwards
+# the explicitly requested --version as VIG_OS_VERSION so the scaffold pins the
+# image actually installed.
+
+@test "init-workspace honors VIG_OS_VERSION for the scaffolded .vig-os pin (#852)" {
+    run grep -q 'VIG_OS_VERSION' "$INIT_WORKSPACE_SH"
+    assert_success
+}
+
+@test "init-workspace writes DEVCONTAINER_VERSION from the VIG_OS_VERSION override (#852)" {
+    # shellcheck disable=SC2016
+    run grep -F 'DEVCONTAINER_VERSION=${VIG_OS_VERSION}' "$INIT_WORKSPACE_SH"
+    assert_success
+}

--- a/tests/bats/install.bats
+++ b/tests/bats/install.bats
@@ -382,3 +382,11 @@ setup() {
     run head -1 "$INSTALL_SH"
     assert_output "#!/usr/bin/env bash"
 }
+
+# ── .vig-os version-pin override (#852) ───────────────────────────────────────
+
+@test "install.sh forwards --version to init-workspace as VIG_OS_VERSION (#852)" {
+    # shellcheck disable=SC2016
+    run grep -F 'VIG_OS_VERSION=$VERSION' "$INSTALL_SH"
+    assert_success
+}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -260,7 +260,7 @@ def host(test_container):
 # --- Helpers and fixtures for init-workspace.sh ---
 
 
-def _build_podman_cmd(container_image, workspace_mount, smoke_test):
+def _build_podman_cmd(container_image, workspace_mount, smoke_test, extra_env=None):
     """Build podman command for init-workspace script."""
     cmd = ["podman", "run", "--rm", "-v", workspace_mount]
     if smoke_test:
@@ -276,6 +276,8 @@ def _build_podman_cmd(container_image, workspace_mount, smoke_test):
         )
     else:
         cmd.append("-it")
+    for key, value in (extra_env or {}).items():
+        cmd.extend(["-e", f"{key}={value}"])
     cmd.extend([container_image, "/root/assets/init-workspace.sh"])
     if smoke_test:
         cmd.append("--smoke-test")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -684,6 +684,36 @@ class TestVigOsConfig:
             "IMAGE_TAG placeholder should be replaced in .vig-os"
         )
 
+    def test_init_workspace_pins_requested_version(self, container_image, tmp_path):
+        """VIG_OS_VERSION override pins the scaffolded .vig-os (#852).
+
+        The image bakes the release it was built from into the scaffolded
+        .vig-os, which is stale for release candidates (the repo pin only
+        advances at finalize). install.sh forwards the requested --version as
+        VIG_OS_VERSION; init-workspace must honor it over the baked value.
+        """
+        from .conftest import is_running_in_container
+
+        if is_running_in_container():
+            pytest.skip("host-path mount test; covered on the CI host runner")
+
+        workspace = tmp_path / "version-pin-ws"
+        workspace.mkdir()
+        cmd = _build_podman_cmd(
+            container_image,
+            f"{workspace}:/workspace",
+            smoke_test=True,
+            extra_env={"VIG_OS_VERSION": "9.9.9-rc9"},
+        )
+        _run_noninteractive_init(cmd)
+
+        vig_os_file = workspace / ".vig-os"
+        assert vig_os_file.exists(), ".vig-os not scaffolded"
+        content = vig_os_file.read_text(encoding="utf-8")
+        assert "DEVCONTAINER_VERSION=9.9.9-rc9" in content, (
+            f".vig-os does not pin the requested version:\n{content}"
+        )
+
     def test_initialize_writes_devcontainer_version_to_env(self, initialized_workspace):
         """Test initialize.sh writes DEVCONTAINER_VERSION to .devcontainer/.env."""
         init_script = (


### PR DESCRIPTION
## Summary

Forward-fix for the 0.4.0-rc1 smoke-test failure ([#852](https://github.com/vig-os/devcontainer/issues/852)). The candidate run itself was fully green — the failure was downstream, in the consumer scaffold the RC installs.

**Root cause chain:** the Nix image bakes the release it was built from into the scaffolded `.vig-os` (flake bootstrap, from the repo-root pin). That pin only advances at **finalize**, so every RC image scaffolds the *previous* release's pin — and `install.sh` never wrote its `--version` into the scaffold. The smoke-test receiver ran `install.sh --version 0.4.0-rc1 --force`, got a deploy PR with the new prek-era scaffold **still pinned to `DEVCONTAINER_VERSION=0.3.9`**, and its CI Lint job ran `just precommit` → `prek run --all-files` inside the Debian 0.3.9 image → `command not found`. (The Debian build passed the per-tag `IMAGE_TAG` build-arg at build time; the reproducible Nix build can't bake the tag without breaking the same-commit-same-digest property — hence an install-time override.)

**Fix (TDD, RED → GREEN commits):**
- `install.sh`: an explicit `--version` is forwarded into the init container as `VIG_OS_VERSION` (bash-3.2-safe empty-array expansion; `latest` keeps the baked pin, which equals the promoted release).
- `assets/init-workspace.sh`: pins `DEVCONTAINER_VERSION=${VIG_OS_VERSION}` in the scaffolded `.vig-os` post-prune, charset-validated.

The receiver needs no change — it already passes `--version "${TAG}"` and curls `install.sh` from the dispatched tag, so **rc2 will exercise the fixed path end-to-end**.

## Verification

- RED: 3 new bats structure tests failed before the implementation; GREEN after (0 failures across `init-workspace.bats` + `install.bats`).
- New integration test (`test_init_workspace_pins_requested_version`) runs the real containerized init with `VIG_OS_VERSION=9.9.9-rc9` and asserts the scaffolded pin — runs in CI against the image built from this branch.
- Host-side functional run: `TEMPLATE_DIR=assets/workspace ... VIG_OS_VERSION=9.9.9-rc9 bash assets/init-workspace.sh --no-prompts --force` → `.vig-os` contains `DEVCONTAINER_VERSION=9.9.9-rc9`.
- `install.sh --dry-run --version 0.4.0-rc1` shows `-e VIG_OS_VERSION=0.4.0-rc1`; dry-run without `--version` shows no override.
- `just precommit` (full suite, all files): green, exit 0.

Refs: #852