### PR TITLE
fix(workspace): preserve the consumer .pre-commit-config.yaml on upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The baked CPython recorded its nixpkgs build compilers in `sysconfig` (`CC`/`CXX`/`LINKCC`/`LDSHARED`/`BLDSHARED`/`LDCXXSHARED`), but the image ships no compiler — PEP 517 backends inherited the phantom names verbatim: scikit-build-core exports `CC`/`CXX`, so CMake hard-failed on the missing `g++` instead of discovering the project-flake toolchain on `PATH`, and setuptools invoked the literal `gcc`.
   - The image build now sanitizes the baked `_sysconfigdata*.py` / `_sysconfig_vars*.json` / config `Makefile` first tokens to the generic POSIX `cc`/`c++`, restoring `PATH` compiler discovery. Implemented as a shadow copy in the final image layer — no CPython rebuild, dev-shell toolchain untouched, and the no-compiler-baked consumer contract stands (documented via [#882](https://github.com/vig-os/devcontainer/issues/882)).
 
+- **Scaffold upgrade replaces `.pre-commit-config.yaml`, silently clobbering repo-specific hook config** ([#878](https://github.com/vig-os/devcontainer/issues/878))
+  - The upgrade overwrote the consumer's `.pre-commit-config.yaml` wholesale, dropping the repo-specific global `exclude:` block and per-hook `exclude:` keys — the hook suite then rewrote data files it must never touch and false-flagged PEM marker literals. The file is now preserved on upgrade (like `justfile.project`, [#877](https://github.com/vig-os/devcontainer/issues/877)).
+  - Because template hook-stack evolution no longer arrives automatically, `init-workspace --force` prints a diff of the preserved file against the incoming template so consumers can fold changes in deliberately, and warns (non-fatally) when the preserved config does not parse under `prek validate-config` — a config the runner cannot load breaks every commit in the new image.
+
 ### Security
 
 ## [0.4.0](https://github.com/vig-os/devcontainer/releases/tag/0.4.0) - 2026-07-06

--- a/assets/init-workspace.sh
+++ b/assets/init-workspace.sh
@@ -51,6 +51,13 @@ PRESERVE_FILES=(
     # The consumer owns its project manifest (#738): a (re)scaffold must never
     # overwrite an existing pyproject.toml with the generic template one.
     "pyproject.toml"
+    # The consumer owns its hook configuration (#878): repos carry repo-specific
+    # global/per-hook `exclude:` patterns (data tables, generated files, PEM
+    # marker literals) that a template overwrite silently destroyed — the hook
+    # suite then rewrote files it must never touch. Preserved like
+    # justfile.project; the upgrade prints a diff against the template below so
+    # hook-stack evolution stays visible.
+    ".pre-commit-config.yaml"
 )
 
 # Base recipes the shipped .github/workflows/ci.yml depends on (sync, precommit,
@@ -324,6 +331,11 @@ ENVRC_PREEXISTED=false
 JUSTFILE_PROJECT_PREEXISTED=false
 [[ -f "$WORKSPACE_DIR/justfile.project" ]] && JUSTFILE_PROJECT_PREEXISTED=true
 
+# A preserved .pre-commit-config.yaml may lag the template hook stack (#878);
+# record it so the post-scaffold guard can surface the divergence.
+PRECOMMIT_CONFIG_PREEXISTED=false
+[[ -f "$WORKSPACE_DIR/.pre-commit-config.yaml" ]] && PRECOMMIT_CONFIG_PREEXISTED=true
+
 # Copy template contents to workspace
 echo "Initializing workspace from template..."
 echo "Copying files from $TEMPLATE_DIR to $WORKSPACE_DIR..."
@@ -549,6 +561,32 @@ if [[ "$JUSTFILE_PROJECT_PREEXISTED" == "true" && -f "$WORKSPACE_DIR/justfile.pr
                 printf '%s\n' "$recipe_block"
             done
         } >> "$WORKSPACE_DIR/justfile.project"
+    fi
+fi
+
+# A preserved .pre-commit-config.yaml is the consumer's (#878) — never
+# overwritten, so their global/per-hook `exclude:` patterns survive. The cost
+# is that template hook-stack evolution (runner migrations, new hooks, compat
+# fixes) no longer arrives automatically: print the divergence from the
+# template so consumers can fold in what they need deliberately, and gate the
+# preserved file through `prek validate-config` — a config the runner cannot
+# load breaks every commit in the new image. Both are warnings, never fatal.
+if [[ "$PRECOMMIT_CONFIG_PREEXISTED" == "true" \
+    && -f "$WORKSPACE_DIR/.pre-commit-config.yaml" \
+    && -f "$TEMPLATE_DIR/.pre-commit-config.yaml" ]] \
+    && ! diff -q "$TEMPLATE_DIR/.pre-commit-config.yaml" \
+        "$WORKSPACE_DIR/.pre-commit-config.yaml" > /dev/null 2>&1; then
+    echo "Preserved .pre-commit-config.yaml differs from the template (yours was kept, #878)."
+    echo "Template changes NOT applied (fold in what you need, see MIGRATION.md):"
+    echo "─────────────────────────────────────────────────────────────"
+    diff -u "$WORKSPACE_DIR/.pre-commit-config.yaml" \
+        "$TEMPLATE_DIR/.pre-commit-config.yaml" || true
+    echo "─────────────────────────────────────────────────────────────"
+    if command -v prek > /dev/null 2>&1; then
+        if ! (cd "$WORKSPACE_DIR" && prek validate-config .pre-commit-config.yaml > /dev/null 2>&1); then
+            echo "Warning: preserved .pre-commit-config.yaml does not validate under prek (#878)." >&2
+            echo "         Every commit will fail until it parses — run 'prek validate-config .pre-commit-config.yaml' and fix it." >&2
+        fi
     fi
 fi
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -89,6 +89,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The baked CPython recorded its nixpkgs build compilers in `sysconfig` (`CC`/`CXX`/`LINKCC`/`LDSHARED`/`BLDSHARED`/`LDCXXSHARED`), but the image ships no compiler — PEP 517 backends inherited the phantom names verbatim: scikit-build-core exports `CC`/`CXX`, so CMake hard-failed on the missing `g++` instead of discovering the project-flake toolchain on `PATH`, and setuptools invoked the literal `gcc`.
   - The image build now sanitizes the baked `_sysconfigdata*.py` / `_sysconfig_vars*.json` / config `Makefile` first tokens to the generic POSIX `cc`/`c++`, restoring `PATH` compiler discovery. Implemented as a shadow copy in the final image layer — no CPython rebuild, dev-shell toolchain untouched, and the no-compiler-baked consumer contract stands (documented via [#882](https://github.com/vig-os/devcontainer/issues/882)).
 
+- **Scaffold upgrade replaces `.pre-commit-config.yaml`, silently clobbering repo-specific hook config** ([#878](https://github.com/vig-os/devcontainer/issues/878))
+  - The upgrade overwrote the consumer's `.pre-commit-config.yaml` wholesale, dropping the repo-specific global `exclude:` block and per-hook `exclude:` keys — the hook suite then rewrote data files it must never touch and false-flagged PEM marker literals. The file is now preserved on upgrade (like `justfile.project`, [#877](https://github.com/vig-os/devcontainer/issues/877)).
+  - Because template hook-stack evolution no longer arrives automatically, `init-workspace --force` prints a diff of the preserved file against the incoming template so consumers can fold changes in deliberately, and warns (non-fatally) when the preserved config does not parse under `prek validate-config` — a config the runner cannot load breaks every commit in the new image.
+
 ### Security
 
 ## [0.4.0](https://github.com/vig-os/devcontainer/releases/tag/0.4.0) - 2026-07-06

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -217,22 +217,31 @@ re-scaffold:
    block and fold it into your own recipes; also verify the root `justfile`
    still carries the scaffold `import?` lines — without them no layered
    recipe is reachable (the installer warns if the block is missing).
-2. **`justfile.project` hook recipe** — your preserved `precommit` recipe still
+2. **`.pre-commit-config.yaml` is preserved on upgrade** — earlier upgrades
+   replaced it wholesale, silently dropping repo-specific global and per-hook
+   `exclude:` patterns (the autofix hooks then rewrote data files they must
+   never touch, [#878](https://github.com/vig-os/devcontainer/issues/878)).
+   The installer now keeps your file and prints a diff against the incoming
+   template — review it and fold in the template evolution you want (e.g.
+   `default_language_version`, runner-compat fixes, new hooks). It also warns
+   if the preserved config does not parse under the shipped runner; check
+   with `prek validate-config .pre-commit-config.yaml`.
+3. **`justfile.project` hook recipe** — your preserved `precommit` recipe still
    runs `uv run pre-commit run --all-files`; `pre-commit` is gone from the
    0.4.0 image and venv. Change it to `prek run --all-files`.
-3. **Recipe renames** — the managed base recipes are now `devc-*`-namespaced
+4. **Recipe renames** — the managed base recipes are now `devc-*`-namespaced
    and the template test recipe is `just test` (formerly `just test-pytest`).
    Run `just --list` once and update any scripts/muscle memory.
-4. **typos config precedence** — if your repo owns a `typos.toml` or
+5. **typos config precedence** — if your repo owns a `typos.toml` or
    `_typos.toml`, it silently **shadows** the shipped `.typos.toml`. Merge the
    shipped `[default.extend-words]` entries (`Nd`, `unexcepted`, `ba` — needed
    by scaffold-shipped content such as `version-check.sh` and the synced
    `.devcontainer/CHANGELOG.md`) into your file.
-5. **Committed binary/generated artifacts** (plot exports, PDFs, golden `.bin`
+6. **Committed binary/generated artifacts** (plot exports, PDFs, golden `.bin`
    fixtures, SVGs): add them to your typos `[files] extend-exclude` and
    consider a global `exclude:` in `.pre-commit-config.yaml` so the autofix
    hooks (end-of-file-fixer, trailing-whitespace) don't rewrite them.
-6. **Project name re-derivation** — the re-scaffold substitutes placeholders
+7. **Project name re-derivation** — the re-scaffold substitutes placeholders
    from the current directory/`--name`; template-origin files (e.g.
    `tests/test_example.py`) may be rewritten to a name that differs from your
    original scaffold. Review the diff before committing.

--- a/tests/bats/init-workspace.bats
+++ b/tests/bats/init-workspace.bats
@@ -743,3 +743,83 @@ EOF
     run grep -F "import? 'justfile.project'" "$INIT_WORKSPACE_SH"
     assert_success
 }
+
+# ── upgrade must not clobber a customized .pre-commit-config.yaml (#878) ──────
+# The scaffold upgrade replaced the consumer's .pre-commit-config.yaml
+# wholesale, silently dropping the repo-specific global `exclude:` block and
+# per-hook `exclude:` keys (hyrr: the hook suite then "fixed" ~45 physics data
+# files it must never touch, and detect-private-key false-flagged a file with
+# PEM marker literals). Like justfile.project (#877), the consumer owns the
+# file: it is preserved on upgrade, the upgrade prints a diff against the
+# template so hook-stack evolution stays visible, and a prek parse gate warns
+# when the preserved config would break every commit in the new image.
+
+# A consumer .pre-commit-config.yaml: global + per-hook excludes (hyrr shape).
+_custom_precommit_config() {
+    cat > "$1/.pre-commit-config.yaml" <<'EOF'
+# SENTINEL-878 consumer hook config
+exclude: ^data/stopping/|\.dat$
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: cef0300fd0fc4d2a87a85fa2093c6b283ea36f4b  # v5.0.0
+    hooks:
+      - id: detect-private-key
+        exclude: ^worker/src/index\.ts$
+EOF
+}
+
+@test "upgrade preserves a customized .pre-commit-config.yaml (#878)" {
+    ws="$BATS_TEST_TMPDIR/e2e-878-preserve"
+    mkdir -p "$ws"
+    _custom_precommit_config "$ws"
+    run _upgrade both "$ws"
+    assert_success
+    # the consumer file survives verbatim: global exclude + per-hook exclude
+    run grep -q 'SENTINEL-878' "$ws/.pre-commit-config.yaml"
+    assert_success
+    run grep -q '^exclude: \^data/stopping/' "$ws/.pre-commit-config.yaml"
+    assert_success
+    run grep -q 'worker/src/index' "$ws/.pre-commit-config.yaml"
+    assert_success
+}
+
+@test "upgrade prints a template diff hint for a preserved .pre-commit-config.yaml (#878)" {
+    ws="$BATS_TEST_TMPDIR/e2e-878-diff"
+    mkdir -p "$ws"
+    _custom_precommit_config "$ws"
+    run _upgrade both "$ws"
+    assert_success
+    assert_output --partial 'Preserved .pre-commit-config.yaml differs from the template'
+    # the hint shows template evolution the preserved file lacks
+    assert_output --partial 'default_language_version'
+}
+
+@test "no .pre-commit-config.yaml diff hint when it matches the template (#878)" {
+    # Fresh scaffold delivers the template file; re-running the upgrade must
+    # stay silent (no spurious warning on every upgrade of a stock consumer).
+    ws="$BATS_TEST_TMPDIR/e2e-878-stock"
+    mkdir -p "$ws"
+    run _upgrade both "$ws"
+    assert_success
+    run _upgrade both "$ws"
+    assert_success
+    refute_output --partial 'Preserved .pre-commit-config.yaml differs from the template'
+}
+
+@test "upgrade warns when the preserved .pre-commit-config.yaml does not validate (#878)" {
+    # A preserved config prek cannot load breaks every commit in the new
+    # image; the upgrade must warn loudly — and stay non-fatal (#877 parse
+    # gate precedent).
+    ws="$BATS_TEST_TMPDIR/e2e-878-invalid"
+    mkdir -p "$ws"
+    cat > "$ws/.pre-commit-config.yaml" <<'EOF'
+# SENTINEL-878 broken consumer config
+repos: this-is-not-a-repo-list
+EOF
+    run _upgrade both "$ws"
+    assert_success
+    assert_output --partial 'does not validate'
+    # and the broken file is still preserved, not clobbered
+    run grep -q 'SENTINEL-878' "$ws/.pre-commit-config.yaml"
+    assert_success
+}


### PR DESCRIPTION
## Description

Closes #878

The scaffold upgrade (`init-workspace.sh --force`) replaced the consumer's `.pre-commit-config.yaml` wholesale — it was not in `PRESERVE_FILES` — silently dropping repo-specific configuration: the global `exclude:` block (hyrr: physics data tables, generated schemas, jupytext pairs — post-upgrade the hook suite "fixed" ~45 files it must never touch) and per-hook `exclude:` keys (hyrr: the `detect-private-key` exclusion for a file carrying PEM marker literals → false positive).

## Design decision

Chosen: **preserve-with-managed-warning**, the first option listed on the issue and the one consistent with the #877 precedent (#891): the consumer owns the file. `.pre-commit-config.yaml` joins `PRESERVE_FILES`, and the upgrade adds two non-fatal guards:

- **Diff hint** — when the preserved file differs from the incoming template, the installer prints a unified diff so template hook-stack evolution stays visible and consumers fold it in deliberately (nothing is lost silently in either direction: the consumer file is kept verbatim, the template delta is printed in full). A stock consumer whose file matches the template gets no noise.
- **Parse gate** — the preserved config is checked with `prek validate-config` (prek ships in `devTools`, so it is on PATH in the image and the dev-shell); a config the runner cannot load breaks every commit in the new image, so the installer warns loudly, pointing at the exact command. Same philosophy as the #877 `just --list` parse gate: probe with the real tool, warn, never fail the scaffold.

No `.bak-upgrade` backup file is needed: under preserve, the consumer's data is never touched, and the diff output carries the template side.

Why not **replace-but-carry-over** (rewrite from template, re-apply consumer `exclude:`/`files:` keys):

- **No YAML parser is guaranteed at init-workspace runtime.** The image `pythonEnv` is python3.14 + vig-utils (rich) + pip-licenses — no PyYAML; `devTools` carries no `yq`. A structured merge would need a new image dependency for one upgrade step, and a regex/awk-based merge would risk corrupting exactly the file it must protect (block scalars, nested hook maps).
- **Key-level carry-over still loses data silently.** Real consumers customize more than excludes — they add whole hooks and repos (jupytext, schema checks). Carrying over only `exclude:`/`files:` keys would drop those just as silently as today's wholesale replacement.
- **It reverses the 0.4.0 ownership direction.** The `justfile.project` precedent (#877/#891) deliberately made these team-owned, customizable files; the hook config is the same class — the issue exists precisely because repos must customize it.

### Implications for #881 and template-driven hook evolution

A pure preserve means hook-stack evolution (runner migrations, compat fixes like `default_language_version: python3.14` #803 or `typos --force-exclude` #859, new hooks) no longer arrives automatically — a consumer upgrading from a pre-prek scaffold keeps a pre-prek-era config. This PR mitigates that with the always-printed template diff plus the MIGRATION.md step, and the design keeps the #881 path open rather than harder: the new post-scaffold guard block is the natural hook point for future surgical repairs on the preserved file (#877-style), e.g. an upgrade-time scan/rewrite of retired `pre-commit` invocations in preserved files, or a targeted key repair once a YAML-capable tool is in the toolchain. Config-side, prek is a drop-in reader of `.pre-commit-config.yaml`, so preserved configs keep loading; the `pre-commit` *binary* references that #881 covers live in `justfile.project`/`.githooks`, which were already preserved before this PR — #881's scope is unchanged.

## Changes Made

- `assets/init-workspace.sh`:
  - `.pre-commit-config.yaml` added to `PRESERVE_FILES` (with the #878 rationale comment, mirroring the neighboring entries).
  - `PRECOMMIT_CONFIG_PREEXISTED` recorded pre-scaffold (same pattern as `JUSTFILE_PROJECT_PREEXISTED`).
  - Post-scaffold guard: prints the consumer-vs-template unified diff when they differ, then warns (non-fatally) if `prek validate-config` rejects the preserved file; silent for stock consumers; `prek` absence is tolerated.
- `tests/bats/init-workspace.bats`: four new end-to-end tests (customizations survive verbatim; diff hint printed with template content visible; no hint when the file matches the template; invalid preserved config warns and stays preserved). TDD: RED committed first, then GREEN.
- `docs/MIGRATION.md`: new step 2 in the 0.3.x upgrade checklist describing the preservation, the diff review, and the `prek validate-config` check.
- `CHANGELOG.md` (+ hook-synced `.devcontainer` mirror): Unreleased/Fixed entry.

## Type of Change

- [x] `fix` -- Bug fix

### Modifiers

- [ ] Breaking change (`!`)

## Changelog Entry

### Fixed

- **Scaffold upgrade replaces `.pre-commit-config.yaml`, silently clobbering repo-specific hook config** ([#878](https://github.com/vig-os/devcontainer/issues/878))
  - The upgrade overwrote the consumer's `.pre-commit-config.yaml` wholesale, dropping the repo-specific global `exclude:` block and per-hook `exclude:` keys — the hook suite then rewrote data files it must never touch and false-flagged PEM marker literals. The file is now preserved on upgrade (like `justfile.project`, [#877](https://github.com/vig-os/devcontainer/issues/877)).
  - Because template hook-stack evolution no longer arrives automatically, `init-workspace --force` prints a diff of the preserved file against the incoming template so consumers can fold changes in deliberately, and warns (non-fatally) when the preserved config does not parse under `prek validate-config` — a config the runner cannot load breaks every commit in the new image.

## Testing

- [x] Tests pass locally: `bats tests/bats/init-workspace.bats` (72 ok), full hook suite green (`just precommit`)
- [x] Manual testing performed (describe below)

### Manual Testing Details

Ran `init-workspace.sh --force` against a temp workspace carrying a hyrr-shaped `.pre-commit-config.yaml` (global `exclude: ^data/stopping/|\.dat$` + `detect-private-key` per-hook exclude): the consumer file survived verbatim, the installer printed the "yours was kept" banner with the full unified diff against the template, and the scaffold completed successfully. A second run on a stock (template-identical) workspace printed no warning.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published
