### PR TITLE
chore(image): remove the pre-commit compat shim (one-cycle deprecation ends)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- **`pre-commit` compat shim removed from the image** ([#897](https://github.com/vig-os/devcontainer/issues/897))
+  - The one-release-cycle `pre-commit → prek` shim shipped in 0.4.x ([#881](https://github.com/vig-os/devcontainer/issues/881)) is gone; `pre-commit` invocations now fail with exit 127.
+  - Consumers had the 0.4.x cycle to rename invocations; the upgrade-time scan still warns with `file:line` on preserved surfaces — see `docs/MIGRATION.md` for the rename checklist (justfile recipes, repo-owned `.githooks/`, CI configs → `prek`).
+
 ### Fixed
 
 ### Security

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- **`pre-commit` compat shim removed from the image** ([#897](https://github.com/vig-os/devcontainer/issues/897))
+  - The one-release-cycle `pre-commit → prek` shim shipped in 0.4.x ([#881](https://github.com/vig-os/devcontainer/issues/881)) is gone; `pre-commit` invocations now fail with exit 127.
+  - Consumers had the 0.4.x cycle to rename invocations; the upgrade-time scan still warns with `file:line` on preserved surfaces — see `docs/MIGRATION.md` for the rename checklist (justfile recipes, repo-owned `.githooks/`, CI configs → `prek`).
+
 ### Fixed
 
 ### Security

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -236,9 +236,11 @@ re-scaffold:
    lines in `.pre-commit-config.yaml`, and CI configs. The installer scans
    the preserved surfaces and warns with `file:line`
    ([#881](https://github.com/vig-os/devcontainer/issues/881)). As a bridge,
-   0.4.x images ship a deprecated `pre-commit → prek` shim that prints a
-   stderr notice and is **removed in 0.5** — treat the notice as the
-   migration deadline, not a supported path. While editing old `.githooks`
+   0.4.x images shipped a deprecated `pre-commit → prek` shim that printed a
+   stderr notice; the one-cycle window is over and **0.5 images carry no
+   `pre-commit` binary at all** ([#897](https://github.com/vig-os/devcontainer/issues/897))
+   — unrenamed invocations now fail with exit 127, so act on the installer's
+   scan warnings before committing. While editing old `.githooks`
    scripts, also change `#!/bin/bash` shebangs to `#!/usr/bin/env bash`:
    `/bin/bash` does not exist on NixOS hosts, so those hooks fail outside
    the container even after the rename.

--- a/flake.nix
+++ b/flake.nix
@@ -570,19 +570,6 @@
             pythonEnv
             bandit
 
-            # DEPRECATED — remove in 0.5 (#881): one-release-cycle
-            # `pre-commit -> prek` compat shim. #778 dropped the Python
-            # pre-commit for prek, but consumer files preserved on upgrade
-            # (justfile.project recipes, repo-managed .githooks scripts)
-            # still invoke `pre-commit` and exited 127 at commit time. prek
-            # is drop-in for run-style invocations, so the shim dispatches
-            # and prints a one-line stderr notice (stdout stays clean for
-            # pipelines) until consumers rename their invocations.
-            (writeShellScriptBin "pre-commit" ''
-              echo "pre-commit: deprecated compat shim, dispatching to prek — rename your invocation; the shim is removed in 0.5 (vig-os/devcontainer#881)" >&2
-              exec ${prek}/bin/prek "$@"
-            '')
-
             # Rust/cargo + just LSP/formatter tools. The Debian image installed
             # these via cargo-binstall; Nix-native from nixpkgs here (#666).
             cargo-binstall

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -645,29 +645,10 @@ class TestDevelopmentTools:
         result = host.run("prek --version")
         assert result.rc == 0, "prek --version failed"
         assert "prek" in result.stdout.lower()
-
-    def test_pre_commit_compat_shim(self, host):
-        """One-cycle `pre-commit -> prek` compat shim (#881, remove in 0.5).
-
-        The Python pre-commit was dropped for prek (#778), but preserved
-        consumer files (justfile.project recipes, repo-managed .githooks)
-        still invoke `pre-commit` and exited 127 at commit time. The shim
-        dispatches to prek and prints a one-line deprecation notice on
-        stderr so scripts keep working while consumers migrate.
-        """
-        result = host.run("pre-commit --version")
-        assert result.rc == 0, "pre-commit compat shim failed (#881)"
-        # dispatches to prek: the version banner is prek's
-        assert "prek" in result.stdout.lower(), (
-            f"shim did not dispatch to prek: {result.stdout}"
-        )
-        # deprecation notice on stderr (not stdout, so pipelines stay clean)
-        assert "deprecated" in result.stderr.lower(), (
-            f"shim did not print the deprecation notice: {result.stderr}"
-        )
-        assert "prek" in result.stderr.lower(), "deprecation notice must point at prek"
-        assert "deprecated" not in result.stdout.lower(), (
-            "deprecation notice leaked to stdout"
+        # The Python pre-commit is intentionally dropped from the image (#778);
+        # the one-cycle #881 compat shim ended with 0.5 (#897).
+        assert host.run("command -v pre-commit").rc != 0, (
+            "pre-commit should be absent from the image (prek supersedes it, #778)"
         )
 
     def test_ruff_installed(self, host):


### PR DESCRIPTION
## Description

Removes the one-release-cycle `pre-commit -> prek` compat shim from the image, ending the deprecation window opened by #881. The 0.4.1 release (with the shim) is frozen on `release/0.4.1`; `dev` is the 0.5 line, so the scheduled removal lands here.

## Type of Change

- [ ] `feat` -- New feature
- [ ] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [x] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [ ] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- **flake.nix**: dropped the `writeShellScriptBin "pre-commit"` block (marked `DEPRECATED — remove in 0.5 (#881)`) from `imageTools` — the exact inverse of the #881 diff; nothing else in the flake touched.
- **tests/test_image.py**: removed `test_pre_commit_compat_shim`; restored the #778 absence assertion that #881 displaced in `test_pre_commit_installed` (`command -v pre-commit` must fail in the image).
- **docs/MIGRATION.md**: upgrade step 3 now states 0.5 images carry no `pre-commit` binary (exit 127); the rename checklist and the #881 upgrade-time scan guidance stay. `assets/init-workspace.sh` untouched — its scan and "through 0.4.x only" wording remain accurate.
- **CHANGELOG.md** + `assets/workspace/.devcontainer/CHANGELOG.md` (sync-manifest mirror): `Removed` entry under `## Unreleased`.

## Changelog Entry

### Removed

- **`pre-commit` compat shim removed from the image** ([#897](https://github.com/vig-os/devcontainer/issues/897))
  - The one-release-cycle `pre-commit → prek` shim shipped in 0.4.x ([#881](https://github.com/vig-os/devcontainer/issues/881)) is gone; `pre-commit` invocations now fail with exit 127.
  - Consumers had the 0.4.x cycle to rename invocations; the upgrade-time scan still warns with `file:line` on preserved surfaces — see `docs/MIGRATION.md` for the rename checklist (justfile recipes, repo-owned `.githooks/`, CI configs → `prek`).

## Testing

- [x] Tests pass locally (`just test-image` scope relevant to the change)
- [x] Manual testing performed (describe below)

### Manual Testing Details

TDD RED/GREEN against locally built images (`just build`, ~46 s warm store each):

- **RED** (shim-bearing image at `origin/dev`): flipped `test_pre_commit_installed` fails — `command -v pre-commit` resolves to `/bin/pre-commit` (the shim).
- **GREEN** (shim-free rebuild): `tests/test_image.py::TestDevelopmentTools` + `::TestPythonEnvironment` — **27 passed** in 16.82 s.
- Full hook suite green: `just precommit` (`prek run --all-files`) — all hooks Passed, 0 Failed.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

Closes #897
