### PR TITLE
fix(workspace): upgrade report excludes .venv/docs from the ADDED walk (#951)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Upgrade preview report follows template symlinks** ([#949](https://github.com/vig-os/devcontainer/issues/949))
   - On the Nix image the baked template is a tree of symlinks into the nix store, so the `--preview`/`--force` classifier's `find … -type f` matched zero files and the OVERWRITTEN/ADDED report was always empty even though the real copy (`rsync -avL`) still overwrote them. The classifier now uses `find -L` to follow symlinks and match the copy semantics.
 
+- **Upgrade preview no longer over-reports the baked `.venv` tree** ([#951](https://github.com/vig-os/devcontainer/issues/951))
+  - Follow-up to the [#949](https://github.com/vig-os/devcontainer/issues/949) preview fix: `find -L` also descended the baked `.venv` symlink tree, so the ADDED section listed phantom `.venv/…/site-packages/*` files the real upgrade never writes. The report `find` now mirrors the static excludes the rsync copy applies (`.venv`, `docs/issues/`, `docs/pull-requests/`), so ADDED matches what the upgrade actually does.
+
 - **Autochangelog now records grouped Renovate PRs** ([#936](https://github.com/vig-os/devcontainer/issues/936))
   - `renovate-changelog-pr` parsed the update table only when the change cell used an ASCII `->` arrow, but Renovate renders it with the Unicode arrow `→` (U+2192). Every real Renovate PR body therefore parsed to nothing; a changelog entry only appeared when the PR *title* happened to match (digest bumps, single `update X to Y`), so grouped dependency PRs were silently skipped. The change-cell parser now accepts both arrows.
 

--- a/assets/init-workspace.sh
+++ b/assets/init-workspace.sh
@@ -531,7 +531,9 @@ if [[ "$FORCE" == "true" ]]; then
         else
             ADDED+=("$rel_path")
         fi
-    done < <(find -L "$TEMPLATE_DIR" -type f ! -path "*/.git/*" -print0)
+    done < <(find -L "$TEMPLATE_DIR" -type f \
+        ! -path "*/.git/*" ! -path "*/.venv/*" \
+        ! -path "*/docs/issues/*" ! -path "*/docs/pull-requests/*" -print0)
 
     # Mode-prune deletions (#886): paths that exist right now and the upgrade
     # would remove. Mirrors the prune guards further down (#738/#859/#877).

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -82,6 +82,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Upgrade preview report follows template symlinks** ([#949](https://github.com/vig-os/devcontainer/issues/949))
   - On the Nix image the baked template is a tree of symlinks into the nix store, so the `--preview`/`--force` classifier's `find … -type f` matched zero files and the OVERWRITTEN/ADDED report was always empty even though the real copy (`rsync -avL`) still overwrote them. The classifier now uses `find -L` to follow symlinks and match the copy semantics.
 
+- **Upgrade preview no longer over-reports the baked `.venv` tree** ([#951](https://github.com/vig-os/devcontainer/issues/951))
+  - Follow-up to the [#949](https://github.com/vig-os/devcontainer/issues/949) preview fix: `find -L` also descended the baked `.venv` symlink tree, so the ADDED section listed phantom `.venv/…/site-packages/*` files the real upgrade never writes. The report `find` now mirrors the static excludes the rsync copy applies (`.venv`, `docs/issues/`, `docs/pull-requests/`), so ADDED matches what the upgrade actually does.
+
 - **Autochangelog now records grouped Renovate PRs** ([#936](https://github.com/vig-os/devcontainer/issues/936))
   - `renovate-changelog-pr` parsed the update table only when the change cell used an ASCII `->` arrow, but Renovate renders it with the Unicode arrow `→` (U+2192). Every real Renovate PR body therefore parsed to nothing; a changelog entry only appeared when the PR *title* happened to match (digest bumps, single `update X to Y`), so grouped dependency PRs were silently skipped. The change-cell parser now accepts both arrows.
 

--- a/tests/bats/init-workspace.bats
+++ b/tests/bats/init-workspace.bats
@@ -385,6 +385,54 @@ _preview_symlinked_template() {
     assert_output --partial "sentinel-add.txt"
 }
 
+# ── upgrade preview must not over-report the baked .venv symlink tree (#951) ───
+# The #949 fix switched the report classifier to `find -L`, which correctly
+# follows the store-symlink template. But `find -L` also descends the baked
+# .venv symlink tree, so the ADDED section listed phantom
+# .venv/.../site-packages/* files the real rsync copy never writes — the copy
+# excludes .git, .venv, docs/issues/ and docs/pull-requests/. The report `find`
+# must mirror those static excludes so ADDED matches what the upgrade will do.
+
+# Build a TEMPLATE_DIR that contains both a normal symlinked template file and a
+# symlinked file inside a baked .venv tree (mirrors the Nix image), then run the
+# --preview report against workspace $1 and echo it.
+_preview_symlinked_template_venv() {
+    local ws="$1"
+    local tmpl="$BATS_TEST_TMPDIR/tmpl-951"
+    local store="$BATS_TEST_TMPDIR/store-951"
+    mkdir -p "$tmpl/.venv/lib/python3.12/site-packages" "$store"
+    printf 'template add body\n' >"$store/add-src"
+    printf 'phantom venv body\n' >"$store/venv-src"
+    # A normal symlinked template file that must still be reported as ADDED...
+    ln -s "$store/add-src" "$tmpl/sentinel-add.txt"
+    # ...and a symlinked file inside the baked .venv tree that must NOT be.
+    ln -s "$store/venv-src" \
+        "$tmpl/.venv/lib/python3.12/site-packages/phantom-venv-pkg.py"
+    local stub="$BATS_TEST_TMPDIR/stub-bin-951"
+    mkdir -p "$stub"
+    printf '#!/usr/bin/env bash\nexit 0\n' >"$stub/just"
+    chmod +x "$stub/just"
+    env PATH="$stub:$PATH" \
+        TEMPLATE_DIR="$tmpl" \
+        WORKSPACE_DIR="$ws" \
+        SHORT_NAME=testproj \
+        GITHUB_REPOSITORY=test/repo \
+        bash "$INIT_WORKSPACE_SH" --preview --force --no-prompts --mode both
+}
+
+@test "upgrade preview omits the baked .venv symlink tree from ADDED (#951)" {
+    ws="$BATS_TEST_TMPDIR/e2e-preview-venv"
+    mkdir -p "$ws"
+    run _preview_symlinked_template_venv "$ws"
+    assert_success
+    # The real symlinked template file is still reported as ADDED...
+    assert_output --partial "will be ADDED"
+    assert_output --partial "sentinel-add.txt"
+    # ...but the baked .venv tree the rsync copy excludes is not over-reported.
+    refute_output --partial "phantom-venv-pkg.py"
+    refute_output --partial "site-packages"
+}
+
 # ── script structure ──────────────────────────────────────────────────────────
 
 @test "init-workspace.sh is executable" {


### PR DESCRIPTION
## Problem

`--preview`/`--force` upgrade report over-reported ~1763 phantom `.venv/…/site-packages/*` files in the **ADDED** section that the real upgrade never writes, making the ADDED list unusable. Report-only bug — no data risk.

## Root cause

The #949 fix switched the report classifier to `find -L` (`assets/init-workspace.sh:534`) so it follows the Nix image's store-symlink template — correct for the OVERWRITTEN section. But `find -L` now also follows the baked template's `.venv` symlink tree. The report `find` excluded only `.git`, whereas the real rsync copy excludes more:

```
rsync -avL --delete --exclude='.git' --exclude='.venv' --exclude='docs/issues/' --exclude='docs/pull-requests/' …
```

So every symlinked `.venv` file leaked into ADDED.

## Fix

Mirror the copy's static excludes in the report `find` (single-site change, line 534):

```sh
done < <(find -L "$TEMPLATE_DIR" -type f \
    ! -path "*/.git/*" ! -path "*/.venv/*" \
    ! -path "*/docs/issues/*" ! -path "*/docs/pull-requests/*" -print0)
```

`.venv` is the one that leaks today; the two `docs/*` excludes are for parity so future template changes can't leak either.

## Test evidence (TDD)

New bats test `upgrade preview omits the baked .venv symlink tree from ADDED (#951)` places a symlinked `.venv/…/site-packages/phantom-venv-pkg.py` (mirroring the image's baked venv) plus a normal symlinked template file under `TEMPLATE_DIR`, and asserts the normal file is still in ADDED while the `.venv` file is not.

- **RED** (before fix): `refute_output --partial "phantom-venv-pkg.py"` failed — the `.venv` file showed in ADDED.
- **GREEN** (after fix): new test passes; the two existing #949 OVERWRITTEN/ADDED tests still pass; full `init-workspace.bats` suite 124/124 green.

Full `prek run --all-files` hook suite green (sync-manifest mirror of `CHANGELOG.md` re-staged).

Refs: #951
Closes #951