### PR TITLE
feat(manifest): dual-key DEVKIT_VERSION pin parser with legacy fallback

### DIFF
--- a/.github/actions/resolve-image/action.yml
+++ b/.github/actions/resolve-image/action.yml
@@ -40,34 +40,46 @@ runs:
         fi
 
         if [[ -f .vig-os ]]; then
-          VERSION=""
+          # Prefer the renamed DEVKIT_VERSION key, falling back to the legacy
+          # DEVCONTAINER_VERSION so un-migrated pins keep resolving (#781). Both
+          # keys are captured and preferred after the read, so DEVKIT_VERSION
+          # wins regardless of line order.
+          DEVKIT_VERSION=""
+          LEGACY_VERSION=""
           while IFS= read -r line || [[ -n "${line:-}" ]]; do
             [[ -z "${line//[[:space:]]/}" ]] && continue
             [[ "$line" =~ ^[[:space:]]*# ]] && continue
 
             case "$line" in
-              DEVCONTAINER_VERSION=*)
-                VERSION="${line#*=}"
-                VERSION="${VERSION#"${VERSION%%[![:space:]]*}"}"
-                VERSION="${VERSION%"${VERSION##*[![:space:]]}"}"
+              DEVKIT_VERSION=*|DEVCONTAINER_VERSION=*)
+                key="${line%%=*}"
+                value="${line#*=}"
+                value="${value#"${value%%[![:space:]]*}"}"
+                value="${value%"${value##*[![:space:]]}"}"
 
-                if [[ "$VERSION" =~ ^\".*\"$ ]]; then
-                  VERSION="${VERSION:1:-1}"
-                elif [[ "$VERSION" =~ ^\'.*\'$ ]]; then
-                  VERSION="${VERSION:1:-1}"
+                if [[ "$value" =~ ^\".*\"$ ]]; then
+                  value="${value:1:-1}"
+                elif [[ "$value" =~ ^\'.*\'$ ]]; then
+                  value="${value:1:-1}"
                 fi
-                break
+
+                if [[ "$key" == "DEVKIT_VERSION" ]]; then
+                  DEVKIT_VERSION="$value"
+                else
+                  LEGACY_VERSION="$value"
+                fi
                 ;;
             esac
           done < .vig-os
 
+          VERSION="${DEVKIT_VERSION:-$LEGACY_VERSION}"
           if [[ -n "$VERSION" ]]; then
             echo "tag=$VERSION" >> "$GITHUB_OUTPUT"
             exit 0
           fi
         fi
 
-        echo "ERROR: Could not resolve DEVCONTAINER_VERSION from .vig-os and no image-tag override was provided."
+        echo "ERROR: Could not resolve DEVKIT_VERSION (or legacy DEVCONTAINER_VERSION) from .vig-os and no image-tag override was provided."
         exit 1
 
     - name: Validate image accessibility
@@ -99,7 +111,7 @@ runs:
           if echo "$PROBE_ERR" | grep -qiE 'unauthorized|denied|authentication|forbidden|toomanyrequests|rate limit'; then
             echo "::error::Cannot access image manifest: ${IMAGE} — authentication required or denied. Set the GHCR_PULL_TOKEN secret (or grant the workflow token packages:read) and pass it to this action."
           else
-            echo "::error::Cannot access image manifest: ${IMAGE} — the tag does not exist or is not readable. Check that DEVCONTAINER_VERSION in .vig-os points at a published image tag."
+            echo "::error::Cannot access image manifest: ${IMAGE} — the tag does not exist or is not readable. Check that DEVKIT_VERSION (or legacy DEVCONTAINER_VERSION) in .vig-os points at a published image tag."
           fi
           exit 1
         fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Version-pin parsers accept the renamed `DEVKIT_VERSION` key** ([#781](https://github.com/vig-os/devcontainer/issues/781))
+  - As the first step of the `devcontainer` → `devkit` rename, every `.vig-os`
+    version-pin reader now prefers a `DEVKIT_VERSION` key and falls back to the
+    legacy `DEVCONTAINER_VERSION` when it is absent, so un-migrated consumer pins
+    keep resolving (soft cutover). When both keys are present, `DEVKIT_VERSION`
+    wins regardless of line order. Covers the `resolve-image` composite action
+    (root + scaffold), the scaffold `initialize.sh` / `version-check.sh` scripts,
+    and the Nix image build.
+
 ### Changed
 
 ### Deprecated

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Version-pin parsers accept the renamed `DEVKIT_VERSION` key** ([#781](https://github.com/vig-os/devcontainer/issues/781))
+  - As the first step of the `devcontainer` → `devkit` rename, every `.vig-os`
+    version-pin reader now prefers a `DEVKIT_VERSION` key and falls back to the
+    legacy `DEVCONTAINER_VERSION` when it is absent, so un-migrated consumer pins
+    keep resolving (soft cutover). When both keys are present, `DEVKIT_VERSION`
+    wins regardless of line order. Covers the `resolve-image` composite action
+    (root + scaffold), the scaffold `initialize.sh` / `version-check.sh` scripts,
+    and the Nix image build.
+
 ### Changed
 
 ### Deprecated

--- a/assets/workspace/.devcontainer/scripts/initialize.sh
+++ b/assets/workspace/.devcontainer/scripts/initialize.sh
@@ -17,32 +17,45 @@ DEVCONTAINER_DIR="$(dirname "$SCRIPT_DIR")"
 load_vig_os_config() {
     local config_file="$DEVCONTAINER_DIR/../.vig-os"
     local env_file="$DEVCONTAINER_DIR/.env"
+    local devkit_version=""
+    local legacy_version=""
     local devcontainer_version=""
 
     if [[ ! -f "$config_file" ]]; then
         return 0
     fi
 
+    # Prefer the renamed DEVKIT_VERSION key, falling back to the legacy
+    # DEVCONTAINER_VERSION so un-migrated pins keep resolving (#781). Both keys
+    # are captured and preferred after the read, so DEVKIT_VERSION wins
+    # regardless of line order.
     while IFS= read -r line || [[ -n "${line:-}" ]]; do
         [[ -z "${line//[[:space:]]/}" ]] && continue
         [[ "$line" =~ ^[[:space:]]*# ]] && continue
 
         case "$line" in
-            DEVCONTAINER_VERSION=*)
-                devcontainer_version="${line#*=}"
-                devcontainer_version="${devcontainer_version#"${devcontainer_version%%[![:space:]]*}"}"
-                devcontainer_version="${devcontainer_version%"${devcontainer_version##*[![:space:]]}"}"
+            DEVKIT_VERSION=*|DEVCONTAINER_VERSION=*)
+                local key="${line%%=*}"
+                local value="${line#*=}"
+                value="${value#"${value%%[![:space:]]*}"}"
+                value="${value%"${value##*[![:space:]]}"}"
 
-                if [[ "$devcontainer_version" =~ ^\".*\"$ ]]; then
-                    devcontainer_version="${devcontainer_version:1:-1}"
-                elif [[ "$devcontainer_version" =~ ^\'.*\'$ ]]; then
-                    devcontainer_version="${devcontainer_version:1:-1}"
+                if [[ "$value" =~ ^\".*\"$ ]]; then
+                    value="${value:1:-1}"
+                elif [[ "$value" =~ ^\'.*\'$ ]]; then
+                    value="${value:1:-1}"
                 fi
-                break
+
+                if [[ "$key" == "DEVKIT_VERSION" ]]; then
+                    devkit_version="$value"
+                else
+                    legacy_version="$value"
+                fi
                 ;;
         esac
     done < "$config_file"
 
+    devcontainer_version="${devkit_version:-$legacy_version}"
     if [[ -z "$devcontainer_version" ]]; then
         return 0
     fi

--- a/assets/workspace/.devcontainer/scripts/version-check.sh
+++ b/assets/workspace/.devcontainer/scripts/version-check.sh
@@ -194,32 +194,45 @@ record_check() {
 get_current_version() {
     local config_file="$DEVCONTAINER_DIR/../.vig-os"
     local line
+    local devkit_version=""
+    local legacy_version=""
     local version=""
 
     if [[ ! -f "$config_file" ]]; then
         return 1
     fi
 
+    # Prefer the renamed DEVKIT_VERSION key, falling back to the legacy
+    # DEVCONTAINER_VERSION so un-migrated pins keep resolving (#781). Both keys
+    # are captured and preferred after the read, so DEVKIT_VERSION wins
+    # regardless of line order.
     while IFS= read -r line || [[ -n "$line" ]]; do
         [[ -z "${line//[[:space:]]/}" ]] && continue
         [[ "$line" =~ ^[[:space:]]*# ]] && continue
 
         case "$line" in
-            DEVCONTAINER_VERSION=*)
-                version="${line#*=}"
-                version="${version#"${version%%[![:space:]]*}"}"
-                version="${version%"${version##*[![:space:]]}"}"
+            DEVKIT_VERSION=*|DEVCONTAINER_VERSION=*)
+                local key="${line%%=*}"
+                local value="${line#*=}"
+                value="${value#"${value%%[![:space:]]*}"}"
+                value="${value%"${value##*[![:space:]]}"}"
 
-                if [[ "$version" =~ ^\".*\"$ ]]; then
-                    version="${version:1:-1}"
-                elif [[ "$version" =~ ^\'.*\'$ ]]; then
-                    version="${version:1:-1}"
+                if [[ "$value" =~ ^\".*\"$ ]]; then
+                    value="${value:1:-1}"
+                elif [[ "$value" =~ ^\'.*\'$ ]]; then
+                    value="${value:1:-1}"
                 fi
-                break
+
+                if [[ "$key" == "DEVKIT_VERSION" ]]; then
+                    devkit_version="$value"
+                else
+                    legacy_version="$value"
+                fi
                 ;;
         esac
     done < "$config_file"
 
+    version="${devkit_version:-$legacy_version}"
     if [[ -z "$version" || "$version" == "dev" || "$version" == "latest" ]]; then
         return 1  # Not a pinned version
     fi

--- a/assets/workspace/.github/actions/resolve-image/action.yml
+++ b/assets/workspace/.github/actions/resolve-image/action.yml
@@ -40,34 +40,46 @@ runs:
         fi
 
         if [[ -f .vig-os ]]; then
-          VERSION=""
+          # Prefer the renamed DEVKIT_VERSION key, falling back to the legacy
+          # DEVCONTAINER_VERSION so un-migrated pins keep resolving (#781). Both
+          # keys are captured and preferred after the read, so DEVKIT_VERSION
+          # wins regardless of line order.
+          DEVKIT_VERSION=""
+          LEGACY_VERSION=""
           while IFS= read -r line || [[ -n "${line:-}" ]]; do
             [[ -z "${line//[[:space:]]/}" ]] && continue
             [[ "$line" =~ ^[[:space:]]*# ]] && continue
 
             case "$line" in
-              DEVCONTAINER_VERSION=*)
-                VERSION="${line#*=}"
-                VERSION="${VERSION#"${VERSION%%[![:space:]]*}"}"
-                VERSION="${VERSION%"${VERSION##*[![:space:]]}"}"
+              DEVKIT_VERSION=*|DEVCONTAINER_VERSION=*)
+                key="${line%%=*}"
+                value="${line#*=}"
+                value="${value#"${value%%[![:space:]]*}"}"
+                value="${value%"${value##*[![:space:]]}"}"
 
-                if [[ "$VERSION" =~ ^\".*\"$ ]]; then
-                  VERSION="${VERSION:1:-1}"
-                elif [[ "$VERSION" =~ ^\'.*\'$ ]]; then
-                  VERSION="${VERSION:1:-1}"
+                if [[ "$value" =~ ^\".*\"$ ]]; then
+                  value="${value:1:-1}"
+                elif [[ "$value" =~ ^\'.*\'$ ]]; then
+                  value="${value:1:-1}"
                 fi
-                break
+
+                if [[ "$key" == "DEVKIT_VERSION" ]]; then
+                  DEVKIT_VERSION="$value"
+                else
+                  LEGACY_VERSION="$value"
+                fi
                 ;;
             esac
           done < .vig-os
 
+          VERSION="${DEVKIT_VERSION:-$LEGACY_VERSION}"
           if [[ -n "$VERSION" ]]; then
             echo "tag=$VERSION" >> "$GITHUB_OUTPUT"
             exit 0
           fi
         fi
 
-        echo "ERROR: Could not resolve DEVCONTAINER_VERSION from .vig-os and no image-tag override was provided."
+        echo "ERROR: Could not resolve DEVKIT_VERSION (or legacy DEVCONTAINER_VERSION) from .vig-os and no image-tag override was provided."
         exit 1
 
     - name: Validate image accessibility
@@ -99,7 +111,7 @@ runs:
           if echo "$PROBE_ERR" | grep -qiE 'unauthorized|denied|authentication|forbidden|toomanyrequests|rate limit'; then
             echo "::error::Cannot access image manifest: ${IMAGE} — authentication required or denied. Set the GHCR_PULL_TOKEN secret (or grant the workflow token packages:read) and pass it to this action."
           else
-            echo "::error::Cannot access image manifest: ${IMAGE} — the tag does not exist or is not readable. Check that DEVCONTAINER_VERSION in .vig-os points at a published image tag."
+            echo "::error::Cannot access image manifest: ${IMAGE} — the tag does not exist or is not readable. Check that DEVKIT_VERSION (or legacy DEVCONTAINER_VERSION) in .vig-os points at a published image tag."
           fi
           exit 1
         fi

--- a/flake.nix
+++ b/flake.nix
@@ -864,9 +864,12 @@
 
                     # Resolve the built tag: the explicit VIG_OS_VERSION override
                     # (release build, via --impure) when present, else the repo's
-                    # pinned DEVCONTAINER_VERSION. Empty override => pure/plain
-                    # `nix build`, so this is the reproducible repo pin (#921/#642).
-                    dcver="$(sed -n 's/^DEVCONTAINER_VERSION=//p' ${./.vig-os})"
+                    # pinned version. Empty override => pure/plain `nix build`, so
+                    # this is the reproducible repo pin (#921/#642). Prefer the
+                    # renamed DEVKIT_VERSION key, falling back to the legacy
+                    # DEVCONTAINER_VERSION so an un-migrated pin still builds (#781).
+                    dcver="$(sed -n 's/^DEVKIT_VERSION=//p' ${./.vig-os})"
+                    [ -n "$dcver" ] || dcver="$(sed -n 's/^DEVCONTAINER_VERSION=//p' ${./.vig-os})"
                     imageVersion="${imageVersionOverride}"
                     [ -n "$imageVersion" ] || imageVersion="$dcver"
 

--- a/tests/bats/manifest-parsers.bats
+++ b/tests/bats/manifest-parsers.bats
@@ -37,6 +37,25 @@ DEVKIT_FUTURE_FLAG=whatever
 EOF
 }
 
+# The rename (#781) moves the pin key to DEVKIT_VERSION. Write a manifest that
+# carries only the new key to $1.
+_devkit_only_manifest() {
+    cat > "$1" <<'EOF'
+# vig-os devkit configuration
+DEVKIT_VERSION=1.2.3
+EOF
+}
+
+# Write a manifest carrying BOTH keys with different values to $1 — the parser
+# must prefer DEVKIT_VERSION over the legacy DEVCONTAINER_VERSION (#781).
+_dual_key_manifest() {
+    cat > "$1" <<'EOF'
+# vig-os devkit configuration
+DEVCONTAINER_VERSION=0.4.0
+DEVKIT_VERSION=1.2.3
+EOF
+}
+
 # Build a minimal consumer fixture tree at $1 (root with .vig-os written by
 # $2, .devcontainer/scripts with the real initialize.sh/version-check.sh and
 # a stubbed copy-host-user-conf.sh).
@@ -93,4 +112,38 @@ _fixture_tree() {
     full_out="$(bash "$full/.devcontainer/scripts/version-check.sh" config \
         | sed "s|$full|ROOT|")"
     [ "$legacy_out" = "$full_out" ]
+}
+
+@test "initialize.sh reads the renamed DEVKIT_VERSION pin (#781)" {
+    root="$BATS_TEST_TMPDIR/init-devkit"
+    _fixture_tree "$root" _devkit_only_manifest
+    run bash "$root/.devcontainer/scripts/initialize.sh"
+    assert_success
+    run grep -x 'DEVCONTAINER_VERSION=1.2.3' "$root/.devcontainer/.env"
+    assert_success
+}
+
+@test "initialize.sh prefers DEVKIT_VERSION over legacy pin (#781)" {
+    root="$BATS_TEST_TMPDIR/init-dual"
+    _fixture_tree "$root" _dual_key_manifest
+    run bash "$root/.devcontainer/scripts/initialize.sh"
+    assert_success
+    run grep -x 'DEVCONTAINER_VERSION=1.2.3' "$root/.devcontainer/.env"
+    assert_success
+}
+
+@test "version-check.sh reads the renamed DEVKIT_VERSION pin (#781)" {
+    root="$BATS_TEST_TMPDIR/vc-devkit"
+    _fixture_tree "$root" _devkit_only_manifest
+    run bash "$root/.devcontainer/scripts/version-check.sh" config
+    assert_success
+    assert_output --partial "Current ver:    1.2.3"
+}
+
+@test "version-check.sh prefers DEVKIT_VERSION over legacy pin (#781)" {
+    root="$BATS_TEST_TMPDIR/vc-dual"
+    _fixture_tree "$root" _dual_key_manifest
+    run bash "$root/.devcontainer/scripts/version-check.sh" config
+    assert_success
+    assert_output --partial "Current ver:    1.2.3"
 }

--- a/tests/test_resolve_image_manifest.py
+++ b/tests/test_resolve_image_manifest.py
@@ -44,6 +44,26 @@ DEVKIT_MODULES="native rust"
 DEVKIT_FUTURE_FLAG=whatever
 """
 
+# The rename (#781) moves the version pin key DEVCONTAINER_VERSION -> DEVKIT_VERSION.
+# The parser must read the new key, preferring it over the legacy one regardless of
+# file order, while still resolving a legacy-only manifest (soft cutover).
+DEVKIT_ONLY_MANIFEST = """\
+# vig-os devkit configuration
+DEVKIT_VERSION=1.2.3
+"""
+
+DUAL_KEY_LEGACY_FIRST = """\
+# vig-os devkit configuration
+DEVCONTAINER_VERSION=0.4.0
+DEVKIT_VERSION=1.2.3
+"""
+
+DUAL_KEY_DEVKIT_FIRST = """\
+# vig-os devkit configuration
+DEVKIT_VERSION=1.2.3
+DEVCONTAINER_VERSION=0.4.0
+"""
+
 
 def _resolve_step_script() -> str:
     """The bash body of the action's 'Resolve image tag' step."""
@@ -94,3 +114,18 @@ def test_resolver_output_identical_for_legacy_and_full_manifest(
     legacy = _run_resolver(tmp_path, VERSION_ONLY_MANIFEST, "legacy")
     full = _run_resolver(tmp_path, FULL_MANIFEST, "full")
     assert legacy == full == "tag=0.4.0\n"
+
+
+def test_resolver_reads_devkit_version(tmp_path: Path) -> None:
+    """The renamed pin key DEVKIT_VERSION resolves on its own (#781)."""
+    output = _run_resolver(tmp_path, DEVKIT_ONLY_MANIFEST, "devkit")
+    assert output == "tag=1.2.3\n"
+
+
+def test_resolver_prefers_devkit_over_legacy_regardless_of_order(
+    tmp_path: Path,
+) -> None:
+    """DEVKIT_VERSION wins over legacy DEVCONTAINER_VERSION in either order (#781)."""
+    legacy_first = _run_resolver(tmp_path, DUAL_KEY_LEGACY_FIRST, "legacy-first")
+    devkit_first = _run_resolver(tmp_path, DUAL_KEY_DEVKIT_FIRST, "devkit-first")
+    assert legacy_first == devkit_first == "tag=1.2.3\n"


### PR DESCRIPTION
## Summary

First slice of the `devcontainer` → `devkit` rename (**#781**): make every `.vig-os`
version-pin reader accept the renamed **`DEVKIT_VERSION`** key, falling back to the legacy
`DEVCONTAINER_VERSION` when it is absent.

This is the **load-bearing** first step — landing it makes every later rename slice
(image ref, dispatch targets, pin-key writeback) **non-breaking** for consumers: a repo whose
`.vig-os` still says `DEVCONTAINER_VERSION` keeps resolving, and one re-scaffolded to
`DEVKIT_VERSION` resolves too. Soft cutover, per the approved plan.

## Behaviour

- Reads prefer `DEVKIT_VERSION`; fall back to `DEVCONTAINER_VERSION` when the new key is absent.
- Both keys are captured and preferred **after** the read, so `DEVKIT_VERSION` wins **regardless
  of line order** (not "first match wins").
- A legacy-only manifest resolves exactly as before (byte-identical) — no regression.

## Read sites updated (all five)

| Site | Consumer |
|------|----------|
| `.github/actions/resolve-image/action.yml` | CI image-tag resolution |
| `assets/workspace/.github/actions/resolve-image/action.yml` | scaffold mirror (sync target) |
| `assets/workspace/.devcontainer/scripts/initialize.sh` | writes compose `.env` pin |
| `assets/workspace/.devcontainer/scripts/version-check.sh` | in-container version report |
| `flake.nix` | Nix image build tag |

**Out of scope for this slice** (later PRs): the image ref `ghcr.io/vig-os/devcontainer`, the
written `.env` / compose var name, and the *written* pin key (`init-workspace.sh` / `release.yml`
finalize still write `DEVCONTAINER_VERSION`). `install.sh` does **not** read the version pin from
`.vig-os`, so it is untouched here.

## Testing

TDD (RED → GREEN):

- `tests/test_resolve_image_manifest.py` — new `DEVKIT_VERSION`-only + dual-key precedence
  (both orders) cases. **4 passed.**
- `tests/bats/manifest-parsers.bats` — new `DEVKIT_VERSION` read + precedence cases for
  `initialize.sh` and `version-check.sh`, with the four legacy `#885` regression tests intact.
  **8 passed.**
- `just precommit` (full suite, incl. shellcheck/actionlint/nixfmt/sync-manifest) — **green.**

Refs: #781
