### PR TITLE
ci(release): gate RC dispatch on CI only, defer draft/approval to final

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -309,6 +309,7 @@ jobs:
         id: pr
         env:
           VERSION: ${{ steps.vars.outputs.version }}
+          RELEASE_KIND: ${{ steps.vars.outputs.release_kind }}
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
@@ -339,28 +340,39 @@ jobs:
 
           echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
 
-          if [ "$IS_DRAFT" = "true" ]; then
-            echo "ERROR: PR #$PR_NUMBER is still in draft status"
-            echo "Mark it ready for review first: gh pr ready $PR_NUMBER"
-            exit 1
-          fi
-
-          if [ "$REVIEW_DECISION" = "APPROVED" ]; then
-            echo "PR #$PR_NUMBER is approved"
-          elif [ "$REVIEW_DECISION" = "null" ] || [ -z "$REVIEW_DECISION" ]; then
-            # Bot approval fallback when gh pr list leaves reviewDecision empty (#438)
-            APPROVED_COUNT=$(retry --retries 3 --backoff 5 --max-backoff 30 -- gh api \
-              --paginate --slurp \
-              "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/reviews" \
-              | jq 'add | map(select(.state == "APPROVED")) | length')
-            if [ "$APPROVED_COUNT" -eq 0 ]; then
-              echo "ERROR: PR #$PR_NUMBER does not have approvals (reviewDecision: $REVIEW_DECISION, approved reviews: 0)"
+          # The draft + approval gate applies only to the final release, which
+          # burns the immutable X.Y.Z tag. Release candidates are disposable
+          # verification artifacts (auto-incrementing rcN tags, never touch
+          # :latest, no GitHub Release, pruned at promote), so they gate on CI
+          # only and may run against a still-draft, not-yet-approved PR. The
+          # approval that protects `main` is re-enforced by promote-release's
+          # merge job regardless. See #902.
+          if [ "$RELEASE_KIND" = "final" ]; then
+            if [ "$IS_DRAFT" = "true" ]; then
+              echo "ERROR: PR #$PR_NUMBER is still in draft status"
+              echo "Mark it ready for review first: gh pr ready $PR_NUMBER"
               exit 1
             fi
-            echo "reviewDecision='$REVIEW_DECISION' but $APPROVED_COUNT approved review(s) found"
+
+            if [ "$REVIEW_DECISION" = "APPROVED" ]; then
+              echo "PR #$PR_NUMBER is approved"
+            elif [ "$REVIEW_DECISION" = "null" ] || [ -z "$REVIEW_DECISION" ]; then
+              # Bot approval fallback when gh pr list leaves reviewDecision empty (#438)
+              APPROVED_COUNT=$(retry --retries 3 --backoff 5 --max-backoff 30 -- gh api \
+                --paginate --slurp \
+                "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/reviews" \
+                | jq 'add | map(select(.state == "APPROVED")) | length')
+              if [ "$APPROVED_COUNT" -eq 0 ]; then
+                echo "ERROR: PR #$PR_NUMBER does not have approvals (reviewDecision: $REVIEW_DECISION, approved reviews: 0)"
+                exit 1
+              fi
+              echo "reviewDecision='$REVIEW_DECISION' but $APPROVED_COUNT approved review(s) found"
+            else
+              echo "ERROR: PR #$PR_NUMBER does not have approvals (status: $REVIEW_DECISION)"
+              exit 1
+            fi
           else
-            echo "ERROR: PR #$PR_NUMBER does not have approvals (status: $REVIEW_DECISION)"
-            exit 1
+            echo "Release kind '$RELEASE_KIND': deferring draft/approval gate to the final release (CI checks still enforced below)"
           fi
 
           # Check CI status
@@ -390,7 +402,11 @@ jobs:
             exit 1
           fi
 
