### PR TITLE
feat(workspace): nix-direct direnv CI lane + version-skew hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Nix-direct CI lane for direnv-mode consumers** ([#854](https://github.com/vig-os/devcontainer/issues/854))
+  - `direnv` mode now scaffolds a host-native `ci.yml` overlay (`assets/workspace-direnv/`, applied like the bare overlay and keyed off the persisted `DEVKIT_MODE`): no `resolve-image`, no in-container jobs — the runner installs Nix (with the vig-os Cachix substituter, SHA-pinned `install-nix`/`cachix` actions reused from this repo's own lane) and drives the same `just sync|precommit|test` contract inside the flake dev-shell via `nix develop -c`, dropping the container-only `PREK_HOME`/`UV_PROJECT_ENVIRONMENT` env.
+  - Documented boundary in `docs/MIGRATION.md` ("direnv-mode CI"): only `ci.yml` is converted for direnv mode; the other shipped workflows (`prepare-release`, `promote-release`, `release*`, `sync-issues`, `renovate-changelog-build`, `sync-main-to-dev`) stay container-based and devcontainer-mode-only until the full workflow audit rides the devkit rename ([#781](https://github.com/vig-os/devcontainer/issues/781)); the container-independent ones (`codeql`, `scorecard`, `renovate-changelog-commit`, `release-extension`) keep working in every mode.
+
 - **Opt-in capability modules for `mkProjectShell`** ([#884](https://github.com/vig-os/devcontainer/issues/884))
   - `modules = [ "native" ]` composes curated capability modules (packages + env vars + shellHook fragments) onto the project dev-shell; contract recorded in `docs/rfcs/ADR-capability-modules.md`.
   - Zero-module shells are byte-identical to the previous builder and the published image stays base-only; `extraPackages` remains the per-repo escape hatch and wins PATH lookup.
@@ -46,6 +50,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Consumers had the 0.4.x cycle to rename invocations; the upgrade-time scan still warns with `file:line` on preserved surfaces — see `docs/MIGRATION.md` for the rename checklist (justfile recipes, repo-owned `.githooks/`, CI configs → `prek`).
 
 ### Fixed
+
+- **Version-skew hardening for the shipped CI glue** ([#854](https://github.com/vig-os/devcontainer/issues/854))
+  - **CI-wired skew guard:** the shipped container `ci.yml` and the new direnv `ci.yml` lint jobs now fail fast with an actionable `::error::` if the toolchain does not provide `prek`, turning an opaque `just precommit` exit 127 (old scaffold vs new image, or an image too old to ship the prek hook runner) into a one-line diagnosis.
+  - **`prepare-release.yml` resolver unified:** the scaffold's forked inline-awk image resolver with a silent `latest` fallback is replaced by the shared `resolve-image` action, which hard-fails on a missing/unreadable `DEVCONTAINER_VERSION` pin.
+  - **`devc-upgrade` honors the pin:** the recipe read `install.sh` from `main` regardless of the consumer's pin; it now reads `DEVCONTAINER_VERSION` from `.vig-os` and upgrades to that generation (script ref + `--version`), keeping `main`/`latest` only for unpinned repos.
+  - **pipefail in every mode:** `set shell := ["bash", "-euo", "pipefail", "-c"]` moved from the devc-only `justfile.devc` to the root `justfile` (the SSoT), so direnv/bare recipes get pipefail too.
+  - **`init-precommit.sh` derives its root** from the script location instead of a hard-coded `/workspace/{{SHORT_NAME}}`.
+  - **Stale doc fixed:** `docs/container-ci-quirks.md` no longer describes a removed `uv run bandit` `pre-commit` hook; the private-image (unauthenticated `resolve-image` probe + missing `credentials:`) limitation is documented, with the first-class fix tracked in [#920](https://github.com/vig-os/devcontainer/issues/920).
 
 ### Security
 

--- a/assets/init-workspace.sh
+++ b/assets/init-workspace.sh
@@ -645,6 +645,22 @@ else
             echo "Warning: bare-mode overlay not found at $BARE_OVERLAY_DIR; the scaffolded ci.yml is container-based." >&2
         fi
     fi
+
+    # direnv mode runs CI on the host via the flake dev-shell (nix develop), not
+    # in the image: overlay the nix-direct ci.yml variant over the container-based
+    # template one (#854). Same managed-file semantics as the bare overlay above,
+    # so upgrades of a direnv workspace re-apply the overlay too. The other
+    # scaffolded workflows stay container-based and are devcontainer-mode-only
+    # (documented in docs/MIGRATION.md).
+    if [[ "$MODE" == "direnv" ]]; then
+        DIRENV_OVERLAY_DIR="$SCRIPT_DIR/workspace-direnv"
+        if [[ -d "$DIRENV_OVERLAY_DIR" ]]; then
+            echo "Deploying direnv-mode overlay (nix-direct CI)..."
+            rsync -avL "$DIRENV_OVERLAY_DIR/" "$WORKSPACE_DIR/"
+        else
+            echo "Warning: direnv-mode overlay not found at $DIRENV_OVERLAY_DIR; the scaffolded ci.yml is container-based." >&2
+        fi
+    fi
 fi
 
 # The Nix-built image stores the baked template as read-only symlinks into the

--- a/assets/workspace-direnv/.github/workflows/ci.yml
+++ b/assets/workspace-direnv/.github/workflows/ci.yml
@@ -1,0 +1,176 @@
+# CI Workflow (direnv mode, nix-direct)
+#
+# The `direnv` delivery mode ships the Nix flake + .envrc but no
+# .devcontainer/, so this CI variant runs on the host runner WITHOUT the
+# container / resolve-image machinery (which hard-depends on a `.vig-os` pin and
+# GHCR access). Instead it provisions Nix + the vig-os Cachix substituter and
+# drives the same `just sync|precommit|test` contract inside the flake dev-shell
+# via `nix develop -c` — the dev-shell is the toolchain SSoT (uv, ruff, prek,
+# just), so the container-only `PREK_HOME` / `UV_PROJECT_ENVIRONMENT` env is
+# dropped. Mirrors the vig-os parent repo's own project-checks job (#854).
+#
+# The other scaffolded workflows (prepare-release, promote-release, release*,
+# sync-issues, renovate-changelog-build, sync-main-to-dev) still run in-container
+# and hard-depend on `.vig-os`/resolve-image — they are devcontainer-mode-only.
+# See docs/MIGRATION.md ("direnv-mode CI") for the supported boundary.
+#
+# Jobs:
+#   1. lint    — Pre-commit hooks (prek) inside the flake dev-shell
+#   2. test    — Pytest inside the flake dev-shell
+#   3. summary — Aggregate results for branch protection
+#
+# Triggers:
+#   - Pull requests to dev, release/**, and main
+#   - Manual workflow_dispatch
+#
+
+name: CI
+
+on:  # yamllint disable-line rule:truthy
+  pull_request:
+    branches:
+      - dev
+      - 'release/**'
+      - main
+  workflow_dispatch:
+    inputs:
+      test-suite:
+        description: 'Test suite to run'
+        required: false
+        default: 'all'
+        type: choice
+        options:
+          - all
+          - lint
+          - test
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    name: Lint & Format
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    if: |
+      github.event_name != 'workflow_dispatch' ||
+      inputs.test-suite == 'all' ||
+      inputs.test-suite == 'lint'
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+
+      # Nix installer SHA-pinned to match the vig-os toolchain (nix-cachix.yml,
+      # setup-env). The vig-os public Cachix substituter (pull-only, no token)
+      # makes the flake dev-shell a fast binary-cache pull; accept-flake-config
+      # lets the pinned vigos input contribute its own substituters.
+      - name: Install Nix (upstream CppNix)
+        uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3  # v31.10.6
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+            accept-flake-config = true
+            extra-substituters = https://vig-os.cachix.org
+            extra-trusted-public-keys = vig-os.cachix.org-1:yoOYRi3bvnM6ThxO0joLt7vtzhTfkq3r6jykeUMg7Bk=
+
+      # Optional: push this repo's own closure to a consumer-owned Cachix cache.
+      # Skipped unless the repo sets the CACHIX_CACHE variable; pulls need no
+      # token, so the vig-os substituter above already warms the dev-shell.
+      - name: Configure Cachix
+        if: vars.CACHIX_CACHE != ''
+        uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71  # v17
+        with:
+          name: ${{ vars.CACHIX_CACHE }}
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
+      # Version-skew guard (#854): fail with an actionable message if the flake
+      # dev-shell does not provide the `prek` hook runner, instead of an opaque
+      # `just precommit` crash deep in the log.
+      - name: Verify toolchain (prek present in dev-shell)
+        run: |
+          if ! nix develop -c command -v prek >/dev/null 2>&1; then
+            echo "::error::'prek' is not provided by the flake dev-shell — the vigos flake input likely predates the prek hook runner (#778), or the dev-shell failed to build (see logs above)."
+            echo "Fix: 'nix flake update vigos' to a devkit generation that ships prek. See docs/MIGRATION.md."
+            exit 1
+          fi
+          echo "prek present in dev-shell"
+
+      - name: Sync project dependencies
+        run: nix develop -c just sync
+
+      - name: Run pre-commit hooks
+        run: nix develop -c just precommit
+
+  test:
+    name: Tests
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    if: |
+      github.event_name != 'workflow_dispatch' ||
+      inputs.test-suite == 'all' ||
+      inputs.test-suite == 'test'
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+
+      - name: Install Nix (upstream CppNix)
+        uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3  # v31.10.6
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+            accept-flake-config = true
+            extra-substituters = https://vig-os.cachix.org
+            extra-trusted-public-keys = vig-os.cachix.org-1:yoOYRi3bvnM6ThxO0joLt7vtzhTfkq3r6jykeUMg7Bk=
+
+      - name: Configure Cachix
+        if: vars.CACHIX_CACHE != ''
+        uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71  # v17
+        with:
+          name: ${{ vars.CACHIX_CACHE }}
+          authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
+      - name: Sync project dependencies
+        run: nix develop -c just sync
+
+      - name: Run tests
+        run: nix develop -c just test
+
+  summary:
+    name: CI Summary
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    needs: [lint, test]
+    if: always()
+
+    steps:
+      - name: Check results
+        run: |
+          echo "CI Results Summary"
+          echo "==================="
+          echo ""
+          echo "Lint: ${{ needs.lint.result }}"
+          echo "Test: ${{ needs.test.result }}"
+          echo ""
+
+          FAILED=false
+
+          if [ "${{ needs.lint.result }}" = "failure" ]; then
+            echo "ERROR: Lint checks failed"
+            FAILED=true
+          fi
+
+          if [ "${{ needs.test.result }}" = "failure" ]; then
+            echo "ERROR: Tests failed"
+            FAILED=true
+          fi
+
+          if [ "$FAILED" = "true" ]; then
+            echo ""
+            echo "One or more checks failed"
+            exit 1
+          fi
+
+          echo ""
+          echo "All executed checks passed"

--- a/assets/workspace-direnv/.github/workflows/ci.yml
+++ b/assets/workspace-direnv/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
       # `just precommit` crash deep in the log.
       - name: Verify toolchain (prek present in dev-shell)
         run: |
-          if ! nix develop -c command -v prek >/dev/null 2>&1; then
+          if ! nix develop -c bash -c 'command -v prek' >/dev/null 2>&1; then
             echo "::error::'prek' is not provided by the flake dev-shell — the vigos flake input likely predates the prek hook runner (#778), or the dev-shell failed to build (see logs above)."
             echo "Fix: 'nix flake update vigos' to a devkit generation that ships prek. See docs/MIGRATION.md."
             exit 1

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Nix-direct CI lane for direnv-mode consumers** ([#854](https://github.com/vig-os/devcontainer/issues/854))
+  - `direnv` mode now scaffolds a host-native `ci.yml` overlay (`assets/workspace-direnv/`, applied like the bare overlay and keyed off the persisted `DEVKIT_MODE`): no `resolve-image`, no in-container jobs — the runner installs Nix (with the vig-os Cachix substituter, SHA-pinned `install-nix`/`cachix` actions reused from this repo's own lane) and drives the same `just sync|precommit|test` contract inside the flake dev-shell via `nix develop -c`, dropping the container-only `PREK_HOME`/`UV_PROJECT_ENVIRONMENT` env.
+  - Documented boundary in `docs/MIGRATION.md` ("direnv-mode CI"): only `ci.yml` is converted for direnv mode; the other shipped workflows (`prepare-release`, `promote-release`, `release*`, `sync-issues`, `renovate-changelog-build`, `sync-main-to-dev`) stay container-based and devcontainer-mode-only until the full workflow audit rides the devkit rename ([#781](https://github.com/vig-os/devcontainer/issues/781)); the container-independent ones (`codeql`, `scorecard`, `renovate-changelog-commit`, `release-extension`) keep working in every mode.
+
 - **Opt-in capability modules for `mkProjectShell`** ([#884](https://github.com/vig-os/devcontainer/issues/884))
   - `modules = [ "native" ]` composes curated capability modules (packages + env vars + shellHook fragments) onto the project dev-shell; contract recorded in `docs/rfcs/ADR-capability-modules.md`.
   - Zero-module shells are byte-identical to the previous builder and the published image stays base-only; `extraPackages` remains the per-repo escape hatch and wins PATH lookup.
@@ -46,6 +50,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Consumers had the 0.4.x cycle to rename invocations; the upgrade-time scan still warns with `file:line` on preserved surfaces — see `docs/MIGRATION.md` for the rename checklist (justfile recipes, repo-owned `.githooks/`, CI configs → `prek`).
 
 ### Fixed
+
+- **Version-skew hardening for the shipped CI glue** ([#854](https://github.com/vig-os/devcontainer/issues/854))
+  - **CI-wired skew guard:** the shipped container `ci.yml` and the new direnv `ci.yml` lint jobs now fail fast with an actionable `::error::` if the toolchain does not provide `prek`, turning an opaque `just precommit` exit 127 (old scaffold vs new image, or an image too old to ship the prek hook runner) into a one-line diagnosis.
+  - **`prepare-release.yml` resolver unified:** the scaffold's forked inline-awk image resolver with a silent `latest` fallback is replaced by the shared `resolve-image` action, which hard-fails on a missing/unreadable `DEVCONTAINER_VERSION` pin.
+  - **`devc-upgrade` honors the pin:** the recipe read `install.sh` from `main` regardless of the consumer's pin; it now reads `DEVCONTAINER_VERSION` from `.vig-os` and upgrades to that generation (script ref + `--version`), keeping `main`/`latest` only for unpinned repos.
+  - **pipefail in every mode:** `set shell := ["bash", "-euo", "pipefail", "-c"]` moved from the devc-only `justfile.devc` to the root `justfile` (the SSoT), so direnv/bare recipes get pipefail too.
+  - **`init-precommit.sh` derives its root** from the script location instead of a hard-coded `/workspace/{{SHORT_NAME}}`.
+  - **Stale doc fixed:** `docs/container-ci-quirks.md` no longer describes a removed `uv run bandit` `pre-commit` hook; the private-image (unauthenticated `resolve-image` probe + missing `credentials:`) limitation is documented, with the first-class fix tracked in [#920](https://github.com/vig-os/devcontainer/issues/920).
 
 ### Security
 

--- a/assets/workspace/.devcontainer/justfile.devc
+++ b/assets/workspace/.devcontainer/justfile.devc
@@ -3,7 +3,9 @@
 # Managed by vigOS devcontainer. Customizations go in root justfile.
 # ===============================================================================
 
-set shell := ["bash", "-euo", "pipefail", "-c"]
+# Note: `set shell := [...pipefail...]` lives in the root justfile (the SSoT) so
+# it applies in every delivery mode, including direnv/bare which have no
+# justfile.devc (#854).
 
 # -------------------------------------------------------------------------------
 # VERSION CHECK
@@ -37,6 +39,21 @@ devc-check *args:
 [group('info')]
 devc-upgrade:
     #!/usr/bin/env bash
+    # Honor the consumer's pinned devkit generation (#854): read
+    # DEVCONTAINER_VERSION from .vig-os and upgrade to THAT tag (both the
+    # install.sh script ref and the pinned image version), not whatever
+    # `main`/`latest` happens to be. An unpinned or `latest` manifest keeps the
+    # floating `main`/`latest` behavior.
+    REF="main"
+    PIN_ARGS=()
+    if [[ -f .vig-os ]]; then
+        PINNED="$(awk -F= '/^DEVCONTAINER_VERSION=/{gsub(/^[ \t"]+|[ \t"]+$/, "", $2); print $2; exit}' .vig-os || true)"
+        if [[ -n "${PINNED:-}" && "$PINNED" != "latest" ]]; then
+            REF="$PINNED"
+            PIN_ARGS=(--version "$PINNED")
+        fi
+    fi
+
     # Detect if running inside a container
     if [[ -f "/.dockerenv" ]] || [[ -n "${container:-}" ]]; then
         echo ""
@@ -50,13 +67,13 @@ devc-upgrade:
         echo ""
         echo "Or use the curl method:"
         echo ""
-        echo "    curl -sSf https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh | bash -s -- --force ."
+        echo "    curl -sSf https://raw.githubusercontent.com/vig-os/devcontainer/${REF}/install.sh | bash -s -- --force ${PIN_ARGS[*]} ."
         echo ""
         exit 1
     fi
 
     # We're on the host - proceed with upgrade
-    echo "🚀 Upgrading devcontainer to latest version..."
+    echo "🚀 Upgrading devcontainer (target: $REF)..."
     echo ""
 
     # Check if podman or docker is available
@@ -77,11 +94,11 @@ devc-upgrade:
     echo "✓ Using $RUNTIME"
     echo ""
     echo "Note: the installer refuses upgrades on main/dev/release/* or a dirty tree."
-    echo "      Preview first:  curl -sSf https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh | bash -s -- --force --preview ."
-    echo "      Bypass guard:   curl -sSf https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh | bash -s -- --force --skip-preflight ."
+    echo "      Preview first:  curl -sSf https://raw.githubusercontent.com/vig-os/devcontainer/${REF}/install.sh | bash -s -- --force ${PIN_ARGS[*]} --preview ."
+    echo "      Bypass guard:   curl -sSf https://raw.githubusercontent.com/vig-os/devcontainer/${REF}/install.sh | bash -s -- --force ${PIN_ARGS[*]} --skip-preflight ."
     echo ""
     echo "Downloading and running install script..."
-    curl -sSf https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh | bash -s -- --force .
+    curl -sSf "https://raw.githubusercontent.com/vig-os/devcontainer/${REF}/install.sh" | bash -s -- --force "${PIN_ARGS[@]}" .
 
 # -------------------------------------------------------------------------------
 # DEVCONTAINER (host-side only)

--- a/assets/workspace/.devcontainer/scripts/init-precommit.sh
+++ b/assets/workspace/.devcontainer/scripts/init-precommit.sh
@@ -1,8 +1,11 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
-# {{SHORT_NAME}} is replaced during template initialization
-PROJECT_ROOT="/workspace/{{SHORT_NAME}}"
+# Derive the project root from this script's own location
+# (<project-root>/.devcontainer/scripts/init-precommit.sh) rather than a
+# hard-coded /workspace/<name>, so it works regardless of the mount point (#854).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
 if [ -f "$PROJECT_ROOT/.pre-commit-config.yaml" ]; then
     echo "Setting up Git hooks (this may take a few minutes)..."

--- a/assets/workspace/.github/workflows/ci.yml
+++ b/assets/workspace/.github/workflows/ci.yml
@@ -88,6 +88,19 @@ jobs:
       - name: Fix git safe.directory
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
 
+      # Version-skew guard (#854): fail with an actionable message if the CI
+      # image predates the prek hook runner (#778), instead of an opaque
+      # `just precommit` exit 127 deep in the log. The image tag comes from the
+      # .vig-os DEVCONTAINER_VERSION pin.
+      - name: Verify toolchain (prek present)
+        run: |
+          if ! command -v prek >/dev/null 2>&1; then
+            echo "::error::'prek' not found in the CI image (ghcr.io/vig-os/devcontainer). The image pinned by .vig-os DEVCONTAINER_VERSION predates the prek hook runner (#778)."
+            echo "Fix: bump .vig-os DEVCONTAINER_VERSION to an image that ships prek, or re-run the devkit installer. See docs/MIGRATION.md."
+            exit 1
+          fi
+          echo "prek present: $(command -v prek)"
+
       - name: Sync project dependencies
         run: just sync
 

--- a/assets/workspace/.github/workflows/prepare-release.yml
+++ b/assets/workspace/.github/workflows/prepare-release.yml
@@ -34,7 +34,7 @@ jobs:
     outputs:
       version: ${{ steps.vars.outputs.version }}
       release_branch: ${{ steps.vars.outputs.release_branch }}
-      image_tag: ${{ steps.resolve_image.outputs.image_tag }}
+      image_tag: ${{ steps.resolve_image.outputs.image-tag }}
 
     steps:
       - name: Checkout repository
@@ -59,29 +59,13 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "release_branch=$RELEASE_BRANCH" >> "$GITHUB_OUTPUT"
 
-      - name: Resolve container image tag
+      # Resolve + validate the pinned devcontainer image via the shared
+      # resolve-image action (#854): hard-fails on a missing/unreadable
+      # DEVCONTAINER_VERSION instead of silently falling back to `latest`, so
+      # this workflow can no longer diverge from ci.yml's resolver semantics.
+      - name: Resolve container image
         id: resolve_image
-        run: |
-          set -euo pipefail
-          TAG=""
-          if [ -f ".vig-os" ]; then
-            TAG=$(awk -F= '/^DEVCONTAINER_VERSION=/{gsub(/^[ \t"]+|[ \t"]+$/, "", $2); print $2; exit}' .vig-os || true)
-          fi
-          if [ -z "${TAG:-}" ]; then
-            TAG="latest"
-          fi
-          echo "image_tag=$TAG" >> "$GITHUB_OUTPUT"
-
-      - name: Validate image accessibility
-        env:
-          IMAGE_TAG: ${{ steps.resolve_image.outputs.image_tag }}
-        run: |
-          set -euo pipefail
-          IMAGE="ghcr.io/vig-os/devcontainer:${IMAGE_TAG}"
-          if ! docker manifest inspect "$IMAGE" > /dev/null 2>&1; then
-            echo "ERROR: Cannot access image manifest: $IMAGE"
-            exit 1
-          fi
+        uses: ./.github/actions/resolve-image
 
       - name: Verify release branch does not exist
         env:
@@ -132,7 +116,7 @@ jobs:
         env:
           VERSION: ${{ steps.vars.outputs.version }}
           RELEASE_BRANCH: ${{ steps.vars.outputs.release_branch }}
-          IMAGE_TAG: ${{ steps.resolve_image.outputs.image_tag }}
+          IMAGE_TAG: ${{ steps.resolve_image.outputs.image-tag }}
           DRY_RUN: ${{ inputs.dry-run }}
         run: |
           echo "Validation passed"

--- a/assets/workspace/docs/container-ci-quirks.md
+++ b/assets/workspace/docs/container-ci-quirks.md
@@ -38,8 +38,10 @@ using `devcontainer up`) are not supported in this workflow.
 
 ## Security scope
 
-`bandit` can still run via the `pre-commit` lint hook (`uv run bandit`), but
-there is no separate CI security-report job with JSON artifact uploads.
+`bandit` can still run as a `prek` lint hook (add it to
+`.pre-commit-config.yaml`; the hook runner is `prek`, not the removed
+`pre-commit` binary — see docs/MIGRATION.md), but there is no separate CI
+security-report job with JSON artifact uploads.
 
 ## Dependency review scope
 
@@ -58,3 +60,23 @@ from the template workspace's `.pre-commit-config.yaml` (which uses version
 tags as revs).  This repository pins hooks by commit hash, so the cached
 environments do not match and prek downloads fresh environments at
 runtime.
+
+## Public-image assumption (private / rate-limited registries)
+
+**Limitation (tracked, not yet fixed):** the shipped container workflows assume
+`ghcr.io/vig-os/devcontainer` is **publicly pullable and unauthenticated**.
+
+- The `resolve-image` action validates the tag with an unauthenticated
+  `docker manifest inspect` and swallows its stderr, so an auth or rate-limit
+  failure surfaces only as the generic "Cannot access image manifest" error.
+- The in-container jobs (`ci.yml`, `prepare-release.yml`, …) declare
+  `container: { image: … }` with **no `credentials:` block**, so a private
+  image (or an anonymous pull throttled by GHCR) fails opaquely at the job's
+  container-pull step.
+
+If you pin a **private** devkit image, add a `credentials:` block to each
+container job (`username`/`password` from a registry PAT secret) yourself for
+now. A first-class fix (authenticated probe + templated `credentials:`) is
+tracked in [#920](https://github.com/vig-os/devcontainer/issues/920) and rides
+the devkit rename cycle
+([#781](https://github.com/vig-os/devcontainer/issues/781)).

--- a/assets/workspace/justfile
+++ b/assets/workspace/justfile
@@ -2,6 +2,12 @@
 # MAIN JUSTFILE - Orchestrates all recipe sources
 # ===============================================================================
 
+# Run every recipe under a strict bash so pipelines fail on the first error.
+# Lives here (not justfile.devc) so it applies in ALL delivery modes — direnv
+# and bare have no .devcontainer/justfile.devc, yet their justfile.project
+# recipes must still get pipefail (#854).
+set shell := ["bash", "-euo", "pipefail", "-c"]
+
 # Show available commands
 [group('info')]
 help:

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -39,6 +39,12 @@ one of four modes:
 - **`direnv`** — a minimal `flake.nix` + `.envrc` stub. `direnv allow` (or
   `nix develop`) drops you into the shared toolchain on the host, no container.
   The stub is never overwritten on re-scaffold; update with `nix flake update`.
+  The shipped `ci.yml` is a **nix-direct** variant
+  ([#854](https://github.com/vig-os/devcontainer/issues/854)): no image
+  resolution and no in-container jobs — the runner installs Nix (with the vig-os
+  Cachix substituter) and drives the same `just sync` / `just precommit` /
+  `just test` contract inside the flake dev-shell via `nix develop -c`. See
+  [direnv-mode CI](#direnv-mode-ci) for the supported boundary.
 - **`both`** — everything above (the default).
 - **`bare`** — the standards layer only
   ([#885](https://github.com/vig-os/devcontainer/issues/885)): justfiles,
@@ -51,6 +57,30 @@ one of four modes:
 
 The chosen mode is persisted as `DEVKIT_MODE` in the `.vig-os` manifest (below),
 so upgrades never need `--mode` again.
+
+### direnv-mode CI
+
+`direnv` (and `bare`) consumers cannot run the container-based CI: with no
+`.devcontainer/`, a `.vig-os`-driven `resolve-image` job hard-fails and bricks
+every workflow that runs `container: ghcr.io/vig-os/devcontainer:<pin>`. To keep
+the main lane working, `direnv` mode ships a **nix-direct `ci.yml`** overlay
+([#854](https://github.com/vig-os/devcontainer/issues/854)) that runs on the host
+runner (`install-nix` + Cachix → `nix develop -c just sync|precommit|test`),
+mirroring this repo's own project-checks job.
+
+**Supported boundary (until the devkit rename cycle,
+[#781](https://github.com/vig-os/devcontainer/issues/781), completes the full
+workflow audit):** only `ci.yml` is converted for direnv mode. These shipped
+workflows stay **container-based and devcontainer-mode-only**, so a direnv-only
+consumer should delete or disable them (they still work unchanged in
+`both`/`devcontainer` mode):
+
+- `prepare-release.yml`, `promote-release.yml`, `release*.yml`,
+  `sync-issues.yml`, `renovate-changelog-build.yml`, `sync-main-to-dev.yml`
+  — all resolve/consume the pinned image via `.vig-os`.
+
+Container-independent workflows keep working in every mode: `codeql.yml`,
+`scorecard.yml`, `renovate-changelog-commit.yml`, `release-extension.yml`.
 
 ## The `.vig-os` project manifest
 
@@ -392,7 +422,12 @@ re-scaffold:
    scan warnings before committing. While editing old `.githooks`
    scripts, also change `#!/bin/bash` shebangs to `#!/usr/bin/env bash`:
    `/bin/bash` does not exist on NixOS hosts, so those hooks fail outside
-   the container even after the rename.
+   the container even after the rename. In CI, the reverse skew (an old scaffold
+   still calling `pre-commit` against a new image, or a new scaffold on an image
+   too old to ship `prek`) now surfaces as a one-line `::error::` from the
+   `Verify toolchain (prek present)` guard step in the shipped `ci.yml` lint job
+   ([#854](https://github.com/vig-os/devcontainer/issues/854)), instead of an
+   opaque `exit 127` deep in the `just precommit` log.
 4. **Recipe renames** — the managed base recipes are now `devc-*`-namespaced
    and the template test recipe is `just test` (formerly `just test-pytest`).
    Run `just --list` once and update any scripts/muscle memory.

--- a/tests/bats/init-precommit.bats
+++ b/tests/bats/init-precommit.bats
@@ -1,0 +1,55 @@
+#!/usr/bin/env bats
+# BATS tests for the scaffolded .devcontainer/scripts/init-precommit.sh
+#
+# The script installs the git-hook environment on container init. It must derive
+# the project root from its own location, not a hard-coded /workspace/<name>
+# path, so it works regardless of where the workspace is mounted (#854).
+
+setup() {
+    load test_helper
+    INIT_PRECOMMIT_SH="$PROJECT_ROOT/assets/workspace/.devcontainer/scripts/init-precommit.sh"
+}
+
+@test "init-precommit.sh does not hard-code /workspace/{{SHORT_NAME}} (#854)" {
+    run grep -F '/workspace/{{SHORT_NAME}}' "$INIT_PRECOMMIT_SH"
+    assert_failure
+}
+
+@test "init-precommit.sh derives the project root from its own location (#854)" {
+    run grep -q 'BASH_SOURCE' "$INIT_PRECOMMIT_SH"
+    assert_success
+}
+
+@test "init-precommit.sh runs prek from a root at an arbitrary mount point (#854)" {
+    # Reproduce the on-disk layout: <root>/.devcontainer/scripts/init-precommit.sh
+    root="$BATS_TEST_TMPDIR/some/other/mount/proj"
+    mkdir -p "$root/.devcontainer/scripts"
+    cp "$INIT_PRECOMMIT_SH" "$root/.devcontainer/scripts/init-precommit.sh"
+    printf 'repos: []\n' > "$root/.pre-commit-config.yaml"
+
+    # Stub prek: record the CWD it is invoked from.
+    stub="$BATS_TEST_TMPDIR/stub-bin"
+    mkdir -p "$stub"
+    cat > "$stub/prek" <<EOF
+#!/usr/bin/env bash
+pwd > "$BATS_TEST_TMPDIR/prek-cwd"
+exit 0
+EOF
+    chmod +x "$stub/prek"
+
+    run env PATH="$stub:$PATH" bash "$root/.devcontainer/scripts/init-precommit.sh"
+    assert_success
+    assert_output --partial "Git hooks installed successfully"
+    # prek ran with the derived project root as CWD (resolve symlinks for macOS /tmp)
+    run cat "$BATS_TEST_TMPDIR/prek-cwd"
+    assert_output "$(cd "$root" && pwd -P)"
+}
+
+@test "init-precommit.sh skips cleanly when no config is present (#854)" {
+    root="$BATS_TEST_TMPDIR/noconfig/proj"
+    mkdir -p "$root/.devcontainer/scripts"
+    cp "$INIT_PRECOMMIT_SH" "$root/.devcontainer/scripts/init-precommit.sh"
+    run bash "$root/.devcontainer/scripts/init-precommit.sh"
+    assert_success
+    assert_output --partial "skipping"
+}

--- a/tests/bats/init-workspace.bats
+++ b/tests/bats/init-workspace.bats
@@ -1446,3 +1446,80 @@ _upgrade_legacy() {
     assert_success
     assert_output --partial ".devcontainer/ (pre-existing"
 }
+
+# ── direnv nix-direct CI lane (#854) ──────────────────────────────────────────
+# `direnv` ships the flake + .envrc but no .devcontainer/, so its CI cannot run
+# in the container. init-workspace overlays a nix-direct ci.yml variant (like the
+# bare overlay): no resolve-image, no container jobs — the runner installs Nix
+# and drives `nix develop -c just sync|precommit|test`.
+
+@test "direnv-mode ci.yml is nix-direct: no image resolution, no container jobs (#854)" {
+    ws="$BATS_TEST_TMPDIR/e2e-direnv-ci"
+    mkdir -p "$ws"
+    run _scaffold direnv "$ws"
+    assert_success
+    # no container/resolve-image machinery (ignore explanatory comment lines)
+    run bash -c "grep -vE '^[[:space:]]*#' '$ws/.github/workflows/ci.yml' | grep -E 'resolve-image|container:'"
+    assert_failure
+    # nix-direct: install-nix + nix develop drive the just contract
+    run grep -q 'cachix/install-nix-action' "$ws/.github/workflows/ci.yml"
+    assert_success
+    run grep -q 'nix develop -c just' "$ws/.github/workflows/ci.yml"
+    assert_success
+    # scorecard-conform: every action reference is SHA-pinned
+    run bash -c "grep 'uses:' '$ws/.github/workflows/ci.yml' | grep -vE '@[0-9a-f]{40}'"
+    assert_failure
+}
+
+@test "direnv-mode ci.yml drops the container-only env (#854)" {
+    ws="$BATS_TEST_TMPDIR/e2e-direnv-ci-env"
+    mkdir -p "$ws"
+    run _scaffold direnv "$ws"
+    assert_success
+    run bash -c "grep -vE '^[[:space:]]*#' '$ws/.github/workflows/ci.yml' | grep -E 'PREK_HOME|UV_PROJECT_ENVIRONMENT'"
+    assert_failure
+}
+
+@test "direnv-mode ci.yml wires the prek version-skew guard (#854)" {
+    ws="$BATS_TEST_TMPDIR/e2e-direnv-ci-guard"
+    mkdir -p "$ws"
+    run _scaffold direnv "$ws"
+    assert_success
+    run grep -q 'command -v prek' "$ws/.github/workflows/ci.yml"
+    assert_success
+}
+
+@test "prepare-release.yml uses the shared resolve-image action, no latest fallback (#854)" {
+    wf="$TEMPLATE_DIR/.github/workflows/prepare-release.yml"
+    run grep -q 'uses: ./.github/actions/resolve-image' "$wf"
+    assert_success
+    # the forked inline awk resolver + silent `latest` fallback is gone
+    run grep -q 'TAG="latest"' "$wf"
+    assert_failure
+}
+
+@test "container-mode ci.yml wires the prek version-skew guard (#854)" {
+    # The devcontainer-mode lint job must fail fast with an actionable message
+    # when the pinned image predates prek, rather than an opaque exit 127.
+    ws="$BATS_TEST_TMPDIR/e2e-container-guard"
+    mkdir -p "$ws"
+    run _scaffold devcontainer "$ws"
+    assert_success
+    run grep -q 'command -v prek' "$ws/.github/workflows/ci.yml"
+    assert_success
+}
+
+@test "direnv overlay leaves devcontainer + bare + both modes container-based (#854)" {
+    # The overlay is direnv-only: the other modes keep the container ci.yml
+    # (devcontainer/both) or the bare host-native one.
+    for mode in devcontainer both; do
+        ws="$BATS_TEST_TMPDIR/e2e-direnv-neg-$mode"
+        mkdir -p "$ws"
+        run _scaffold "$mode" "$ws"
+        assert_success
+        run grep -q 'resolve-image' "$ws/.github/workflows/ci.yml"
+        assert_success
+        run grep -q 'nix develop -c just' "$ws/.github/workflows/ci.yml"
+        assert_failure
+    done
+}

--- a/tests/bats/just.bats
+++ b/tests/bats/just.bats
@@ -15,6 +15,56 @@ setup() {
     assert_output --partial "Available recipes"
 }
 
+# ── pipefail shell in the root justfile (#854) ────────────────────────────────
+# `set shell := ["bash","-euo","pipefail","-c"]` used to live only in the
+# devc-managed justfile.devc, so in direnv/bare mode (no .devcontainer/) the
+# identical justfile.project recipes ran under just's default `sh -cu` without
+# pipefail. The setting belongs in the root justfile, which ships in every mode.
+
+@test "root justfile template sets the pipefail shell (#854)" {
+    run grep -qF 'set shell := ["bash", "-euo", "pipefail", "-c"]' \
+        assets/workspace/justfile
+    assert_success
+}
+
+@test "justfile.devc no longer duplicates the shell setting (SSoT, #854)" {
+    run grep -qE '^[[:space:]]*set shell' assets/workspace/.devcontainer/justfile.devc
+    assert_failure
+}
+
+@test "scaffolded root justfile loads with the pipefail shell set (#854)" {
+    run bash -c "cd assets/workspace && just --summary >/dev/null"
+    assert_success
+}
+
+# ── devc-upgrade honors the .vig-os pin (#854) ────────────────────────────────
+# The scaffolded devc-upgrade recipe used to always curl install.sh from `main`,
+# silently moving a pinned consumer to HEAD. It must read DEVCONTAINER_VERSION
+# from .vig-os and upgrade to THAT generation instead.
+
+@test "devc-upgrade reads DEVCONTAINER_VERSION from .vig-os (#854)" {
+    run grep -q 'DEVCONTAINER_VERSION' \
+        assets/workspace/.devcontainer/justfile.devc
+    assert_success
+}
+
+@test "devc-upgrade curls install.sh from the pinned ref, not hard-wired main (#854)" {
+    # The functional upgrade curl must interpolate the resolved ref (${REF}),
+    # and no install.sh curl in the recipe may be pinned literally to /main/.
+    # shellcheck disable=SC2016  # grepping for the LITERAL '${REF}' in the recipe
+    run grep -q 'githubusercontent.com/vig-os/devcontainer/${REF}/install.sh' \
+        assets/workspace/.devcontainer/justfile.devc
+    assert_success
+    run grep -F 'vig-os/devcontainer/main/install.sh' \
+        assets/workspace/.devcontainer/justfile.devc
+    assert_failure
+}
+
+@test "devc-upgrade forwards --version for a pinned consumer (#854)" {
+    run grep -q -- '--version' assets/workspace/.devcontainer/justfile.devc
+    assert_success
+}
+
 @test "prepare-release dispatches workflow from dev ref" {
     run bash -lc "awk '/^prepare-release version ref=\"\" \\*flags:/{flag=1; next} /^$/{if(flag){exit}} flag' justfile.gh | grep -Fq -- 'REF=\"dev\"'"
     assert_success


### PR DESCRIPTION
## Description

Closes #854 — the last issue of milestone 0.5. Delivers **Part A** (a nix-direct
CI lane for direnv-mode consumers) and the live **Part B** version-skew hardening
items from the CI-glue audit, with a documented boundary for the deferred work.

## Type of Change

- [x] `feat` -- New feature
- [x] `fix` -- Bug fix
- [x] `docs` -- Documentation only
- [x] `test` -- Adding or updating tests

## Changes Made

### Part A — nix-direct CI lane (direnv mode)
- New `assets/workspace-direnv/.github/workflows/ci.yml` overlay: host runner,
  `install-nix` + vig-os Cachix substituter (SHA-pinned actions reused from this
  repo's own lane), then `nix develop -c just sync|precommit|test`. No
  `resolve-image`, no `container:` jobs; container-only `PREK_HOME` /
  `UV_PROJECT_ENVIRONMENT` env dropped.
- `init-workspace.sh` deploys the overlay when `DEVKIT_MODE=direnv`, mirroring
  the existing bare-mode overlay (managed file, re-applied on upgrade).
- **Documented boundary** (`docs/MIGRATION.md` → "direnv-mode CI"): only `ci.yml`
  is converted for direnv; `prepare-release`, `promote-release`, `release*`,
  `sync-issues`, `renovate-changelog-build`, `sync-main-to-dev` stay
  container-based and devcontainer-mode-only until the full 13-workflow audit
  rides the devkit rename (#781). Container-independent workflows (`codeql`,
  `scorecard`, `renovate-changelog-commit`, `release-extension`) work in every
  mode.

### Part B — version-skew hardening
| # | Item | Status |
|---|------|--------|
| 1 | CI-wired `prek` skew guard | **Fixed** — container ci.yml + direnv ci.yml lint jobs fail fast with an actionable `::error::` |
| 2 | `prepare-release.yml` forked awk resolver + silent `latest` fallback | **Fixed** — unified onto the shared `resolve-image` action (hard-fail) |
| 3 | Old-scaffold + new-image MIGRATION callout | **Residual closed** — CI skew guard tied into the pre-commit→prek upgrade step (bulk already covered by #881/#897) |
| 4 | `devc-upgrade` curls install.sh from `main` regardless of pin | **Fixed** — reads `DEVCONTAINER_VERSION` from `.vig-os`, upgrades to that ref + `--version` |
| 5 | `set shell` pipefail only in `justfile.devc` | **Fixed** — moved to the root `justfile` (SSoT), applies in all modes |
| 6 | Stale `bandit` / `pre-commit` doc | **Fixed** — `docs/container-ci-quirks.md` |
| 7 | `init-precommit.sh` hard-codes `/workspace/{{SHORT_NAME}}` | **Fixed** — derives root from script location |
| 8 | Private-image consumers (unauth probe + no `credentials:`) | **Documented + deferred** — loud limitation note in `container-ci-quirks.md`; first-class fix filed as #920 (Backlog) |

## Changelog Entry

### Added
- **Nix-direct CI lane for direnv-mode consumers** ([#854](https://github.com/vig-os/devcontainer/issues/854))

### Fixed
- **Version-skew hardening for the shipped CI glue** ([#854](https://github.com/vig-os/devcontainer/issues/854))

(Full sub-bullets in `CHANGELOG.md`; mirror auto-synced to
`assets/workspace/.devcontainer/CHANGELOG.md`.)

## Testing

- [x] Tests pass locally
- [x] Manual testing performed (describe below)

### Manual Testing Details
- New bats: direnv/container overlay shape, prek guards, `prepare-release`
  resolver, `devc-upgrade` pin honoring, root-justfile pipefail move,
  `init-precommit` path derivation (RED→GREEN for the script-level changes).
- Full suites green: `init-workspace.bats` (108), `install.bats` (87),
  `just.bats` (43), `init-precommit.bats` (4); whole `tests/bats/*.bats` run
  exit 0 (358 ok, ~10 skipped, 0 failures).
- `just precommit` — full hook suite green (exit 0), including shellcheck,
  yamllint, check-action-pins, sync-manifest.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have updated the documentation accordingly
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes
Deferred item 8 (private-image support) is split to #920 rather than
half-implemented, per the issue's "don't gold-plate" guidance; the limitation is
documented loudly for consumers who pin a private devkit image today.

Refs: #854
