### PR TITLE
ci(renovate): exempt requires-python from the pep621 pin rule

### DIFF
--- a/assets/workspace/.github/renovate-default.json
+++ b/assets/workspace/.github/renovate-default.json
@@ -30,6 +30,12 @@
       "semanticCommitScope": "pip"
     },
     {
+      "description": "requires-python is a deliberate range: the Nix toolchain pins the exact interpreter via flake.lock, so an == pin is redundant and unsatisfiable against nixpkgs. Exempt it from the pin rule above. Refs #666.",
+      "matchManagers": ["pep621"],
+      "matchDepTypes": ["requires-python"],
+      "enabled": false
+    },
+    {
       "description": "Python — group minor/patch",
       "matchManagers": ["pep621"],
       "matchUpdateTypes": ["minor", "patch"],


### PR DESCRIPTION
## Summary

The shared `renovate-default` preset applies `rangeStrategy: pin` to the whole `pep621` manager. That pins **every** range, including `requires-python` — which the Nix migration (Refs #666) deliberately set to a range `>=3.14,<3.15` because the Nix toolchain pins the exact interpreter via `flake.lock`, making an `==` pin redundant and *unsatisfiable against nixpkgs*.

Renovate kept regenerating the pin (#861, now closed). This adds a scoped rule that exempts `requires-python` (`matchDepTypes: ["requires-python"]`) from the pin while still pinning real package dependencies.

## Validation
- `renovate-config-validator --strict` passes on the changed preset.
- Full pre-commit suite green (52 passed, 3 skipped).

## Note
The preset is resolved by Renovate from the repo **default branch (main)**, so this only fully takes effect for Renovate once promoted to main. #861 was closed (branch retained) to suppress recreation in the meantime.

Refs: #934
Closes #934