### PR TITLE
fix(ci): break renovate changelog self-commit loop and sync workspace mirror

### DIFF
--- a/.github/workflows/renovate-changelog-build.yml
+++ b/.github/workflows/renovate-changelog-build.yml
@@ -1,5 +1,7 @@
-# Append Keep-a-Changelog Unreleased entries for Renovate dependency PRs (Refs: #506, #562).
+# Append Keep-a-Changelog Unreleased entries for Renovate dependency PRs (Refs: #506, #562, #863).
 # Read-only build on pull_request; privileged commit runs via workflow_run from default branch.
+# The sender-login guard skips synchronize events raised by the changelog commit bot's own
+# push (which uses an app token that re-triggers workflows), breaking the self-commit loop.
 
 name: Renovate changelog build
 
@@ -14,6 +16,7 @@ jobs:
     name: Resolve image tag
     if: >-
       github.event.pull_request.user.login == 'renovate[bot]' &&
+      github.event.sender.login != 'commit-action-bot[bot]' &&
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-24.04
     timeout-minutes: 2
@@ -40,6 +43,7 @@ jobs:
     name: Build changelog artifact
     if: >-
       github.event.pull_request.user.login == 'renovate[bot]' &&
+      github.event.sender.login != 'commit-action-bot[bot]' &&
       github.event.pull_request.head.repo.full_name == github.repository
     needs: [resolve-image]
     runs-on: ubuntu-24.04
@@ -73,6 +77,10 @@ jobs:
           if git diff --quiet CHANGELOG.md 2>/dev/null; then
             echo "modified=false" >> "$GITHUB_OUTPUT"
           else
+            # Keep the preserved-on-upgrade mirror in lockstep with root CHANGELOG.md
+            # so the sync-manifest gate stays green. The scripts/manifest.toml entry
+            # for CHANGELOG.md is a verbatim copy (no transform), so cp == sync output.
+            cp CHANGELOG.md assets/workspace/.devcontainer/CHANGELOG.md
             echo "modified=true" >> "$GITHUB_OUTPUT"
           fi
 
@@ -92,6 +100,9 @@ jobs:
           } > changelog-artifact/metadata.env
           if [[ "${MODIFIED}" == "true" ]]; then
             cp CHANGELOG.md changelog-artifact/
+            mkdir -p changelog-artifact/assets/workspace/.devcontainer
+            cp assets/workspace/.devcontainer/CHANGELOG.md \
+              changelog-artifact/assets/workspace/.devcontainer/CHANGELOG.md
           fi
 
       - name: Upload changelog artifact

--- a/.github/workflows/renovate-changelog-commit.yml
+++ b/.github/workflows/renovate-changelog-commit.yml
@@ -64,4 +64,4 @@ jobs:
             docs(changelog): add unreleased entry for renovate PR ${{ steps.metadata.outputs.pr_number }}
 
             Refs: #${{ steps.metadata.outputs.pr_number }}
