### PR TITLE
fix: install #python template pytest via dependency-group

### DIFF
--- a/templates/python/pyproject.toml
+++ b/templates/python/pyproject.toml
@@ -5,12 +5,12 @@ description = "Example package — rename example_pkg to your project's package.
 requires-python = ">=3.14,<3.15"
 dependencies = []
 
-[project.optional-dependencies]
-dev = ["pytest==9.1.1", "pytest-cov==7.1.0"]
-
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/example_pkg"]
+
+[dependency-groups]
+dev = ["pytest==9.1.1", "pytest-cov==7.1.0"]


### PR DESCRIPTION
## Problem
`templates/python/pyproject.toml` declares dev tooling as an extra (`[project.optional-dependencies].dev`), but the scaffold's managed `sync` is groups-only by design (`sync *args="--all-groups"`). So a project scaffolded from `nix flake init -t ...#python` that follows the template README ("Then `just sync` and `just test`") can't find pytest — `just test` fails with `Failed to spawn: pytest`. Not caught by CI (no test inits the template and runs its test flow).

## Fix
Move `pytest`/`pytest-cov` to `[dependency-groups].dev` (PEP 735). Aligns the template with the scaffold's 'extras are opt-in' contract; the documented `just sync && just test` flow now works.

## Verification
Scaffolded a copy of the template: `uv sync --all-groups` installs pytest==9.1.1 / pytest-cov==7.1.0; `uv run pytest` → 1 passed. Full `prek run --all-files` green.

## Notes
- Template/config change, no test to break (`test_just_test_recipe` covers only the language-neutral base) — TDD skipped per repo policy for template/config.
- Independent of the smoke-test fix (devcontainer-smoke-test#206); the smoke-test does not use the template.

Refs: #944