### PR TITLE
feat(image)!: cut over to ghcr.io/vig-os/devkit + rename flake attrs

### DIFF
--- a/.github/actions/build-image/action.yml
+++ b/.github/actions/build-image/action.yml
@@ -1,6 +1,6 @@
 # Composite action to build the Nix-built devcontainer image to a tar.
 #
-# Builds `packages.devcontainerImage` (flake `dockerTools.buildLayeredImage`)
+# Builds `packages.devkitImage` (flake `dockerTools.buildLayeredImage`)
 # natively for the runner's architecture and writes a gzipped OCI tar. Nix is
 # the only build path (the Debian Containerfile was decommissioned in #642).
 #
@@ -25,7 +25,7 @@
 #   tar-file: Path to the saved tar file
 
 name: 'Build Container Image'
-description: 'Build the Nix-built devcontainer image (flake devcontainerImage) for an architecture'
+description: 'Build the Nix-built devcontainer image (flake devkitImage) for an architecture'
 
 inputs:
   version:
@@ -118,7 +118,7 @@ runs:
         # tar; docker/podman load handles gzip. The flake sets the OCI labels.
         # `--impure` lets the flake read VIG_OS_VERSION (the true build tag);
         # see the env note above and the flake's imageVersionOverride (#921).
-        nix build .#devcontainerImage --impure --print-build-logs
+        nix build .#devkitImage --impure --print-build-logs
         cp -L result "${{ inputs.output-file }}"
         ls -lL "${{ inputs.output-file }}"
 

--- a/.github/actions/build-image/action.yml
+++ b/.github/actions/build-image/action.yml
@@ -12,7 +12,7 @@
 #   release-date / release-url / build-timestamp / vcs-ref: release metadata
 #     (kept for caller compatibility; the Nix image stamps its own static,
 #     reproducible OCI labels in flake.nix, so these are not baked into it)
-#   registry: Container registry URL (default: ghcr.io/vig-os/devcontainer)
+#   registry: Container registry URL (default: ghcr.io/vig-os/devkit)
 #   output-file: Path for the tar output
 #   cachix-cache / cachix-auth-token: passed to flake provisioning (setup-env)
 #   push-image-closure: when 'true', push the built image closure to Cachix as a
@@ -21,7 +21,7 @@
 #     guarded on the auth token so fork PRs (no secret) never fail.
 #
 # Outputs:
-#   image-tag: Full image tag (e.g., ghcr.io/vig-os/devcontainer:1.0.0-amd64)
+#   image-tag: Full image tag (e.g., ghcr.io/vig-os/devkit:1.0.0-amd64)
 #   tar-file: Path to the saved tar file
 
 name: 'Build Container Image'
@@ -53,7 +53,7 @@ inputs:
   registry:
     description: 'Container registry URL'
     required: false
-    default: 'ghcr.io/vig-os/devcontainer'
+    default: 'ghcr.io/vig-os/devkit'
   output-file:
     description: 'Path for the tar output'
     required: false

--- a/.github/actions/resolve-image/action.yml
+++ b/.github/actions/resolve-image/action.yml
@@ -90,7 +90,7 @@ runs:
         REGISTRY_USERNAME: ${{ inputs.registry-username }}
       run: |
         set -euo pipefail
-        IMAGE="ghcr.io/vig-os/devcontainer:${IMAGE_TAG}"
+        IMAGE="ghcr.io/vig-os/devkit:${IMAGE_TAG}"
         echo "Validating image availability: $IMAGE"
 
         # Authenticate before the probe when a token is supplied, so private or

--- a/.github/actions/test-image/action.yml
+++ b/.github/actions/test-image/action.yml
@@ -29,7 +29,7 @@
 #     with:
 #       image-tag: '1.0.0-amd64'
 #       image-source: 'registry'
-#       registry: 'ghcr.io/vig-os/devcontainer'
+#       registry: 'ghcr.io/vig-os/devkit'
 
 name: 'Test Container Image'
 description: 'Set up test environment and run container tests'
@@ -41,7 +41,7 @@ inputs:
   registry:
     description: 'Container registry URL'
     required: false
-    default: 'ghcr.io/vig-os/devcontainer'
+    default: 'ghcr.io/vig-os/devkit'
   image-source:
     description: 'Image source: "tar" (load from file), "registry" (pull), or "local" (already loaded)'
     required: false

--- a/.github/actions/test-integration/action.yml
+++ b/.github/actions/test-integration/action.yml
@@ -11,7 +11,7 @@
 #
 # Inputs:
 #   image-tag: Image tag to test (e.g., 1.0.0-amd64)
-#   registry: Container registry URL (default: ghcr.io/vig-os/devcontainer)
+#   registry: Container registry URL (default: ghcr.io/vig-os/devkit)
 #
 # Outputs:
 #   test-result: Test exit code (0=pass, non-zero=fail)
@@ -31,7 +31,7 @@ inputs:
   registry:
     description: 'Container registry URL'
     required: false
-    default: 'ghcr.io/vig-os/devcontainer'
+    default: 'ghcr.io/vig-os/devkit'
   ref:
     description: 'Git ref to checkout (e.g., commit SHA, branch, tag)'
     required: false

--- a/.github/workflows/nix-image.yml
+++ b/.github/workflows/nix-image.yml
@@ -24,7 +24,7 @@
 # `nix`/`direnv` are live inside the container.
 #
 # Multi-arch: each leg builds natively on its own runner (no QEMU /
-# cross-compilation) — `nix build .#devcontainerImage` resolves to x86_64-linux
+# cross-compilation) — `nix build .#devkitImage` resolves to x86_64-linux
 # on the amd64 runner and aarch64-linux on the arm64 runner, so the per-arch
 # image config carries the correct `architecture`. The index is then assembled
 # with `docker buildx imagetools create`, mirroring the proven release.yml flow.
@@ -101,7 +101,7 @@ jobs:
           set -euo pipefail
           # buildLayeredImage emits a gzipped OCI tarball at ./result. Built
           # natively for ${{ matrix.arch }} on this runner's own architecture.
-          nix build .#devcontainerImage --print-build-logs
+          nix build .#devkitImage --print-build-logs
           # Stage it where the test-image composite action expects a tar file.
           cp -L result /tmp/nix-devcontainer-image.tar.gz
           ls -lL /tmp/nix-devcontainer-image.tar.gz

--- a/.github/workflows/nix-image.yml
+++ b/.github/workflows/nix-image.yml
@@ -55,7 +55,7 @@ permissions:
   contents: read
 
 env:
-  REGISTRY: ghcr.io/vig-os/devcontainer
+  REGISTRY: ghcr.io/vig-os/devkit
   # Disposable discovery index tag. NOT a cutover tag (versioned/:latest is #639).
   INDEX_TAG: nix-dev
 
@@ -128,7 +128,7 @@ jobs:
           du -h /tmp/nix-devcontainer-image.tar.gz
 
       # Reuse the shared composite action: it loads the tar into podman, retags
-      # it to ghcr.io/vig-os/devcontainer:nix-image (local only, never pushed),
+      # it to ghcr.io/vig-os/devkit:nix-image (local only, never pushed),
       # and runs tests/test_image.py via TEST_CONTAINER_TAG. Gating now (#666):
       # the Nix image passes the full suite, so a failure here fails CI.
       - name: Load image and run portable testinfra

--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -111,7 +111,7 @@ jobs:
           ARCHS: ${{ steps.vars.outputs.architectures }}
         run: |
           set -euo pipefail
-          REPO="ghcr.io/vig-os/devcontainer"
+          REPO="ghcr.io/vig-os/devkit"
           IFS=' ' read -ra ARCH_ARRAY <<< "$ARCHS"
           for arch in "${ARCH_ARRAY[@]}"; do
             echo "Verifying image: $REPO:$VERSION-$arch"
