### PR TITLE
fix(setup): rc4 field-validation batch — direnv commits, prune, scripts

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -148,7 +148,7 @@ repos:
     hooks:
       - id: typos
         name: typos (source typo checker)
-        entry: typos
+        entry: typos --force-exclude
         language: system
 
   # License Compliance Check (runs only when dependencies change)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,6 +182,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **rc4 field-validation fix batch: direnv-mode commits, pipe-safe scripts, prune/typos/installer hardening** ([#859](https://github.com/vig-os/devcontainer/issues/859))
+  - Scaffolded `.githooks/*` now use `#!/usr/bin/env bash` (hosts without `/bin/bash`, e.g. NixOS, could not run them) and accept the nix dev-shell (`IN_NIX_SHELL`) as a sanctioned commit environment — previously direnv-mode consumers could not commit at all (the guard demanded the container)
+  - Restored the `${BASH_SOURCE[0]:-$0}` pipe-safety fallback in the scaffolded lifecycle scripts (`initialize`/`post-create`/`post-attach`/`version-check`) — a regression from the 0.3.x scaffold caught by a consumer's own regression tests
+  - `--mode devcontainer` no longer deletes a consumer's **pre-existing** `flake.nix`/`.envrc` (two real repos lost their own nix-direnv setup); the prune now only removes stub files the scaffold itself created, mirroring the #738 guard
+  - The installer's final `just sync` is non-fatal when the preserved old-generation `justfile.project` predates the `sync` recipe (warns and points to MIGRATION.md instead of failing an otherwise complete scaffold)
+  - The typos hook (repo + scaffold) passes `--force-exclude` so `[files] extend-exclude` applies to explicitly-passed staged files — three consumer repos hit garbage findings on committed binary artifacts (PDFs, SVGs, `.bin` fixtures)
+  - `docs/MIGRATION.md` gained the field-validated "Upgrading an existing 0.3.x consumer" checklist (prek recipe migration, recipe renames, typos config precedence/shadowing, artifact excludes, name re-derivation)
 - **Shipped consumer `prepare-release.yml` caps its PR body under GitHub's 65,536-char limit** ([#857](https://github.com/vig-os/devcontainer/issues/857))
   - #812 capped the PR body only in this repo's own workflow; the scaffolded consumer copy still interpolated the full frozen changelog section uncapped, so a consumer with a large release (the 0.4.0-rc3 smoke test seeds this repo's ~67k-char section) failed `Create draft PR to main` with `GraphQL: Body is too long`. The shipped workflow now applies the same line-boundary truncation with a pointer to the release branch's full `CHANGELOG.md`
 - **Scaffold ships `.typos.toml` so the shipped typos hook passes out of the box** ([#855](https://github.com/vig-os/devcontainer/issues/855))

--- a/assets/init-workspace.sh
+++ b/assets/init-workspace.sh
@@ -288,6 +288,15 @@ if [[ -d "$WORKSPACE_DIR/.devcontainer" ]] \
     DEVCONTAINER_PREEXISTED=true
 fi
 
+# Same guard for the consumer's own nix-direnv files (#859): the
+# devcontainer-mode prune may only remove the flake stub/`.envrc` that this
+# scaffold would create, never a pre-existing setup (they are PRESERVE_FILES,
+# so rsync never overwrites them either — the prune must match).
+FLAKE_PREEXISTED=false
+[[ -f "$WORKSPACE_DIR/flake.nix" ]] && FLAKE_PREEXISTED=true
+ENVRC_PREEXISTED=false
+[[ -f "$WORKSPACE_DIR/.envrc" ]] && ENVRC_PREEXISTED=true
+
 # Copy template contents to workspace
 echo "Initializing workspace from template..."
 echo "Copying files from $TEMPLATE_DIR to $WORKSPACE_DIR..."
@@ -351,8 +360,20 @@ chmod -R u+w "$WORKSPACE_DIR"
 #   both         -> keep everything
 case "$MODE" in
     devcontainer)
-        echo "Pruning to 'devcontainer' mode: removing flake.nix and .envrc..."
-        rm -f "$WORKSPACE_DIR/flake.nix" "$WORKSPACE_DIR/.envrc"
+        # Only prune the stub files this scaffold created; a consumer's own
+        # pre-existing flake.nix/.envrc must survive (#859).
+        if [[ "$FLAKE_PREEXISTED" == "true" ]]; then
+            echo "devcontainer mode: preserving existing flake.nix (#859)"
+        else
+            echo "Pruning to 'devcontainer' mode: removing flake.nix..."
+            rm -f "$WORKSPACE_DIR/flake.nix"
+        fi
+        if [[ "$ENVRC_PREEXISTED" == "true" ]]; then
+            echo "devcontainer mode: preserving existing .envrc (#859)"
+        else
+            echo "Pruning to 'devcontainer' mode: removing .envrc..."
+            rm -f "$WORKSPACE_DIR/.envrc"
+        fi
         ;;
     direnv)
         # Only drop a .devcontainer/ that this scaffold created; never delete a
