### PR TITLE
fix(changelog): insert renovate entries at the top of ### Changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Renovate changelog entries land as plain `### Changed` bullets, not under `#### Modules`** ([#867](https://github.com/vig-os/devcontainer/issues/867))
+  - `renovate-changelog-pr` appended entries at the bottom of the `### Changed` block, so with the `#### Modules` sub-heading convention ([#816](https://github.com/vig-os/devcontainer/issues/816)) a dependency bump was filed beneath `#### Modules` and read as a module change. Entries now insert at the top of `### Changed`, above any `####` sub-heading, with Keep-a-Changelog spacing preserved.
+
 ### Security
 
 ## [0.4.0] - TBD

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -66,6 +66,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Renovate changelog entries land as plain `### Changed` bullets, not under `#### Modules`** ([#867](https://github.com/vig-os/devcontainer/issues/867))
+  - `renovate-changelog-pr` appended entries at the bottom of the `### Changed` block, so with the `#### Modules` sub-heading convention ([#816](https://github.com/vig-os/devcontainer/issues/816)) a dependency bump was filed beneath `#### Modules` and read as a module change. Entries now insert at the top of `### Changed`, above any `####` sub-heading, with Keep-a-Changelog spacing preserved.
+
 ### Security
 
 ## [0.4.0] - TBD

--- a/packages/vig-utils/src/vig_utils/renovate_changelog_pr.py
+++ b/packages/vig-utils/src/vig_utils/renovate_changelog_pr.py
@@ -153,38 +153,31 @@ def insert_renovate_changelog_entry(
         return changelog, False
 
     changed_idx: int | None = None
-    next_sec: int | None = None
     for i in range(unreleased_start, unreleased_end):
-        line = lines[i]
-        if line.startswith("### Changed"):
+        if lines[i].startswith("### Changed"):
             changed_idx = i
-            continue
-        if (
-            changed_idx is not None
-            and line.startswith("### ")
-            and not line.startswith("### Changed")
-        ):
-            next_sec = i
             break
     if changed_idx is None:
         return changelog, False
 
-    # Insert before the next ### heading, or at end of ## Unreleased if Changed is last subsection
-    insert_at = next_sec if next_sec is not None else unreleased_end
-
-    # Do not consume the first blank line after ### Changed (empty subsection): keep
-    # Keep-a-Changelog spacing between the heading and the first list item.
-    min_insert = changed_idx + 1
-    if changed_idx + 1 < len(lines) and lines[changed_idx + 1].strip() == "":
-        min_insert = changed_idx + 2
-
-    # Keep blank line between list items and the following heading (Keep-a-Changelog)
-    while insert_at > min_insert and lines[insert_at - 1].strip() == "":
-        insert_at -= 1
+    # Insert at the TOP of ### Changed, as a plain bullet above any #### sub-heading
+    # (e.g. the #### Modules convention) rather than appended at the bottom of the
+    # block. Keep the blank line after the heading for Keep-a-Changelog spacing.
+    insert_at = changed_idx + 1
+    if insert_at < len(lines) and lines[insert_at].strip() == "":
+        insert_at += 1
 
     if not entry.endswith("\n"):
         entry = entry + "\n"
-    new_lines = lines[:insert_at] + [entry] + lines[insert_at:]
+
+    # When the section opens with a heading (empty ### Changed, or a #### sub-heading
+    # as its first content), append a blank line so the new bullet keeps Keep-a-Changelog
+    # spacing before that heading.
+    addition = [entry]
+    if insert_at < len(lines) and lines[insert_at].lstrip().startswith("#"):
+        addition.append("\n")
+
+    new_lines = lines[:insert_at] + addition + lines[insert_at:]
     return "".join(new_lines), True
 
 

--- a/packages/vig-utils/tests/test_renovate_changelog_pr.py
+++ b/packages/vig-utils/tests/test_renovate_changelog_pr.py
@@ -87,7 +87,8 @@ def test_format_single_missing_old() -> None:
     )
 
 
-def test_insert_appends_to_changed_section() -> None:
+def test_insert_prepends_to_changed_section() -> None:
+    """New entries go at the top of ### Changed, above existing bullets."""
     changelog = textwrap.dedent(
         """\
         ## Unreleased
@@ -104,6 +105,7 @@ def test_insert_appends_to_changed_section() -> None:
     entry = "- **New** ([#2](https://github.com/o/r/pull/2))\n"
     new_content, did = insert_renovate_changelog_entry(changelog, 2, entry)
     assert did is True
+    assert new_content.index(entry) < new_content.index("**Existing**")
     assert new_content.index(entry) < new_content.index("### Deprecated")
     assert "**Existing**" in new_content
 

--- a/packages/vig-utils/tests/test_renovate_changelog_pr.py
+++ b/packages/vig-utils/tests/test_renovate_changelog_pr.py
@@ -145,6 +145,31 @@ def test_insert_idempotent() -> None:
     assert new_content == changelog
 
 
+def test_insert_above_subheading_in_changed() -> None:
+    """Renovate entries land as a plain ### Changed bullet, above any #### sub-heading."""
+    changelog = textwrap.dedent(
+        """\
+        ## Unreleased
+
+        ### Changed
+
+        #### Modules
+
+        - **Module thing** ([#1](https://github.com/o/r/pull/1))
+
+        ### Deprecated
+        """
+    )
+    entry = "- **Renovate: update `x`** ([#2](https://github.com/o/r/pull/2))\n"
+    new_content, did = insert_renovate_changelog_entry(changelog, 2, entry)
+    assert did is True
+    # Plain bullet at the top of ### Changed, not nested under #### Modules
+    assert new_content.index(entry) < new_content.index("#### Modules")
+    assert "### Changed\n\n- **Renovate" in new_content
+    # Keep-a-Changelog spacing preserved before the sub-heading
+    assert "\n\n#### Modules" in new_content
+
+
 def test_insert_changed_is_last_section_before_version() -> None:
     """### Changed with no following ### subsection still gets new bullets."""
     changelog = textwrap.dedent(


### PR DESCRIPTION
Fixes #867. Cosmetic follow-up split out of #863 / PR #864.

## Problem

`insert_renovate_changelog_entry` appended entries at the **bottom** of `## Unreleased → ### Changed`. With the `#### Modules` sub-heading convention (#816), a Renovate dependency bump landed **under `#### Modules`**, misattributing it as a module change (seen on #862).

## Fix

Insert at the **top** of `### Changed` — a plain bullet above any `####` sub-heading — reusing the existing post-heading offset, and add a trailing blank line when the section opens with a heading so Keep-a-Changelog spacing is preserved. The position-independent idempotency guard (`_pr_marked_in_changed`) is unchanged.

## Testing (TDD)

- RED: `test_insert_above_subheading_in_changed` (fails on old code — entry landed below `#### Modules`).
- GREEN: fix applied; renamed `test_insert_appends_to_changed_section` → `test_insert_prepends_to_changed_section` and asserted top placement. `uv run pytest packages/vig-utils/tests/test_renovate_changelog_pr.py` → 12 passed.
- Manual smoke: ran `renovate-changelog-pr` against a `#### Modules` fixture — the bullet now sits above `#### Modules`.
- `prek run --all-files` green (incl. `sync-manifest`).

## Rollout note

The tool runs from the baked `renovate-changelog-pr` console script in the published image, so this goes live for Renovate PRs after the next image rebuild that bakes the updated `vig-utils`.