### PR TITLE
fix(nix): sanitize image sysconfig compiler records to generic cc/c++

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Renovate changelog entries land as plain `### Changed` bullets, not under `#### Modules`** ([#867](https://github.com/vig-os/devcontainer/issues/867))
   - `renovate-changelog-pr` appended entries at the bottom of the `### Changed` block, so with the `#### Modules` sub-heading convention ([#816](https://github.com/vig-os/devcontainer/issues/816)) a dependency bump was filed beneath `#### Modules` and read as a module change. Entries now insert at the top of `### Changed`, above any `####` sub-heading, with Keep-a-Changelog spacing preserved.
 
+- **Image Python advertised the phantom Nix build toolchain (`gcc`/`g++`) in sysconfig** ([#879](https://github.com/vig-os/devcontainer/issues/879))
+  - The baked CPython recorded its nixpkgs build compilers in `sysconfig` (`CC`/`CXX`/`LINKCC`/`LDSHARED`/`BLDSHARED`/`LDCXXSHARED`), but the image ships no compiler — PEP 517 backends inherited the phantom names verbatim: scikit-build-core exports `CC`/`CXX`, so CMake hard-failed on the missing `g++` instead of discovering the project-flake toolchain on `PATH`, and setuptools invoked the literal `gcc`.
+  - The image build now sanitizes the baked `_sysconfigdata*.py` / `_sysconfig_vars*.json` / config `Makefile` first tokens to the generic POSIX `cc`/`c++`, restoring `PATH` compiler discovery. Implemented as a shadow copy in the final image layer — no CPython rebuild, dev-shell toolchain untouched, and the no-compiler-baked consumer contract stands (documented via [#882](https://github.com/vig-os/devcontainer/issues/882)).
+
 ### Security
 
 ## [0.4.0](https://github.com/vig-os/devcontainer/releases/tag/0.4.0) - 2026-07-06

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -75,6 +75,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Renovate changelog entries land as plain `### Changed` bullets, not under `#### Modules`** ([#867](https://github.com/vig-os/devcontainer/issues/867))
   - `renovate-changelog-pr` appended entries at the bottom of the `### Changed` block, so with the `#### Modules` sub-heading convention ([#816](https://github.com/vig-os/devcontainer/issues/816)) a dependency bump was filed beneath `#### Modules` and read as a module change. Entries now insert at the top of `### Changed`, above any `####` sub-heading, with Keep-a-Changelog spacing preserved.
 
+- **Image Python advertised the phantom Nix build toolchain (`gcc`/`g++`) in sysconfig** ([#879](https://github.com/vig-os/devcontainer/issues/879))
+  - The baked CPython recorded its nixpkgs build compilers in `sysconfig` (`CC`/`CXX`/`LINKCC`/`LDSHARED`/`BLDSHARED`/`LDCXXSHARED`), but the image ships no compiler — PEP 517 backends inherited the phantom names verbatim: scikit-build-core exports `CC`/`CXX`, so CMake hard-failed on the missing `g++` instead of discovering the project-flake toolchain on `PATH`, and setuptools invoked the literal `gcc`.
+  - The image build now sanitizes the baked `_sysconfigdata*.py` / `_sysconfig_vars*.json` / config `Makefile` first tokens to the generic POSIX `cc`/`c++`, restoring `PATH` compiler discovery. Implemented as a shadow copy in the final image layer — no CPython rebuild, dev-shell toolchain untouched, and the no-compiler-baked consumer contract stands (documented via [#882](https://github.com/vig-os/devcontainer/issues/882)).
+
 ### Security
 
 ## [0.4.0](https://github.com/vig-os/devcontainer/releases/tag/0.4.0) - 2026-07-06

--- a/flake.nix
+++ b/flake.nix
@@ -964,6 +964,56 @@
 
               contents = imageTools ++ [ bootstrap ];
 
+              # Sanitize the baked CPython's sysconfig compiler records (#879).
+              # nixpkgs' python bakes its Nix build toolchain into sysconfig
+              # (`_sysconfigdata*.py` / `_sysconfig_vars*.json` / config Makefile):
+              # CC='gcc', CXX='g++', and link commands starting with those names.
+              # The image deliberately ships no compiler (consumer contract:
+              # toolchains come from the project flake — documented via #882),
+              # so those are phantom names: PEP 517 backends inherit them
+              # verbatim — scikit-build-core exports CC/CXX into the
+              # environment, making CMake hard-fail on the missing 'g++'
+              # instead of doing PATH discovery, and setuptools invokes the
+              # literal 'gcc'. Rewriting the first tokens to the generic POSIX
+              # 'cc'/'c++' restores PATH discovery against whatever toolchain
+              # the project provides (and yields an honest "no compiler found"
+              # when none does).
+              #
+              # Mechanism: a last-layer shadow copy, not a CPython rebuild.
+              # fakeRootCommands runs in the image-root staging dir, so files
+              # created under ./nix/store/<python>/... are tarred into the
+              # customisation layer (ordered last) and override the python
+              # layer's copies at container runtime; the dev-shell toolchain
+              # and every python-dependent derivation stay fully cached. The
+              # python layer's stale `_sysconfigdata*.pyc` are hash-based
+              # (CHECKED_HASH), so the interpreter detects the changed source
+              # and recompiles instead of serving the old values. Note
+              # `enableFakechroot` can NOT do this: its layer tar excludes
+              # ./nix/store. Deterministic (fixed sed over fixed input), so
+              # digest reproducibility is preserved.
+              fakeRootCommands = ''
+                pylib=${python}/lib/python${python.pythonVersion}
+                shadow=.$pylib
+                mkdir -p "$shadow"
+                cp "$pylib"/_sysconfigdata__*.py "$pylib"/_sysconfig_vars__*.json "$shadow/"
+                cfg="$(basename "$pylib"/config-*)"
+                mkdir -p "$shadow/$cfg"
+                cp "$pylib/$cfg/Makefile" "$shadow/$cfg/"
+                chmod -R u+w "$shadow"
+                sed -i -E \
+                  -e "s/'(CC|LINKCC|LDSHARED|BLDSHARED)': 'gcc(['[:space:]])/'\1': 'cc\2/" \
+                  -e "s/'(CXX|LDCXXSHARED)': 'g\+\+(['[:space:]])/'\1': 'c++\2/" \
+                  "$shadow"/_sysconfigdata__*.py
+                sed -i -E \
+                  -e 's/"(CC|LINKCC|LDSHARED|BLDSHARED)": "gcc(["[:space:]])/"\1": "cc\2/' \
+                  -e 's/"(CXX|LDCXXSHARED)": "g\+\+(["[:space:]])/"\1": "c++\2/' \
+                  "$shadow"/_sysconfig_vars__*.json
+                sed -i -E \
+                  -e 's/^(CC=[[:space:]]*)gcc$/\1cc/' \
+                  -e 's/^(CXX=[[:space:]]*)g\+\+$/\1c++/' \
+                  "$shadow/$cfg/Makefile"
+              '';
+
               # Deterministic epoch timestamp keeps the digest reproducible.
               created = "1970-01-01T00:00:00Z";
 

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -512,6 +512,50 @@ class TestPythonEnvironment:
             f"Expected uv {expected}, got: {result.stdout}"
         )
 
+    def test_sysconfig_compiler_vars_are_generic(self, host):
+        """sysconfig must expose generic PATH compiler names, not the Nix build toolchain (#879).
+
+        The baked CPython records its build-time toolchain in sysconfig
+        (``_sysconfigdata*.py``): CC='gcc', CXX='g++', and link commands
+        starting with those names. The image ships no compiler, and PEP 517
+        build backends inherit these values verbatim — scikit-build-core
+        exports CC/CXX into the environment, so CMake hard-fails on the
+        phantom 'g++' ("Could not find the compiler specified in the
+        environment variable CXX") instead of doing normal PATH discovery,
+        and setuptools invokes the literal 'gcc'. Sanitized values are the
+        generic POSIX names ('cc'/'c++'), which resolve against whatever
+        toolchain the project flake provides on PATH — and produce an honest
+        "no compiler found" when none does.
+        """
+        result = host.run(
+            'python3 -c "import json, sysconfig; '
+            "vars = ('CC', 'CXX', 'LINKCC', 'LDSHARED', 'BLDSHARED', 'LDCXXSHARED'); "
+            'print(json.dumps({k: sysconfig.get_config_var(k) for k in vars}))"'
+        )
+        assert result.rc == 0, f"sysconfig query failed: {result.stderr}"
+        config = json.loads(result.stdout)
+
+        expected_first_token = {
+            "CC": "cc",
+            "CXX": "c++",
+            "LINKCC": "cc",
+            "LDSHARED": "cc",
+            "BLDSHARED": "cc",
+            "LDCXXSHARED": "c++",
+        }
+        for var, expected in expected_first_token.items():
+            value = config[var] or ""
+            tokens = value.split()
+            first = tokens[0] if tokens else ""
+            assert first == expected, (
+                f"sysconfig {var} must start with the generic {expected!r} so "
+                f"PEP 517 backends fall back to PATH compiler discovery; "
+                f"got {value!r}"
+            )
+            assert "/nix/store/" not in first, (
+                f"sysconfig {var} leaks a Nix store compiler path: {value!r}"
+            )
+
     def test_uv_venv_workflow(self, host):
         """Test that uv sync creates venv and manages project dependencies correctly."""
         if not _pypi_reachable(host):


### PR DESCRIPTION
## Description

Closes #879. In the 0.4.0 image, any `uv sync` needing a source build hard-fails: the baked CPython records its Nix build toolchain in sysconfig (`CC='gcc'`, `CXX='g++'`, and link commands starting with those names), the image ships no compiler, and PEP 517 backends inherit the phantom names verbatim — scikit-build-core exports them so CMake aborts on the missing `g++` instead of doing PATH discovery.

This rewrites the first token of `CC`/`CXX`/`LINKCC`/`LDSHARED`/`BLDSHARED`/`LDCXXSHARED` to the generic POSIX `cc`/`c++` in `_sysconfigdata__*.py`, `_sysconfig_vars__*.json`, and the config `Makefile`, restoring normal PATH compiler discovery against whatever toolchain the project flake provides (see the native-build contract, #882 / PR #888) — and an honest "no compiler found" when none does.

Mechanism: a last-layer shadow copy via `fakeRootCommands` — no CPython rebuild, dev-shell toolchain untouched, all python-dependent derivations stay cached; deterministic seds preserve digest reproducibility. Stale hash-based `.pyc`s (CHECKED_HASH) self-invalidate.

## Type of Change

- [x] `fix` -- Bug fix

## Changes Made

- `flake.nix`: `fakeRootCommands` sanitize step in the image customisation layer
- `tests/test_image.py`: `test_sysconfig_compiler_vars_are_generic` — asserts generic first tokens and no `/nix/store/` leakage (TDD: committed RED first)
- `CHANGELOG.md` (+ workspace mirror): Unreleased/Fixed entry

## Changelog Entry

### Fixed
- **Image sysconfig no longer records the Nix build toolchain** ([#879](https://github.com/vig-os/devcontainer/issues/879))
  - `CC`/`CXX` and link commands sanitized to generic `cc`/`c++`, so PEP 517 source builds fall back to PATH compiler discovery (project-flake toolchains work; honest error otherwise)

## Testing

- RED: new test failed against the unpatched image (`CC='gcc'`)
- GREEN: full image test suite 114/114 passing locally after the fix, including the new test
- `just precommit` full suite green

Refs: #879