### PR TITLE
fix(security): except openssh CVE-2026-60002 pending nixpkgs 10.4p1 bump

### DIFF
--- a/.vulnixignore
+++ b/.vulnixignore
@@ -255,3 +255,28 @@ CVE-2026-9545
 CVE-2026-9546
 CVE-2026-9547
 CVE-2026-9080
+
+# ============================================================================
+# Triage 2026-07-10 — openssh client use-after-free (release-cycle fix, #963).
+# Verified ONLINE against NVD/MITRE/GHSA, the upstream OpenSSH release, and the
+# nixpkgs branch contents (nixos-26.05, release-26.05, staging-26.05, master,
+# nixpkgs-unstable) on 2026-07-10. Real product match (openssh the SSH client,
+# no CPE collision). Surfaced in the vulnix feed 2026-07-10 (nightly
+# security-scan went red that morning, run 29079456127).
+# ============================================================================
+
+# openssh 10.3p1 — CVE-2026-60002 (CVSS 7.7 HIGH per MITRE; NVD scores 9.4
+#   CRITICAL): use-after-free in the ssh(1) CLIENT (not sshd) when a
+#   malicious/compromised server changes its host key during key re-exchange
+#   (CWE-416). openssh is in-closure (a direct dev tool; git-over-ssh). The
+#   client is genuinely reachable, but exploitation needs a dev-initiated
+#   connection OUT to an attacker-controlled SSH server that mutates its host
+#   key mid-rekey — bounded by the single-user dev model and typically-known
+#   hosts. Fixed upstream in 10.4p1 (2026-07-06) but NOT yet in any nixpkgs
+#   branch (all still 10.3p1); the bump is merged into the 26.05 staging
+#   pipeline (nixpkgs #539452 -> staging-nixos, backport #539933 ->
+#   staging-nixos-26.05, 2026-07-10) and has not reached nixos-26.05. Flip to a
+#   nixpkgs rev-advance once 10.4p1 lands in the pinned channel; short expiry to
+#   force near-term re-check.
+Expiration: 2026-07-24
+CVE-2026-60002

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `worktree_pr` PR title format aligned with `pr_create`: no manual issue number in title.
   - Obsolete `.claude/commands/` wrappers deleted (superseded by skills providing `/X` directly).
 
+### Security
+
+- **Accept the openssh 10.3p1 client use-after-free (CVE-2026-60002) in the vulnix register pending the nixpkgs bump to 10.4p1** ([#963](https://github.com/vig-os/devcontainer/issues/963))
+  - The 2026-07-10 nightly security scan went red at the blocking vulnix gate on CVE-2026-60002 (CVSS 7.7 HIGH per MITRE, 9.4 CRITICAL per NVD): a use-after-free in the OpenSSH **client** (`ssh(1)`, not `sshd`) triggered when a malicious/compromised server changes its host key during key re-exchange. `openssh` is in the image closure and the client is reachable, but exploitation requires connecting out to an attacker-controlled SSH server that mutates its host key mid-rekey — bounded by the single-user dev model — so this is a time-boxed risk acceptance, not a dismissal.
+  - Fixed upstream in openssh 10.4p1 (2026-07-06), but the bump has not reached the pinned `nixos-26.05` channel (still 10.3p1, as are `release-26.05`, `staging-26.05`, `master`, `nixpkgs-unstable`); it is merged into the 26.05 staging pipeline (nixpkgs [#539452](https://github.com/NixOS/nixpkgs/pull/539452), backport [#539933](https://github.com/NixOS/nixpkgs/pull/539933)). Added a short-dated `.vulnixignore` exception (expires 2026-07-24) to unblock the gate; the block is dropped and the pin advanced once 10.4p1 lands in `nixos-26.05`.
+
 ## [0.5.0](https://github.com/vig-os/devcontainer/releases/tag/0.5.0) - 2026-07-09
 
 ### Added

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -47,6 +47,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `worktree_pr` PR title format aligned with `pr_create`: no manual issue number in title.
   - Obsolete `.claude/commands/` wrappers deleted (superseded by skills providing `/X` directly).
 
+### Security
+
+- **Accept the openssh 10.3p1 client use-after-free (CVE-2026-60002) in the vulnix register pending the nixpkgs bump to 10.4p1** ([#963](https://github.com/vig-os/devcontainer/issues/963))
+  - The 2026-07-10 nightly security scan went red at the blocking vulnix gate on CVE-2026-60002 (CVSS 7.7 HIGH per MITRE, 9.4 CRITICAL per NVD): a use-after-free in the OpenSSH **client** (`ssh(1)`, not `sshd`) triggered when a malicious/compromised server changes its host key during key re-exchange. `openssh` is in the image closure and the client is reachable, but exploitation requires connecting out to an attacker-controlled SSH server that mutates its host key mid-rekey — bounded by the single-user dev model — so this is a time-boxed risk acceptance, not a dismissal.
+  - Fixed upstream in openssh 10.4p1 (2026-07-06), but the bump has not reached the pinned `nixos-26.05` channel (still 10.3p1, as are `release-26.05`, `staging-26.05`, `master`, `nixpkgs-unstable`); it is merged into the 26.05 staging pipeline (nixpkgs [#539452](https://github.com/NixOS/nixpkgs/pull/539452), backport [#539933](https://github.com/NixOS/nixpkgs/pull/539933)). Added a short-dated `.vulnixignore` exception (expires 2026-07-24) to unblock the gate; the block is dropped and the pin advanced once 10.4p1 lands in `nixos-26.05`.
+
 ## [0.5.0](https://github.com/vig-os/devcontainer/releases/tag/0.5.0) - 2026-07-09
 
 ### Added


### PR DESCRIPTION
## What & why

The nightly Scheduled Security Scan went red ([run 29079456127](https://github.com/vig-os/devcontainer/actions/runs/29079456127), 2026-07-10) at the blocking `vulnix-gate` on **CVE-2026-60002** — a use-after-free in the OpenSSH **client** (`ssh(1)`, not `sshd`) triggered when a malicious/compromised server changes its host key during key re-exchange (CWE-416). CVSS 7.7 HIGH (MITRE) / 9.4 CRITICAL (NVD).

Fixed upstream in **openssh 10.4p1** (2026-07-06), but the bump has **not** reached any nixpkgs branch yet (all still `10.3p1`: `nixos-26.05` pinned channel, `release-26.05`, `staging-26.05`, `master`, `nixpkgs-unstable`). It is merged into the 26.05 staging pipeline (nixpkgs [#539452](https://github.com/NixOS/nixpkgs/pull/539452) → `staging-nixos`, backport [#539933](https://github.com/NixOS/nixpkgs/pull/539933) → `staging-nixos-26.05`), so the "advance the rev" lever has nowhere to land today.

## Change

Time-boxed `.vulnixignore` exception for CVE-2026-60002 (**expires 2026-07-24**) with full provenance/reachability rationale, matching the curl #941 / podman #905 precedent, plus a `### Security` changelog entry (root + mirrored scaffold copy). **Flip to a nixpkgs rev-advance** once 10.4p1 reaches `nixos-26.05`; the short expiry forces near-term re-review.

## Verification

- `check-expirations` ✅ — 54 exceptions validated, none expired.
- `vulnix-gate` simulation ✅ — with CVE-2026-60002 present the gate now **passes** (exit 0); a control un-excepted HIGH still **fails**, confirming the gate itself still works.
- Full `pre-commit` suite green locally (incl. `sync-manifest`, so the two changelog mirrors are consistent).

Targets `release/0.5.1` (release-cycle fix). Cherry-pick / forward to `dev` separately since `main` is affected identically.

Refs: #963
