### PR TITLE
feat(flake): generate .pre-commit-config.yaml from one flake hook definition, consumer-extensible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `native` module ships first (`stdenv.cc`, `cmake`, `gnumake`, `pkg-config`, generic `CC`/`CXX`) — the long-term [#879](https://github.com/vig-os/devcontainer/issues/879) answer; `geant4`/`rust`/`fortran`/`root` stay ask-gated candidates.
   - Per-module flake checks (`checks.<system>.module-<name>`) plus a uv C-extension sdist smoke test (`tests/test_flake_modules.py`).
 
+- **Flake-generated pre-commit hooks: one definition, consumer-extensible** ([#883](https://github.com/vig-os/devcontainer/issues/883))
+  - `nix/hooks.nix` now defines the pre-commit hook set once; it renders the sandbox-pure `checks.pre-commit` gate, the committed `.pre-commit-config.yaml` + scaffold copy (drift CI-gated by `tests/test_flake_hooks.py` against `nix eval .#lib.hooksPortable` — the hand-synced triangle and the manifest transform chain are retired), and the consumer surface.
+  - `mkProjectShell` gains opt-in `hooks` (toggle base hooks, per-hook `excludes`/overrides, fully custom hooks) and `hooksExcludes` (global excludes): entering the shell installs the rendered config via git-hooks.nix; a preserved hand-edited YAML ([#878](https://github.com/vig-os/devcontainer/issues/878)) is never overwritten, and the zero-hooks dev-shell stays byte-identical.
+  - Consumer contract and migration steps in `docs/MIGRATION.md`; the `.vig-os` manifest raw-YAML opt-out flag is tracked in [#885](https://github.com/vig-os/devcontainer/issues/885).
+
 ### Changed
 
 ### Deprecated

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -15,6 +15,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `native` module ships first (`stdenv.cc`, `cmake`, `gnumake`, `pkg-config`, generic `CC`/`CXX`) — the long-term [#879](https://github.com/vig-os/devcontainer/issues/879) answer; `geant4`/`rust`/`fortran`/`root` stay ask-gated candidates.
   - Per-module flake checks (`checks.<system>.module-<name>`) plus a uv C-extension sdist smoke test (`tests/test_flake_modules.py`).
 
+- **Flake-generated pre-commit hooks: one definition, consumer-extensible** ([#883](https://github.com/vig-os/devcontainer/issues/883))
+  - `nix/hooks.nix` now defines the pre-commit hook set once; it renders the sandbox-pure `checks.pre-commit` gate, the committed `.pre-commit-config.yaml` + scaffold copy (drift CI-gated by `tests/test_flake_hooks.py` against `nix eval .#lib.hooksPortable` — the hand-synced triangle and the manifest transform chain are retired), and the consumer surface.
+  - `mkProjectShell` gains opt-in `hooks` (toggle base hooks, per-hook `excludes`/overrides, fully custom hooks) and `hooksExcludes` (global excludes): entering the shell installs the rendered config via git-hooks.nix; a preserved hand-edited YAML ([#878](https://github.com/vig-os/devcontainer/issues/878)) is never overwritten, and the zero-hooks dev-shell stays byte-identical.
+  - Consumer contract and migration steps in `docs/MIGRATION.md`; the `.vig-os` manifest raw-YAML opt-out flag is tracked in [#885](https://github.com/vig-os/devcontainer/issues/885).
+
 ### Changed
 
 ### Deprecated

--- a/assets/workspace/flake.nix
+++ b/assets/workspace/flake.nix
@@ -55,6 +55,28 @@
         devShells.default = vigos.lib.mkProjectShell {
           inherit pkgs;
           extraPackages = extraPackages pkgs;
+
+          # Opt-in: let the flake GENERATE .pre-commit-config.yaml from the
+          # shared base hook set instead of hand-managing the scaffolded
+          # YAML — toggle base hooks, add per-hook/global excludes, or add
+          # fully custom hooks; hook updates then flow with `nix flake
+          # update vigos`, and your customization lives HERE (preserved).
+          # Contract + migration steps: docs/MIGRATION.md ("Customizing
+          # pre-commit hooks from the project flake"). Uncomment to opt in,
+          # then delete .pre-commit-config.yaml and add it to .gitignore
+          # (the generated config refuses to overwrite an existing file).
+          #
+          #   hooks = {
+          #     typos.enable = false;                    # toggle a base hook
+          #     detect-private-keys.excludes = [ "worker/src/index\\.ts" ];
+          #     my-data-check = {                        # fully custom hook
+          #       enable = true;
+          #       entry = "./scripts/check-dat.sh";
+          #       files = "\\.dat$";
+          #       language = "system";
+          #     };
+          #   };
+          #   hooksExcludes = [ "^data/stopping/" "\\.dat$" ]; # global excludes
         };
 
         # Opt-in local dev services (#795): a daemonless process-compose stack

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -196,6 +196,58 @@ The in-image behavior when no toolchain is provided is tracked in
 [#879](https://github.com/vig-os/devcontainer/issues/879); the toolchain
 itself always comes from one of the tiers above.
 
+## Customizing pre-commit hooks from the project flake (opt-in)
+
+Since [#883](https://github.com/vig-os/devcontainer/issues/883) the shared
+hook set is defined once in the vigOS flake, and a consumer can compose it
+from the **preserved** project `flake.nix` instead of hand-editing the
+scaffolded `.pre-commit-config.yaml`:
+
+```nix
+devShells.default = vigos.lib.mkProjectShell {
+  inherit pkgs;
+  hooks = {
+    pymarkdown.enable = false;                            # toggle a base hook
+    detect-private-keys.excludes = [ "worker/src/index\\.ts" ];
+    "no-commit-to-branch".settings.pattern = [ "^wip/.*$" ];
+    my-data-check = {                                     # fully custom hook
+      enable = true;
+      entry = "./scripts/check-dat.sh";
+      files = "\\.dat$";
+      language = "system";
+    };
+  };
+  hooksExcludes = [ "^data/stopping/" "\\.dat$" ];        # global excludes
+};
+```
+
+The contract:
+
+- **Opt-in only.** Without a `hooks`/`hooksExcludes` argument nothing changes:
+  the dev-shell is byte-identical to before and your (preserved,
+  [#878](https://github.com/vig-os/devcontainer/issues/878))
+  `.pre-commit-config.yaml` stays the runner config, hand-managed by you.
+- **Opting in makes the flake the generator.** On shell entry
+  ([git-hooks.nix](https://github.com/cachix/git-hooks.nix)'s installation
+  script inside the `shellHook`) the rendered config is installed as
+  `.pre-commit-config.yaml` — a symlink into the Nix store. Add
+  `.pre-commit-config.yaml` to `.gitignore`: it is a generated artifact now
+  and regenerates on every toolchain bump.
+- **A hand-edited file is never clobbered.** If a regular (non-symlink)
+  `.pre-commit-config.yaml` exists, the installation script *refuses* and
+  warns instead of overwriting. To complete the opt-in, port your
+  customizations (global `exclude:`, per-hook `exclude:`) into the
+  `hooks`/`hooksExcludes` block as above, then delete the YAML and gitignore
+  it. To opt back out, remove the `hooks` argument and commit a plain YAML
+  again.
+- **Residual:** the `pymarkdown` hook is not in nixpkgs, so the generated
+  base set does not include it (the scaffolded YAML runs it from its upstream
+  pre-commit repo). Add it as a custom hook if you need it under generation.
+- The planned declarative `.vig-os` manifest
+  ([#885](https://github.com/vig-os/devcontainer/issues/885)) will carry an
+  explicit raw-YAML opt-out flag so the choice is recorded per-repo rather
+  than inferred from the file state.
+
 ## Updating
 
 - **Downstream dev environment:** `nix flake update vigos` (or re-run

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -227,12 +227,19 @@ The contract:
   the dev-shell is byte-identical to before and your (preserved,
   [#878](https://github.com/vig-os/devcontainer/issues/878))
   `.pre-commit-config.yaml` stays the runner config, hand-managed by you.
-- **Opting in makes the flake the generator.** On shell entry
-  ([git-hooks.nix](https://github.com/cachix/git-hooks.nix)'s installation
-  script inside the `shellHook`) the rendered config is installed as
-  `.pre-commit-config.yaml` — a symlink into the Nix store. Add
+- **Opting in makes the flake the generator.** On shell entry (a
+  config-only snippet inside the `shellHook`) the rendered
+  [git-hooks.nix](https://github.com/cachix/git-hooks.nix) config is
+  installed as `.pre-commit-config.yaml` — a symlink into the Nix store. Add
   `.pre-commit-config.yaml` to `.gitignore`: it is a generated artifact now
   and regenerates on every toolchain bump.
+- **`.githooks` stays the hook entry point — generation never rewires
+  `core.hooksPath`.** Opting in only maintains the config symlink; it never
+  touches `core.hooksPath` or installs anything into `.git/hooks`, so the
+  scaffold's `.githooks` scripts (sanctioned-environment guard, any
+  repo-owned additions) keep running all stages, and `.githooks/pre-commit`'s
+  `prek run` picks the generated config up from the repo root. Opting back
+  out leaves the git wiring untouched for the same reason.
 - **A hand-edited file is never clobbered.** If a regular (non-symlink)
   `.pre-commit-config.yaml` exists, the installation script *refuses* and
   warns instead of overwriting. To complete the opt-in, port your

--- a/docs/NIX.md
+++ b/docs/NIX.md
@@ -326,35 +326,51 @@ These are decided inline in `flake.nix`; summarized here.
   `just precommit` runs `prek run --all-files`, and the baked hook cache is
   `PREK_HOME=/opt/prek-cache`.
 
-  **Two hook artifacts, kept in agreement.** The flake is the SSoT for the hook
-  *toolchain* and exposes a Nix-verified gate, but the runner still reads a
-  committed config, so there are two artifacts that must agree:
+  **One hook definition, three renders (#883; supersedes the former
+  "two hook artifacts" model).** `nix/hooks.nix` defines every pre-commit hook
+  exactly once, and the flake renders it three ways:
 
-  1. The committed **`.pre-commit-config.yaml`** is the hand-maintained,
-     PATH-based **runner** config that `prek` executes locally, in the image, and
-     in the downstream scaffold (`assets/workspace/`, which has no flake and whose
-     `language: system` hooks resolve from the image toolchain). It is *not*
-     generated from Nix: a store-path-bound generated file would not be portable
-     to the scaffold and would churn on every nixpkgs bump. The scaffold copy is
-     mirrored from it by the `sync-manifest` hook.
-  2. The flake's **`checks.pre-commit`** (built by `git-hooks.nix` with
-     `package = pkgs.prek`) runs the **sandbox-pure subset** of those hooks under
-     `nix flake check` — no network, no project venv. It reuses `treefmtEval` for
-     the single formatting hook (nixfmt + ruff-format + taplo), the nix-provided
-     pure linters (ruff, shellcheck, yamllint, typos, `taplo lint`), the
-     `just --fmt --check` justfile-format check (the committed `just-fmt` hook,
-     mirrored in check mode since the sandbox is read-only), the
-     `pre-commit-hooks` meta hooks, and the `vig-utils`/`bandit` hooks wired to
-     hermetic Nix binaries (`${vigUtils}/bin/…`, `${pkgs.bandit}/bin/bandit`).
+  1. The flake's **`checks.pre-commit`** (built by `git-hooks.nix` with
+     `package = pkgs.prek`) evaluates the definition's **sandbox-pure
+     profile** under `nix flake check` — no network, no project venv. It
+     reuses `treefmtEval` for the single formatting hook (nixfmt +
+     ruff-format + taplo), the nix-provided pure linters (ruff, shellcheck,
+     yamllint, typos, `taplo lint`), the `just --fmt --check`
+     justfile-format check (the runner hook mirrored in check mode since the
+     sandbox is read-only), the `pre-commit-hooks` meta hooks, and the
+     `vig-utils`/`bandit` hooks wired to hermetic Nix binaries
+     (`${vigUtils}/bin/…`, `${pkgs.bandit}/bin/bandit`).
+  2. The committed **`.pre-commit-config.yaml`** (and its scaffold copy in
+     `assets/workspace/`) is the definition's **PATH-portable render** — the
+     runner config `prek` executes locally, in the image, and in the
+     downstream scaffold. It stays a committed file rather than a gitignored
+     store artifact so it is portable and does not churn on nixpkgs bumps,
+     but it is no longer hand-maintained in parallel:
+     `tests/test_flake_hooks.py` diffs the render
+     (`nix eval .#lib.hooksPortable`) against both committed files
+     (normalized, every hook id/args/files/excludes/stages) and fails CI on
+     any drift. The former `sync-manifest` transform chain for the scaffold
+     copy is retired — the fidelity test is the single agreement mechanism.
+  3. The **consumer generation surface**: `mkProjectShell`'s opt-in
+     `hooks`/`hooksExcludes` arguments compose the definition's consumer
+     profile with per-repo overrides, and git-hooks.nix's installation
+     script (in the `shellHook`) installs the rendered
+     `.pre-commit-config.yaml` — gitignored and regenerated on shell entry,
+     upstream's recommended model. See `docs/MIGRATION.md` ("Customizing
+     pre-commit hooks from the project flake") for the consumer contract,
+     including the guarantee that a preserved hand-edited YAML is never
+     overwritten (#878) and the planned `.vig-os` manifest opt-out flag
+     (#885).
 
   Hooks that cannot run in the sandbox stay **runner-only** in the committed
-  config and are deliberately excluded from `checks.pre-commit`: the generators
+  render and carry no gate profile in `nix/hooks.nix`: the generators
   `generate-docs`/`sync-manifest`, `pip-licenses` (reads `uv.lock`), `pymarkdown`
-  (not in nixpkgs), `no-commit-to-branch` and `destroyed-symlinks`
+  (not in nixpkgs — also the one residual missing from the consumer generation
+  profile), `no-commit-to-branch` and `destroyed-symlinks`
   (git-state-dependent), `check-agent-identity` (inspects the commit
   author/committer), and the `commit-msg`/`prepare-commit-msg`-stage hooks (never
   run by `--all-files`). `checks.pre-commit` is thus a Nix-verified guarantee that
-  the pure hooks in the committed config stay correct; the impure ones remain
+  the pure hooks stay correct; the impure ones remain
   covered by CI's `prek run --all-files`. One fidelity note: the meta
   `debug-statements` hook parses the file's Python AST, so its `git-hooks.nix`
   package is pinned to the 3.14 `pre-commit-hooks` build to match the runner

--- a/flake.nix
+++ b/flake.nix
@@ -182,6 +182,13 @@
       # docs/rfcs/ADR-capability-modules.md for the v1 contract.
       capabilityModules = import ./nix/modules/default.nix;
 
+      # One definition of the pre-commit hook set (#883): nix/hooks.nix
+      # renders the sandbox-pure `checks.pre-commit` gate, the PATH-portable
+      # committed `.pre-commit-config.yaml` + scaffold copy (drift-gated by
+      # tests/test_flake_hooks.py via `lib.hooksPortable`), and the consumer
+      # generation surface (mkProjectShell's `hooks`/`hooksExcludes`).
+      hooksModule = import ./nix/hooks.nix { inherit (nixpkgs) lib; };
+
       # Binary names exposed for the parity test. Prefer the package's declared
       # `meta.mainProgram` (the canonical executable name, e.g. ripgrep -> rg,
       # neovim -> nvim, claude-code -> claude); fall back to the pname.
@@ -200,12 +207,15 @@
       #     inherit pkgs;
       #     modules = [ "native" ];           # opt-in capability modules (#884)
       #     extraPackages = [ pkgs.foo ];
+      #     hooks = { pymarkdown.enable = false; };  # opt-in generated hooks (#883)
       #   };
       mkProjectShell =
         {
           pkgs,
           modules ? [ ],
           extraPackages ? [ ],
+          hooks ? null,
+          hooksExcludes ? [ ],
           shellHook ? ''echo "devcontainer dev environment loaded (nix)"'',
         }:
         let
@@ -241,6 +251,48 @@
           moduleShellHook = pkgs.lib.concatMapStrings (
             m: pkgs.lib.optionalString ((m.shellHook or "") != "") ((m.shellHook or "") + "\n")
           ) moduleDefs;
+
+          # ------------------------------------------------------------------
+          # Flake-generated pre-commit config (#883) — OPT-IN. Passing `hooks`
+          # (an attrset, even empty) or `hooksExcludes` composes the shared
+          # base hook set (nix/hooks.nix consumer profile) with the consumer's
+          # per-hook overrides / custom hooks / global excludes via
+          # git-hooks.nix, and wires its installation script into the
+          # shellHook: entering the shell installs the rendered
+          # `.pre-commit-config.yaml` (a symlink to the store — gitignore it).
+          # git-hooks.nix REFUSES to touch an existing regular file, so a
+          # preserved hand-edited config (#878) is never overwritten — the
+          # consumer deletes it to complete the opt-in (docs/MIGRATION.md).
+          # With the default `hooks = null` every fragment below is empty and
+          # the shell stays byte-identical to the no-hooks builder (parity:
+          # tests/test_flake_devshell.py, tests/test_flake_hooks.py).
+          # ------------------------------------------------------------------
+          hooksEnabled = hooks != null || hooksExcludes != [ ];
+          consumerHooksBase = hooksModule.consumer pkgs;
+          # Base values at priority 999: they beat git-hooks.nix's own
+          # built-in hook defaults (mkDefault, 1000 — equal priorities would
+          # conflict, e.g. the built-in nixfmt entry vs the base one) and
+          # lose to any consumer fragment (plain assignment, 100), so e.g.
+          # `typos.enable = false` wins while untouched fields keep their
+          # base value (module-system merge).
+          consumerHooksDefaults = pkgs.lib.mapAttrs (
+            _: hook: pkgs.lib.mapAttrs (_: pkgs.lib.mkOverride 999) hook
+          ) consumerHooksBase.hooks;
+          hooksRun = git-hooks-nix.lib.${pkgs.stdenv.hostPlatform.system}.run {
+            # Only the rendered config + installation script are consumed; the
+            # sandbox check derivation (which would need the project tree) is
+            # never built, so a placeholder src suffices.
+            src = pkgs.emptyDirectory;
+            package = pkgs.prek;
+            imports = [
+              {
+                config.hooks = consumerHooksDefaults;
+                config.excludes = consumerHooksBase.excludes ++ hooksExcludes;
+              }
+              { config.hooks = if hooks == null then { } else hooks; }
+            ];
+          };
+          hooksShellHook = pkgs.lib.optionalString hooksEnabled (hooksRun.shellHook + "\n");
 
           # uv's Python-download metadata, pinned to the uv release we provision.
           # The nixpkgs build of uv ships with its embedded Python-download list
@@ -331,7 +383,8 @@
               ]
               ++ extraPackages
               ++ modulePackages;
-            shellHook = ldLibraryPathHook + "\n" + nvimIsolationHook + "\n" + moduleShellHook + shellHook;
+            shellHook =
+              ldLibraryPathHook + "\n" + nvimIsolationHook + "\n" + moduleShellHook + hooksShellHook + shellHook;
 
             UV_PYTHON = "${python}/bin/python3.14";
             UV_PYTHON_DOWNLOADS = "never";
@@ -346,6 +399,14 @@
             # downloads a managed CPython for pre-commit's manylinux-wheel hooks,
             # which a Nix-store interpreter cannot load there. Refs #632, #683.
             UV_PYTHON_DOWNLOADS_JSON_URL = uvPythonDownloadsJsonUrl;
+          }
+          # Expose the rendered hook config for tests/tooling ONLY when the
+          # consumer opted in, so the zero-hooks derivation is untouched.
+          # passthru is not part of the derivation environment. Refs #883.
+          // pkgs.lib.optionalAttrs hooksEnabled {
+            passthru = {
+              hooksConfigFile = hooksRun.config.configFile;
+            };
           }
         );
 
@@ -448,151 +509,30 @@
         ]);
 
         # ------------------------------------------------------------------
-        # preCommitCheck — the sandbox-pure subset of the committed
-        # `.pre-commit-config.yaml`, run by the `prek` runner as
+        # preCommitCheck — the sandbox-pure profile of the ONE hook-set
+        # definition (nix/hooks.nix, #883), run by the `prek` runner as
         # `checks.pre-commit` under `nix flake check`. Refs #778 (supersedes #40).
         #
         # `checks.pre-commit` builds in the Nix sandbox: NO network, NO project
-        # venv. Only hooks that are pure under those constraints are enabled
-        # here. Impure / generator / stage-gated hooks stay RUNNER-ONLY in the
-        # committed config (which prek runs from the toolchain PATH): generate-docs
-        # + sync-manifest (repo scripts needing python+repo), pip-licenses (reads
-        # uv.lock), pymarkdown (not in nixpkgs), no-commit-to-branch +
-        # check-agent-identity (inspect git state/identity, absent in the
-        # sandbox), and the commit-msg / prepare-commit-msg stage hooks (never run
-        # by `--all-files`).
-        #
-        # The committed `.pre-commit-config.yaml` stays the hand-maintained,
-        # PATH-based runner SSoT (it must stay portable to the downstream scaffold,
-        # which has no flake). This check is the Nix-verified guarantee that the
-        # pure hooks agree with it. See docs/NIX.md for the two-artifact model.
-        preCommitCheck = git-hooks-nix.lib.${system}.run {
-          src = ./.;
-          # Run the hooks with prek (Rust) instead of the Python pre-commit.
-          package = pkgs.prek;
-          # Mirror the committed config's top-level `exclude`.
-          excludes = [
-            "^\\.github_data/"
-            "^docs/issues/"
-            "^docs/pull-requests/"
-          ];
-          hooks = {
-            # Formatting: ONE treefmt hook (nixfmt-rfc-style + ruff-format +
-            # taplo) reusing the flake's treefmtEval — the same wrapper `nix fmt`
-            # and `checks.formatting` use. Replaces the individual nixfmt /
-            # ruff-format / taplo-format hooks with the same formatters. #777,#778.
-            treefmt = {
-              enable = true;
-              packageOverrides.treefmt = treefmtEval.config.build.wrapper;
-            };
-
-            # Pure linters, resolved from nix-provided tools (no venv).
-            ruff.enable = true;
-            shellcheck = {
-              enable = true;
-              args = [ "-x" ];
-              excludes = [ "(^|/)\\.envrc$" ];
-            };
-            yamllint = {
-              enable = true;
-              args = [
-                "--format"
-                "parsable"
-                "--strict"
-              ];
-            };
-            typos.enable = true;
-
-            # taplo semantic lint (formatting is covered by treefmt above). The
-            # built-in `taplo` hook formats, so define lint explicitly to mirror
-            # the committed `taplo-lint` hook.
-            taplo-lint = {
-              enable = true;
-              name = "taplo-lint";
-              entry = "${pkgs.taplo}/bin/taplo lint --config .taplo.toml";
-              language = "system";
-              types = [ "toml" ];
-            };
-
-            # just formats justfiles; `just` is in devTools so this pure hook can
-            # run in the sandbox. The committed `just-fmt` runner hook rewrites in
-            # place (`just --fmt --unstable`); the Nix check must not mutate the
-            # source, so mirror it in check mode (`--check`) — justfile-format
-            # drift is thus caught by `checks.pre-commit` like every other pure
-            # hook. Refs #778.
-            just-fmt = {
-              enable = true;
-              name = "just-fmt";
-              entry = "${pkgs.just}/bin/just --fmt --check --unstable";
-              language = "system";
-              files = "^justfile(\\..*)?$";
-              pass_filenames = false;
-            };
-
-            # pre-commit-hooks meta hooks (git-hooks.nix built-ins, sandbox-pure).
-            # Attr names follow git-hooks.nix (some pluralised vs the raw
-            # pre-commit-hooks ids). `destroyed-symlinks` has no git-hooks.nix
-            # built-in and is git-state-dependent, so it stays runner-only in the
-            # committed config (like no-commit-to-branch).
-            check-added-large-files.enable = true;
-            check-case-conflicts.enable = true;
-            check-json.enable = true;
-            check-merge-conflicts.enable = true;
-            check-symlinks.enable = true;
-            check-toml.enable = true;
-            check-yaml.enable = true;
-            # debug-statements parses the file's Python AST, so it must run under
-            # the project's interpreter (3.14): nixpkgs' default pre-commit-hooks
-            # is built for 3.13, which rejects the parenthesis-free multi-type
-            # `except A, B:` (PEP 758, valid in 3.14) the repo uses. Pin the hook's
-            # package to the 3.14 build so it matches the committed-config runner
-            # (which runs under the image/dev-shell 3.14). Refs #778.
-            python-debug-statements = {
-              enable = true;
-              package = python.pkgs.pre-commit-hooks;
-            };
-            detect-private-keys.enable = true;
-            end-of-file-fixer.enable = true;
-            mixed-line-endings.enable = true;
-            trim-trailing-whitespace.enable = true;
-
-            # vig-utils / bandit hooks wired to the hermetic Nix binaries
-            # (${vigUtils}/bin/… + ${pkgs.bandit}/bin/bandit) — sandbox-pure, no
-            # `uv run`. They mirror the committed config's file filters/args.
-            check-action-pins = {
-              enable = true;
-              name = "check-action-pins";
-              entry = "${vigUtils}/bin/check-action-pins";
-              language = "system";
-              files = "^\\.github/(workflows/.*\\.ya?ml|actions/.*/action\\.ya?ml)$";
-              pass_filenames = false;
-            };
-            check-skill-names = {
-              enable = true;
-              name = "check-skill-names";
-              entry = "${vigUtils}/bin/check-skill-names .claude/skills";
-              language = "system";
-              files = "^\\.claude/skills/";
-              pass_filenames = false;
-            };
-            check-expirations = {
-              enable = true;
-              name = "check-expirations";
-              entry = "${vigUtils}/bin/check-expirations .trivyignore .vulnixignore";
-              language = "system";
-              files = "^\\.(trivyignore|vulnixignore)$";
-              pass_filenames = false;
-            };
-            bandit = {
-              enable = true;
-              name = "bandit";
-              entry = "${pkgs.bandit}/bin/bandit -r packages/vig-utils/src/ assets/workspace/ -ll";
-              language = "system";
-              types = [ "python" ];
-              pass_filenames = false;
-            };
-          };
-        };
+        # venv. nix/hooks.nix marks which hooks are pure under those
+        # constraints (`check` fragments, wired here to the hermetic Nix
+        # binaries: treefmtEval's wrapper, ${vigUtils}/bin/…, the 3.14
+        # pre-commit-hooks build for debug-statements); the impure /
+        # generator / stage-gated hooks stay RUNNER-ONLY in the committed
+        # `.pre-commit-config.yaml`, which the SAME definition renders and
+        # tests/test_flake_hooks.py drift-gates. See docs/NIX.md
+        # ("One hook definition, three renders").
+        preCommitCheck = git-hooks-nix.lib.${system}.run (
+          {
+            src = ./.;
+            # Run the hooks with prek (Rust) instead of the Python pre-commit.
+            package = pkgs.prek;
+          }
+          // hooksModule.checkArgs {
+            inherit pkgs vigUtils python;
+            treefmtWrapper = treefmtEval.config.build.wrapper;
+          }
+        );
 
         # The toolchain SSoT plus the runtime substrate a bare layered image
         # lacks (an FHS base distro would provide these; here we add them
@@ -1191,6 +1131,10 @@
           mkProjectServices
           devTools
           ;
+        # PATH-portable renders of the one hook-set definition (#883):
+        # `runner` must match the committed .pre-commit-config.yaml,
+        # `scaffold` the assets/workspace copy (tests/test_flake_hooks.py).
+        hooksPortable = hooksModule.portable;
       };
       overlays.default = overlay;
 

--- a/flake.nix
+++ b/flake.nix
@@ -293,12 +293,14 @@
             package = pkgs.prek;
             imports = [
               {
-                config.hooks = consumerHooksDefaults;
-                config.excludes = consumerHooksBase.excludes ++ hooksExcludes;
-                # Never let git-hooks.nix install into `.git/hooks` or rewire
-                # `core.hooksPath` — the config-only snippet below owns the
-                # shellHook and `.githooks` stays the entry point (#908).
-                config.install.enable = false;
+                config = {
+                  hooks = consumerHooksDefaults;
+                  excludes = consumerHooksBase.excludes ++ hooksExcludes;
+                  # Never let git-hooks.nix install into `.git/hooks` or rewire
+                  # `core.hooksPath` — the config-only snippet below owns the
+                  # shellHook and `.githooks` stays the entry point (#908).
+                  install.enable = false;
+                };
               }
               { config.hooks = if hooks == null then { } else hooks; }
             ];

--- a/flake.nix
+++ b/flake.nix
@@ -257,12 +257,19 @@
           # (an attrset, even empty) or `hooksExcludes` composes the shared
           # base hook set (nix/hooks.nix consumer profile) with the consumer's
           # per-hook overrides / custom hooks / global excludes via
-          # git-hooks.nix, and wires its installation script into the
-          # shellHook: entering the shell installs the rendered
-          # `.pre-commit-config.yaml` (a symlink to the store — gitignore it).
-          # git-hooks.nix REFUSES to touch an existing regular file, so a
-          # preserved hand-edited config (#878) is never overwritten — the
+          # git-hooks.nix. Only the RENDERED CONFIG is consumed: entering the
+          # shell installs `.pre-commit-config.yaml` (a symlink to the store —
+          # gitignore it) via the builder's own snippet below, NOT
+          # git-hooks.nix's installation script (install.enable = false).
+          # That stock script would unset/reset `core.hooksPath` and install
+          # only the pre-commit stage into `.git/hooks`, silently bypassing
+          # the scaffold's `.githooks` entry point (sanctioned-environment
+          # guard, consumer-owned scripts) — PR #908 review. The snippet
+          # keeps git-hooks.nix's refusal semantics: a regular (non-symlink)
+          # `.pre-commit-config.yaml` (#878) is never overwritten — the
           # consumer deletes it to complete the opt-in (docs/MIGRATION.md).
+          # `.githooks/pre-commit` runs `prek run`, which reads the repo-root
+          # config, so the generated hooks execute through the existing wiring.
           # With the default `hooks = null` every fragment below is empty and
           # the shell stays byte-identical to the no-hooks builder (parity:
           # tests/test_flake_devshell.py, tests/test_flake_hooks.py).
@@ -288,11 +295,47 @@
               {
                 config.hooks = consumerHooksDefaults;
                 config.excludes = consumerHooksBase.excludes ++ hooksExcludes;
+                # Never let git-hooks.nix install into `.git/hooks` or rewire
+                # `core.hooksPath` — the config-only snippet below owns the
+                # shellHook and `.githooks` stays the entry point (#908).
+                config.install.enable = false;
               }
               { config.hooks = if hooks == null then { } else hooks; }
             ];
           };
-          hooksShellHook = pkgs.lib.optionalString hooksEnabled (hooksRun.shellHook + "\n");
+          # Config-only installation snippet (replaces hooksRun.shellHook):
+          # maintain the `.pre-commit-config.yaml` -> store symlink exactly
+          # like git-hooks.nix's installationScript — staleness check, refusal
+          # on a regular file (#878), GC root when nix-store is available —
+          # minus every `.git/hooks` / `core.hooksPath` mutation (#908).
+          hooksConfigFile = hooksRun.config.configFile;
+          hooksConfigInstall = ''
+            if ! ${pkgs.gitMinimal}/bin/git rev-parse --git-dir &> /dev/null; then
+              echo 1>&2 "WARNING: vigos hooks: .git not found; skipping generated pre-commit config installation."
+            else
+              GIT_WC=$(${pkgs.gitMinimal}/bin/git rev-parse --show-toplevel)
+              if ! readlink "$GIT_WC/.pre-commit-config.yaml" >/dev/null \
+                || [[ $(readlink "$GIT_WC/.pre-commit-config.yaml") != ${hooksConfigFile} ]]; then
+                if [ -e "$GIT_WC/.pre-commit-config.yaml" ] && [ ! -L "$GIT_WC/.pre-commit-config.yaml" ]; then
+                  echo 1>&2 "vigos hooks: WARNING: Refusing to install the generated config over an existing .pre-commit-config.yaml"
+                  echo 1>&2 ""
+                  echo 1>&2 "  To complete the flake-generated hooks opt-in (docs/MIGRATION.md):"
+                  echo 1>&2 "    1. Port your customizations into mkProjectShell's hooks/hooksExcludes."
+                  echo 1>&2 "    2. Remove .pre-commit-config.yaml"
+                  echo 1>&2 "    3. Add .pre-commit-config.yaml to .gitignore"
+                else
+                  echo 1>&2 "vigos hooks: installing generated .pre-commit-config.yaml"
+                  [ -L "$GIT_WC/.pre-commit-config.yaml" ] && unlink "$GIT_WC/.pre-commit-config.yaml"
+                  if command -v nix-store >/dev/null 2>&1; then
+                    nix-store --add-root "$GIT_WC/.pre-commit-config.yaml" --indirect --realise ${hooksConfigFile} >/dev/null
+                  else
+                    ln -fs ${hooksConfigFile} "$GIT_WC/.pre-commit-config.yaml"
+                  fi
+                fi
+              fi
+            fi
+          '';
+          hooksShellHook = pkgs.lib.optionalString hooksEnabled (hooksConfigInstall + "\n");
 
           # uv's Python-download metadata, pinned to the uv release we provision.
           # The nixpkgs build of uv ships with its embedded Python-download list
@@ -405,7 +448,7 @@
           # passthru is not part of the derivation environment. Refs #883.
           // pkgs.lib.optionalAttrs hooksEnabled {
             passthru = {
-              hooksConfigFile = hooksRun.config.configFile;
+              inherit hooksConfigFile;
             };
           }
         );

--- a/nix/hooks.nix
+++ b/nix/hooks.nix
@@ -1,0 +1,682 @@
+# One definition of the pre-commit hook set (#883).
+#
+# Every hook lives exactly once in `hookDefs` below, with one record per
+# artifact it appears in:
+#
+#   - `yaml`      — its PATH-portable representation in the committed runner
+#                   config (`.pre-commit-config.yaml`; `scaffold = true` also
+#                   places it in `assets/workspace/.pre-commit-config.yaml`).
+#                   Rendered by `portable.{runner,scaffold}` and drift-gated
+#                   against the committed files by tests/test_flake_hooks.py,
+#                   so the YAMLs can no longer diverge from this definition.
+#   - `check`     — its sandbox-pure git-hooks.nix fragment for the flake's
+#                   `checks.pre-commit` gate (store-path entries, hermetic;
+#                   `null` = runner-only, cannot run in the Nix sandbox).
+#   - `consumer`  — its git-hooks.nix fragment for the consumer generation
+#                   surface (`mkProjectShell { hooks = …; }`): entering the
+#                   shell installs the rendered config via git-hooks.nix's
+#                   installation script (`null` = not generatable, e.g.
+#                   pymarkdown, which is not in nixpkgs — documented residual
+#                   in docs/NIX.md).
+#
+# `checkName`/`consumerName` map a committed hook id to the git-hooks.nix
+# attribute name where they differ (git-hooks.nix pluralises some
+# pre-commit-hooks ids, e.g. check-case-conflict -> check-case-conflicts).
+{ lib }:
+let
+  # Topic-branch naming convention enforced by no-commit-to-branch:
+  # chore/<summary>, <type>/<issue>-<summary>, worktree/<issue>; main and dev
+  # are allowed (pushing there is blocked server-side, not here).
+  branchNamePattern = "^(?!main$)(?!dev$)(?!^(chore)/[a-z0-9]+(-[a-z0-9]+)*$)(?!^(feature|bugfix|hotfix|release|docs|test|refactor)/[0-9]+-[a-z0-9]+(-[a-z0-9]+)*$)(?!^worktree/[0-9]+$).+$";
+
+  # Top-level exclude — one regex string in the committed YAML, a list for
+  # git-hooks.nix (which joins with `|`). Same paths, two spellings.
+  yamlExclude = "^.github_data/|^docs/issues/|^docs/pull-requests/";
+  baseExcludes = [
+    "^\\.github_data/"
+    "^docs/issues/"
+    "^docs/pull-requests/"
+  ];
+
+  # Upstream repos (pinned revs) for the portable render of hooks that the
+  # runner installs from a remote pre-commit repo rather than the PATH.
+  remoteRepos = {
+    pre-commit-hooks = {
+      repo = "https://github.com/pre-commit/pre-commit-hooks";
+      rev = "cef0300fd0fc4d2a87a85fa2093c6b283ea36f4b"; # v5.0.0
+    };
+    yamllint = {
+      repo = "https://github.com/adrienverge/yamllint";
+      rev = "81e9f98ffd059efe8aa9c1b1a42e5cce61b640c6"; # v1.35.1
+    };
+    pymarkdown = {
+      repo = "https://github.com/jackdewinter/pymarkdown";
+      rev = "f93643d339dfee2a1022e7b05e8b5a281bfac553"; # v0.9.23
+    };
+  };
+
+  # Shared per-hook filters used by more than one artifact of the same hook.
+  shellcheckExclude = "(^|/)\\.envrc$";
+  yamllintArgs = [
+    "--format"
+    "parsable"
+    "--strict"
+  ];
+  justfileFiles = "^justfile(\\..*)?$";
+  actionPinsFiles = "^\\.github/(workflows/.*\\.ya?ml|actions/.*/action\\.ya?ml)$";
+  expirationsFiles = "^\\.(trivyignore|vulnixignore)$";
+
+  hookDefs = {
+    # ── Formatting ──────────────────────────────────────────────────────
+    # The gate runs ONE treefmt hook (nixfmt-rfc-style + ruff-format +
+    # taplo) reusing the flake's treefmt wrapper — the same formatting
+    # `nix fmt` and `checks.formatting` use (#777, #778). The runner keeps
+    # the individual PATH-portable formatter hooks below (ruff-format,
+    # taplo-format, nixfmt), because the treefmt wrapper is a store path
+    # and the committed config must stay PATH-portable.
+    treefmt = {
+      check =
+        { treefmtWrapper, ... }:
+        {
+          enable = true;
+          packageOverrides.treefmt = treefmtWrapper;
+        };
+    };
+
+    # ── pre-commit-hooks meta hooks ─────────────────────────────────────
+    # Enforce topic branch naming (runner-only: inspects git state, absent
+    # in the Nix sandbox). Consumers can override the pattern via
+    # `hooks."no-commit-to-branch".settings.{branch,pattern}`.
+    no-commit-to-branch = {
+      repo = "pre-commit-hooks";
+      scaffold = true;
+      yaml = {
+        name = "branch-name (enforce <type>/<issue>-<summary>)";
+        args = [
+          "--branch"
+          "__none__" # override default so main/dev are not protected
+          "--pattern"
+          branchNamePattern
+        ];
+      };
+      consumer = _: {
+        enable = true;
+        settings = {
+          branch = [ "__none__" ];
+          pattern = [ branchNamePattern ];
+        };
+      };
+    };
+    check-added-large-files = {
+      repo = "pre-commit-hooks";
+      scaffold = true;
+      yaml = { };
+      check = _: {
+        enable = true;
+      };
+      consumer = _: {
+        enable = true;
+      };
+    };
+    check-case-conflict = {
+      repo = "pre-commit-hooks";
+      scaffold = true;
+      yaml = { };
+      checkName = "check-case-conflicts";
+      check = _: {
+        enable = true;
+      };
+      consumerName = "check-case-conflicts";
+      consumer = _: {
+        enable = true;
+      };
+    };
+    check-json = {
+      repo = "pre-commit-hooks";
+      scaffold = true;
+      yaml = { };
+      check = _: {
+        enable = true;
+      };
+      consumer = _: {
+        enable = true;
+      };
+    };
+    check-merge-conflict = {
+      repo = "pre-commit-hooks";
+      scaffold = true;
+      yaml = { };
+      checkName = "check-merge-conflicts";
+      check = _: {
+        enable = true;
+      };
+      consumerName = "check-merge-conflicts";
+      consumer = _: {
+        enable = true;
+      };
+    };
+    check-symlinks = {
+      repo = "pre-commit-hooks";
+      scaffold = true;
+      yaml = { };
+      check = _: {
+        enable = true;
+      };
+      consumer = _: {
+        enable = true;
+      };
+    };
+    check-toml = {
+      repo = "pre-commit-hooks";
+      scaffold = true;
+      yaml = { };
+      check = _: {
+        enable = true;
+      };
+      consumer = _: {
+        enable = true;
+      };
+    };
+    check-yaml = {
+      repo = "pre-commit-hooks";
+      scaffold = true;
+      # git-hooks.nix' check-yaml built-in hardcodes --multi, so the runner
+      # matches it here to keep runner and gate in agreement (#778).
+      yaml = {
+        args = [ "--allow-multiple-documents" ];
+      };
+      check = _: {
+        enable = true;
+      };
+      consumer = _: {
+        enable = true;
+      };
+    };
+    # debug-statements parses the file's Python AST, so the gate pins the
+    # hook's package to the project-interpreter (3.14) build: the default
+    # is built for 3.13, which rejects PEP 758 parenthesis-free
+    # `except A, B:` used in this repo (#778, #803).
+    debug-statements = {
+      repo = "pre-commit-hooks";
+      scaffold = true;
+      yaml = { };
+      checkName = "python-debug-statements";
+      check =
+        { python, ... }:
+        {
+          enable = true;
+          package = python.pkgs.pre-commit-hooks;
+        };
+      consumerName = "python-debug-statements";
+      consumer = pkgs: {
+        enable = true;
+        package = pkgs.python314.pkgs.pre-commit-hooks;
+      };
+    };
+    # Runner-only in the gate (git-state-dependent, and git-hooks.nix has no
+    # built-in); the consumer render wires the pre-commit-hooks binary.
+    destroyed-symlinks = {
+      repo = "pre-commit-hooks";
+      scaffold = true;
+      yaml = { };
+      consumer = pkgs: {
+        enable = true;
+        name = "destroyed-symlinks";
+        entry = "${pkgs.python3Packages.pre-commit-hooks}/bin/destroyed-symlinks";
+        language = "system";
+        types = [ "file" ];
+      };
+    };
+    detect-private-key = {
+      repo = "pre-commit-hooks";
+      scaffold = true;
+      yaml = { };
+      checkName = "detect-private-keys";
+      check = _: {
+        enable = true;
+      };
+      consumerName = "detect-private-keys";
+      consumer = _: {
+        enable = true;
+      };
+    };
+    end-of-file-fixer = {
+      repo = "pre-commit-hooks";
+      scaffold = true;
+      yaml = { };
+      check = _: {
+        enable = true;
+      };
+      consumer = _: {
+        enable = true;
+      };
+    };
+    mixed-line-ending = {
+      repo = "pre-commit-hooks";
+      scaffold = true;
+      yaml = { };
+      checkName = "mixed-line-endings";
+      check = _: {
+        enable = true;
+      };
+      consumerName = "mixed-line-endings";
+      consumer = _: {
+        enable = true;
+      };
+    };
+    trailing-whitespace = {
+      repo = "pre-commit-hooks";
+      scaffold = true;
+      yaml = { };
+      checkName = "trim-trailing-whitespace";
+      check = _: {
+        enable = true;
+      };
+      consumerName = "trim-trailing-whitespace";
+      consumer = _: {
+        enable = true;
+      };
+    };
+
+    # ── Linters (language: system, resolved from the flake toolchain) ───
+    ruff = {
+      scaffold = true;
+      yaml = {
+        name = "ruff (lint/fix python)";
+        entry = "ruff check --fix";
+        language = "system";
+        types = [ "python" ];
+      };
+      check = _: {
+        enable = true;
+      };
+      consumer = _: {
+        enable = true;
+      };
+    };
+    ruff-format = {
+      scaffold = true;
+      yaml = {
+        name = "ruff-format (format python)";
+        entry = "ruff format";
+        language = "system";
+        types = [ "python" ];
+      };
+      # Gate coverage comes from the treefmt hook above.
+      consumer = _: {
+        enable = true;
+      };
+    };
+    yamllint = {
+      repo = "yamllint";
+      scaffold = true;
+      yaml = {
+        args = yamllintArgs;
+      };
+      check = _: {
+        enable = true;
+        args = yamllintArgs;
+      };
+      consumer = _: {
+        enable = true;
+        args = yamllintArgs;
+      };
+    };
+    # taplo semantic lint + format (runner-only ids; the gate covers
+    # formatting via treefmt and lint via a store-path taplo-lint below).
+    taplo-format = {
+      yaml = {
+        name = "taplo-format";
+        entry = "taplo format --config .taplo.toml";
+        language = "system";
+        types = [ "toml" ];
+      };
+    };
+    taplo-lint = {
+      yaml = {
+        name = "taplo-lint";
+        entry = "taplo lint --config .taplo.toml";
+        language = "system";
+        types = [ "toml" ];
+      };
+      check =
+        { pkgs, ... }:
+        {
+          enable = true;
+          name = "taplo-lint";
+          entry = "${pkgs.taplo}/bin/taplo lint --config .taplo.toml";
+          language = "system";
+          types = [ "toml" ];
+        };
+    };
+    # shellcheck runs as a language:system hook resolved from the flake
+    # (the shellcheck-py manylinux wheel cannot run in the Nix image, #778).
+    # .envrc files are direnv stdlib scripts with no shebang; excluded.
+    shellcheck = {
+      scaffold = true;
+      yaml = {
+        name = "shellcheck";
+        entry = "shellcheck";
+        language = "system";
+        types = [ "shell" ];
+        args = [ "-x" ];
+        exclude = shellcheckExclude;
+      };
+      check = _: {
+        enable = true;
+        args = [ "-x" ];
+        excludes = [ shellcheckExclude ];
+      };
+      consumer = _: {
+        enable = true;
+        args = [ "-x" ];
+        excludes = [ shellcheckExclude ];
+      };
+    };
+    # Markdown lint — runner-only everywhere: pymarkdown is not in nixpkgs,
+    # so neither the sandbox gate nor the consumer generation can resolve
+    # it (documented residual, docs/NIX.md).
+    pymarkdown = {
+      repo = "pymarkdown";
+      scaffold = true;
+      yaml = {
+        name = "pymarkdown";
+        args = [
+          "-c"
+          ".pymarkdown"
+          "fix"
+        ];
+        exclude = "^(README\\.md|CONTRIBUTE\\.md|TESTING\\.md)";
+      };
+    };
+    # just formats justfiles. The runner rewrites in place; the Nix gate
+    # must not mutate the source, so it mirrors the hook in check mode
+    # (`--check`) — justfile-format drift still fails the gate (#778).
+    just-fmt = {
+      scaffold = true;
+      yaml = {
+        name = "just (format justfiles)";
+        entry = "just --fmt --unstable";
+        language = "system";
+        files = justfileFiles;
+        pass_filenames = false;
+      };
+      check =
+        { pkgs, ... }:
+        {
+          enable = true;
+          name = "just-fmt";
+          entry = "${pkgs.just}/bin/just --fmt --check --unstable";
+          language = "system";
+          files = justfileFiles;
+          pass_filenames = false;
+        };
+      consumer = pkgs: {
+        enable = true;
+        name = "just-fmt";
+        entry = "${pkgs.just}/bin/just --fmt --unstable";
+        language = "system";
+        files = justfileFiles;
+        pass_filenames = false;
+      };
+    };
+    nixfmt = {
+      scaffold = true;
+      yaml = {
+        name = "nixfmt (format/check nix files)";
+        entry = "nixfmt --check";
+        language = "system";
+        files = "\\.nix$";
+        types = [ "file" ];
+      };
+      # Gate coverage comes from the treefmt hook above.
+      consumer = pkgs: {
+        enable = true;
+        name = "nixfmt";
+        entry = "${pkgs.nixfmt-rfc-style}/bin/nixfmt --check";
+        language = "system";
+        files = "\\.nix$";
+      };
+    };
+    typos = {
+      scaffold = true;
+      yaml = {
+        name = "typos (source typo checker)";
+        entry = "typos --force-exclude";
+        language = "system";
+      };
+      check = _: {
+        enable = true;
+      };
+      consumer = _: {
+        enable = true;
+      };
+    };
+
+    # ── Repo generators / project-venv hooks (runner-only: need network,
+    #    the uv venv, or repo scripts — impossible in the Nix sandbox) ────
+    generate-docs = {
+      yaml = {
+        name = "generate-docs (regenerate from templates)";
+        entry = "uv run python docs/generate.py";
+        language = "system";
+        files = "^(docs/templates/.*\\.j2|docs/narrative/.*\\.md|scripts/requirements\\.yaml|justfile|CHANGELOG\\.md|\\.claude/skills/.*/SKILL\\.md)$";
+        pass_filenames = false;
+      };
+    };
+    sync-manifest = {
+      yaml = {
+        name = "sync-manifest";
+        entry = "uv run python scripts/sync_manifest.py sync assets/workspace/";
+        language = "system";
+        pass_filenames = false;
+      };
+    };
+    pip-licenses = {
+      yaml = {
+        name = "pip-licenses (check dependency licenses)";
+        entry = "uv run pip-licenses --fail-on=\"GPL-3.0-only;GPL-3.0-or-later;AGPL-3.0-only;AGPL-3.0-or-later\"";
+        language = "system";
+        files = "^(pyproject\\.toml|uv\\.lock|requirements.*\\.txt)$";
+        pass_filenames = false;
+      };
+    };
+
+    # ── vig-utils / bandit hooks — the gate wires the hermetic Nix
+    #    binaries (${vigUtils}/bin/…, ${pkgs.bandit}/bin/bandit), the
+    #    runner resolves them from the project venv via `uv run`. ─────────
+    check-action-pins = {
+      yaml = {
+        name = "check-action-pins (verify SHA-pinned actions)";
+        entry = "uv run check-action-pins";
+        language = "system";
+        files = actionPinsFiles;
+        pass_filenames = false;
+      };
+      check =
+        { vigUtils, ... }:
+        {
+          enable = true;
+          name = "check-action-pins";
+          entry = "${vigUtils}/bin/check-action-pins";
+          language = "system";
+          files = actionPinsFiles;
+          pass_filenames = false;
+        };
+    };
+    bandit = {
+      yaml = {
+        name = "bandit (Python security linting)";
+        entry = "uv run bandit -r packages/vig-utils/src/ assets/workspace/ -ll";
+        language = "system";
+        types = [ "python" ];
+        pass_filenames = false;
+      };
+      check =
+        { pkgs, ... }:
+        {
+          enable = true;
+          name = "bandit";
+          entry = "${pkgs.bandit}/bin/bandit -r packages/vig-utils/src/ assets/workspace/ -ll";
+          language = "system";
+          types = [ "python" ];
+          pass_filenames = false;
+        };
+    };
+    check-skill-names = {
+      yaml = {
+        name = "check-skill-names (enforce naming convention)";
+        entry = "uv run check-skill-names .claude/skills";
+        language = "system";
+        files = "^\\.claude/skills/";
+        pass_filenames = false;
+      };
+      check =
+        { vigUtils, ... }:
+        {
+          enable = true;
+          name = "check-skill-names";
+          entry = "${vigUtils}/bin/check-skill-names .claude/skills";
+          language = "system";
+          files = "^\\.claude/skills/";
+          pass_filenames = false;
+        };
+    };
+    # Security exception expiry enforcement (#566). Ships to the scaffold
+    # (consumer repos carry .trivyignore/.vulnixignore too), so the
+    # consumer render keeps the PATH-portable `uv run` entry.
+    check-expirations = {
+      scaffold = true;
+      yaml = {
+        name = "check-expirations (.trivyignore/.vulnixignore expiry enforcement)";
+        entry = "uv run check-expirations .trivyignore .vulnixignore";
+        language = "system";
+        files = expirationsFiles;
+        pass_filenames = false;
+      };
+      check =
+        { vigUtils, ... }:
+        {
+          enable = true;
+          name = "check-expirations";
+          entry = "${vigUtils}/bin/check-expirations .trivyignore .vulnixignore";
+          language = "system";
+          files = expirationsFiles;
+          pass_filenames = false;
+        };
+      consumer = _: {
+        enable = true;
+        name = "check-expirations";
+        entry = "uv run check-expirations .trivyignore .vulnixignore";
+        language = "system";
+        files = expirationsFiles;
+        pass_filenames = false;
+      };
+    };
+
+    # ── AI-agent identity + commit-message hooks (stage-gated / git-state
+    #    hooks: never run by `--all-files`, runner-only; Refs #163) ────────
+    prepare-commit-msg-strip-trailers = {
+      yaml = {
+        name = "strip agent trailers from commit message";
+        entry = "uv run prepare-commit-msg-strip-trailers";
+        language = "system";
+        stages = [ "prepare-commit-msg" ];
+        pass_filenames = true;
+      };
+    };
+    check-agent-identity = {
+      yaml = {
+        name = "check agent identity";
+        entry = "uv run check-agent-identity";
+        language = "system";
+        pass_filenames = false;
+      };
+    };
+    validate-commit-msg = {
+      yaml = {
+        name = "validate commit message";
+        entry = "uv run validate-commit-msg";
+        language = "system";
+        stages = [ "commit-msg" ];
+        args = [
+          "--types"
+          "feat,fix,docs,chore,refactor,test,ci,build,revert,style"
+          "--scopes"
+          "agent,ci,setup,image,vigutils"
+          "--refs-optional-types"
+          "chore"
+          "--blocked-patterns"
+          ".github/agent-blocklist.toml"
+        ];
+      };
+    };
+  };
+
+  # ── Renders ───────────────────────────────────────────────────────────
+  # PATH-portable pre-commit config data (the committed YAML artifacts).
+  # `includeAll = false` restricts to the scaffold subset (`scaffold = true`).
+  portableFor =
+    includeAll:
+    let
+      selected = lib.filterAttrs (
+        _: d: (d.yaml or null) != null && (includeAll || (d.scaffold or false))
+      ) hookDefs;
+      repoOrder = [
+        "pre-commit-hooks"
+        "local"
+        "yamllint"
+        "pymarkdown"
+      ];
+      hooksOf =
+        repoKey:
+        lib.mapAttrsToList (id: d: { inherit id; } // d.yaml) (
+          lib.filterAttrs (_: d: (d.repo or "local") == repoKey) selected
+        );
+      blockFor =
+        repoKey:
+        let
+          hs = hooksOf repoKey;
+        in
+        lib.optional (hs != [ ]) (
+          (if repoKey == "local" then { repo = "local"; } else remoteRepos.${repoKey}) // { hooks = hs; }
+        );
+    in
+    {
+      exclude = yamlExclude;
+      # Build python-language hooks with the project interpreter (3.14) so
+      # PEP 758 syntax never false-flags under an older parser (#803).
+      default_language_version.python = "python3.14";
+      repos = lib.concatMap blockFor repoOrder;
+    };
+
+  # git-hooks.nix hook attrsets for a given artifact (`check`/`consumer`).
+  collectFor =
+    field: nameField: ctx:
+    lib.listToAttrs (
+      lib.mapAttrsToList (id: d: lib.nameValuePair (d.${nameField} or id) (d.${field} ctx)) (
+        lib.filterAttrs (_: d: (d.${field} or null) != null) hookDefs
+      )
+    );
+in
+{
+  # Data for `nix eval .#lib.hooksPortable` — the drift gate's SSoT side.
+  portable = {
+    runner = portableFor true;
+    scaffold = portableFor false;
+  };
+
+  # Arguments for git-hooks.nix `run` building the sandbox-pure
+  # `checks.pre-commit` gate. ctx: { pkgs, treefmtWrapper, vigUtils, python }.
+  checkArgs = ctx: {
+    excludes = baseExcludes;
+    hooks = collectFor "check" "checkName" ctx;
+  };
+
+  # Base hook set for the consumer generation surface
+  # (`mkProjectShell { hooks = …; }`). ctx: pkgs.
+  consumer = pkgs: {
+    excludes = baseExcludes;
+    hooks = collectFor "consumer" "consumerName" pkgs;
+  };
+}

--- a/scripts/manifest.toml
+++ b/scripts/manifest.toml
@@ -95,40 +95,8 @@ transforms = [
   { type = "Sed", pattern = "uv run derive-branch-summary", replace = "derive-branch-summary" },
 ]
 
-[[entries]]
-src = ".pre-commit-config.yaml"
-transforms = [
-  # ruff/ruff-format/typos stay as repo-local language:system hooks in the
-  # scaffold too, resolved from the toolchain baked into the devcontainer image
-  # (devTools SSoT). The #697 decoupling shipped self-contained upstream hooks
-  # because the integration suite still ran the published Debian image, whose
-  # PATH lacked those tools; that workaround is dropped now that the suite runs
-  # the freshly-built Nix image — whose non-FHS userland cannot even execute the
-  # upstream manylinux hook binaries. #701.
-  { type = "RemovePrecommitHooks", hook_ids = [
-    "generate-docs",
-    "sync-manifest",
-    "pip-licenses",
-    "check-action-pins",
-    "bandit",
-    "check-skill-names",
-    "prepare-commit-msg-strip-trailers",
-    "check-agent-identity",
-    "validate-commit-msg",
-    "taplo-format",
-    "taplo-lint",
-  ] },
-  { type = "Sed", pattern = "bandit -r packages/vig-utils/src/ assets/workspace/", replace = "bandit -r src/" },
-  { type = "StripTrailingBlankLines" },
-  { type = "ReplaceBlock", start_pattern = "^\\s+args: \\[$", end_pattern = "^\\s+\\]$", replacement = """
-        # Optional: customize commit types, scopes, or refs-optional types via CLI arguments.
-        # By default, scopes are not enforced. Set --scopes to require specific scopes.
-        # Examples (choose one args line):
-        #   args: ["--types", "feat,fix,docs,chore"]
-        #   args: ["--scopes", "api,cli,utils"]
-        #   args: ["--refs-optional-types", "chore"]
-        #   args: ["--types", "feat,fix,docs", "--scopes", "api,cli,utils", "--refs-optional-types", "chore"]
-""" },
-  { type = "Sed", pattern = "-r packages/vig-utils/src/ assets/workspace/ ", replace = "-r src/ " },
-  { type = "StripTrailingBlankLines" },
-]
+# NOTE (#883): the scaffold's .pre-commit-config.yaml is no longer derived
+# from the root config by manifest transforms. Both files are PATH-portable
+# renders of the ONE hook-set definition in nix/hooks.nix; drift between
+# either committed YAML and that definition is CI-gated by
+# tests/test_flake_hooks.py (nix eval .#lib.hooksPortable).

--- a/tests/test_flake_hooks.py
+++ b/tests/test_flake_hooks.py
@@ -1,0 +1,293 @@
+"""Fidelity gate for the flake-defined pre-commit hook set (issue #883).
+
+``nix/hooks.nix`` is the single definition of the pre-commit hook set. It
+renders three artifacts:
+
+1. the sandbox-pure ``checks.pre-commit`` gate (git-hooks.nix + prek),
+2. the PATH-portable runner config — the committed ``.pre-commit-config.yaml``,
+3. the scaffold template copy (``assets/workspace/.pre-commit-config.yaml``).
+
+The committed YAML files stay committed (PATH-portable, no store-path churn —
+see docs/NIX.md), so this module is the drift gate: it evaluates the portable
+render from the flake (``nix eval .#lib.hooksPortable``) and asserts it is
+data-identical to the committed files — every hook id, args, files, excludes
+and stages. Any hand edit to either YAML that is not mirrored in
+``nix/hooks.nix`` (or vice versa) fails CI here.
+
+It also covers the consumer surface: ``mkProjectShell``'s ``hooks`` /
+``hooksExcludes`` arguments (per-hook toggle/override, custom hooks, global
+excludes) and the zero-hooks-arg parity guarantee (no generation side effects
+unless a consumer opts in).
+
+Refs: #883
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+# Repository root (two levels up: tests/ -> repo root).
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+ROOT_CONFIG = REPO_ROOT / ".pre-commit-config.yaml"
+SCAFFOLD_CONFIG = REPO_ROOT / "assets" / "workspace" / ".pre-commit-config.yaml"
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("nix") is None,
+    reason="nix is not installed; flake hook fidelity tests require Nix",
+)
+
+
+def _nix_env() -> dict[str, str]:
+    """Environment for nix invocations with flakes enabled and the public cache."""
+    env = os.environ.copy()
+    env.setdefault(
+        "NIX_CONFIG",
+        "experimental-features = nix-command flakes\n"
+        "extra-substituters = https://vig-os.cachix.org\n"
+        "extra-trusted-public-keys = "
+        "vig-os.cachix.org-1:yoOYRi3bvnM6ThxO0joLt7vtzhTfkq3r6jykeUMg7Bk=",
+    )
+    return env
+
+
+def _run_nix(args: list[str], timeout: int = 600) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["nix", *args],
+        capture_output=True,
+        text=True,
+        env=_nix_env(),
+        timeout=timeout,
+        cwd=REPO_ROOT,
+    )
+
+
+def _normalize(config: dict[str, Any]) -> dict[str, Any]:
+    """Flatten a pre-commit config into comparable, order-independent data.
+
+    Returns ``{"exclude", "default_language_version", "hooks"}`` where
+    ``hooks`` maps each hook id to its full dict (plus the owning ``repo`` and
+    ``rev``), so repo-block grouping and ordering differences between the
+    committed YAML and the flake render never mask (or fake) a real drift.
+    """
+    hooks: dict[str, Any] = {}
+    for repo_block in config.get("repos", []):
+        for hook in repo_block.get("hooks", []):
+            entry = dict(hook)
+            entry["repo"] = repo_block["repo"]
+            if "rev" in repo_block:
+                entry["rev"] = repo_block["rev"]
+            hook_id = entry.pop("id")
+            assert hook_id not in hooks, f"duplicate hook id: {hook_id}"
+            hooks[hook_id] = entry
+    return {
+        "exclude": config.get("exclude"),
+        "default_language_version": config.get("default_language_version"),
+        "hooks": hooks,
+    }
+
+
+def _diff_hooks(rendered: dict[str, Any], committed: dict[str, Any]) -> str:
+    """Human-readable normalized diff (empty string == no drift)."""
+    lines: list[str] = []
+    for key in ("exclude", "default_language_version"):
+        if rendered[key] != committed[key]:
+            lines.append(
+                f"{key}: rendered={rendered[key]!r} committed={committed[key]!r}"
+            )
+    all_ids = sorted(set(rendered["hooks"]) | set(committed["hooks"]))
+    for hook_id in all_ids:
+        r = rendered["hooks"].get(hook_id)
+        c = committed["hooks"].get(hook_id)
+        if r == c:
+            continue
+        if r is None:
+            lines.append(f"{hook_id}: only in committed YAML: {c!r}")
+        elif c is None:
+            lines.append(f"{hook_id}: only in flake render: {r!r}")
+        else:
+            for field in sorted(set(r) | set(c)):
+                if r.get(field) != c.get(field):
+                    lines.append(
+                        f"{hook_id}.{field}: rendered={r.get(field)!r} committed={c.get(field)!r}"
+                    )
+    return "\n".join(lines)
+
+
+@pytest.fixture(scope="module")
+def rendered_portable() -> dict[str, Any]:
+    """The PATH-portable render of the hook set, straight from the flake."""
+    result = _run_nix(["eval", "--json", ".#lib.hooksPortable"])
+    assert result.returncode == 0, (
+        "nix eval .#lib.hooksPortable failed (is nix/hooks.nix wired into the flake?):\n"
+        + result.stderr
+    )
+    return json.loads(result.stdout)
+
+
+class TestPortableRenderFidelity:
+    """The one Nix definition renders exactly the committed YAML artifacts."""
+
+    def test_runner_render_matches_committed_config(
+        self, rendered_portable: dict[str, Any]
+    ) -> None:
+        """Zero normalized diff between the flake render and the root YAML."""
+        committed = _normalize(yaml.safe_load(ROOT_CONFIG.read_text()))
+        rendered = _normalize(rendered_portable["runner"])
+        diff = _diff_hooks(rendered, committed)
+        assert diff == "", (
+            f"nix/hooks.nix drifted from .pre-commit-config.yaml:\n{diff}"
+        )
+
+    def test_scaffold_render_matches_scaffold_config(
+        self, rendered_portable: dict[str, Any]
+    ) -> None:
+        """Zero normalized diff between the flake render and the scaffold copy."""
+        committed = _normalize(yaml.safe_load(SCAFFOLD_CONFIG.read_text()))
+        rendered = _normalize(rendered_portable["scaffold"])
+        diff = _diff_hooks(rendered, committed)
+        assert diff == "", (
+            "nix/hooks.nix (scaffold profile) drifted from "
+            f"assets/workspace/.pre-commit-config.yaml:\n{diff}"
+        )
+
+    def test_scaffold_render_is_subset_of_runner(
+        self, rendered_portable: dict[str, Any]
+    ) -> None:
+        """Every scaffold hook is the identical runner hook (one definition)."""
+        runner = _normalize(rendered_portable["runner"])["hooks"]
+        scaffold = _normalize(rendered_portable["scaffold"])["hooks"]
+        for hook_id, hook in scaffold.items():
+            assert hook == runner.get(hook_id), (
+                f"scaffold hook {hook_id} diverges from runner"
+            )
+
+
+class TestConsumerHooksSurface:
+    """mkProjectShell's ``hooks`` / ``hooksExcludes`` consumer surface."""
+
+    @pytest.fixture(scope="class")
+    def consumer_config(self) -> dict[str, Any]:
+        """Build the generated config for a customized consumer shell."""
+        expr = f"""
+        let
+          flake = builtins.getFlake "path:{REPO_ROOT}";
+          system = builtins.currentSystem;
+          pkgs = import flake.inputs.nixpkgs {{ inherit system; }};
+          shell = flake.lib.mkProjectShell {{
+            inherit pkgs;
+            hooks = {{
+              typos.enable = false;
+              detect-private-keys.excludes = [ "worker/src/index\\\\.ts" ];
+              my-data-check = {{
+                enable = true;
+                name = "my-data-check";
+                entry = "./scripts/check-dat.sh";
+                files = "\\\\.dat$";
+                language = "system";
+              }};
+            }};
+            hooksExcludes = [ "^data/stopping/" ];
+          }};
+        in
+        shell.hooksConfigFile
+        """
+        result = _run_nix(
+            ["build", "--impure", "--no-link", "--print-out-paths", "--expr", expr],
+            timeout=1800,
+        )
+        assert result.returncode == 0, (
+            "building the generated hook config failed:\n" + result.stderr
+        )
+        return json.loads(Path(result.stdout.strip()).read_text())
+
+    def test_custom_hook_is_rendered(self, consumer_config: dict[str, Any]) -> None:
+        hooks = _normalize(consumer_config)["hooks"]
+        assert "my-data-check" in hooks
+        assert hooks["my-data-check"]["entry"] == "./scripts/check-dat.sh"
+
+    def test_base_hook_can_be_disabled(self, consumer_config: dict[str, Any]) -> None:
+        assert "typos" not in _normalize(consumer_config)["hooks"]
+
+    def test_base_hooks_are_present(self, consumer_config: dict[str, Any]) -> None:
+        hooks = _normalize(consumer_config)["hooks"]
+        for expected in (
+            "check-yaml",
+            "ruff",
+            "shellcheck",
+            "yamllint",
+            "no-commit-to-branch",
+        ):
+            assert expected in hooks, (
+                f"base hook {expected} missing from generated config"
+            )
+
+    def test_per_hook_excludes_merge(self, consumer_config: dict[str, Any]) -> None:
+        hooks = _normalize(consumer_config)["hooks"]
+        assert "worker/src/index\\.ts" in hooks["detect-private-keys"]["exclude"]
+
+    def test_global_excludes_merge(self, consumer_config: dict[str, Any]) -> None:
+        exclude = consumer_config["exclude"]
+        assert "^data/stopping/" in exclude
+        # The base excludes stay active alongside the consumer additions.
+        assert ".github_data" in exclude
+
+
+class TestZeroHooksParity:
+    """Without a ``hooks``/``hooksExcludes`` opt-in nothing changes."""
+
+    def test_zero_hooks_shell_matches_default_devshell(self) -> None:
+        """mkProjectShell without hooks args is the flake's own dev-shell (same drv)."""
+        expr = f"""
+        let
+          flake = builtins.getFlake "path:{REPO_ROOT}";
+          system = builtins.currentSystem;
+          pkgs = import flake.inputs.nixpkgs {{
+            inherit system;
+            overlays = [ flake.overlays.default ];
+            config.allowUnfree = true;
+          }};
+        in {{
+          default = flake.devShells.${{system}}.default.drvPath;
+          zeroHooks = (flake.lib.mkProjectShell {{ inherit pkgs; }}).drvPath;
+        }}
+        """
+        result = _run_nix(["eval", "--impure", "--json", "--expr", expr])
+        assert result.returncode == 0, result.stderr
+        paths = json.loads(result.stdout)
+        assert paths["default"] == paths["zeroHooks"]
+
+    def test_zero_hooks_shellhook_has_no_generation(self) -> None:
+        """The default shellHook carries no git-hooks.nix installation script."""
+        result = _run_nix(
+            ["eval", "--raw", ".#devShells.x86_64-linux.default.shellHook"],
+        )
+        assert result.returncode == 0, result.stderr
+        assert ".pre-commit-config.yaml" not in result.stdout
+        assert "git-hooks.nix" not in result.stdout
+
+    def test_opted_in_shellhook_installs_config(self) -> None:
+        """Opting in wires the git-hooks.nix installation script into shellHook."""
+        expr = f"""
+        let
+          flake = builtins.getFlake "path:{REPO_ROOT}";
+          system = builtins.currentSystem;
+          pkgs = import flake.inputs.nixpkgs {{ inherit system; }};
+          shell = flake.lib.mkProjectShell {{
+            inherit pkgs;
+            hooks = {{ }};
+          }};
+        in
+        shell.shellHook
+        """
+        result = _run_nix(["eval", "--impure", "--raw", "--expr", expr])
+        assert result.returncode == 0, result.stderr
+        assert ".pre-commit-config.yaml" in result.stdout

--- a/tests/test_flake_hooks.py
+++ b/tests/test_flake_hooks.py
@@ -171,43 +171,46 @@ class TestPortableRenderFidelity:
             )
 
 
+@pytest.fixture(scope="module")
+def consumer_config() -> dict[str, Any]:
+    """Build the generated config for a customized consumer shell."""
+    expr = f"""
+    let
+      flake = builtins.getFlake "path:{REPO_ROOT}";
+      system = builtins.currentSystem;
+      pkgs = import flake.inputs.nixpkgs {{ inherit system; }};
+      shell = flake.lib.mkProjectShell {{
+        inherit pkgs;
+        hooks = {{
+          typos.enable = false;
+          detect-private-keys.excludes = [ "worker/src/index\\\\.ts" ];
+          my-data-check = {{
+            enable = true;
+            name = "my-data-check";
+            entry = "./scripts/check-dat.sh";
+            files = "\\\\.dat$";
+            language = "system";
+          }};
+        }};
+        hooksExcludes = [ "^data/stopping/" ];
+      }};
+    in
+    shell.hooksConfigFile
+    """
+    result = _run_nix(
+        ["build", "--impure", "--no-link", "--print-out-paths", "--expr", expr],
+        timeout=1800,
+    )
+    assert result.returncode == 0, (
+        "building the generated hook config failed:\n" + result.stderr
+    )
+    # The generated file is JSON preceded by "# …" comment lines; YAML is
+    # a JSON superset that treats them as comments, so parse with yaml.
+    return yaml.safe_load(Path(result.stdout.strip()).read_text())
+
+
 class TestConsumerHooksSurface:
     """mkProjectShell's ``hooks`` / ``hooksExcludes`` consumer surface."""
-
-    @pytest.fixture(scope="class")
-    def consumer_config(self) -> dict[str, Any]:
-        """Build the generated config for a customized consumer shell."""
-        expr = f"""
-        let
-          flake = builtins.getFlake "path:{REPO_ROOT}";
-          system = builtins.currentSystem;
-          pkgs = import flake.inputs.nixpkgs {{ inherit system; }};
-          shell = flake.lib.mkProjectShell {{
-            inherit pkgs;
-            hooks = {{
-              typos.enable = false;
-              detect-private-keys.excludes = [ "worker/src/index\\\\.ts" ];
-              my-data-check = {{
-                enable = true;
-                name = "my-data-check";
-                entry = "./scripts/check-dat.sh";
-                files = "\\\\.dat$";
-                language = "system";
-              }};
-            }};
-            hooksExcludes = [ "^data/stopping/" ];
-          }};
-        in
-        shell.hooksConfigFile
-        """
-        result = _run_nix(
-            ["build", "--impure", "--no-link", "--print-out-paths", "--expr", expr],
-            timeout=1800,
-        )
-        assert result.returncode == 0, (
-            "building the generated hook config failed:\n" + result.stderr
-        )
-        return json.loads(Path(result.stdout.strip()).read_text())
 
     def test_custom_hook_is_rendered(self, consumer_config: dict[str, Any]) -> None:
         hooks = _normalize(consumer_config)["hooks"]

--- a/tests/test_flake_hooks.py
+++ b/tests/test_flake_hooks.py
@@ -70,13 +70,21 @@ def _run_nix(args: list[str], timeout: int = 600) -> subprocess.CompletedProcess
     )
 
 
+# The only top-level keys the flake render emits. Anything else in a
+# committed YAML (e.g. a hand-added ``fail_fast: true``) is drift the
+# per-hook comparison would silently miss, so _normalize surfaces it.
+KNOWN_TOP_LEVEL_KEYS = frozenset({"exclude", "default_language_version", "repos"})
+
+
 def _normalize(config: dict[str, Any]) -> dict[str, Any]:
     """Flatten a pre-commit config into comparable, order-independent data.
 
-    Returns ``{"exclude", "default_language_version", "hooks"}`` where
-    ``hooks`` maps each hook id to its full dict (plus the owning ``repo`` and
-    ``rev``), so repo-block grouping and ordering differences between the
-    committed YAML and the flake render never mask (or fake) a real drift.
+    Returns ``{"exclude", "default_language_version", "unexpected_top_level",
+    "hooks"}`` where ``hooks`` maps each hook id to its full dict (plus the
+    owning ``repo`` and ``rev``), so repo-block grouping and ordering
+    differences between the committed YAML and the flake render never mask
+    (or fake) a real drift, and ``unexpected_top_level`` lists any top-level
+    key outside the rendered schema.
     """
     hooks: dict[str, Any] = {}
     for repo_block in config.get("repos", []):
@@ -91,6 +99,7 @@ def _normalize(config: dict[str, Any]) -> dict[str, Any]:
     return {
         "exclude": config.get("exclude"),
         "default_language_version": config.get("default_language_version"),
+        "unexpected_top_level": sorted(set(config) - KNOWN_TOP_LEVEL_KEYS),
         "hooks": hooks,
     }
 
@@ -98,7 +107,7 @@ def _normalize(config: dict[str, Any]) -> dict[str, Any]:
 def _diff_hooks(rendered: dict[str, Any], committed: dict[str, Any]) -> str:
     """Human-readable normalized diff (empty string == no drift)."""
     lines: list[str] = []
-    for key in ("exclude", "default_language_version"):
+    for key in ("exclude", "default_language_version", "unexpected_top_level"):
         if rendered[key] != committed[key]:
             lines.append(
                 f"{key}: rendered={rendered[key]!r} committed={committed[key]!r}"
@@ -135,6 +144,13 @@ def rendered_portable() -> dict[str, Any]:
 
 class TestPortableRenderFidelity:
     """The one Nix definition renders exactly the committed YAML artifacts."""
+
+    def test_normalize_flags_unexpected_top_level_keys(self) -> None:
+        """A hand-added top-level key (e.g. fail_fast) cannot pass unnoticed."""
+        sneaky = {"repos": [], "fail_fast": True}
+        clean = {"repos": []}
+        assert _normalize(sneaky)["unexpected_top_level"] == ["fail_fast"]
+        assert _diff_hooks(_normalize(clean), _normalize(sneaky)) != ""
 
     def test_runner_render_matches_committed_config(
         self, rendered_portable: dict[str, Any]
@@ -209,6 +225,26 @@ def consumer_config() -> dict[str, Any]:
     return yaml.safe_load(Path(result.stdout.strip()).read_text())
 
 
+@pytest.fixture(scope="module")
+def opted_in_shellhook() -> str:
+    """The shellHook of a minimally opted-in (``hooks = { }``) shell."""
+    expr = f"""
+    let
+      flake = builtins.getFlake "path:{REPO_ROOT}";
+      system = builtins.currentSystem;
+      pkgs = import flake.inputs.nixpkgs {{ inherit system; }};
+      shell = flake.lib.mkProjectShell {{
+        inherit pkgs;
+        hooks = {{ }};
+      }};
+    in
+    shell.shellHook
+    """
+    result = _run_nix(["eval", "--impure", "--raw", "--expr", expr])
+    assert result.returncode == 0, result.stderr
+    return result.stdout
+
+
 class TestConsumerHooksSurface:
     """mkProjectShell's ``hooks`` / ``hooksExcludes`` consumer surface."""
 
@@ -277,20 +313,29 @@ class TestZeroHooksParity:
         assert ".pre-commit-config.yaml" not in result.stdout
         assert "git-hooks.nix" not in result.stdout
 
-    def test_opted_in_shellhook_installs_config(self) -> None:
-        """Opting in wires the git-hooks.nix installation script into shellHook."""
-        expr = f"""
-        let
-          flake = builtins.getFlake "path:{REPO_ROOT}";
-          system = builtins.currentSystem;
-          pkgs = import flake.inputs.nixpkgs {{ inherit system; }};
-          shell = flake.lib.mkProjectShell {{
-            inherit pkgs;
-            hooks = {{ }};
-          }};
-        in
-        shell.shellHook
+    def test_opted_in_shellhook_installs_config(
+        self, opted_in_shellhook: str
+    ) -> None:
+        """Opting in wires the config installation into the shellHook.
+
+        The refuse-to-overwrite semantics (#878) must survive: a regular
+        (non-symlink) ``.pre-commit-config.yaml`` is never clobbered.
         """
-        result = _run_nix(["eval", "--impure", "--raw", "--expr", expr])
-        assert result.returncode == 0, result.stderr
-        assert ".pre-commit-config.yaml" in result.stdout
+        assert ".pre-commit-config.yaml" in opted_in_shellhook
+        assert "Refusing" in opted_in_shellhook
+
+    def test_opted_in_shellhook_never_rewires_hookspath(
+        self, opted_in_shellhook: str
+    ) -> None:
+        """Opting in must not touch ``core.hooksPath`` or ``.git/hooks``.
+
+        The scaffold's ``.githooks`` directory stays the single hook entry
+        point (its sanctioned-environment guard and any consumer-owned
+        scripts keep running); the generated config is picked up by
+        ``.githooks/pre-commit``'s ``prek run`` via the repo-root symlink.
+        PR #908 review defect: git-hooks.nix's stock installation script
+        unset/reset ``core.hooksPath`` and installed only the pre-commit
+        stage into ``.git/hooks``, silently bypassing ``.githooks``.
+        """
+        assert "core.hooksPath" not in opted_in_shellhook
+        assert "uninstall" not in opted_in_shellhook

--- a/tests/test_flake_hooks.py
+++ b/tests/test_flake_hooks.py
@@ -313,9 +313,7 @@ class TestZeroHooksParity:
         assert ".pre-commit-config.yaml" not in result.stdout
         assert "git-hooks.nix" not in result.stdout
 
-    def test_opted_in_shellhook_installs_config(
-        self, opted_in_shellhook: str
-    ) -> None:
+    def test_opted_in_shellhook_installs_config(self, opted_in_shellhook: str) -> None:
         """Opting in wires the config installation into the shellHook.
 
         The refuse-to-overwrite semantics (#878) must survive: a regular


### PR DESCRIPTION
## Description

Makes the flake the single definition of the pre-commit hook set and exposes it as consumer-extensible config on `mkProjectShell`, per the #883 spec.

`nix/hooks.nix` defines every hook exactly once and renders three artifacts:

1. **`checks.pre-commit`** — the sandbox-pure gate (git-hooks.nix + `prek`). Refactor-verified: the gate's `rawConfig` is byte-identical to the pre-refactor baseline.
2. **The PATH-portable runner YAML** — the committed `.pre-commit-config.yaml` and the scaffold copy. They stay committed (portable, no store-path churn), but are no longer hand-synced: `tests/test_flake_hooks.py` diffs the render (`nix eval .#lib.hooksPortable`) against both files (normalized: every hook id, args, files, excludes, stages) and fails CI on any drift. The `sync-manifest` transform chain for the scaffold copy is retired (`scripts/manifest.toml`) — collapse, not a fourth representation. The sandbox-impure subset (generators, `pymarkdown`, stage hooks, …) is included as render-only entries, so the normalized diff is **empty** — no residual.
3. **The consumer surface** — `mkProjectShell` gains opt-in `hooks` (toggle base hooks, per-hook `excludes`/overrides via module-system merge, fully custom hooks with the full pre-commit schema) and `hooksExcludes` (global excludes). Opting in wires a config-only snippet into the `shellHook`: entering the shell installs the rendered `.pre-commit-config.yaml` (gitignored symlink, regenerated on toolchain bumps) and touches nothing else — git-hooks.nix's own installation script is disabled (`install.enable = false`), so `core.hooksPath` and `.git/hooks` are never modified and the scaffold's `.githooks` stays the single hook entry point.

Consumer contract (docs/MIGRATION.md): generation is opt-in; a preserved hand-edited YAML (#878) is **never overwritten** — git-hooks.nix refuses and warns, so the consumer ports excludes into the flake, deletes the YAML and gitignores it. The `.vig-os` raw-YAML opt-out flag is cross-referenced to #885 (not implemented here). Residual for generated configs: `pymarkdown` is not in nixpkgs, so it is not in the generated base set (documented).

Parity: with no `hooks`/`hooksExcludes` argument the dev-shell derivation is **byte-identical** (`drvPath` unchanged vs baseline; asserted continuously by `TestZeroHooksParity`).

## Type of Change

- [x] `feat` -- New feature

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- `nix/hooks.nix` (new): one hook-set definition — per-hook `yaml` (portable render), `check` (gate fragment), `consumer` (generation fragment) records; renderers `portable.{runner,scaffold}`, `checkArgs`, `consumer`.
- `flake.nix`: `preCommitCheck` now consumes `hooksModule.checkArgs` (rawConfig unchanged); `mkProjectShell` gains `hooks ? null` / `hooksExcludes ? [ ]` (base at module priority 999 so consumer fragments win per-field; `passthru.hooksConfigFile` exposed only when opted in); `lib.hooksPortable` exported for the drift gate.
- `tests/test_flake_hooks.py` (new, TDD RED→GREEN): fidelity diff (runner + scaffold + scaffold⊆runner), consumer surface (custom hook, disable, per-hook/global excludes), zero-hooks parity.
- `assets/workspace/flake.nix`: commented `hooks`/`hooksExcludes` example.
- `scripts/manifest.toml`: `.pre-commit-config.yaml` entry removed (drift gate replaces the transform chain).
- `docs/NIX.md`: "two hook artifacts" section superseded by "one hook definition, three renders".
- `docs/MIGRATION.md`: consumer contract + migration steps.

## Changelog Entry

### Added
- **Flake-generated pre-commit hooks: one definition, consumer-extensible** ([#883](https://github.com/vig-os/devcontainer/issues/883))
  - `nix/hooks.nix` now defines the pre-commit hook set once; it renders the sandbox-pure `checks.pre-commit` gate, the committed `.pre-commit-config.yaml` + scaffold copy (drift CI-gated by `tests/test_flake_hooks.py` against `nix eval .#lib.hooksPortable` — the hand-synced triangle and the manifest transform chain are retired), and the consumer surface.
  - `mkProjectShell` gains opt-in `hooks` (toggle base hooks, per-hook `excludes`/overrides, fully custom hooks) and `hooksExcludes` (global excludes): entering the shell installs the rendered config as a repo-root symlink without ever touching `core.hooksPath` — the scaffold's `.githooks` entry point stays in charge; a preserved hand-edited YAML ([#878](https://github.com/vig-os/devcontainer/issues/878)) is never overwritten, and the zero-hooks dev-shell stays byte-identical.
  - Consumer contract and migration steps in `docs/MIGRATION.md`; the `.vig-os` manifest raw-YAML opt-out flag is tracked in [#885](https://github.com/vig-os/devcontainer/issues/885).

## Review follow-up (hooksPath defect)

The review-confirmed defect — git-hooks.nix's stock installation script unsetting/resetting `core.hooksPath` and installing only the `pre-commit` stage into `.git/hooks` on opt-in — is fixed structurally:

- `install.enable = false` on the consumer git-hooks.nix run disables the stock installation script entirely; only the rendered `configFile` is consumed.
- `mkProjectShell` owns a minimal shellHook snippet that replicates the script's config maintenance verbatim minus the git wiring: staleness check on the `.pre-commit-config.yaml` symlink, **refusal** on an existing regular file (#878 semantics preserved), GC root via `nix-store --add-root` (with `ln -fs` fallback). It never reads or writes `core.hooksPath` and never installs into `.git/hooks`, so opting in/out leaves the scaffold's `.githooks` wiring untouched (no flap on rebuild-vs-bump ordering).
- Generated hooks still execute: `assets/workspace/.githooks/pre-commit` runs `prek run` with no `-c`, so prek reads `.pre-commit-config.yaml` at the repo root — exactly the symlink to the generated store config. Verified in a scratch git repo: after the shellHook the symlink points at the generated config, `core.hooksPath` remains `.githooks`, `.git/hooks` gains no files, a second entry is a no-op, and a hand-edited regular file triggers the refusal warning untouched.
- Tests: `test_opted_in_shellhook_never_rewires_hookspath` (no `core.hooksPath`, no `uninstall` in the generated shellHook) + refusal-message assertion in `test_opted_in_shellhook_installs_config`; zero-hooks `drvPath` re-verified identical to the `dev` tip. Review nit also taken: the fidelity gate now flags unexpected top-level keys (e.g. `fail_fast: true`) in either committed YAML.

## Testing

- [x] Tests pass locally (`just test`) — targeted suites: `tests/test_flake_hooks.py` (11 passed), `tests/test_transforms.py` (4 passed), `tests/test_downstream_flake.py` (1 passed)
- [x] Manual testing performed (describe below)

### Manual Testing Details

- Fidelity gate: `nix eval .#lib.hooksPortable` diffed against both committed YAMLs — normalized diff empty.
- Gate equivalence: `nix eval .#checks.x86_64-linux.pre-commit.config.rawConfig` identical before/after the refactor; `nix build .#checks.x86_64-linux.pre-commit` green.
- Parity: `nix eval .#devShells.x86_64-linux.default.drvPath` identical before/after.
- `nix flake check --no-build` green; `deadnix`/`statix` checks built green.
- Full hook suite: `just precommit` (prek, all files) — all hooks Passed/Skipped, 0 failed.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

Closes #883

