### PR TITLE
ci(security): scope packages:write to the job in nix-image workflow

### DIFF
--- a/.github/workflows/nix-image.yml
+++ b/.github/workflows/nix-image.yml
@@ -49,9 +49,10 @@ on:  # yamllint disable-line rule:truthy
       - '.github/workflows/nix-image.yml'
   workflow_dispatch:
 
+# Least-privilege default (Scorecard TokenPermissions): top-level is read-only;
+# each job escalates `packages: write` for itself where it pushes to GHCR.
 permissions:
   contents: read
-  packages: write   # push per-arch discovery tags + assemble the multi-arch index
 
 env:
   REGISTRY: ghcr.io/vig-os/devcontainer
@@ -63,6 +64,10 @@ jobs:
     name: Build Nix image & run portable testinfra (${{ matrix.arch }})
     runs-on: ${{ matrix.arch == 'amd64' && 'ubuntu-24.04' || 'ubuntu-24.04-arm' }}
     timeout-minutes: 45
+    # Job-scoped write: the GHCR login + per-arch discovery-tag push need it.
+    permissions:
+      contents: read
+      packages: write
     # Gating (#666): the Nix image now passes the full portable testinfra suite,
     # so a regression here fails CI. (The per-arch push step below stays
     # continue-on-error — a registry hiccup must not fail the build/test gate.)


### PR DESCRIPTION
Closes the last live Scorecard \`TokenPermissions\` finding (alert #7627).

## What

`nix-image.yml` granted `packages: write` at the **top level**, so every job in
the workflow inherited a writable `GITHUB_TOKEN`. Scorecard scores that 0.

This defaults the top-level token to `contents: read` and escalates
`packages: write` per job:
- `build-and-test` — new job-scoped block (GHCR login + per-arch discovery-tag push)
- `multi-arch-index` — already self-scoped, unchanged

No behavioural change; the same jobs retain the same write scope, just declared at
job level. Alert #7627 auto-resolves on the next Scorecard run of `main`.

## Context

Part of the post-#642 security-tab close-out (#931): the 308 orphaned Debian
Trivy alerts were cleared by deleting the dead `container-image-latest` analysis
chain, and the 12 job-level Scorecard writes (release/promote/sync automation,
minimal required scope) were dismissed as won't-fix. This PR is the one
finding worth fixing in code.

Refs: #931