### PR TITLE
docs: retire the documented Debian fallback path (T4.4)

### DIFF
--- a/.github/workflows/nix-image.yml
+++ b/.github/workflows/nix-image.yml
@@ -183,8 +183,8 @@ jobs:
 
       # Regression guard (#664): a Nix image bakes the workspace template as
       # read-only /nix/store symlinks, so the scaffold must produce REAL, writable
-      # files (not dangling symlinks on the host). The install/integration suite
-      # only covers the Debian image, so assert the Nix scaffold here.
+      # files (not dangling symlinks on the host). Assert it here, directly on
+      # the freshly built per-arch image.
       - name: Assert the scaffold has no dangling store symlinks (#664)
         if: matrix.arch == 'amd64'
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- **Documented Debian fallback retired** ([#642](https://github.com/vig-os/devcontainer/issues/642))
+  - The build has been Nix-only since 0.4.0; docs and workflow comments no longer present the Debian image as a rollback path. Pinning the frozen 0.3.9 release remains possible but unsupported.
+
 ### Fixed
 
 - **Renovate changelog artifact drops the workspace mirror; `metadata.env` breaks on parenthesized branches** ([#874](https://github.com/vig-os/devcontainer/issues/874))

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -66,6 +66,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- **Documented Debian fallback retired** ([#642](https://github.com/vig-os/devcontainer/issues/642))
+  - The build has been Nix-only since 0.4.0; docs and workflow comments no longer present the Debian image as a rollback path. Pinning the frozen 0.3.9 release remains possible but unsupported.
+
 ### Fixed
 
 - **Renovate changelog artifact drops the workspace mirror; `metadata.env` breaks on parenthesized branches** ([#874](https://github.com/vig-os/devcontainer/issues/874))

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -134,19 +134,14 @@ re-scaffold:
    `tests/test_example.py`) may be rewritten to a name that differs from your
    original scaffold. Review the diff before committing.
 
-## Staying on the Debian image (rollback)
+## The retired Debian line (historical)
 
-The final Debian-built release is **0.3.9**; every release from 0.4.0 onward is
-Nix-built. Released images are never deleted, so a consumer can stay on — or
-roll back to — the last Debian image by pinning it in the repo-root `.vig-os`:
-
-```text
-DEVCONTAINER_VERSION=0.3.9
-```
-
-The Debian line is frozen: it receives no CVE fixes (the nightly scan already
-reports fixable HIGH/CRITICAL findings against it), so treat the pin as a
-temporary escape hatch, not a supported track.
+The Debian build path was decommissioned in
+[#642](https://github.com/vig-os/devcontainer/issues/642): the final
+Debian-built release is **0.3.9**, and every release from 0.4.0 onward is
+Nix-built. Released images are never deleted, so 0.3.9 remains pullable
+(`DEVCONTAINER_VERSION=0.3.9` in the repo-root `.vig-os`), but the line is
+frozen — it receives no CVE fixes and is not a supported rollback track.
 
 ## Upcoming rename: `devcontainer` → `devkit`
 


### PR DESCRIPTION
## Description

Closes #642 (T4.4 — Decommission the Debian path, tracking #625).

The removal work itself already landed on `dev`: `Containerfile` and `build/Containerfile` are gone, no `type=gha` Docker-cache wiring remains, and the build is Nix-only (0.4.0 promoted, satisfying the #639 + one-green-release-cycle dependency). This PR finishes the task by pruning the last places that still presented Debian as a current/fallback path, and verifies the acceptance criteria.

## Type of Change

- [x] `docs` -- Documentation only

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

**Pruned:**

- `docs/MIGRATION.md` — converted "Staying on the Debian image (rollback)" into a brief historical note ("The retired Debian line (historical)"): the Debian path is decommissioned per #642; pinning the frozen 0.3.9 (`DEVCONTAINER_VERSION=0.3.9` in `.vig-os`) remains possible but is explicitly not a supported rollback track. The historical "What changed" narrative and the "No apt" consumer contract are untouched, and the "Adding tools the image does not ship" section was deliberately left alone (extended in parallel by #882).
- `.github/workflows/nix-image.yml` — the #664 scaffold-guard comment claimed "the install/integration suite only covers the Debian image"; that suite now runs against the Nix image, so the dead clause was reworded. No workflow behavior changed.
- `CHANGELOG.md` (+ synced workspace mirror) — `### Removed` entry under `## Unreleased`.

**Reviewed and kept (already clean / legitimately historical):**

- `docs/CONTAINER_SECURITY.md`, `docs/NIX.md`, `.github/workflows/security-scan.yml`, `.github/actions/build-image/action.yml` — already rewritten to the Nix posture; remaining `apt`/Debian mentions are accurate contrasts ("no apt/dpkg DB") or past-tense notes referencing #642.
- `README.md` — "Ubuntu/Debian" is host-OS install guidance; "no Debian/Docker base image" describes the current Nix build.
- `.github/actions/setup-env/action.yml`, `test-image/action.yml`, `ci.yml` — "apt path" there is live GitHub-runner host provisioning (podman install), not the image.
- `docs/security/nix-cutover-scan-overlap.md`, `docs/issues/*`, `docs/pull-requests/*`, released `CHANGELOG.md` entries — historical records, untouched.

## Changelog Entry

### Removed
- **Documented Debian fallback retired** ([#642](https://github.com/vig-os/devcontainer/issues/642))
  - The build has been Nix-only since 0.4.0; docs and workflow comments no longer present the Debian image as a rollback path. Pinning the frozen 0.3.9 release remains possible but unsupported.

## Testing

- [x] Tests pass locally (`just test`) — N/A: docs/comments-only change; TDD not applicable (non-testable change per project rules)
- [x] Manual testing performed (describe below)

### Manual Testing Details

Acceptance verification (repo-wide grep excluding the `docs/issues/`, `docs/pull-requests/` archives and changelog history):

- `type=gha` — **zero** hits.
- `Containerfile` — only historical/past-tense references remain: MIGRATION.md's "What changed" narrative, `build-image/action.yml`'s "decommissioned in #642" note, a provenance aside in `flake.nix`, and a generic podman-build test fixture in `tests/test_integration.py`.
- Full hook suite green locally: `prek run --all-files` — all hooks Passed (sync-manifest re-synced the workspace changelog mirror, committed here).

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

- **Issues the maintainer can close once this merges** (reconciliation itself is owned by the #677 housekeeping task; not touched here): **#602 / #521** (nightly HIGH/CRITICAL gate on the Debian/apt image — superseded by the blocking vulnix gate, #637/#639) and **#604** (stale Trivy alerts — the apt-based scan categories are retired with the Debian path).
- Two harmless stale asides left as-is (out of scope, code comments not docs): `tests/test_integration.py:606` still says env vars are "set in the image via Containerfile ENV" (now flake image config), and `docs/NIX.md`'s "Publish cutover" section still frames the #639 `:latest` flip as pending although 0.4.0 is promoted. Candidates for a follow-up docs tidy if desired.

Refs: #642
