### PR TITLE
fix(setup): ship .typos.toml with the workspace scaffold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,6 +182,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Scaffold ships `.typos.toml` so the shipped typos hook passes out of the box** ([#855](https://github.com/vig-os/devcontainer/issues/855))
+  - The scaffolded `.pre-commit-config.yaml` runs the `typos` hook, but the exception config stayed repo-local — consumers linted scaffold-shipped content (`version-check.sh`'s `Nd` duration syntax, the synced changelog's "unexcepted" CVE-policy term) with zero exceptions and failed immediately, as the 0.4.0-rc2 smoke test showed. `.typos.toml` now syncs into the workspace template via `scripts/manifest.toml`, same as `.yamllint`/`.pymarkdown`
 - **`install.sh --version` now pins the scaffolded `.vig-os` to the requested version** ([#852](https://github.com/vig-os/devcontainer/issues/852))
   - The Nix image bakes the release it was built from into the scaffolded `.vig-os` (correct for finals, where the repo pin is bumped at finalize — but stale for release candidates), and `install.sh` never wrote its `--version` into the scaffold. An RC install therefore pinned the previous release: the 0.4.0-rc1 smoke test scaffolded the new prek-era workspace pinned to the Debian 0.3.9 image and its CI lint failed with `prek: command not found`. `install.sh` now forwards an explicit `--version` as `VIG_OS_VERSION` and `init-workspace.sh` pins it in `.vig-os` post-scaffold; plain `latest` installs keep the baked pin
 - **Release-lane Trivy scan aligned with the ratified awareness-only posture** ([#849](https://github.com/vig-os/devcontainer/issues/849))

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -182,6 +182,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Scaffold ships `.typos.toml` so the shipped typos hook passes out of the box** ([#855](https://github.com/vig-os/devcontainer/issues/855))
+  - The scaffolded `.pre-commit-config.yaml` runs the `typos` hook, but the exception config stayed repo-local — consumers linted scaffold-shipped content (`version-check.sh`'s `Nd` duration syntax, the synced changelog's "unexcepted" CVE-policy term) with zero exceptions and failed immediately, as the 0.4.0-rc2 smoke test showed. `.typos.toml` now syncs into the workspace template via `scripts/manifest.toml`, same as `.yamllint`/`.pymarkdown`
 - **`install.sh --version` now pins the scaffolded `.vig-os` to the requested version** ([#852](https://github.com/vig-os/devcontainer/issues/852))
   - The Nix image bakes the release it was built from into the scaffolded `.vig-os` (correct for finals, where the repo pin is bumped at finalize — but stale for release candidates), and `install.sh` never wrote its `--version` into the scaffold. An RC install therefore pinned the previous release: the 0.4.0-rc1 smoke test scaffolded the new prek-era workspace pinned to the Debian 0.3.9 image and its CI lint failed with `prek: command not found`. `install.sh` now forwards an explicit `--version` as `VIG_OS_VERSION` and `init-workspace.sh` pins it in `.vig-os` post-scaffold; plain `latest` installs keep the baked pin
 - **Release-lane Trivy scan aligned with the ratified awareness-only posture** ([#849](https://github.com/vig-os/devcontainer/issues/849))

--- a/assets/workspace/.typos.toml
+++ b/assets/workspace/.typos.toml
@@ -1,0 +1,10 @@
+# Typos configuration
+# https://github.com/crate-ci/typos
+
+[default.extend-words]
+# Shell scripting: sed label syntax uses 'ba' (branch to label 'a')
+ba = "ba"
+# CVE policy term (#637): a finding "unexcepted" = not in the exception register
+unexcepted = "unexcepted"
+# version-check.sh duration placeholder (#759): 'Nd' = N days (cf. Nw/Nh/Nm)
+Nd = "Nd"

--- a/scripts/manifest.toml
+++ b/scripts/manifest.toml
@@ -30,6 +30,9 @@ src = ".gitmessage"
 src = ".yamllint"
 
 [[entries]]
+src = ".typos.toml"
+
+[[entries]]
 src = ".pymarkdown"
 
 [[entries]]

--- a/tests/bats/init-workspace.bats
+++ b/tests/bats/init-workspace.bats
@@ -524,3 +524,12 @@ _scaffold() {
     run grep -F 'DEVCONTAINER_VERSION=${VIG_OS_VERSION}' "$INIT_WORKSPACE_SH"
     assert_success
 }
+
+@test "template ships .typos.toml alongside the typos hook (#855)" {
+    # The scaffold's .pre-commit-config.yaml runs the typos hook; without the
+    # exception config, scaffold-shipped content (version-check.sh's Nd
+    # duration syntax, the synced changelog's "unexcepted" policy term) fails
+    # every consumer's lint out of the box.
+    run test -f "$TEMPLATE_DIR/.typos.toml"
+    assert_success
+}


### PR DESCRIPTION
## Summary

Forward-fix for the rc2 smoke-test failure ([#855](https://github.com/vig-os/devcontainer/issues/855), diagnosis posted there). Strong convergence signal from rc2: the #853 `.vig-os` pin works (`DEVCONTAINER_VERSION=0.4.0-rc2` in the deploy PR), the Lint job runs inside the rc2 image, the **whole prek suite executes and the Tests job passes** — the only remaining failure is the `typos` hook flagging scaffold-shipped content (`Nd`, `unexcepted`) that this repo excepts in `.typos.toml` but never shipped.

Fix: add `.typos.toml` to `scripts/manifest.toml` so sync-manifest ships it with the workspace template — the same SSoT mechanism as `.yamllint`/`.pymarkdown`.

## Verification

- TDD: new bats template test RED before (`not ok 56`), GREEN after the manifest entry + sync.
- Shipped copy content-identical to the repo root config (sync-manifest keeps it so).
- `just precommit` (full suite, all files): green, exit 0.
- Changelog entry added to the open `## [0.4.0] - TBD` section.

Refs: #855