### PR TITLE
docs(changelog): move renovate numpy entry above #### Modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,10 +52,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Renovate: update `numpy` to `v2.5.1`** ([#865](https://github.com/vig-os/devcontainer/pull/865))
+
 #### Modules
 
 - **homeManagerModules.default is now the umbrella** importing every `vigos.*` module, each disabled by default ([#818](https://github.com/vig-os/devcontainer/issues/818)); existing imports keep working unchanged.
-- **Renovate: update `numpy` to `v2.5.1`** ([#865](https://github.com/vig-os/devcontainer/pull/865))
 
 ### Deprecated
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -52,10 +52,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Renovate: update `numpy` to `v2.5.1`** ([#865](https://github.com/vig-os/devcontainer/pull/865))
+
 #### Modules
 
 - **homeManagerModules.default is now the umbrella** importing every `vigos.*` module, each disabled by default ([#818](https://github.com/vig-os/devcontainer/issues/818)); existing imports keep working unchanged.
-- **Renovate: update `numpy` to `v2.5.1`** ([#865](https://github.com/vig-os/devcontainer/pull/865))
 
 ### Deprecated
 


### PR DESCRIPTION
## Description

The #865 changelog entry landed under `### Changed → #### Modules` because the changelog build job runs the vig-utils **baked into the published 0.4.0 image**, which predates the #867/#868 placement fix. The tool fix deploys with the next image release (decision: no workflow change needed); this PR just moves the misplaced entry to the top of `### Changed` where the fixed tool would have put it (root + workspace mirror via sync-manifest).

Refs #867 (original placement defect), #865 (the entry).

## Type of Change

- [x] `docs` -- Documentation only

## Changes Made

- `CHANGELOG.md` + `assets/workspace/.devcontainer/CHANGELOG.md`: moved the numpy bullet from inside `#### Modules` to the top of `### Changed`.

## Changelog Entry

No changelog needed — this edit *is* the changelog correction; no user-visible behavior change.

## Testing

- `just precommit` full suite green locally (exit 0).
- Docs-only change — TDD exception.