### PR TITLE
fix(workspace): upgrade preview report follows template symlinks (#949)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Upgrade preview report follows template symlinks** ([#949](https://github.com/vig-os/devcontainer/issues/949))
+  - On the Nix image the baked template is a tree of symlinks into the nix store, so the `--preview`/`--force` classifier's `find … -type f` matched zero files and the OVERWRITTEN/ADDED report was always empty even though the real copy (`rsync -avL`) still overwrote them. The classifier now uses `find -L` to follow symlinks and match the copy semantics.
+
 - **Autochangelog now records grouped Renovate PRs** ([#936](https://github.com/vig-os/devcontainer/issues/936))
   - `renovate-changelog-pr` parsed the update table only when the change cell used an ASCII `->` arrow, but Renovate renders it with the Unicode arrow `→` (U+2192). Every real Renovate PR body therefore parsed to nothing; a changelog entry only appeared when the PR *title* happened to match (digest bumps, single `update X to Y`), so grouped dependency PRs were silently skipped. The change-cell parser now accepts both arrows.
 

--- a/assets/init-workspace.sh
+++ b/assets/init-workspace.sh
@@ -531,7 +531,7 @@ if [[ "$FORCE" == "true" ]]; then
         else
             ADDED+=("$rel_path")
         fi
-    done < <(find "$TEMPLATE_DIR" -type f ! -path "*/.git/*" -print0)
+    done < <(find -L "$TEMPLATE_DIR" -type f ! -path "*/.git/*" -print0)
 
     # Mode-prune deletions (#886): paths that exist right now and the upgrade
     # would remove. Mirrors the prune guards further down (#738/#859/#877).

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -79,6 +79,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Upgrade preview report follows template symlinks** ([#949](https://github.com/vig-os/devcontainer/issues/949))
+  - On the Nix image the baked template is a tree of symlinks into the nix store, so the `--preview`/`--force` classifier's `find … -type f` matched zero files and the OVERWRITTEN/ADDED report was always empty even though the real copy (`rsync -avL`) still overwrote them. The classifier now uses `find -L` to follow symlinks and match the copy semantics.
+
 - **Autochangelog now records grouped Renovate PRs** ([#936](https://github.com/vig-os/devcontainer/issues/936))
   - `renovate-changelog-pr` parsed the update table only when the change cell used an ASCII `->` arrow, but Renovate renders it with the Unicode arrow `→` (U+2192). Every real Renovate PR body therefore parsed to nothing; a changelog entry only appeared when the PR *title* happened to match (digest bumps, single `update X to Y`), so grouped dependency PRs were silently skipped. The change-cell parser now accepts both arrows.
 

--- a/tests/bats/init-workspace.bats
+++ b/tests/bats/init-workspace.bats
@@ -330,6 +330,61 @@ _scaffold() {
     assert_success
 }
 
+# ── upgrade preview/report follows template symlinks (#949) ───────────────────
+# The Nix image bakes assets/workspace as a tree of symlinks into the nix store,
+# so the --preview/--force classifier's `find -type f` matched ZERO files and the
+# OVERWRITTEN/ADDED report was always empty. The real copy uses `rsync -avL`
+# (follows symlinks), so only the report was blind. The classifier must follow
+# symlinks (find -L) to match the copy semantics.
+
+# Build a TEMPLATE_DIR whose files are symlinks into a store-like dir (mirrors
+# the baked Nix image), then run the --preview report against workspace $1 and
+# echo it. `just` is stubbed so nothing external is required.
+_preview_symlinked_template() {
+    local ws="$1"
+    local tmpl="$BATS_TEST_TMPDIR/tmpl-949"
+    local store="$BATS_TEST_TMPDIR/store-949"
+    mkdir -p "$tmpl" "$store"
+    printf 'template overwrite body\n' >"$store/overwrite-src"
+    printf 'template add body\n' >"$store/add-src"
+    # Symlinked template files (as the nix store bakes them), not regular files.
+    ln -s "$store/overwrite-src" "$tmpl/sentinel-overwrite.txt"
+    ln -s "$store/add-src" "$tmpl/sentinel-add.txt"
+    local stub="$BATS_TEST_TMPDIR/stub-bin-949"
+    mkdir -p "$stub"
+    printf '#!/usr/bin/env bash\nexit 0\n' >"$stub/just"
+    chmod +x "$stub/just"
+    env PATH="$stub:$PATH" \
+        TEMPLATE_DIR="$tmpl" \
+        WORKSPACE_DIR="$ws" \
+        SHORT_NAME=testproj \
+        GITHUB_REPOSITORY=test/repo \
+        bash "$INIT_WORKSPACE_SH" --preview --force --no-prompts --mode both
+}
+
+@test "upgrade preview lists a symlinked template file that conflicts under OVERWRITTEN (#949)" {
+    ws="$BATS_TEST_TMPDIR/e2e-preview-overwrite"
+    mkdir -p "$ws"
+    # A workspace file the symlinked template would overwrite.
+    printf 'consumer body\n' >"$ws/sentinel-overwrite.txt"
+    run _preview_symlinked_template "$ws"
+    assert_success
+    refute_output --partial "No existing files would be overwritten"
+    assert_output --partial "will be OVERWRITTEN"
+    assert_output --partial "sentinel-overwrite.txt"
+}
+
+@test "upgrade preview lists a symlinked, workspace-absent template file under ADDED (#949)" {
+    ws="$BATS_TEST_TMPDIR/e2e-preview-add"
+    mkdir -p "$ws"
+    printf 'consumer body\n' >"$ws/sentinel-overwrite.txt"
+    run _preview_symlinked_template "$ws"
+    assert_success
+    refute_output --partial "No new files would be added"
+    assert_output --partial "will be ADDED"
+    assert_output --partial "sentinel-add.txt"
+}
+
 # ── script structure ──────────────────────────────────────────────────────────
 
 @test "init-workspace.sh is executable" {


### PR DESCRIPTION
## Problem
On the Nix image the baked template `/root/assets/workspace` is a tree of **symlinks into the nix store**. The `--preview`/`--force` upgrade classifier at `assets/init-workspace.sh:534` walked it with `find "$TEMPLATE_DIR" -type f …`, which matches **zero** files against a symlink tree (verified: `find -type f` → 0, `find -L -type f` → 1872). So the OVERWRITTEN / ADDED / PRESERVED report was always empty ("No existing files would be overwritten").

## Root cause
The real copy uses `rsync -avL`, which **follows symlinks**, so files were still overwritten — only the *report* was blind. The `DELETED` section is computed separately and was unaffected. This is the sole `find` over `$TEMPLATE_DIR`.

## Fix
Make the classifier follow symlinks to match the copy semantics:

```diff
-    done < <(find "$TEMPLATE_DIR" -type f ! -path "*/.git/*" -print0)
+    done < <(find -L "$TEMPLATE_DIR" -type f ! -path "*/.git/*" -print0)
```

## Tests (TDD, red → green)
Added two bats tests in `tests/bats/init-workspace.bats` that seed a **symlinked** `TEMPLATE_DIR` (mirroring the baked image) and drive `--preview --force --no-prompts` against a host workspace:
- a symlinked template file whose path already exists in the workspace must be listed under **OVERWRITTEN**;
- a symlinked, workspace-absent template file must be listed under **ADDED**.

Both **failed** on the old code (report said "No existing files would be overwritten" / "No new files would be added") and **pass** with the fix. Full `init-workspace.bats` suite: 123 passed, 0 failed. Full `prek run --all-files` hook suite: green (sync-manifest propagated the CHANGELOG entry to the scaffold copy).

Refs: #949
Closes #949
