### PR TITLE
ci(security): open a tracking issue when the vulnix scan gate fails

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -14,6 +14,11 @@
 # Jobs:
 #   1. scan-nix-image - build the image closure, run vulnix (+ Trivy SBOM)
 #
+# On failure:
+#   - A deduplicated `security-scan` tracking issue is opened (#965). Scheduled
+#     runs execute from the default branch with no other signal, so a red gate
+#     must surface as an issue, not just a red run.
+#
 # Artifacts:
 #   - vulnix findings (JSON + table) and a CycloneDX SBOM (uploaded)
 
@@ -38,8 +43,8 @@ jobs:
   # step is BLOCKING (#639): the nixpkgs baseline was advanced to 26.05 and the
   # residual findings triaged into .vulnixignore (see docs/security/
   # nix-cutover-scan-overlap.md), so any new unexcepted HIGH/CRITICAL fails the
-  # scan. SARIF upload to the Security tab + a deduplicated issue can be added
-  # alongside the actual publish-cutover.
+  # scan, which opens a deduplicated tracking issue (#965). SARIF upload to the
+  # Security tab can still be added alongside the actual publish-cutover.
   scan-nix-image:
     name: Scan Nix image (vulnix + SBOM)
     runs-on: ubuntu-24.04
@@ -48,6 +53,7 @@ jobs:
     timeout-minutes: 90
     permissions:
       contents: read
+      issues: write  # open a deduplicated tracking issue when the vulnix gate fails (#965)
 
     steps:
       - name: Checkout repository
@@ -185,3 +191,49 @@ jobs:
             echo "vulnix over-reports CVEs already patched in nixpkgs; triage findings"
             echo "into \`.vulnixignore\` and advance the nixpkgs rev before #639."
           } >> "$GITHUB_STEP_SUMMARY"
+
+      # Restore the deduplicated tracking issue lost in the Debian->Nix cutover
+      # (#965): a scheduled run from the default branch has no other signal, so a
+      # red vulnix gate must surface as an issue, not just a red run.
+      - name: Open a tracking issue when the vulnix gate fails
+        # failure() lets this step run despite the failing gate; the outcome
+        # guard scopes it to a gate failure (not an infra/scan crash upstream).
+        if: ${{ failure() && steps.vulnix-gate.outcome == 'failure' }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          SECURITY_URL: ${{ github.server_url }}/${{ github.repository }}/security
+        run: |
+          set -euo pipefail
+          # Refresh the (Nix-era) label; --force updates an existing label's
+          # description/color, correcting the stale ":latest image" text.
+          gh label create security-scan \
+            --description 'Automated nightly security scan findings for the Nix devcontainer image' \
+            --color BFD4F2 --force 2>/dev/null || true
+          # Dedup by the auto-issue's distinctive title, NOT the label alone, so
+          # we never collide with human-filed security-scan issues (per-CVE
+          # triage, this very regression, etc.). One open tracking issue at a
+          # time; it is closed when a later scheduled run passes the gate.
+          TITLE='Nightly security scan: unexcepted HIGH/CRITICAL vulnix findings'
+          EXISTING=$(gh issue list --state open --label security-scan \
+            --search "\"$TITLE\" in:title" --json number -q '.[0].number // empty')
+          if [ -n "$EXISTING" ]; then
+            echo "Open tracking issue already exists: #$EXISTING -- skipping create"
+            exit 0
+          fi
+          BODY="$(cat <<EOF
+          The nightly vulnix gate found **unexcepted HIGH/CRITICAL** CVEs in the Nix image closure (after \`.vulnixignore\`).
+
+          - **Scan target:** flake \`devcontainerImageEnv\` (image package closure)
+          - **Scan date (UTC):** $(date -u +%Y-%m-%dT%H:%M:%SZ)
+          - **Workflow run:** ${RUN_URL}
+          - **Findings artifact:** \`nix-image-cve-scan\` on the run above (\`vulnix-findings.json\`, \`vulnix-report.txt\`)
+          - **Security tab:** ${SECURITY_URL}
+
+          **To remediate:** advance the pinned nixpkgs rev if a fix has landed, or add a time-boxed \`.vulnixignore\` exception with a rationale (see \`docs/CONTAINER_SECURITY.md\`). Close this issue once a later scheduled run passes the gate.
+          EOF
+          )"
+          gh issue create \
+            --title "$TITLE" \
+            --label security-scan --label security \
+            --body "$BODY"


### PR DESCRIPTION
## What & why

Restores the deduplicated **auto-issue on scan failure** that was lost in the Debian→Nix cutover (`1d4e9db1`), so a red nightly vulnix gate surfaces as a GitHub issue rather than a silent red run. Full root-cause history in #965.

The trigger case was 2026-07-10 ([run 29079456127](https://github.com/vig-os/devcontainer/actions/runs/29079456127), CVE-2026-60002, fixed in #963/#964) — the first gate failure to reach `main` post-0.5.0 with no issue-creation step, so it had to be caught by hand.

## Change (single file: `.github/workflows/security-scan.yml`)

- Grant the `scan-nix-image` job `issues: write`.
- New step **"Open a tracking issue when the vulnix gate fails"**, gated on `failure() && steps.vulnix-gate.outcome == 'failure'` (so infra/scan crashes don't file a "findings" issue).
- Adapted from the old Debian step, with two improvements:
  - **Dedup by the auto-issue's distinctive title**, not the `security-scan` label alone — the old label-only dedup would now false-match human-filed `security-scan` issues (e.g. #963, this #965) and never fire.
  - **Refreshes the stale label description** (`--force`): was *"...for :latest image"*, now the Nix image.
- Body links the run + the `nix-image-cve-scan` artifact (`vulnix-findings.json`/`vulnix-report.txt`) and gives the remediate path (advance the pin or add a time-boxed `.vulnixignore` exception).
- Updated two stale doc comments (header "On failure" note; the old "can be added alongside the publish-cutover" TODO).

## Verification

- Full `pre-commit` suite green (yamllint, check-action-pins — no new pinned action, `gh` CLI only).
- Embedded `run:` script `shellcheck`-clean and dry-run rendered: search arg `"Nightly security scan: …" in:title` and the heredoc body (backticks literal, `$(date)`/`${RUN_URL}` expanded) both correct.

**Not changelog-tracked** (`ci` scope, maintainer-facing CI infra). Targets `release/0.5.1` so 0.5.1 ships with working alerting.

Refs: #965