-          FILE_PATHS: CHANGELOG.md
+          FILE_PATHS: CHANGELOG.md,assets/workspace/.devcontainer/CHANGELOG.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,6 +182,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Renovate changelog automation no longer self-triggers an empty-commit loop and keeps the workspace mirror in sync** ([#863](https://github.com/vig-os/devcontainer/issues/863))
+  - The changelog commit is pushed with a GitHub App token (which re-triggers workflows), but the build gated only on the PR author (permanently `renovate[bot]`) and never the pusher, and `commit-action` has no empty-diff guard — so the bot's own no-op commits fired fresh `synchronize` events without end (#862 accrued 150+ identical empty commits before the build was disabled by hand). The build now skips `synchronize` events raised by the changelog commit bot (`github.event.sender.login`), severing the loop
+  - The automation committed only root `CHANGELOG.md`, leaving the `scripts/manifest.toml` mirror `assets/workspace/.devcontainer/CHANGELOG.md` stale so the `sync-manifest` gate failed on every Renovate PR; the build now mirrors the verbatim copy and commits both files
 - **rc4 field-validation fix batch: direnv-mode commits, pipe-safe scripts, prune/typos/installer hardening** ([#859](https://github.com/vig-os/devcontainer/issues/859))
   - Scaffolded `.githooks/*` now use `#!/usr/bin/env bash` (hosts without `/bin/bash`, e.g. NixOS, could not run them) and accept the nix dev-shell (`IN_NIX_SHELL`) as a sanctioned commit environment — previously direnv-mode consumers could not commit at all (the guard demanded the container)
   - Restored the `${BASH_SOURCE[0]:-$0}` pipe-safety fallback in the scaffolded lifecycle scripts (`initialize`/`post-create`/`post-attach`/`version-check`) — a regression from the 0.3.x scaffold caught by a consumer's own regression tests

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -182,6 +182,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Renovate changelog automation no longer self-triggers an empty-commit loop and keeps the workspace mirror in sync** ([#863](https://github.com/vig-os/devcontainer/issues/863))
+  - The changelog commit is pushed with a GitHub App token (which re-triggers workflows), but the build gated only on the PR author (permanently `renovate[bot]`) and never the pusher, and `commit-action` has no empty-diff guard — so the bot's own no-op commits fired fresh `synchronize` events without end (#862 accrued 150+ identical empty commits before the build was disabled by hand). The build now skips `synchronize` events raised by the changelog commit bot (`github.event.sender.login`), severing the loop
+  - The automation committed only root `CHANGELOG.md`, leaving the `scripts/manifest.toml` mirror `assets/workspace/.devcontainer/CHANGELOG.md` stale so the `sync-manifest` gate failed on every Renovate PR; the build now mirrors the verbatim copy and commits both files
 - **rc4 field-validation fix batch: direnv-mode commits, pipe-safe scripts, prune/typos/installer hardening** ([#859](https://github.com/vig-os/devcontainer/issues/859))
   - Scaffolded `.githooks/*` now use `#!/usr/bin/env bash` (hosts without `/bin/bash`, e.g. NixOS, could not run them) and accept the nix dev-shell (`IN_NIX_SHELL`) as a sanctioned commit environment — previously direnv-mode consumers could not commit at all (the guard demanded the container)
   - Restored the `${BASH_SOURCE[0]:-$0}` pipe-safety fallback in the scaffolded lifecycle scripts (`initialize`/`post-create`/`post-attach`/`version-check`) — a regression from the 0.3.x scaffold caught by a consumer's own regression tests

--- a/assets/workspace/.github/workflows/renovate-changelog-build.yml
+++ b/assets/workspace/.github/workflows/renovate-changelog-build.yml
@@ -1,5 +1,7 @@
-# Append Keep-a-Changelog Unreleased entries for Renovate dependency PRs (Refs: #506, #562).
+# Append Keep-a-Changelog Unreleased entries for Renovate dependency PRs (Refs: #506, #562, #863).
 # Read-only build on pull_request; privileged commit runs via workflow_run from default branch.
+# The sender-login guard skips synchronize events raised by the changelog commit bot's own
+# push (which uses an app token that re-triggers workflows), breaking the self-commit loop.
 
 name: Renovate changelog build
 
@@ -14,6 +16,7 @@ jobs:
     name: Resolve image tag
     if: >-
       github.event.pull_request.user.login == 'renovate[bot]' &&
+      github.event.sender.login != 'commit-action-bot[bot]' &&
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-24.04
     timeout-minutes: 2
@@ -40,6 +43,7 @@ jobs:
     name: Build changelog artifact
     if: >-
       github.event.pull_request.user.login == 'renovate[bot]' &&
+      github.event.sender.login != 'commit-action-bot[bot]' &&
       github.event.pull_request.head.repo.full_name == github.repository
     needs: [resolve-image]
     runs-on: ubuntu-24.04
@@ -73,6 +77,10 @@ jobs:
           if git diff --quiet CHANGELOG.md 2>/dev/null; then
             echo "modified=false" >> "$GITHUB_OUTPUT"
           else
+            # Keep the preserved-on-upgrade mirror in lockstep with root CHANGELOG.md
+            # so the sync-manifest gate stays green. The scripts/manifest.toml entry
+            # for CHANGELOG.md is a verbatim copy (no transform), so cp == sync output.
+            cp CHANGELOG.md assets/workspace/.devcontainer/CHANGELOG.md
             echo "modified=true" >> "$GITHUB_OUTPUT"
           fi
 
@@ -92,6 +100,9 @@ jobs:
           } > changelog-artifact/metadata.env
           if [[ "${MODIFIED}" == "true" ]]; then
             cp CHANGELOG.md changelog-artifact/
+            mkdir -p changelog-artifact/assets/workspace/.devcontainer
+            cp assets/workspace/.devcontainer/CHANGELOG.md \
+              changelog-artifact/assets/workspace/.devcontainer/CHANGELOG.md
           fi
 
       - name: Upload changelog artifact

--- a/assets/workspace/.github/workflows/renovate-changelog-commit.yml
+++ b/assets/workspace/.github/workflows/renovate-changelog-commit.yml
@@ -64,4 +64,4 @@ jobs:
             docs(changelog): add unreleased entry for renovate PR ${{ steps.metadata.outputs.pr_number }}
 
             Refs: #${{ steps.metadata.outputs.pr_number }}
-          FILE_PATHS: CHANGELOG.md
+          FILE_PATHS: CHANGELOG.md,assets/workspace/.devcontainer/CHANGELOG.md


### PR DESCRIPTION
Fixes #863.

## What was wrong

The Renovate changelog automation had two independent defects, both surfaced on #862 (which accrued **150+ identical empty commits** before the build workflow was disabled by hand to stop it):

1. **Self-triggering loop.** `renovate-changelog-commit.yml` pushes with a GitHub App token (re-triggers workflows); the build gated only on the PR **author** (permanently `renovate[bot]`), never the **pusher**, and `commit-action` has no empty-diff guard → the bot's own no-op commits fired fresh `synchronize` events without end.
2. **Stale workspace mirror (red CI).** The bot committed only root `CHANGELOG.md`, leaving the `scripts/manifest.toml` mirror `assets/workspace/.devcontainer/CHANGELOG.md` stale, so the `sync-manifest` gate failed on every Renovate PR — independent of the loop.

## Fix

- **Loop:** guard both build jobs on `github.event.sender.login != 'commit-action-bot[bot]'`, so a `synchronize` raised by the commit bot's push no longer starts a build. Net effect: exactly one changelog commit per Renovate PR.
- **Mirror:** the build copies root `CHANGELOG.md` → the verbatim mirror and ships both in the artifact; `renovate-changelog-commit.yml` commits `FILE_PATHS: CHANGELOG.md,assets/workspace/.devcontainer/CHANGELOG.md` (precedent: `prepare-release.yml`).

Shipped copies under `assets/workspace/.github/workflows/` regenerated via `scripts/sync_manifest.py` (identical to root).

## Testing

CI-config + changelog only (no unit-testable logic). `prek run --all-files` green locally, including `sync-manifest`.

## Operational note

`renovate-changelog-build.yml` is **disabled manually** right now to stop the active loop. Re-enable once this reaches `dev` (via `sync-main-to-dev`), then use #862 to validate the flow end-to-end.