### PR TITLE
fix: grant packages: read on reusable-calling release jobs

### DIFF
--- a/assets/workspace/.github/workflows/release.yml
+++ b/assets/workspace/.github/workflows/release.yml
@@ -76,6 +76,7 @@ jobs:
       actions: write
       contents: write
       pull-requests: read
+      packages: read
     with:
       version: ${{ inputs.version }}
       release_kind: ${{ inputs.release-kind }}
@@ -105,6 +106,7 @@ jobs:
     uses: ./.github/workflows/release-publish.yml
     permissions:
       contents: write
+      packages: read
     with:
       version: ${{ needs.core.outputs.version }}
       finalize_sha: ${{ needs.core.outputs.finalize_sha }}


### PR DESCRIPTION
## Problem
#920 added `packages: read` to the reusable release workflows' jobs (`release-core` x3, `release-publish` x2) to pull the authenticated GHCR image, but the reusable-**calling** jobs (`core`, `publish`) in the scaffold `release.yml` weren't updated to grant it. A reusable workflow can't request a permission its calling job didn't grant → a consumer release run fails with `startup_failure`.

Surfaced by the 0.5.0-rc1 smoke-test's downstream release orchestration (release run startup_failure). Worked in 0.4.1 (no `packages: read` anywhere). Never caught upstream (the devcontainer repo's own release.yml is monolithic; the split lives only in the shipped scaffold). Refs vig-os/devcontainer#943.

## Fix
Grant `packages: read` on the `core` and `publish` calling jobs. Verified each caller's grant is now a superset of its callee's requested scopes:
- release-core needs {actions:write, contents:write, pull-requests:read, packages:read} — core now grants all (actions:write was already present).
- release-publish needs {contents:write, packages:read} — publish now grants both.
- release-extension needs {contents:read} — extension caller inherits the workflow-level {contents:read, packages:read}.

`promote-release.yml` audited: it calls no reusables and already sets `packages: read` where needed — no change.

Refs: #947