### PR TITLE
fix(workspace): ship nested scaffold docs + fix imageless DEVKIT_ORG default (#953, #954)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Nested scaffold docs dropped by unanchored preserve excludes** ([#953](https://github.com/vig-os/devcontainer/issues/953))
+  - `init-workspace.sh` built its rsync preserve excludes as `--exclude=$name`, so bare `PRESERVE_FILES` entries (`README.md`, `CHANGELOG.md`) matched by basename at every depth and silently dropped devkit-authored nested docs (`.devcontainer/README.md`, `.devcontainer/CHANGELOG.md`, `.claude/skills/*/README.md`) on `--force` upgrades — files the `--preview` report still listed as ADDED. The excludes are now root-anchored (`--exclude=/$name`), matching `is_preserved_file`'s exact-path semantics: root docs stay preserved, nested docs ship.
+
+- **Imageless `--no-prompts` defaulted the org to a bogus `vigOS/devc` literal** ([#954](https://github.com/vig-os/devcontainer/issues/954))
+  - With no `ORG_NAME` env and no manifest `DEVKIT_ORG`, the org defaulted to the hardcoded `vigOS/devc` — a `/`-bearing value that sed-substituted into `{{ORG_NAME}}` in generated files (e.g. the LICENSE copyright line). The default now derives from the `GITHUB_REPOSITORY` owner segment (already resolved on this path via `DEVKIT_REPO`), falling back to the literal `vigOS` only when no usable owner/repo is present.
+
 - **Broken links, duplicate sections, and name/title mismatches in agent skills** ([#912](https://github.com/vig-os/devcontainer/issues/912))
   - All `../../rules/*.mdc` links in `.claude/skills/` now point to the correct skill files or `CLAUDE.md` (`.claude/rules/` was removed in #626).
   - `../docs/RELEASE_CYCLE.md` links in `pr_create` and `pr_post-merge` corrected to `../../../docs/RELEASE_CYCLE.md`.

--- a/assets/init-workspace.sh
+++ b/assets/init-workspace.sh
@@ -689,10 +689,17 @@ if [[ "$SMOKE_TEST" == "true" ]]; then
     fi
 else
     # Build exclude list for preserved files that already exist
+    # Root-anchor each exclude (leading slash) so it matches the exact
+    # transfer-root path, not the basename at every depth (#953). Bare names
+    # like README.md/CHANGELOG.md protect the consumer's ROOT docs only;
+    # without the anchor rsync also skipped devkit-authored NESTED docs
+    # (.devcontainer/README.md, .claude/skills/*/README.md), which the preview
+    # (is_preserved_file, exact rel-path) still promised as ADDED. The anchor
+    # matches is_preserved_file's exact-path semantics.
     EXCLUDE_ARGS=()
     for preserved in "${PRESERVE_FILES[@]}"; do
         if [[ -e "$WORKSPACE_DIR/$preserved" ]]; then
-            EXCLUDE_ARGS+=("--exclude=$preserved")
+            EXCLUDE_ARGS+=("--exclude=/$preserved")
         fi
     done
 

--- a/assets/init-workspace.sh
+++ b/assets/init-workspace.sh
@@ -22,7 +22,8 @@
 #   SHORT_NAME           - Project short name (required unless the workspace
 #                          .vig-os persists DEVKIT_PROJECT, #885)
 #   ORG_NAME             - Organization name (optional, defaults to DEVKIT_ORG
-#                          from .vig-os, else "vigOS/devc")
+#                          from .vig-os, else the GITHUB_REPOSITORY owner
+#                          segment, else the literal "vigOS")
 #   GITHUB_REPOSITORY    - owner/repo for Renovate preset extends (optional if
 #                          persisted as DEVKIT_REPO or origin is github.com)
 #   VIG_OS_VERSION       - Override the DEVCONTAINER_VERSION pinned in the scaffolded
@@ -317,8 +318,22 @@ if [[ -z "${ORG_NAME:-}" && -n "$MANIFEST_ORG" ]]; then
     echo "Organization name from .vig-os manifest: $ORG_NAME"
 fi
 if [[ "$NO_PROMPTS" == "true" ]]; then
-    # Non-interactive mode: use env var/manifest or default
-    ORG_NAME="${ORG_NAME:-vigOS/devc}"
+    # Non-interactive mode: env var/manifest, else derive the org from the
+    # repo owner already in hand (#954). A hardcoded "vigOS/devc" default is a
+    # bogus org — it contains a '/', which sed-substitutes into {{ORG_NAME}} in
+    # generated files (e.g. the LICENSE copyright). GITHUB_REPOSITORY (owner/repo)
+    # is available on this path (DEVKIT_REPO uses it), so take its owner segment;
+    # fall back to a sane literal only when no usable owner/repo is present.
+    if [[ -z "${ORG_NAME:-}" ]]; then
+        _repo_owner="${GITHUB_REPOSITORY:-}"
+        _repo_owner="${_repo_owner%%/*}"
+        if [[ -n "$_repo_owner" && "${GITHUB_REPOSITORY:-}" != "OWNER/REPO" ]]; then
+            ORG_NAME="$_repo_owner"
+        else
+            ORG_NAME="vigOS"
+        fi
+        unset _repo_owner
+    fi
 elif [[ -z "${ORG_NAME:-}" ]]; then
     # Interactive mode: prompt user
     read -rp "Enter the name of your organization, e.g. 'vigOS': " ORG_NAME

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Nested scaffold docs dropped by unanchored preserve excludes** ([#953](https://github.com/vig-os/devcontainer/issues/953))
+  - `init-workspace.sh` built its rsync preserve excludes as `--exclude=$name`, so bare `PRESERVE_FILES` entries (`README.md`, `CHANGELOG.md`) matched by basename at every depth and silently dropped devkit-authored nested docs (`.devcontainer/README.md`, `.devcontainer/CHANGELOG.md`, `.claude/skills/*/README.md`) on `--force` upgrades — files the `--preview` report still listed as ADDED. The excludes are now root-anchored (`--exclude=/$name`), matching `is_preserved_file`'s exact-path semantics: root docs stay preserved, nested docs ship.
+
+- **Imageless `--no-prompts` defaulted the org to a bogus `vigOS/devc` literal** ([#954](https://github.com/vig-os/devcontainer/issues/954))
+  - With no `ORG_NAME` env and no manifest `DEVKIT_ORG`, the org defaulted to the hardcoded `vigOS/devc` — a `/`-bearing value that sed-substituted into `{{ORG_NAME}}` in generated files (e.g. the LICENSE copyright line). The default now derives from the `GITHUB_REPOSITORY` owner segment (already resolved on this path via `DEVKIT_REPO`), falling back to the literal `vigOS` only when no usable owner/repo is present.
+
 - **Broken links, duplicate sections, and name/title mismatches in agent skills** ([#912](https://github.com/vig-os/devcontainer/issues/912))
   - All `../../rules/*.mdc` links in `.claude/skills/` now point to the correct skill files or `CLAUDE.md` (`.claude/rules/` was removed in #626).
   - `../docs/RELEASE_CYCLE.md` links in `pr_create` and `pr_post-merge` corrected to `../../../docs/RELEASE_CYCLE.md`.

--- a/tests/bats/init-workspace.bats
+++ b/tests/bats/init-workspace.bats
@@ -383,6 +383,38 @@ _scaffold() {
     assert_output --partial 'EXCLUDE_ARGS+=("--exclude=$preserved")'
 }
 
+# ── preserve excludes must be root-anchored, not basename-matched (#953) ──────
+# PRESERVE_FILES lists bare names (README.md/CHANGELOG.md) to protect the
+# consumer's ROOT docs. Built as `--exclude=$preserved` (no leading slash),
+# rsync matches by basename at EVERY depth, silently dropping devkit-authored
+# NESTED docs (.devcontainer/README.md, .claude/skills/*/README.md). The preview
+# classifies via the exact rel-path is_preserved_file, so it promised those
+# nested docs as ADDED while the copy never wrote them. Root-anchoring the
+# excludes (--exclude=/$preserved) restores the exact-path semantics.
+
+@test "upgrade copies devkit-authored nested docs while preserving root docs (#953)" {
+    ws="$BATS_TEST_TMPDIR/e2e-953-nested"
+    mkdir -p "$ws"
+    # consumer's pre-existing ROOT docs: must survive the upgrade untouched
+    printf '# SENTINEL-953 consumer root readme\n' >"$ws/README.md"
+    printf '# SENTINEL-953 consumer root changelog\n' >"$ws/CHANGELOG.md"
+    run _upgrade both "$ws"
+    assert_success
+    # root docs preserved (PRESERVE_FILES, exact root-relative match)
+    run grep -q 'SENTINEL-953 consumer root readme' "$ws/README.md"
+    assert_success
+    run grep -q 'SENTINEL-953 consumer root changelog' "$ws/CHANGELOG.md"
+    assert_success
+    # devkit-authored NESTED docs are copied, not dropped by an unanchored
+    # basename exclude that matched the root docs' names at every depth
+    run test -f "$ws/.devcontainer/README.md"
+    assert_success
+    run test -f "$ws/.devcontainer/CHANGELOG.md"
+    assert_success
+    run test -f "$ws/.claude/skills/inception_explore/README.md"
+    assert_success
+}
+
 @test "init-workspace.sh accepts --smoke-test flag" {
     run grep -- '--smoke-test' "$INIT_WORKSPACE_SH"
     assert_success

--- a/tests/bats/init-workspace.bats
+++ b/tests/bats/init-workspace.bats
@@ -380,7 +380,7 @@ _scaffold() {
     # shellcheck disable=SC2016
     assert_output --partial 'if [[ -e "$WORKSPACE_DIR/$preserved" ]]; then'
     # shellcheck disable=SC2016
-    assert_output --partial 'EXCLUDE_ARGS+=("--exclude=$preserved")'
+    assert_output --partial 'EXCLUDE_ARGS+=("--exclude=/$preserved")'
 }
 
 # ── preserve excludes must be root-anchored, not basename-matched (#953) ──────

--- a/tests/bats/init-workspace.bats
+++ b/tests/bats/init-workspace.bats
@@ -1324,6 +1324,41 @@ _upgrade_no_flags() {
     assert_success
 }
 
+# ── imageless --no-prompts must not default the org to a bogus literal (#954) ─
+# On --no-prompts with no ORG_NAME env and no manifest DEVKIT_ORG, ORG_NAME
+# defaulted to the hardcoded literal "vigOS/devc" — a bogus org (contains '/')
+# that gets sed-substituted into {{ORG_NAME}} in generated files (e.g. the
+# LICENSE copyright line). GITHUB_REPOSITORY (owner/repo) is available on this
+# path (DEVKIT_REPO uses it), so derive the org from its owner segment instead.
+
+@test "no-prompts derives DEVKIT_ORG from the repo owner, not a bogus literal (#954)" {
+    ws="$BATS_TEST_TMPDIR/e2e-954-org"
+    mkdir -p "$ws"
+    stub="$BATS_TEST_TMPDIR/stub-bin-954"
+    mkdir -p "$stub"
+    printf '#!/usr/bin/env bash\nexit 0\n' >"$stub/just"
+    chmod +x "$stub/just"
+    # no ORG_NAME env, no manifest DEVKIT_ORG: the org must come from the owner
+    # segment of GITHUB_REPOSITORY, not the hardcoded slash-bearing literal.
+    run env -u ORG_NAME PATH="$stub:$PATH" \
+        TEMPLATE_DIR="$PROJECT_ROOT/assets/workspace" \
+        WORKSPACE_DIR="$ws" \
+        SHORT_NAME=testproj \
+        GITHUB_REPOSITORY=some-org/repo \
+        bash "$INIT_WORKSPACE_SH" --force --no-prompts --mode both
+    assert_success
+    # persisted org is the owner segment, never the bogus '/'-bearing literal
+    run grep -x 'DEVKIT_ORG=some-org' "$ws/.vig-os"
+    assert_success
+    run grep -q 'vigOS/devc' "$ws/.vig-os"
+    assert_failure
+    # the org substitution into generated files carries no '/'-bearing org
+    run grep -q 'Copyright 2025 some-org' "$ws/LICENSE"
+    assert_success
+    run grep -q 'vigOS/devc' "$ws/LICENSE"
+    assert_failure
+}
+
 @test "manifest-bearing upgrade keeps devcontainer shape and names, no flags (#885)" {
     ws="$BATS_TEST_TMPDIR/e2e-885-up-devc"
     mkdir -p "$ws"

--- a/tests/bats/init-workspace.bats
+++ b/tests/bats/init-workspace.bats
@@ -1317,8 +1317,9 @@ _upgrade_no_flags() {
     assert_success
     run grep -x 'DEVKIT_PROJECT=testproj' "$ws/.vig-os"
     assert_success
-    # _scaffold sets no ORG_NAME, so the --no-prompts default is persisted
-    run grep -x 'DEVKIT_ORG=vigOS/devc' "$ws/.vig-os"
+    # _scaffold sets no ORG_NAME, so the org is derived from the
+    # GITHUB_REPOSITORY owner segment (test/repo -> test), #954.
+    run grep -x 'DEVKIT_ORG=test' "$ws/.vig-os"
     assert_success
     run grep -x 'DEVKIT_REPO=test/repo' "$ws/.vig-os"
     assert_success


### PR DESCRIPTION
Two related `assets/init-workspace.sh` bug fixes, TDD, one PR into `dev`.

## #953 — scaffold copy drops nested README.md/CHANGELOG.md
**Problem:** `PRESERVE_FILES` lists bare names (`README.md`, `CHANGELOG.md`) to protect the consumer's ROOT docs. The copy built `--exclude=$preserved` (no leading slash), so rsync matched by **basename at every depth** and silently dropped devkit-authored NESTED docs (`.devcontainer/README.md`, `.devcontainer/CHANGELOG.md`, `.claude/skills/*/README.md`) on `--force` upgrades — files the `--preview` report (exact-path `is_preserved_file`) still promised under ADDED.

**Fix:** root-anchor each exclude (`--exclude=/$preserved`), matching `is_preserved_file`'s exact-path semantics. Root docs stay preserved; nested docs now ship.

**RED→GREEN:** new bats test seeds a consumer root `README.md`/`CHANGELOG.md`, runs a `--force` upgrade, then asserts the root docs are preserved AND `.devcontainer/README.md`, `.devcontainer/CHANGELOG.md`, `.claude/skills/inception_explore/README.md` were copied. Failed on the nested-doc assertion before the fix; green after.

## #954 — imageless `--no-prompts` defaults org to literal `vigOS/devc`
**Problem:** under `--no-prompts` with no `ORG_NAME` env and no manifest `DEVKIT_ORG`, the org defaulted to the hardcoded `vigOS/devc` — a bogus `/`-bearing org that sed-substitutes into `{{ORG_NAME}}` in generated files (e.g. the LICENSE copyright line). `GITHUB_REPOSITORY` (owner/repo) is already available on this path (`DEVKIT_REPO` uses it) but ORG ignored it.

**Fix:** default the org to the `GITHUB_REPOSITORY` owner segment (`${GITHUB_REPOSITORY%%/*}`), falling back to the sane literal `vigOS` only when no usable owner/repo is present (empty or `OWNER/REPO`).

**RED→GREEN:** new bats test runs `--no-prompts` with `GITHUB_REPOSITORY=some-org/repo` and no `ORG_NAME`/manifest org, then asserts `.vig-os` persists `DEVKIT_ORG=some-org` (not `vigOS/devc`) and the LICENSE org substitution is slash-free. Persisted `vigOS/devc` before the fix; green after. The existing #885 write-back test's assertion was updated from `DEVKIT_ORG=vigOS/devc` to `DEVKIT_ORG=test` to reflect the corrected owner-derived default.

## Verification
- Full bats suite (`tests/bats/init-workspace.bats`): 123 passed, 0 failed (existing #949/#951 and all prior tests still green).
- Full `prek run --all-files`: green (sync-manifest mirrored the changelog into `assets/workspace/.devcontainer/CHANGELOG.md`, folded into the fix commit).

Closes #953
Closes #954
