### PR TITLE
fix(workspace): preserve .typos.toml and harden init-workspace upgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Preserve a customized `.typos.toml` on upgrade** ([#913](https://github.com/vig-os/devcontainer/issues/913))
+  - `.typos.toml` joins the preserved-file set so a consumer's spell-check exceptions survive a `--force` upgrade; the upgrade prints the template diff (like `.pre-commit-config.yaml`, [#878](https://github.com/vig-os/devcontainer/issues/878)). Previously the generic template overwrote it and the `typos` hook then "corrected" real content.
+  - A consumer carrying the legacy `_typos.toml` no longer also receives the template `.typos.toml`, avoiding two active typos configs.
+
+- **Render preserved-file diff previews with `git diff`** ([#916](https://github.com/vig-os/devcontainer/issues/916))
+  - The preserved-file upgrade preview called `diff`, which the image does not ship, printing `command not found` into an empty box; it now uses `git diff --no-index`.
+
+- **Scan preserved CI workflows for the retired `pre-commit` binary** ([#916](https://github.com/vig-os/devcontainer/issues/916))
+  - The upgrade reference scan ([#881](https://github.com/vig-os/devcontainer/issues/881)) now also covers preserved `.github/workflows/*.yml`, flagging real `pre-commit` invocations with `file:line` while ignoring comments and step `name:` descriptions.
+
+- **Resolve the GitHub origin before scaffolding the workspace** ([#916](https://github.com/vig-os/devcontainer/issues/916))
+  - Under `--no-prompts`, a missing or underivable origin now aborts before any files are copied, instead of leaving a half-scaffolded workspace mid-run.
+
 - **Scaffold upgrade strands base recipes in a preserved `justfile.project`** ([#877](https://github.com/vig-os/devcontainer/issues/877))
   - 0.4.0 moved `lint`/`format`/`precommit`/`test`/`test-cov`/`sync`/`update` into `justfile.project`, which is preserved on upgrade — 0.3.x consumers never received them and the shipped `ci.yml` failed with `justfile does not contain recipe 'sync'`. `init-workspace --force` now appends the missing base recipes from the template into the preserved file (customized recipes always win; idempotent).
   - The retired `.devcontainer/justfile.base` is removed on upgrade where the scaffold manages `.devcontainer/` (never in `direnv` mode, [#738](https://github.com/vig-os/devcontainer/issues/738)), and the installer warns if the root `justfile` lacks the scaffold `import?` block.

--- a/assets/init-workspace.sh
+++ b/assets/init-workspace.sh
@@ -370,12 +370,14 @@ PRECOMMIT_CONFIG_PREEXISTED=false
 TYPOS_CONFIG_PREEXISTED=false
 [[ -f "$WORKSPACE_DIR/.typos.toml" ]] && TYPOS_CONFIG_PREEXISTED=true
 
-# Resolve (and validate) the GitHub origin for renovate.json BEFORE the first
-# filesystem mutation (#916): under --no-prompts a missing/underivable origin
-# must abort while the workspace is still pristine, not after rsync has left a
-# half-scaffolded tree. The resolved value feeds the placeholder substitution
-# below; nothing between here and the copy depends on files being present yet.
-resolve_github_repository
+# Under --no-prompts, resolve (and validate) the GitHub origin for renovate.json
+# BEFORE the first filesystem mutation (#916): a missing/underivable origin must
+# abort while the workspace is still pristine, not after rsync has left a
+# half-scaffolded tree. In interactive mode the resolution (which prompts) stays
+# after the copy, at its original call site below, to preserve prompt ordering.
+if [[ "$NO_PROMPTS" == "true" ]]; then
+    resolve_github_repository
+fi
 
 # Copy template contents to workspace
 echo "Initializing workspace from template..."
@@ -511,6 +513,14 @@ if [[ -n "${VIG_OS_VERSION:-}" && -f "$WORKSPACE_DIR/.vig-os" ]]; then
     fi
     echo "Pinning DEVCONTAINER_VERSION=${VIG_OS_VERSION} in .vig-os..."
     sed -i "s/^DEVCONTAINER_VERSION=.*/DEVCONTAINER_VERSION=${VIG_OS_VERSION}/" "$WORKSPACE_DIR/.vig-os"
+fi
+
+# Interactive origin resolution (the renovate.json owner/repo prompt) runs here,
+# after the copy, to keep the prompt ordering consumers and the integration
+# tests expect. Under --no-prompts this already resolved before the copy (#916),
+# so this call is a no-op then (GITHUB_REPOSITORY is set).
+if [[ "$NO_PROMPTS" != "true" ]]; then
+    resolve_github_repository
 fi
 
 # Replace placeholders in files (using pre-built manifest from image)

--- a/assets/init-workspace.sh
+++ b/assets/init-workspace.sh
@@ -370,6 +370,13 @@ PRECOMMIT_CONFIG_PREEXISTED=false
 TYPOS_CONFIG_PREEXISTED=false
 [[ -f "$WORKSPACE_DIR/.typos.toml" ]] && TYPOS_CONFIG_PREEXISTED=true
 
+# Resolve (and validate) the GitHub origin for renovate.json BEFORE the first
+# filesystem mutation (#916): under --no-prompts a missing/underivable origin
+# must abort while the workspace is still pristine, not after rsync has left a
+# half-scaffolded tree. The resolved value feeds the placeholder substitution
+# below; nothing between here and the copy depends on files being present yet.
+resolve_github_repository
+
 # Copy template contents to workspace
 echo "Initializing workspace from template..."
 echo "Copying files from $TEMPLATE_DIR to $WORKSPACE_DIR..."
@@ -496,8 +503,6 @@ if [[ -n "${VIG_OS_VERSION:-}" && -f "$WORKSPACE_DIR/.vig-os" ]]; then
     echo "Pinning DEVCONTAINER_VERSION=${VIG_OS_VERSION} in .vig-os..."
     sed -i "s/^DEVCONTAINER_VERSION=.*/DEVCONTAINER_VERSION=${VIG_OS_VERSION}/" "$WORKSPACE_DIR/.vig-os"
 fi
-
-resolve_github_repository
 
 # Replace placeholders in files (using pre-built manifest from image)
 echo "Replacing placeholders in files..."

--- a/assets/init-workspace.sh
+++ b/assets/init-workspace.sh
@@ -248,6 +248,29 @@ is_preserved_file() {
     return 1
 }
 
+# Preview the template-vs-preserved divergence for a preserved consumer file
+# (#878, #913). A preserved file never receives template evolution
+# automatically, so surface the diff for the consumer to fold in deliberately.
+# The image ships git but no diff(1)/cmp(1) (#916): use `git diff --no-index`,
+# whose --quiet form gates the block and which exits 1 (the expected "they
+# diverged" signal, not an error) when the files differ. Returns 0 when a diff
+# was printed (files differ), 1 when identical or either file is missing.
+print_preserved_template_diff() {
+    local rel="$1"
+    local preserved="$WORKSPACE_DIR/$rel"
+    local template="$TEMPLATE_DIR/$rel"
+    [[ -f "$preserved" && -f "$template" ]] || return 1
+    if git diff --no-index --quiet -- "$template" "$preserved" > /dev/null 2>&1; then
+        return 1  # identical: nothing to surface
+    fi
+    echo "Preserved $rel differs from the template (yours was kept)."
+    echo "Template changes NOT applied (fold in what you need, see MIGRATION.md):"
+    echo "─────────────────────────────────────────────────────────────"
+    git diff --no-index -- "$template" "$preserved" || true
+    echo "─────────────────────────────────────────────────────────────"
+    return 0
+}
+
 # Warn if forcing (prompt user) - show which files would be overwritten
 if [[ "$FORCE" == "true" ]]; then
     echo ""
@@ -571,17 +594,8 @@ fi
 # template so consumers can fold in what they need deliberately, and gate the
 # preserved file through `prek validate-config` — a config the runner cannot
 # load breaks every commit in the new image. Both are warnings, never fatal.
-if [[ "$PRECOMMIT_CONFIG_PREEXISTED" == "true" \
-    && -f "$WORKSPACE_DIR/.pre-commit-config.yaml" \
-    && -f "$TEMPLATE_DIR/.pre-commit-config.yaml" ]] \
-    && ! diff -q "$TEMPLATE_DIR/.pre-commit-config.yaml" \
-        "$WORKSPACE_DIR/.pre-commit-config.yaml" > /dev/null 2>&1; then
-    echo "Preserved .pre-commit-config.yaml differs from the template (yours was kept, #878)."
-    echo "Template changes NOT applied (fold in what you need, see MIGRATION.md):"
-    echo "─────────────────────────────────────────────────────────────"
-    diff -u "$WORKSPACE_DIR/.pre-commit-config.yaml" \
-        "$TEMPLATE_DIR/.pre-commit-config.yaml" || true
-    echo "─────────────────────────────────────────────────────────────"
+if [[ "$PRECOMMIT_CONFIG_PREEXISTED" == "true" ]] \
+    && print_preserved_template_diff ".pre-commit-config.yaml"; then
     if command -v prek > /dev/null 2>&1; then
         if ! (cd "$WORKSPACE_DIR" && prek validate-config .pre-commit-config.yaml > /dev/null 2>&1); then
             echo "Warning: preserved .pre-commit-config.yaml does not validate under prek (#878)." >&2

--- a/assets/init-workspace.sh
+++ b/assets/init-workspace.sh
@@ -495,6 +495,15 @@ fi
 # which is correct for finals but stale for release candidates: the repo-root
 # pin only advances at finalize. install.sh forwards its --version here so the
 # scaffold pins the image actually installed.
+#
+# NOTE (#916): when VIG_OS_VERSION is unset (raw `podman run … init-workspace.sh`
+# outside install.sh), the scaffold keeps the baked pin. We cannot stamp the
+# true image version from the runtime here: the ONLY in-image version record is
+# this same baked template .vig-os (built from the repo-root pin), so reading it
+# back is a no-op and still stale for RC images. Stamping the actual built tag
+# for RCs requires a build-side change — bake the true tag into the image as an
+# authoritative record (an env var or VERSION file distinct from the repo-root
+# pin) that this block could read when VIG_OS_VERSION is unset.
 if [[ -n "${VIG_OS_VERSION:-}" && -f "$WORKSPACE_DIR/.vig-os" ]]; then
     if [[ ! "$VIG_OS_VERSION" =~ ^[A-Za-z0-9._-]+$ ]]; then
         echo "Error: invalid VIG_OS_VERSION: $VIG_OS_VERSION" >&2

--- a/assets/init-workspace.sh
+++ b/assets/init-workspace.sh
@@ -58,6 +58,12 @@ PRESERVE_FILES=(
     # justfile.project; the upgrade prints a diff against the template below so
     # hook-stack evolution stays visible.
     ".pre-commit-config.yaml"
+    # The consumer owns its spell-check exceptions (#913): repos curate
+    # repo-specific extend-words/extend-exclude that a template overwrite
+    # silently destroyed, so the typos hook then flagged legitimate domain
+    # terms. Preserved like .pre-commit-config.yaml; the upgrade prints a diff
+    # against the template below. (Legacy `_typos.toml` handled at copy time.)
+    ".typos.toml"
 )
 
 # Base recipes the shipped .github/workflows/ci.yml depends on (sync, precommit,
@@ -359,6 +365,11 @@ JUSTFILE_PROJECT_PREEXISTED=false
 PRECOMMIT_CONFIG_PREEXISTED=false
 [[ -f "$WORKSPACE_DIR/.pre-commit-config.yaml" ]] && PRECOMMIT_CONFIG_PREEXISTED=true
 
+# A preserved .typos.toml is the consumer's spell-check exception set (#913);
+# record it so the post-scaffold guard can surface template divergence.
+TYPOS_CONFIG_PREEXISTED=false
+[[ -f "$WORKSPACE_DIR/.typos.toml" ]] && TYPOS_CONFIG_PREEXISTED=true
+
 # Copy template contents to workspace
 echo "Initializing workspace from template..."
 echo "Copying files from $TEMPLATE_DIR to $WORKSPACE_DIR..."
@@ -403,6 +414,16 @@ else
     # (rather than copying-then-pruning) keeps a real .devcontainer/ intact.
     if [[ "$MODE" == "direnv" ]]; then
         EXCLUDE_ARGS+=("--exclude=.devcontainer")
+    fi
+
+    # Legacy typos config (#913): the `typos` tool reads .typos.toml, typos.toml
+    # AND _typos.toml. A consumer still carrying _typos.toml (and no .typos.toml)
+    # must not also receive the template .typos.toml, or two active configs
+    # collide. Skip shipping the template one; their _typos.toml stands as the
+    # single config (a preserved .typos.toml is already excluded above).
+    if [[ -f "$WORKSPACE_DIR/_typos.toml" && ! -f "$WORKSPACE_DIR/.typos.toml" ]]; then
+        echo "Consumer carries legacy _typos.toml; not shipping template .typos.toml (#913)."
+        EXCLUDE_ARGS+=("--exclude=.typos.toml")
     fi
 
     rsync -avL --exclude='.git' --exclude='.venv' "${EXCLUDE_ARGS[@]}" "$TEMPLATE_DIR/" "$WORKSPACE_DIR/"
@@ -602,6 +623,14 @@ if [[ "$PRECOMMIT_CONFIG_PREEXISTED" == "true" ]] \
             echo "         Every commit will fail until it parses — run 'prek validate-config .pre-commit-config.yaml' and fix it." >&2
         fi
     fi
+fi
+
+# A preserved .typos.toml is the consumer's (#913) — never overwritten, so
+# their spell-check exceptions survive; the cost is that template exception
+# evolution no longer arrives automatically. Print the divergence so consumers
+# can fold in what they need deliberately. Non-fatal, like the #878 guard.
+if [[ "$TYPOS_CONFIG_PREEXISTED" == "true" ]]; then
+    print_preserved_template_diff ".typos.toml" || true
 fi
 
 # The retired `pre-commit` binary (#778) exits 127 at first use: a preserved

--- a/assets/init-workspace.sh
+++ b/assets/init-workspace.sh
@@ -643,7 +643,10 @@ fi
 # a command word (start/whitespace/shell punctuation on both sides), so the
 # config FILENAME (leading `.`), pre-commit-hooks repo URLs (leading `/`),
 # pre-commit.com links (trailing `.`), and `prek` never trip it; comment
-# lines and bare YAML stage-name list items (`- pre-commit`) are filtered.
+# lines, bare YAML stage-name list items (`- pre-commit`), and YAML `name:`
+# step descriptions (a workflow's "Run pre-commit hooks" step name, #916) are
+# filtered. Preserved consumer CI workflows are scanned too (#916): a workflow
+# that still runs the retired binary breaks the same way as a justfile recipe.
 PRECOMMIT_REF_PATTERN='(^|[[:space:]("'"'"';&|=`])pre-commit([[:space:])"'"'"';&|]|$)'
 PRECOMMIT_SCAN_TARGETS=()
 for scan_file in "$WORKSPACE_DIR/justfile.project" "$WORKSPACE_DIR/.pre-commit-config.yaml"; do
@@ -651,12 +654,15 @@ for scan_file in "$WORKSPACE_DIR/justfile.project" "$WORKSPACE_DIR/.pre-commit-c
 done
 while IFS= read -r scan_file; do
     PRECOMMIT_SCAN_TARGETS+=("$scan_file")
-done < <(find "$WORKSPACE_DIR/.githooks" -type f 2>/dev/null | sort)
+done < <({ find "$WORKSPACE_DIR/.githooks" -type f 2>/dev/null
+          find "$WORKSPACE_DIR/.github/workflows" -maxdepth 1 -type f \
+              \( -name '*.yml' -o -name '*.yaml' \) 2>/dev/null; } | sort)
 PRECOMMIT_REF_HITS=""
 if [[ ${#PRECOMMIT_SCAN_TARGETS[@]} -gt 0 ]]; then
     PRECOMMIT_REF_HITS="$(grep -nHE "$PRECOMMIT_REF_PATTERN" "${PRECOMMIT_SCAN_TARGETS[@]}" 2>/dev/null \
         | grep -vE '^[^:]*:[0-9]+:[[:space:]]*#' \
-        | grep -vE '^[^:]*:[0-9]+:[[:space:]]*-[[:space:]]+pre-commit[[:space:]]*$' || true)"
+        | grep -vE '^[^:]*:[0-9]+:[[:space:]]*-[[:space:]]+pre-commit[[:space:]]*$' \
+        | grep -vE '^[^:]*:[0-9]+:[[:space:]]*(-[[:space:]]+)?name:' || true)"
 fi
 if [[ -n "$PRECOMMIT_REF_HITS" ]]; then
     echo "Warning: the retired 'pre-commit' binary is still invoked by preserved file(s) (#881):" >&2

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -88,6 +88,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Preserve a customized `.typos.toml` on upgrade** ([#913](https://github.com/vig-os/devcontainer/issues/913))
+  - `.typos.toml` joins the preserved-file set so a consumer's spell-check exceptions survive a `--force` upgrade; the upgrade prints the template diff (like `.pre-commit-config.yaml`, [#878](https://github.com/vig-os/devcontainer/issues/878)). Previously the generic template overwrote it and the `typos` hook then "corrected" real content.
+  - A consumer carrying the legacy `_typos.toml` no longer also receives the template `.typos.toml`, avoiding two active typos configs.
+
+- **Render preserved-file diff previews with `git diff`** ([#916](https://github.com/vig-os/devcontainer/issues/916))
+  - The preserved-file upgrade preview called `diff`, which the image does not ship, printing `command not found` into an empty box; it now uses `git diff --no-index`.
+
+- **Scan preserved CI workflows for the retired `pre-commit` binary** ([#916](https://github.com/vig-os/devcontainer/issues/916))
+  - The upgrade reference scan ([#881](https://github.com/vig-os/devcontainer/issues/881)) now also covers preserved `.github/workflows/*.yml`, flagging real `pre-commit` invocations with `file:line` while ignoring comments and step `name:` descriptions.
+
+- **Resolve the GitHub origin before scaffolding the workspace** ([#916](https://github.com/vig-os/devcontainer/issues/916))
+  - Under `--no-prompts`, a missing or underivable origin now aborts before any files are copied, instead of leaving a half-scaffolded workspace mid-run.
+
 - **Scaffold upgrade strands base recipes in a preserved `justfile.project`** ([#877](https://github.com/vig-os/devcontainer/issues/877))
   - 0.4.0 moved `lint`/`format`/`precommit`/`test`/`test-cov`/`sync`/`update` into `justfile.project`, which is preserved on upgrade — 0.3.x consumers never received them and the shipped `ci.yml` failed with `justfile does not contain recipe 'sync'`. `init-workspace --force` now appends the missing base recipes from the template into the preserved file (customized recipes always win; idempotent).
   - The retired `.devcontainer/justfile.base` is removed on upgrade where the scaffold manages `.devcontainer/` (never in `direnv` mode, [#738](https://github.com/vig-os/devcontainer/issues/738)), and the installer warns if the root `justfile` lacks the scaffold `import?` block.

--- a/tests/bats/init-workspace.bats
+++ b/tests/bats/init-workspace.bats
@@ -988,3 +988,53 @@ EOF
     run test -e "$ws/.typos.toml"
     assert_failure
 }
+
+# ── pre-commit reference scan must cover preserved workflows (#916) ────────────
+# The #881 scan only looked at justfile.project and .githooks/, but a consumer
+# CI workflow that still invokes the retired `pre-commit` binary breaks the same
+# way. Extend the scan to preserved .github/workflows/*.yml. A YAML `name:` step
+# description or a comment mention must NOT be flagged; only real invocations.
+
+@test "pre-commit scan flags a real invocation in a consumer workflow (#916)" {
+    ws="$BATS_TEST_TMPDIR/e2e-916-workflow-hit"
+    mkdir -p "$ws/.github/workflows"
+    # consumer-owned workflow (not in the template set) survives the rsync
+    cat > "$ws/.github/workflows/consumer-ci.yml" <<'EOF'
+name: Consumer CI
+on: [push]
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      # pre-commit MENTIONONLY: migrate to prek before 0.5
+      - name: Run pre-commit hooks
+        run: uv run pre-commit run --all-files
+EOF
+    run _upgrade both "$ws"
+    assert_success
+    assert_output --partial "retired 'pre-commit' binary"
+    # the real invocation line is flagged with file:line
+    assert_output --regexp '\.github/workflows/consumer-ci\.yml:[0-9]+'
+    # neither the comment mention nor the step `name:` description is flagged
+    refute_output --partial 'MENTIONONLY'
+    refute_output --partial 'Run pre-commit hooks'
+}
+
+@test "no pre-commit warning for a workflow that only mentions it (#916)" {
+    ws="$BATS_TEST_TMPDIR/e2e-916-workflow-clean"
+    mkdir -p "$ws/.github/workflows"
+    cat > "$ws/.github/workflows/consumer-clean.yml" <<'EOF'
+name: Consumer CI
+on: [push]
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      # pre-commit was replaced by prek
+      - name: Run pre-commit hooks
+        run: uv run prek run --all-files
+EOF
+    run _upgrade both "$ws"
+    assert_success
+    refute_output --partial "retired 'pre-commit' binary"
+}

--- a/tests/bats/init-workspace.bats
+++ b/tests/bats/init-workspace.bats
@@ -977,7 +977,7 @@ EOF
     # the template .typos.toml alongside it would give two active configs.
     ws="$BATS_TEST_TMPDIR/e2e-913-legacy"
     mkdir -p "$ws"
-    printf '# SENTINEL-913 legacy typos config\n[default.extend-words]\nteh = "teh"\n' \
+    printf '# SENTINEL-913 legacy typos config\n[default.extend-words]\nmyterm = "myterm"\n' \
         >"$ws/_typos.toml"
     run _upgrade both "$ws"
     assert_success

--- a/tests/bats/init-workspace.bats
+++ b/tests/bats/init-workspace.bats
@@ -906,3 +906,29 @@ EOF
     assert_success
     refute_output --partial "retired 'pre-commit' binary"
 }
+
+# ── preserved-file diff preview must use git, not diff(1) (#916) ──────────────
+# The image ships git but no diff(1)/cmp(1); the #878 preview called `diff`,
+# which prints "diff: command not found" and an empty box in-container. Render
+# the divergence with `git diff --no-index` (its --quiet form gates the block;
+# --no-index exits 1 when files differ, which is the expected signal).
+
+@test "preserved-file diff preview uses git diff --no-index, not diff(1)/cmp(1) (#916)" {
+    run grep -nE 'git diff --no-index' "$INIT_WORKSPACE_SH"
+    assert_success
+    # no bare diff(1) or cmp(1) invocation survives (both absent from the image)
+    run grep -nE '(^|[[:space:]])(diff|cmp)[[:space:]]+-' "$INIT_WORKSPACE_SH"
+    assert_failure
+}
+
+@test "preserved .pre-commit-config.yaml diff preview renders real content, not 'command not found' (#916)" {
+    ws="$BATS_TEST_TMPDIR/e2e-916-gitdiff"
+    mkdir -p "$ws"
+    _custom_precommit_config "$ws"
+    run _upgrade both "$ws"
+    assert_success
+    refute_output --partial 'command not found'
+    assert_output --partial 'Preserved .pre-commit-config.yaml differs from the template'
+    # a real hunk line from the template the preserved file lacks
+    assert_output --partial 'default_language_version'
+}

--- a/tests/bats/init-workspace.bats
+++ b/tests/bats/init-workspace.bats
@@ -933,3 +933,58 @@ EOF
     # a real hunk line from the template the preserved file lacks
     assert_output --partial 'default_language_version'
 }
+
+# ── upgrade must preserve a customized .typos.toml, no dual configs (#913) ────
+# The typos hook reads a project's spell-check exceptions; a consumer curates
+# repo-specific extend-words/extend-exclude that a template overwrite silently
+# destroyed (their lint then flags legitimate domain terms). Preserve it like
+# .pre-commit-config.yaml (#878) and print the template diff. The `typos` tool
+# also reads the legacy `_typos.toml`, so a consumer carrying that must NOT also
+# receive the template `.typos.toml` — two active configs would collide.
+
+@test ".typos.toml is preserved on --force upgrade (#913)" {
+    # shellcheck disable=SC2016
+    run grep -E '"\.typos\.toml"' "$INIT_WORKSPACE_SH"
+    assert_success
+}
+
+@test "upgrade preserves a customized .typos.toml (#913)" {
+    ws="$BATS_TEST_TMPDIR/e2e-913-preserve"
+    mkdir -p "$ws"
+    printf '# SENTINEL-913 consumer typos config\n[default.extend-words]\nfoo = "foo"\n' \
+        >"$ws/.typos.toml"
+    run _upgrade both "$ws"
+    assert_success
+    run grep -q 'SENTINEL-913' "$ws/.typos.toml"
+    assert_success
+}
+
+@test "upgrade prints a template diff hint for a preserved .typos.toml (#913)" {
+    ws="$BATS_TEST_TMPDIR/e2e-913-diff"
+    mkdir -p "$ws"
+    # a config lacking the template's exception words
+    printf '# SENTINEL-913 minimal consumer typos config\n' >"$ws/.typos.toml"
+    run _upgrade both "$ws"
+    assert_success
+    refute_output --partial 'command not found'
+    assert_output --partial 'Preserved .typos.toml differs from the template'
+    # a template exception word the preserved file lacks shows in the diff
+    assert_output --partial 'unexcepted'
+}
+
+@test "upgrade with a legacy _typos.toml does not leave dual typos configs (#913)" {
+    # vault scenario: consumer carries _typos.toml and no .typos.toml. Shipping
+    # the template .typos.toml alongside it would give two active configs.
+    ws="$BATS_TEST_TMPDIR/e2e-913-legacy"
+    mkdir -p "$ws"
+    printf '# SENTINEL-913 legacy typos config\n[default.extend-words]\nteh = "teh"\n' \
+        >"$ws/_typos.toml"
+    run _upgrade both "$ws"
+    assert_success
+    # legacy config preserved verbatim
+    run grep -q 'SENTINEL-913' "$ws/_typos.toml"
+    assert_success
+    # template .typos.toml NOT shipped -> single active config
+    run test -e "$ws/.typos.toml"
+    assert_failure
+}

--- a/tests/bats/init-workspace.bats
+++ b/tests/bats/init-workspace.bats
@@ -1038,3 +1038,25 @@ EOF
     assert_success
     refute_output --partial "retired 'pre-commit' binary"
 }
+
+# ── origin must resolve before any filesystem mutation (#916) ─────────────────
+# Under --no-prompts, the GITHUB_REPOSITORY resolution ran AFTER the rsync copy,
+# so an abort left a half-scaffolded tree behind. Resolve (and validate) the
+# origin BEFORE the first filesystem mutation so a failure leaves the workspace
+# untouched.
+
+@test "no-prompts without a derivable origin aborts before mutating the workspace (#916)" {
+    ws="$BATS_TEST_TMPDIR/e2e-916-no-origin"
+    mkdir -p "$ws"
+    # no .git origin and GITHUB_REPOSITORY unset (cleared: CI may export it)
+    run env -u GITHUB_REPOSITORY \
+        TEMPLATE_DIR="$PROJECT_ROOT/assets/workspace" \
+        WORKSPACE_DIR="$ws" \
+        SHORT_NAME=probe \
+        bash "$INIT_WORKSPACE_SH" --no-prompts --mode both
+    assert_failure
+    assert_output --partial 'GITHUB_REPOSITORY is required'
+    # the workspace was never scaffolded: still empty (no template files copied)
+    run bash -c "ls -A '$ws'"
+    assert_output ""
+}

--- a/tests/bats/init-workspace.bats
+++ b/tests/bats/init-workspace.bats
@@ -916,8 +916,9 @@ EOF
 @test "preserved-file diff preview uses git diff --no-index, not diff(1)/cmp(1) (#916)" {
     run grep -nE 'git diff --no-index' "$INIT_WORKSPACE_SH"
     assert_success
-    # no bare diff(1) or cmp(1) invocation survives (both absent from the image)
-    run grep -nE '(^|[[:space:]])(diff|cmp)[[:space:]]+-' "$INIT_WORKSPACE_SH"
+    # no bare diff(1) short-flag or cmp(1) invocation survives (both absent from
+    # the image); `git diff --no-index` (long flags) is the sanctioned form.
+    run grep -nE '(^|[[:space:]])diff -[a-z]|(^|[[:space:]])cmp[[:space:]]' "$INIT_WORKSPACE_SH"
     assert_failure
 }
 


### PR DESCRIPTION
## Summary

Addresses **#913** (fully) and four items of the **#916** hardening bundle, all found during 0.4.1-rc1 consumer-upgrade testing. All changes are in `assets/init-workspace.sh` with BATS coverage (TDD, test-then-fix per item).

## Changes

- **Preserve `.typos.toml` (#913).** Added to `PRESERVE_FILES` so a consumer's spell-check exceptions survive `--force`; prints the template diff like #878. A consumer carrying the legacy `_typos.toml` no longer also receives the template `.typos.toml` (no dual active config — the exact corruption seen on vault, where `typos` rewrote `Nd`→`And` in the scaffold's own `version-check.sh`).
- **`git diff --no-index` for preserved-file previews (#916).** The image ships no `diff`/`cmp`, so the #878 preview box printed `command not found`; now uses `git`.
- **Scan preserved CI workflows (#916).** The #881 reference scan now also covers preserved `.github/workflows/*.yml`, flagging real `pre-commit` invocations with `file:line` while ignoring comments and step `name:` descriptions.
- **Resolve origin before mutation (#916).** Under `--no-prompts`, an underivable origin now aborts before any files are copied, instead of leaving a half-scaffolded tree.

## Not included

- **F5 (`.vig-os` pin on bare `docker run`)** cannot be fixed runtime-only — the image has no authoritative built-tag record. Split out to **#921** (build-side); a NOTE was added at the stamping site. The `install.sh` path is already correct.
- **F6 (`.gitignore` clobber warning; source-stub skip)** deferred — both are ambiguous/risky per the issue's "only if clean" guidance; recommend a dedicated issue if wanted.

## Verification

- `bats tests/bats/init-workspace.bats` → 84/84 (+9 new); `tests/bats/init.bats` → 29/29.
- Full `prek run --all-files` green locally (shellcheck, typos, agent-identity, sync-manifest).

Closes #913. Refs #916, #921.