### PR TITLE
ci(release): target the renamed devkit-smoke-test validation repo

### DIFF
--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -219,7 +219,7 @@ jobs:
           client-id: ${{ secrets.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
           owner: vig-os
-          repositories: devcontainer-smoke-test
+          repositories: devkit-smoke-test
 
       - name: Verify downstream published final release
         env:
@@ -233,7 +233,7 @@ jobs:
           LAST_ERROR=""
           for i in $(seq 1 "$RETRIES"); do
             API_OUTPUT=""
-            if API_OUTPUT=$(gh api "repos/vig-os/devcontainer-smoke-test/releases/tags/$VERSION" 2>&1); then
+            if API_OUTPUT=$(gh api "repos/vig-os/devkit-smoke-test/releases/tags/$VERSION" 2>&1); then
               RELEASE_JSON="$API_OUTPUT"
               break
             fi
@@ -262,7 +262,7 @@ jobs:
             exit 1
           done
           if [ -z "$RELEASE_JSON" ]; then
-            echo "ERROR: No downstream release for tag $VERSION on devcontainer-smoke-test"
+            echo "ERROR: No downstream release for tag $VERSION on devkit-smoke-test"
             if [ -n "$LAST_ERROR" ]; then
               echo "$LAST_ERROR"
             fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1378,7 +1378,7 @@ jobs:
             echo "  1. Smoke-test dispatch runs in the smoke-test job."
             echo "  2. If downstream pre-release passes, run: just finalize-release $BASE_VERSION"
           else
-            echo "  1. Smoke-test dispatch runs in the smoke-test job; wait for downstream final release on devcontainer-smoke-test."
+            echo "  1. Smoke-test dispatch runs in the smoke-test job; wait for downstream final release on devkit-smoke-test."
             echo "  2. Run: just promote-release $BASE_VERSION — updates :latest, publishes the draft GitHub Release, merges the release PR to main."
           fi
 
@@ -1399,7 +1399,7 @@ jobs:
           client-id: ${{ secrets.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
           owner: vig-os
-          repositories: devcontainer-smoke-test
+          repositories: devkit-smoke-test
 
       # Local actions from ./.github/actions/* require repository checkout in this job workspace.
       - name: Checkout repository
@@ -1425,7 +1425,7 @@ jobs:
         run: |
           set -euo pipefail
           retry --retries 3 --backoff 10 --max-backoff 10 -- \
-            gh api repos/vig-os/devcontainer-smoke-test/dispatches \
+            gh api repos/vig-os/devkit-smoke-test/dispatches \
               -f event_type=smoke-test-trigger \
               -f "client_payload[tag]=$RELEASE_TAG" \
               -f "client_payload[release_kind]=$RELEASE_KIND" \
@@ -1444,7 +1444,7 @@ jobs:
           RELEASE_KIND: ${{ needs.validate.outputs.release_kind }}
         run: |
           echo "✓ Triggered smoke-test dispatch for release tag: $RELEASE_TAG"
-          echo "Downstream validation is asynchronous; verify in devcontainer-smoke-test."
+          echo "Downstream validation is asynchronous; verify in devkit-smoke-test."
           if [ "$RELEASE_KIND" = "final" ]; then
             echo "Final: when downstream smoke-test has published its release for this tag, run: just promote-release $RELEASE_TAG"
           fi
@@ -1471,7 +1471,7 @@ jobs:
 
             **Next Steps:**
             1. Review smoke-test dispatch logs in this workflow run.
-            2. Validate token/repository_dispatch permissions for \`vig-os/devcontainer-smoke-test\`.
+            2. Validate token/repository_dispatch permissions for \`vig-os/devkit-smoke-test\`.
             3. Re-trigger dispatch after fixing the root cause.
             `;
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     key (soft cutover). The docker-compose `.env` interpolation variable is
     unchanged in this slice.
 
+- **Release dispatch targets the renamed `devkit-smoke-test` repo** ([#781](https://github.com/vig-os/devcontainer/issues/781))
+  - The cross-repo smoke-test validation repository was renamed
+    `devcontainer-smoke-test` → `devkit-smoke-test`. `release.yml` /
+    `promote-release.yml` now target the new name for the `repository_dispatch`,
+    the scoped app token, and the downstream published-release gate — GitHub's API
+    does not reliably redirect `POST …/dispatches` across a rename. The smoke-test
+    template mirror (`assets/smoke-test/`) and the release docs are updated to
+    match. The source repository name is unchanged in this slice.
+
 - **Documented `install.sh` one-liners follow redirects (`curl -sSfL`)** ([#781](https://github.com/vig-os/devcontainer/issues/781))
   - Pre-rename hardening: every documented `curl … | bash` install/upgrade
     one-liner (README, `install.sh` help text, `MIGRATION.md`, the smoke-test

--- a/assets/smoke-test/.github/workflows/repository-dispatch.yml
+++ b/assets/smoke-test/.github/workflows/repository-dispatch.yml
@@ -16,7 +16,7 @@ name: Repository Dispatch Listener
 #                client_payload.correlation_id
 #
 # NOTE: Changes to this template may require manual redeploy to
-# vig-os/devcontainer-smoke-test and promotion through PRs until merged to main.
+# vig-os/devkit-smoke-test and promotion through PRs until merged to main.
 #
 # If this repo (or a fork) orchestrates workspace release.yml for candidates,
 # pass workflow_dispatch input rc-number=<N> where N is needs.validate.outputs.rc_number

--- a/assets/smoke-test/README.md
+++ b/assets/smoke-test/README.md
@@ -85,7 +85,7 @@ Deployment history is tracked through:
 If this repository is lost or needs to be rebuilt, recreate it from the
 `vig-os/devcontainer` image/template:
 
-1. Create a new empty repository (for example `vig-os/devcontainer-smoke-test`).
+1. Create a new empty repository (for example `vig-os/devkit-smoke-test`).
 2. Clone it locally and run the installer with smoke-test assets enabled:
 
    ```bash

--- a/assets/smoke-test/renovate.json
+++ b/assets/smoke-test/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "github>vig-os/devcontainer-smoke-test//.github/renovate-default"
+    "github>vig-os/devkit-smoke-test//.github/renovate-default"
   ],
   "enabledManagers": ["github-actions"]
 }

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -29,6 +29,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     key (soft cutover). The docker-compose `.env` interpolation variable is
     unchanged in this slice.
 
+- **Release dispatch targets the renamed `devkit-smoke-test` repo** ([#781](https://github.com/vig-os/devcontainer/issues/781))
+  - The cross-repo smoke-test validation repository was renamed
+    `devcontainer-smoke-test` → `devkit-smoke-test`. `release.yml` /
+    `promote-release.yml` now target the new name for the `repository_dispatch`,
+    the scoped app token, and the downstream published-release gate — GitHub's API
+    does not reliably redirect `POST …/dispatches` across a rename. The smoke-test
+    template mirror (`assets/smoke-test/`) and the release docs are updated to
+    match. The source repository name is unchanged in this slice.
+
 - **Documented `install.sh` one-liners follow redirects (`curl -sSfL`)** ([#781](https://github.com/vig-os/devcontainer/issues/781))
   - Pre-rename hardening: every documented `curl … | bash` install/upgrade
     one-liner (README, `install.sh` help text, `MIGRATION.md`, the smoke-test

--- a/docs/CROSS_REPO_RELEASE_GATE.md
+++ b/docs/CROSS_REPO_RELEASE_GATE.md
@@ -17,7 +17,7 @@ This gate exists to:
 
 ### Triggering
 
-During release publish, the orchestrator sends a `repository_dispatch` event to `vig-os/devcontainer-smoke-test`.
+During release publish, the orchestrator sends a `repository_dispatch` event to `vig-os/devkit-smoke-test`.
 
 Payload contract:
 
@@ -66,7 +66,7 @@ If the validation repository also runs the shipped workspace `release.yml` workf
 
 **`vig-os/devcontainer` `release.yml`:** Dispatches downstream validation during publish but does **not** block on downstream GitHub Release state for RC or final tags. The former validate step that required a published downstream pre-release for the latest RC before finalization was **removed**; it duplicated concerns now owned by promotion.
 
-**`vig-os/devcontainer` `promote-release.yml`:** Before updating GHCR `:latest`, publishing the draft GitHub Release, and merging the release PR, the `validate` job requires a **published** downstream release for the final version tag on `vig-os/devcontainer-smoke-test` that is **not** a draft and **not** a pre-release (`Verify downstream published final release`). For the canonical smoke-test flow, the receiver dispatches downstream `promote-release.yml` after `release.yml` and required release PR checks succeed, which publishes the downstream final release so this gate is satisfied without a manual publish step on the smoke-test repo.
+**`vig-os/devcontainer` `promote-release.yml`:** Before updating GHCR `:latest`, publishing the draft GitHub Release, and merging the release PR, the `validate` job requires a **published** downstream release for the final version tag on `vig-os/devkit-smoke-test` that is **not** a draft and **not** a pre-release (`Verify downstream published final release`). For the canonical smoke-test flow, the receiver dispatches downstream `promote-release.yml` after `release.yml` and required release PR checks succeed, which publishes the downstream final release so this gate is satisfied without a manual publish step on the smoke-test repo.
 
 If promote validation fails, retry after the downstream release is in the expected state; `release.yml` rollback handling applies only to failures within that workflow.
 
@@ -112,9 +112,9 @@ Common failure patterns:
 Examples for manual inspection:
 
 ```bash
-gh -R vig-os/devcontainer-smoke-test run list --workflow repository-dispatch.yml --limit 5
-gh -R vig-os/devcontainer-smoke-test run view <RUN_ID>
-gh -R vig-os/devcontainer-smoke-test release view <TAG>
+gh -R vig-os/devkit-smoke-test run list --workflow repository-dispatch.yml --limit 5
+gh -R vig-os/devkit-smoke-test run view <RUN_ID>
+gh -R vig-os/devkit-smoke-test release view <TAG>
 ```
 
 ## Source of Truth

--- a/docs/RELEASE_CYCLE.md
+++ b/docs/RELEASE_CYCLE.md
@@ -134,13 +134,13 @@ graph TB
 1. **Preparation** (`prepare-release`): Freeze CHANGELOG on dev, create release branch, reset Unreleased on dev, open draft PR
 2. **Review & Testing**: CI validation, fix issues, publish candidates to verify; mark PR ready and get approvals last (this is the final-release gate, not the candidate gate)
 3. **Candidate Publish** (`publish-candidate`): Build/test/publish `X.Y.Z-rcN` and dispatch cross-repo validation workflow
-4. **Cross-Repo Validation**: Smoke-test runs asynchronously after candidate and final publish; see `docs/CROSS_REPO_RELEASE_GATE.md`. Before promotion, **`promote-release.yml`** requires a published **final** (non-draft, non-prerelease) GitHub Release for the version tag on `devcontainer-smoke-test` so human acceptance downstream is reflected before `:latest` and the draft release are published.
+4. **Cross-Repo Validation**: Smoke-test runs asynchronously after candidate and final publish; see `docs/CROSS_REPO_RELEASE_GATE.md`. Before promotion, **`promote-release.yml`** requires a published **final** (non-draft, non-prerelease) GitHub Release for the version tag on `devkit-smoke-test` so human acceptance downstream is reflected before `:latest` and the draft release are published.
 5. **Finalization & Post-Release**: Publish final image/tag, open a **draft** GitHub Release for human review, then merge PR to `main` and let sync automation update `dev`
 6. **Promote & cleanup**: `promote-release.yml` updates `:latest`, publishes the draft release, merges the release PR, then runs a **best-effort** cleanup job (Refs [#463](https://github.com/vig-os/devcontainer/issues/463), [#583](https://github.com/vig-os/devcontainer/issues/583)): deletes GHCR RC image versions for `${VERSION}-rc*` (per-arch tags included) and matching RC cosign signatures, and deletes remote git RC tags for that base version when **no** GitHub Release is linked. GHCR deletes use **`GITHUB_TOKEN`** with **repo Admin** on the `devcontainer` package (see [Registry and cleanup tokens](#registry-and-cleanup-tokens-upstream)); the cleanup step fails loudly when RC tags remain. The cleanup job uses `continue-on-error`, so promote still completes. **Before this cleanup runs, migrate any consumers still pinned to an RC tag** (via `DEVCONTAINER_VERSION` in their `.vig-os` file) **to the final tag** — see [Phase 5](#phase-5-post-release-cleanup) ([#880](https://github.com/vig-os/devcontainer/issues/880)).
 
 ## Immutable releases, tag rulesets, and forward-fix policy
 
-This section applies to **`vig-os/devcontainer`** (this repo) and, for matching supply-chain posture, **`vig-os/devcontainer-smoke-test`**. It does **not** describe release workflows in consumer projects; those are documented in [Downstream release workflows](DOWNSTREAM_RELEASE.md).
+This section applies to **`vig-os/devcontainer`** (this repo) and, for matching supply-chain posture, **`vig-os/devkit-smoke-test`**. It does **not** describe release workflows in consumer projects; those are documented in [Downstream release workflows](DOWNSTREAM_RELEASE.md).
 
 **GitHub immutability (organization settings):** With **immutable releases** enabled, a **published** GitHub Release (including a published **pre-release**) locks its **linked** tag and release assets. A git tag with **no** linked published release is **not** immutable via that feature. **Tag rulesets** are separate: they can restrict creating, updating, or deleting tags regardless of releases.
 
@@ -150,7 +150,7 @@ This section applies to **`vig-os/devcontainer`** (this repo) and, for matching 
 - **Candidates (`X.Y.Z-rcN`)**: Candidate mode creates and pushes the **git tag**, publishes **GHCR** images (and related signing/attestations), and triggers smoke-test dispatch. It does **not** create a GitHub **Release** object for the RC—only **final** runs use `gh release create` (as a draft). The RC tag is therefore **not** locked by immutable releases until/unless you add a published release or a tag ruleset applies.
 - **Forward-fix (automation)**: Rollback **does not** delete remote tags—this is a **workflow choice** to avoid rewriting history, not GitHub declaring the tag immutable. Recovery is **forward-fix** (new RC, then final when ready). If a retry publishes the same tag, the workflow skips re-creating the tag when it already points at the finalized commit.
 - **Post-promote RC cleanup**: After a successful **`promote-release`** merge to `main`, automation may delete stale **git** RC tags (only when no GitHub Release is associated) and matching **GHCR** RC package versions for that base semver; see step 6 under [Release Phases](#release-phases). Tags tied to a published or draft GitHub Release are not removed by this job.
-- **Repository settings** (manual; not stored in git): enable **immutable releases** and **tag rulesets** as appropriate for `vig-os/devcontainer` and `vig-os/devcontainer-smoke-test`. See GitHub: [Preventing changes to your releases](https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/preventing-changes-to-your-releases). Use **RELEASE_APP** in bypass lists only where tag creation requires it.
+- **Repository settings** (manual; not stored in git): enable **immutable releases** and **tag rulesets** as appropriate for `vig-os/devcontainer` and `vig-os/devkit-smoke-test`. See GitHub: [Preventing changes to your releases](https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/preventing-changes-to-your-releases). Use **RELEASE_APP** in bypass lists only where tag creation requires it.
 
 ---
 
@@ -575,7 +575,7 @@ Release automation relies on two GitHub Apps with different scopes:
 
 Additional requirement:
 - `COMMIT_APP` must be allowed in branch protection bypass rules for `dev` so sync commits can be pushed by automation.
-- `RELEASE_APP` must be installed on the validation repository (`vig-os/devcontainer-smoke-test`) with Contents read and Actions read/write permissions so `release.yml` can send `repository_dispatch` and `repository-dispatch.yml` can trigger workflow runs there for candidate and final release validation.
+- `RELEASE_APP` must be installed on the validation repository (`vig-os/devkit-smoke-test`) with Contents read and Actions read/write permissions so `release.yml` can send `repository_dispatch` and `repository-dispatch.yml` can trigger workflow runs there for candidate and final release validation.
 
 #### prepare-release.yml (Release Preparation Workflow)
 
@@ -657,7 +657,7 @@ gh workflow run prepare-release.yml --ref dev -f "version=1.0.0" -f "dry-run=tru
    - Updates `latest` only in final mode
    - Verifies manifests exist
 
-5. **smoke-test** (runs after publish) - Triggers `repository_dispatch` on `vig-os/devcontainer-smoke-test` (validation repo)
+5. **smoke-test** (runs after publish) - Triggers `repository_dispatch` on `vig-os/devkit-smoke-test` (validation repo)
    - Candidate and final modes trigger cross-repository validation `repository_dispatch` with `client_payload[tag]=<publish-tag>`
    - Dispatch failures mark the workflow as failed and create a targeted issue
    - Dispatch failures do **not** rollback branch/tag: publish outputs are already public. Only a **published** GitHub Release locks its tag via **immutable releases**; RC tags in this repo have no release object. Automation still avoids tag deletion (forward-fix policy).
@@ -757,7 +757,7 @@ gh workflow run release.yml \
 ## Related documentation
 
 - **[Downstream release workflows](DOWNSTREAM_RELEASE.md)** — release process for **consumer projects** that deploy templates from `assets/workspace/` (prepare-release, release orchestration, extension hook, publish). This guide does not duplicate that material.
-- **[Cross-repo release validation gate](CROSS_REPO_RELEASE_GATE.md)** — contract between this repo’s `release.yml` and `vig-os/devcontainer-smoke-test` (`repository_dispatch`, RC/final gates).
+- **[Cross-repo release validation gate](CROSS_REPO_RELEASE_GATE.md)** — contract between this repo’s `release.yml` and `vig-os/devkit-smoke-test` (`repository_dispatch`, RC/final gates).
 
 ## QMS and Compliance
 

--- a/justfile
+++ b/justfile
@@ -222,7 +222,7 @@ test version="dev":
 #      - Builds and tests container images; creates X.Y.Z tag; pushes versioned GHCR images
 #      - Creates draft GitHub Release; dispatches smoke-test (not :latest yet)
 #      - On failure: automatic rollback and issue creation
-#   7. Wait for devcontainer-smoke-test to publish its final release for X.Y.Z
+#   7. Wait for devkit-smoke-test to publish its final release for X.Y.Z
 #   8. just promote-release X.Y.Z    - Triggers promote-release.yml that:
 #      - Updates GHCR :latest, publishes the draft GitHub Release, merges release PR to main
 #      - Merging to main triggers sync-main-to-dev.yml (PR main -> dev, auto-merge if clean)


### PR DESCRIPTION
## Summary

Stage 1 slice of **#781**. The cross-repo smoke-test validation repository has been
renamed **`vig-os/devcontainer-smoke-test` → `vig-os/devkit-smoke-test`** (done),
so the release orchestration must target the new name.

GitHub does **not** reliably redirect `POST …/dispatches` or scoped app-token
targets across a repo rename, so these must be updated in code rather than relying
on the redirect.

## Changes
- **`release.yml`** — smoke-test `repository_dispatch`, scoped app token
  (`repositories:`), and operator messages → `devkit-smoke-test`.
- **`promote-release.yml`** — scoped app token + the downstream published-release
  gate (`repos/vig-os/devkit-smoke-test/releases/tags/…`).
- **Template mirror `assets/smoke-test/`** — README example, dispatch-listener
  comment, and the `renovate.json` preset (`github>vig-os/devkit-smoke-test//…`).
- **Docs** — `RELEASE_CYCLE.md`, `CROSS_REPO_RELEASE_GATE.md`, `justfile` runbook comment.

## Scope
- The **source** repo name (`vig-os/devcontainer`) is unchanged — that rename + the
  smoke-test repo's own back-references ride **Stage 3**.
- **Released** `CHANGELOG` entries naming the old repo are left intact (immutable history).

## Testing
`just precommit` (full suite incl. actionlint / sync-manifest) — green. No functional
dispatch runs on PR CI; the new targets exercise at the next release.

Refs: #781