-          echo "✓ PR #$PR_NUMBER verified: ready and approved"
+          if [ "$RELEASE_KIND" = "final" ]; then
+            echo "✓ PR #$PR_NUMBER verified: ready, approved, CI green"
+          else
+            echo "✓ PR #$PR_NUMBER verified: CI green (draft/approval gate deferred to final)"
+          fi
 
       - name: Validate and parse architectures
         id: matrix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Release-candidate dispatch gates on CI only** ([#902](https://github.com/vig-os/devcontainer/issues/902))
+  - `release.yml` no longer requires the release PR to be marked ready-for-review and approved before publishing a candidate — candidate dispatch now gates on CI status only, so RCs are freely dispatchable during verification while the PR stays a draft.
+  - The draft + approval gate now applies only to the **final** release (the step that burns the immutable `X.Y.Z` tag); `promote-release.yml`'s merge job still re-enforces approval before merging to `main`, so `main` and `:latest` remain fully protected.
+  - Release docs, `justfile`, and `CONTRIBUTE.md` reordered accordingly: publish candidates to verify first, then mark ready and get approval before `finalize-release`.
+
 ### Deprecated
 
 ### Removed

--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -244,7 +244,10 @@ reference, see [docs/RELEASE_CYCLE.md](docs/RELEASE_CYCLE.md).
 3. **Review and test the release**
    - Monitor CI on the draft PR
    - Fix any issues via bugfix PRs to `release/X.Y.Z`
-   - Mark PR as ready for review and get approval
+   - Publish candidates to verify: `just publish-candidate X.Y.Z` (gates on CI
+     only; the PR may stay a draft — repeat as needed)
+   - Mark PR as ready for review and get approval (required only for the final
+     release, once the candidate is verified)
 
 4. **Finalize and publish** (validates, finalizes CHANGELOG, builds, tests, signs, and publishes)
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Release-candidate dispatch gates on CI only** ([#902](https://github.com/vig-os/devcontainer/issues/902))
+  - `release.yml` no longer requires the release PR to be marked ready-for-review and approved before publishing a candidate — candidate dispatch now gates on CI status only, so RCs are freely dispatchable during verification while the PR stays a draft.
+  - The draft + approval gate now applies only to the **final** release (the step that burns the immutable `X.Y.Z` tag); `promote-release.yml`'s merge job still re-enforces approval before merging to `main`, so `main` and `:latest` remain fully protected.
+  - Release docs, `justfile`, and `CONTRIBUTE.md` reordered accordingly: publish candidates to verify first, then mark ready and get approval before `finalize-release`.
+
 ### Deprecated
 
 ### Removed

--- a/docs/RELEASE_CYCLE.md
+++ b/docs/RELEASE_CYCLE.md
@@ -114,13 +114,13 @@ graph TB
     G --> H{Issues found?}
     H -->|Yes| I["Fix via bugfix PRs"]
     I --> G
-    H -->|No| J["Mark PR ready<br/>Get approval"]
-    J --> K["just publish-candidate X.Y.Z"]
+    H -->|No| K["just publish-candidate X.Y.Z<br/>(CI-green only, PR still draft)"]
     K --> L["Workflow: build & test<br/>(no CHANGELOG changes)"]
     L --> M["Publish X.Y.Z-rcN"]
     M --> U{External gate pass?}
     U -->|No| I
-    U -->|Yes| N["just finalize-release X.Y.Z"]
+    U -->|Yes| J["Mark PR ready<br/>Get approval"]
+    J --> N["just finalize-release X.Y.Z"]
     N --> O["Workflow: set release date<br/>build & test"]
     O --> P{Tests pass?}
     P -->|No| Q["Automatic rollback<br/>+ issue creation"]
@@ -132,7 +132,7 @@ graph TB
 ### Release Phases
 
 1. **Preparation** (`prepare-release`): Freeze CHANGELOG on dev, create release branch, reset Unreleased on dev, open draft PR
-2. **Review & Testing**: CI validation, mark PR ready, fix issues, get approvals
+2. **Review & Testing**: CI validation, fix issues, publish candidates to verify; mark PR ready and get approvals last (this is the final-release gate, not the candidate gate)
 3. **Candidate Publish** (`publish-candidate`): Build/test/publish `X.Y.Z-rcN` and dispatch cross-repo validation workflow
 4. **Cross-Repo Validation**: Smoke-test runs asynchronously after candidate and final publish; see `docs/CROSS_REPO_RELEASE_GATE.md`. Before promotion, **`promote-release.yml`** requires a published **final** (non-draft, non-prerelease) GitHub Release for the version tag on `devcontainer-smoke-test` so human acceptance downstream is reflected before `:latest` and the draft release are published.
 5. **Finalization & Post-Release**: Publish final image/tag, open a **draft** GitHub Release for human review, then merge PR to `main` and let sync automation update `dev`
@@ -215,9 +215,9 @@ Next steps:
   1. Test release: git checkout release/1.0.0
   2. Review draft PR and monitor CI
   3. Fix any issues via bugfix PRs to release/1.0.0
-  4. Mark PR as ready for review (gh pr ready <PR_NUMBER>)
-  5. Get PR approval from reviewer
-  6. Publish candidate: just publish-candidate 1.0.0
+  4. Publish candidates to verify: just publish-candidate 1.0.0 (repeat as needed)
+  5. Mark PR as ready for review (gh pr ready <PR_NUMBER>)
+  6. Get PR approval from reviewer
   7. Final release: just finalize-release 1.0.0
 ```
 
@@ -263,19 +263,21 @@ This is the main quality gate. The release branch and draft PR serve as the coor
    gh workflow run ci.yml --ref release/1.0.0
    ```
 
-3. **Mark PR as Ready for Review**
+3. **Publish Candidates to Verify** (as needed)
 
-   Once initial CI passes and CHANGELOG is reviewed:
+   Release candidates are the verification vehicle. Publish one whenever you
+   want to exercise the actual built image:
 
    ```bash
-   # Mark PR as ready for review (removes draft status)
-   gh pr ready <PR_NUMBER>
-
-   # Or via GitHub UI:
-   # Navigate to PR → Click "Ready for review" button
+   # Infers the next X.Y.Z-rcN automatically
+   just publish-candidate 1.0.0
    ```
 
-   This signals to reviewers that the release is ready for formal review.
+   Candidate dispatch gates on **CI only** — the PR may stay a draft and need
+   not be approved yet ([#902](https://github.com/vig-os/devcontainer/issues/902)).
+   RCs are disposable: auto-incrementing `rcN` tags that never touch `:latest`,
+   create no GitHub Release, and are pruned at promote. Iterate freely until the
+   image behaves as intended.
 
 4. **Local Testing** (optional)
 
@@ -325,11 +327,27 @@ This is the main quality gate. The release branch and draft PR serve as the coor
    - Address feedback
    - Iterate until approved
 
-**Iteration:** Repeat steps 4-6 until all checks pass and reviewers approve.
+7. **Mark Ready for Review & Get Approval** (gate into finalization)
+
+   Once the candidate behaves correctly and the CHANGELOG is settled, promote
+   the PR out of draft and collect approval — this is the gate the **final**
+   release enforces (candidates do not):
+
+   ```bash
+   # Removes draft status (or use the "Ready for review" button in the UI)
+   gh pr ready <PR_NUMBER>
+   ```
+
+   Because this happens last, the approval lands on the exact diff that ships,
+   not an intermediate one.
+
+**Iteration:** Repeat steps 3-6 until the candidate is verified and reviewers
+approve, then do step 7 once before finalizing.
 
 ### Phase 3: Finalization (GitHub Actions Workflow)
 
-**Prerequisites:**
+**Prerequisites** (enforced for the **final** release only; candidates in
+Phase 2 require just the first bullet):
 - All CI checks passed on `release/X.Y.Z`
 - PR marked as ready for review (not draft)
 - PR has required approvals
@@ -338,10 +356,8 @@ This is the main quality gate. The release branch and draft PR serve as the coor
 **Execute:**
 
 ```bash
-# Publish next candidate (X.Y.Z-rcN inferred automatically)
-just publish-candidate X.Y.Z
-
 # Publish final release (X.Y.Z + latest)
+# Requires at least one candidate published during Phase 2.
 just finalize-release X.Y.Z
 
 # Monitor progress
@@ -357,7 +373,7 @@ The `release.yml` workflow performs the entire remaining release process. Behavi
    - Checks release branch exists
    - Verifies CHANGELOG has `## [X.Y.Z] - TBD`
    - For **final**: allows an existing **draft** GitHub Release for the publish tag (retry path); rejects a **published** (non-draft) release for the same tag
-   - Confirms PR exists, is not draft, is approved, and CI passed
+   - Confirms PR exists and CI passed; for **final** also requires it to be not draft and approved (candidates skip the draft/approval gate — [#902](https://github.com/vig-os/devcontainer/issues/902))
    - Records pre-finalization commit for rollback
 
 2. ✅ **Finalize** job (skipped if --dry-run)
@@ -619,7 +635,7 @@ gh workflow run prepare-release.yml --ref dev -f "version=1.0.0" -f "dry-run=tru
    - Verifies release branch exists
    - Checks CHANGELOG has `[X.Y.Z] - TBD`
    - For **final**: rejects a **published** GitHub Release for the publish tag; allows an existing **draft** (retry path)
-   - Verifies PR: not draft, approved, CI passed
+   - Verifies PR: CI passed (both kinds); for **final** also not draft and approved (candidates defer the draft/approval gate — [#902](https://github.com/vig-os/devcontainer/issues/902))
    - Records pre-finalization commit for rollback
    - Outputs: PR number, release date, pre-finalization SHA, publish tag metadata
 
@@ -820,7 +836,7 @@ just finalize-release X.Y.Z
 
 #### "PR is still in draft status"
 
-**Cause:** Release PR hasn't been marked as ready for review
+**Cause:** The **final** release PR hasn't been marked as ready for review. (Candidates don't hit this — they defer the draft/approval gate; see [#902](https://github.com/vig-os/devcontainer/issues/902).)
 
 **Solution:**
 
@@ -834,7 +850,7 @@ gh pr ready <PR_NUMBER>
 
 #### "PR has not been approved"
 
-**Cause:** PR needs at least one approval
+**Cause:** The **final** release PR needs at least one approval. (Candidates don't require approval; see [#902](https://github.com/vig-os/devcontainer/issues/902).)
 
 **Solution:**
 

--- a/docs/templates/CONTRIBUTE.md.j2
+++ b/docs/templates/CONTRIBUTE.md.j2
@@ -182,7 +182,10 @@ reference, see [docs/RELEASE_CYCLE.md](docs/RELEASE_CYCLE.md).
 3. **Review and test the release**
    - Monitor CI on the draft PR
    - Fix any issues via bugfix PRs to `release/X.Y.Z`
-   - Mark PR as ready for review and get approval
+   - Publish candidates to verify: `just publish-candidate X.Y.Z` (gates on CI
+     only; the PR may stay a draft — repeat as needed)
+   - Mark PR as ready for review and get approval (required only for the final
+     release, once the candidate is verified)
 
 4. **Finalize and publish** (validates, finalizes CHANGELOG, builds, tests, signs, and publishes)
 

--- a/justfile
+++ b/justfile
@@ -212,16 +212,18 @@ test version="dev":
 # Process:
 #   1. just prepare-release X.Y.Z    - Create release/X.Y.Z branch, draft PR
 #   2. Test release branch, fix bugs as needed via PRs to release branch
-#   3. Mark PR ready for review (gh pr ready PR_NUMBER)
-#   4. Get PR approval from reviewer
-#   5. just finalize-release X.Y.Z   - Triggers release.yml (final) that:
-#      - Validates PR status and all prerequisites
+#   3. just publish-candidate X.Y.Z  - Build/test/publish X.Y.Z-rcN to verify
+#                                       (gates on CI only; PR may stay draft); repeat as needed
+#   4. Mark PR ready for review (gh pr ready PR_NUMBER)
+#   5. Get PR approval from reviewer
+#   6. just finalize-release X.Y.Z   - Triggers release.yml (final) that:
+#      - Validates PR status and all prerequisites (requires an RC published in step 3)
 #      - Sets release date in CHANGELOG, syncs PR docs
 #      - Builds and tests container images; creates X.Y.Z tag; pushes versioned GHCR images
 #      - Creates draft GitHub Release; dispatches smoke-test (not :latest yet)
 #      - On failure: automatic rollback and issue creation
-#   6. Wait for devcontainer-smoke-test to publish its final release for X.Y.Z
-#   7. just promote-release X.Y.Z    - Triggers promote-release.yml that:
+#   7. Wait for devcontainer-smoke-test to publish its final release for X.Y.Z
+#   8. just promote-release X.Y.Z    - Triggers promote-release.yml that:
 #      - Updates GHCR :latest, publishes the draft GitHub Release, merges release PR to main
 #      - Merging to main triggers sync-main-to-dev.yml (PR main -> dev, auto-merge if clean)
 # ===============================================================================


### PR DESCRIPTION
## Summary

Moves the release approval gate off the **release-candidate (RC)** dispatch and onto the **final** dispatch.

Today `release.yml`'s `validate` job runs the same "Find and verify PR" gate for *both* `release-kind=candidate` and `release-kind=final`: it requires the release PR to be **non-draft**, **approved**, and **CI-green** before it will cut anything. That forces a reviewer to approve the release PR *before* any RC image exists — i.e. before the artifact they would functionally verify has been built — and lands approval on an intermediate diff rather than the one that ships.

RCs are already low-blast-radius: an RC burns a fresh auto-incrementing `X.Y.Z-rcN` tag + `:X.Y.Z-rcN` GHCR images (+cosign/SBOM) and dispatches the smoke-test. It does **not** touch `:latest`, creates **no** GitHub Release on this repo, merges nothing, and is pruned at promote. Gating that behind full PR approval is over-restrictive.

## What changed

- **`release.yml`** (`validate` job): the draft (`isDraft`) + approval (`reviewDecision`) checks are now guarded by `if [ "$RELEASE_KIND" = "final" ]`. The CI-status checks stay unconditional — **candidates gate on CI-green only**.
- **Docs / justfile / CONTRIBUTE**: reordered so candidates are published to verify *first*, then the PR is marked ready + approved *before* `finalize-release`. `docs/RELEASE_CYCLE.md` flowchart, phase summaries, prerequisites, and troubleshooting updated; `CONTRIBUTE.md` change made in its Jinja template (`docs/templates/CONTRIBUTE.md.j2`).
- **CHANGELOG**: `Changed` entry under `## Unreleased` (+ synced workspace mirror).

## Why this is safe

The gate that protects `main` is **never lost**: `promote-release.yml`'s `merge` job independently re-verifies not-draft + approved + CI before merging to `main` and undrafting the Release. Final still burns the immutable `X.Y.Z` tag, so it keeps the ready + approval gate. Promote is unchanged.

## Design decisions (from discussion)

- **RC gate = CI-green only** (not fully ungated): keeps the cheap "no RC on a red branch" floor and a thin supply-chain floor; `build-and-test`/`vulnix-gate` run inside the RC anyway.
- **Approval at the final dispatch** (not deferred to promote): final burns the immutable tag, so it deserves human sign-off at that step.

## Verification

- `just precommit` green end-to-end locally (incl. `generate-docs`, `sync-manifest` idempotent).
- No unit test covers the `release.yml` gate (no `release.bats`); this workflow change is verified by the hook suite + the conditional logic. The RC/final paths differ only by the guarded block.

Refs: #902
