### PR TITLE
docs(install): follow redirects in documented curl one-liners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Documented `install.sh` one-liners follow redirects (`curl -sSfL`)** ([#781](https://github.com/vig-os/devcontainer/issues/781))
+  - Pre-rename hardening: every documented `curl … | bash` install/upgrade
+    one-liner (README, `install.sh` help text, `MIGRATION.md`, the smoke-test
+    template, and the in-container upgrade hint) now passes `-L` so the fetch
+    follows HTTP redirects, keeping the bootstrap working across the upcoming
+    `devcontainer` → `devkit` repository rename. Repository and image URLs are
+    unchanged in this slice.
+
 ### Deprecated
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ That's it! All development tools (Python, git, pre-commit, just, etc.) are inclu
 ### One-Line Install
 
 ```bash
-curl -sSf https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh | bash -s -- ~/my-project
+curl -sSfL https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh | bash -s -- ~/my-project
 ```
 
 This will:
@@ -42,26 +42,26 @@ also `both`. `devcontainer` scaffolds `.devcontainer/` only; `direnv` scaffolds
 
 ```bash
 # Use specific version
-curl -sSf https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh | bash -s -- --version 0.2.1 ~/my-project
+curl -sSfL https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh | bash -s -- --version 0.2.1 ~/my-project
 
 # Upgrade existing project (overwrites template files)
-curl -sSf https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh | bash -s -- --force ~/my-project
+curl -sSfL https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh | bash -s -- --force ~/my-project
 
 # Override project name
-curl -sSf https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh | bash -s -- --name my_custom_name ~/my-project
+curl -sSfL https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh | bash -s -- --name my_custom_name ~/my-project
 
 # Override organization name (default: vigOS)
-curl -sSf https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh | bash -s -- --org MyOrg ~/my-project
+curl -sSfL https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh | bash -s -- --org MyOrg ~/my-project
 
 # Choose the delivery mode: devcontainer | direnv | both (default: both)
-curl -sSf https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh | bash -s -- --mode direnv ~/my-project
+curl -sSfL https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh | bash -s -- --mode direnv ~/my-project
 
 # Preview without executing
-curl -sSf https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh | bash -s -- --dry-run ~/my-project
+curl -sSfL https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh | bash -s -- --dry-run ~/my-project
 
 # Force specific runtime
-curl -sSf https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh | bash -s -- --docker ~/my-project
-curl -sSf https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh | bash -s -- --podman ~/my-project
+curl -sSfL https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh | bash -s -- --docker ~/my-project
+curl -sSfL https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh | bash -s -- --podman ~/my-project
 ```
 
 > **Note:** If podman or docker is not installed, the script provides OS-specific installation instructions for macOS, Ubuntu/Debian, Fedora, Arch Linux, and Windows.

--- a/assets/smoke-test/README.md
+++ b/assets/smoke-test/README.md
@@ -89,7 +89,7 @@ If this repository is lost or needs to be rebuilt, recreate it from the
 2. Clone it locally and run the installer with smoke-test assets enabled:
 
    ```bash
-   curl -sSf https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh | bash -s -- --smoke-test .
+   curl -sSfL https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh | bash -s -- --smoke-test .
    ```
 
 3. Commit the generated files and push to `main`.

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -20,6 +20,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Documented `install.sh` one-liners follow redirects (`curl -sSfL`)** ([#781](https://github.com/vig-os/devcontainer/issues/781))
+  - Pre-rename hardening: every documented `curl … | bash` install/upgrade
+    one-liner (README, `install.sh` help text, `MIGRATION.md`, the smoke-test
+    template, and the in-container upgrade hint) now passes `-L` so the fetch
+    follows HTTP redirects, keeping the bootstrap working across the upcoming
+    `devcontainer` → `devkit` repository rename. Repository and image URLs are
+    unchanged in this slice.
+
 ### Deprecated
 
 ### Removed

--- a/assets/workspace/.devcontainer/scripts/version-check.sh
+++ b/assets/workspace/.devcontainer/scripts/version-check.sh
@@ -297,7 +297,7 @@ notify_update() {
     echo ""
     echo -e "  Or without just:"
     echo ""
-    echo -e "    curl -sSf https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh | bash -s -- --force ."
+    echo -e "    curl -sSfL https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh | bash -s -- --force ."
     echo ""
     echo -e "  After upgrading, rebuild the container in VS Code."
     echo ""

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -377,7 +377,7 @@ dedicated working branch as a single reviewable, revertible diff
 To see what an upgrade would change before running it, use `--preview`:
 
 ```bash
-curl -sSf https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh \
+curl -sSfL https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh \
   | bash -s -- --force --preview .
 ```
 

--- a/docs/templates/README.md.j2
+++ b/docs/templates/README.md.j2
@@ -20,7 +20,7 @@ That's it! All development tools (Python, git, pre-commit, just, etc.) are inclu
 ### One-Line Install
 
 ```bash
-curl -sSf https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh | bash -s -- ~/my-project
+curl -sSfL https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh | bash -s -- ~/my-project
 ```
 
 This will:
@@ -40,26 +40,26 @@ also `both`. `devcontainer` scaffolds `.devcontainer/` only; `direnv` scaffolds
 
 ```bash
 # Use specific version
-curl -sSf https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh | bash -s -- --version 0.2.1 ~/my-project
+curl -sSfL https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh | bash -s -- --version 0.2.1 ~/my-project
 
 # Upgrade existing project (overwrites template files)
-curl -sSf https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh | bash -s -- --force ~/my-project
+curl -sSfL https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh | bash -s -- --force ~/my-project
 
 # Override project name
-curl -sSf https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh | bash -s -- --name my_custom_name ~/my-project
+curl -sSfL https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh | bash -s -- --name my_custom_name ~/my-project
 
 # Override organization name (default: vigOS)
-curl -sSf https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh | bash -s -- --org MyOrg ~/my-project
+curl -sSfL https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh | bash -s -- --org MyOrg ~/my-project
 
 # Choose the delivery mode: devcontainer | direnv | both (default: both)
-curl -sSf https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh | bash -s -- --mode direnv ~/my-project
+curl -sSfL https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh | bash -s -- --mode direnv ~/my-project
 
 # Preview without executing
-curl -sSf https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh | bash -s -- --dry-run ~/my-project
+curl -sSfL https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh | bash -s -- --dry-run ~/my-project
 
 # Force specific runtime
-curl -sSf https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh | bash -s -- --docker ~/my-project
-curl -sSf https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh | bash -s -- --podman ~/my-project
+curl -sSfL https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh | bash -s -- --docker ~/my-project
+curl -sSfL https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh | bash -s -- --podman ~/my-project
 ```
 
 > **Note:** If podman or docker is not installed, the script provides OS-specific installation instructions for macOS, Ubuntu/Debian, Fedora, Arch Linux, and Windows.

--- a/install.sh
+++ b/install.sh
@@ -2,8 +2,8 @@
 # vigOS devcontainer quick install script
 #
 # Usage:
-#   curl -sSf https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh | bash
-#   curl -sSf https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh | bash -s -- [OPTIONS] [PATH]
+#   curl -sSfL https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh | bash
+#   curl -sSfL https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh | bash -s -- [OPTIONS] [PATH]
 #
 # Options:
 #   --force           Overwrite existing files (for upgrades)
@@ -22,10 +22,10 @@
 #   -h, --help        Show this help message
 #
 # Examples:
-#   curl -sSf https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh | bash
-#   curl -sSf ... | bash -s -- ~/Projects/my-project
-#   curl -sSf ... | bash -s -- --version 0.2.1 --force ./my-project
-#   curl -sSf ... | bash -s -- --org MyOrg ./my-project
+#   curl -sSfL https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh | bash
+#   curl -sSfL ... | bash -s -- ~/Projects/my-project
+#   curl -sSfL ... | bash -s -- --version 0.2.1 --force ./my-project
+#   curl -sSfL ... | bash -s -- --org MyOrg ./my-project
 
 set -euo pipefail
 
@@ -67,8 +67,8 @@ usage() {
 vigOS Devcontainer Install Script
 
 USAGE:
-    curl -sSf https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh | bash
-    curl -sSf ... | bash -s -- [OPTIONS] [PATH]
+    curl -sSfL https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh | bash
+    curl -sSfL ... | bash -s -- [OPTIONS] [PATH]
 
 OPTIONS:
     --force           Overwrite existing files (for upgrades)
@@ -92,25 +92,25 @@ OPTIONS:
 
 EXAMPLES:
     # Initialize current directory with latest version
-    curl -sSf https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh | bash
+    curl -sSfL https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh | bash
 
     # Initialize specific directory
-    curl -sSf ... | bash -s -- ~/Projects/my-new-project
+    curl -sSfL ... | bash -s -- ~/Projects/my-new-project
 
     # Upgrade existing project
-    curl -sSf ... | bash -s -- --force ./my-project
+    curl -sSfL ... | bash -s -- --force ./my-project
 
     # Use specific version
-    curl -sSf ... | bash -s -- --version 0.2.1 ./my-project
+    curl -sSfL ... | bash -s -- --version 0.2.1 ./my-project
 
     # Override project name
-    curl -sSf ... | bash -s -- --name my_custom_name ./my-project
+    curl -sSfL ... | bash -s -- --name my_custom_name ./my-project
 
     # Use custom organization name
-    curl -sSf ... | bash -s -- --org MyOrg ./my-project
+    curl -sSfL ... | bash -s -- --org MyOrg ./my-project
 
     # Scaffold only the Nix/direnv stub (no .devcontainer/)
-    curl -sSf ... | bash -s -- --mode direnv ./my-project
+    curl -sSfL ... | bash -s -- --mode direnv ./my-project
 EOF
 }
 
@@ -726,7 +726,7 @@ if [ ! -t 0 ]; then
         err "This script requires an interactive terminal"
         echo ""
         echo "Try running directly instead of piping:"
-        echo "  curl -sSf https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh -o install.sh"
+        echo "  curl -sSfL https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh -o install.sh"
         echo "  bash install.sh $PROJECT_PATH"
         exit 1
     fi


### PR DESCRIPTION
## Summary

Stage 1 pre-rename hardening for **#781**: add `-L` to every documented
`curl … | bash` install/upgrade one-liner so the fetch **follows HTTP redirects**.
This keeps the bootstrap working across the upcoming `devcontainer` → `devkit`
repository rename (GitHub redirects the old repo URL, but `curl` only follows it
with `-L`).

## Changes (`curl -sSf` → `curl -sSfL`)
- `docs/templates/README.md.j2` (→ regenerated `README.md`)
- `install.sh` help/usage text
- `docs/MIGRATION.md`
- `assets/smoke-test/README.md`
- `assets/workspace/.devcontainer/scripts/version-check.sh` (in-container upgrade hint)

## Explicitly out of scope (deferred)
- **Repository URLs** (`github.com/vig-os/devcontainer`, `raw.githubusercontent.com/…`) — flipping
  them to `devkit` now would 404 until the Stage 3 repo rename; GitHub redirects the old URLs, so
  they stay valid meanwhile. They canonicalize at Stage 3.
- **Image refs** (`ghcr.io/vig-os/devcontainer`) — ride PR 2 (image-ref cutover).

The `curl -fsSL https://get.docker.com` calls already follow redirects and are untouched.

## Testing
`just precommit` (full suite incl. `generate-docs`, `sync-manifest`) — green. README regenerated from the template.

Refs: #781