@@ -144,7 +144,7 @@ jobs:
           VERSION: ${{ steps.vars.outputs.version }}
         run: |
           set -euo pipefail
-          REPO="ghcr.io/vig-os/devcontainer"
+          REPO="ghcr.io/vig-os/devkit"
           retry --retries 3 --backoff 10 --max-backoff 30 -- \
             cosign verify "$REPO:$VERSION" \
               --certificate-identity-regexp='https://github.com/vig-os/devcontainer/.github/workflows/release.yml@refs/heads/release/' \
@@ -326,7 +326,7 @@ jobs:
           ARCHS: ${{ needs.validate.outputs.architectures }}
         run: |
           set -euo pipefail
-          REPO="ghcr.io/vig-os/devcontainer"
+          REPO="ghcr.io/vig-os/devkit"
           IFS=' ' read -ra ARCH_ARRAY <<< "$ARCHS"
           ARCH_IMAGES=()
           for arch in "${ARCH_ARRAY[@]}"; do

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -872,7 +872,7 @@ jobs:
       - name: Build the vulnix scan target (image package closure)
         run: |
           set -euo pipefail
-          nix build .#devcontainerImageEnv --print-build-logs
+          nix build .#devkitImageEnv --print-build-logs
 
       # First-class, BLOCKING push of the scan-target closure to Cachix (#776) so
       # the CVE-scan closure is cache-backed too (nightly + re-runs substitute it

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1055,7 +1055,7 @@ jobs:
           ARCHS: ${{ needs.validate.outputs.architectures }}
         run: |
           set -euo pipefail
-          REPO="ghcr.io/vig-os/devcontainer"
+          REPO="ghcr.io/vig-os/devkit"
 
           IFS=' ' read -ra ARCH_ARRAY <<< "$ARCHS"
 
@@ -1088,7 +1088,7 @@ jobs:
           ARCHS: ${{ needs.validate.outputs.architectures }}
         run: |
           set -euo pipefail
-          REPO="ghcr.io/vig-os/devcontainer"
+          REPO="ghcr.io/vig-os/devkit"
 
           IFS=' ' read -ra ARCH_ARRAY <<< "$ARCHS"
 
@@ -1112,7 +1112,7 @@ jobs:
           ARCHS: ${{ needs.validate.outputs.architectures }}
         run: |
           set -euo pipefail
-          REPO="ghcr.io/vig-os/devcontainer"
+          REPO="ghcr.io/vig-os/devkit"
 
           IFS=' ' read -ra ARCH_ARRAY <<< "$ARCHS"
 
@@ -1138,7 +1138,7 @@ jobs:
         continue-on-error: true
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610  # v0.24.0
         with:
-          image: ghcr.io/vig-os/devcontainer:${{ needs.validate.outputs.publish_version }}
+          image: ghcr.io/vig-os/devkit:${{ needs.validate.outputs.publish_version }}
           artifact-name: sbom-${{ needs.validate.outputs.publish_version }}.spdx.json
           output-file: /tmp/sbom.spdx.json
           format: spdx-json
@@ -1151,7 +1151,7 @@ jobs:
         if: steps.sbom_generate.outcome == 'failure'
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610  # v0.24.0
         with:
-          image: ghcr.io/vig-os/devcontainer:${{ needs.validate.outputs.publish_version }}
+          image: ghcr.io/vig-os/devkit:${{ needs.validate.outputs.publish_version }}
           artifact-name: sbom-${{ needs.validate.outputs.publish_version }}.spdx.json
           output-file: /tmp/sbom.spdx.json
           format: spdx-json
@@ -1168,7 +1168,7 @@ jobs:
           PUBLISH_VERSION: ${{ needs.validate.outputs.publish_version }}
         run: |
           set -euo pipefail
