### PR TITLE
feat(manifest): write scaffolded .vig-os pin under DEVKIT_VERSION

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -551,8 +551,8 @@ jobs:
           VERSION: ${{ needs.validate.outputs.version }}
         run: |
           set -euo pipefail
-          sed -i "s/^DEVCONTAINER_VERSION=.*/DEVCONTAINER_VERSION=$VERSION/" .vig-os
-          echo "✓ Set DEVCONTAINER_VERSION=$VERSION in .vig-os"
+          sed -i -E "s/^(DEVKIT_VERSION|DEVCONTAINER_VERSION)=.*/DEVKIT_VERSION=$VERSION/" .vig-os
+          echo "✓ Set DEVKIT_VERSION=$VERSION in .vig-os"
 
       - name: Collect finalization files
         if: needs.validate.outputs.release_kind == 'final'

--- a/.vig-os
+++ b/.vig-os
@@ -1,2 +1,2 @@
-# vig-os devcontainer configuration
-DEVCONTAINER_VERSION=0.5.1
+# vig-os devkit configuration
+DEVKIT_VERSION=0.5.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Scaffolded `.vig-os` pins under `DEVKIT_VERSION`** ([#781](https://github.com/vig-os/devcontainer/issues/781))
+  - The scaffold/release writeback now emits the renamed `DEVKIT_VERSION` key:
+    the template manifest, `init-workspace.sh`, the `release.yml` finalize step,
+    the repo-root `.vig-os`, and the scaffolded `devc-upgrade` recipe. A `--force`
+    upgrade migrates a legacy `DEVCONTAINER_VERSION` pin to `DEVKIT_VERSION`
+    (the `.vig-os` overwrite drops the stale key). Readers still accept the legacy
+    key (soft cutover). The docker-compose `.env` interpolation variable is
+    unchanged in this slice.
+
 ### Deprecated
 
 ### Removed

--- a/assets/init-workspace.sh
+++ b/assets/init-workspace.sh
@@ -26,7 +26,7 @@
 #                          segment, else the literal "vigOS")
 #   GITHUB_REPOSITORY    - owner/repo for Renovate preset extends (optional if
 #                          persisted as DEVKIT_REPO or origin is github.com)
-#   VIG_OS_VERSION       - Override the DEVCONTAINER_VERSION pinned in the scaffolded
+#   VIG_OS_VERSION       - Override the DEVKIT_VERSION pinned in the scaffolded
 #                          .vig-os (optional; install.sh forwards its --version, #852)
 #
 # The workspace .vig-os is the project's declarative manifest (#885): the
@@ -886,8 +886,11 @@ if [[ -n "${VIG_OS_VERSION:-}" && -f "$WORKSPACE_DIR/.vig-os" ]]; then
         echo "Error: invalid VIG_OS_VERSION: $VIG_OS_VERSION" >&2
         exit 1
     fi
-    echo "Pinning DEVCONTAINER_VERSION=${VIG_OS_VERSION} in .vig-os..."
-    sed -i "s/^DEVCONTAINER_VERSION=.*/DEVCONTAINER_VERSION=${VIG_OS_VERSION}/" "$WORKSPACE_DIR/.vig-os"
+    echo "Pinning DEVKIT_VERSION=${VIG_OS_VERSION} in .vig-os..."
+    # Rewrite whichever version key the manifest carries to the renamed
+    # DEVKIT_VERSION, so a stray legacy DEVCONTAINER_VERSION line is migrated
+    # rather than left stale (#781).
+    sed -i -E "s/^(DEVKIT_VERSION|DEVCONTAINER_VERSION)=.*/DEVKIT_VERSION=${VIG_OS_VERSION}/" "$WORKSPACE_DIR/.vig-os"
 fi
 
 # Interactive origin resolution (the renovate.json owner/repo prompt) runs here,

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -20,6 +20,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Scaffolded `.vig-os` pins under `DEVKIT_VERSION`** ([#781](https://github.com/vig-os/devcontainer/issues/781))
+  - The scaffold/release writeback now emits the renamed `DEVKIT_VERSION` key:
+    the template manifest, `init-workspace.sh`, the `release.yml` finalize step,
+    the repo-root `.vig-os`, and the scaffolded `devc-upgrade` recipe. A `--force`
+    upgrade migrates a legacy `DEVCONTAINER_VERSION` pin to `DEVKIT_VERSION`
+    (the `.vig-os` overwrite drops the stale key). Readers still accept the legacy
+    key (soft cutover). The docker-compose `.env` interpolation variable is
+    unchanged in this slice.
+
 ### Deprecated
 
 ### Removed

--- a/assets/workspace/.devcontainer/justfile.devc
+++ b/assets/workspace/.devcontainer/justfile.devc
@@ -40,14 +40,14 @@ devc-check *args:
 devc-upgrade:
     #!/usr/bin/env bash
     # Honor the consumer's pinned devkit generation (#854): read
-    # DEVCONTAINER_VERSION from .vig-os and upgrade to THAT tag (both the
-    # install.sh script ref and the pinned image version), not whatever
-    # `main`/`latest` happens to be. An unpinned or `latest` manifest keeps the
-    # floating `main`/`latest` behavior.
+    # DEVKIT_VERSION (or the legacy DEVCONTAINER_VERSION for un-migrated pins,
+    # #781) from .vig-os and upgrade to THAT tag (both the install.sh script ref
+    # and the pinned image version), not whatever `main`/`latest` happens to be.
+    # An unpinned or `latest` manifest keeps the floating `main`/`latest` behavior.
     REF="main"
     PIN_ARGS=()
     if [[ -f .vig-os ]]; then
-        PINNED="$(awk -F= '/^DEVCONTAINER_VERSION=/{gsub(/^[ \t"]+|[ \t"]+$/, "", $2); print $2; exit}' .vig-os || true)"
+        PINNED="$(awk -F= '/^DEVKIT_VERSION=/{gsub(/^[ \t"]+|[ \t"]+$/, "", $2); devkit=$2} /^DEVCONTAINER_VERSION=/{gsub(/^[ \t"]+|[ \t"]+$/, "", $2); legacy=$2} END{print (devkit != "" ? devkit : legacy)}' .vig-os || true)"
         if [[ -n "${PINNED:-}" && "$PINNED" != "latest" ]]; then
             REF="$PINNED"
             PIN_ARGS=(--version "$PINNED")

--- a/assets/workspace/.github/workflows/ci.yml
+++ b/assets/workspace/.github/workflows/ci.yml
@@ -97,12 +97,12 @@ jobs:
       # Version-skew guard (#854): fail with an actionable message if the CI
       # image predates the prek hook runner (#778), instead of an opaque
       # `just precommit` exit 127 deep in the log. The image tag comes from the
-      # .vig-os DEVCONTAINER_VERSION pin.
+      # .vig-os DEVKIT_VERSION pin.
       - name: Verify toolchain (prek present)
         run: |
           if ! command -v prek >/dev/null 2>&1; then
-            echo "::error::'prek' not found in the CI image (ghcr.io/vig-os/devcontainer). The image pinned by .vig-os DEVCONTAINER_VERSION predates the prek hook runner (#778)."
-            echo "Fix: bump .vig-os DEVCONTAINER_VERSION to an image that ships prek, or re-run the devkit installer. See docs/MIGRATION.md."
+            echo "::error::'prek' not found in the CI image (ghcr.io/vig-os/devcontainer). The image pinned by .vig-os DEVKIT_VERSION predates the prek hook runner (#778)."
+            echo "Fix: bump .vig-os DEVKIT_VERSION to an image that ships prek, or re-run the devkit installer. See docs/MIGRATION.md."
             exit 1
           fi
           echo "prek present: $(command -v prek)"

--- a/assets/workspace/.github/workflows/prepare-release.yml
+++ b/assets/workspace/.github/workflows/prepare-release.yml
@@ -62,8 +62,9 @@ jobs:
 
       # Resolve + validate the pinned devcontainer image via the shared
       # resolve-image action (#854): hard-fails on a missing/unreadable
-      # DEVCONTAINER_VERSION instead of silently falling back to `latest`, so
-      # this workflow can no longer diverge from ci.yml's resolver semantics.
+      # DEVKIT_VERSION (or legacy DEVCONTAINER_VERSION) instead of silently
+      # falling back to `latest`, so this workflow can no longer diverge from
+      # ci.yml's resolver semantics.
       - name: Resolve container image
         id: resolve_image
         uses: ./.github/actions/resolve-image

--- a/assets/workspace/.vig-os
+++ b/assets/workspace/.vig-os
@@ -5,9 +5,9 @@
 # upgrades need no mode/identity flags. Future per-project devkit flags
 # (e.g. the #883 hook opt-out) live in this file too.
 
-# Scaffold/image version pin (managed by release automation; kept under the
-# legacy name until the devkit rename, #781).
-DEVCONTAINER_VERSION={{IMAGE_TAG}}
+# Scaffold/image version pin (managed by release automation). Readers also
+# accept the legacy DEVCONTAINER_VERSION key for un-migrated consumers (#781).
+DEVKIT_VERSION={{IMAGE_TAG}}
 
 # Delivery mode: devcontainer | direnv | both | bare. Ships empty (= unset:
 # resolved and written back on scaffold) so an aborted upgrade can never

--- a/flake.nix
+++ b/flake.nix
@@ -882,8 +882,8 @@
                     # Bake the devcontainer version into the scaffolded `.vig-os`,
                     # replacing the {{IMAGE_TAG}} placeholder. The Debian build
                     # relied on the IMAGE_TAG build-arg; the reproducible Nix image
-                    # reads the repo's pinned DEVCONTAINER_VERSION, so a scaffolded
-                    # workspace pins the devcontainer release it was built from. #642.
+                    # reads the repo's pinned DEVKIT_VERSION, so a scaffolded
+                    # workspace pins the devkit release it was built from. #642.
                     sed -i "s/{{IMAGE_TAG}}/$imageVersion/g" "$out/root/assets/workspace/.vig-os"
 
                     # Bake the build-time placeholder manifest so

--- a/tests/bats/init-workspace.bats
+++ b/tests/bats/init-workspace.bats
@@ -665,9 +665,9 @@ _preview_symlinked_template_venv() {
     assert_success
 }
 
-@test "init-workspace writes DEVCONTAINER_VERSION from the VIG_OS_VERSION override (#852)" {
+@test "init-workspace writes DEVKIT_VERSION from the VIG_OS_VERSION override (#852)" {
     # shellcheck disable=SC2016
-    run grep -F 'DEVCONTAINER_VERSION=${VIG_OS_VERSION}' "$INIT_WORKSPACE_SH"
+    run grep -F 'DEVKIT_VERSION=${VIG_OS_VERSION}' "$INIT_WORKSPACE_SH"
     assert_success
 }
 
@@ -702,8 +702,26 @@ _scaffold_with_version_file() {
     printf '0.5.0-rc3\n' >"$verfile"
     run _scaffold_with_version_file bare "$ws" "$verfile"
     assert_success
+    run grep '^DEVKIT_VERSION=' "$ws/.vig-os"
+    assert_output "DEVKIT_VERSION=0.5.0-rc3"
+}
+
+@test "init-workspace migrates a legacy DEVCONTAINER_VERSION pin to DEVKIT_VERSION (#781)" {
+    ws="$BATS_TEST_TMPDIR/e2e-781-migrate"
+    mkdir -p "$ws"
+    # Pre-seed a legacy version-only manifest: a --force upgrade overwrites
+    # .vig-os from the template (which now carries DEVKIT_VERSION), so the stale
+    # legacy key must be gone and the renamed key pinned to the new version.
+    printf '# vig-os devcontainer configuration\nDEVCONTAINER_VERSION=0.3.9\n' \
+        > "$ws/.vig-os"
+    verfile="$BATS_TEST_TMPDIR/VERSION-781"
+    printf '1.0.0\n' >"$verfile"
+    run _scaffold_with_version_file bare "$ws" "$verfile"
+    assert_success
     run grep '^DEVCONTAINER_VERSION=' "$ws/.vig-os"
-    assert_output "DEVCONTAINER_VERSION=0.5.0-rc3"
+    assert_failure
+    run grep '^DEVKIT_VERSION=' "$ws/.vig-os"
+    assert_output "DEVKIT_VERSION=1.0.0"
 }
 
 @test "init-workspace leaves the baked pin untouched when no VERSION record exists (#921)" {
@@ -713,8 +731,8 @@ _scaffold_with_version_file() {
     # the template's baked placeholder survives (no image build happened here).
     run _scaffold_with_version_file bare "$ws" "$BATS_TEST_TMPDIR/does-not-exist"
     assert_success
-    run grep '^DEVCONTAINER_VERSION=' "$ws/.vig-os"
-    assert_output "DEVCONTAINER_VERSION={{IMAGE_TAG}}"
+    run grep '^DEVKIT_VERSION=' "$ws/.vig-os"
+    assert_output "DEVKIT_VERSION={{IMAGE_TAG}}"
 }
 
 @test "init-workspace prefers an explicit VIG_OS_VERSION over the VERSION record (#921)" {
@@ -735,8 +753,8 @@ _scaffold_with_version_file() {
         GITHUB_REPOSITORY=test/repo \
         bash "$INIT_WORKSPACE_SH" --force --no-prompts --mode bare
     assert_success
-    run grep '^DEVCONTAINER_VERSION=' "$ws/.vig-os"
-    assert_output "DEVCONTAINER_VERSION=1.2.3"
+    run grep '^DEVKIT_VERSION=' "$ws/.vig-os"
+    assert_output "DEVKIT_VERSION=1.2.3"
 }
 
 @test "template ships .typos.toml alongside the typos hook (#855)" {
@@ -1394,7 +1412,7 @@ _upgrade_no_flags() {
 }
 
 @test "template .vig-os carries the manifest key set (#885)" {
-    for key in DEVCONTAINER_VERSION DEVKIT_MODE DEVKIT_PROJECT DEVKIT_ORG \
+    for key in DEVKIT_VERSION DEVKIT_MODE DEVKIT_PROJECT DEVKIT_ORG \
         DEVKIT_REPO DEVKIT_MODULES; do
         run grep -E "^${key}=" "$TEMPLATE_DIR/.vig-os"
         assert_success

--- a/tests/bats/just.bats
+++ b/tests/bats/just.bats
@@ -70,10 +70,17 @@ EOF
 
 # ── devc-upgrade honors the .vig-os pin (#854) ────────────────────────────────
 # The scaffolded devc-upgrade recipe used to always curl install.sh from `main`,
-# silently moving a pinned consumer to HEAD. It must read DEVCONTAINER_VERSION
-# from .vig-os and upgrade to THAT generation instead.
+# silently moving a pinned consumer to HEAD. It must read the pin (DEVKIT_VERSION,
+# or legacy DEVCONTAINER_VERSION, #781) from .vig-os and upgrade to THAT
+# generation instead.
 
-@test "devc-upgrade reads DEVCONTAINER_VERSION from .vig-os (#854)" {
+@test "devc-upgrade reads DEVKIT_VERSION from .vig-os (#854, #781)" {
+    run grep -q 'DEVKIT_VERSION' \
+        assets/workspace/.devcontainer/justfile.devc
+    assert_success
+}
+
+@test "devc-upgrade still honors a legacy DEVCONTAINER_VERSION pin (#781)" {
     run grep -q 'DEVCONTAINER_VERSION' \
         assets/workspace/.devcontainer/justfile.devc
     assert_success

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -673,13 +673,11 @@ class TestVigOsConfig:
         assert vig_os_file.exists(), ".vig-os not found in workspace root"
         assert vig_os_file.is_file(), ".vig-os is not a regular file"
 
-    def test_vig_os_contains_devcontainer_version(self, initialized_workspace):
-        """Test that .vig-os contains DEVCONTAINER_VERSION key."""
+    def test_vig_os_contains_devkit_version(self, initialized_workspace):
+        """Test that .vig-os contains the renamed DEVKIT_VERSION key (#781)."""
         vig_os_file = initialized_workspace / ".vig-os"
         content = vig_os_file.read_text(encoding="utf-8")
-        assert "DEVCONTAINER_VERSION=" in content, (
-            "DEVCONTAINER_VERSION key not found in .vig-os"
-        )
+        assert "DEVKIT_VERSION=" in content, "DEVKIT_VERSION key not found in .vig-os"
         assert "{{IMAGE_TAG}}" not in content, (
             "IMAGE_TAG placeholder should be replaced in .vig-os"
         )
@@ -710,7 +708,7 @@ class TestVigOsConfig:
         vig_os_file = workspace / ".vig-os"
         assert vig_os_file.exists(), ".vig-os not scaffolded"
         content = vig_os_file.read_text(encoding="utf-8")
-        assert "DEVCONTAINER_VERSION=9.9.9-rc9" in content, (
+        assert "DEVKIT_VERSION=9.9.9-rc9" in content, (
             f".vig-os does not pin the requested version:\n{content}"
         )
 


### PR DESCRIPTION
## Summary

Stage 1 slice of **#781**: flip the version-pin **write** path to the renamed
`DEVKIT_VERSION` key. Builds on the merged dual-key reader (#968), so this is a
**soft cutover** — readers still accept the legacy `DEVCONTAINER_VERSION`.

## Changes
- **Template `assets/workspace/.vig-os`** — `DEVKIT_VERSION={{IMAGE_TAG}}`.
- **`init-workspace.sh`** — writeback sed rewrites either key → `DEVKIT_VERSION`
  (migrates a stray legacy line); header comment updated.
- **`release.yml` finalize** — writes `DEVKIT_VERSION` to the repo-root `.vig-os`.
- **Repo-root `.vig-os`** — now `DEVKIT_VERSION=0.5.1` (dogfoods the new key).
- **`justfile.devc` `devc-upgrade`** — **reader missed by the initial parser sweep**
  (it reads the pin via `awk`, not `sed/grep/case`); now dual-keyed, preferring
  `DEVKIT_VERSION` with the legacy fallback.
- **`flake.nix`** — comment only (the `{{IMAGE_TAG}}` substitution is key-agnostic).
- Scaffold `ci.yml` / `prepare-release.yml` — user-facing pin-key mentions updated.

## Migration behaviour
`.vig-os` is **not** in `PRESERVE_FILES`, so a `--force` upgrade overwrites it from
the template (now `DEVKIT_VERSION`) and the stale legacy key naturally drops. New
bats test `init-workspace migrates a legacy DEVCONTAINER_VERSION pin to
DEVKIT_VERSION (#781)` covers this end to end.

## Out of scope (later slices)
The docker-compose **`.env` interpolation variable** stays `DEVCONTAINER_VERSION`
(it's the compose var, not the pin) — its rename rides the image-ref cutover (PR 2).

## Testing
- `tests/bats/init-workspace.bats` — 7 version-pin tests green (incl. migration); full file 127 green. TDD RED→GREEN.
- `tests/bats/just.bats` — `devc-upgrade` reads `DEVKIT_VERSION`, still honors legacy. Green.
- `tests/test_integration.py` — scaffolded-`.vig-os` assertions flipped to `DEVKIT_VERSION` (container tests run in CI).
- `just precommit` (full suite) — green.

Refs: #781