### PR TITLE
fix(workspace): parameterize sync recipe so extras are opt-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Template `sync` recipe no longer forces `--all-extras`** ([#892](https://github.com/vig-os/devcontainer/issues/892))
+  - The shipped `justfile.project` `sync` recipe used `uv sync --all-extras --all-groups`, which forced every optional extra to install. Repos that quarantine platform-limited dependencies (e.g. cp312/cp313-only wheels) in extras got a hard `just sync` failure on the cp314 image.
+  - The recipe is now parameterized (`sync *args="--all-groups"`) and defaults to `--all-groups`: dev groups stay synced while extras become opt-in via `just sync --all-extras`. The `update` recipe (which calls `just sync`) uses the new default unchanged.
+
 - **Version-skew hardening for the shipped CI glue** ([#854](https://github.com/vig-os/devcontainer/issues/854))
   - **CI-wired skew guard:** the shipped container `ci.yml` and the new direnv `ci.yml` lint jobs now fail fast with an actionable `::error::` if the toolchain does not provide `prek`, turning an opaque `just precommit` exit 127 (old scaffold vs new image, or an image too old to ship the prek hook runner) into a one-line diagnosis.
   - **`prepare-release.yml` resolver unified:** the scaffold's forked inline-awk image resolver with a silent `latest` fallback is replaced by the shared `resolve-image` action, which hard-fails on a missing/unreadable `DEVCONTAINER_VERSION` pin.

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -51,6 +51,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Template `sync` recipe no longer forces `--all-extras`** ([#892](https://github.com/vig-os/devcontainer/issues/892))
+  - The shipped `justfile.project` `sync` recipe used `uv sync --all-extras --all-groups`, which forced every optional extra to install. Repos that quarantine platform-limited dependencies (e.g. cp312/cp313-only wheels) in extras got a hard `just sync` failure on the cp314 image.
+  - The recipe is now parameterized (`sync *args="--all-groups"`) and defaults to `--all-groups`: dev groups stay synced while extras become opt-in via `just sync --all-extras`. The `update` recipe (which calls `just sync`) uses the new default unchanged.
+
 - **Version-skew hardening for the shipped CI glue** ([#854](https://github.com/vig-os/devcontainer/issues/854))
   - **CI-wired skew guard:** the shipped container `ci.yml` and the new direnv `ci.yml` lint jobs now fail fast with an actionable `::error::` if the toolchain does not provide `prek`, turning an opaque `just precommit` exit 127 (old scaffold vs new image, or an image too old to ship the prek hook runner) into a one-line diagnosis.
   - **`prepare-release.yml` resolver unified:** the scaffold's forked inline-awk image resolver with a silent `latest` fallback is replaced by the shared `resolve-image` action, which hard-fails on a missing/unreadable `DEVCONTAINER_VERSION` pin.

--- a/assets/workspace/justfile.project
+++ b/assets/workspace/justfile.project
@@ -54,10 +54,10 @@ test-cov *args:
 # DEPENDENCIES
 # -------------------------------------------------------------------------------
 
-# Sync all dependencies (idempotent, fast if nothing changed)
+# Sync dependencies (all groups; extras are opt-in, e.g. `just sync --all-extras`)
 [group('deps')]
-sync:
-    @if [ -f pyproject.toml ]; then uv sync --all-extras --all-groups; fi
+sync *args="--all-groups":
+    @if [ -f pyproject.toml ]; then uv sync {{ args }}; fi
 
 # Update all dependencies
 [group('deps')]

--- a/tests/bats/init-workspace.bats
+++ b/tests/bats/init-workspace.bats
@@ -683,7 +683,7 @@ EOF
     run bash -c "cd '$ws' && '$real_just' --show test"
     assert_output --partial 'SENTINEL-877-custom-test'
     # ...and each appended recipe appears exactly once
-    run bash -c "grep -c '^sync:' '$ws/justfile.project'"
+    run bash -c "grep -Ec '^sync[ :]' '$ws/justfile.project'"
     assert_output "1"
 }
 
@@ -708,7 +708,7 @@ EOF
     run _upgrade both "$ws"
     assert_success
     # nothing was appended: sync still defined exactly once, no repair banner
-    run bash -c "grep -c '^sync:' '$ws/justfile.project'"
+    run bash -c "grep -Ec '^sync[ :]' '$ws/justfile.project'"
     assert_output "1"
     run grep -q 'BASE RECIPES appended' "$ws/justfile.project"
     assert_failure

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -3254,7 +3254,7 @@ class TestVersionCheckJustIntegration:
             pytest.skip("justfile.devc not found")
 
         content = justfile_devc.read_text()
-        for recipe_name in ["lint:", "format:", "precommit:", "sync:", "update:"]:
+        for recipe_name in ["lint:", "format:", "precommit:", "sync ", "update:"]:
             assert recipe_name not in content, (
                 f"{recipe_name.rstrip(':')} should not exist in justfile.devc"
             )
@@ -3269,7 +3269,7 @@ class TestVersionCheckJustIntegration:
             pytest.skip("justfile.project not found")
 
         content = justfile_project.read_text()
-        for recipe_name in ["lint:", "format:", "precommit:", "sync:", "update:"]:
+        for recipe_name in ["lint:", "format:", "precommit:", "sync ", "update:"]:
             assert recipe_name in content, (
                 f"{recipe_name.rstrip(':')} should exist in justfile.project"
             )

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -991,7 +991,7 @@ class TestDevContainerUserConf:
     def test_project_installed_after_init(self, initialized_workspace):
         """Regression: uv.lock must reference the actual project name after init.
 
-        init-workspace.sh runs `just sync` which calls `uv sync --all-extras`.
+        init-workspace.sh runs `just sync` which calls `uv sync --all-groups`.
         This resolves the lock file for the renamed project and installs it.
 
         Before the fix, init did not sync, so uv.lock still referenced


### PR DESCRIPTION
Closes #892

## Summary

The shipped consumer template recipe `sync` in `assets/workspace/justfile.project` forced `uv sync --all-extras --all-groups`. `--all-extras` installs every optional extra unconditionally, so repos that quarantine platform-limited dependencies (e.g. cp312/cp313-only wheels) in extras hit a hard `just sync` failure on the cp314 image.

This parameterizes the recipe and drops the forced `--all-extras`:

```
# before
sync:
    @if [ -f pyproject.toml ]; then uv sync --all-extras --all-groups; fi

# after
sync *args="--all-groups":
    @if [ -f pyproject.toml ]; then uv sync {{ args }}; fi
```

Dev groups stay synced by default; extras are now opt-in via `just sync --all-extras`. The `update` recipe (which calls `just sync`) uses the new default unchanged.

## Changelog

Under `## Unreleased` → `### Fixed` (root `CHANGELOG.md`, mirrored to `assets/workspace/.devcontainer/CHANGELOG.md` by the `sync-manifest` hook):

- **Template `sync` recipe no longer forces `--all-extras`** ([#892](https://github.com/vig-os/devcontainer/issues/892)) — recipe is parameterized (`sync *args`, default `--all-groups`); extras become opt-in, fixing hard-fails on repos with platform-limited optional extras.

## Verification

- `just --show sync` / `just --show update` parse correctly with the new signature.
- Confirmed the `init-workspace.sh` `extract_template_recipe` awk repair (#877) still detects the `sync` recipe with the new `sync *args="--all-groups":` header.
- Updated the stale `uv sync --all-extras` comment in `tests/test_integration.py` to reflect the new default (`--all-groups`). No test pins the template `sync` recipe body, so no behavioral test change was needed — this is a template/config change.
- `just precommit` (full hook suite) green.