### PR TITLE
fix(image): one-cycle pre-commit->prek compat shim + upgrade-time reference scan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The baked CPython recorded its nixpkgs build compilers in `sysconfig` (`CC`/`CXX`/`LINKCC`/`LDSHARED`/`BLDSHARED`/`LDCXXSHARED`), but the image ships no compiler — PEP 517 backends inherited the phantom names verbatim: scikit-build-core exports `CC`/`CXX`, so CMake hard-failed on the missing `g++` instead of discovering the project-flake toolchain on `PATH`, and setuptools invoked the literal `gcc`.
   - The image build now sanitizes the baked `_sysconfigdata*.py` / `_sysconfig_vars*.json` / config `Makefile` first tokens to the generic POSIX `cc`/`c++`, restoring `PATH` compiler discovery. Implemented as a shadow copy in the final image layer — no CPython rebuild, dev-shell toolchain untouched, and the no-compiler-baked consumer contract stands (documented via [#882](https://github.com/vig-os/devcontainer/issues/882)).
 
+- **Scaffold upgrade replaces `.pre-commit-config.yaml`, silently clobbering repo-specific hook config** ([#878](https://github.com/vig-os/devcontainer/issues/878))
+  - The upgrade overwrote the consumer's `.pre-commit-config.yaml` wholesale, dropping the repo-specific global `exclude:` block and per-hook `exclude:` keys — the hook suite then rewrote data files it must never touch and false-flagged PEM marker literals. The file is now preserved on upgrade (like `justfile.project`, [#877](https://github.com/vig-os/devcontainer/issues/877)).
+  - Because template hook-stack evolution no longer arrives automatically, `init-workspace --force` prints a diff of the preserved file against the incoming template so consumers can fold changes in deliberately, and warns (non-fatally) when the preserved config does not parse under `prek validate-config` — a config the runner cannot load breaks every commit in the new image.
+
 ### Security
 
 ## [0.4.0](https://github.com/vig-os/devcontainer/releases/tag/0.4.0) - 2026-07-06

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The upgrade overwrote the consumer's `.pre-commit-config.yaml` wholesale, dropping the repo-specific global `exclude:` block and per-hook `exclude:` keys — the hook suite then rewrote data files it must never touch and false-flagged PEM marker literals. The file is now preserved on upgrade (like `justfile.project`, [#877](https://github.com/vig-os/devcontainer/issues/877)).
   - Because template hook-stack evolution no longer arrives automatically, `init-workspace --force` prints a diff of the preserved file against the incoming template so consumers can fold changes in deliberately, and warns (non-fatally) when the preserved config does not parse under `prek validate-config` — a config the runner cannot load breaks every commit in the new image.
 
+- **`pre-commit` binary dropped without a compat path — preserved consumer recipes and `.githooks` calling it break** ([#881](https://github.com/vig-os/devcontainer/issues/881))
+  - The 0.4.0 image retired the Python `pre-commit` for `prek` ([#778](https://github.com/vig-os/devcontainer/issues/778)), but files preserved on upgrade still invoke it and exit 127 (field-validated on a 0.3.5 → 0.4.0 consumer: the preserved `justfile.project` `precommit` recipe and repo-managed `.githooks` scripts broke every commit). The image now ships a **deprecated one-cycle `pre-commit → prek` shim** (stderr notice, removed in 0.5) so consumer hook scripts keep working while they migrate.
+  - `init-workspace --force` scans the post-scaffold `justfile.project`, `.githooks/` scripts and `.pre-commit-config.yaml` for invocation-shaped `pre-commit` references and warns (non-fatally) with `file:line`, pointing at the MIGRATION.md rename checklist — which now also covers the NixOS `#!/bin/bash` shebang gotcha in old-scaffold `.githooks`.
+
 ### Security
 
 ## [0.4.0](https://github.com/vig-os/devcontainer/releases/tag/0.4.0) - 2026-07-06

--- a/assets/init-workspace.sh
+++ b/assets/init-workspace.sh
@@ -51,6 +51,13 @@ PRESERVE_FILES=(
     # The consumer owns its project manifest (#738): a (re)scaffold must never
     # overwrite an existing pyproject.toml with the generic template one.
     "pyproject.toml"
+    # The consumer owns its hook configuration (#878): repos carry repo-specific
+    # global/per-hook `exclude:` patterns (data tables, generated files, PEM
+    # marker literals) that a template overwrite silently destroyed — the hook
+    # suite then rewrote files it must never touch. Preserved like
+    # justfile.project; the upgrade prints a diff against the template below so
+    # hook-stack evolution stays visible.
+    ".pre-commit-config.yaml"
 )
 
 # Base recipes the shipped .github/workflows/ci.yml depends on (sync, precommit,
@@ -324,6 +331,11 @@ ENVRC_PREEXISTED=false
 JUSTFILE_PROJECT_PREEXISTED=false
 [[ -f "$WORKSPACE_DIR/justfile.project" ]] && JUSTFILE_PROJECT_PREEXISTED=true
 
+# A preserved .pre-commit-config.yaml may lag the template hook stack (#878);
+# record it so the post-scaffold guard can surface the divergence.
+PRECOMMIT_CONFIG_PREEXISTED=false
+[[ -f "$WORKSPACE_DIR/.pre-commit-config.yaml" ]] && PRECOMMIT_CONFIG_PREEXISTED=true
+
 # Copy template contents to workspace
 echo "Initializing workspace from template..."
 echo "Copying files from $TEMPLATE_DIR to $WORKSPACE_DIR..."
@@ -549,6 +561,32 @@ if [[ "$JUSTFILE_PROJECT_PREEXISTED" == "true" && -f "$WORKSPACE_DIR/justfile.pr
                 printf '%s\n' "$recipe_block"
             done
         } >> "$WORKSPACE_DIR/justfile.project"
+    fi
+fi
+
+# A preserved .pre-commit-config.yaml is the consumer's (#878) — never
+# overwritten, so their global/per-hook `exclude:` patterns survive. The cost
+# is that template hook-stack evolution (runner migrations, new hooks, compat
+# fixes) no longer arrives automatically: print the divergence from the
+# template so consumers can fold in what they need deliberately, and gate the
+# preserved file through `prek validate-config` — a config the runner cannot
+# load breaks every commit in the new image. Both are warnings, never fatal.
+if [[ "$PRECOMMIT_CONFIG_PREEXISTED" == "true" \
+    && -f "$WORKSPACE_DIR/.pre-commit-config.yaml" \
+    && -f "$TEMPLATE_DIR/.pre-commit-config.yaml" ]] \
+    && ! diff -q "$TEMPLATE_DIR/.pre-commit-config.yaml" \
+        "$WORKSPACE_DIR/.pre-commit-config.yaml" > /dev/null 2>&1; then
+    echo "Preserved .pre-commit-config.yaml differs from the template (yours was kept, #878)."
+    echo "Template changes NOT applied (fold in what you need, see MIGRATION.md):"
+    echo "─────────────────────────────────────────────────────────────"
+    diff -u "$WORKSPACE_DIR/.pre-commit-config.yaml" \
+        "$TEMPLATE_DIR/.pre-commit-config.yaml" || true
+    echo "─────────────────────────────────────────────────────────────"
+    if command -v prek > /dev/null 2>&1; then
+        if ! (cd "$WORKSPACE_DIR" && prek validate-config .pre-commit-config.yaml > /dev/null 2>&1); then
+            echo "Warning: preserved .pre-commit-config.yaml does not validate under prek (#878)." >&2
+            echo "         Every commit will fail until it parses — run 'prek validate-config .pre-commit-config.yaml' and fix it." >&2
+        fi
     fi
 fi
 

--- a/assets/init-workspace.sh
+++ b/assets/init-workspace.sh
@@ -590,6 +590,40 @@ if [[ "$PRECOMMIT_CONFIG_PREEXISTED" == "true" \
     fi
 fi
 
+# The retired `pre-commit` binary (#778) exits 127 at first use: a preserved
+# justfile.project recipe, a consumer-owned .githooks script, or a hook entry
+# in the preserved .pre-commit-config.yaml that still invokes it breaks even
+# after a clean re-scaffold — the image ships prek plus a one-cycle compat
+# shim (removed in 0.5). Scan the post-scaffold state of those surfaces for
+# invocation-shaped references and warn with file:line (#881). Non-fatal,
+# like the #877/#878 guards. The pattern only matches `pre-commit` framed as
+# a command word (start/whitespace/shell punctuation on both sides), so the
+# config FILENAME (leading `.`), pre-commit-hooks repo URLs (leading `/`),
+# pre-commit.com links (trailing `.`), and `prek` never trip it; comment
+# lines and bare YAML stage-name list items (`- pre-commit`) are filtered.
+PRECOMMIT_REF_PATTERN='(^|[[:space:]("'"'"';&|=`])pre-commit([[:space:])"'"'"';&|]|$)'
+PRECOMMIT_SCAN_TARGETS=()
+for scan_file in "$WORKSPACE_DIR/justfile.project" "$WORKSPACE_DIR/.pre-commit-config.yaml"; do
+    [[ -f "$scan_file" ]] && PRECOMMIT_SCAN_TARGETS+=("$scan_file")
+done
+while IFS= read -r scan_file; do
+    PRECOMMIT_SCAN_TARGETS+=("$scan_file")
+done < <(find "$WORKSPACE_DIR/.githooks" -type f 2>/dev/null | sort)
+PRECOMMIT_REF_HITS=""
+if [[ ${#PRECOMMIT_SCAN_TARGETS[@]} -gt 0 ]]; then
+    PRECOMMIT_REF_HITS="$(grep -nHE "$PRECOMMIT_REF_PATTERN" "${PRECOMMIT_SCAN_TARGETS[@]}" 2>/dev/null \
+        | grep -vE '^[^:]*:[0-9]+:[[:space:]]*#' \
+        | grep -vE '^[^:]*:[0-9]+:[[:space:]]*-[[:space:]]+pre-commit[[:space:]]*$' || true)"
+fi
+if [[ -n "$PRECOMMIT_REF_HITS" ]]; then
+    echo "Warning: the retired 'pre-commit' binary is still invoked by preserved file(s) (#881):" >&2
+    printf '%s\n' "$PRECOMMIT_REF_HITS" | sed "s|^$WORKSPACE_DIR/|         |" >&2
+    echo "         The image ships 'prek' (drop-in for run-style invocations); a temporary" >&2
+    echo "         pre-commit->prek shim keeps these working through 0.4.x only — it is" >&2
+    echo "         removed in 0.5. Rename the invocations to 'prek' (see MIGRATION.md," >&2
+    echo "         'Upgrading an existing 0.3.x consumer')." >&2
+fi
+
 # Sync dependencies: resolves uv.lock for the new project name and installs the
 # project. Non-fatal (#859): a preserved old-generation justfile.project may not
 # define `sync` yet — the scaffold itself is complete at this point, so warn and

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -89,6 +89,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The baked CPython recorded its nixpkgs build compilers in `sysconfig` (`CC`/`CXX`/`LINKCC`/`LDSHARED`/`BLDSHARED`/`LDCXXSHARED`), but the image ships no compiler — PEP 517 backends inherited the phantom names verbatim: scikit-build-core exports `CC`/`CXX`, so CMake hard-failed on the missing `g++` instead of discovering the project-flake toolchain on `PATH`, and setuptools invoked the literal `gcc`.
   - The image build now sanitizes the baked `_sysconfigdata*.py` / `_sysconfig_vars*.json` / config `Makefile` first tokens to the generic POSIX `cc`/`c++`, restoring `PATH` compiler discovery. Implemented as a shadow copy in the final image layer — no CPython rebuild, dev-shell toolchain untouched, and the no-compiler-baked consumer contract stands (documented via [#882](https://github.com/vig-os/devcontainer/issues/882)).
 
+- **Scaffold upgrade replaces `.pre-commit-config.yaml`, silently clobbering repo-specific hook config** ([#878](https://github.com/vig-os/devcontainer/issues/878))
+  - The upgrade overwrote the consumer's `.pre-commit-config.yaml` wholesale, dropping the repo-specific global `exclude:` block and per-hook `exclude:` keys — the hook suite then rewrote data files it must never touch and false-flagged PEM marker literals. The file is now preserved on upgrade (like `justfile.project`, [#877](https://github.com/vig-os/devcontainer/issues/877)).
+  - Because template hook-stack evolution no longer arrives automatically, `init-workspace --force` prints a diff of the preserved file against the incoming template so consumers can fold changes in deliberately, and warns (non-fatally) when the preserved config does not parse under `prek validate-config` — a config the runner cannot load breaks every commit in the new image.
+
 ### Security
 
 ## [0.4.0](https://github.com/vig-os/devcontainer/releases/tag/0.4.0) - 2026-07-06

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -93,6 +93,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The upgrade overwrote the consumer's `.pre-commit-config.yaml` wholesale, dropping the repo-specific global `exclude:` block and per-hook `exclude:` keys — the hook suite then rewrote data files it must never touch and false-flagged PEM marker literals. The file is now preserved on upgrade (like `justfile.project`, [#877](https://github.com/vig-os/devcontainer/issues/877)).
   - Because template hook-stack evolution no longer arrives automatically, `init-workspace --force` prints a diff of the preserved file against the incoming template so consumers can fold changes in deliberately, and warns (non-fatally) when the preserved config does not parse under `prek validate-config` — a config the runner cannot load breaks every commit in the new image.
 
+- **`pre-commit` binary dropped without a compat path — preserved consumer recipes and `.githooks` calling it break** ([#881](https://github.com/vig-os/devcontainer/issues/881))
+  - The 0.4.0 image retired the Python `pre-commit` for `prek` ([#778](https://github.com/vig-os/devcontainer/issues/778)), but files preserved on upgrade still invoke it and exit 127 (field-validated on a 0.3.5 → 0.4.0 consumer: the preserved `justfile.project` `precommit` recipe and repo-managed `.githooks` scripts broke every commit). The image now ships a **deprecated one-cycle `pre-commit → prek` shim** (stderr notice, removed in 0.5) so consumer hook scripts keep working while they migrate.
+  - `init-workspace --force` scans the post-scaffold `justfile.project`, `.githooks/` scripts and `.pre-commit-config.yaml` for invocation-shaped `pre-commit` references and warns (non-fatally) with `file:line`, pointing at the MIGRATION.md rename checklist — which now also covers the NixOS `#!/bin/bash` shebang gotcha in old-scaffold `.githooks`.
+
 ### Security
 
 ## [0.4.0](https://github.com/vig-os/devcontainer/releases/tag/0.4.0) - 2026-07-06

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -217,22 +217,31 @@ re-scaffold:
    block and fold it into your own recipes; also verify the root `justfile`
    still carries the scaffold `import?` lines — without them no layered
    recipe is reachable (the installer warns if the block is missing).
-2. **`justfile.project` hook recipe** — your preserved `precommit` recipe still
+2. **`.pre-commit-config.yaml` is preserved on upgrade** — earlier upgrades
+   replaced it wholesale, silently dropping repo-specific global and per-hook
+   `exclude:` patterns (the autofix hooks then rewrote data files they must
+   never touch, [#878](https://github.com/vig-os/devcontainer/issues/878)).
+   The installer now keeps your file and prints a diff against the incoming
+   template — review it and fold in the template evolution you want (e.g.
+   `default_language_version`, runner-compat fixes, new hooks). It also warns
+   if the preserved config does not parse under the shipped runner; check
+   with `prek validate-config .pre-commit-config.yaml`.
+3. **`justfile.project` hook recipe** — your preserved `precommit` recipe still
    runs `uv run pre-commit run --all-files`; `pre-commit` is gone from the
    0.4.0 image and venv. Change it to `prek run --all-files`.
-3. **Recipe renames** — the managed base recipes are now `devc-*`-namespaced
+4. **Recipe renames** — the managed base recipes are now `devc-*`-namespaced
    and the template test recipe is `just test` (formerly `just test-pytest`).
    Run `just --list` once and update any scripts/muscle memory.
-4. **typos config precedence** — if your repo owns a `typos.toml` or
+5. **typos config precedence** — if your repo owns a `typos.toml` or
    `_typos.toml`, it silently **shadows** the shipped `.typos.toml`. Merge the
    shipped `[default.extend-words]` entries (`Nd`, `unexcepted`, `ba` — needed
    by scaffold-shipped content such as `version-check.sh` and the synced
    `.devcontainer/CHANGELOG.md`) into your file.
-5. **Committed binary/generated artifacts** (plot exports, PDFs, golden `.bin`
+6. **Committed binary/generated artifacts** (plot exports, PDFs, golden `.bin`
    fixtures, SVGs): add them to your typos `[files] extend-exclude` and
    consider a global `exclude:` in `.pre-commit-config.yaml` so the autofix
    hooks (end-of-file-fixer, trailing-whitespace) don't rewrite them.
-6. **Project name re-derivation** — the re-scaffold substitutes placeholders
+7. **Project name re-derivation** — the re-scaffold substitutes placeholders
    from the current directory/`--name`; template-origin files (e.g.
    `tests/test_example.py`) may be rewritten to a name that differs from your
    original scaffold. Review the diff before committing.

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -226,9 +226,22 @@ re-scaffold:
    `default_language_version`, runner-compat fixes, new hooks). It also warns
    if the preserved config does not parse under the shipped runner; check
    with `prek validate-config .pre-commit-config.yaml`.
-3. **`justfile.project` hook recipe** — your preserved `precommit` recipe still
-   runs `uv run pre-commit run --all-files`; `pre-commit` is gone from the
-   0.4.0 image and venv. Change it to `prek run --all-files`.
+3. **`pre-commit` invocations → `prek`** — the `pre-commit` binary is gone
+   from the 0.4.0 image and venv; the hook runner is `prek` (a drop-in for
+   `run`-style invocations, [#778](https://github.com/vig-os/devcontainer/issues/778)).
+   Rename every invocation in files the upgrade preserves or your repo owns:
+   the `justfile.project` `precommit` recipe (`uv run pre-commit run
+   --all-files` → `prek run --all-files`), repo-managed `.githooks/` scripts
+   beyond the scaffold-shipped three (e.g. a `pre-push` hook), hook `entry:`
+   lines in `.pre-commit-config.yaml`, and CI configs. The installer scans
+   the preserved surfaces and warns with `file:line`
+   ([#881](https://github.com/vig-os/devcontainer/issues/881)). As a bridge,
+   0.4.x images ship a deprecated `pre-commit → prek` shim that prints a
+   stderr notice and is **removed in 0.5** — treat the notice as the
+   migration deadline, not a supported path. While editing old `.githooks`
+   scripts, also change `#!/bin/bash` shebangs to `#!/usr/bin/env bash`:
+   `/bin/bash` does not exist on NixOS hosts, so those hooks fail outside
+   the container even after the rename.
 4. **Recipe renames** — the managed base recipes are now `devc-*`-namespaced
    and the template test recipe is `just test` (formerly `just test-pytest`).
    Run `just --list` once and update any scripts/muscle memory.

--- a/flake.nix
+++ b/flake.nix
@@ -570,6 +570,19 @@
             pythonEnv
             bandit
 
+            # DEPRECATED — remove in 0.5 (#881): one-release-cycle
+            # `pre-commit -> prek` compat shim. #778 dropped the Python
+            # pre-commit for prek, but consumer files preserved on upgrade
+            # (justfile.project recipes, repo-managed .githooks scripts)
+            # still invoke `pre-commit` and exited 127 at commit time. prek
+            # is drop-in for run-style invocations, so the shim dispatches
+            # and prints a one-line stderr notice (stdout stays clean for
+            # pipelines) until consumers rename their invocations.
+            (writeShellScriptBin "pre-commit" ''
+              echo "pre-commit: deprecated compat shim, dispatching to prek — rename your invocation; the shim is removed in 0.5 (vig-os/devcontainer#881)" >&2
+              exec ${prek}/bin/prek "$@"
+            '')
+
             # Rust/cargo + just LSP/formatter tools. The Debian image installed
             # these via cargo-binstall; Nix-native from nixpkgs here (#666).
             cargo-binstall

--- a/tests/bats/init-workspace.bats
+++ b/tests/bats/init-workspace.bats
@@ -823,3 +823,86 @@ EOF
     run grep -q 'SENTINEL-878' "$ws/.pre-commit-config.yaml"
     assert_success
 }
+
+# ── upgrade must flag preserved files still invoking `pre-commit` (#881) ──────
+# The 0.4.0 image ships `prek` only (#778); a one-cycle `pre-commit` shim
+# covers 0.4.x. Preserved consumer files (justfile.project recipes, extra
+# .githooks scripts, .pre-commit-config.yaml entries) that still invoke the
+# retired binary would otherwise exit 127 at first use — the upgrade must
+# scan them and warn with file:line, non-fatally (#877/#878 precedent).
+
+@test "upgrade warns file:line when preserved files still invoke pre-commit (#881)" {
+    ws="$BATS_TEST_TMPDIR/e2e-881-hit"
+    mkdir -p "$ws/.githooks"
+    # vault shape: preserved recipe calls the retired binary
+    cat > "$ws/justfile.project" <<'EOF'
+# SENTINEL-881 consumer recipes
+sync:
+    uv sync
+
+precommit:
+    uv run pre-commit run --all-files
+
+test:
+    @echo test
+EOF
+    # consumer-owned hook outside the template set survives the rsync
+    cat > "$ws/.githooks/pre-push" <<'EOF'
+#!/bin/bash
+pre-commit run --all-files
+EOF
+    chmod +x "$ws/.githooks/pre-push"
+    run _upgrade both "$ws"
+    assert_success
+    assert_output --partial "retired 'pre-commit' binary"
+    # file:line listing for both surfaces
+    assert_output --regexp 'justfile\.project:[0-9]+'
+    assert_output --regexp '\.githooks/pre-push:[0-9]+'
+    # points at the migration doc and the drop-in runner
+    assert_output --partial 'MIGRATION.md'
+    assert_output --partial 'prek'
+}
+
+@test "no pre-commit-reference warning on a stock scaffold (#881)" {
+    ws="$BATS_TEST_TMPDIR/e2e-881-stock"
+    mkdir -p "$ws"
+    run _upgrade both "$ws"
+    assert_success
+    refute_output --partial "retired 'pre-commit' binary"
+    run _upgrade both "$ws"
+    assert_success
+    refute_output --partial "retired 'pre-commit' binary"
+}
+
+@test "pre-commit scan skips filenames, repo URLs, stage names, prek (#881)" {
+    # False-positive guard: none of these are invocations of the retired
+    # binary — the config filename, pre-commit-hooks repo URLs, YAML stage
+    # names, comments, and the prek runner itself must not trip the warning.
+    ws="$BATS_TEST_TMPDIR/e2e-881-clean"
+    mkdir -p "$ws"
+    cat > "$ws/.pre-commit-config.yaml" <<'EOF'
+# SENTINEL-881 clean consumer config: mentions .pre-commit-config.yaml
+default_stages: [pre-commit]
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: cef0300fd0fc4d2a87a85fa2093c6b283ea36f4b  # v5.0.0
+    hooks:
+      - id: end-of-file-fixer
+        stages:
+          - pre-commit
+EOF
+    cat > "$ws/justfile.project" <<'EOF'
+# SENTINEL-881 clean consumer recipes (see https://pre-commit.com)
+sync:
+    uv sync
+
+precommit:
+    prek run --all-files
+
+test:
+    @echo test
+EOF
+    run _upgrade both "$ws"
+    assert_success
+    refute_output --partial "retired 'pre-commit' binary"
+}

--- a/tests/bats/init-workspace.bats
+++ b/tests/bats/init-workspace.bats
@@ -743,3 +743,83 @@ EOF
     run grep -F "import? 'justfile.project'" "$INIT_WORKSPACE_SH"
     assert_success
 }
+
+# ── upgrade must not clobber a customized .pre-commit-config.yaml (#878) ──────
+# The scaffold upgrade replaced the consumer's .pre-commit-config.yaml
+# wholesale, silently dropping the repo-specific global `exclude:` block and
+# per-hook `exclude:` keys (hyrr: the hook suite then "fixed" ~45 physics data
+# files it must never touch, and detect-private-key false-flagged a file with
+# PEM marker literals). Like justfile.project (#877), the consumer owns the
+# file: it is preserved on upgrade, the upgrade prints a diff against the
+# template so hook-stack evolution stays visible, and a prek parse gate warns
+# when the preserved config would break every commit in the new image.
+
+# A consumer .pre-commit-config.yaml: global + per-hook excludes (hyrr shape).
+_custom_precommit_config() {
+    cat > "$1/.pre-commit-config.yaml" <<'EOF'
+# SENTINEL-878 consumer hook config
+exclude: ^data/stopping/|\.dat$
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: cef0300fd0fc4d2a87a85fa2093c6b283ea36f4b  # v5.0.0
+    hooks:
+      - id: detect-private-key
+        exclude: ^worker/src/index\.ts$
+EOF
+}
+
+@test "upgrade preserves a customized .pre-commit-config.yaml (#878)" {
+    ws="$BATS_TEST_TMPDIR/e2e-878-preserve"
+    mkdir -p "$ws"
+    _custom_precommit_config "$ws"
+    run _upgrade both "$ws"
+    assert_success
+    # the consumer file survives verbatim: global exclude + per-hook exclude
+    run grep -q 'SENTINEL-878' "$ws/.pre-commit-config.yaml"
+    assert_success
+    run grep -q '^exclude: \^data/stopping/' "$ws/.pre-commit-config.yaml"
+    assert_success
+    run grep -q 'worker/src/index' "$ws/.pre-commit-config.yaml"
+    assert_success
+}
+
+@test "upgrade prints a template diff hint for a preserved .pre-commit-config.yaml (#878)" {
+    ws="$BATS_TEST_TMPDIR/e2e-878-diff"
+    mkdir -p "$ws"
+    _custom_precommit_config "$ws"
+    run _upgrade both "$ws"
+    assert_success
+    assert_output --partial 'Preserved .pre-commit-config.yaml differs from the template'
+    # the hint shows template evolution the preserved file lacks
+    assert_output --partial 'default_language_version'
+}
+
+@test "no .pre-commit-config.yaml diff hint when it matches the template (#878)" {
+    # Fresh scaffold delivers the template file; re-running the upgrade must
+    # stay silent (no spurious warning on every upgrade of a stock consumer).
+    ws="$BATS_TEST_TMPDIR/e2e-878-stock"
+    mkdir -p "$ws"
+    run _upgrade both "$ws"
+    assert_success
+    run _upgrade both "$ws"
+    assert_success
+    refute_output --partial 'Preserved .pre-commit-config.yaml differs from the template'
+}
+
+@test "upgrade warns when the preserved .pre-commit-config.yaml does not validate (#878)" {
+    # A preserved config prek cannot load breaks every commit in the new
+    # image; the upgrade must warn loudly — and stay non-fatal (#877 parse
+    # gate precedent).
+    ws="$BATS_TEST_TMPDIR/e2e-878-invalid"
+    mkdir -p "$ws"
+    cat > "$ws/.pre-commit-config.yaml" <<'EOF'
+# SENTINEL-878 broken consumer config
+repos: this-is-not-a-repo-list
+EOF
+    run _upgrade both "$ws"
+    assert_success
+    assert_output --partial 'does not validate'
+    # and the broken file is still preserved, not clobbered
+    run grep -q 'SENTINEL-878' "$ws/.pre-commit-config.yaml"
+    assert_success
+}

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -665,9 +665,7 @@ class TestDevelopmentTools:
         assert "deprecated" in result.stderr.lower(), (
             f"shim did not print the deprecation notice: {result.stderr}"
         )
-        assert "prek" in result.stderr.lower(), (
-            "deprecation notice must point at prek"
-        )
+        assert "prek" in result.stderr.lower(), "deprecation notice must point at prek"
         assert "deprecated" not in result.stdout.lower(), (
             "deprecation notice leaked to stdout"
         )

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -645,9 +645,31 @@ class TestDevelopmentTools:
         result = host.run("prek --version")
         assert result.rc == 0, "prek --version failed"
         assert "prek" in result.stdout.lower()
-        # The Python pre-commit is intentionally dropped from the image (#778).
-        assert host.run("command -v pre-commit").rc != 0, (
-            "pre-commit should be absent from the image (prek supersedes it, #778)"
+
+    def test_pre_commit_compat_shim(self, host):
+        """One-cycle `pre-commit -> prek` compat shim (#881, remove in 0.5).
+
+        The Python pre-commit was dropped for prek (#778), but preserved
+        consumer files (justfile.project recipes, repo-managed .githooks)
+        still invoke `pre-commit` and exited 127 at commit time. The shim
+        dispatches to prek and prints a one-line deprecation notice on
+        stderr so scripts keep working while consumers migrate.
+        """
+        result = host.run("pre-commit --version")
+        assert result.rc == 0, "pre-commit compat shim failed (#881)"
+        # dispatches to prek: the version banner is prek's
+        assert "prek" in result.stdout.lower(), (
+            f"shim did not dispatch to prek: {result.stdout}"
+        )
+        # deprecation notice on stderr (not stdout, so pipelines stay clean)
+        assert "deprecated" in result.stderr.lower(), (
+            f"shim did not print the deprecation notice: {result.stderr}"
+        )
+        assert "prek" in result.stderr.lower(), (
+            "deprecation notice must point at prek"
+        )
+        assert "deprecated" not in result.stdout.lower(), (
+            "deprecation notice leaked to stdout"
         )
 
     def test_ruff_installed(self, host):


### PR DESCRIPTION
## Description

Closes #881. **Stacked on #895** (branched from `bugfix/878-preserve-precommit-config`; this PR shows only its own commits once #895 merges).

Field evidence (EXOPET/vault, 0.3.5 → 0.4.0): the 0.4.0 image ships `prek` only (#778), but consumer files preserved on upgrade still invoke `pre-commit` and exit 127 — the preserved `justfile.project` `precommit:` recipe and the repo-managed `.githooks/{pre-commit,commit-msg,prepare-commit-msg}` hooks broke every commit in-image. Even a repaired justfile cannot save a consumer whose own hook scripts call the removed tool, so the fix has an image half and an upgrade half.

## Type of Change

- [x] `fix` -- Bug fix

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

**(a) Image compat shim, one release cycle** (`flake.nix`, `imageTools`):

- A `writeShellScriptBin "pre-commit"` shim that prints a one-line deprecation notice to **stderr** (stdout stays clean for pipelines) and `exec`s `${prek}/bin/prek "$@"` — prek is drop-in for `run`-style invocations. Marked `DEPRECATED — remove in 0.5 (#881)`. Image-only (`imageTools`, not `devTools`), so the dev-shell, home modules, and the parity gate are untouched.

**(b) Upgrade-time scan** (`assets/init-workspace.sh`, alongside the #877/#878 guards):

- After the scaffold, `init-workspace --force` scans the post-scaffold `justfile.project`, all `.githooks/` files, and `.pre-commit-config.yaml` for invocation-shaped `pre-commit` references and warns **non-fatally** with `file:line`, pointing at `prek`, the shim's one-cycle lifespan, and the MIGRATION.md checklist.
- False-positive handling: the pattern only matches `pre-commit` framed as a command word (start/whitespace/shell punctuation on both sides), so the `.pre-commit-config.yaml` filename (leading `.`), `pre-commit/pre-commit-hooks` repo URLs (leading `/`), `pre-commit.com` links (trailing `.`), and `prek` never trip it; comment lines and YAML stage-name list items (`- pre-commit`) are filtered. Scanning post-scaffold state means fresh scaffolds and rsync-refreshed template hooks (which call `prek`) are silent by construction.

**Docs**: MIGRATION.md upgrade-checklist step 3 rewritten — full rename surface (justfile recipes, repo-owned `.githooks` beyond the shipped three, hook `entry:` lines, CI configs), the shim's 0.4.x-only lifespan, and the NixOS `#!/bin/bash` → `#!/usr/bin/env bash` shebang gotcha in old-scaffold hooks.

## Changelog Entry

### Fixed
- **`pre-commit` binary dropped without a compat path — preserved consumer recipes and `.githooks` calling it break** ([#881](https://github.com/vig-os/devcontainer/issues/881))
  - The 0.4.0 image retired the Python `pre-commit` for `prek` ([#778](https://github.com/vig-os/devcontainer/issues/778)), but files preserved on upgrade still invoke it and exit 127 (field-validated on a 0.3.5 → 0.4.0 consumer: the preserved `justfile.project` `precommit` recipe and repo-managed `.githooks` scripts broke every commit). The image now ships a **deprecated one-cycle `pre-commit → prek` shim** (stderr notice, removed in 0.5) so consumer hook scripts keep working while they migrate.
  - `init-workspace --force` scans the post-scaffold `justfile.project`, `.githooks/` scripts and `.pre-commit-config.yaml` for invocation-shaped `pre-commit` references and warns (non-fatally) with `file:line`, pointing at the MIGRATION.md rename checklist — which now also covers the NixOS `#!/bin/bash` shebang gotcha in old-scaffold `.githooks`.

## Testing

- [x] Tests pass locally (`just test`)
- [x] Manual testing performed (describe below)

TDD, both halves RED-committed first:

- bats: `upgrade warns file:line when preserved files still invoke pre-commit (#881)` RED (`not ok`) → GREEN; plus stock-scaffold and false-positive no-hit guards. Full `init-workspace.bats` suite: **75/75 ok**.
- image: `test_pre_commit_compat_shim` RED against the pre-shim locally built image (`exit 127: pre-commit: command not found` — the exact field failure) → GREEN after rebuild. `TestDevelopmentTools`: **24 passed**.

### Manual Testing Details

```
$ podman run --rm ghcr.io/vig-os/devcontainer:dev bash -lc 'pre-commit --version'
pre-commit: deprecated compat shim, dispatching to prek — rename your invocation; the shim is removed in 0.5 (vig-os/devcontainer#881)
prek 0.3.11
```

Full hook suite: `just precommit` exit 0, 52 hooks passed, 0 failed.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published (**stacked on #895**, review in progress)

## Additional Notes

- The shim is deliberately a bridge, not a supported path: the deprecation notice is the consumer-visible removal deadline (0.5), cross-referenced in the flake comment and MIGRATION.md.
- `test_pre_commit_installed` no longer asserts `pre-commit` absence (superseded by the shim test for this one cycle); re-add the absence assertion when the shim is removed in 0.5.

Refs: #881
