### PR TITLE
fix(ci): strip assets/workspace mirror leak from renovate-changelog consumer template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Renovate changelog template no longer leaks the upstream `assets/workspace` mirror** ([#914](https://github.com/vig-os/devcontainer/issues/914))
+  - The synced consumer `renovate-changelog-build.yml`/`-commit.yml` copied the `assets/workspace/.devcontainer/CHANGELOG.md` mirror plumbing verbatim; consumers have no such tree, so the steps hard-failed under `set -euo pipefail` on every Renovate changelog run. Manifest transforms now strip the mirror copies, leaving the template touching only the consumer's own `CHANGELOG.md`.
+
 - **Scaffold upgrade strands base recipes in a preserved `justfile.project`** ([#877](https://github.com/vig-os/devcontainer/issues/877))
   - 0.4.0 moved `lint`/`format`/`precommit`/`test`/`test-cov`/`sync`/`update` into `justfile.project`, which is preserved on upgrade — 0.3.x consumers never received them and the shipped `ci.yml` failed with `justfile does not contain recipe 'sync'`. `init-workspace --force` now appends the missing base recipes from the template into the preserved file (customized recipes always win; idempotent).
   - The retired `.devcontainer/justfile.base` is removed on upgrade where the scaffold manages `.devcontainer/` (never in `direnv` mode, [#738](https://github.com/vig-os/devcontainer/issues/738)), and the installer warns if the root `justfile` lacks the scaffold `import?` block.

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -88,6 +88,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Renovate changelog template no longer leaks the upstream `assets/workspace` mirror** ([#914](https://github.com/vig-os/devcontainer/issues/914))
+  - The synced consumer `renovate-changelog-build.yml`/`-commit.yml` copied the `assets/workspace/.devcontainer/CHANGELOG.md` mirror plumbing verbatim; consumers have no such tree, so the steps hard-failed under `set -euo pipefail` on every Renovate changelog run. Manifest transforms now strip the mirror copies, leaving the template touching only the consumer's own `CHANGELOG.md`.
+
 - **Scaffold upgrade strands base recipes in a preserved `justfile.project`** ([#877](https://github.com/vig-os/devcontainer/issues/877))
   - 0.4.0 moved `lint`/`format`/`precommit`/`test`/`test-cov`/`sync`/`update` into `justfile.project`, which is preserved on upgrade — 0.3.x consumers never received them and the shipped `ci.yml` failed with `justfile does not contain recipe 'sync'`. `init-workspace --force` now appends the missing base recipes from the template into the preserved file (customized recipes always win; idempotent).
   - The retired `.devcontainer/justfile.base` is removed on upgrade where the scaffold manages `.devcontainer/` (never in `direnv` mode, [#738](https://github.com/vig-os/devcontainer/issues/738)), and the installer warns if the root `justfile` lacks the scaffold `import?` block.

--- a/assets/workspace/.github/workflows/renovate-changelog-build.yml
+++ b/assets/workspace/.github/workflows/renovate-changelog-build.yml
@@ -77,10 +77,6 @@ jobs:
           if git diff --quiet CHANGELOG.md 2>/dev/null; then
             echo "modified=false" >> "$GITHUB_OUTPUT"
           else
-            # Keep the preserved-on-upgrade mirror in lockstep with root CHANGELOG.md
-            # so the sync-manifest gate stays green. The scripts/manifest.toml entry
-            # for CHANGELOG.md is a verbatim copy (no transform), so cp == sync output.
-            cp CHANGELOG.md assets/workspace/.devcontainer/CHANGELOG.md
             echo "modified=true" >> "$GITHUB_OUTPUT"
           fi
 
@@ -103,9 +99,6 @@ jobs:
           } > changelog-artifact/metadata.env
           if [[ "${MODIFIED}" == "true" ]]; then
             cp CHANGELOG.md changelog-artifact/
-            mkdir -p changelog-artifact/assets/workspace/.devcontainer
-            cp assets/workspace/.devcontainer/CHANGELOG.md \
-              changelog-artifact/assets/workspace/.devcontainer/CHANGELOG.md
           fi
 
       - name: Upload changelog artifact

--- a/assets/workspace/.github/workflows/renovate-changelog-commit.yml
+++ b/assets/workspace/.github/workflows/renovate-changelog-commit.yml
@@ -64,4 +64,4 @@ jobs:
             docs(changelog): add unreleased entry for renovate PR ${{ steps.metadata.outputs.pr_number }}
 
             Refs: #${{ steps.metadata.outputs.pr_number }}
-          FILE_PATHS: CHANGELOG.md,assets/workspace/.devcontainer/CHANGELOG.md
+          FILE_PATHS: CHANGELOG.md

--- a/scripts/manifest.toml
+++ b/scripts/manifest.toml
@@ -60,11 +60,22 @@ src = ".github/ISSUE_TEMPLATE/"
 [[entries]]
 src = ".github/actions/resolve-image/"
 
+# Consumers of the template have no assets/workspace/ mirror tree, so the
+# upstream-only lockstep copies of that mirror hard-fail under `set -euo pipefail`
+# on every consumer Renovate changelog run. Strip the mirror plumbing from the
+# template while preserving the consumer-facing CHANGELOG.md handling (#914).
 [[entries]]
 src = ".github/workflows/renovate-changelog-build.yml"
+transforms = [
+  { type = "RemoveBlock", start_pattern = '# Keep the preserved-on-upgrade mirror', end_pattern = 'cp CHANGELOG\.md assets/workspace/\.devcontainer/CHANGELOG\.md' },
+  { type = "RemoveBlock", start_pattern = 'mkdir -p changelog-artifact/assets/workspace', end_pattern = 'changelog-artifact/assets/workspace/\.devcontainer/CHANGELOG\.md' },
+]
 
 [[entries]]
 src = ".github/workflows/renovate-changelog-commit.yml"
+transforms = [
+  { type = "Sed", pattern = ',assets/workspace/\.devcontainer/CHANGELOG\.md', replace = "" },
+]
 
 [[entries]]
 src = ".github/workflows/scorecard.yml"

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -73,6 +73,45 @@ class TestWorkspaceInterpreterPath:
         assert "/opt/venv" not in interpreter
 
 
+class TestRenovateChangelogTemplateNoMirrorLeak:
+    """Synced renovate-changelog workflows must not leak the upstream-only mirror (#914).
+
+    The devcontainer repo keeps assets/workspace/.devcontainer/CHANGELOG.md in
+    lockstep with the root CHANGELOG.md, but consumers of the template have no
+    assets/workspace/ tree. Under ``set -euo pipefail`` the mirror copies hard-fail
+    on every consumer Renovate changelog run, so they must be stripped from the
+    synced template while the consumer-facing logic is preserved.
+    """
+
+    def test_build_workflow_drops_workspace_mirror(self, tmp_path):
+        """build.yml must not reference assets/workspace but keep the consumer copy."""
+        sync_manifest = _load_sync_manifest()
+        sync_manifest.sync(project_root, tmp_path)
+
+        build = (
+            tmp_path / ".github" / "workflows" / "renovate-changelog-build.yml"
+        ).read_text()
+
+        # The upstream-only mirror tree must not leak into the consumer template.
+        assert "assets/workspace" not in build
+        # Consumer-facing artifact copy and metadata logic must survive.
+        assert "cp CHANGELOG.md changelog-artifact/" in build
+        assert "metadata.env" in build
+        assert "renovate-changelog-pr" in build
+
+    def test_commit_workflow_only_commits_consumer_changelog(self, tmp_path):
+        """commit.yml FILE_PATHS must list only the consumer's own CHANGELOG.md."""
+        sync_manifest = _load_sync_manifest()
+        sync_manifest.sync(project_root, tmp_path)
+
+        commit = (
+            tmp_path / ".github" / "workflows" / "renovate-changelog-commit.yml"
+        ).read_text()
+
+        assert "assets/workspace" not in commit
+        assert "FILE_PATHS: CHANGELOG.md\n" in commit
+
+
 class TestRemovePrecommitHooks:
     """Tests for RemovePrecommitHooks transform."""
 


### PR DESCRIPTION
## Summary

Fixes #914 — the manifest synced the devcontainer repo's own `renovate-changelog-build.yml` / `-commit.yml` into the consumer template verbatim, carrying the upstream-only `assets/workspace/.devcontainer/CHANGELOG.md` mirror plumbing. Consumers have no `assets/workspace/` tree, so under `set -euo pipefail` those steps hard-failed on every Renovate changelog run.

## Change

Added manifest transforms (`scripts/manifest.toml`) that strip, **from the consumer template only**:
- the `cp CHANGELOG.md assets/workspace/.devcontainer/CHANGELOG.md` step and the `assets/workspace` artifact-copy block in `renovate-changelog-build.yml` (keeping the consumer-facing `cp CHANGELOG.md changelog-artifact/` and `metadata.env` logic);
- the extra `,assets/workspace/.devcontainer/CHANGELOG.md` path from `FILE_PATHS` in `renovate-changelog-commit.yml`.

The devcontainer repo's own root workflows are unchanged; only the generated `assets/workspace/…` copies drop the mirror. Regenerated via `just sync-workspace`.

## Verification

- `uv run pytest tests/test_transforms.py -q` → 6 passed (2 new tests RED→GREEN).
- Generated consumer workflows: `grep -c assets/workspace` = 0 on both; valid YAML.
- Root workflows unchanged (empty diff).
- Full `prek run --all-files` green locally (incl. `sync-manifest`, `yamllint`).

Discovered during 0.4.1-rc1 consumer-upgrade testing. Refs #874.