### PR TITLE
feat(flake): opt-in capability modules on mkProjectShell (native first)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,6 +213,15 @@ jobs:
           uv run pytest tests/test_flake_devshell.py \
             -k "exposes_python3_and_precommit or hook_runner_is_prek or no_nix_cxx_runtime_leak" -v
 
+      # Run the capability-module contract tests (#884): the `native` module
+      # shell exposes the C/C++ toolchain on its own PATH and exports generic
+      # CC/CXX, plus the C-extension sdist smoke. nix-fast-build above already
+      # builds `checks.*.module-native`, so `nix develop` is warm; the sdist
+      # smoke needs PyPI, which this lane already uses (setup-env runs
+      # `uv sync`), so it is included rather than deselected. Refs #884.
+      - name: Check capability-module contracts (native)
+        run: uv run pytest tests/test_flake_modules.py -v
+
       # Validate the scaffolded downstream stub (assets/workspace/flake.nix)
       # against THIS toolchain, not the published vigos, so a change to the flake
       # API (lib.mkProjectShell / overlays.default) can't silently break a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Opt-in capability modules for `mkProjectShell`** ([#884](https://github.com/vig-os/devcontainer/issues/884))
+  - `modules = [ "native" ]` composes curated capability modules (packages + env vars + shellHook fragments) onto the project dev-shell; contract recorded in `docs/rfcs/ADR-capability-modules.md`.
+  - Zero-module shells are byte-identical to the previous builder and the published image stays base-only; `extraPackages` remains the per-repo escape hatch and wins PATH lookup.
+  - `native` module ships first (`stdenv.cc`, `cmake`, `gnumake`, `pkg-config`, generic `CC`/`CXX`) — the long-term [#879](https://github.com/vig-os/devcontainer/issues/879) answer; `geant4`/`rust`/`fortran`/`root` stay ask-gated candidates.
+  - Per-module flake checks (`checks.<system>.module-<name>`) plus a uv C-extension sdist smoke test (`tests/test_flake_modules.py`).
+
 ### Changed
 
 ### Deprecated

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Opt-in capability modules for `mkProjectShell`** ([#884](https://github.com/vig-os/devcontainer/issues/884))
+  - `modules = [ "native" ]` composes curated capability modules (packages + env vars + shellHook fragments) onto the project dev-shell; contract recorded in `docs/rfcs/ADR-capability-modules.md`.
+  - Zero-module shells are byte-identical to the previous builder and the published image stays base-only; `extraPackages` remains the per-repo escape hatch and wins PATH lookup.
+  - `native` module ships first (`stdenv.cc`, `cmake`, `gnumake`, `pkg-config`, generic `CC`/`CXX`) — the long-term [#879](https://github.com/vig-os/devcontainer/issues/879) answer; `geant4`/`rust`/`fortran`/`root` stay ask-gated candidates.
+  - Per-module flake checks (`checks.<system>.module-<name>`) plus a uv C-extension sdist smoke test (`tests/test_flake_modules.py`).
+
 ### Changed
 
 ### Deprecated

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -109,27 +109,35 @@ tiered contract:
 1. **Pure-Python / wheel-only projects — nothing to do.** Pre-compiled
    manylinux wheels load out of the box (see above); the image works as-is.
 
-2. **Native deps, `direnv` mode (preferred).** Provide the toolchain via the
-   project flake:
+2. **Native deps, `direnv` mode (preferred).** Enable the curated `native`
+   capability module in the project flake
+   ([#884](https://github.com/vig-os/devcontainer/issues/884), contract in
+   [`docs/rfcs/ADR-capability-modules.md`](rfcs/ADR-capability-modules.md)):
 
    ```nix
    devShells.default = vigos.lib.mkProjectShell {
      inherit pkgs;
-     extraPackages = [
-       pkgs.stdenv.cc # C/C++ compiler wrapper: puts cc/c++ on PATH, exports CC/CXX
-       pkgs.cmake
-       pkgs.pkg-config
-     ];
+     modules = [ "native" ]; # stdenv.cc, cmake, gnumake, pkg-config + CC/CXX
    };
    ```
 
-   Inside `nix develop` / `direnv` the stdenv compiler wrapper exports working
-   `CC`/`CXX`, so build backends find a real compiler regardless of what the
-   image's baked interpreter recorded at image-build time (the sysconfig
-   mechanics are tracked in
+   The module is the shipped, tested equivalent of the hand-rolled
+   `extraPackages = [ pkgs.stdenv.cc pkgs.cmake pkgs.gnumake pkgs.pkg-config ]`
+   list (which still works and still wins PATH lookup over module packages if
+   you need to override a tool). Inside `nix develop` / `direnv` the shell
+   puts `cc`/`c++` on PATH and exports generic `CC`/`CXX`, so build backends
+   find a real compiler regardless of what the image's baked interpreter
+   recorded at image-build time (the image's sysconfig records are sanitized
+   to the same generic names —
    [#879](https://github.com/vig-os/devcontainer/issues/879)). This path is
    field-validated by the 0.4.0 downstream runs
    ([#639](https://github.com/vig-os/devcontainer/issues/639)).
+
+   Capability modules are a **dev-shell / direnv-mode feature only**: enabling
+   one changes nothing about the published image, which stays base-only.
+   `native` is the only module shipped today; `geant4`, `rust`,
+   `fortran`/`f2py`, and `root` are named candidates gated on a concrete
+   consumer ask.
 
 3. **Native deps, `devcontainer` mode (middle path).** No direnv migration
    required: the baked Nix has flakes enabled, so run the sync *through* a Nix
@@ -160,10 +168,8 @@ project flake provides all of it, pinned:
 ```nix
 devShells.default = vigos.lib.mkProjectShell {
   inherit pkgs;
+  modules = [ "native" ]; # compiler + generic build tools
   extraPackages = [
-    pkgs.stdenv.cc
-    pkgs.cmake
-    pkgs.pkg-config
     pkgs.geant4 # headers + libs + Geant4 CMake config
     pkgs.root # ROOT, likewise
   ];

--- a/docs/NIX.md
+++ b/docs/NIX.md
@@ -20,9 +20,12 @@ everywhere — the dev-shell now and the image's `imageTools` set.
   `nix develop` (or `direnv`) gives you exactly that toolchain.
 - **`mkProjectShell`** is also a reusable `lib` output: downstream repos build
   their own shell as `devTools ++ extraPackages` (see the scaffolded
-  `assets/workspace/flake.nix`). For projects that compile native Python
-  extensions, `extraPackages` is where the C/C++ toolchain comes from — see
-  the [native-build contract](./MIGRATION.md#the-native-build-contract).
+  `assets/workspace/flake.nix`), optionally composing opt-in
+  [capability modules](#capability-modules-mkprojectshell-modules) via
+  `modules = [ "native" ]`. For projects that compile native Python
+  extensions, the `native` module (or a hand-rolled `extraPackages`) is where
+  the C/C++ toolchain comes from — see the
+  [native-build contract](./MIGRATION.md#the-native-build-contract).
 - **`mkProjectServices`** is the local-dev-services counterpart (#795): a `lib`
   builder that turns declared [services-flake](https://github.com/juspay/services-flake)
   modules into a daemonless `process-compose` stack (`nix run .#services`) —
@@ -58,6 +61,9 @@ access is unavailable, so the dev-shell/image parity test stays a CI pytest):
   signatures whose intentionally-unused args those linters would otherwise flag.
 - **`devShell`** — the dev-shell closure builds.
 - **`devShellTools`** — the parity-test SSoT evaluates to a non-empty list.
+- **`module-<name>`** — one devshell build per shipped capability module,
+  generated from the `nix/modules/` registry (a module cannot ship without
+  its check).
 
 ### Dev-shell ↔ image parity guard
 
@@ -68,6 +74,38 @@ straight from the flake (`nix eval .#devShellTools`, derived from each package's
 asserting it exits 0. The test list is generated *from* the SSoT, so it can never
 drift from the tool list it guards. It is skipped automatically when `nix` is not
 on `PATH` (e.g. the podman image CI lane).
+
+## Capability modules (`mkProjectShell` `modules`)
+
+`mkProjectShell` composes opt-in **capability modules**
+([#884](https://github.com/vig-os/devcontainer/issues/884); contract and
+composition rules in
+[ADR-capability-modules](rfcs/ADR-capability-modules.md)): a consumer
+declares a capability by name instead of hand-picking packages:
+
+```nix
+devShells.default = vigos.lib.mkProjectShell {
+  inherit pkgs;
+  modules = [ "native" ]; # opt-in capability modules
+  extraPackages = [ pkgs.my-extra ]; # per-repo escape hatch, unchanged
+};
+```
+
+- A module (defined in `nix/modules/`) contributes **packages, env vars, and
+  shellHook fragments only** (v1 contract). `extraPackages` wins PATH lookup
+  over module packages; the consumer `shellHook` runs last.
+- **Zero cost when unused:** `modules = [ ]` (the default) produces a shell
+  byte-identical to the pre-module builder — pure-Python consumers are
+  untouched, and the **published image stays base-only** (modules are a
+  direnv-mode/devshell feature).
+- **Shipped:** `native` — `stdenv.cc`, `cmake`, `gnumake`, `pkg-config` plus
+  generic `CC=cc`/`CXX=c++` exports; the curated form of the
+  [native-build contract](./MIGRATION.md#the-native-build-contract)'s
+  preferred tier. **Candidates (ask-gated, not shipped):** `geant4`, `rust`,
+  `fortran`/`f2py`, `root`.
+- Each shipped module gets a `checks.<system>.module-<name>` devshell build
+  and, for `native`, the uv C-extension sdist smoke test in
+  `tests/test_flake_modules.py`.
 
 ## Home-manager modules — versioning & release policy
 

--- a/docs/rfcs/ADR-capability-modules.md
+++ b/docs/rfcs/ADR-capability-modules.md
@@ -1,0 +1,116 @@
+---
+rfc: ADR-capability-modules
+date: 2026-07-07
+title: Opt-in capability modules on mkProjectShell
+status: accepted
+authors:
+  - Carlos Vigo (c-vigo)
+---
+
+# Design note: capability modules for `mkProjectShell`
+
+**Decision (TL;DR):** `mkProjectShell` gains an opt-in
+`modules = [ "<name>" … ]` string list. A module is a curated, tested,
+Renovate-tracked contribution of **packages, environment variables, and
+shellHook fragments — nothing else in v1** — defined once in `nix/modules/` and
+composed onto the existing plain-`mkShell` builder. The zero-module path is
+**byte-identical** to today's dev-shell (same derivation hash), the published
+image stays base-only, and `native` is the only module that ships now; further
+modules are gated on a concrete consumer ask. This is the modular layer
+[ADR-nix-devenv-strategy](ADR-nix-devenv-strategy.md) anticipated — it reopens
+none of that ADR's builder decisions (plain `pkgs.mkShell`, no
+`cachix/devenv` / `numtide/devshell`, services via process-compose).
+
+## Problem
+
+0.4.0 downstream validation (#639/#879/#882) settled *where* native toolchains
+come from — the project flake, direnv-mode — but every consumer hand-rolls the
+same `extraPackages` content. There is no curated, tested definition of a
+capability, and "no C++ in my pure-Python repo" is guaranteed only by omission.
+
+## v1 module contract
+
+A module is a function `pkgs -> contribution`, where the contribution is an
+attrset with exactly these (all optional) fields:
+
+| Field | Type | Composed how |
+|-------|------|--------------|
+| `packages` | list of derivations | appended to the shell's `packages`, **after** `extraPackages` |
+| `env` | attrset of strings | merged into the `mkShell` attrset; the builder's own env pins win |
+| `shellHook` | string | concatenated (newline-terminated) **before** the consumer `shellHook` |
+
+Explicitly **not** in v1:
+
+- **Hooks contribution** (e.g. `native` adding `clang-format` to the #883
+  consumer hook set) — open design question, recorded here for #883's wave;
+  the seam keeps the `mkProjectShell` diff region small so #883's `hooks`
+  argument lands beside `modules` without conflict.
+- **Per-module option attrsets** (e.g. Geant4 dataset selection) — see
+  migration path below.
+
+## Composition rules
+
+- **Consumer surface:** `modules = [ "native" ]` — names, not attrsets.
+  Unknown names `throw` at eval time listing the available modules.
+- **Order & precedence:**
+  - `packages = devTools ++ [ python ] ++ extraPackages ++ modulePackages` —
+    earlier entries win PATH lookup, so `extraPackages` (the per-repo escape
+    hatch, unchanged) overrides a module, and the toolchain SSoT overrides
+    both. Module order in the list is the tiebreak among modules.
+  - `env`: modules merge left-to-right (later module wins); the builder's
+    reserved variables (`UV_PYTHON`, `UV_PYTHON_DOWNLOADS`,
+    `UV_PYTHON_DOWNLOADS_JSON_URL`, `BATS_LIB_PATH`) always win — a module
+    cannot break the Python bootstrap.
+  - `shellHook`: builder hooks (LD_LIBRARY_PATH guard, nvim isolation), then
+    module hooks in list order, then the consumer `shellHook` — the consumer
+    keeps the last word.
+- **Zero-module invariant:** `modules = [ ]` (the default) contributes an
+  empty list, an empty attrset, and an empty string — the resulting
+  derivation is byte-identical to the pre-#884 shell, asserted by comparing
+  `devShells.<system>.default.drvPath` and by the unchanged parity suite
+  (`tests/test_flake_devshell.py`). The image continues to bake `devTools`
+  only; modules are a direnv-mode/devshell feature.
+
+## Shipped and candidate modules
+
+- **`native` (ships now):** `stdenv.cc`, `cmake`, `gnumake`, `pkg-config`,
+  plus `CC=cc` / `CXX=c++` exports. The generic sdist-building capability and
+  #879's long-term answer: the image-side sysconfig sanitize (0.4.1) makes
+  build backends do PATH discovery with generic names; this module provides
+  the PATH (demonstrated need: hyrr/pycatima, #639).
+- **Ask-gated candidates (named, not shipped — YAGNI):** `geant4`
+  (fast-follow once an EXOMA/EXOPET repo asks), `rust`, `fortran`/`f2py`,
+  `root`. Each ships with its own devshell smoke check (e.g. `geant4-config`
+  resolves) the release it lands.
+
+## Migration path to per-module options
+
+When a module needs configuration (e.g. Geant4 datasets), `modules` also
+accepts an attrset entry `{ name = "geant4"; datasets = [ … ]; }` alongside
+plain strings — additive, no break for the string form. Not built until the
+first module needs it.
+
+## Testing
+
+- Per-module flake check `checks.<system>.module-<name>` (generated from the
+  module registry, so a new module cannot ship without its check) builds the
+  module's devshell on every default system, including both Linux systems.
+- `tests/test_flake_modules.py` smoke-tests the `native` module end-to-end: a
+  trivial setuptools C-extension fixture builds as an sdist and installs
+  (compiles) with `uv` inside the module devshell.
+
+## Coordination
+
+- **#885 (`DEVKIT_MODULES` in `.vig-os`):** the scaffold-level declaration
+  maps onto this flake-level contract — one name list, two layers; this issue
+  is the foundation, #885 the plumbing.
+- **#883 (consumer hooks):** lands `hooks` as a sibling argument; module
+  hooks-contribution is the recorded open question above.
+
+## References
+
+`flake.nix` (`mkProjectShell`, `nix/modules/`),
+[MIGRATION.md — native-build contract](../MIGRATION.md#the-native-build-contract),
+[docs/NIX.md](../NIX.md), issues #884 (this), #882, #879, #854, #639, #883,
+#885; sibling ADRs [ADR-nix-devenv-strategy](ADR-nix-devenv-strategy.md),
+[ADR-home-environment-modules](ADR-home-environment-modules.md).

--- a/flake.nix
+++ b/flake.nix
@@ -176,6 +176,12 @@
       # ---------------------------------------------------------------------
       devTools = import ./nix/devtools.nix;
 
+      # Capability-module registry (#884): name -> (pkgs -> { packages, env,
+      # shellHook }). Consumed by mkProjectShell's `modules` argument and by
+      # the generated per-module `checks.<system>.module-<name>` below. See
+      # docs/rfcs/ADR-capability-modules.md for the v1 contract.
+      capabilityModules = import ./nix/modules/default.nix;
+
       # Binary names exposed for the parity test. Prefer the package's declared
       # `meta.mainProgram` (the canonical executable name, e.g. ripgrep -> rg,
       # neovim -> nvim, claude-code -> claude); fall back to the pname.
@@ -192,15 +198,50 @@
       # extra packages:
       #   devShells.default = inputs.devcontainer.lib.mkProjectShell {
       #     inherit pkgs;
+      #     modules = [ "native" ];           # opt-in capability modules (#884)
       #     extraPackages = [ pkgs.foo ];
       #   };
       mkProjectShell =
         {
           pkgs,
+          modules ? [ ],
           extraPackages ? [ ],
           shellHook ? ''echo "devcontainer dev environment loaded (nix)"'',
         }:
         let
+          # ------------------------------------------------------------------
+          # Capability modules (#884) — resolve the requested names against the
+          # nix/modules/ registry and fold their contributions (v1 contract:
+          # packages + env + shellHook fragments only; composition rules in
+          # docs/rfcs/ADR-capability-modules.md). With `modules = [ ]` every
+          # merge below is the identity — empty list, empty attrset, empty
+          # string — so the zero-module shell stays byte-identical to the
+          # pre-#884 builder (parity: tests/test_flake_devshell.py). Kept as
+          # one self-contained block so #883's `hooks` argument can land
+          # beside it without conflict.
+          # ------------------------------------------------------------------
+          moduleDefs = map (
+            name:
+            (capabilityModules.${name} or (throw (
+              "mkProjectShell: unknown capability module '${name}'; available: "
+              + pkgs.lib.concatStringsSep ", " (builtins.attrNames capabilityModules)
+            ))
+            )
+              pkgs
+          ) modules;
+          # Appended AFTER extraPackages: earlier entries win PATH lookup, so
+          # the per-repo escape hatch overrides a module's tool choice.
+          modulePackages = pkgs.lib.concatMap (m: m.packages or [ ]) moduleDefs;
+          # Left-to-right merge (later module wins); the builder's own env
+          # pins (UV_PYTHON, UV_PYTHON_DOWNLOADS, …) always win — see the
+          # mkShell attrset merge below.
+          moduleEnv = pkgs.lib.foldl' (acc: m: acc // (m.env or { })) { } moduleDefs;
+          # Newline-terminated fragments, before the consumer shellHook (the
+          # consumer keeps the last word).
+          moduleShellHook = pkgs.lib.concatMapStrings (
+            m: pkgs.lib.optionalString ((m.shellHook or "") != "") ((m.shellHook or "") + "\n")
+          ) moduleDefs;
+
           # uv's Python-download metadata, pinned to the uv release we provision.
           # The nixpkgs build of uv ships with its embedded Python-download list
           # stripped, so it cannot fetch a managed CPython on its own. CI
@@ -264,42 +305,49 @@
             export NVIM_APPNAME="vigos-dev"
           '';
         in
-        pkgs.mkShell {
-          # The toolchain SSoT, plus a bare Python interpreter so the downstream
-          # dev-shell matches the image's PATH (`python`/`python3`). The bare
-          # interpreter is not in `devTools`: the image already provides it via
-          # `pythonEnv` in `imageTools`, and a bare interpreter in the SSoT would
-          # collide with `pythonEnv` there. The hook runner (`prek`) lives in
-          # `devTools`, so it reaches both the dev-shell and the image from one
-          # place — the former standalone `pre-commit` here is dropped (#778).
-          # Safe for CI despite the FHS pymarkdown/manylinux constraint: the
-          # dev-shell pins `UV_PYTHON` (below) to this same store CPython, and
-          # the CI PATH-forwarding (setup-env) filters this interpreter out so
-          # `uv` still builds the runner venv from a downloaded managed CPython.
-          # No new LD_LIBRARY_PATH, so the #703 FHS leak-guard is unaffected.
-          # Refs #729, #778.
-          packages =
-            (devTools pkgs)
-            ++ [
-              python
-            ]
-            ++ extraPackages;
-          shellHook = ldLibraryPathHook + "\n" + nvimIsolationHook + "\n" + shellHook;
+        pkgs.mkShell (
+          # Module env first: the builder's attrset below wins any collision,
+          # so a capability module can never break the Python bootstrap pins
+          # (UV_PYTHON, UV_PYTHON_DOWNLOADS, …). Refs #884.
+          moduleEnv
+          // {
+            # The toolchain SSoT, plus a bare Python interpreter so the downstream
+            # dev-shell matches the image's PATH (`python`/`python3`). The bare
+            # interpreter is not in `devTools`: the image already provides it via
+            # `pythonEnv` in `imageTools`, and a bare interpreter in the SSoT would
+            # collide with `pythonEnv` there. The hook runner (`prek`) lives in
+            # `devTools`, so it reaches both the dev-shell and the image from one
+            # place — the former standalone `pre-commit` here is dropped (#778).
+            # Safe for CI despite the FHS pymarkdown/manylinux constraint: the
+            # dev-shell pins `UV_PYTHON` (below) to this same store CPython, and
+            # the CI PATH-forwarding (setup-env) filters this interpreter out so
+            # `uv` still builds the runner venv from a downloaded managed CPython.
+            # No new LD_LIBRARY_PATH, so the #703 FHS leak-guard is unaffected.
+            # Refs #729, #778.
+            packages =
+              (devTools pkgs)
+              ++ [
+                python
+              ]
+              ++ extraPackages
+              ++ modulePackages;
+            shellHook = ldLibraryPathHook + "\n" + nvimIsolationHook + "\n" + moduleShellHook + shellHook;
 
-          UV_PYTHON = "${python}/bin/python3.14";
-          UV_PYTHON_DOWNLOADS = "never";
+            UV_PYTHON = "${python}/bin/python3.14";
+            UV_PYTHON_DOWNLOADS = "never";
 
-          # Resolve the bats helper libraries from the Nix store. The wrapper
-          # also sets this when `bats` runs, but exporting it in the dev-shell
-          # makes the path visible (and works for a bare `bats` too). Refs #695.
-          BATS_LIB_PATH = "${batsWithLibs pkgs}/share/bats";
+            # Resolve the bats helper libraries from the Nix store. The wrapper
+            # also sets this when `bats` runs, but exporting it in the dev-shell
+            # makes the path visible (and works for a bare `bats` too). Refs #695.
+            BATS_LIB_PATH = "${batsWithLibs pkgs}/share/bats";
 
-          # For CI only: the pin above means downloads never happen in the
-          # dev-shell, but CI forwards this URL (NOT UV_PYTHON) so its FHS runner
-          # downloads a managed CPython for pre-commit's manylinux-wheel hooks,
-          # which a Nix-store interpreter cannot load there. Refs #632, #683.
-          UV_PYTHON_DOWNLOADS_JSON_URL = uvPythonDownloadsJsonUrl;
-        };
+            # For CI only: the pin above means downloads never happen in the
+            # dev-shell, but CI forwards this URL (NOT UV_PYTHON) so its FHS runner
+            # downloads a managed CPython for pre-commit's manylinux-wheel hooks,
+            # which a Nix-store interpreter cannot load there. Refs #632, #683.
+            UV_PYTHON_DOWNLOADS_JSON_URL = uvPythonDownloadsJsonUrl;
+          }
+        );
 
       # ---------------------------------------------------------------------
       # mkProjectServices — reusable local dev-services builder (#795).
@@ -717,6 +765,19 @@
             touch "$out"
           '';
         }
+        # One devshell build per capability module (#884), generated from the
+        # nix/modules/ registry so a module cannot ship without its check —
+        # `module-<name>` evaluates and builds on every default system
+        # (x86_64-linux in Tier-0 CI; the others via `--all-systems` eval).
+        # tests/test_flake_modules.py reuses these as its `nix develop` entry
+        # points for the deeper smoke tests (toolchain on PATH, uv sdist build).
+        // pkgs.lib.mapAttrs' (
+          name: _:
+          pkgs.lib.nameValuePair "module-${name}" (mkProjectShell {
+            inherit pkgs;
+            modules = [ name ];
+          })
+        ) capabilityModules
         # The ci homeConfigurations build as Tier-0 checks. x86_64-darwin is
         # the eval-only best-effort tier (ADR platform table): it exists as a
         # homeConfiguration but gets no build leg. Refs #819.

--- a/nix/modules/default.nix
+++ b/nix/modules/default.nix
@@ -1,0 +1,14 @@
+# Capability-module registry (#884, docs/rfcs/ADR-capability-modules.md).
+#
+# Maps a module name (the string consumers pass in mkProjectShell's
+# `modules = [ "<name>" … ]`) to its definition: a function
+# `pkgs -> { packages, env, shellHook }` (all fields optional — the v1
+# contract). mkProjectShell resolves names against this attrset and the
+# flake generates a per-system `checks.<system>.module-<name>` devshell
+# build for every entry, so a module cannot ship without its check.
+#
+# Candidate modules — geant4, rust, fortran/f2py, root — are deliberately
+# NOT defined until a concrete consumer asks (YAGNI; see the ADR).
+{
+  native = import ./native.nix;
+}

--- a/nix/modules/native.nix
+++ b/nix/modules/native.nix
@@ -1,0 +1,31 @@
+# `native` capability module (#884): the generic native-build (sdist)
+# capability — compiler + the build tools PEP 517 backends actually invoke
+# (scikit-build-core, setuptools, meson-python). The long-term consumer
+# answer to #879: the image-side sysconfig sanitize (0.4.1, #893) makes
+# build backends fall back to PATH discovery with generic cc/c++ names,
+# and this module provides that PATH. Field-validated need: hyrr/pycatima
+# (#639). Third-party libraries (Geant4, ROOT, OCCT, …) stay per-project
+# `extraPackages` — or a future ask-gated module.
+pkgs: {
+  packages = with pkgs; [
+    # C/C++ compiler wrapper: puts cc/c++ (and gcc/g++) on PATH and links
+    # against the same Nix C++ runtime the toolchain SSoT already exposes.
+    stdenv.cc
+    cmake
+    gnumake
+    pkg-config
+  ];
+
+  # Generic POSIX names, not store paths: build backends that consult the
+  # environment resolve them via the PATH above, matching the sanitized
+  # image sysconfig (#879/#893) and staying honest when a consumer swaps
+  # the compiler via extraPackages (which wins PATH lookup — see the ADR
+  # composition rules). Exported as a shellHook fragment, NOT as `env`:
+  # stdenv.cc's own setup hook exports CC=gcc/CXX=g++ while `nix develop`
+  # computes the shell environment, which would clobber a static env attr;
+  # the shellHook runs after every setup hook, so the generic names win.
+  shellHook = ''
+    export CC=cc
+    export CXX=c++
+  '';
+}

--- a/tests/fixtures/native_ext/native_ext.c
+++ b/tests/fixtures/native_ext/native_ext.c
@@ -1,0 +1,33 @@
+/* Trivial C extension for the native capability-module smoke test (#884). */
+#include <Python.h>
+
+static PyObject *
+answer(PyObject *self, PyObject *args)
+{
+    (void) self;
+    (void) args;
+    return PyLong_FromLong(42);
+}
+
+static PyMethodDef methods[] = {
+    { "answer", answer, METH_NOARGS, "Return 42." },
+    { NULL, NULL, 0, NULL },
+};
+
+static struct PyModuleDef module = {
+    PyModuleDef_HEAD_INIT,
+    "native_ext",
+    NULL,
+    -1,
+    methods,
+    NULL,
+    NULL,
+    NULL,
+    NULL,
+};
+
+PyMODINIT_FUNC
+PyInit_native_ext(void)
+{
+    return PyModule_Create(&module);
+}

--- a/tests/fixtures/native_ext/pyproject.toml
+++ b/tests/fixtures/native_ext/pyproject.toml
@@ -1,0 +1,12 @@
+# Trivial C-extension fixture for the `native` capability-module smoke test
+# (tests/test_flake_modules.py). Built as an sdist and compiled by uv inside
+# the module devshell — the pycatima-class scenario from #639/#879. Refs #884.
+[build-system]
+requires = [ "setuptools>=77" ]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "native-ext"
+version = "0.1.0"
+description = "Trivial C extension exercising the native capability module"
+requires-python = ">=3.12"

--- a/tests/fixtures/native_ext/pyproject.toml
+++ b/tests/fixtures/native_ext/pyproject.toml
@@ -2,7 +2,7 @@
 # (tests/test_flake_modules.py). Built as an sdist and compiled by uv inside
 # the module devshell — the pycatima-class scenario from #639/#879. Refs #884.
 [build-system]
-requires = [ "setuptools>=77" ]
+requires = ["setuptools>=77"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/tests/fixtures/native_ext/setup.py
+++ b/tests/fixtures/native_ext/setup.py
@@ -1,0 +1,5 @@
+"""C-extension build script for the native capability-module fixture (#884)."""
+
+from setuptools import Extension, setup
+
+setup(ext_modules=[Extension("native_ext", sources=["native_ext.c"])])

--- a/tests/test_flake_modules.py
+++ b/tests/test_flake_modules.py
@@ -131,9 +131,7 @@ def test_native_module_exports_generic_cc_cxx(current_system: str) -> None:
     # The default shellHook banner writes to stdout, so only the last line is
     # the probe's answer.
     got = proc.stdout.splitlines()[-1] if proc.stdout else ""
-    assert got == "cc:c++", (
-        f"native module must export CC=cc and CXX=c++; got {got!r}"
-    )
+    assert got == "cc:c++", f"native module must export CC=cc and CXX=c++; got {got!r}"
 
 
 def test_native_module_builds_c_extension_sdist_with_uv(
@@ -158,7 +156,7 @@ def test_native_module_builds_c_extension_sdist_with_uv(
         "uv venv .venv\n"
         "uv pip install --python .venv/bin/python dist/native_ext-0.1.0.tar.gz\n"
         '.venv/bin/python -c "import native_ext; '
-        'assert native_ext.answer() == 42; print(\'sdist-ok\')"\n'
+        "assert native_ext.answer() == 42; print('sdist-ok')\"\n"
     )
     proc = _develop_native(current_system, script, pure=False)
     assert proc.returncode == 0 and "sdist-ok" in proc.stdout, (

--- a/tests/test_flake_modules.py
+++ b/tests/test_flake_modules.py
@@ -1,0 +1,164 @@
+"""Capability-module devshell tests (issue #884).
+
+``mkProjectShell`` accepts an opt-in ``modules = [ "<name>" … ]`` string list
+(see ``docs/rfcs/ADR-capability-modules.md``). Each shipped module is exposed
+as a per-system flake check ``checks.<system>.module-<name>`` (generated from
+the ``nix/modules/`` registry), which doubles as the entry point here: these
+tests ``nix develop`` the ``native`` module's shell and assert its contract —
+the C/C++ toolchain is on the shell's own PATH, generic ``CC``/``CXX`` are
+exported, and a trivial setuptools C-extension sdist builds and installs with
+``uv`` (the pycatima-class scenario from #639/#879 that motivated the module).
+
+The zero-module parity guarantee (the default dev-shell is byte-identical to
+the pre-module builder) is covered by ``tests/test_flake_devshell.py`` staying
+green unchanged, not here.
+
+The suite is skipped automatically when ``nix`` is not on PATH (mirroring the
+other flake test modules) so it never breaks unrelated lanes.
+
+Refs: #884
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+# Repository root (two levels up: tests/ -> repo root).
+REPO_ROOT = Path(__file__).resolve().parent.parent
+FIXTURE = REPO_ROOT / "tests" / "fixtures" / "native_ext"
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("nix") is None,
+    reason="nix is not installed; capability-module tests require Nix",
+)
+
+
+def _nix_env() -> dict[str, str]:
+    """Environment for nix invocations with flakes enabled and the public cache."""
+    env = os.environ.copy()
+    env.setdefault(
+        "NIX_CONFIG",
+        "experimental-features = nix-command flakes\n"
+        "extra-substituters = https://vig-os.cachix.org\n"
+        "extra-trusted-public-keys = "
+        "vig-os.cachix.org-1:yoOYRi3bvnM6ThxO0joLt7vtzhTfkq3r6jykeUMg7Bk=",
+    )
+    return env
+
+
+@pytest.fixture(scope="session")
+def current_system() -> str:
+    """The Nix system double for the host (e.g. x86_64-linux)."""
+    result = subprocess.run(
+        ["nix", "eval", "--raw", "--impure", "--expr", "builtins.currentSystem"],
+        capture_output=True,
+        text=True,
+        env=_nix_env(),
+        timeout=120,
+    )
+    if result.returncode != 0:
+        pytest.fail("Failed to resolve builtins.currentSystem:\n" + result.stderr)
+    return result.stdout.strip()
+
+
+def _develop_native(
+    current_system: str, script: str, *, pure: bool = True, timeout: int = 1800
+) -> subprocess.CompletedProcess[str]:
+    """Run a bash script inside the ``native`` module's devshell.
+
+    With ``pure=True`` (default) it uses ``--ignore-environment`` (keeping only
+    HOME) so assertions exercise the shell's *own* PATH/env contribution and
+    cannot be satisfied by a host toolchain leaking through the inherited
+    environment — the same guard ``test_devshell_exposes_python3_and_precommit``
+    uses (#729). ``pure=False`` keeps the ambient environment for steps that
+    need the host's network/TLS configuration (e.g. uv fetching a build
+    backend from PyPI).
+    """
+    isolation = ["--ignore-environment", "--keep", "HOME"] if pure else []
+    return subprocess.run(
+        [
+            "nix",
+            "develop",
+            *isolation,
+            f"{REPO_ROOT}#checks.{current_system}.module-native",
+            "-c",
+            "bash",
+            "-c",
+            script,
+        ],
+        capture_output=True,
+        text=True,
+        env=_nix_env(),
+        timeout=timeout,
+    )
+
+
+def test_native_module_provides_build_toolchain(current_system: str) -> None:
+    """The ``native`` module puts the sdist-building toolchain on PATH (#884).
+
+    ``stdenv.cc`` (cc/c++), ``cmake``, ``gnumake`` and ``pkg-config`` are the
+    curated definition of the generic native-build capability — what
+    scikit-build-core / setuptools / meson-python sdist builds actually invoke.
+    """
+    proc = _develop_native(
+        current_system,
+        "for bin in cc c++ cmake make pkg-config; do command -v $bin; done",
+    )
+    assert proc.returncode == 0, (
+        "native-module devshell is missing toolchain binaries: "
+        f"rc={proc.returncode} stdout={proc.stdout.strip()!r} "
+        f"stderr={proc.stderr.strip()[:300]}"
+    )
+
+
+def test_native_module_exports_generic_cc_cxx(current_system: str) -> None:
+    """The ``native`` module exports ``CC=cc`` / ``CXX=c++`` (#884).
+
+    Generic POSIX names, not store paths: build backends that consult the
+    environment resolve them via the module-provided PATH, matching the
+    image-side sysconfig sanitize (#879/#893) which rewrote the baked
+    interpreter's compiler records to the same generic names.
+    """
+    proc = _develop_native(current_system, 'printf "%s:%s" "$CC" "$CXX"')
+    assert proc.returncode == 0, (
+        f"failed to read CC/CXX from the native-module devshell: {proc.stderr[:300]}"
+    )
+    assert proc.stdout.strip() == "cc:c++", (
+        f"native module must export CC=cc and CXX=c++; got {proc.stdout.strip()!r}"
+    )
+
+
+def test_native_module_builds_c_extension_sdist_with_uv(
+    current_system: str, tmp_path: Path
+) -> None:
+    """A trivial C-extension sdist builds and installs with uv in the shell (#884).
+
+    End-to-end acceptance for the module: package the fixture as an sdist
+    (``uv build --sdist``), then compile-install it into a fresh venv
+    (``uv pip install <sdist>``) and import it — exactly the path ``uv sync``
+    takes for a dependency with no ``cp314`` wheel (pycatima-class, #639/#879).
+    The devshell pins ``UV_PYTHON`` to the store CPython and forbids managed
+    downloads, so the compile runs against the same interpreter the consumer
+    contract prescribes.
+    """
+    project = tmp_path / "native-ext"
+    shutil.copytree(FIXTURE, project)
+    script = (
+        "set -euo pipefail\n"
+        f"cd {project}\n"
+        "uv build --sdist --out-dir dist\n"
+        "uv venv .venv\n"
+        "uv pip install --python .venv/bin/python dist/native_ext-0.1.0.tar.gz\n"
+        '.venv/bin/python -c "import native_ext; '
+        'assert native_ext.answer() == 42; print(\'sdist-ok\')"\n'
+    )
+    proc = _develop_native(current_system, script, pure=False)
+    assert proc.returncode == 0 and "sdist-ok" in proc.stdout, (
+        "uv sdist build/install failed inside the native-module devshell: "
+        f"rc={proc.returncode}\nstdout:\n{proc.stdout}\nstderr:\n{proc.stderr[-2000:]}"
+    )

--- a/tests/test_flake_modules.py
+++ b/tests/test_flake_modules.py
@@ -124,12 +124,15 @@ def test_native_module_exports_generic_cc_cxx(current_system: str) -> None:
     image-side sysconfig sanitize (#879/#893) which rewrote the baked
     interpreter's compiler records to the same generic names.
     """
-    proc = _develop_native(current_system, 'printf "%s:%s" "$CC" "$CXX"')
+    proc = _develop_native(current_system, 'printf "\\n%s:%s" "$CC" "$CXX"')
     assert proc.returncode == 0, (
         f"failed to read CC/CXX from the native-module devshell: {proc.stderr[:300]}"
     )
-    assert proc.stdout.strip() == "cc:c++", (
-        f"native module must export CC=cc and CXX=c++; got {proc.stdout.strip()!r}"
+    # The default shellHook banner writes to stdout, so only the last line is
+    # the probe's answer.
+    got = proc.stdout.splitlines()[-1] if proc.stdout else ""
+    assert got == "cc:c++", (
+        f"native module must export CC=cc and CXX=c++; got {got!r}"
     )
 
 


### PR DESCRIPTION
## Description

Implements the modular capability layer on top of `mkProjectShell` (#884): consumers declare capabilities (`modules = [ "native" ]`) instead of hand-picking packages. Ships the v1 contract design note, the composition seam, the `native` module, per-module flake checks, a uv C-extension sdist smoke test, and consumer docs. Builder-level decisions from ADR-nix-devenv-strategy are not reopened (plain `mkShell` stays; no devenv/devshell frameworks).

Closes #884

## Type of Change

- [x] `feat` -- New feature

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- **Design note** `docs/rfcs/ADR-capability-modules.md`: v1 module contract = packages + env vars + shellHook fragments only; composition/precedence rules with `extraPackages`/`shellHook`; zero-module byte-identical invariant; migration path to per-module option attrsets; hooks-contribution recorded as an open question for #883; `DEVKIT_MODULES` (#885) cross-referenced as the scaffold-level mapping.
- **Composition seam** in `mkProjectShell` (flake.nix): new `modules ? [ ]` argument resolves names against the new `nix/modules/` registry and folds contributions — `packages` appended after `extraPackages` (escape hatch wins PATH lookup), `env` merged under the builder's own pins (a module can never break the UV_PYTHON bootstrap), shellHook fragments before the consumer hook. One self-contained diff region, merge-friendly for #883's `hooks` argument. Unknown names throw with the available list.
- **`native` module** (`nix/modules/native.nix`): `stdenv.cc`, `cmake`, `gnumake`, `pkg-config` + generic `CC=cc`/`CXX=c++` exports (via shellHook fragment — stdenv.cc's setup hook would clobber static env attrs). The long-term #879 answer: the 0.4.1 image sysconfig sanitize makes build backends do PATH discovery; this module provides the PATH. `geant4`/`rust`/`fortran`/`root` stay ask-gated candidates (named in docs, not shipped — YAGNI).
- **Checks**: generated `checks.<system>.module-<name>` devshell build per registry entry (a module cannot ship without its check); evaluates on all default systems incl. x86_64-linux and aarch64-linux.
- **Tests**: `tests/test_flake_modules.py` — toolchain-on-PATH (env-isolated), generic CC/CXX, and an end-to-end uv sdist build+install of a trivial setuptools C-extension fixture (`tests/fixtures/native_ext/`) inside the module devshell.
- **Docs**: MIGRATION.md native-build contract tier 2 now leads with the `modules = [ "native" ]` one-liner (hand-rolled `extraPackages` stays as the equivalent/escape hatch); worked Geant4/ROOT example updated; NIX.md gains a capability-modules section; explicit statement everywhere that the published image stays base-only.

## Changelog Entry

### Added

- **Opt-in capability modules for `mkProjectShell`** ([#884](https://github.com/vig-os/devcontainer/issues/884))
  - `modules = [ "native" ]` composes curated capability modules (packages + env vars + shellHook fragments) onto the project dev-shell; contract recorded in `docs/rfcs/ADR-capability-modules.md`.
  - Zero-module shells are byte-identical to the previous builder and the published image stays base-only; `extraPackages` remains the per-repo escape hatch and wins PATH lookup.
  - `native` module ships first (`stdenv.cc`, `cmake`, `gnumake`, `pkg-config`, generic `CC`/`CXX`) — the long-term [#879](https://github.com/vig-os/devcontainer/issues/879) answer; `geant4`/`rust`/`fortran`/`root` stay ask-gated candidates.
  - Per-module flake checks (`checks.<system>.module-<name>`) plus a uv C-extension sdist smoke test (`tests/test_flake_modules.py`).

## Testing

- [x] Tests pass locally (`just test` subset relevant to the change)
- [x] Manual testing performed (describe below)

### Manual Testing Details

- **Zero-module parity (byte-identical):** `nix eval .#devShells.<sys>.default.drvPath` identical before/after on both Linux systems — `vwmxsdhqfrmi986p9agf67cdn9m3dl01-nix-shell.drv` (x86_64-linux), `p8h7b0svl7kf22rqvsnw23l7f45q4chb-nix-shell.drv` (aarch64-linux). `tests/test_flake_devshell.py` untouched and green: 11 passed, 1 skipped (host-gated), 17 s.
- **Module tests (TDD):** committed RED first (`checks.x86_64-linux.module-native` did not exist); after the seam landed: `tests/test_flake_modules.py` 3 passed — incl. the sdist smoke (`uv build --sdist` -> `uv pip install <sdist>` -> `import native_ext; answer() == 42`) inside the `native` devshell.
- **Module check eval on both systems (+darwin):** `checks.{x86_64-linux,aarch64-linux,aarch64-darwin}.module-native.drvPath` all evaluate; x86_64-linux built.
- **Flake gates:** `nix build` of `checks.x86_64-linux.{module-native,devShell,deadnix,statix,devShellTools,formatting,pre-commit}` green (7.8 s warm); `tests/test_flake_checks.py` + `tests/test_downstream_flake.py` (full `nix flake check` + scaffold-against-local-toolchain) 15 passed, 17 s.
- **Error path:** unknown module name throws `unknown capability module 'nope'; available: native`.
- **Hooks:** full `just precommit` (prek, all files) green.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

- Coordination: #885 (`DEVKIT_MODULES` in `.vig-os`) maps onto this flake-level contract; #883's consumer `hooks` argument lands beside the seam (module hooks-contribution is the recorded open question in the design note).
- The aarch64-linux / darwin module checks are eval-verified locally; CI covers builds per the existing per-system lanes.

Refs: #884

