### PR TITLE
fix(ci): upload hidden changelog mirror and quote renovate metadata.env

### DIFF
--- a/.github/workflows/renovate-changelog-build.yml
+++ b/.github/workflows/renovate-changelog-build.yml
@@ -93,10 +93,13 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p changelog-artifact
+          # %q-quote values: the commit workflow sources this file, and grouped
+          # Renovate branch names contain shell metacharacters (e.g. parentheses
+          # in renovate/python-(minor-and-patch)).
           {
-            echo "MODIFIED=${MODIFIED}"
-            echo "PR_NUMBER=${PR_NUMBER}"
-            echo "HEAD_REF=${HEAD_REF}"
+            printf 'MODIFIED=%q\n' "${MODIFIED}"
+            printf 'PR_NUMBER=%q\n' "${PR_NUMBER}"
+            printf 'HEAD_REF=%q\n' "${HEAD_REF}"
           } > changelog-artifact/metadata.env
           if [[ "${MODIFIED}" == "true" ]]; then
             cp CHANGELOG.md changelog-artifact/
@@ -110,4 +113,7 @@ jobs:
         with:
           name: renovate-changelog
           path: changelog-artifact/
+          # The workspace mirror lives under the hidden .devcontainer directory,
+          # which upload-artifact excludes by default.
+          include-hidden-files: true
           retention-days: 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Renovate changelog artifact drops the workspace mirror; `metadata.env` breaks on parenthesized branches** ([#874](https://github.com/vig-os/devcontainer/issues/874))
+  - `upload-artifact` silently excluded the mirror under the hidden `.devcontainer` directory, so the bot commit updated only the root `CHANGELOG.md` and tripped the `sync-manifest` gate; now uploaded with `include-hidden-files: true`.
+  - `metadata.env` values are `%q`-quoted so grouped Renovate branch names (e.g. `renovate/python-(minor-and-patch)`) survive being `source`d by the commit workflow.
+
 - **Renovate changelog entries land as plain `### Changed` bullets, not under `#### Modules`** ([#867](https://github.com/vig-os/devcontainer/issues/867))
   - `renovate-changelog-pr` appended entries at the bottom of the `### Changed` block, so with the `#### Modules` sub-heading convention ([#816](https://github.com/vig-os/devcontainer/issues/816)) a dependency bump was filed beneath `#### Modules` and read as a module change. Entries now insert at the top of `### Changed`, above any `####` sub-heading, with Keep-a-Changelog spacing preserved.
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -66,6 +66,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Renovate changelog artifact drops the workspace mirror; `metadata.env` breaks on parenthesized branches** ([#874](https://github.com/vig-os/devcontainer/issues/874))
+  - `upload-artifact` silently excluded the mirror under the hidden `.devcontainer` directory, so the bot commit updated only the root `CHANGELOG.md` and tripped the `sync-manifest` gate; now uploaded with `include-hidden-files: true`.
+  - `metadata.env` values are `%q`-quoted so grouped Renovate branch names (e.g. `renovate/python-(minor-and-patch)`) survive being `source`d by the commit workflow.
+
 - **Renovate changelog entries land as plain `### Changed` bullets, not under `#### Modules`** ([#867](https://github.com/vig-os/devcontainer/issues/867))
   - `renovate-changelog-pr` appended entries at the bottom of the `### Changed` block, so with the `#### Modules` sub-heading convention ([#816](https://github.com/vig-os/devcontainer/issues/816)) a dependency bump was filed beneath `#### Modules` and read as a module change. Entries now insert at the top of `### Changed`, above any `####` sub-heading, with Keep-a-Changelog spacing preserved.
 

--- a/assets/workspace/.github/workflows/renovate-changelog-build.yml
+++ b/assets/workspace/.github/workflows/renovate-changelog-build.yml
@@ -93,10 +93,13 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p changelog-artifact
+          # %q-quote values: the commit workflow sources this file, and grouped
+          # Renovate branch names contain shell metacharacters (e.g. parentheses
+          # in renovate/python-(minor-and-patch)).
           {
-            echo "MODIFIED=${MODIFIED}"
-            echo "PR_NUMBER=${PR_NUMBER}"
-            echo "HEAD_REF=${HEAD_REF}"
+            printf 'MODIFIED=%q\n' "${MODIFIED}"
+            printf 'PR_NUMBER=%q\n' "${PR_NUMBER}"
+            printf 'HEAD_REF=%q\n' "${HEAD_REF}"
           } > changelog-artifact/metadata.env
           if [[ "${MODIFIED}" == "true" ]]; then
             cp CHANGELOG.md changelog-artifact/
@@ -110,4 +113,7 @@ jobs:
         with:
           name: renovate-changelog
           path: changelog-artifact/
+          # The workspace mirror lives under the hidden .devcontainer directory,
+          # which upload-artifact excludes by default.
+          include-hidden-files: true
           retention-days: 1


### PR DESCRIPTION
## Description

Fixes the two residual defects in the Renovate changelog automation surfaced when the workflow was re-enabled after #863/#864, verified live on PRs #861/#862 (mirror missing from bot commit → `sync-manifest` red) and #865/#866 (commit stage crash on parenthesized branch names).

Closes #874

## Type of Change

- [x] `fix` -- Bug fix

## Changes Made

- `Upload changelog artifact` step now sets `include-hidden-files: true` — `upload-artifact` (≥ v4.4) silently excludes hidden directories, dropping `assets/workspace/.devcontainer/CHANGELOG.md` from the artifact so the commit workflow could never commit the mirror.
- `metadata.env` values are written with `printf '%s=%q'` instead of unquoted `echo`, so grouped Renovate branch names (`renovate/python-(minor-and-patch)`) survive being `source`d by `renovate-changelog-commit.yml`.
- Workspace copy of the workflow updated via `sync-manifest`; changelog entry added (root + mirror).

## Changelog Entry

### Fixed
- **Renovate changelog artifact drops the workspace mirror; `metadata.env` breaks on parenthesized branches** ([#874](https://github.com/vig-os/devcontainer/issues/874))
  - `upload-artifact` silently excluded the mirror under the hidden `.devcontainer` directory, so the bot commit updated only the root `CHANGELOG.md` and tripped the `sync-manifest` gate; now uploaded with `include-hidden-files: true`.
  - `metadata.env` values are `%q`-quoted so grouped Renovate branch names (e.g. `renovate/python-(minor-and-patch)`) survive being `source`d by the commit workflow.

## Testing

- Workflow-YAML-only change — TDD exception (non-testable config).
- Root cause confirmed empirically: downloaded the actual `renovate-changelog` artifact from run 28799680160 (PR #862) — it contains only `CHANGELOG.md` + `metadata.env`, no mirror; commit-stage failures for #865/#866 (runs 28799792964 / 28799804936) show `metadata.env: line 3: syntax error near unexpected token '('`.
- Full pre-commit suite green locally (`just precommit`, exit 0, all files).
- End-to-end verification after merge: re-tick the rebase checkboxes on #861/#862/#865/#866 — Renovate rewrites the branches, the automation must add one bot commit per PR touching both changelogs, with green `sync-manifest`.