### PR TITLE
docs(changelog): record the 0.5.0 curl CVE vulnix exception in Security

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **`init-precommit.sh` derives its root** from the script location instead of a hard-coded `/workspace/{{SHORT_NAME}}`.
   - **Stale doc fixed:** `docs/container-ci-quirks.md` no longer describes a removed `uv run bandit` `pre-commit` hook; the private-image (unauthenticated `resolve-image` probe + missing `credentials:`) limitation is documented, with the first-class fix tracked in [#920](https://github.com/vig-os/devcontainer/issues/920).
 
+### Security
+
+- **Accept the curl 8.20.0 advisory batch in the vulnix register pending a patched upstream release** ([#941](https://github.com/vig-os/devcontainer/issues/941))
+  - The 2026-06-24 curl disclosure added 17 HIGH/CRITICAL CVEs against curl 8.20.0 to the vulnix feed (four CVSS 9.8 — an HTTP/2 stream-dependency-tree UAF, a cross-origin Digest auth-state leak, a SASL double-free, and a stale proxy-password leak — plus a CVSS 9.1 batch and further HIGHs); they surfaced 2026-07-08 and blocked the 0.5.0-rc1 publish at the release vulnix gate. curl is reachable in the image (https/git-over-https, flake fetches, the docker→podman shim), so this is a time-boxed risk acceptance, not a dismissal.
+  - No fixed curl exists to advance to: 8.20.0 is the newest release upstream and in both `nixos-26.05` and `nixpkgs-unstable`, so the "advance the rev" lever has nowhere to land. Added a short-dated `.vulnixignore` exception (expires 2026-07-22) to unblock the gate; the block is dropped and the pin advanced once Renovate's `nix` manager surfaces a patched curl.
+
 ## [0.4.1](https://github.com/vig-os/devcontainer/releases/tag/0.4.1) - 2026-07-08
 
 ### Added

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -118,6 +118,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **`init-precommit.sh` derives its root** from the script location instead of a hard-coded `/workspace/{{SHORT_NAME}}`.
   - **Stale doc fixed:** `docs/container-ci-quirks.md` no longer describes a removed `uv run bandit` `pre-commit` hook; the private-image (unauthenticated `resolve-image` probe + missing `credentials:`) limitation is documented, with the first-class fix tracked in [#920](https://github.com/vig-os/devcontainer/issues/920).
 
+### Security
+
+- **Accept the curl 8.20.0 advisory batch in the vulnix register pending a patched upstream release** ([#941](https://github.com/vig-os/devcontainer/issues/941))
+  - The 2026-06-24 curl disclosure added 17 HIGH/CRITICAL CVEs against curl 8.20.0 to the vulnix feed (four CVSS 9.8 — an HTTP/2 stream-dependency-tree UAF, a cross-origin Digest auth-state leak, a SASL double-free, and a stale proxy-password leak — plus a CVSS 9.1 batch and further HIGHs); they surfaced 2026-07-08 and blocked the 0.5.0-rc1 publish at the release vulnix gate. curl is reachable in the image (https/git-over-https, flake fetches, the docker→podman shim), so this is a time-boxed risk acceptance, not a dismissal.
+  - No fixed curl exists to advance to: 8.20.0 is the newest release upstream and in both `nixos-26.05` and `nixpkgs-unstable`, so the "advance the rev" lever has nowhere to land. Added a short-dated `.vulnixignore` exception (expires 2026-07-22) to unblock the gate; the block is dropped and the pin advanced once Renovate's `nix` manager surfaces a patched curl.
+
 ## [0.4.1](https://github.com/vig-os/devcontainer/releases/tag/0.4.1) - 2026-07-08
 
 ### Added


### PR DESCRIPTION
## Summary

The 0.5.0 release accepted the **curl 8.20.0 advisory batch** (17 HIGH/CRITICAL CVEs) into `.vulnixignore` (#941 / PR #942) to unblock the RC at the release vulnix gate — but the change shipped **without a `CHANGELOG.md` entry**. The `## [0.5.0]` section had no `### Security` subsection at all.

This is inconsistent with the immediately preceding release: the 0.4.1 podman exception (#905) *did* get a `### Security` entry. Since the CHANGELOG is the register of record for accepted CVEs, the omission leaves a live risk acceptance undocumented.

## Change

- Add a `### Security` entry to the (released) `## [0.5.0]` section documenting the curl exception, its severity spread (4× CVSS 9.8, a 9.1 batch, further HIGHs), reachability, the `2026-07-22` expiry, and the remediation path (drop the block once a patched curl surfaces via Renovate's `nix` manager).
- The scaffold mirror `assets/workspace/.devcontainer/CHANGELOG.md` is updated by the `sync-manifest` hook (same as #905).

## Note on the frozen section

Per changelog hygiene, entries below `## Unreleased` are normally never edited. This is a deliberate correction of an omission — the entry *should* have been present at freeze time — placed in the release the exception actually shipped in, matching the #905 precedent rather than back-dating it into `Unreleased`.

Refs: #941