### PR TITLE
fix(changelog): parse Renovate change cells with the Unicode arrow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Autochangelog now records grouped Renovate PRs** ([#936](https://github.com/vig-os/devcontainer/issues/936))
+  - `renovate-changelog-pr` parsed the update table only when the change cell used an ASCII `->` arrow, but Renovate renders it with the Unicode arrow `→` (U+2192). Every real Renovate PR body therefore parsed to nothing; a changelog entry only appeared when the PR *title* happened to match (digest bumps, single `update X to Y`), so grouped dependency PRs were silently skipped. The change-cell parser now accepts both arrows.
+
 - **Imageless upgrades stamp the real built tag** ([#921](https://github.com/vig-os/devcontainer/issues/921))
   - The image now bakes an authoritative built-tag record (`/root/assets/VERSION`) distinct from the template `.vig-os` pin: the release `build-image` action runs `nix build --impure` with `VIG_OS_VERSION` set to the true publish tag (RCs included), which the flake reads via `builtins.getEnv`. A plain, pure `nix build` reads `""` and falls back to the checked-in repo pin, so ordinary builds stay bit-reproducible.
   - `init-workspace.sh` reads that record when no `VIG_OS_VERSION` is forwarded, so a bare `podman run … init-workspace.sh` upgrade (no `install.sh`) now pins `.vig-os` to the image's real tag instead of the stale baked template pin ([#916](https://github.com/vig-os/devcontainer/issues/916)); an explicit `VIG_OS_VERSION` still wins, and an absent record leaves the pin untouched.

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -57,6 +57,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Autochangelog now records grouped Renovate PRs** ([#936](https://github.com/vig-os/devcontainer/issues/936))
+  - `renovate-changelog-pr` parsed the update table only when the change cell used an ASCII `->` arrow, but Renovate renders it with the Unicode arrow `→` (U+2192). Every real Renovate PR body therefore parsed to nothing; a changelog entry only appeared when the PR *title* happened to match (digest bumps, single `update X to Y`), so grouped dependency PRs were silently skipped. The change-cell parser now accepts both arrows.
+
 - **Imageless upgrades stamp the real built tag** ([#921](https://github.com/vig-os/devcontainer/issues/921))
   - The image now bakes an authoritative built-tag record (`/root/assets/VERSION`) distinct from the template `.vig-os` pin: the release `build-image` action runs `nix build --impure` with `VIG_OS_VERSION` set to the true publish tag (RCs included), which the flake reads via `builtins.getEnv`. A plain, pure `nix build` reads `""` and falls back to the checked-in repo pin, so ordinary builds stay bit-reproducible.
   - `init-workspace.sh` reads that record when no `VIG_OS_VERSION` is forwarded, so a bare `podman run … init-workspace.sh` upgrade (no `install.sh`) now pins `.vig-os` to the image's real tag instead of the stale baked template pin ([#916](https://github.com/vig-os/devcontainer/issues/916)); an explicit `VIG_OS_VERSION` still wins, and an absent record leaves the pin untouched.

--- a/packages/vig-utils/src/vig_utils/renovate_changelog_pr.py
+++ b/packages/vig-utils/src/vig_utils/renovate_changelog_pr.py
@@ -20,11 +20,12 @@ def _strip_md_link(cell: str) -> str:
 def _parse_change_cell(cell: str) -> tuple[str | None, str | None]:
     """Return (old, new) from a Renovate-style change cell."""
     text = cell.strip()
-    m = re.search(r"`([^`]+)`\s*->\s*`([^`]+)`", text)
+    # Renovate renders the arrow as U+2192 (→); accept ASCII -> as well.
+    m = re.search(r"`([^`]+)`\s*(?:->|→)\s*`([^`]+)`", text)
     if m:
         return m.group(1).strip(), m.group(2).strip()
-    # Digest / unquoted: abc -> def
-    m = re.search(r"(\S+)\s*->\s*(\S+)", text)
+    # Digest / unquoted: abc → def
+    m = re.search(r"(\S+)\s*(?:->|→)\s*(\S+)", text)
     if m:
         return m.group(1).strip(), m.group(2).strip()
     return None, None

--- a/packages/vig-utils/tests/test_renovate_changelog_pr.py
+++ b/packages/vig-utils/tests/test_renovate_changelog_pr.py
@@ -50,6 +50,37 @@ def test_parse_body_markdown_table() -> None:
     assert updates[1][0] == "actions/cache"
 
 
+def test_parse_body_markdown_table_unicode_arrow() -> None:
+    # Renovate renders the change cell with a Unicode arrow (U+2192), not ASCII "->".
+    body = textwrap.dedent(
+        """
+        This PR contains the following updates:
+
+        | Package | Type | Update | Change |
+        |---------|------|--------|--------|
+        | [docker/login-action](https://github.com/docker/login-action) | action | minor | `v4.2.0` → `v4.4.0` |
+        | [aquasecurity/trivy](https://github.com/aquasecurity/trivy) | uses-with | minor | `v0.71.2` → `v0.72.0` |
+        """
+    ).strip()
+    updates = parse_renovate_pr_updates("ci(actions): update github-actions", body)
+    assert len(updates) == 2
+    assert updates[0] == ("docker/login-action", "v4.2.0", "v4.4.0")
+    assert updates[1] == ("aquasecurity/trivy", "v0.71.2", "v0.72.0")
+
+
+def test_parse_change_cell_unicode_arrow_digest() -> None:
+    # Unquoted digest cell with a Unicode arrow must also parse.
+    body = textwrap.dedent(
+        """
+        | Package | Type | Update | Change |
+        |---------|------|--------|--------|
+        | [actions/checkout](https://github.com/actions/checkout) | action | digest | abc1234 → def5678 |
+        """
+    ).strip()
+    updates = parse_renovate_pr_updates("chore(deps): update all", body)
+    assert updates == [("actions/checkout", "abc1234", "def5678")]
+
+
 def test_format_single_with_old_new() -> None:
     entry = format_changelog_entry(
         42,


### PR DESCRIPTION
## Summary

The autochangelog was silently dropping grouped Renovate PRs. `renovate-changelog-pr` parsed the update table only when the change cell used an ASCII `->`, but Renovate renders it with the Unicode arrow `→` (U+2192), e.g. `` `v4.2.0` → `v4.4.0` ``. So `_parse_table_updates` returned `[]` for every real Renovate PR body; a changelog entry only appeared when the PR *title* matched the fallback (digest bumps, single `update X to Y`). Grouped PRs (#866) and pins got nothing.

Discovered while verifying autochangelog behaviour on the recreated #862/#866.

## Change
- `_parse_change_cell`: accept both `→` and `->` (quoted and unquoted/digest cells).

## TDD
- **RED** (`6097c9c7`): tests with the real Unicode arrow — failed (parser returned `[]`).
- **GREEN** (`daf2e54e`): widen the regex — 14/14 file tests pass, full vig-utils suite 516 passed.
- End-to-end: the real #866 body now parses all three updates (`trivy`, `setup-uv`, `docker/login-action`).

Root `CHANGELOG.md` + its verbatim `.devcontainer` mirror updated in lockstep. Full pre-commit suite green.

Refs: #936
Closes #936