### PR TITLE
ci(security): speed up PR Trivy scan (collapse runs + reuse warm cache)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -322,34 +322,41 @@ jobs:
           name: container-image-${{ needs.build-image.outputs.version }}-amd64
           path: /tmp
 
-      - name: Report HIGH/CRITICAL vulnerabilities (non-blocking)
+      # One Trivy pass for every reported severity (was two separate runs, one
+      # per tier). Each trivy-action invocation re-installs Trivy, re-parses the
+      # image tar and cold-pulls the vuln DB, so collapsing HIGH/CRITICAL + MEDIUM
+      # into a single `severity` list drops a whole ~3 min run. Still
+      # non-blocking (exit-code 0) — the authoritative CVE gate is the nightly
+      # vulnix scan (security-scan.yml). `.trivyignore` now also filters MEDIUM;
+      # harmless (awareness only, no MEDIUM-specific entries). trivy-action caches
+      # the DB in $GITHUB_WORKSPACE/.cache/trivy (cache: true default), so this
+      # step populates the cache the SBOM step below reuses. Refs #109, #642.
+      - name: Report HIGH/CRITICAL/MEDIUM vulnerabilities (non-blocking)
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0
         with:
           version: 'v0.71.2'
           input: /tmp/image.tar
           format: 'table'
-          severity: 'HIGH,CRITICAL'
-          exit-code: '0'
+          severity: 'HIGH,CRITICAL,MEDIUM'
+          exit-code: '0'  # Non-blocking report
           trivyignores: '.trivyignore'
 
-      - name: Report MEDIUM severity vulnerabilities (non-blocking)
-        if: always()
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0
-        with:
-          version: 'v0.71.2'
-          input: /tmp/image.tar
-          format: 'table'
-          severity: 'MEDIUM'
-          exit-code: '0'  # Non-blocking report
-
+      # SBOM is a package-inventory pass; it does not need the vuln DB the scan
+      # above already fetched, nor a second Trivy install. Reuse the warm state
+      # (skip-setup-trivy + TRIVY_SKIP_*_DB_UPDATE) so this stops cold-pulling
+      # ~ again on every run. Refs #109.
       - name: Generate container SBOM (CycloneDX)
         if: always()
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0
+        env:
+          TRIVY_SKIP_DB_UPDATE: 'true'
+          TRIVY_SKIP_JAVA_DB_UPDATE: 'true'
         with:
           version: 'v0.71.2'
           input: /tmp/image.tar
           format: 'cyclonedx'
           output: 'sbom-cyclonedx.json'
+          skip-setup-trivy: 'true'
 
       - name: Upload SBOM artifact
         if: always()


### PR DESCRIPTION
## What

Speeds up the `Security Scan` job in `ci.yml`, which was ~11.5 min of a ~14 min PR CI run (83% of wall-clock, on the critical path via `needs: build-image`).

Root cause (from run [28870696086](https://github.com/vig-os/devcontainer/actions/runs/28870696086)): Trivy ran **three times** over the same image tar — HIGH/CRITICAL (3m02s), MEDIUM (3m03s), SBOM (2m42s) — each re-installing Trivy, re-parsing the tar and cold-pulling the vuln DB.

## Changes

- **Collapse the two vuln tables into one** `severity: HIGH,CRITICAL,MEDIUM` invocation — removes a whole Trivy run.
- **SBOM step reuses the warm state** — `skip-setup-trivy: true` + `TRIVY_SKIP_DB_UPDATE`/`TRIVY_SKIP_JAVA_DB_UPDATE`, since SBOM generation needs neither a second Trivy install nor the vuln DB.

Both steps remain **non-blocking** (`exit-code: 0`). The authoritative blocking CVE gate is unchanged — the nightly `vulnix` scan in `security-scan.yml`.

## Why not path-gate?

Considered and rejected (per discussion in #109): an unchanged image can still be hit by a **newly-disclosed** CVE, so every PR keeps scanning. This PR makes the scan cheap instead of conditional.

## Note

`.trivyignore` now also filters MEDIUM findings (previously HIGH/CRITICAL only). Harmless — awareness-only output, and no `.trivyignore` entries are MEDIUM-specific.

Refs: #109