### PR TITLE
feat(setup): preflight guard for scaffold upgrades and --preview diff report

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Preflight guard and diff preview for scaffold upgrades** ([#886](https://github.com/vig-os/devcontainer/issues/886))
+  - `install.sh --force` upgrades now refuse on `main`/`dev`/`release/*`/detached HEAD and on a dirty tree, so every upgrade lands as a reviewable, revertible diff on a dedicated branch; on a protected branch with a clean tree the installer offers to create and switch to `chore/devkit-upgrade-<version>`, and non-git directories get a warn-and-confirm path. A single `--skip-preflight` flag bypasses the guard; `--smoke-test` runs and fresh installs are exempt.
+  - New `--preview` mode prints the add/overwrite/preserve/delete file report (including mode-prune deletions such as the retired `.devcontainer/justfile.base`) and exits without changing any files — unlike `--dry-run`, which only prints the container command.
+
 ### Changed
 
 ### Deprecated

--- a/assets/init-workspace.sh
+++ b/assets/init-workspace.sh
@@ -1,12 +1,14 @@
 #!/bin/bash
 # Initialize workspace by copying template files
 #
-# Usage: init-workspace [--force] [--no-prompts] [--smoke-test] [--mode MODE]
+# Usage: init-workspace [--force] [--no-prompts] [--smoke-test] [--preview] [--mode MODE]
 #
 # Options:
 #   --force       Overwrite existing files (for upgrades)
 #   --no-prompts  Run non-interactively (requires SHORT_NAME env var)
 #   --smoke-test  Deploy smoke-test-specific assets
+#   --preview     Print the add/overwrite/preserve/delete report an upgrade
+#                 would produce, then exit 0 without touching the tree (#886)
 #   --mode MODE   Delivery mode: devcontainer | direnv | both
 #                 devcontainer  scaffold .devcontainer/ only (no flake.nix/.envrc)
 #                 direnv        scaffold flake.nix + .envrc only (no .devcontainer/)
@@ -29,6 +31,7 @@ WORKSPACE_DIR="${WORKSPACE_DIR:-/workspace}"
 FORCE=false
 NO_PROMPTS=false
 SMOKE_TEST=false
+PREVIEW=false
 # Delivery mode: devcontainer | direnv | both. Empty = prompt (or "both" with --no-prompts).
 MODE=""
 
@@ -90,6 +93,10 @@ while [[ $# -gt 0 ]]; do
             SMOKE_TEST=true
             shift
             ;;
+        --preview)
+            PREVIEW=true
+            shift
+            ;;
         --mode)
             MODE="$2"
             shift 2
@@ -100,7 +107,7 @@ while [[ $# -gt 0 ]]; do
             ;;
         *)
             echo "Unknown option: $1" >&2
-            echo "Usage: init-workspace [--force] [--no-prompts] [--smoke-test] [--mode MODE]" >&2
+            echo "Usage: init-workspace [--force] [--no-prompts] [--smoke-test] [--preview] [--mode MODE]" >&2
             exit 1
             ;;
     esac
@@ -118,6 +125,14 @@ esac
 # Smoke mode must run unattended and allow overwriting existing content.
 if [[ "$SMOKE_TEST" == "true" ]]; then
     NO_PROMPTS=true
+    FORCE=true
+fi
+
+# A preview is by definition of an upgrade (#886): ride the --force report
+# path (and pass the "workspace not empty" check) without requiring an
+# explicit --force. The preview exits right after the report, before any
+# mutation.
+if [[ "$PREVIEW" == "true" ]]; then
     FORCE=true
 fi
 
@@ -248,18 +263,62 @@ is_preserved_file() {
     return 1
 }
 
+# Record whether the consumer already had a populated .devcontainer/ before the
+# scaffold (#738). In direnv mode we must neither overwrite nor delete it.
+# Recorded before the file report below so the DELETED listing (#886) can
+# mirror the prune guards; pure reads, nothing is mutated here.
+DEVCONTAINER_PREEXISTED=false
+if [[ -d "$WORKSPACE_DIR/.devcontainer" ]] \
+    && [[ -n "$(ls -A "$WORKSPACE_DIR/.devcontainer" 2>/dev/null)" ]]; then
+    DEVCONTAINER_PREEXISTED=true
+fi
+
+# Same guard for the consumer's own nix-direnv files (#859): the
+# devcontainer-mode prune may only remove the flake stub/`.envrc` that this
+# scaffold would create, never a pre-existing setup (they are PRESERVE_FILES,
+# so rsync never overwrites them either — the prune must match).
+FLAKE_PREEXISTED=false
+[[ -f "$WORKSPACE_DIR/flake.nix" ]] && FLAKE_PREEXISTED=true
+ENVRC_PREEXISTED=false
+[[ -f "$WORKSPACE_DIR/.envrc" ]] && ENVRC_PREEXISTED=true
+
+# A preserved justfile.project may predate the 0.4.0 base-recipe relocation
+# (#877); record it so the post-scaffold repair can append what is missing.
+JUSTFILE_PROJECT_PREEXISTED=false
+[[ -f "$WORKSPACE_DIR/justfile.project" ]] && JUSTFILE_PROJECT_PREEXISTED=true
+
+# A preserved .pre-commit-config.yaml may lag the template hook stack (#878);
+# record it so the post-scaffold guard can surface the divergence.
+PRECOMMIT_CONFIG_PREEXISTED=false
+[[ -f "$WORKSPACE_DIR/.pre-commit-config.yaml" ]] && PRECOMMIT_CONFIG_PREEXISTED=true
+
 # Warn if forcing (prompt user) - show which files would be overwritten
 if [[ "$FORCE" == "true" ]]; then
     echo ""
     echo "Checking for files that would be affected..."
 
-    # Find files that exist in both template and workspace
+    # Classify how each template file lands in the workspace
     CONFLICTS=()
     PRESERVED=()
+    ADDED=()
     while IFS= read -r -d '' template_file; do
         # Get relative path from template directory
         rel_path="${template_file#"$TEMPLATE_DIR"/}"
         workspace_file="$WORKSPACE_DIR/$rel_path"
+
+        # Mode filters (#886): skip template paths the chosen delivery mode
+        # never scaffolds. direnv mode excludes .devcontainer/ from the copy
+        # entirely (#738); devcontainer mode prunes the flake.nix/.envrc stubs
+        # it would itself create — unless they pre-exist (#859), in which case
+        # they fall through to the PRESERVED listing below.
+        if [[ "$MODE" == "direnv" && "$rel_path" == .devcontainer/* ]]; then
+            continue
+        fi
+        if [[ "$MODE" == "devcontainer" ]] \
+            && [[ "$rel_path" == "flake.nix" || "$rel_path" == ".envrc" ]] \
+            && [[ ! -e "$workspace_file" ]]; then
+            continue
+        fi
 
         if [[ -e "$workspace_file" ]]; then
             if is_preserved_file "$rel_path"; then
@@ -267,8 +326,25 @@ if [[ "$FORCE" == "true" ]]; then
             else
                 CONFLICTS+=("$rel_path")
             fi
+        else
+            ADDED+=("$rel_path")
         fi
     done < <(find "$TEMPLATE_DIR" -type f ! -path "*/.git/*" -print0)
+
+    # Mode-prune deletions (#886): paths that exist right now and the upgrade
+    # would remove. Mirrors the prune guards further down (#738/#859/#877).
+    DELETIONS=()
+    if [[ "$MODE" == "direnv" ]]; then
+        if [[ -e "$WORKSPACE_DIR/.devcontainer" && "$DEVCONTAINER_PREEXISTED" != "true" ]]; then
+            DELETIONS+=(".devcontainer/")
+        fi
+    else
+        # The devcontainer-mode flake.nix/.envrc prune only removes stubs this
+        # scaffold itself creates (#859), so it never deletes an existing file.
+        if [[ -f "$WORKSPACE_DIR/.devcontainer/justfile.base" ]]; then
+            DELETIONS+=(".devcontainer/justfile.base")
+        fi
+    fi
 
     # Show preserved files
     if [[ ${#PRESERVED[@]} -gt 0 ]]; then
@@ -296,6 +372,39 @@ if [[ "$FORCE" == "true" ]]; then
         echo ""
     fi
 
+    # Show paths the mode prune would delete (#886)
+    if [[ ${#DELETIONS[@]} -gt 0 ]]; then
+        echo ""
+        echo "The following ${#DELETIONS[@]} path(s) will be DELETED:"
+        echo "─────────────────────────────────────────────────────────────"
+        for deletion in "${DELETIONS[@]}"; do
+            echo "  ✗  $deletion"
+        done
+        echo "─────────────────────────────────────────────────────────────"
+        echo ""
+    fi
+
+    # Preview mode (#886): also list the files new to the tree, then stop
+    # before anything is mutated. The ADDED listing is preview-only so the
+    # interactive --force report stays compact.
+    if [[ "$PREVIEW" == "true" ]]; then
+        if [[ ${#ADDED[@]} -eq 0 ]]; then
+            echo ""
+            echo "No new files would be added."
+        else
+            echo ""
+            echo "The following ${#ADDED[@]} file(s) will be ADDED:"
+            echo "─────────────────────────────────────────────────────────────"
+            for added in "${ADDED[@]}"; do
+                echo "  +  $added"
+            done
+            echo "─────────────────────────────────────────────────────────────"
+        fi
+        echo ""
+        echo "Preview complete — no files were changed."
+        exit 0
+    fi
+
     # Only prompt for confirmation in interactive mode
     if [[ "$NO_PROMPTS" != "true" ]]; then
         read -rp "Continue with --force? (y/N): " -n 1 -r
@@ -308,33 +417,6 @@ if [[ "$FORCE" == "true" ]]; then
         echo "Proceeding with --force (non-interactive mode)"
     fi
 fi
-
-# Record whether the consumer already had a populated .devcontainer/ before the
-# scaffold (#738). In direnv mode we must neither overwrite nor delete it.
-DEVCONTAINER_PREEXISTED=false
-if [[ -d "$WORKSPACE_DIR/.devcontainer" ]] \
-    && [[ -n "$(ls -A "$WORKSPACE_DIR/.devcontainer" 2>/dev/null)" ]]; then
-    DEVCONTAINER_PREEXISTED=true
-fi
-
-# Same guard for the consumer's own nix-direnv files (#859): the
-# devcontainer-mode prune may only remove the flake stub/`.envrc` that this
-# scaffold would create, never a pre-existing setup (they are PRESERVE_FILES,
-# so rsync never overwrites them either — the prune must match).
-FLAKE_PREEXISTED=false
-[[ -f "$WORKSPACE_DIR/flake.nix" ]] && FLAKE_PREEXISTED=true
-ENVRC_PREEXISTED=false
-[[ -f "$WORKSPACE_DIR/.envrc" ]] && ENVRC_PREEXISTED=true
-
-# A preserved justfile.project may predate the 0.4.0 base-recipe relocation
-# (#877); record it so the post-scaffold repair can append what is missing.
-JUSTFILE_PROJECT_PREEXISTED=false
-[[ -f "$WORKSPACE_DIR/justfile.project" ]] && JUSTFILE_PROJECT_PREEXISTED=true
-
-# A preserved .pre-commit-config.yaml may lag the template hook stack (#878);
-# record it so the post-scaffold guard can surface the divergence.
-PRECOMMIT_CONFIG_PREEXISTED=false
-[[ -f "$WORKSPACE_DIR/.pre-commit-config.yaml" ]] && PRECOMMIT_CONFIG_PREEXISTED=true
 
 # Copy template contents to workspace
 echo "Initializing workspace from template..."

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Preflight guard and diff preview for scaffold upgrades** ([#886](https://github.com/vig-os/devcontainer/issues/886))
+  - `install.sh --force` upgrades now refuse on `main`/`dev`/`release/*`/detached HEAD and on a dirty tree, so every upgrade lands as a reviewable, revertible diff on a dedicated branch; on a protected branch with a clean tree the installer offers to create and switch to `chore/devkit-upgrade-<version>`, and non-git directories get a warn-and-confirm path. A single `--skip-preflight` flag bypasses the guard; `--smoke-test` runs and fresh installs are exempt.
+  - New `--preview` mode prints the add/overwrite/preserve/delete file report (including mode-prune deletions such as the retired `.devcontainer/justfile.base`) and exits without changing any files — unlike `--dry-run`, which only prints the container command.
+
 ### Changed
 
 ### Deprecated

--- a/assets/workspace/.devcontainer/justfile.devc
+++ b/assets/workspace/.devcontainer/justfile.devc
@@ -30,7 +30,10 @@ devc-check *args:
     "$SCRIPT_DIR/version-check.sh" {{ if args == '' { 'check' } else { args } }}
 
 # Upgrade devcontainer to latest version (host-side only)
-# This recipe MUST be run from a host terminal, not inside the container
+# This recipe MUST be run from a host terminal, not inside the container.
+# The installer preflight (#886) refuses upgrades on main/dev/release/* or a
+# dirty tree; use the curl form to pass --preview (file report, no changes)
+# or --skip-preflight (bypass the guard) when needed.
 [group('info')]
 devc-upgrade:
     #!/usr/bin/env bash
@@ -72,6 +75,10 @@ devc-upgrade:
     fi
 
     echo "✓ Using $RUNTIME"
+    echo ""
+    echo "Note: the installer refuses upgrades on main/dev/release/* or a dirty tree."
+    echo "      Preview first:  curl -sSf https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh | bash -s -- --force --preview ."
+    echo "      Bypass guard:   curl -sSf https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh | bash -s -- --force --skip-preflight ."
     echo ""
     echo "Downloading and running install script..."
     curl -sSf https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh | bash -s -- --force .

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -199,6 +199,36 @@ itself always comes from one of the tiers above.
   (Renovate's `nix` manager opens the PR); `flake.lock` is the controlling
   version document.
 
+### Upgrade preflight guard and preview
+
+An upgrade (`just devc-upgrade`, or `install.sh --force`) rewrites and deletes
+files across the consumer tree, so the installer requires it to land on a
+dedicated working branch as a single reviewable, revertible diff
+([#886](https://github.com/vig-os/devcontainer/issues/886)):
+
+- **Protected branches refuse** — `main`, `dev`, `release/*` (prefix), and a
+  detached `HEAD`. On a protected branch with a clean tree the installer
+  offers to create and switch to `chore/devkit-upgrade-<version>` for you;
+  non-interactively it refuses with that command as the hint.
+- **Dirty trees refuse** — `git status --porcelain` must be empty (staged,
+  unstaged, or untracked-unignored changes all count; gitignored clutter such
+  as `.venv/` does not). Commit or stash first.
+- **Non-git directories warn** — there is no VCS safety net, so the installer
+  asks for explicit confirmation before continuing.
+- **`--skip-preflight` bypasses** both checks; `--smoke-test` runs and fresh
+  installs (no `--force`) are exempt.
+
+To see what an upgrade would change before running it, use `--preview`:
+
+```bash
+curl -sSf https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh \
+  | bash -s -- --force --preview .
+```
+
+It prints the add/overwrite/preserve/delete file report and exits without
+touching the tree (unlike `--dry-run`, which only prints the container command
+and computes no file report).
+
 ## Upgrading an existing 0.3.x consumer — manual steps
 
 `install.sh --version <X> --force` refreshes the scaffold and pins `<X>` in

--- a/install.sh
+++ b/install.sh
@@ -15,7 +15,10 @@
 #   --repo OWNER/REPO GitHub repo for Renovate preset (default: detect from origin or OWNER/REPO)
 #   --mode MODE       Delivery mode: devcontainer | direnv | both (default: prompt, both non-interactively)
 #   --smoke-test      Deploy smoke-test-specific assets
-#   --dry-run         Show what would be done without executing
+#   --preview         Print the add/overwrite/preserve/delete file report for an
+#                     upgrade and exit without changing anything
+#   --skip-preflight  Bypass the upgrade preflight guard (branch + clean-tree checks)
+#   --dry-run         Show the container command that would run without executing
 #   -h, --help        Show this help message
 #
 # Examples:
@@ -39,6 +42,8 @@ ORG_NAME="vigOS"
 GITHUB_REPO_OVERRIDE=""
 MODE=""
 SMOKE_TEST=""
+PREVIEW=""
+SKIP_PREFLIGHT=false
 
 # Colors (disabled if not a tty)
 if [ -t 1 ]; then
@@ -75,7 +80,12 @@ OPTIONS:
     --mode MODE       Delivery mode: devcontainer | direnv | both
                       (default: prompt interactively; "both" non-interactively)
     --smoke-test      Deploy smoke-test-specific assets
-    --dry-run         Show what would be done
+    --preview         Preview an upgrade: print the add/overwrite/preserve/delete
+                      file report and exit without changing any files
+    --skip-preflight  Bypass the upgrade preflight guard (--force refuses on
+                      main/dev/release/*/detached HEAD and on a dirty tree)
+    --dry-run         Show the container command that would run (unlike
+                      --preview, no file report is computed)
     -h, --help        Show this help
 
 EXAMPLES:
@@ -283,6 +293,102 @@ run_user_conf() {
     fi
 }
 
+# ── Upgrade preflight guard (#886) ────────────────────────────────────────────
+# An upgrade (`--force`) rewrites and deletes files across the consumer tree,
+# so it must land on a dedicated working branch with a clean tree, where it
+# stays a single reviewable, revertible diff. The guard runs host-side because
+# only the host reliably sees git state: the container mounts $PROJECT_PATH
+# alone, so in a git worktree (where .git is a file pointing at an unmounted
+# gitdir) git is unusable inside the container.
+
+# Read a yes/no confirmation for the preflight guard.
+# Returns 0 on yes, 1 on no or when no interactive input is available.
+# stdin is used when it is a terminal or a redirected pipe/file; in the
+# curl | bash form the script itself occupies stdin, so the prompt goes to
+# /dev/tty and the reply never consumes script text.
+preflight_confirm() {
+    local prompt="$1" reply="" invoked
+    invoked="$(basename -- "${0#-}")"
+    if [ -t 0 ]; then
+        read -rp "$prompt" reply
+    elif [ "$invoked" = "bash" ] || [ "$invoked" = "sh" ]; then
+        if [ -e /dev/tty ]; then
+            read -rp "$prompt" reply </dev/tty || return 1
+        else
+            return 1
+        fi
+    else
+        read -rp "$prompt" reply || return 1
+    fi
+    [[ "$reply" =~ ^[Yy]$ ]]
+}
+
+# Gate the --force (upgrade) path on git state. Refuses (exit != 0) on a dirty
+# tree, on a detached HEAD, and on protected branches (main, dev, release/*
+# by prefix) — on the latter, with a clean tree, it offers to create and
+# switch to chore/devkit-upgrade-<version> and proceed there. A non-git
+# directory gets a loud warning plus an explicit confirmation. Every refusal
+# prints the --skip-preflight bypass. Under --dry-run nothing is mutated (the
+# branch offer only reports what it would do).
+run_preflight_guard() {
+    local path="$1"
+    local skip_hint="Re-run with --skip-preflight to bypass the upgrade preflight guard."
+    local branch upgrade_branch dirty
+
+    if ! command -v git >/dev/null 2>&1 \
+        || ! git -C "$path" rev-parse --git-dir >/dev/null 2>&1; then
+        warn "preflight: $path is not a git repository (or git is unavailable)."
+        warn "There is no VCS safety net here: a bad upgrade cannot be reviewed or reverted."
+        if preflight_confirm "Continue the upgrade anyway? (y/N): "; then
+            return 0
+        fi
+        err "preflight: upgrade refused (no git repository, not confirmed)."
+        echo "  Put the project under version control first, or:"
+        echo "  $skip_hint"
+        exit 1
+    fi
+
+    dirty="$(git -C "$path" status --porcelain 2>/dev/null || true)"
+    if [ -n "$dirty" ]; then
+        err "preflight: refusing to upgrade on a dirty tree."
+        echo "  An upgrade must be the only change in its diff — commit or stash this first:"
+        printf '%s\n' "$dirty" | head -10 | sed 's/^/    /'
+        echo "  $skip_hint"
+        exit 1
+    fi
+
+    upgrade_branch="chore/devkit-upgrade-$VERSION"
+    if ! branch="$(git -C "$path" symbolic-ref --quiet --short HEAD)"; then
+        err "preflight: refusing to upgrade on a detached HEAD."
+        echo "  Check out a working branch first, e.g.:"
+        echo "    git -C \"$path\" switch -c $upgrade_branch"
+        echo "  $skip_hint"
+        exit 1
+    fi
+
+    case "$branch" in
+        main|dev|release/*)
+            warn "preflight: '$branch' is a protected branch — upgrades need a dedicated branch."
+            if preflight_confirm "Create and switch to '$upgrade_branch' now? (y/N): "; then
+                if [ "$DRY_RUN" = true ]; then
+                    info "dry-run: would create and switch to '$upgrade_branch'"
+                elif git -C "$path" checkout -b "$upgrade_branch"; then
+                    info "Switched to new branch '$upgrade_branch'"
+                else
+                    err "preflight: could not create branch '$upgrade_branch'."
+                    exit 1
+                fi
+            else
+                err "preflight: refusing to upgrade on protected branch '$branch'."
+                echo "  Create a dedicated branch and re-run:"
+                echo "    git -C \"$path\" checkout -b $upgrade_branch"
+                echo "  $skip_hint"
+                exit 1
+            fi
+            ;;
+    esac
+}
+
 # Parse arguments
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -328,6 +434,14 @@ while [ $# -gt 0 ]; do
             ;;
         --smoke-test)
             SMOKE_TEST="--smoke-test"
+            shift
+            ;;
+        --preview)
+            PREVIEW="--preview"
+            shift
+            ;;
+        --skip-preflight)
+            SKIP_PREFLIGHT=true
             shift
             ;;
         --skip-pull)
@@ -390,6 +504,18 @@ if [ -z "$GITHUB_REPOSITORY" ] && [ -d "$PROJECT_PATH/.git" ]; then
 fi
 if [ -z "$GITHUB_REPOSITORY" ]; then
     GITHUB_REPOSITORY="OWNER/REPO"
+fi
+
+# Preflight-gate --force upgrades (#886). Exemptions:
+# - --smoke-test: the downstream release gate runs `install.sh --version <tag>
+#   --smoke-test --force --docker .` headless on a CI checkout;
+# - --preview: report-only, exits before mutating anything (#885 mode switches
+#   point users at it first, so it must work from any branch/tree state);
+# - fresh installs (no --force): the "workspace not empty" refusal in
+#   init-workspace.sh already covers accidental re-runs.
+if [ -n "$FORCE" ] && [ -z "$SMOKE_TEST" ] && [ -z "$PREVIEW" ] \
+    && [ "$SKIP_PREFLIGHT" = false ]; then
+    run_preflight_guard "$PROJECT_PATH"
 fi
 
 # Detect container runtime
@@ -483,6 +609,10 @@ if [ -n "$SMOKE_TEST" ]; then
     CMD+=(--smoke-test)
 fi
 
+if [ -n "$PREVIEW" ]; then
+    CMD+=(--preview)
+fi
+
 if [ -n "$MODE" ]; then
     CMD+=(--mode "$MODE")
 fi
@@ -540,13 +670,25 @@ else
 fi
 
 # Run the initialization
-info "Initializing workspace..."
+if [ -n "$PREVIEW" ]; then
+    info "Previewing upgrade (no files will be changed)..."
+else
+    info "Initializing workspace..."
+fi
 echo ""
 
 # Execute the container using array expansion (safe from shell injection)
 if ! "${CMD[@]}"; then
     err "Failed to initialize workspace"
     exit 1
+fi
+
+# Preview mode: init-workspace.sh printed the file report and exited before
+# mutating anything — skip all post-initialization (user conf, git setup).
+if [ -n "$PREVIEW" ]; then
+    echo ""
+    success "Preview complete — no files were changed in $PROJECT_PATH"
+    exit 0
 fi
 
 # ── Post-initialization: host-side setup ──────────────────────────────────────

--- a/tests/bats/init-workspace.bats
+++ b/tests/bats/init-workspace.bats
@@ -906,3 +906,102 @@ EOF
     assert_success
     refute_output --partial "retired 'pre-commit' binary"
 }
+
+# ── --preview: report-only upgrade preview (#886) ─────────────────────────────
+# `--preview` runs the existing conflict-report machinery (OVERWRITTEN /
+# PRESERVED), extended with the mode-prune DELETED listing and the ADDED
+# listing, then exits 0 before mutating anything. install.sh forwards it; a
+# preview is by definition of an upgrade, so it must ride the --force report
+# path without requiring --force.
+
+# Run the real script in preview mode against workspace $1 (extra args pass
+# through, e.g. --mode). `uv` is stubbed like _upgrade for consistency; a
+# correct preview never reaches the `just sync` step anyway.
+_preview() {
+    local ws="$1"
+    shift
+    local stub="$BATS_TEST_TMPDIR/stub-uv-886"
+    mkdir -p "$stub"
+    printf '#!/usr/bin/env bash\nexit 0\n' >"$stub/uv"
+    chmod +x "$stub/uv"
+    env PATH="$stub:$PATH" \
+        TEMPLATE_DIR="$PROJECT_ROOT/assets/workspace" \
+        WORKSPACE_DIR="$ws" \
+        SHORT_NAME=testproj \
+        GITHUB_REPOSITORY=test/repo \
+        bash "$INIT_WORKSPACE_SH" --preview --no-prompts "$@"
+}
+
+@test "init-workspace --preview exits 0 and prints the file report (#886)" {
+    ws="$BATS_TEST_TMPDIR/e2e-886-report"
+    mkdir -p "$ws"
+    _upgrade both "$ws"
+    run _preview "$ws" --mode both
+    assert_success
+    assert_output --partial "OVERWRITTEN"
+    assert_output --partial "PRESERVED"
+    assert_output --partial "Preview complete"
+}
+
+@test "init-workspace --preview leaves the tree byte-identical (#886)" {
+    ws="$BATS_TEST_TMPDIR/e2e-886-intact"
+    mkdir -p "$ws"
+    _upgrade both "$ws"
+    cp -a "$ws" "$ws.before"
+    run _preview "$ws" --mode both
+    assert_success
+    run diff -r "$ws" "$ws.before"
+    assert_success
+}
+
+@test "init-workspace --preview lists prune deletions without deleting (#886)" {
+    # The retired .devcontainer/justfile.base is removed on a real upgrade
+    # (#877); the preview must list it as DELETED and leave it in place.
+    ws="$BATS_TEST_TMPDIR/e2e-886-deletions"
+    mkdir -p "$ws/.devcontainer"
+    printf '# retired 0.3.x base recipes\n' >"$ws/.devcontainer/justfile.base"
+    run _preview "$ws" --mode both
+    assert_success
+    assert_output --partial "DELETED"
+    assert_output --partial ".devcontainer/justfile.base"
+    run test -f "$ws/.devcontainer/justfile.base"
+    assert_success
+}
+
+@test "init-workspace --preview lists the direnv-mode .devcontainer prune (#886)" {
+    # direnv mode prunes a .devcontainer/ that did not pre-exist with content
+    # (#738); the preview must list the removal and leave the dir in place.
+    ws="$BATS_TEST_TMPDIR/e2e-886-direnv-prune"
+    mkdir -p "$ws/.devcontainer"
+    run _preview "$ws" --mode direnv
+    assert_success
+    assert_output --partial "DELETED"
+    assert_output --partial ".devcontainer/"
+    run test -d "$ws/.devcontainer"
+    assert_success
+}
+
+@test "init-workspace --preview works without --force on a populated tree (#886)" {
+    # install.sh forwards --preview on its own; the preview must not trip the
+    # "Workspace is not empty" refusal nor require an explicit --force.
+    ws="$BATS_TEST_TMPDIR/e2e-886-no-force"
+    mkdir -p "$ws"
+    _upgrade both "$ws"
+    run _preview "$ws" --mode both
+    assert_success
+    refute_output --partial "Workspace is not empty"
+}
+
+@test "init-workspace --preview lists template files new to the tree as ADDED (#886)" {
+    ws="$BATS_TEST_TMPDIR/e2e-886-added"
+    mkdir -p "$ws"
+    _upgrade both "$ws"
+    rm "$ws/justfile"
+    run _preview "$ws" --mode both
+    assert_success
+    assert_output --partial "ADDED"
+    assert_output --partial "justfile"
+    # ...and the preview did not scaffold it back
+    run test -e "$ws/justfile"
+    assert_failure
+}

--- a/tests/bats/install.bats
+++ b/tests/bats/install.bats
@@ -18,6 +18,7 @@
 # - os detection
 # - runtime detection
 # - git repository setup
+# - upgrade preflight guard (#886)
 
 setup() {
     load test_helper
@@ -111,7 +112,11 @@ setup() {
 # ── force flag ────────────────────────────────────────────────────────────────
 
 @test "force flag is forwarded to init-workspace.sh" {
-    run bash "$INSTALL_SH" --dry-run --force .
+    # Clean feature-branch fixture: the upgrade preflight guard (#886) would
+    # refuse `.` on a CI checkout (detached HEAD) or a dirty dev tree.
+    repo="$BATS_TEST_TMPDIR/force-forward"
+    _make_repo "$repo"
+    run bash "$INSTALL_SH" --dry-run --force "$repo"
     assert_success
     assert_output --partial "--force"
 }
@@ -389,4 +394,252 @@ setup() {
     # shellcheck disable=SC2016
     run grep -F 'VIG_OS_VERSION=$VERSION' "$INSTALL_SH"
     assert_success
+}
+
+# ── upgrade preflight guard (#886) ────────────────────────────────────────────
+# `install.sh --force` (the upgrade path) must refuse on protected branches
+# (main / dev / release/* prefix / detached HEAD) and on a dirty tree, offer a
+# dedicated chore/devkit-upgrade-<version> branch as the way out, and honor
+# the single --skip-preflight escape hatch. --smoke-test runs (the headless
+# release gate), --preview (report-only) and fresh installs (no --force) are
+# exempt. All cases run under --dry-run: a passing guard stops at the printed
+# container command (no image pull / container run), and the guard itself
+# never mutates the repo under --dry-run.
+
+# git with a fixed identity, no signing — fixtures live outside any workspace
+# gitconfig includeIf, so nothing may depend on the host identity setup.
+_git() {
+    git -c user.email=t@example.com -c user.name=T -c commit.gpgsign=false "$@"
+}
+
+# Create a one-commit git repo fixture at $1 on branch $2 (default: an
+# allowed feature branch).
+_make_repo() {
+    local dir="$1" branch="${2:-feature/886-fixture}"
+    mkdir -p "$dir"
+    _git init -q -b "$branch" "$dir"
+    _git -C "$dir" commit -q --allow-empty -m "chore: init"
+}
+
+@test "preflight: --force refuses on main with the branch hint (#886)" {
+    repo="$BATS_TEST_TMPDIR/on-main"
+    _make_repo "$repo" main
+    run bash "$INSTALL_SH" --dry-run --force "$repo" </dev/null
+    assert_failure
+    assert_output --partial "main"
+    assert_output --partial "chore/devkit-upgrade"
+    assert_output --partial "--skip-preflight"
+}
+
+@test "preflight: --force refuses on dev (#886)" {
+    repo="$BATS_TEST_TMPDIR/on-dev"
+    _make_repo "$repo" dev
+    run bash "$INSTALL_SH" --dry-run --force "$repo" </dev/null
+    assert_failure
+    assert_output --partial "dev"
+    assert_output --partial "--skip-preflight"
+}
+
+@test "preflight: --force refuses on release/* by prefix (#886)" {
+    repo="$BATS_TEST_TMPDIR/on-release"
+    _make_repo "$repo" release/0.5.0
+    run bash "$INSTALL_SH" --dry-run --force "$repo" </dev/null
+    assert_failure
+    assert_output --partial "release/0.5.0"
+    assert_output --partial "--skip-preflight"
+}
+
+@test "preflight: --force refuses on detached HEAD (#886)" {
+    repo="$BATS_TEST_TMPDIR/detached"
+    _make_repo "$repo"
+    _git -C "$repo" checkout -q --detach
+    run bash "$INSTALL_SH" --dry-run --force "$repo" </dev/null
+    assert_failure
+    assert_output --partial "detached"
+    assert_output --partial "--skip-preflight"
+}
+
+@test "preflight: --force refuses on a dirty tree (tracked change) (#886)" {
+    repo="$BATS_TEST_TMPDIR/dirty-tracked"
+    _make_repo "$repo"
+    echo "v1" > "$repo/file.txt"
+    _git -C "$repo" add file.txt
+    _git -C "$repo" commit -q -m "chore: add file"
+    echo "v2" >> "$repo/file.txt"
+    run bash "$INSTALL_SH" --dry-run --force "$repo" </dev/null
+    assert_failure
+    assert_output --partial "dirty"
+    assert_output --partial "--skip-preflight"
+}
+
+@test "preflight: --force refuses on an untracked-unignored file (#886)" {
+    repo="$BATS_TEST_TMPDIR/dirty-untracked"
+    _make_repo "$repo"
+    echo "wip" > "$repo/untracked.txt"
+    run bash "$INSTALL_SH" --dry-run --force "$repo" </dev/null
+    assert_failure
+    assert_output --partial "dirty"
+    assert_output --partial "--skip-preflight"
+}
+
+@test "preflight: gitignored clutter does not count as dirty (#886)" {
+    repo="$BATS_TEST_TMPDIR/ignored-clutter"
+    _make_repo "$repo"
+    printf '.venv/\n' > "$repo/.gitignore"
+    _git -C "$repo" add .gitignore
+    _git -C "$repo" commit -q -m "chore: add gitignore"
+    mkdir -p "$repo/.venv"
+    echo "junk" > "$repo/.venv/junk"
+    run bash "$INSTALL_SH" --dry-run --force "$repo" </dev/null
+    assert_success
+    assert_output --partial "Would execute:"
+}
+
+@test "preflight: clean feature branch proceeds (#886)" {
+    repo="$BATS_TEST_TMPDIR/clean-feature"
+    _make_repo "$repo"
+    run bash "$INSTALL_SH" --dry-run --force "$repo" </dev/null
+    assert_success
+    assert_output --partial "Would execute:"
+}
+
+@test "preflight: guard works in a git worktree (.git file) (#886)" {
+    repo="$BATS_TEST_TMPDIR/wt-parent"
+    _make_repo "$repo" main
+    wt="$BATS_TEST_TMPDIR/wt-on-dev"
+    _git -C "$repo" worktree add -q -b dev "$wt"
+    # the fixture really is a linked worktree: .git is a file, not a directory
+    run test -f "$wt/.git"
+    assert_success
+    run bash "$INSTALL_SH" --dry-run --force "$wt" </dev/null
+    assert_failure
+    assert_output --partial "dev"
+    assert_output --partial "--skip-preflight"
+}
+
+@test "preflight: clean feature-branch git worktree proceeds (#886)" {
+    repo="$BATS_TEST_TMPDIR/wt-parent-ok"
+    _make_repo "$repo" main
+    wt="$BATS_TEST_TMPDIR/wt-on-feature"
+    _git -C "$repo" worktree add -q -b feature/886-wt "$wt"
+    run bash "$INSTALL_SH" --dry-run --force "$wt" </dev/null
+    assert_success
+    assert_output --partial "Would execute:"
+}
+
+@test "preflight: --skip-preflight bypasses branch and tree checks (#886)" {
+    repo="$BATS_TEST_TMPDIR/skip-preflight"
+    _make_repo "$repo" main
+    echo "wip" > "$repo/untracked.txt"
+    run bash "$INSTALL_SH" --dry-run --force --skip-preflight "$repo" </dev/null
+    assert_success
+    assert_output --partial "Would execute:"
+}
+
+@test "preflight: --smoke-test is exempt from the guard (#886)" {
+    # The downstream smoke-test CI runs `install.sh --version <tag>
+    # --smoke-test --force --docker .` headless on a CI checkout — the guard
+    # must never gate that release path.
+    repo="$BATS_TEST_TMPDIR/smoke-exempt"
+    _make_repo "$repo" main
+    echo "wip" > "$repo/untracked.txt"
+    run bash "$INSTALL_SH" --dry-run --force --smoke-test "$repo" </dev/null
+    assert_success
+    assert_output --partial "Would execute:"
+    assert_output --partial "--smoke-test"
+}
+
+@test "preflight: non-git dir refuses non-interactively with a loud warning (#886)" {
+    dir="$BATS_TEST_TMPDIR/non-git"
+    mkdir -p "$dir"
+    touch "$dir/some-file"
+    run bash "$INSTALL_SH" --dry-run --force "$dir" </dev/null
+    assert_failure
+    assert_output --partial "not a git repository"
+    assert_output --partial "--skip-preflight"
+}
+
+@test "preflight: non-git dir proceeds after explicit confirmation (#886)" {
+    dir="$BATS_TEST_TMPDIR/non-git-confirm"
+    mkdir -p "$dir"
+    touch "$dir/some-file"
+    run bash -c "echo y | bash '$INSTALL_SH' --dry-run --force '$dir'"
+    assert_success
+    assert_output --partial "Would execute:"
+}
+
+@test "preflight: non-git dir aborts when confirmation is declined (#886)" {
+    dir="$BATS_TEST_TMPDIR/non-git-decline"
+    mkdir -p "$dir"
+    touch "$dir/some-file"
+    run bash -c "echo n | bash '$INSTALL_SH' --dry-run --force '$dir'"
+    assert_failure
+    assert_output --partial "--skip-preflight"
+}
+
+@test "preflight: dry-run branch offer never mutates the repo (#886)" {
+    repo="$BATS_TEST_TMPDIR/offer-dry-run"
+    _make_repo "$repo" main
+    run bash -c "echo y | bash '$INSTALL_SH' --dry-run --force '$repo'"
+    assert_success
+    assert_output --partial "Would execute:"
+    # accepting the offer under --dry-run must not create/switch branches
+    run _git -C "$repo" symbolic-ref --short HEAD
+    assert_output "main"
+    run _git -C "$repo" branch --list "chore/devkit-upgrade-*"
+    assert_output ""
+}
+
+@test "preflight: declining the protected-branch offer refuses with the hint (#886)" {
+    repo="$BATS_TEST_TMPDIR/offer-decline"
+    _make_repo "$repo" main
+    run bash -c "echo n | bash '$INSTALL_SH' --dry-run --force '$repo'"
+    assert_failure
+    assert_output --partial "chore/devkit-upgrade"
+    assert_output --partial "--skip-preflight"
+}
+
+@test "preflight: fresh install (no --force) is exempt (#886)" {
+    dir="$BATS_TEST_TMPDIR/fresh-install"
+    mkdir -p "$dir"
+    run bash "$INSTALL_SH" --dry-run "$dir" </dev/null
+    assert_success
+    assert_output --partial "Would execute:"
+}
+
+# ── --preview forwarding and docs (#886) ──────────────────────────────────────
+
+@test "install.sh forwards --preview to init-workspace.sh (#886)" {
+    repo="$BATS_TEST_TMPDIR/preview-forward"
+    _make_repo "$repo"
+    run bash "$INSTALL_SH" --dry-run --preview "$repo"
+    assert_success
+    assert_output --partial "--preview"
+}
+
+@test "preflight: --preview is exempt from the guard (report-only) (#886)" {
+    # A preview never mutates the tree, and #885's destructive mode switches
+    # will point users at it first — it must work from any branch/tree state.
+    repo="$BATS_TEST_TMPDIR/preview-exempt"
+    _make_repo "$repo" main
+    echo "wip" > "$repo/untracked.txt"
+    run bash "$INSTALL_SH" --dry-run --force --preview "$repo" </dev/null
+    assert_success
+    assert_output --partial "Would execute:"
+}
+
+@test "help lists --skip-preflight and --preview (#886)" {
+    run bash "$INSTALL_SH" --help
+    assert_success
+    assert_output --partial "--skip-preflight"
+    assert_output --partial "--preview"
+}
+
+@test "help documents how --preview differs from --dry-run (#886)" {
+    run bash "$INSTALL_SH" --help
+    assert_success
+    # --preview computes the file-level report; --dry-run only prints the
+    # container command.
+    assert_output --partial "overwrite/preserve/delete"
+    assert_output --partial "container command"
 }

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -484,7 +484,40 @@ class TestInstallScriptUnit:
         assert "1.2.3" in result.stdout
 
     def test_force_flag_in_dry_run(self, install_script, tmp_path):
-        """Test --force flag is passed to init-workspace.sh."""
+        """Test --force flag is passed to init-workspace.sh.
+
+        Uses a clean feature-branch git fixture: the upgrade preflight guard
+        (#886) refuses --force on non-git directories, protected branches,
+        and dirty trees.
+        """
+        git_env = [
+            "git",
+            "-c",
+            "user.email=t@example.com",
+            "-c",
+            "user.name=T",
+            "-c",
+            "commit.gpgsign=false",
+        ]
+        subprocess.run(
+            [*git_env, "init", "-q", "-b", "feature/886-fixture", str(tmp_path)],
+            check=True,
+            timeout=10,
+        )
+        subprocess.run(
+            [
+                *git_env,
+                "-C",
+                str(tmp_path),
+                "commit",
+                "-q",
+                "--allow-empty",
+                "-m",
+                "chore: init",
+            ],
+            check=True,
+            timeout=10,
+        )
         result = subprocess.run(
             [str(install_script), "--dry-run", "--force", str(tmp_path)],
             capture_output=True,


### PR DESCRIPTION
## Description

Adds the upgrade preflight guard and diff preview specified in #886: `install.sh --force` (the upgrade path) now requires a dedicated working branch with a clean tree, so every scaffold upgrade lands as a single reviewable, revertible diff; a new `--preview` mode prints the full file report without touching the tree.

Closes #886

## Type of Change

- [x] `feat` -- New feature
- [ ] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [ ] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- **`install.sh` — host-side preflight guard on the `--force` path only** (the host is the only place git state is reliable; a worktree's gitdir is not mounted into the container):
  - refuses on `main`, `dev`, `release/*` (prefix), and detached `HEAD`;
  - refuses on a dirty tree (`git status --porcelain` must be empty; gitignored clutter passes);
  - on a protected branch with a clean tree, offers to create and switch to `chore/devkit-upgrade-<version>`; non-interactively it refuses with that command as the hint;
  - non-git directories get a loud "no VCS safety net" warning plus an explicit confirmation;
  - a single `--skip-preflight` flag bypasses, printed in every refusal;
  - exemptions: `--smoke-test` (the downstream release gate runs `install.sh --version <tag> --smoke-test --force --docker .` headless — verified against devcontainer-smoke-test `repository-dispatch.yml`), `--preview` (report-only), and fresh installs (no `--force`);
  - under `--dry-run` the guard still evaluates but never mutates (accepting the branch offer only reports what it would do).
- **`assets/init-workspace.sh` — `--preview` mode**: rides the existing conflict-report machinery (now mode-aware: direnv-mode `.devcontainer/` and devcontainer-mode stub filters), extended with an ADDED listing and the mode-prune DELETED listing (`.devcontainer/justfile.base` on upgrades, the direnv-mode `.devcontainer/` prune), then exits 0 before any mutation. `install.sh` forwards the flag and skips all post-init (user conf, git setup) in preview. Kept cleanly callable for #885's destructive mode switches.
- **`devc-upgrade` recipe**: surfaces the guard and the new flags in its help/output text (no logic change).
- **Docs**: `docs/MIGRATION.md` gains an "Upgrade preflight guard and preview" section; `install.sh --help` documents `--skip-preflight` and the `--preview` vs `--dry-run` distinction.

## Changelog Entry

### Added
- **Preflight guard and diff preview for scaffold upgrades** ([#886](https://github.com/vig-os/devcontainer/issues/886))
  - `install.sh --force` upgrades now refuse on `main`/`dev`/`release/*`/detached HEAD and on a dirty tree, so every upgrade lands as a reviewable, revertible diff on a dedicated branch; on a protected branch with a clean tree the installer offers to create and switch to `chore/devkit-upgrade-<version>`, and non-git directories get a warn-and-confirm path. A single `--skip-preflight` flag bypasses the guard; `--smoke-test` runs and fresh installs are exempt.
  - New `--preview` mode prints the add/overwrite/preserve/delete file report (including mode-prune deletions such as the retired `.devcontainer/justfile.base`) and exits without changing any files — unlike `--dry-run`, which only prints the container command.

## Testing

- [x] Tests pass locally (`just test`)
- [x] Manual testing performed (describe below)

### Manual Testing Details

TDD (RED commit first, then implementation):

- `tests/bats/install.bats`: 78/78 — protected branches (main/dev/`release/*` prefix), detached HEAD, dirty tree (tracked + untracked-unignored), gitignored-only clutter passes, git-worktree fixture (`.git` file) both refusing and passing, `--skip-preflight`, `--smoke-test` exemption, non-git warn/confirm/decline, dry-run branch offer never mutates, fresh-install exemption, `--preview` forwarding + guard exemption, help text.
- `tests/bats/init-workspace.bats`: 81/81 — `--preview` exits 0 with the report, leaves the tree byte-identical (`diff -r` against a pre-copy), lists `.devcontainer/justfile.base` and the direnv-mode `.devcontainer/` prune as DELETED without deleting, works without `--force` on a populated tree, lists ADDED files without scaffolding them.
- `uv run pytest`: 820 passed; the two `tests/test_image.py` failures are stale-local-image artifacts (one also fails on the dev base commit; the other is the manifest sha check against a local image that predates this branch's changelog/justfile.devc edits — CI rebuilds the image from the branch).
- Full hook suite green: `just precommit` → exit 0.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Additional Notes

- Accepted residual gap (per the issue's alternatives): direct `podman run … init-workspace.sh --force` invocations bypass the host guard.
- The `nix-image.yml` CI scaffold check runs `init-workspace.sh` directly against a fresh temp dir — host guard not in its path, unaffected.

Refs: #886
