### PR TITLE
docs(migration): formalize the native-build contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Renovate: update `numpy` to `v2.5.1`** ([#865](https://github.com/vig-os/devcontainer/pull/865))
 
+- **MIGRATION.md: formalized the native-build contract** ([#882](https://github.com/vig-os/devcontainer/issues/882))
+  - Tiered policy for native Python builds (wheel-only / toolchain from the project flake via `mkProjectShell.extraPackages` / in-container `nix develop -c` middle path), a worked Geant4/ROOT example, and the explicit non-goal of shipping a C/C++ toolchain in the base image. Cross-links [#879](https://github.com/vig-os/devcontainer/issues/879) and [#854](https://github.com/vig-os/devcontainer/issues/854).
+
 #### Modules
 
 - **homeManagerModules.default is now the umbrella** importing every `vigos.*` module, each disabled by default ([#818](https://github.com/vig-os/devcontainer/issues/818)); existing imports keep working unchanged.

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -54,6 +54,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Renovate: update `numpy` to `v2.5.1`** ([#865](https://github.com/vig-os/devcontainer/pull/865))
 
+- **MIGRATION.md: formalized the native-build contract** ([#882](https://github.com/vig-os/devcontainer/issues/882))
+  - Tiered policy for native Python builds (wheel-only / toolchain from the project flake via `mkProjectShell.extraPackages` / in-container `nix develop -c` middle path), a worked Geant4/ROOT example, and the explicit non-goal of shipping a C/C++ toolchain in the base image. Cross-links [#879](https://github.com/vig-os/devcontainer/issues/879) and [#854](https://github.com/vig-os/devcontainer/issues/854).
+
 #### Modules
 
 - **homeManagerModules.default is now the umbrella** importing every `vigos.*` module, each disabled by default ([#818](https://github.com/vig-os/devcontainer/issues/818)); existing imports keep working unchanged.

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -98,6 +98,98 @@ language toolchains like Rust, Go, or a C/C++ compiler. Source extra tools
 If a toolchain recurs across vigOS projects, promote it to a shared, opt-in
 module rather than baking it into every consumer's image.
 
+### The native-build contract
+
+`uv sync` compiles a dependency from sdist whenever PyPI has no wheel for the
+image's CPython (`cp314`) — common for scientific packages (pycatima, f2py
+extensions, anything built with scikit-build-core or meson-python). The image
+ships **no C/C++ compiler**, so where that toolchain comes from is an explicit,
+tiered contract:
+
+1. **Pure-Python / wheel-only projects — nothing to do.** Pre-compiled
+   manylinux wheels load out of the box (see above); the image works as-is.
+
+2. **Native deps, `direnv` mode (preferred).** Provide the toolchain via the
+   project flake:
+
+   ```nix
+   devShells.default = vigos.lib.mkProjectShell {
+     inherit pkgs;
+     extraPackages = [
+       pkgs.stdenv.cc # C/C++ compiler wrapper: puts cc/c++ on PATH, exports CC/CXX
+       pkgs.cmake
+       pkgs.pkg-config
+     ];
+   };
+   ```
+
+   Inside `nix develop` / `direnv` the stdenv compiler wrapper exports working
+   `CC`/`CXX`, so build backends find a real compiler regardless of what the
+   image's baked interpreter recorded at image-build time (the sysconfig
+   mechanics are tracked in
+   [#879](https://github.com/vig-os/devcontainer/issues/879)). This path is
+   field-validated by the 0.4.0 downstream runs
+   ([#639](https://github.com/vig-os/devcontainer/issues/639)).
+
+3. **Native deps, `devcontainer` mode (middle path).** No direnv migration
+   required: the baked Nix has flakes enabled, so run the sync *through* a Nix
+   shell inside the container:
+
+   ```bash
+   # Against the project flake (pinned, reproducible):
+   nix develop -c just sync
+
+   # Ad-hoc, when the project has no flake yet:
+   nix shell nixpkgs#gcc nixpkgs#cmake -c uv sync
+   ```
+
+   This is the supported interim answer for devcontainer-mode repos whose
+   dependencies lack `cp314` wheels. The pinned `nix develop -c` form also
+   works in CI until the nix-direct CI lane
+   ([#854](https://github.com/vig-os/devcontainer/issues/854)) lands; #854
+   tracks running consumer CI inside the project devshell so the contract is
+   enforced in CI, not just locally.
+
+#### Worked example: heavyweight scientific dependencies
+
+A bare compiler is often not enough. An extension that links against Geant4 or
+ROOT needs the library's headers, shared objects, and CMake package config at
+build time — none of which a fatter base image could supply generically. The
+project flake provides all of it, pinned:
+
+```nix
+devShells.default = vigos.lib.mkProjectShell {
+  inherit pkgs;
+  extraPackages = [
+    pkgs.stdenv.cc
+    pkgs.cmake
+    pkgs.pkg-config
+    pkgs.geant4 # headers + libs + Geant4 CMake config
+    pkgs.root # ROOT, likewise
+  ];
+};
+```
+
+`nix develop` composes the include/library/CMake search paths from these
+packages, so the build backend compiles against the exact Geant4/ROOT revision
+pinned by the project's `flake.lock`. This is why the answer to "the build
+needs gcc" is the flake, not the image: the same mechanism scales from a bare
+compiler to a full scientific stack.
+
+#### Non-goal: a C/C++ toolchain in the base image
+
+The published image will **not** ship gcc/cmake:
+
+- it breaks the minimal-image stance and inflates every consumer, most of
+  which never compile anything;
+- it still would not suffice — real native builds also need third-party
+  headers, libraries, and build config (see the Geant4 example above), which
+  only a pinned project flake provides reproducibly.
+
+The in-image behavior when no toolchain is provided is tracked in
+[#879](https://github.com/vig-os/devcontainer/issues/879); the toolchain
+itself always comes from one of the tiers above.
+
 ## Updating
 
 - **Downstream dev environment:** `nix flake update vigos` (or re-run

--- a/docs/NIX.md
+++ b/docs/NIX.md
@@ -20,7 +20,9 @@ everywhere — the dev-shell now and the image's `imageTools` set.
   `nix develop` (or `direnv`) gives you exactly that toolchain.
 - **`mkProjectShell`** is also a reusable `lib` output: downstream repos build
   their own shell as `devTools ++ extraPackages` (see the scaffolded
-  `assets/workspace/flake.nix`).
+  `assets/workspace/flake.nix`). For projects that compile native Python
+  extensions, `extraPackages` is where the C/C++ toolchain comes from — see
+  the [native-build contract](./MIGRATION.md#the-native-build-contract).
 - **`mkProjectServices`** is the local-dev-services counterpart (#795): a `lib`
   builder that turns declared [services-flake](https://github.com/juspay/services-flake)
   modules into a daemonless `process-compose` stack (`nix run .#services`) —


### PR DESCRIPTION
## Description

Formalize the native-build contract in `docs/MIGRATION.md`: state, as official
policy, where C/C++ toolchains for native Python (sdist) builds come from —
the project flake, not the base image. 0.4.0 field validation (#639,
EXOMA/hyrr) showed `uv sync` hard-fails in the image for any dependency
without a cp314 wheel; the mechanical half is #879, this PR documents the
contract half.

Closes #882

## Type of Change

- [x] `docs` -- Documentation only

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- `docs/MIGRATION.md` — new "The native-build contract" subsection under
  "Adding tools the image does not ship":
  - the tiered contract with copy-pasteable snippets: (1) pure-Python /
    wheel-only — image works as-is; (2) direnv mode (preferred) —
    `mkProjectShell { extraPackages = [ pkgs.stdenv.cc pkgs.cmake pkgs.pkg-config ]; }`;
    (3) devcontainer mode (middle path) — in-container `nix develop -c just sync`
    or ad-hoc `nix shell nixpkgs#gcc nixpkgs#cmake -c uv sync`;
  - worked heavyweight example adding `pkgs.geant4` / `pkgs.root`, showing why
    a bare compiler in the base image would not suffice;
  - explicit non-goal: no C/C++ toolchain in the published image, with
    rationale;
  - cross-links to #879 (sysconfig mechanics), #854 (nix-direct CI lane),
    #639 (field evidence).
- `docs/NIX.md` — one-line pointer from the `mkProjectShell` lib-output bullet
  to the new contract section.
- `CHANGELOG.md` — entry under `## Unreleased` / `### Changed` (mirror
  `assets/workspace/.devcontainer/CHANGELOG.md` regenerated by the
  sync-manifest hook).

All snippets validated against the repo: `mkProjectShell` in `flake.nix`
accepts `extraPackages ? [ ]`; the pinned nixpkgs
(`34268251cf5547d39063f2c5ea9a196246f7f3a6`) evaluates `geant4-11.4.1`,
`root-6.40.00`, `gcc-wrapper-15.2.0` (`stdenv.cc`), `cmake-4.1.2`.

## Changelog Entry

### Changed
- **MIGRATION.md: formalized the native-build contract** ([#882](https://github.com/vig-os/devcontainer/issues/882))
  - Tiered policy for native Python builds (wheel-only / toolchain from the project flake via `mkProjectShell.extraPackages` / in-container `nix develop -c` middle path), a worked Geant4/ROOT example, and the explicit non-goal of shipping a C/C++ toolchain in the base image. Cross-links [#879](https://github.com/vig-os/devcontainer/issues/879) and [#854](https://github.com/vig-os/devcontainer/issues/854).

## Testing

- [ ] Tests pass locally (`just test`) — n/a, docs-only
- [x] Manual testing performed (describe below)

### Manual Testing Details

TDD not applicable: documentation-only change, no testable behavior.
Verification performed instead:

- `just precommit` (full hook suite, all files): exit 0, 52 hooks Passed,
  0 Failed (includes pymarkdown, typos, sync-manifest, generate-docs).
- Nix snippets checked against `flake.nix`'s actual `mkProjectShell` signature
  and package names evaluated against the pinned nixpkgs revision (versions
  above).

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly (MIGRATION.md is a direct file, not template-generated; `generate-docs` hook passed)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

- #879 is referenced as tracked work only; no implementation details of that
  in-flight fix are asserted here.
- The edit stays strictly within the "Adding tools the image does not ship"
  area to avoid conflicts with #642 (Debian-era MIGRATION.md pruning) running
  in parallel; the changelog edit is a tight 4-line insertion.

Refs: #882
