### PR TITLE
fix(workspace): repair preserved justfile.project with missing base recipes on upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Scaffold upgrade strands base recipes in a preserved `justfile.project`** ([#877](https://github.com/vig-os/devcontainer/issues/877))
+  - 0.4.0 moved `lint`/`format`/`precommit`/`test`/`test-cov`/`sync`/`update` into `justfile.project`, which is preserved on upgrade — 0.3.x consumers never received them and the shipped `ci.yml` failed with `justfile does not contain recipe 'sync'`. `init-workspace --force` now appends the missing base recipes from the template into the preserved file (customized recipes always win; idempotent).
+  - The retired `.devcontainer/justfile.base` is removed on upgrade where the scaffold manages `.devcontainer/` (never in `direnv` mode, [#738](https://github.com/vig-os/devcontainer/issues/738)), and the installer warns if the root `justfile` lacks the scaffold `import?` block.
+
 - **Renovate changelog artifact drops the workspace mirror; `metadata.env` breaks on parenthesized branches** ([#874](https://github.com/vig-os/devcontainer/issues/874))
   - `upload-artifact` silently excluded the mirror under the hidden `.devcontainer` directory, so the bot commit updated only the root `CHANGELOG.md` and tripped the `sync-manifest` gate; now uploaded with `include-hidden-files: true`.
   - `metadata.env` values are `%q`-quoted so grouped Renovate branch names (e.g. `renovate/python-(minor-and-patch)`) survive being `source`d by the commit workflow.

--- a/assets/init-workspace.sh
+++ b/assets/init-workspace.sh
@@ -53,6 +53,13 @@ PRESERVE_FILES=(
     "pyproject.toml"
 )
 
+# Base recipes the shipped .github/workflows/ci.yml depends on (sync, precommit,
+# test) plus their template siblings. Since 0.4.0 they live in justfile.project,
+# which is preserved on upgrade — a pre-0.4.0 consumer never receives them and
+# in-container CI fails with "justfile does not contain recipe 'sync'" (#877).
+# The upgrade repair below appends the missing ones from the template.
+CI_CONTRACT_RECIPES=(lint format precommit test test-cov sync update)
+
 # Get script directory for manifest location
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 MANIFEST_FILE="$SCRIPT_DIR/.placeholder-manifest.txt"
@@ -208,6 +215,21 @@ if [[ -z "$MODE" ]]; then
 fi
 echo "Delivery mode set to: $MODE"
 
+# Print one recipe block from the template justfile.project: the immediately
+# preceding comment/attribute lines, the recipe header, and the indented body.
+# Used to repair a preserved pre-0.4.0 justfile.project that lacks the
+# relocated base recipes (#877); the template stays the single source of truth.
+extract_template_recipe() {
+    local recipe="$1"
+    awk -v r="$recipe" '
+        found && /^[[:space:]]/ { print; next }
+        found { exit }
+        /^(#|\[)/ { buf = buf $0 ORS; next }
+        $0 ~ ("^" r "([[:space:]][^:]*)?:") { found = 1; printf "%s", buf; print; next }
+        { buf = "" }
+    ' "$TEMPLATE_DIR/justfile.project"
+}
+
 # Helper: check if a file is in the preserve list
 is_preserved_file() {
     local file="$1"
@@ -296,6 +318,11 @@ FLAKE_PREEXISTED=false
 [[ -f "$WORKSPACE_DIR/flake.nix" ]] && FLAKE_PREEXISTED=true
 ENVRC_PREEXISTED=false
 [[ -f "$WORKSPACE_DIR/.envrc" ]] && ENVRC_PREEXISTED=true
+
+# A preserved justfile.project may predate the 0.4.0 base-recipe relocation
+# (#877); record it so the post-scaffold repair can append what is missing.
+JUSTFILE_PROJECT_PREEXISTED=false
+[[ -f "$WORKSPACE_DIR/justfile.project" ]] && JUSTFILE_PROJECT_PREEXISTED=true
 
 # Copy template contents to workspace
 echo "Initializing workspace from template..."
@@ -390,6 +417,16 @@ case "$MODE" in
         ;;
 esac
 
+# 0.4.0 retired .devcontainer/justfile.base (recipes relocated to
+# justfile.project), so drop the stale copy an upgraded 0.3.x repo carries —
+# nothing imports it anymore (#877). Only when this scaffold manages
+# .devcontainer/: a direnv-mode consumer's own .devcontainer/ is never
+# touched (#738).
+if [[ "$MODE" != "direnv" && -f "$WORKSPACE_DIR/.devcontainer/justfile.base" ]]; then
+    echo "Removing retired .devcontainer/justfile.base (recipes live in justfile.project since 0.4.0)..."
+    rm -f "$WORKSPACE_DIR/.devcontainer/justfile.base"
+fi
+
 # Pin the explicitly requested devcontainer version (#852). The image bakes
 # the release it was built from into the scaffolded .vig-os (flake bootstrap),
 # which is correct for finals but stale for release candidates: the repo-root
@@ -456,6 +493,47 @@ fi
 echo "Setting executable permissions on shell scripts and hooks..."
 find "$WORKSPACE_DIR" -type f -name "*.sh" -exec chmod +x {} \;
 find "$WORKSPACE_DIR/.githooks" -type f -exec chmod +x {} \; 2>/dev/null || true
+
+# The root justfile is managed (rsync overwrites it on upgrade), so the
+# scaffold import block must be present at this point; without it every
+# layered recipe is unreachable, however complete justfile.project is
+# (#877, observed in the field). Warn loudly — this indicates a broken
+# scaffold or external interference.
+if [[ -f "$WORKSPACE_DIR/justfile" ]] \
+    && ! grep -qF "import? 'justfile.project'" "$WORKSPACE_DIR/justfile"; then
+    echo "Warning: root justfile lacks the scaffold import block (import? 'justfile.project')." >&2
+    echo "         Restore the imports from the template or layered recipes stay unreachable (see MIGRATION.md)." >&2
+fi
+
+# Repair a preserved pre-0.4.0 justfile.project (#877): the shipped ci.yml
+# calls `just sync` / `just precommit` / `just test`, so an upgrade must
+# deliver the CI-contract recipes. Append (from the template) only those that
+# do not resolve anywhere in the import graph — customized consumer recipes
+# always win, and re-running the upgrade is a no-op.
+if [[ "$JUSTFILE_PROJECT_PREEXISTED" == "true" && -f "$WORKSPACE_DIR/justfile.project" ]]; then
+    MISSING_RECIPES=()
+    for recipe in "${CI_CONTRACT_RECIPES[@]}"; do
+        if ! (cd "$WORKSPACE_DIR" && just --show "$recipe" > /dev/null 2>&1); then
+            MISSING_RECIPES+=("$recipe")
+        fi
+    done
+    if [[ ${#MISSING_RECIPES[@]} -gt 0 ]]; then
+        echo "Preserved justfile.project lacks base recipe(s): ${MISSING_RECIPES[*]}"
+        echo "Appending them from the template (review the marked block, fold into your own recipes as needed)..."
+        {
+            echo ""
+            echo "# ==============================================================================="
+            echo "# BASE RECIPES appended by init-workspace on upgrade (vig-os/devcontainer#877)."
+            echo "# Since 0.4.0 these live in justfile.project (preserved on upgrade); the shipped"
+            echo "# ci.yml requires sync/precommit/test. Review, keep, or fold into your own."
+            echo "# ==============================================================================="
+            for recipe in "${MISSING_RECIPES[@]}"; do
+                echo ""
+                extract_template_recipe "$recipe"
+            done
+        } >> "$WORKSPACE_DIR/justfile.project"
+    fi
+fi
 
 # Sync dependencies: resolves uv.lock for the new project name and installs the
 # project. Non-fatal (#859): a preserved old-generation justfile.project may not

--- a/assets/init-workspace.sh
+++ b/assets/init-workspace.sh
@@ -511,12 +511,24 @@ fi
 # do not resolve anywhere in the import graph — customized consumer recipes
 # always win, and re-running the upgrade is a no-op.
 if [[ "$JUSTFILE_PROJECT_PREEXISTED" == "true" && -f "$WORKSPACE_DIR/justfile.project" ]]; then
-    MISSING_RECIPES=()
-    for recipe in "${CI_CONTRACT_RECIPES[@]}"; do
-        if ! (cd "$WORKSPACE_DIR" && just --show "$recipe" > /dev/null 2>&1); then
-            MISSING_RECIPES+=("$recipe")
-        fi
-    done
+    if ! command -v just > /dev/null 2>&1; then
+        echo "Warning: 'just' not found on PATH; skipping base-recipe repair (#877)." >&2
+        MISSING_RECIPES=()
+    # If the import graph does not parse (e.g. a syntax error in the preserved
+    # justfile.project), `just --show` fails for EVERY recipe — probing would
+    # misread all of them as missing and append duplicates on each run.
+    elif ! (cd "$WORKSPACE_DIR" && just --list > /dev/null 2>&1); then
+        echo "Warning: justfile graph does not parse; skipping base-recipe repair (#877)." >&2
+        echo "         Fix the syntax error (run 'just --list' to see it) and re-run init-workspace." >&2
+        MISSING_RECIPES=()
+    else
+        MISSING_RECIPES=()
+        for recipe in "${CI_CONTRACT_RECIPES[@]}"; do
+            if ! (cd "$WORKSPACE_DIR" && just --show "$recipe" > /dev/null 2>&1); then
+                MISSING_RECIPES+=("$recipe")
+            fi
+        done
+    fi
     if [[ ${#MISSING_RECIPES[@]} -gt 0 ]]; then
         echo "Preserved justfile.project lacks base recipe(s): ${MISSING_RECIPES[*]}"
         echo "Appending them from the template (review the marked block, fold into your own recipes as needed)..."
@@ -528,8 +540,13 @@ if [[ "$JUSTFILE_PROJECT_PREEXISTED" == "true" && -f "$WORKSPACE_DIR/justfile.pr
             echo "# ci.yml requires sync/precommit/test. Review, keep, or fold into your own."
             echo "# ==============================================================================="
             for recipe in "${MISSING_RECIPES[@]}"; do
+                recipe_block="$(extract_template_recipe "$recipe")"
+                if [[ -z "$recipe_block" ]]; then
+                    echo "Warning: recipe '$recipe' not found in the template justfile.project; skipping it (#877)." >&2
+                    continue
+                fi
                 echo ""
-                extract_template_recipe "$recipe"
+                printf '%s\n' "$recipe_block"
             done
         } >> "$WORKSPACE_DIR/justfile.project"
     fi

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -68,6 +68,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Scaffold upgrade strands base recipes in a preserved `justfile.project`** ([#877](https://github.com/vig-os/devcontainer/issues/877))
+  - 0.4.0 moved `lint`/`format`/`precommit`/`test`/`test-cov`/`sync`/`update` into `justfile.project`, which is preserved on upgrade — 0.3.x consumers never received them and the shipped `ci.yml` failed with `justfile does not contain recipe 'sync'`. `init-workspace --force` now appends the missing base recipes from the template into the preserved file (customized recipes always win; idempotent).
+  - The retired `.devcontainer/justfile.base` is removed on upgrade where the scaffold manages `.devcontainer/` (never in `direnv` mode, [#738](https://github.com/vig-os/devcontainer/issues/738)), and the installer warns if the root `justfile` lacks the scaffold `import?` block.
+
 - **Renovate changelog artifact drops the workspace mirror; `metadata.env` breaks on parenthesized branches** ([#874](https://github.com/vig-os/devcontainer/issues/874))
   - `upload-artifact` silently excluded the mirror under the hidden `.devcontainer` directory, so the bot commit updated only the root `CHANGELOG.md` and tripped the `sync-manifest` gate; now uploaded with `include-hidden-files: true`.
   - `metadata.env` values are `%q`-quoted so grouped Renovate branch names (e.g. `renovate/python-(minor-and-patch)`) survive being `source`d by the commit workflow.

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -114,22 +114,33 @@ module rather than baking it into every consumer's image.
 checklist ([#859](https://github.com/vig-os/devcontainer/issues/859)) after the
 re-scaffold:
 
-1. **`justfile.project` hook recipe** — your preserved `precommit` recipe still
+1. **Base recipes moved into `justfile.project`** — 0.4.0 retired
+   `.devcontainer/justfile.base`; `lint`/`format`/`precommit`/`test`/
+   `test-cov`/`sync`/`update` now live in `justfile.project`, which is
+   preserved on upgrade. The shipped `ci.yml` calls `just sync` /
+   `just precommit` / `just test`, so the installer appends any of these
+   recipes your preserved file does not already resolve (a clearly marked
+   block, [#877](https://github.com/vig-os/devcontainer/issues/877)) and
+   removes the stale `.devcontainer/justfile.base`. Review the appended
+   block and fold it into your own recipes; also verify the root `justfile`
+   still carries the scaffold `import?` lines — without them no layered
+   recipe is reachable (the installer warns if the block is missing).
+2. **`justfile.project` hook recipe** — your preserved `precommit` recipe still
    runs `uv run pre-commit run --all-files`; `pre-commit` is gone from the
    0.4.0 image and venv. Change it to `prek run --all-files`.
-2. **Recipe renames** — the managed base recipes are now `devc-*`-namespaced
+3. **Recipe renames** — the managed base recipes are now `devc-*`-namespaced
    and the template test recipe is `just test` (formerly `just test-pytest`).
    Run `just --list` once and update any scripts/muscle memory.
-3. **typos config precedence** — if your repo owns a `typos.toml` or
+4. **typos config precedence** — if your repo owns a `typos.toml` or
    `_typos.toml`, it silently **shadows** the shipped `.typos.toml`. Merge the
    shipped `[default.extend-words]` entries (`Nd`, `unexcepted`, `ba` — needed
    by scaffold-shipped content such as `version-check.sh` and the synced
    `.devcontainer/CHANGELOG.md`) into your file.
-4. **Committed binary/generated artifacts** (plot exports, PDFs, golden `.bin`
+5. **Committed binary/generated artifacts** (plot exports, PDFs, golden `.bin`
    fixtures, SVGs): add them to your typos `[files] extend-exclude` and
    consider a global `exclude:` in `.pre-commit-config.yaml` so the autofix
    hooks (end-of-file-fixer, trailing-whitespace) don't rewrite them.
-5. **Project name re-derivation** — the re-scaffold substitutes placeholders
+6. **Project name re-derivation** — the re-scaffold substitutes placeholders
    from the current directory/`--name`; template-origin files (e.g.
    `tests/test_example.py`) may be rewritten to a name that differs from your
    original scaffold. Review the diff before committing.

--- a/tests/bats/init-workspace.bats
+++ b/tests/bats/init-workspace.bats
@@ -687,6 +687,33 @@ EOF
     assert_output "1"
 }
 
+@test "repair skips with a warning when the justfile graph does not parse (#877)" {
+    # A syntax error in the preserved justfile.project makes `just --show`
+    # fail for EVERY recipe, so the probe would misread all of them as
+    # missing and append duplicates on each --force run — turning a fixable
+    # parse error into hard "recipe redefined" failures. The repair must
+    # detect the broken graph, warn, and skip all appends (non-fatally).
+    ws="$BATS_TEST_TMPDIR/e2e-877-broken"
+    mkdir -p "$ws"
+    cat > "$ws/justfile.project" <<'EOF'
+# SENTINEL-877 broken consumer file: defines sync but has a syntax error
+sync:
+    @echo "SENTINEL-877-consumer-sync"
+
+this line is not valid justfile syntax
+EOF
+    run _upgrade both "$ws"
+    assert_success
+    assert_output --partial 'skipping base-recipe repair'
+    run _upgrade both "$ws"
+    assert_success
+    # nothing was appended: sync still defined exactly once, no repair banner
+    run bash -c "grep -c '^sync:' '$ws/justfile.project'"
+    assert_output "1"
+    run grep -q 'BASE RECIPES appended' "$ws/justfile.project"
+    assert_failure
+}
+
 @test "upgrade removes the retired .devcontainer/justfile.base (#877)" {
     ws="$BATS_TEST_TMPDIR/e2e-877-stale"
     mkdir -p "$ws/.devcontainer"

--- a/tests/bats/init-workspace.bats
+++ b/tests/bats/init-workspace.bats
@@ -605,3 +605,114 @@ _scaffold() {
     run grep -F 'entry: typos --force-exclude' "$TEMPLATE_DIR/.pre-commit-config.yaml"
     assert_success
 }
+
+# ── upgrade must deliver the CI-contract base recipes (#877) ──────────────────
+# 0.4.0 relocated the base recipes (lint/format/precommit/test/test-cov/sync/
+# update) from the retired .devcontainer/justfile.base into justfile.project,
+# which is preserved on upgrade — so a 0.3.x consumer never received them while
+# the shipped ci.yml calls `just sync` / `just precommit` / `just test` (CI
+# failed with "justfile does not contain recipe 'sync'"). The upgrade must
+# append whichever contract recipes the preserved file does not resolve, and
+# drop the stale .devcontainer/justfile.base.
+
+# Run the real script as an upgrade: real `just` stays on PATH (the repair
+# probes recipes via `just --show`), `uv` is stubbed so the trailing
+# `just sync` is a fast no-op instead of a real dependency sync.
+_upgrade() {
+    local mode="$1" ws="$2"
+    local stub="$BATS_TEST_TMPDIR/stub-uv"
+    mkdir -p "$stub"
+    printf '#!/usr/bin/env bash\nexit 0\n' >"$stub/uv"
+    chmod +x "$stub/uv"
+    env PATH="$stub:$PATH" \
+        TEMPLATE_DIR="$PROJECT_ROOT/assets/workspace" \
+        WORKSPACE_DIR="$ws" \
+        SHORT_NAME=testproj \
+        GITHUB_REPOSITORY=test/repo \
+        bash "$INIT_WORKSPACE_SH" --force --no-prompts --mode "$mode"
+}
+
+# A pre-0.4.0 consumer justfile.project: team recipes, no base recipes.
+_pre040_project_justfile() {
+    cat > "$1/justfile.project" <<'EOF'
+# SENTINEL-877 pre-0.4.0 consumer recipes (no base recipes)
+project := "consumer877"
+
+[group('info')]
+info:
+    @echo "Project: {{ project }}"
+EOF
+}
+
+@test "upgrade appends missing CI-contract recipes to a preserved justfile.project (#877)" {
+    real_just="$(command -v just)"
+    ws="$BATS_TEST_TMPDIR/e2e-877-repair"
+    mkdir -p "$ws"
+    _pre040_project_justfile "$ws"
+    run _upgrade both "$ws"
+    assert_success
+    # consumer content is preserved, not overwritten
+    run grep -q 'SENTINEL-877' "$ws/justfile.project"
+    assert_success
+    # every CI-contract recipe resolves after the upgrade
+    for r in lint format precommit test test-cov sync update; do
+        run bash -c "cd '$ws' && '$real_just' --show $r"
+        assert_success
+    done
+}
+
+@test "justfile.project repair keeps customized recipes and is idempotent (#877)" {
+    real_just="$(command -v just)"
+    ws="$BATS_TEST_TMPDIR/e2e-877-idem"
+    mkdir -p "$ws"
+    _pre040_project_justfile "$ws"
+    cat >> "$ws/justfile.project" <<'EOF'
+
+# consumer-customized test runner
+test *args:
+    @echo "SENTINEL-877-custom-test"
+EOF
+    run _upgrade both "$ws"
+    assert_success
+    run _upgrade both "$ws"
+    assert_success
+    # still parses (a duplicate append would be a just parse error)...
+    run bash -c "cd '$ws' && '$real_just' --list"
+    assert_success
+    # ...the customized recipe wins over the template one...
+    run bash -c "cd '$ws' && '$real_just' --show test"
+    assert_output --partial 'SENTINEL-877-custom-test'
+    # ...and each appended recipe appears exactly once
+    run bash -c "grep -c '^sync:' '$ws/justfile.project'"
+    assert_output "1"
+}
+
+@test "upgrade removes the retired .devcontainer/justfile.base (#877)" {
+    ws="$BATS_TEST_TMPDIR/e2e-877-stale"
+    mkdir -p "$ws/.devcontainer"
+    printf '# retired 0.3.x base recipes\n' >"$ws/.devcontainer/justfile.base"
+    run _upgrade both "$ws"
+    assert_success
+    run test -e "$ws/.devcontainer/justfile.base"
+    assert_failure
+}
+
+@test "direnv-mode upgrade leaves a pre-existing .devcontainer untouched, incl. justfile.base (#877)" {
+    # A consumer-owned .devcontainer/ is never modified in direnv mode (#738);
+    # the stale-file cleanup must respect that boundary.
+    ws="$BATS_TEST_TMPDIR/e2e-877-direnv"
+    mkdir -p "$ws/.devcontainer"
+    printf '# consumer-owned devcontainer file\n' >"$ws/.devcontainer/justfile.base"
+    run _upgrade direnv "$ws"
+    assert_success
+    run test -f "$ws/.devcontainer/justfile.base"
+    assert_success
+}
+
+@test "init-workspace verifies the root justfile scaffold import block (#877)" {
+    # One field consumer (talys) ended up with a root justfile carrying no
+    # `import?` lines at all, so even present recipes were unreachable. The
+    # script must check for the scaffold import block and warn when absent.
+    run grep -F "import? 'justfile.project'" "$INIT_WORKSPACE_SH"
+    assert_success
+}


### PR DESCRIPTION
## Description

Closes #877

The 0.4.0 scaffold retired `.devcontainer/justfile.base` and relocated the base recipes (`lint`, `format`, `precommit`, `test`, `test-cov`, `sync`, `update`) into `justfile.project` — a PRESERVE_FILES entry. Upgrading 0.3.x consumers therefore kept their old `justfile.project` and never received the recipes, while the shipped `ci.yml` calls `just sync` / `just precommit` / `just test`, so in-container CI failed with `justfile does not contain recipe 'sync'` (observed on hyrr and talys during 0.4.0 field validation).

## Design decision

Chosen: **option (b) from the issue — upgrade-time repair** of the preserved `justfile.project`. `init-workspace --force` now probes each CI-contract recipe with `just --show` against the assembled import graph and appends only the missing ones, sourcing the recipe blocks verbatim from the template `justfile.project` (which stays the SSoT) under a clearly marked, review-me banner.

Why not the alternatives:

- **(a) Move the recipes into a managed justfile** (`justfile.devc` or a resurrected base file): `justfile.devc` lives under `.devcontainer/`, which a `direnv`-mode workspace does not have — the recipes would vanish there. Any managed root-level file would also collide (just duplicate-recipe parse error) with fresh 0.4.0 scaffolds and consumers that already migrated the recipes into their `justfile.project`, and it would reverse the deliberate 0.4.0 decision that teams own and customize these recipes (the field complaint about `sync` semantics shows they need to).
- **(c) MIGRATION.md step + warning only**: keeps every upgraded consumer's CI red until a human intervenes; the repair is deterministic and safe, so automating it is strictly better. The MIGRATION.md step and the existing non-fatal warning are still included.

Properties of the repair: customized consumer recipes always win (only unresolved names are appended), re-running the upgrade is a no-op, and fresh scaffolds are untouched (they get the template file wholesale).

## Changes Made

- `assets/init-workspace.sh`:
  - `CI_CONTRACT_RECIPES` list + `extract_template_recipe()` (awk block extraction from the template `justfile.project`).
  - Post-scaffold repair: appends missing CI-contract recipes to a preserved `justfile.project` under a marked banner.
  - Removes the retired `.devcontainer/justfile.base` on upgrade — only where the scaffold manages `.devcontainer/` (never in `direnv` mode, respecting the #738 boundary).
  - Warns loudly if the managed root `justfile` lacks the scaffold `import?` block (talys field case: recipes present but unreachable).
- `tests/bats/init-workspace.bats`: five new tests (repair delivers all seven recipes; customized recipes win + idempotency; stale `justfile.base` removed; `direnv`-mode pre-existing `.devcontainer/` untouched; import-block verification present). TDD: RED committed first, then GREEN.
- `docs/MIGRATION.md`: new step 1 in the 0.3.x upgrade checklist describing the relocation, the automatic repair, and the root-justfile import check.
- `CHANGELOG.md` (+ hook-synced `.devcontainer` mirror): Unreleased/Fixed entry.

## Type of Change

- [x] `fix` -- Bug fix

### Modifiers

- [ ] Breaking change (`!`)

## Changelog Entry

### Fixed
- **Scaffold upgrade strands base recipes in a preserved `justfile.project`** ([#877](https://github.com/vig-os/devcontainer/issues/877))
  - 0.4.0 moved `lint`/`format`/`precommit`/`test`/`test-cov`/`sync`/`update` into `justfile.project`, which is preserved on upgrade — 0.3.x consumers never received them and the shipped `ci.yml` failed with `justfile does not contain recipe 'sync'`. `init-workspace --force` now appends the missing base recipes from the template into the preserved file (customized recipes always win; idempotent).
  - The retired `.devcontainer/justfile.base` is removed on upgrade where the scaffold manages `.devcontainer/` (never in `direnv` mode, [#738](https://github.com/vig-os/devcontainer/issues/738)), and the installer warns if the root `justfile` lacks the scaffold `import?` block.

## Testing

- [x] Tests pass locally: `bats tests/bats/init-workspace.bats tests/bats/install.bats` (123 ok), `uv run pytest tests/test_install_script.py` (23 passed)
- [x] Manual testing performed (describe below)

### Manual Testing Details

Ran `init-workspace.sh --force` against a temp workspace carrying a pre-0.4.0 `justfile.project` (own `project` var + `info` recipe, no base recipes): consumer content preserved, all seven recipes appended under the marked banner, `just --list` parses and resolves the full layered graph; second run appended nothing.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Out of scope / follow-up

The template `sync` recipe's semantics change (plain `uv sync` → `uv sync --all-extras --all-groups`), noted at the end of #877, is deliberately untouched here; the repair appends the current template recipe as-is. It likely deserves its own issue (it breaks repos that quarantine platform-limited deps in optional extras, e.g. hyrr's `geometry` extra).