-          REPO="ghcr.io/vig-os/devcontainer"
+          REPO="ghcr.io/vig-os/devkit"
 
           # Get the digest for the multi-arch manifest
           DIGEST=$(retry --retries 3 --backoff 5 --max-backoff 30 -- \
@@ -1186,7 +1186,7 @@ jobs:
           PUBLISH_VERSION: ${{ needs.validate.outputs.publish_version }}
         run: |
           set -euo pipefail
-          REPO="ghcr.io/vig-os/devcontainer"
+          REPO="ghcr.io/vig-os/devkit"
           DIGEST=$(retry --retries 3 --backoff 5 --max-backoff 30 -- \
             docker buildx imagetools inspect "$REPO:$PUBLISH_VERSION" --format '{{json .Manifest.Digest}}' | tr -d '"')
           echo "digest=$DIGEST" >> $GITHUB_OUTPUT
@@ -1197,7 +1197,7 @@ jobs:
         continue-on-error: true
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373  # v4.1.1
         with:
-          subject-name: ghcr.io/vig-os/devcontainer
+          subject-name: ghcr.io/vig-os/devkit
           subject-digest: ${{ steps.digest.outputs.digest }}
           push-to-registry: true
 
@@ -1209,7 +1209,7 @@ jobs:
         if: steps.attest_provenance.outcome == 'failure'
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373  # v4.1.1
         with:
-          subject-name: ghcr.io/vig-os/devcontainer
+          subject-name: ghcr.io/vig-os/devkit
           subject-digest: ${{ steps.digest.outputs.digest }}
           push-to-registry: true
 
@@ -1218,7 +1218,7 @@ jobs:
         continue-on-error: true
         uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763  # v4.1.1
         with:
-          subject-name: ghcr.io/vig-os/devcontainer
+          subject-name: ghcr.io/vig-os/devkit
           subject-digest: ${{ steps.digest.outputs.digest }}
           sbom-path: /tmp/sbom.spdx.json
           push-to-registry: true
@@ -1231,7 +1231,7 @@ jobs:
         if: steps.attest_sbom.outcome == 'failure'
         uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763  # v4.1.1
         with:
-          subject-name: ghcr.io/vig-os/devcontainer
+          subject-name: ghcr.io/vig-os/devkit
           subject-digest: ${{ steps.digest.outputs.digest }}
           sbom-path: /tmp/sbom.spdx.json
           push-to-registry: true
@@ -1364,9 +1364,9 @@ jobs:
           echo "  Release Kind: $RELEASE_KIND"
           echo "  Tag: $PUBLISH_VERSION"
           echo "  Images:"
-          echo "    - ghcr.io/vig-os/devcontainer:$PUBLISH_VERSION"
+          echo "    - ghcr.io/vig-os/devkit:$PUBLISH_VERSION"
           if [ "$RELEASE_KIND" = "final" ]; then
-            echo "    - ghcr.io/vig-os/devcontainer:latest (after just promote-release $BASE_VERSION)"
+            echo "    - ghcr.io/vig-os/devkit:latest (after just promote-release $BASE_VERSION)"
           fi
           echo "  Security:"
           echo "    - Cosign signature attached"
@@ -1657,7 +1657,7 @@ jobs:
             - This issue created for investigation
 
             **Manual Cleanup May Be Needed:**
-            - If images were pushed to GHCR before the failure, they are **not** automatically deleted. Check \`ghcr.io/vig-os/devcontainer:${publishVersion}-*\` and remove any orphaned images manually.
+            - If images were pushed to GHCR before the failure, they are **not** automatically deleted. Check \`ghcr.io/vig-os/devkit:${publishVersion}-*\` and remove any orphaned images manually.
             - If a **draft** GitHub Release exists for this tag, edit or manage it from the Releases UI (**publishing** locks the linked tag and assets when **immutable releases** are enabled).
 
             **Next Steps:**

--- a/.github/workflows/renovate-changelog-build.yml
+++ b/.github/workflows/renovate-changelog-build.yml
@@ -52,7 +52,7 @@ jobs:
     needs: [resolve-image]
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/vig-os/devcontainer:${{ needs.resolve-image.outputs.image-tag }}
+      image: ghcr.io/vig-os/devkit:${{ needs.resolve-image.outputs.image-tag }}
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GHCR_PULL_TOKEN || github.token }}

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -38,7 +38,7 @@ jobs:
   #
   # A Nix image has no apt/dpkg DB, so Trivy's OS-package scanner goes dark.
   # vulnix (nixpkgs-native) becomes the PRIMARY CVE signal here, scanning the
-  # image's package closure (flake `devcontainerImageEnv`); Trivy stays on for a
+  # image's package closure (flake `devkitImageEnv`); Trivy stays on for a
   # CycloneDX SBOM + an SBOM-mode vuln view (defense in depth). The vulnix-gate
   # step is BLOCKING (#639): the nixpkgs baseline was advanced to 26.05 and the
   # residual findings triaged into .vulnixignore (see docs/security/
@@ -89,7 +89,7 @@ jobs:
       - name: Build the vulnix scan target (image package closure)
         run: |
           set -euo pipefail
-          nix build .#devcontainerImageEnv --print-build-logs
+          nix build .#devkitImageEnv --print-build-logs
 
       - name: Run vulnix (primary CVE scanner)
         # NOTE: no blanket `|| true`. vulnix exit codes: 0 = clean, 1 = only
@@ -142,7 +142,7 @@ jobs:
       - name: Build the Nix image for SBOM generation
         run: |
           set -euo pipefail
-          nix build .#devcontainerImage --print-build-logs
+          nix build .#devkitImage --print-build-logs
           cp -L result /tmp/nix-image.tar.gz
 
       - name: Generate Nix image SBOM (CycloneDX)
@@ -183,7 +183,7 @@ jobs:
           {
             echo "## Nix image CVE scan (vulnix + SBOM)"
             echo ""
-            echo "- **Scan target:** flake \`devcontainerImageEnv\` (image package closure)"
+            echo "- **Scan target:** flake \`devkitImageEnv\` (image package closure)"
             echo "- **Primary scanner:** vulnix (nixpkgs-native)"
             echo "- **Date (UTC):** $(date -u +%Y-%m-%dT%H:%M:%SZ)"
             echo "- **Gate:** ${{ steps.vulnix-gate.outcome }} (blocking: fails on unexcepted HIGH/CRITICAL findings)"
@@ -224,7 +224,7 @@ jobs:
           BODY="$(cat <<EOF
           The nightly vulnix gate found **unexcepted HIGH/CRITICAL** CVEs in the Nix image closure (after \`.vulnixignore\`).
 
-          - **Scan target:** flake \`devcontainerImageEnv\` (image package closure)
+          - **Scan target:** flake \`devkitImageEnv\` (image package closure)
           - **Scan date (UTC):** $(date -u +%Y-%m-%dT%H:%M:%SZ)
           - **Workflow run:** ${RUN_URL}
           - **Findings artifact:** \`nix-image-cve-scan\` on the run above (\`vulnix-findings.json\`, \`vulnix-report.txt\`)

--- a/.github/workflows/sync-issues.yml
+++ b/.github/workflows/sync-issues.yml
@@ -61,7 +61,7 @@ jobs:
     needs: [resolve-image]
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/vig-os/devcontainer:${{ needs.resolve-image.outputs.image-tag }}
+      image: ghcr.io/vig-os/devkit:${{ needs.resolve-image.outputs.image-tag }}
     timeout-minutes: 10
     defaults:
       run:

--- a/.github/workflows/sync-main-to-dev.yml
+++ b/.github/workflows/sync-main-to-dev.yml
@@ -63,7 +63,7 @@ jobs:
     needs: [resolve-image]
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/vig-os/devcontainer:${{ needs.resolve-image.outputs.image-tag }}
+      image: ghcr.io/vig-os/devkit:${{ needs.resolve-image.outputs.image-tag }}
     timeout-minutes: 5
     defaults:
       run:
@@ -108,7 +108,7 @@ jobs:
     if: needs.check.outputs.up_to_date != 'true'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/vig-os/devcontainer:${{ needs.resolve-image.outputs.image-tag }}
+      image: ghcr.io/vig-os/devkit:${{ needs.resolve-image.outputs.image-tag }}
     timeout-minutes: 10
     defaults:
       run:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Image published to the new `ghcr.io/vig-os/devkit` package** ([#781](https://github.com/vig-os/devcontainer/issues/781))
+  - The container image reference moves from `ghcr.io/vig-os/devcontainer` to a
+    **new GHCR package `ghcr.io/vig-os/devkit`** across the flake, CI/release
+    workflows, `install.sh`, the scaffold template (compose + workflows), and
+    documentation. The Nix flake output attributes are renamed to match
+    (`devcontainerImage` → `devkitImage`, `devcontainerImageEnv` → `devkitImageEnv`).
+    The old `ghcr.io/vig-os/devcontainer` package is frozen at `0.5.1` and remains
+    pullable; consumers move to the new package on their next
+    `install.sh --force` re-scaffold. The source-repo URL and the image's OCI
+    `source` label are unchanged in this slice (they follow the repository rename).
+
 - **Scaffolded `.vig-os` pins under `DEVKIT_VERSION`** ([#781](https://github.com/vig-os/devcontainer/issues/781))
   - The scaffold/release writeback now emits the renamed `DEVKIT_VERSION` key:
     the template manifest, `init-workspace.sh`, the `release.yml` finalize step,

--- a/README.md
+++ b/README.md
@@ -74,25 +74,25 @@ curl -sSfL https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh
 1. **Pull the latest image**
 
    ```bash
-   podman pull ghcr.io/vig-os/devcontainer:latest
+   podman pull ghcr.io/vig-os/devkit:latest
    # or
-   docker pull ghcr.io/vig-os/devcontainer:latest
+   docker pull ghcr.io/vig-os/devkit:latest
    ```
 
    To pull a specific version, use the bare semver tag (without `v` prefix):
 
    ```bash
-   podman pull ghcr.io/vig-os/devcontainer:0.2.1
+   podman pull ghcr.io/vig-os/devkit:0.2.1
    ```
 
 2. **Initialize a workspace inside `PATH_TO_PROJECT`**
 
    ```bash
    podman run -it --rm -v "PATH_TO_PROJECT:/workspace" \
-     ghcr.io/vig-os/devcontainer:latest /root/assets/init-workspace.sh
+     ghcr.io/vig-os/devkit:latest /root/assets/init-workspace.sh
    # or with Docker:
    docker run -it --rm -v "PATH_TO_PROJECT:/workspace" \
-     ghcr.io/vig-os/devcontainer:latest /root/assets/init-workspace.sh
+     ghcr.io/vig-os/devkit:latest /root/assets/init-workspace.sh
    ```
 
    The script copies the devcontainer template (`.devcontainer/`), git hooks, README/CHANGELOG, and auth helpers into your project.
@@ -106,7 +106,7 @@ curl -sSfL https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh
 
    ```bash
    podman run -it --rm -v "PATH_TO_PROJECT:/workspace" \
-     ghcr.io/vig-os/devcontainer:latest /root/assets/init-workspace.sh --force
+     ghcr.io/vig-os/devkit:latest /root/assets/init-workspace.sh --force
    ```
 
    You will be prompted to confirm before files are replaced.
@@ -196,7 +196,7 @@ For detailed command descriptions, run `just --list --unsorted` or `just --help`
 ## Image Details
 
 - **Build**: Nix flake via `dockerTools.buildLayeredImage` (no Debian/Docker base image); bit-reproducible
-- **Registry**: `ghcr.io/vig-os/devcontainer`
+- **Registry**: `ghcr.io/vig-os/devkit`
 - **Architecture**: Multi-platform support (AMD64, ARM64)
 - **License**: Apache
 - **Latest Version**: [0.5.1](https://github.com/vig-os/devcontainer/releases/tag/0.5.1) - 2026-07-10

--- a/TESTING.md
+++ b/TESTING.md
@@ -54,7 +54,7 @@ These tests run against an initialized workspace to verify that the container wo
 Image and integration fixtures:
 
 - `container_tag`: Container tag from `TEST_CONTAINER_TAG` environment variable (defaults to "dev")
-- `container_image`: Full image name (e.g. `ghcr.io/vig-os/devcontainer:dev`)
+- `container_image`: Full image name (e.g. `ghcr.io/vig-os/devkit:dev`)
 - `test_container`: Running container instance for testing (session-scoped)
 - `host`: Testinfra host connection to the container (session-scoped)
 - `initialized_workspace`: Temporary workspace initialized with `init-workspace` script (session-scoped)

--- a/assets/init-workspace.sh
+++ b/assets/init-workspace.sh
@@ -165,8 +165,8 @@ if [[ "$NO_PROMPTS" != "true" ]] && [[ ! -t 0 ]]; then
     echo "Error: This script requires an interactive terminal." >&2
     echo "" >&2
     echo "Please run with the -it flags:" >&2
-    echo "  podman run -it --rm -v \"./:/workspace\" ghcr.io/vig-os/devcontainer:latest /root/assets/init-workspace.sh" >&2
-    echo "  docker run -it --rm -v \"./:/workspace\" ghcr.io/vig-os/devcontainer:latest /root/assets/init-workspace.sh" >&2
+    echo "  podman run -it --rm -v \"./:/workspace\" ghcr.io/vig-os/devkit:latest /root/assets/init-workspace.sh" >&2
+    echo "  docker run -it --rm -v \"./:/workspace\" ghcr.io/vig-os/devkit:latest /root/assets/init-workspace.sh" >&2
     exit 1
 fi
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -20,6 +20,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Image published to the new `ghcr.io/vig-os/devkit` package** ([#781](https://github.com/vig-os/devcontainer/issues/781))
+  - The container image reference moves from `ghcr.io/vig-os/devcontainer` to a
+    **new GHCR package `ghcr.io/vig-os/devkit`** across the flake, CI/release
+    workflows, `install.sh`, the scaffold template (compose + workflows), and
+    documentation. The Nix flake output attributes are renamed to match
+    (`devcontainerImage` → `devkitImage`, `devcontainerImageEnv` → `devkitImageEnv`).
+    The old `ghcr.io/vig-os/devcontainer` package is frozen at `0.5.1` and remains
+    pullable; consumers move to the new package on their next
+    `install.sh --force` re-scaffold. The source-repo URL and the image's OCI
+    `source` label are unchanged in this slice (they follow the repository rename).
+
 - **Scaffolded `.vig-os` pins under `DEVKIT_VERSION`** ([#781](https://github.com/vig-os/devcontainer/issues/781))
   - The scaffold/release writeback now emits the renamed `DEVKIT_VERSION` key:
     the template manifest, `init-workspace.sh`, the `release.yml` finalize step,

--- a/assets/workspace/.devcontainer/docker-compose.yml
+++ b/assets/workspace/.devcontainer/docker-compose.yml
@@ -1,7 +1,7 @@
 ---
 services:
   devcontainer:
-    image: ghcr.io/vig-os/devcontainer:${DEVCONTAINER_VERSION:-latest}
+    image: ghcr.io/vig-os/devkit:${DEVCONTAINER_VERSION:-latest}
     volumes:
       # Mount the project folder to a subdirectory of workspace
       - ..:/workspace/{{SHORT_NAME}}:cached

--- a/assets/workspace/.github/actions/resolve-image/action.yml
+++ b/assets/workspace/.github/actions/resolve-image/action.yml
@@ -90,7 +90,7 @@ runs:
         REGISTRY_USERNAME: ${{ inputs.registry-username }}
       run: |
         set -euo pipefail
-        IMAGE="ghcr.io/vig-os/devcontainer:${IMAGE_TAG}"
+        IMAGE="ghcr.io/vig-os/devkit:${IMAGE_TAG}"
         echo "Validating image availability: $IMAGE"
 
         # Authenticate before the probe when a token is supplied, so private or

--- a/assets/workspace/.github/workflows/ci.yml
+++ b/assets/workspace/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
     needs: [resolve-image]
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/vig-os/devcontainer:${{ needs.resolve-image.outputs.image-tag }}
+      image: ghcr.io/vig-os/devkit:${{ needs.resolve-image.outputs.image-tag }}
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GHCR_PULL_TOKEN || github.token }}
@@ -101,7 +101,7 @@ jobs:
       - name: Verify toolchain (prek present)
         run: |
           if ! command -v prek >/dev/null 2>&1; then
-            echo "::error::'prek' not found in the CI image (ghcr.io/vig-os/devcontainer). The image pinned by .vig-os DEVKIT_VERSION predates the prek hook runner (#778)."
+            echo "::error::'prek' not found in the CI image (ghcr.io/vig-os/devkit). The image pinned by .vig-os DEVKIT_VERSION predates the prek hook runner (#778)."
             echo "Fix: bump .vig-os DEVKIT_VERSION to an image that ships prek, or re-run the devkit installer. See docs/MIGRATION.md."
             exit 1
           fi
@@ -118,7 +118,7 @@ jobs:
     needs: [resolve-image]
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/vig-os/devcontainer:${{ needs.resolve-image.outputs.image-tag }}
+      image: ghcr.io/vig-os/devkit:${{ needs.resolve-image.outputs.image-tag }}
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GHCR_PULL_TOKEN || github.token }}

--- a/assets/workspace/.github/workflows/prepare-release.yml
+++ b/assets/workspace/.github/workflows/prepare-release.yml
@@ -135,7 +135,7 @@ jobs:
     needs: validate
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/vig-os/devcontainer:${{ needs.validate.outputs.image_tag }}
+      image: ghcr.io/vig-os/devkit:${{ needs.validate.outputs.image_tag }}
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GHCR_PULL_TOKEN || github.token }}

--- a/assets/workspace/.github/workflows/promote-release.yml
+++ b/assets/workspace/.github/workflows/promote-release.yml
@@ -53,7 +53,7 @@ jobs:
     needs: [resolve-image]
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/vig-os/devcontainer:${{ needs.resolve-image.outputs.image-tag }}
+      image: ghcr.io/vig-os/devkit:${{ needs.resolve-image.outputs.image-tag }}
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GHCR_PULL_TOKEN || github.token }}
@@ -230,7 +230,7 @@ jobs:
     needs: [resolve-image, validate]
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/vig-os/devcontainer:${{ needs.resolve-image.outputs.image-tag }}
+      image: ghcr.io/vig-os/devkit:${{ needs.resolve-image.outputs.image-tag }}
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GHCR_PULL_TOKEN || github.token }}
@@ -273,7 +273,7 @@ jobs:
     needs: [resolve-image, validate, promote]
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/vig-os/devcontainer:${{ needs.resolve-image.outputs.image-tag }}
+      image: ghcr.io/vig-os/devkit:${{ needs.resolve-image.outputs.image-tag }}
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GHCR_PULL_TOKEN || github.token }}
@@ -394,7 +394,7 @@ jobs:
     needs: [resolve-image, validate, promote, merge]
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/vig-os/devcontainer:${{ needs.resolve-image.outputs.image-tag }}
+      image: ghcr.io/vig-os/devkit:${{ needs.resolve-image.outputs.image-tag }}
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GHCR_PULL_TOKEN || github.token }}

--- a/assets/workspace/.github/workflows/release-core.yml
+++ b/assets/workspace/.github/workflows/release-core.yml
@@ -104,7 +104,7 @@ jobs:
       pull-requests: read
       packages: read
     container:
-      image: ghcr.io/vig-os/devcontainer:${{ needs.resolve-image.outputs.image-tag }}
+      image: ghcr.io/vig-os/devkit:${{ needs.resolve-image.outputs.image-tag }}
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GHCR_PULL_TOKEN || github.token }}
@@ -340,7 +340,7 @@ jobs:
       contents: write
       packages: read
     container:
-      image: ghcr.io/vig-os/devcontainer:${{ needs.validate.outputs.image_tag }}
+      image: ghcr.io/vig-os/devkit:${{ needs.validate.outputs.image_tag }}
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GHCR_PULL_TOKEN || github.token }}
@@ -530,7 +530,7 @@ jobs:
     needs: [validate, finalize]
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/vig-os/devcontainer:${{ needs.validate.outputs.image_tag }}
+      image: ghcr.io/vig-os/devkit:${{ needs.validate.outputs.image_tag }}
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GHCR_PULL_TOKEN || github.token }}

--- a/assets/workspace/.github/workflows/release-publish.yml
+++ b/assets/workspace/.github/workflows/release-publish.yml
@@ -88,7 +88,7 @@ jobs:
     needs: [resolve-image]
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/vig-os/devcontainer:${{ needs.resolve-image.outputs.image-tag }}
+      image: ghcr.io/vig-os/devkit:${{ needs.resolve-image.outputs.image-tag }}
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GHCR_PULL_TOKEN || github.token }}

--- a/assets/workspace/.github/workflows/release.yml
+++ b/assets/workspace/.github/workflows/release.yml
@@ -124,7 +124,7 @@ jobs:
     needs: [resolve-image, core, extension, publish]
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/vig-os/devcontainer:${{ needs.resolve-image.outputs.image-tag }}
+      image: ghcr.io/vig-os/devkit:${{ needs.resolve-image.outputs.image-tag }}
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GHCR_PULL_TOKEN || github.token }}

--- a/assets/workspace/.github/workflows/renovate-changelog-build.yml
+++ b/assets/workspace/.github/workflows/renovate-changelog-build.yml
@@ -52,7 +52,7 @@ jobs:
     needs: [resolve-image]
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/vig-os/devcontainer:${{ needs.resolve-image.outputs.image-tag }}
+      image: ghcr.io/vig-os/devkit:${{ needs.resolve-image.outputs.image-tag }}
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GHCR_PULL_TOKEN || github.token }}

--- a/assets/workspace/.github/workflows/sync-issues.yml
+++ b/assets/workspace/.github/workflows/sync-issues.yml
@@ -67,7 +67,7 @@ jobs:
     needs: [resolve-image]
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/vig-os/devcontainer:${{ needs.resolve-image.outputs.image-tag }}
+      image: ghcr.io/vig-os/devkit:${{ needs.resolve-image.outputs.image-tag }}
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GHCR_PULL_TOKEN || github.token }}

--- a/assets/workspace/.github/workflows/sync-main-to-dev.yml
+++ b/assets/workspace/.github/workflows/sync-main-to-dev.yml
@@ -70,7 +70,7 @@ jobs:
     needs: [resolve-image]
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/vig-os/devcontainer:${{ needs.resolve-image.outputs.image-tag }}
+      image: ghcr.io/vig-os/devkit:${{ needs.resolve-image.outputs.image-tag }}
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GHCR_PULL_TOKEN || github.token }}
@@ -118,7 +118,7 @@ jobs:
     if: needs.check.outputs.up_to_date != 'true'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/vig-os/devcontainer:${{ needs.resolve-image.outputs.image-tag }}
+      image: ghcr.io/vig-os/devkit:${{ needs.resolve-image.outputs.image-tag }}
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GHCR_PULL_TOKEN || github.token }}

--- a/assets/workspace/docs/container-ci-quirks.md
+++ b/assets/workspace/docs/container-ci-quirks.md
@@ -1,7 +1,7 @@
 # Container CI Notes
 
 Behavioral notes for the workspace CI workflow (`.github/workflows/ci.yml`)
-when jobs run inside `ghcr.io/vig-os/devcontainer:*` via GitHub Actions
+when jobs run inside `ghcr.io/vig-os/devkit:*` via GitHub Actions
 `container:`.
 
 ## Tool bootstrap model
@@ -64,7 +64,7 @@ runtime.
 ## Authenticated pulls (private / rate-limited registries)
 
 The shipped container workflows support **authenticated** GHCR pulls, so a
-**private** (or anonymous-rate-limited) `ghcr.io/vig-os/devcontainer` image works
+**private** (or anonymous-rate-limited) `ghcr.io/vig-os/devkit` image works
 without any per-repo YAML edits ([#920](https://github.com/vig-os/devcontainer/issues/920)).
 Public consumers are unaffected: the automatic `GITHUB_TOKEN` performs an
 authenticated pull of a public image, which succeeds unchanged.

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -18,7 +18,7 @@ two ways:
 
 - **Container image** — assembled by `dockerTools.buildLayeredImage` (no base
   distro, no `Dockerfile FROM`), bit-reproducible, and built natively for
-  `amd64` and `arm64`. Published as `ghcr.io/vig-os/devcontainer`.
+  `amd64` and `arm64`. Published as `ghcr.io/vig-os/devkit`.
 - **Bare-nix dev-shell** — the same toolchain via `nix develop` / `direnv`,
   consumed as a flake input (`vigos.url = "github:vig-os/devcontainer"`).
 
@@ -62,7 +62,7 @@ so upgrades never need `--mode` again.
 
 `direnv` (and `bare`) consumers cannot run the container-based CI: with no
 `.devcontainer/`, a `.vig-os`-driven `resolve-image` job hard-fails and bricks
-every workflow that runs `container: ghcr.io/vig-os/devcontainer:<pin>`. To keep
+every workflow that runs `container: ghcr.io/vig-os/devkit:<pin>`. To keep
 the main lane working, `direnv` mode ships a **nix-direct `ci.yml`** overlay
 ([#854](https://github.com/vig-os/devcontainer/issues/854)) that runs on the host
 runner (`install-nix` + Cachix → `nix develop -c just sync|precommit|test`),

--- a/docs/RELEASE_CYCLE.md
+++ b/docs/RELEASE_CYCLE.md
@@ -393,8 +393,8 @@ The `release.yml` workflow performs the entire remaining release process. Behavi
    - Downloads tested images from artifacts
    - Logs in to GitHub Container Registry
    - Pushes images to GHCR with architecture-specific tags
-   - Creates multi-architecture manifest `ghcr.io/vig-os/devcontainer:<publish-tag>`
-   - Creates/updates `ghcr.io/vig-os/devcontainer:latest` only in final mode (and only when both architectures are built)
+   - Creates multi-architecture manifest `ghcr.io/vig-os/devkit:<publish-tag>`
+   - Creates/updates `ghcr.io/vig-os/devkit:latest` only in final mode (and only when both architectures are built)
    - Verifies manifests exist
    - Candidate and final modes: trigger cross-repository validation dispatch with `client_payload[tag]` plus source metadata (`source_repo`, `source_workflow`, `source_run_id`, `source_run_url`, `source_sha`, `correlation_id`)
 
@@ -418,8 +418,8 @@ Release Summary:
   Release Kind: final
   Tag: 1.0.0
   Images:
-    - ghcr.io/vig-os/devcontainer:1.0.0
-    - ghcr.io/vig-os/devcontainer:latest
+    - ghcr.io/vig-os/devkit:1.0.0
+    - ghcr.io/vig-os/devkit:latest
 ```
 
 **Key characteristics:**
@@ -479,11 +479,11 @@ No CHANGELOG reset is needed -- dev already has `## Unreleased` from the prepare
 git tag | grep 1.0.0
 
 # Verify images in registry
-docker pull ghcr.io/vig-os/devcontainer:1.0.0
-docker pull ghcr.io/vig-os/devcontainer:latest
+docker pull ghcr.io/vig-os/devkit:1.0.0
+docker pull ghcr.io/vig-os/devkit:latest
 
 # Check manifests
-docker buildx imagetools inspect ghcr.io/vig-os/devcontainer:1.0.0
+docker buildx imagetools inspect ghcr.io/vig-os/devkit:1.0.0
 ```
 
 ---

--- a/docs/templates/README.md.j2
+++ b/docs/templates/README.md.j2
@@ -72,25 +72,25 @@ curl -sSfL https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh
 1. **Pull the latest image**
 
    ```bash
-   podman pull ghcr.io/vig-os/devcontainer:latest
+   podman pull ghcr.io/vig-os/devkit:latest
    # or
-   docker pull ghcr.io/vig-os/devcontainer:latest
+   docker pull ghcr.io/vig-os/devkit:latest
    ```
 
    To pull a specific version, use the bare semver tag (without `v` prefix):
 
    ```bash
-   podman pull ghcr.io/vig-os/devcontainer:0.2.1
+   podman pull ghcr.io/vig-os/devkit:0.2.1
    ```
 
 2. **Initialize a workspace inside `PATH_TO_PROJECT`**
 
    ```bash
    podman run -it --rm -v "PATH_TO_PROJECT:/workspace" \
-     ghcr.io/vig-os/devcontainer:latest /root/assets/init-workspace.sh
+     ghcr.io/vig-os/devkit:latest /root/assets/init-workspace.sh
    # or with Docker:
    docker run -it --rm -v "PATH_TO_PROJECT:/workspace" \
-     ghcr.io/vig-os/devcontainer:latest /root/assets/init-workspace.sh
+     ghcr.io/vig-os/devkit:latest /root/assets/init-workspace.sh
    ```
 
    The script copies the devcontainer template (`.devcontainer/`), git hooks, README/CHANGELOG, and auth helpers into your project.
@@ -104,7 +104,7 @@ curl -sSfL https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh
 
    ```bash
    podman run -it --rm -v "PATH_TO_PROJECT:/workspace" \
-     ghcr.io/vig-os/devcontainer:latest /root/assets/init-workspace.sh --force
+     ghcr.io/vig-os/devkit:latest /root/assets/init-workspace.sh --force
    ```
 
    You will be prompted to confirm before files are replaced.
@@ -130,7 +130,7 @@ For detailed command descriptions, run `just --list --unsorted` or `just --help`
 ## Image Details
 
 - **Build**: Nix flake via `dockerTools.buildLayeredImage` (no Debian/Docker base image); bit-reproducible
-- **Registry**: `ghcr.io/vig-os/devcontainer`
+- **Registry**: `ghcr.io/vig-os/devkit`
 - **Architecture**: Multi-platform support (AMD64, ARM64)
 - **License**: Apache
 - **Latest Version**: [{{ version }}]({{ release_url }}) - {{ release_date }}

--- a/docs/templates/TESTING.md.j2
+++ b/docs/templates/TESTING.md.j2
@@ -54,7 +54,7 @@ These tests run against an initialized workspace to verify that the container wo
 Image and integration fixtures:
 
 - `container_tag`: Container tag from `TEST_CONTAINER_TAG` environment variable (defaults to "dev")
-- `container_image`: Full image name (e.g. `ghcr.io/vig-os/devcontainer:dev`)
+- `container_image`: Full image name (e.g. `ghcr.io/vig-os/devkit:dev`)
 - `test_container`: Running container instance for testing (session-scoped)
 - `host`: Testinfra host connection to the container (session-scoped)
 - `initialized_workspace`: Temporary workspace initialized with `init-workspace` script (session-scoped)

--- a/flake.nix
+++ b/flake.nix
@@ -582,8 +582,8 @@
         # The toolchain SSoT plus the runtime substrate a bare layered image
         # lacks (an FHS base distro would provide these; here we add them
         # explicitly — this is the discovery surface for FHS gaps). Shared by
-        # the image (`devcontainerImage`) and its vulnix scan target
-        # (`devcontainerImageEnv`, #637).
+        # the image (`devkitImage`) and its vulnix scan target
+        # (`devkitImageEnv`, #637).
         imageTools =
           (devTools pkgs)
           ++ (with pkgs; [
@@ -773,7 +773,7 @@
         # darwin eval. The dev-shell and services stay cross-platform. Refs #774.
         // pkgs.lib.optionalAttrs (pkgs.lib.hasSuffix "-linux" system) {
           # -----------------------------------------------------------------
-          # devcontainerImage — Nix-built devcontainer image (T2.1, #634).
+          # devkitImage — Nix-built devcontainer image (T2.1, #634).
           #
           # Assembled entirely by Nix via `dockerTools.buildLayeredImage` (NOT
           # a Dockerfile `FROM`) so the build is bit-reproducible — the epic's
@@ -793,7 +793,7 @@
           # `pre-commit` — one fewer manylinux/FHS consumer. prek runs the
           # committed `.pre-commit-config.yaml`; the flake's `checks.pre-commit`
           # runs the sandbox-pure subset under `nix flake check`.
-          devcontainerImage =
+          devkitImage =
             let
               # Nix C++/compression runtime exposed on the loader path so
               # runtime-installed manylinux wheels resolve their NEEDED libs.
@@ -842,7 +842,7 @@
               # venv/pre-commit population needs network, so it is best-effort
               # here and the directories are created unconditionally.
               bootstrap =
-                pkgs.runCommand "devcontainer-bootstrap"
+                pkgs.runCommand "devkit-bootstrap"
                   {
                     nativeBuildInputs = [
                       pkgs.coreutils
@@ -1144,12 +1144,12 @@
               };
             };
 
-          # devcontainerImageEnv — vulnix scan target (T3.1, #637). A buildEnv
+          # devkitImageEnv — vulnix scan target (T3.1, #637). A buildEnv
           # whose runtime closure equals the image's package set (imageTools),
           # so `vulnix --closure` sees exactly what ships in the image. The OCI
           # tarball itself is gzipped and exposes no scannable store references,
           # hence this dedicated env rather than scanning the image output.
-          devcontainerImageEnv = pkgs.buildEnv {
+          devkitImageEnv = pkgs.buildEnv {
             name = "devcontainer-image-env";
             paths = imageTools;
             ignoreCollisions = true;

--- a/flake.nix
+++ b/flake.nix
@@ -1031,9 +1031,9 @@
             in
             pkgs.dockerTools.buildLayeredImage {
               # Name matches the published repo so the portable testinfra
-              # (#635), which targets ghcr.io/vig-os/devcontainer:<tag>, runs
+              # (#635), which targets ghcr.io/vig-os/devkit:<tag>, runs
               # unchanged against the loaded image under a unique tag.
-              name = "ghcr.io/vig-os/devcontainer";
+              name = "ghcr.io/vig-os/devkit";
               # Disposable discovery tag, matching the CI workflow's
               # INDEX_TAG (.github/workflows/nix-image.yml). The versioned
               # / :latest cutover is handled separately (#639).

--- a/install.sh
+++ b/install.sh
@@ -30,7 +30,7 @@
 set -euo pipefail
 
 # Configuration
-REGISTRY="ghcr.io/vig-os/devcontainer"
+REGISTRY="ghcr.io/vig-os/devkit"
 VERSION="latest"
 RUNTIME=""
 FORCE=""

--- a/justfile
+++ b/justfile
@@ -53,7 +53,7 @@ info:
         NATIVE_ARCH="linux/amd64"
     fi
     echo "Image: {{ repo }}"
-    echo "Image builder: Nix flake (.#devcontainerImage)"
+    echo "Image builder: Nix flake (.#devkitImage)"
     echo "Native arch: $NATIVE_ARCH"
 
 # Gate Nix prerequisites and bootstrap the project (venv, git hooks, pre-commit)
@@ -91,8 +91,8 @@ build no_cache="":
     # podman under the local `dev` tag. Builds natively for the host arch.
     # `no_cache` is accepted for compatibility but is a no-op — Nix builds are
     # content-addressed (there is no Docker layer cache to bust).
-    echo "Building the Nix devcontainer image (.#devcontainerImage)..."
-    nix build .#devcontainerImage --accept-flake-config --print-build-logs
+    echo "Building the Nix devcontainer image (.#devkitImage)..."
+    nix build .#devkitImage --accept-flake-config --print-build-logs
     loaded=$(podman load -i result | sed -n 's/^Loaded image: //p' | head -n1)
     podman tag "${loaded}" "{{ repo }}:dev"
     echo "Loaded and tagged {{ repo }}:dev (from ${loaded})"

--- a/justfile
+++ b/justfile
@@ -7,7 +7,7 @@
 # ===============================================================================
 # Allow TEST_REGISTRY to override REPO for testing (e.g., localhost:5000/test/)
 
-repo := env("TEST_REGISTRY", "ghcr.io/vig-os/devcontainer")
+repo := env("TEST_REGISTRY", "ghcr.io/vig-os/devkit")
 
 # ===============================================================================
 # INFO

--- a/justfile.gh
+++ b/justfile.gh
@@ -105,4 +105,4 @@ reset-changelog:
 # Pull image from registry (default: latest)
 [group('release')]
 pull version="latest":
-    podman pull "ghcr.io/vig-os/devcontainer:{{ version }}"
+    podman pull "ghcr.io/vig-os/devkit:{{ version }}"

--- a/packages/vig-utils/src/vig_utils/vulnix_gate.py
+++ b/packages/vig-utils/src/vig_utils/vulnix_gate.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Gate HIGH/CRITICAL vulnix findings against an expiry-validated register.
 
-`vulnix` scans the Nix image's package closure (the flake `devcontainerImageEnv`
+`vulnix` scans the Nix image's package closure (the flake `devkitImageEnv`
 target) and emits JSON findings. This gate fails (exit 1) when any HIGH/CRITICAL
 CVE — CVSS v3 base score >= threshold (default 7.0) — is *not* covered by a
 non-expired entry in the exception register (`.vulnixignore`, the same

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -10,7 +10,7 @@ if [[ "$VERSION" =~ ^version= ]]; then
 	VERSION="${VERSION#version=}"
 fi
 
-REPO="${2:-${TEST_REGISTRY:-ghcr.io/vig-os/devcontainer}}"
+REPO="${2:-${TEST_REGISTRY:-ghcr.io/vig-os/devkit}}"
 # Strip trailing slash if present
 REPO="${REPO%/}"
 

--- a/tests/bats/clean.bats
+++ b/tests/bats/clean.bats
@@ -63,8 +63,8 @@ setup() {
     assert_success
 }
 
-@test "clean.sh defaults to ghcr.io/vig-os/devcontainer registry" {
-    run grep 'ghcr.io/vig-os/devcontainer' "$CLEAN_SH"
+@test "clean.sh defaults to ghcr.io/vig-os/devkit registry" {
+    run grep 'ghcr.io/vig-os/devkit' "$CLEAN_SH"
     assert_success
 }
 

--- a/tests/bats/install.bats
+++ b/tests/bats/install.bats
@@ -83,7 +83,7 @@ setup() {
 @test "dry-run includes image registry in command" {
     run bash "$INSTALL_SH" --dry-run .
     assert_success
-    assert_output --partial "ghcr.io/vig-os/devcontainer"
+    assert_output --partial "ghcr.io/vig-os/devkit"
 }
 
 @test "dry-run output is shell-quoted for safe copy-paste" {
@@ -92,7 +92,7 @@ setup() {
     # The command is rendered from the real CMD array via printf '%q', so each
     # argument is shell-safe (quoted only when it contains special characters).
     assert_output --regexp '[^ ]+:/workspace'
-    assert_output --regexp 'ghcr\.io/vig-os/devcontainer:[^ ]+'
+    assert_output --regexp 'ghcr\.io/vig-os/devkit:[^ ]+'
 }
 
 # ── version flag ──────────────────────────────────────────────────────────────
@@ -100,13 +100,13 @@ setup() {
 @test "version flag appears in dry-run command" {
     run bash "$INSTALL_SH" --dry-run --version 1.2.3 .
     assert_success
-    assert_output --partial "ghcr.io/vig-os/devcontainer:1.2.3"
+    assert_output --partial "ghcr.io/vig-os/devkit:1.2.3"
 }
 
 @test "default version is latest" {
     run bash "$INSTALL_SH" --dry-run .
     assert_success
-    assert_output --partial "ghcr.io/vig-os/devcontainer:latest"
+    assert_output --partial "ghcr.io/vig-os/devkit:latest"
 }
 
 # ── force flag ────────────────────────────────────────────────────────────────

--- a/tests/bats/just.bats
+++ b/tests/bats/just.bats
@@ -244,7 +244,7 @@ EOF
 }
 
 @test "release workflow rollback resolves container image independently of core outputs" {
-    run bash -lc "grep -Fq -- 'resolve-image:' assets/workspace/.github/workflows/release.yml && grep -Fq -- 'needs: [resolve-image, core, extension, publish]' assets/workspace/.github/workflows/release.yml && grep -Fq -- 'image: ghcr.io/vig-os/devcontainer:\${{ needs.resolve-image.outputs.image-tag }}' assets/workspace/.github/workflows/release.yml"
+    run bash -lc "grep -Fq -- 'resolve-image:' assets/workspace/.github/workflows/release.yml && grep -Fq -- 'needs: [resolve-image, core, extension, publish]' assets/workspace/.github/workflows/release.yml && grep -Fq -- 'image: ghcr.io/vig-os/devkit:\${{ needs.resolve-image.outputs.image-tag }}' assets/workspace/.github/workflows/release.yml"
     assert_success
 }
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -182,7 +182,7 @@ def container_image(container_tag):
     """
     Construct the full container image name and verify it exists.
     """
-    image_name = f"ghcr.io/vig-os/devcontainer:{container_tag}"
+    image_name = f"ghcr.io/vig-os/devkit:{container_tag}"
 
     # Check if image exists
     result = subprocess.run(
@@ -793,7 +793,7 @@ def devcontainer_up(initialized_workspace, container_tag):
     # Run the devcontainer from the image *under test*, not the published
     # DEVCONTAINER_VERSION baked into the scaffolded .vig-os/.env. The
     # scaffolded docker-compose.yml resolves the runtime image as
-    # ghcr.io/vig-os/devcontainer:${DEVCONTAINER_VERSION:-latest}; compose reads
+    # ghcr.io/vig-os/devkit:${DEVCONTAINER_VERSION:-latest}; compose reads
     # the shell environment over the .env file, so exporting DEVCONTAINER_VERSION
     # here pins compose -- and every `devcontainer exec` below, which inherits
     # os.environ -- to TEST_CONTAINER_TAG. Refs #701.

--- a/tests/docker-compose.test.yml
+++ b/tests/docker-compose.test.yml
@@ -8,7 +8,7 @@
 services:
   # Service to initialize a test workspace using init-workspace.sh
   init-workspace:
-    image: ${TEST_IMAGE:-ghcr.io/vig-os/devcontainer:dev}
+    image: ${TEST_IMAGE:-ghcr.io/vig-os/devkit:dev}
     volumes:
       - test-workspace:/workspace
     # Note: TTY is allocated by 'podman compose run -it', not here
@@ -16,7 +16,7 @@ services:
 
   # Service to inspect the initialized workspace (for debugging)
   workspace-inspector:
-    image: ${TEST_IMAGE:-ghcr.io/vig-os/devcontainer:dev}
+    image: ${TEST_IMAGE:-ghcr.io/vig-os/devkit:dev}
     volumes:
       - test-workspace:/workspace
     command: ls -la /workspace

--- a/tests/test_flake_services.py
+++ b/tests/test_flake_services.py
@@ -148,7 +148,7 @@ def test_services_package_exposed_without_clobbering_linux_packages() -> None:
     ``packages`` used to live entirely inside a Linux-only ``optionalAttrs``
     shallow merge; adding a cross-platform ``services`` package means
     restructuring that guard. Guard the restructure: on ``*-linux`` the image
-    attrs (``devcontainerImage``/``devcontainerImageEnv``/``vulnix``/
+    attrs (``devkitImage``/``devkitImageEnv``/``vulnix``/
     ``nix-fast-build``) must still be present alongside ``services``.
     """
     system = _current_system()
@@ -172,8 +172,8 @@ def test_services_package_exposed_without_clobbering_linux_packages() -> None:
     assert "services" in names, f"packages.{system} has no services package: {names}"
     if system.endswith("-linux"):
         required = {
-            "devcontainerImage",
-            "devcontainerImageEnv",
+            "devkitImage",
+            "devkitImageEnv",
             "vulnix",
             "nix-fast-build",
         }

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -1,7 +1,7 @@
 """
 Integration tests for install.sh — full deployment workflow.
 
-These tests require a built container image (ghcr.io/vig-os/devcontainer:<tag>)
+These tests require a built container image (ghcr.io/vig-os/devkit:<tag>)
 and are run by the test-integration CI job, NOT project-checks.
 
 Tests the full install.sh workflow which:
@@ -60,7 +60,7 @@ class TestInstallScriptIntegration:
 
         atexit.register(cleanup)
 
-        # Extract version from container_image (e.g., "ghcr.io/vig-os/devcontainer:dev" -> "dev")
+        # Extract version from container_image (e.g., "ghcr.io/vig-os/devkit:dev" -> "dev")
         version = container_image.split(":")[-1]
 
         # Run install.sh

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -550,7 +550,7 @@ class TestDevContainerDockerCompose:
         assert "image" in service, "devcontainer service missing 'image' field"
 
         # docker-compose now references version from .env / .vig-os
-        expected_image = "ghcr.io/vig-os/devcontainer:${DEVCONTAINER_VERSION:-latest}"
+        expected_image = "ghcr.io/vig-os/devkit:${DEVCONTAINER_VERSION:-latest}"
         assert service["image"] == expected_image, (
             f"Expected image to be {expected_image}, got: {service['image']}"
         )
@@ -1449,7 +1449,7 @@ class TestDevContainerCLI:
         """The running devcontainer must use the freshly-built image under test.
 
         The scaffolded docker-compose.yml pins the runtime image as
-        ``ghcr.io/vig-os/devcontainer:${DEVCONTAINER_VERSION:-latest}`` and
+        ``ghcr.io/vig-os/devkit:${DEVCONTAINER_VERSION:-latest}`` and
         ``initialize.sh`` writes the pinned ``DEVCONTAINER_VERSION`` (from the
         scaffolded ``.vig-os``) into ``.env``. Without an override the suite
         would validate fresh scaffolding running inside an old *published*
@@ -1480,7 +1480,7 @@ class TestDevContainerCLI:
             f"No running devcontainer found for workspace {workspace_path.name}"
         )
 
-        expected_image = f"ghcr.io/vig-os/devcontainer:{container_tag}"
+        expected_image = f"ghcr.io/vig-os/devkit:{container_tag}"
         assert any(expected_image in image for image in images), (
             f"Devcontainer is running from {images}, but the suite must validate "
             f"the image under test ({expected_image}). DEVCONTAINER_VERSION is not "
@@ -2159,7 +2159,7 @@ class TestJustRecipes:
         assert "build/test images" not in content
         assert "GHCR :latest" not in content
         assert 'pull version="latest"' not in content
-        assert "ghcr.io/vig-os/devcontainer" not in content
+        assert "ghcr.io/vig-os/devkit" not in content
 
 
 class TestDockerComposeProjectOverrides:
@@ -3042,7 +3042,7 @@ class TestVersionComparison:
         if compose_file.exists():
             content = compose_file.read_text()
             # Just verify it contains the image reference
-            assert "ghcr.io/vig-os/devcontainer:" in content
+            assert "ghcr.io/vig-os/devkit:" in content
 
 
 class TestVersionCheckJustIntegration:

--- a/tests/test_workflow_cachix.py
+++ b/tests/test_workflow_cachix.py
@@ -96,7 +96,7 @@ def test_release_vulnix_gate_pushes_scan_target_closure() -> None:
     """The release CVE gate pushes the scan-target closure so scans are cache-backed."""
     wf = _load(RELEASE_WF)
     push_steps = [s for s in _steps_of_job(wf, "vulnix-gate") if _is_closure_push(s)]
-    assert push_steps, "vulnix-gate must push the devcontainerImageEnv closure"
+    assert push_steps, "vulnix-gate must push the devkitImageEnv closure"
     for step in push_steps:
         assert step.get("continue-on-error") is not True, (
             "the scan-target closure push must be blocking"


### PR DESCRIPTION
## Summary

The final Stage-1 slice of **#781**: move the container image to the **new GHCR
package `ghcr.io/vig-os/devkit`** and rename the flake output attributes to match.
The new package is already seeded (`0.5.1` + `latest`, multi-arch, public), so CI
resolves against it.

Two commits:
1. `refactor(flake)` — attribute rename `devcontainerImage` → `devkitImage`,
   `devcontainerImageEnv` → `devkitImageEnv`, `devcontainer-bootstrap` → `devkit-bootstrap`
   (+ all call sites and the flake-services / workflow-cachix test anchors).
2. `feat(image)!` — image **ref** `ghcr.io/vig-os/devcontainer` → `ghcr.io/vig-os/devkit`
   across the flake, CI/release workflows, `install.sh`, the scaffold template
   (compose + workflows + actions), and docs (README/TESTING regenerated from templates).

## Breaking change
Consumers pulling `ghcr.io/vig-os/devcontainer` must move to `ghcr.io/vig-os/devkit`.
The old package is **frozen at `0.5.1` and stays pullable**; the soft-cutover pin parser
(#968) + `install.sh --force` re-scaffold migrate consumers without a hard break.

## Intentionally NOT changed (verified)
- **Released `CHANGELOG` entries**, the **`MIGRATION.md` note** that the old package stays pullable, and the **historical ADR** — all still cite `ghcr.io/vig-os/devcontainer` on purpose.
- **OCI `source` label** and **cosign `--certificate-identity-regexp`** — these are `github.com` *repo* paths and follow the **Stage 3** repository rename, not the image ref.
- **docker-compose `${DEVCONTAINER_VERSION}`** interpolation var — deferred (it's the compose var, not the image ref or pin key).

## Verification
- `nix eval .#devkitImage.imageName` → `ghcr.io/vig-os/devkit` ✅
- `test_flake_services` (evaluates the flake) + `test_workflow_cachix` — green (attr rename).
- `install.bats` / `clean.bats` / `just.bats` / `test_install_script` (unit) — green; caught + fixed a regex-escaped ref (`ghcr\.io/…`) the bulk sed missed.
- `just precommit` full suite — green (README/TESTING regenerated, actionlint, sync-manifest).
- Container/integration image tests run in CI against the seeded `devkit` package.

Refs: #781