@@ -436,10 +457,18 @@ echo "Setting executable permissions on shell scripts and hooks..."
 find "$WORKSPACE_DIR" -type f -name "*.sh" -exec chmod +x {} \;
 find "$WORKSPACE_DIR/.githooks" -type f -exec chmod +x {} \; 2>/dev/null || true
 
-# Sync dependencies: resolves uv.lock for the new project name and installs the project
+# Sync dependencies: resolves uv.lock for the new project name and installs the
+# project. Non-fatal (#859): a preserved old-generation justfile.project may not
+# define `sync` yet — the scaffold itself is complete at this point, so warn and
+# let the consumer sync after migrating their recipes.
 echo "Syncing dependencies..."
 cd "$WORKSPACE_DIR"
-just sync
+if just --show sync > /dev/null 2>&1; then
+    just sync
+else
+    echo "Warning: no 'sync' recipe found (preserved pre-0.4.0 justfile.project?)." >&2
+    echo "         Run 'uv sync' manually after migrating your recipes (see MIGRATION.md)." >&2
+fi
 
 echo "Workspace initialized successfully!"
 echo ""

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -182,6 +182,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **rc4 field-validation fix batch: direnv-mode commits, pipe-safe scripts, prune/typos/installer hardening** ([#859](https://github.com/vig-os/devcontainer/issues/859))
+  - Scaffolded `.githooks/*` now use `#!/usr/bin/env bash` (hosts without `/bin/bash`, e.g. NixOS, could not run them) and accept the nix dev-shell (`IN_NIX_SHELL`) as a sanctioned commit environment — previously direnv-mode consumers could not commit at all (the guard demanded the container)
+  - Restored the `${BASH_SOURCE[0]:-$0}` pipe-safety fallback in the scaffolded lifecycle scripts (`initialize`/`post-create`/`post-attach`/`version-check`) — a regression from the 0.3.x scaffold caught by a consumer's own regression tests
+  - `--mode devcontainer` no longer deletes a consumer's **pre-existing** `flake.nix`/`.envrc` (two real repos lost their own nix-direnv setup); the prune now only removes stub files the scaffold itself created, mirroring the #738 guard
+  - The installer's final `just sync` is non-fatal when the preserved old-generation `justfile.project` predates the `sync` recipe (warns and points to MIGRATION.md instead of failing an otherwise complete scaffold)
+  - The typos hook (repo + scaffold) passes `--force-exclude` so `[files] extend-exclude` applies to explicitly-passed staged files — three consumer repos hit garbage findings on committed binary artifacts (PDFs, SVGs, `.bin` fixtures)
+  - `docs/MIGRATION.md` gained the field-validated "Upgrading an existing 0.3.x consumer" checklist (prek recipe migration, recipe renames, typos config precedence/shadowing, artifact excludes, name re-derivation)
 - **Shipped consumer `prepare-release.yml` caps its PR body under GitHub's 65,536-char limit** ([#857](https://github.com/vig-os/devcontainer/issues/857))
   - #812 capped the PR body only in this repo's own workflow; the scaffolded consumer copy still interpolated the full frozen changelog section uncapped, so a consumer with a large release (the 0.4.0-rc3 smoke test seeds this repo's ~67k-char section) failed `Create draft PR to main` with `GraphQL: Body is too long`. The shipped workflow now applies the same line-boundary truncation with a pointer to the release branch's full `CHANGELOG.md`
 - **Scaffold ships `.typos.toml` so the shipped typos hook passes out of the box** ([#855](https://github.com/vig-os/devcontainer/issues/855))

--- a/assets/workspace/.devcontainer/scripts/initialize.sh
+++ b/assets/workspace/.devcontainer/scripts/initialize.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 
 echo "Initializing devcontainer setup..."
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 DEVCONTAINER_DIR="$(dirname "$SCRIPT_DIR")"
 
 # Copy host user configuration (git, ssh, gh)

--- a/assets/workspace/.devcontainer/scripts/post-attach.sh
+++ b/assets/workspace/.devcontainer/scripts/post-attach.sh
@@ -12,7 +12,7 @@ set -euo pipefail
 
 echo "Running post-attach checks..."
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 PROJECT_ROOT="/workspace/{{SHORT_NAME}}"
 
 "$SCRIPT_DIR/verify-auth.sh"

--- a/assets/workspace/.devcontainer/scripts/post-create.sh
+++ b/assets/workspace/.devcontainer/scripts/post-create.sh
@@ -14,7 +14,7 @@ set -euo pipefail
 
 echo "Running post-create setup..."
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 PROJECT_ROOT="/workspace/{{SHORT_NAME}}"
 
 if [ ! -d "$PROJECT_ROOT" ]; then

--- a/assets/workspace/.devcontainer/scripts/version-check.sh
+++ b/assets/workspace/.devcontainer/scripts/version-check.sh
@@ -26,7 +26,7 @@ set -euo pipefail
 # CONFIGURATION
 # ═══════════════════════════════════════════════════════════════════════════════
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 DEVCONTAINER_DIR="$(dirname "$SCRIPT_DIR")"
 
 # Local config directory (gitignored)

--- a/assets/workspace/.githooks/commit-msg
+++ b/assets/workspace/.githooks/commit-msg
@@ -1,11 +1,13 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Set error handling, fail on any error during script execution
 set -euo pipefail
 
-# Check if we're running inside the dev container
-if [ "${IN_CONTAINER:-}" != "true" ]; then
-	# Outside dev container
-	echo "Please commit your changes within the dev container."
+# Sanctioned environments: the dev container (IN_CONTAINER, set by the
+# image) or the nix-direnv dev-shell (IN_NIX_SHELL, set by nix) — direnv
+# mode has no container (#859).
+if [ "${IN_CONTAINER:-}" != "true" ] && [ -z "${IN_NIX_SHELL:-}" ]; then
+	# Outside both sanctioned environments
+	echo "Please commit your changes within the dev container or the nix dev-shell."
 	exit 1
 fi
 

--- a/assets/workspace/.githooks/pre-commit
+++ b/assets/workspace/.githooks/pre-commit
@@ -1,11 +1,13 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Set error handling, fail on any error during script execution
 set -euo pipefail
 
-# Check if we're running inside the dev container
-if [ "${IN_CONTAINER:-}" != "true" ]; then
-	# Outside dev container
-	echo "Please commit your changes within the dev container."
+# Sanctioned environments: the dev container (IN_CONTAINER, set by the
+# image) or the nix-direnv dev-shell (IN_NIX_SHELL, set by nix) — direnv
+# mode has no container (#859).
+if [ "${IN_CONTAINER:-}" != "true" ] && [ -z "${IN_NIX_SHELL:-}" ]; then
+	# Outside both sanctioned environments
+	echo "Please commit your changes within the dev container or the nix dev-shell."
 	exit 1
 fi
 

--- a/assets/workspace/.githooks/prepare-commit-msg
+++ b/assets/workspace/.githooks/prepare-commit-msg
@@ -1,12 +1,14 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Strip AI agent trailers from commit message before validation.
 # Refs: #163
 set -euo pipefail
 
-# Check if we're running inside the dev container
-if [ "${IN_CONTAINER:-}" != "true" ]; then
-	# Outside dev container
-	echo "Please commit your changes within the dev container."
+# Sanctioned environments: the dev container (IN_CONTAINER, set by the
+# image) or the nix-direnv dev-shell (IN_NIX_SHELL, set by nix) — direnv
+# mode has no container (#859).
+if [ "${IN_CONTAINER:-}" != "true" ] && [ -z "${IN_NIX_SHELL:-}" ]; then
+	# Outside both sanctioned environments
+	echo "Please commit your changes within the dev container or the nix dev-shell."
 	exit 1
 fi
 

--- a/assets/workspace/.pre-commit-config.yaml
+++ b/assets/workspace/.pre-commit-config.yaml
@@ -115,7 +115,7 @@ repos:
     hooks:
       - id: typos
         name: typos (source typo checker)
-        entry: typos
+        entry: typos --force-exclude
         language: system
 
   # Security exception expiry enforcement (Refs: #566)

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -107,6 +107,33 @@ module rather than baking it into every consumer's image.
   (Renovate's `nix` manager opens the PR); `flake.lock` is the controlling
   version document.
 
+## Upgrading an existing 0.3.x consumer — manual steps
+
+`install.sh --version <X> --force` refreshes the scaffold and pins `<X>` in
+`.vig-os`, but files you own are **preserved, not migrated**. Field-validated
+checklist ([#859](https://github.com/vig-os/devcontainer/issues/859)) after the
+re-scaffold:
+
+1. **`justfile.project` hook recipe** — your preserved `precommit` recipe still
+   runs `uv run pre-commit run --all-files`; `pre-commit` is gone from the
+   0.4.0 image and venv. Change it to `prek run --all-files`.
+2. **Recipe renames** — the managed base recipes are now `devc-*`-namespaced
+   and the template test recipe is `just test` (formerly `just test-pytest`).
+   Run `just --list` once and update any scripts/muscle memory.
+3. **typos config precedence** — if your repo owns a `typos.toml` or
+   `_typos.toml`, it silently **shadows** the shipped `.typos.toml`. Merge the
+   shipped `[default.extend-words]` entries (`Nd`, `unexcepted`, `ba` — needed
+   by scaffold-shipped content such as `version-check.sh` and the synced
+   `.devcontainer/CHANGELOG.md`) into your file.
+4. **Committed binary/generated artifacts** (plot exports, PDFs, golden `.bin`
+   fixtures, SVGs): add them to your typos `[files] extend-exclude` and
+   consider a global `exclude:` in `.pre-commit-config.yaml` so the autofix
+   hooks (end-of-file-fixer, trailing-whitespace) don't rewrite them.
+5. **Project name re-derivation** — the re-scaffold substitutes placeholders
+   from the current directory/`--name`; template-origin files (e.g.
+   `tests/test_example.py`) may be rewritten to a name that differs from your
+   original scaffold. Review the diff before committing.
+
 ## Staying on the Debian image (rollback)
 
 The final Debian-built release is **0.3.9**; every release from 0.4.0 onward is

--- a/tests/bats/init-workspace.bats
+++ b/tests/bats/init-workspace.bats
@@ -202,12 +202,15 @@ prune_mode() {
 }
 
 @test "init-workspace.sh prunes the scaffold by delivery mode (#641)" {
-    # devcontainer drops the flake stub; direnv drops the devcontainer scaffold.
+    # devcontainer drops the flake stub (unless pre-existing, #859); direnv
+    # drops the devcontainer scaffold.
     # shellcheck disable=SC2016
-    run grep -A12 'case "\$MODE" in' "$INIT_WORKSPACE_SH"
+    run grep -A28 'case "\$MODE" in' "$INIT_WORKSPACE_SH"
     assert_success
     # shellcheck disable=SC2016
-    assert_output --partial 'rm -f "$WORKSPACE_DIR/flake.nix" "$WORKSPACE_DIR/.envrc"'
+    assert_output --partial 'rm -f "$WORKSPACE_DIR/flake.nix"'
+    # shellcheck disable=SC2016
+    assert_output --partial 'rm -f "$WORKSPACE_DIR/.envrc"'
     # shellcheck disable=SC2016
     assert_output --partial 'rm -rf "$WORKSPACE_DIR/.devcontainer"'
 }

--- a/tests/bats/init-workspace.bats
+++ b/tests/bats/init-workspace.bats
@@ -533,3 +533,72 @@ _scaffold() {
     run test -f "$TEMPLATE_DIR/.typos.toml"
     assert_success
 }
+
+# ── 0.4.0-rc4 field-validation fixes (#859) ──────────────────────────────────
+
+@test "scaffolded githooks use env-based bash shebangs (#859)" {
+    for hook in pre-commit commit-msg prepare-commit-msg; do
+        run head -1 "$TEMPLATE_DIR/.githooks/$hook"
+        assert_output "#!/usr/bin/env bash"
+    done
+}
+
+@test "scaffolded githooks accept the nix dev-shell as sanctioned (#859)" {
+    # direnv mode has no container; the guard must not require IN_CONTAINER
+    # when the commit happens inside the flake dev-shell (IN_NIX_SHELL).
+    for hook in pre-commit commit-msg prepare-commit-msg; do
+        run grep -F 'IN_NIX_SHELL' "$TEMPLATE_DIR/.githooks/$hook"
+        assert_success
+    done
+}
+
+@test "scaffolded lifecycle scripts keep the BASH_SOURCE pipe-safety fallback (#859)" {
+    # Regression caught by a consumer's own tests: bare ${BASH_SOURCE[0]}
+    # dies with "unbound variable" under `set -u` when piped (curl | bash).
+    for script in initialize post-create post-attach version-check; do
+        # shellcheck disable=SC2016
+        run grep -F '${BASH_SOURCE[0]:-$0}' "$TEMPLATE_DIR/.devcontainer/scripts/$script.sh"
+        assert_success
+        # and no bare form remains
+        # shellcheck disable=SC2016
+        run grep -F '${BASH_SOURCE[0]}"' "$TEMPLATE_DIR/.devcontainer/scripts/$script.sh"
+        assert_failure
+    done
+}
+
+@test "init-workspace devcontainer-mode prune keeps pre-existing flake.nix and .envrc (#859)" {
+    # The prune deleted hyrr's and talys' own nix-direnv setup. Only files the
+    # scaffold itself created may be pruned.
+    ws=$(mktemp -d)
+    printf '# my own flake\n' > "$ws/flake.nix"
+    printf 'use flake .#custom\n' > "$ws/.envrc"
+    TEMPLATE_DIR="$PROJECT_ROOT/assets/workspace" WORKSPACE_DIR="$ws" \
+        SHORT_NAME=probe ORG_NAME=Probe GITHUB_REPOSITORY=probe/probe \
+        run bash "$INIT_WORKSPACE_SH" --no-prompts --force --mode devcontainer
+    assert_success
+    run cat "$ws/flake.nix"
+    assert_output "# my own flake"
+    run cat "$ws/.envrc"
+    assert_output "use flake .#custom"
+    rm -rf "$ws"
+}
+
+@test "init-workspace tolerates a preserved justfile.project without a sync recipe (#859)" {
+    # Old-generation consumers (pre-sync recipe) made the installer exit 1
+    # after an otherwise complete scaffold (hyrr). Must warn, not fail.
+    run grep -n 'just sync' "$INIT_WORKSPACE_SH"
+    assert_success
+    # the invocation must be non-fatal
+    run grep -E 'just sync.*\|\||if.*just.*--show.*sync|just --show sync' "$INIT_WORKSPACE_SH"
+    assert_success
+}
+
+@test "typos hook passes --force-exclude in repo and template configs (#859)" {
+    # prek passes staged filenames explicitly; without --force-exclude, typos
+    # ignores [files] extend-exclude and scans binary artifacts (three
+    # consumer repos hit garbage findings on PDFs/SVGs/bin fixtures).
+    run grep -F 'entry: typos --force-exclude' "$PROJECT_ROOT/.pre-commit-config.yaml"
+    assert_success
+    run grep -F 'entry: typos --force-exclude' "$TEMPLATE_DIR/.pre-commit-config.yaml"
+    assert_success
+}


### PR DESCRIPTION
## Summary

Fix batch for the six upstream defects surfaced by the 0.4.0-rc4 field validation (#859; findings comments there cover five repos, two orgs, both delivery modes):

| # | Finding | Fix |
|---|---------|-----|
| 1 | direnv mode cannot commit (guard demands the container) | `.githooks/*` accept `IN_NIX_SHELL` as sanctioned |
| 2 | `.githooks/*` `#!/bin/bash` unusable on NixOS hosts | `#!/usr/bin/env bash` |
| 9 | lifecycle scripts regressed `${BASH_SOURCE[0]:-$0}` → `unbound variable` when piped | fallback restored in all four scripts |
| 12 | `--mode devcontainer` prune deleted consumers' own `flake.nix`/`.envrc` (hyrr, talys) | prune only removes stub files the scaffold created (mirrors #738) |
| 13 | installer's final `just sync` fails on old-generation preserved `justfile.project` | non-fatal with a MIGRATION.md pointer |
| 3/10/11 | typos ignores `[files] extend-exclude` for staged files → garbage findings on binary artifacts in three repos | `entry: typos --force-exclude` (repo + scaffold via manifest sync) |

Plus the field-validated **"Upgrading an existing 0.3.x consumer" checklist in `docs/MIGRATION.md`** (prek recipe migration, recipe renames, typos config shadowing, artifact excludes, name re-derivation).

Remaining findings (7 CodeQL onboarding, 8 name re-derivation, 14 fresh-adoption clobber, 4 autofix-vs-artifacts defaults) are documented in MIGRATION.md and/or tracked for the next cycle in #854 — they are design-level, not rc5-blocking.

## Verification

- TDD: 6 new bats tests RED (confirmed) → GREEN; the prune guard is proven by a **functional host-run** of `init-workspace.sh` with pre-existing `flake.nix`/`.envrc` surviving `--mode devcontainer`; suite 62/62.
- Existing prune test updated to the new guarded behavior (message/shape change).
- `just precommit` (full suite, all files): green, exit 0.
- Local pytest: 63 passed; 3 failures are the known stale-local-`:dev`-image class (image-content tests; CI builds the image from this branch, where they run for real).

Requires **rc5** (image bakes `assets/`), then targeted re-verification per #859's exit criteria.

Refs: #859