### PR TITLE
chore(build): rename internal package identity devcontainer -> devkit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,10 @@
 {
-  "name": "devcontainer-ci-deps",
+  "name": "devkit-ci-deps",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "devcontainer-ci-deps",
+      "name": "devkit-ci-deps",
       "dependencies": {
         "@devcontainers/cli": "0.87.0"
       }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "devcontainer-ci-deps",
+  "name": "devkit-ci-deps",
   "private": true,
   "description": "CI-only npm dependencies tracked by Dependabot",
   "dependencies": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "devcontainer"
+name = "devkit"
 version = "0.1.1"
 description = "vigOS development environment"
 # Range, not an exact pin: the Nix toolchain pins the exact interpreter via
@@ -18,11 +18,11 @@ dependencies = [
 [dependency-groups]
 dev = [
   "vig-utils",
-  { include-group = "devcontainer" },
+  { include-group = "devkit" },
   { include-group = "lint" },
   { include-group = "test" },
 ]
-devcontainer = ["rich==15.0.0", "pip-licenses==5.5.5", "bandit[toml]==1.9.4"]
+devkit = ["rich==15.0.0", "pip-licenses==5.5.5", "bandit[toml]==1.9.4"]
 lint = ["pip-licenses==5.5.5", "bandit[toml]==1.9.4"]
 test = [
   "pytest==9.1.1",

--- a/uv.lock
+++ b/uv.lock
@@ -177,7 +177,7 @@ wheels = [
 ]
 
 [[package]]
-name = "devcontainer"
+name = "devkit"
 version = "0.1.1"
 source = { virtual = "." }
 dependencies = [
@@ -203,7 +203,7 @@ dev = [
     { name = "testcontainers" },
     { name = "vig-utils" },
 ]
-devcontainer = [
+devkit = [
     { name = "bandit" },
     { name = "pip-licenses" },
     { name = "rich" },
@@ -246,7 +246,7 @@ dev = [
     { name = "testcontainers", specifier = "==4.14.2" },
     { name = "vig-utils", editable = "packages/vig-utils" },
 ]
-devcontainer = [
+devkit = [
     { name = "bandit", extras = ["toml"], specifier = "==1.9.4" },
     { name = "pip-licenses", specifier = "==5.5.5" },
     { name = "rich", specifier = "==15.0.0" },


### PR DESCRIPTION
## Summary

Stage 1 slice of the `devcontainer` → `devkit` rename (**#781**): rename the
**internal package identity** — the root `pyproject.toml` project name and `dev`
dependency-group, and the `package.json` / `package-lock.json` CI-deps package.

Metadata only: the root project is not published anywhere and nothing imports it,
so there is **no runtime or consumer impact**. Both lockfiles are regenerated.

## Changes
- `pyproject.toml`: `name = "devcontainer"` → `"devkit"`; dep-group `devcontainer` → `devkit` (+ its `include-group` reference).
- `package.json`: `"devcontainer-ci-deps"` → `"devkit-ci-deps"`. The generic `@devcontainers/cli` dependency is **unchanged**.
- `uv.lock`, `package-lock.json`: regenerated (`uv lock`, `npm install --package-lock-only`).

## Scope note
The **flake attribute** rename (`devcontainerImage` / `devcontainerImageEnv` / `devcontainer-bootstrap`)
was originally grouped here but is **reassigned to PR 2** — it touches the same CI
workflow files as the image-ref change and needs the nix-build verification that
PR 2 already runs, so it's more cohesive there.

## Testing
`just precommit` (full suite) — green. No test references the old package/dep-group name.

Refs: #781