### PR TITLE
fix(security): except podman CVE-2026-57231 pending nixpkgs 26.05 backport

### DIFF
--- a/.vulnixignore
+++ b/.vulnixignore
@@ -194,3 +194,24 @@ CVE-2026-11979
 #   image. No upstream fix published yet (verified NVD/Debian/libssh2 repo,
 #   2026-07-04).
 CVE-2026-58050
+
+# ============================================================================
+# Triage 2026-07-07 — podman host-env-var leak (release-cycle fix, #905).
+# Verified ONLINE against NVD/GHSA and the nixpkgs branch contents
+# (release-26.05, staging-26.05, staging, master, nixpkgs-unstable) on
+# 2026-07-07. Real product match (no CPE collision).
+# ============================================================================
+
+Expiration: 2026-08-06
+# podman 5.8.2 — container engine, a direct devTools member (nix/devtools.nix)
+#   and the binary backing the docker->podman shim (flake.nix). CVE-2026-57231
+#   (CVSS 7.5 HIGH): a malicious image manifest with malformed `Env` entries (a
+#   key with no value, exploitable via the `*` glob) makes podman leak matching
+#   HOST env vars into the container — a supply-chain risk only when running
+#   UNTRUSTED images. Here podman is a rootless CLI running developer/CI-chosen
+#   images, so exposure is bounded by the single-user dev model. Fixed upstream
+#   in 5.8.4 (2026-06-26) and 6.0.0; in nixpkgs the fix is on
+#   master/staging/unstable (5.8.4) but NOT in the pinned release-26.05 (still
+#   5.8.2) — backport PR NixOS/nixpkgs#536367 is open (draft, base
+#   release-26.05). Flip to a nixpkgs rev-advance when it lands; re-check weekly.
+CVE-2026-57231

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The 0.4.0 image retired the Python `pre-commit` for `prek` ([#778](https://github.com/vig-os/devcontainer/issues/778)), but files preserved on upgrade still invoke it and exit 127 (field-validated on a 0.3.5 → 0.4.0 consumer: the preserved `justfile.project` `precommit` recipe and repo-managed `.githooks` scripts broke every commit). The image now ships a **deprecated one-cycle `pre-commit → prek` shim** (stderr notice, removed in 0.5) so consumer hook scripts keep working while they migrate.
   - `init-workspace --force` scans the post-scaffold `justfile.project`, `.githooks/` scripts and `.pre-commit-config.yaml` for invocation-shaped `pre-commit` references and warns (non-fatally) with `file:line`, pointing at the MIGRATION.md rename checklist — which now also covers the NixOS `#!/bin/bash` shebang gotcha in old-scaffold `.githooks`.
 
+### Security
+
+- **Accept podman `CVE-2026-57231` in the vulnix register pending the nixpkgs 26.05 backport** ([#905](https://github.com/vig-os/devcontainer/issues/905))
+  - podman 5.8.2 (affects 5.8.1–5.8.3) leaks matching host environment variables into a container when a malicious image manifest carries malformed `Env` entries (a key with no value, via the `*` glob) — CVSS 7.5, a supply-chain risk only when running untrusted images. The release CVE gate blocked the 0.4.1 RC on this finding.
+  - Fixed upstream in 5.8.4/6.0.0, but the pinned `nixpkgs` `release-26.05` still ships 5.8.2 (backport [NixOS/nixpkgs#536367](https://github.com/NixOS/nixpkgs/pull/536367) open), so advancing the rev cannot remediate yet. Added a short-dated `.vulnixignore` exception (expires 2026-08-06, re-check weekly) to unblock the gate; the exception flips to a nixpkgs rev-advance once the backport lands.
+
 ## [0.4.0](https://github.com/vig-os/devcontainer/releases/tag/0.4.0) - 2026-07-06
 
 ### Added

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -111,6 +111,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The 0.4.0 image retired the Python `pre-commit` for `prek` ([#778](https://github.com/vig-os/devcontainer/issues/778)), but files preserved on upgrade still invoke it and exit 127 (field-validated on a 0.3.5 → 0.4.0 consumer: the preserved `justfile.project` `precommit` recipe and repo-managed `.githooks` scripts broke every commit). The image now ships a **deprecated one-cycle `pre-commit → prek` shim** (stderr notice, removed in 0.5) so consumer hook scripts keep working while they migrate.
   - `init-workspace --force` scans the post-scaffold `justfile.project`, `.githooks/` scripts and `.pre-commit-config.yaml` for invocation-shaped `pre-commit` references and warns (non-fatally) with `file:line`, pointing at the MIGRATION.md rename checklist — which now also covers the NixOS `#!/bin/bash` shebang gotcha in old-scaffold `.githooks`.
 
+### Security
+
+- **Accept podman `CVE-2026-57231` in the vulnix register pending the nixpkgs 26.05 backport** ([#905](https://github.com/vig-os/devcontainer/issues/905))
+  - podman 5.8.2 (affects 5.8.1–5.8.3) leaks matching host environment variables into a container when a malicious image manifest carries malformed `Env` entries (a key with no value, via the `*` glob) — CVSS 7.5, a supply-chain risk only when running untrusted images. The release CVE gate blocked the 0.4.1 RC on this finding.
+  - Fixed upstream in 5.8.4/6.0.0, but the pinned `nixpkgs` `release-26.05` still ships 5.8.2 (backport [NixOS/nixpkgs#536367](https://github.com/NixOS/nixpkgs/pull/536367) open), so advancing the rev cannot remediate yet. Added a short-dated `.vulnixignore` exception (expires 2026-08-06, re-check weekly) to unblock the gate; the exception flips to a nixpkgs rev-advance once the backport lands.
+
 ## [0.4.0](https://github.com/vig-os/devcontainer/releases/tag/0.4.0) - 2026-07-06
 
 ### Added


### PR DESCRIPTION
## Summary

Unblocks the `release/0.4.1` RC, which failed the **Vulnix CVE Gate** ([run 28869306823](https://github.com/vig-os/devcontainer/actions/runs/28869306823)) on a single unexcepted HIGH finding:

```
1 unexcepted HIGH/CRITICAL or unscored vulnix finding(s):
  - CVE-2026-57231 (CVSS 7.5) in podman 5.8.2
```

[CVE-2026-57231](https://cve.threatint.eu/CVE/CVE-2026-57231) (CVSS 7.5): a malicious image manifest with malformed `Env` entries makes podman leak matching **host** environment variables into the container — a supply-chain risk when running untrusted images. `podman` is a direct devTool + the docker-shim binary, so the finding is a real product match.

## Why an exception, not a rev-advance

Fixed upstream in podman 5.8.4/6.0.0, but the pinned `nixpkgs` `release-26.05` (and `staging-26.05`) still ships **5.8.2** — the fix is only on `master`/`staging`/`unstable`. The 26.05 backport [NixOS/nixpkgs#536367](https://github.com/NixOS/nixpkgs/pull/536367) is an **open draft**, so advancing the rev cannot remediate today. This adds a short-dated `.vulnixignore` exception (expires **2026-08-06**, re-check weekly) matching the register's established convention; it flips to a rev-advance once the backport lands.

## Changes

- `.vulnixignore` — new 2026-07-07 triage section accepting `CVE-2026-57231` with provenance, reachability note, upstream/nixpkgs fix status, and expiry.
- `CHANGELOG.md` `[0.4.1]` `### Security` entry (+ auto-synced `.devcontainer` mirror).

## Verification

- `check-expirations`: passed (36 exceptions validated).
- Gate simulation: negative control reproduces the exact CI error against the pre-fix register; **passes** against the updated register.
- Full `just precommit` suite: green.

Closes #905
