### PR TITLE
fix(ci): cap the shipped prepare-release PR body under GitHub's limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,6 +182,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Shipped consumer `prepare-release.yml` caps its PR body under GitHub's 65,536-char limit** ([#857](https://github.com/vig-os/devcontainer/issues/857))
+  - #812 capped the PR body only in this repo's own workflow; the scaffolded consumer copy still interpolated the full frozen changelog section uncapped, so a consumer with a large release (the 0.4.0-rc3 smoke test seeds this repo's ~67k-char section) failed `Create draft PR to main` with `GraphQL: Body is too long`. The shipped workflow now applies the same line-boundary truncation with a pointer to the release branch's full `CHANGELOG.md`
 - **Scaffold ships `.typos.toml` so the shipped typos hook passes out of the box** ([#855](https://github.com/vig-os/devcontainer/issues/855))
   - The scaffolded `.pre-commit-config.yaml` runs the `typos` hook, but the exception config stayed repo-local — consumers linted scaffold-shipped content (`version-check.sh`'s `Nd` duration syntax, the synced changelog's "unexcepted" CVE-policy term) with zero exceptions and failed immediately, as the 0.4.0-rc2 smoke test showed. `.typos.toml` now syncs into the workspace template via `scripts/manifest.toml`, same as `.yamllint`/`.pymarkdown`
 - **`install.sh --version` now pins the scaffolded `.vig-os` to the requested version** ([#852](https://github.com/vig-os/devcontainer/issues/852))

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -182,6 +182,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Shipped consumer `prepare-release.yml` caps its PR body under GitHub's 65,536-char limit** ([#857](https://github.com/vig-os/devcontainer/issues/857))
+  - #812 capped the PR body only in this repo's own workflow; the scaffolded consumer copy still interpolated the full frozen changelog section uncapped, so a consumer with a large release (the 0.4.0-rc3 smoke test seeds this repo's ~67k-char section) failed `Create draft PR to main` with `GraphQL: Body is too long`. The shipped workflow now applies the same line-boundary truncation with a pointer to the release branch's full `CHANGELOG.md`
 - **Scaffold ships `.typos.toml` so the shipped typos hook passes out of the box** ([#855](https://github.com/vig-os/devcontainer/issues/855))
   - The scaffolded `.pre-commit-config.yaml` runs the `typos` hook, but the exception config stayed repo-local — consumers linted scaffold-shipped content (`version-check.sh`'s `Nd` duration syntax, the synced changelog's "unexcepted" CVE-policy term) with zero exceptions and failed immediately, as the 0.4.0-rc2 smoke test showed. `.typos.toml` now syncs into the workspace template via `scripts/manifest.toml`, same as `.yamllint`/`.pymarkdown`
 - **`install.sh --version` now pins the scaffolded `.vig-os` to the requested version** ([#852](https://github.com/vig-os/devcontainer/issues/852))

--- a/assets/workspace/.github/workflows/prepare-release.yml
+++ b/assets/workspace/.github/workflows/prepare-release.yml
@@ -301,12 +301,26 @@ jobs:
           CHANGELOG_CONTENT: ${{ steps.changelog.outputs.changelog }}
         run: |
           set -euo pipefail
-          PR_BODY="# Release $VERSION
+
+          # GitHub caps PR bodies at 65536 chars; a large frozen release
+          # changelog can overflow it (#810/#857). Truncate at a line boundary
+          # and point to the full CHANGELOG.md on the release branch when it
+          # does. Mirrors the upstream prepare-release cap (#812).
+          MAX_BODY=65000
+          HEADER="# Release $VERSION
 
           This PR prepares release $VERSION for merge to main.
 
-          $CHANGELOG_CONTENT
           "
+          PR_BODY="${HEADER}${CHANGELOG_CONTENT}"$'\n'
+
+          if [ "${#PR_BODY}" -gt "$MAX_BODY" ]; then
+            NOTE=$(printf '\n\n_Changelog truncated to fit GitHub'"'"'s %s-char PR-body limit; see `CHANGELOG.md` on `%s` for the full entry._' "$MAX_BODY" "$RELEASE_BRANCH")
+            budget=$(( MAX_BODY - ${#HEADER} - ${#NOTE} ))
+            TRUNCATED="${CHANGELOG_CONTENT:0:budget}"
+            TRUNCATED="${TRUNCATED%$'\n'*}"
+            PR_BODY="${HEADER}${TRUNCATED}${NOTE}"
+          fi
 
           EXISTING_PR_URL=$(retry --retries 3 --backoff 5 --max-backoff 60 -- \
             gh pr list --head "$RELEASE_BRANCH" --base main --state open --json url --jq '.[0].url // empty')


### PR DESCRIPTION
## Summary

Forward-fix for the rc3 smoke-test failure ([#857](https://github.com/vig-os/devcontainer/issues/857), diagnosis posted there). rc3 convergence signal: consumer CI green inside the rc3 image, **deploy PR merged** (validating #853 + #856), downstream release cycle started — and died at `Create draft PR to main` with `GraphQL: Body is too long`.

It's the #810 bug shipped to consumers: #812 capped only this repo's own `prepare-release.yml`; the scaffolded copy (`assets/workspace/.github/workflows/prepare-release.yml`) still interpolated the full changelog section uncapped, and the smoke-test repo's CHANGELOG is seeded from our ~67k-char 0.4.0 section. This ports the identical cap (65,000-char budget, line-boundary truncation, pointer to the release branch's full `CHANGELOG.md`). `release-core.yml` (shipped) has no PR-body write, so this is the only consumer-side site.

The deploy sync carries the fixed workflow to the smoke-test repo on the next candidate (rc4), which should complete the downstream cycle.

## Verification

- Identical cap logic harness-verified against the real 0.4.0 section in #830 (66,794 → 64,869 chars, line-boundary truncation; sub-threshold passthrough byte-identical).
- YAML de-indentation of the new `HEADER` asserted via `yaml.safe_load` (no indent leak).
- `just precommit` (full suite, all files): green, exit 0.
- Changelog entry added to the open `## [0.4.0] - TBD` section.

Refs: #857