### PR TITLE
fix(ci): use release app token for nixpkgs bump PR creation

### DIFF
--- a/.github/workflows/update-nixpkgs-unstable.yml
+++ b/.github/workflows/update-nixpkgs-unstable.yml
@@ -89,10 +89,21 @@ jobs:
           COMMIT_MESSAGE: "chore(nix): bump nixpkgs-unstable (fast-movers refresh)"
           FILE_PATHS: flake.lock
 
+      # PR creation needs pull-requests: write, which the commit app does not
+      # have (least-privilege split: COMMIT_APP_* commits, RELEASE_APP_* does
+      # PR operations). Same two-app pattern as sync-main-to-dev.yml (#817).
+      - name: Generate Release App Token
+        if: steps.detect.outputs.changed == 'true'
+        id: release-app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3
+        with:
+          client-id: ${{ secrets.RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Open PR if none exists
         if: steps.detect.outputs.changed == 'true'
         env:
-          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          GH_TOKEN: ${{ steps.release-app-token.outputs.token }}
         run: |
           set -euo pipefail
           if ! gh pr list --head chore/update-nixpkgs-unstable --base dev --state open \


### PR DESCRIPTION
## Description

Every run of `update-nixpkgs-unstable.yml` so far failed at the final "Open PR if none exists" step with:

```
pull request create failed: GraphQL: Resource not accessible by integration (createPullRequest)
```

**Root cause:** the whole workflow ran on a single token minted from the **commit app** (`COMMIT_APP_*`). That app installation carries `contents: write` only — which is why the earlier steps succeeded (branch `chore/update-nixpkgs-unstable` was created and the signed lock-bump commit landed) while `createPullRequest` was refused. This repo deliberately splits app duties (see the auth comment in `sync-main-to-dev.yml`): `COMMIT_APP_*` for least-privilege git/ref/commit operations, `RELEASE_APP_*` for PR/label operations that require pull-request scopes. Every PR-creating workflow in the repo (`sync-main-to-dev.yml`, `prepare-release.yml`, `promote-release.yml`, `release.yml`) already uses a release-app token for PR operations — e.g. PR #873 was opened this way. `renovate-changelog-commit.yml` (cited in this workflow's comments as the model) only *commits* with the commit app; it never creates PRs, so copying it left the PR step under-privileged.

Note on `actions/create-github-app-token@v3` semantics: with no `permission-*` inputs the minted token inherits **all** of the app installation's permissions, so no token-scoping inputs were missing — the commit app installation simply does not have `pull-requests: write`, by design.

## Type of Change

- [x] `fix` -- Bug fix
- [x] `ci` -- CI/CD pipeline changes

### Modifiers

- [ ] Breaking change (`!`)

## Changes Made

- `.github/workflows/update-nixpkgs-unstable.yml`: add a `Generate Release App Token` step (`RELEASE_APP_CLIENT_ID` / `RELEASE_APP_PRIVATE_KEY`, guarded by the same `changed == 'true'` condition) and switch the `Open PR if none exists` step to that token. Branch creation and the signed commit stay on the commit-app token.
- Deliberately **not** using the default `GITHUB_TOKEN` for PR creation: PRs it opens do not trigger CI, and full CI on the bump PR is this workflow's merge gate. App-token-created PRs do trigger CI (proven by the sync-main-to-dev PRs).

**No org/app settings change required** — the release app already holds `pull-requests: write` (it opens the sync and release PRs today), and its secrets are already available to workflows in this repo.

## Changelog Entry

No changelog needed: the `## Unreleased` section already carries the #817 entry ("Scheduled nixpkgs-unstable lock bump") describing this workflow, which has never shipped in a release; this PR is a CI-internal repair of that same unreleased item.

## Testing

- [x] Manual testing performed (describe below)

### Manual Testing Details

- `prek run --all-files`: full hook suite green (yamllint, check-action-pins, typos, etc.).
- A scheduled workflow cannot be exercised from a PR branch; the real test is a `workflow_dispatch` run of *Update nixpkgs-unstable* after this merges to dev. Expected: the run reuses/reset the existing `chore/update-nixpkgs-unstable` branch, commits the lock bump, and now successfully opens the PR to dev.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly (not applicable)
- [ ] I have updated `CHANGELOG.md` (not needed — see Changelog Entry)
- [x] My changes generate no new warnings or errors
- [ ] I have added tests (not applicable — workflow YAML, validated by lint hooks)
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

Closes #817

This issue belongs to epic #814 (home-environment modules).

Refs: #814