### PR TITLE
refactor(image): keep published image as ghcr.io/vig-os/devcontainer

### DIFF
--- a/.github/actions/build-image/action.yml
+++ b/.github/actions/build-image/action.yml
@@ -12,7 +12,7 @@
 #   release-date / release-url / build-timestamp / vcs-ref: release metadata
 #     (kept for caller compatibility; the Nix image stamps its own static,
 #     reproducible OCI labels in flake.nix, so these are not baked into it)
-#   registry: Container registry URL (default: ghcr.io/vig-os/devkit)
+#   registry: Container registry URL (default: ghcr.io/vig-os/devcontainer)
 #   output-file: Path for the tar output
 #   cachix-cache / cachix-auth-token: passed to flake provisioning (setup-env)
 #   push-image-closure: when 'true', push the built image closure to Cachix as a
@@ -21,7 +21,7 @@
 #     guarded on the auth token so fork PRs (no secret) never fail.
 #
 # Outputs:
-#   image-tag: Full image tag (e.g., ghcr.io/vig-os/devkit:1.0.0-amd64)
+#   image-tag: Full image tag (e.g., ghcr.io/vig-os/devcontainer:1.0.0-amd64)
 #   tar-file: Path to the saved tar file
 
 name: 'Build Container Image'
@@ -53,7 +53,7 @@ inputs:
   registry:
     description: 'Container registry URL'
     required: false
-    default: 'ghcr.io/vig-os/devkit'
+    default: 'ghcr.io/vig-os/devcontainer'
   output-file:
     description: 'Path for the tar output'
     required: false

--- a/.github/actions/resolve-image/action.yml
+++ b/.github/actions/resolve-image/action.yml
@@ -90,7 +90,7 @@ runs:
         REGISTRY_USERNAME: ${{ inputs.registry-username }}
       run: |
         set -euo pipefail
-        IMAGE="ghcr.io/vig-os/devkit:${IMAGE_TAG}"
+        IMAGE="ghcr.io/vig-os/devcontainer:${IMAGE_TAG}"
         echo "Validating image availability: $IMAGE"
 
         # Authenticate before the probe when a token is supplied, so private or

--- a/.github/actions/test-image/action.yml
+++ b/.github/actions/test-image/action.yml
@@ -29,7 +29,7 @@
 #     with:
 #       image-tag: '1.0.0-amd64'
 #       image-source: 'registry'
-#       registry: 'ghcr.io/vig-os/devkit'
+#       registry: 'ghcr.io/vig-os/devcontainer'
 
 name: 'Test Container Image'
 description: 'Set up test environment and run container tests'
@@ -41,7 +41,7 @@ inputs:
   registry:
     description: 'Container registry URL'
     required: false
-    default: 'ghcr.io/vig-os/devkit'
+    default: 'ghcr.io/vig-os/devcontainer'
   image-source:
     description: 'Image source: "tar" (load from file), "registry" (pull), or "local" (already loaded)'
     required: false

--- a/.github/actions/test-integration/action.yml
+++ b/.github/actions/test-integration/action.yml
@@ -11,7 +11,7 @@
 #
 # Inputs:
 #   image-tag: Image tag to test (e.g., 1.0.0-amd64)
-#   registry: Container registry URL (default: ghcr.io/vig-os/devkit)
+#   registry: Container registry URL (default: ghcr.io/vig-os/devcontainer)
 #
 # Outputs:
 #   test-result: Test exit code (0=pass, non-zero=fail)
@@ -31,7 +31,7 @@ inputs:
   registry:
     description: 'Container registry URL'
     required: false
-    default: 'ghcr.io/vig-os/devkit'
+    default: 'ghcr.io/vig-os/devcontainer'
   ref:
     description: 'Git ref to checkout (e.g., commit SHA, branch, tag)'
     required: false

--- a/.github/workflows/nix-image.yml
+++ b/.github/workflows/nix-image.yml
@@ -55,7 +55,7 @@ permissions:
   contents: read
 
 env:
-  REGISTRY: ghcr.io/vig-os/devkit
+  REGISTRY: ghcr.io/vig-os/devcontainer
   # Disposable discovery index tag. NOT a cutover tag (versioned/:latest is #639).
   INDEX_TAG: nix-dev
 
@@ -128,7 +128,7 @@ jobs:
           du -h /tmp/nix-devcontainer-image.tar.gz
 
       # Reuse the shared composite action: it loads the tar into podman, retags
-      # it to ghcr.io/vig-os/devkit:nix-image (local only, never pushed),
+      # it to ghcr.io/vig-os/devcontainer:nix-image (local only, never pushed),
       # and runs tests/test_image.py via TEST_CONTAINER_TAG. Gating now (#666):
       # the Nix image passes the full suite, so a failure here fails CI.
       - name: Load image and run portable testinfra

--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -111,7 +111,7 @@ jobs:
           ARCHS: ${{ steps.vars.outputs.architectures }}
         run: |
           set -euo pipefail
-          REPO="ghcr.io/vig-os/devkit"
+          REPO="ghcr.io/vig-os/devcontainer"
           IFS=' ' read -ra ARCH_ARRAY <<< "$ARCHS"
           for arch in "${ARCH_ARRAY[@]}"; do
             echo "Verifying image: $REPO:$VERSION-$arch"
@@ -144,7 +144,7 @@ jobs:
           VERSION: ${{ steps.vars.outputs.version }}
         run: |
           set -euo pipefail
-          REPO="ghcr.io/vig-os/devkit"
+          REPO="ghcr.io/vig-os/devcontainer"
           retry --retries 3 --backoff 10 --max-backoff 30 -- \
             cosign verify "$REPO:$VERSION" \
               --certificate-identity-regexp='https://github.com/vig-os/devcontainer/.github/workflows/release.yml@refs/heads/release/' \
@@ -326,7 +326,7 @@ jobs:
           ARCHS: ${{ needs.validate.outputs.architectures }}
         run: |
           set -euo pipefail
-          REPO="ghcr.io/vig-os/devkit"
+          REPO="ghcr.io/vig-os/devcontainer"
           IFS=' ' read -ra ARCH_ARRAY <<< "$ARCHS"
           ARCH_IMAGES=()
           for arch in "${ARCH_ARRAY[@]}"; do

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1055,7 +1055,7 @@ jobs:
           ARCHS: ${{ needs.validate.outputs.architectures }}
         run: |
           set -euo pipefail
-          REPO="ghcr.io/vig-os/devkit"
+          REPO="ghcr.io/vig-os/devcontainer"
 
           IFS=' ' read -ra ARCH_ARRAY <<< "$ARCHS"
 
@@ -1088,7 +1088,7 @@ jobs:
           ARCHS: ${{ needs.validate.outputs.architectures }}
         run: |
           set -euo pipefail
-          REPO="ghcr.io/vig-os/devkit"
+          REPO="ghcr.io/vig-os/devcontainer"
 
           IFS=' ' read -ra ARCH_ARRAY <<< "$ARCHS"
 
@@ -1112,7 +1112,7 @@ jobs:
           ARCHS: ${{ needs.validate.outputs.architectures }}
         run: |
           set -euo pipefail
-          REPO="ghcr.io/vig-os/devkit"
+          REPO="ghcr.io/vig-os/devcontainer"
 
           IFS=' ' read -ra ARCH_ARRAY <<< "$ARCHS"
 
@@ -1138,7 +1138,7 @@ jobs:
         continue-on-error: true
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610  # v0.24.0
         with:
-          image: ghcr.io/vig-os/devkit:${{ needs.validate.outputs.publish_version }}
+          image: ghcr.io/vig-os/devcontainer:${{ needs.validate.outputs.publish_version }}
           artifact-name: sbom-${{ needs.validate.outputs.publish_version }}.spdx.json
           output-file: /tmp/sbom.spdx.json
           format: spdx-json
@@ -1151,7 +1151,7 @@ jobs:
         if: steps.sbom_generate.outcome == 'failure'
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610  # v0.24.0
         with:
-          image: ghcr.io/vig-os/devkit:${{ needs.validate.outputs.publish_version }}
+          image: ghcr.io/vig-os/devcontainer:${{ needs.validate.outputs.publish_version }}
           artifact-name: sbom-${{ needs.validate.outputs.publish_version }}.spdx.json
           output-file: /tmp/sbom.spdx.json
           format: spdx-json
@@ -1168,7 +1168,7 @@ jobs:
           PUBLISH_VERSION: ${{ needs.validate.outputs.publish_version }}
         run: |
           set -euo pipefail
-          REPO="ghcr.io/vig-os/devkit"
+          REPO="ghcr.io/vig-os/devcontainer"
 
           # Get the digest for the multi-arch manifest
           DIGEST=$(retry --retries 3 --backoff 5 --max-backoff 30 -- \
@@ -1186,7 +1186,7 @@ jobs:
           PUBLISH_VERSION: ${{ needs.validate.outputs.publish_version }}
         run: |
           set -euo pipefail
-          REPO="ghcr.io/vig-os/devkit"
+          REPO="ghcr.io/vig-os/devcontainer"
           DIGEST=$(retry --retries 3 --backoff 5 --max-backoff 30 -- \
             docker buildx imagetools inspect "$REPO:$PUBLISH_VERSION" --format '{{json .Manifest.Digest}}' | tr -d '"')
           echo "digest=$DIGEST" >> $GITHUB_OUTPUT
@@ -1197,7 +1197,7 @@ jobs:
         continue-on-error: true
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373  # v4.1.1
         with:
-          subject-name: ghcr.io/vig-os/devkit
+          subject-name: ghcr.io/vig-os/devcontainer
           subject-digest: ${{ steps.digest.outputs.digest }}
           push-to-registry: true
 
@@ -1209,7 +1209,7 @@ jobs:
         if: steps.attest_provenance.outcome == 'failure'
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373  # v4.1.1
         with:
-          subject-name: ghcr.io/vig-os/devkit
+          subject-name: ghcr.io/vig-os/devcontainer
           subject-digest: ${{ steps.digest.outputs.digest }}
           push-to-registry: true
 
@@ -1218,7 +1218,7 @@ jobs:
         continue-on-error: true
         uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763  # v4.1.1
         with:
-          subject-name: ghcr.io/vig-os/devkit
+          subject-name: ghcr.io/vig-os/devcontainer
           subject-digest: ${{ steps.digest.outputs.digest }}
           sbom-path: /tmp/sbom.spdx.json
           push-to-registry: true
@@ -1231,7 +1231,7 @@ jobs:
         if: steps.attest_sbom.outcome == 'failure'
         uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763  # v4.1.1
         with:
-          subject-name: ghcr.io/vig-os/devkit
+          subject-name: ghcr.io/vig-os/devcontainer
           subject-digest: ${{ steps.digest.outputs.digest }}
           sbom-path: /tmp/sbom.spdx.json
           push-to-registry: true
@@ -1364,9 +1364,9 @@ jobs:
           echo "  Release Kind: $RELEASE_KIND"
           echo "  Tag: $PUBLISH_VERSION"
           echo "  Images:"
-          echo "    - ghcr.io/vig-os/devkit:$PUBLISH_VERSION"
+          echo "    - ghcr.io/vig-os/devcontainer:$PUBLISH_VERSION"
           if [ "$RELEASE_KIND" = "final" ]; then
-            echo "    - ghcr.io/vig-os/devkit:latest (after just promote-release $BASE_VERSION)"
+            echo "    - ghcr.io/vig-os/devcontainer:latest (after just promote-release $BASE_VERSION)"
           fi
           echo "  Security:"
           echo "    - Cosign signature attached"
@@ -1657,7 +1657,7 @@ jobs:
             - This issue created for investigation
 
             **Manual Cleanup May Be Needed:**
-            - If images were pushed to GHCR before the failure, they are **not** automatically deleted. Check \`ghcr.io/vig-os/devkit:${publishVersion}-*\` and remove any orphaned images manually.
+            - If images were pushed to GHCR before the failure, they are **not** automatically deleted. Check \`ghcr.io/vig-os/devcontainer:${publishVersion}-*\` and remove any orphaned images manually.
             - If a **draft** GitHub Release exists for this tag, edit or manage it from the Releases UI (**publishing** locks the linked tag and assets when **immutable releases** are enabled).
 
             **Next Steps:**

--- a/.github/workflows/renovate-changelog-build.yml
+++ b/.github/workflows/renovate-changelog-build.yml
@@ -52,7 +52,7 @@ jobs:
     needs: [resolve-image]
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/vig-os/devkit:${{ needs.resolve-image.outputs.image-tag }}
+      image: ghcr.io/vig-os/devcontainer:${{ needs.resolve-image.outputs.image-tag }}
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GHCR_PULL_TOKEN || github.token }}

--- a/.github/workflows/sync-issues.yml
+++ b/.github/workflows/sync-issues.yml
@@ -61,7 +61,7 @@ jobs:
     needs: [resolve-image]
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/vig-os/devkit:${{ needs.resolve-image.outputs.image-tag }}
+      image: ghcr.io/vig-os/devcontainer:${{ needs.resolve-image.outputs.image-tag }}
     timeout-minutes: 10
     defaults:
       run:

--- a/.github/workflows/sync-main-to-dev.yml
+++ b/.github/workflows/sync-main-to-dev.yml
@@ -63,7 +63,7 @@ jobs:
     needs: [resolve-image]
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/vig-os/devkit:${{ needs.resolve-image.outputs.image-tag }}
+      image: ghcr.io/vig-os/devcontainer:${{ needs.resolve-image.outputs.image-tag }}
     timeout-minutes: 5
     defaults:
       run:
@@ -108,7 +108,7 @@ jobs:
     if: needs.check.outputs.up_to_date != 'true'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/vig-os/devkit:${{ needs.resolve-image.outputs.image-tag }}
+      image: ghcr.io/vig-os/devcontainer:${{ needs.resolve-image.outputs.image-tag }}
     timeout-minutes: 10
     defaults:
       run:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,16 +20,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Image published to the new `ghcr.io/vig-os/devkit` package** ([#781](https://github.com/vig-os/devcontainer/issues/781))
-  - The container image reference moves from `ghcr.io/vig-os/devcontainer` to a
-    **new GHCR package `ghcr.io/vig-os/devkit`** across the flake, CI/release
-    workflows, `install.sh`, the scaffold template (compose + workflows), and
-    documentation. The Nix flake output attributes are renamed to match
-    (`devcontainerImage` → `devkitImage`, `devcontainerImageEnv` → `devkitImageEnv`).
-    The old `ghcr.io/vig-os/devcontainer` package is frozen at `0.5.1` and remains
-    pullable; consumers move to the new package on their next
-    `install.sh --force` re-scaffold. The source-repo URL and the image's OCI
-    `source` label are unchanged in this slice (they follow the repository rename).
+- **Nix flake image attributes renamed to `devkitImage` / `devkitImageEnv`** ([#781](https://github.com/vig-os/devcontainer/issues/781))
+  - As part of the `devcontainer` → `devkit` project rename, the Nix flake output
+    attributes are renamed (`devcontainerImage` → `devkitImage`,
+    `devcontainerImageEnv` → `devkitImageEnv`). The **published image name is
+    unchanged** — it remains `ghcr.io/vig-os/devcontainer`: the artifact is a dev
+    container, while `devkit` names the project/repository that builds and ships
+    it. Consumers need **no image-ref change** and keep pulling the same image.
 
 - **Scaffolded `.vig-os` pins under `DEVKIT_VERSION`** ([#781](https://github.com/vig-os/devcontainer/issues/781))
   - The scaffold/release writeback now emits the renamed `DEVKIT_VERSION` key:

--- a/README.md
+++ b/README.md
@@ -74,25 +74,25 @@ curl -sSfL https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh
 1. **Pull the latest image**
 
    ```bash
-   podman pull ghcr.io/vig-os/devkit:latest
+   podman pull ghcr.io/vig-os/devcontainer:latest
    # or
-   docker pull ghcr.io/vig-os/devkit:latest
+   docker pull ghcr.io/vig-os/devcontainer:latest
    ```
 
    To pull a specific version, use the bare semver tag (without `v` prefix):
 
    ```bash
-   podman pull ghcr.io/vig-os/devkit:0.2.1
+   podman pull ghcr.io/vig-os/devcontainer:0.2.1
    ```
 
 2. **Initialize a workspace inside `PATH_TO_PROJECT`**
 
    ```bash
    podman run -it --rm -v "PATH_TO_PROJECT:/workspace" \
-     ghcr.io/vig-os/devkit:latest /root/assets/init-workspace.sh
+     ghcr.io/vig-os/devcontainer:latest /root/assets/init-workspace.sh
    # or with Docker:
    docker run -it --rm -v "PATH_TO_PROJECT:/workspace" \
-     ghcr.io/vig-os/devkit:latest /root/assets/init-workspace.sh
+     ghcr.io/vig-os/devcontainer:latest /root/assets/init-workspace.sh
    ```
 
    The script copies the devcontainer template (`.devcontainer/`), git hooks, README/CHANGELOG, and auth helpers into your project.
@@ -106,7 +106,7 @@ curl -sSfL https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh
 
    ```bash
    podman run -it --rm -v "PATH_TO_PROJECT:/workspace" \
-     ghcr.io/vig-os/devkit:latest /root/assets/init-workspace.sh --force
+     ghcr.io/vig-os/devcontainer:latest /root/assets/init-workspace.sh --force
    ```
 
    You will be prompted to confirm before files are replaced.
@@ -196,7 +196,7 @@ For detailed command descriptions, run `just --list --unsorted` or `just --help`
 ## Image Details
 
 - **Build**: Nix flake via `dockerTools.buildLayeredImage` (no Debian/Docker base image); bit-reproducible
-- **Registry**: `ghcr.io/vig-os/devkit`
+- **Registry**: `ghcr.io/vig-os/devcontainer`
 - **Architecture**: Multi-platform support (AMD64, ARM64)
 - **License**: Apache
 - **Latest Version**: [0.5.1](https://github.com/vig-os/devcontainer/releases/tag/0.5.1) - 2026-07-10

--- a/TESTING.md
+++ b/TESTING.md
@@ -54,7 +54,7 @@ These tests run against an initialized workspace to verify that the container wo
 Image and integration fixtures:
 
 - `container_tag`: Container tag from `TEST_CONTAINER_TAG` environment variable (defaults to "dev")
-- `container_image`: Full image name (e.g. `ghcr.io/vig-os/devkit:dev`)
+- `container_image`: Full image name (e.g. `ghcr.io/vig-os/devcontainer:dev`)
 - `test_container`: Running container instance for testing (session-scoped)
 - `host`: Testinfra host connection to the container (session-scoped)
 - `initialized_workspace`: Temporary workspace initialized with `init-workspace` script (session-scoped)

--- a/assets/init-workspace.sh
+++ b/assets/init-workspace.sh
@@ -165,8 +165,8 @@ if [[ "$NO_PROMPTS" != "true" ]] && [[ ! -t 0 ]]; then
     echo "Error: This script requires an interactive terminal." >&2
     echo "" >&2
     echo "Please run with the -it flags:" >&2
-    echo "  podman run -it --rm -v \"./:/workspace\" ghcr.io/vig-os/devkit:latest /root/assets/init-workspace.sh" >&2
-    echo "  docker run -it --rm -v \"./:/workspace\" ghcr.io/vig-os/devkit:latest /root/assets/init-workspace.sh" >&2
+    echo "  podman run -it --rm -v \"./:/workspace\" ghcr.io/vig-os/devcontainer:latest /root/assets/init-workspace.sh" >&2
+    echo "  docker run -it --rm -v \"./:/workspace\" ghcr.io/vig-os/devcontainer:latest /root/assets/init-workspace.sh" >&2
     exit 1
 fi
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -20,16 +20,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Image published to the new `ghcr.io/vig-os/devkit` package** ([#781](https://github.com/vig-os/devcontainer/issues/781))
-  - The container image reference moves from `ghcr.io/vig-os/devcontainer` to a
-    **new GHCR package `ghcr.io/vig-os/devkit`** across the flake, CI/release
-    workflows, `install.sh`, the scaffold template (compose + workflows), and
-    documentation. The Nix flake output attributes are renamed to match
-    (`devcontainerImage` → `devkitImage`, `devcontainerImageEnv` → `devkitImageEnv`).
-    The old `ghcr.io/vig-os/devcontainer` package is frozen at `0.5.1` and remains
-    pullable; consumers move to the new package on their next
-    `install.sh --force` re-scaffold. The source-repo URL and the image's OCI
-    `source` label are unchanged in this slice (they follow the repository rename).
+- **Nix flake image attributes renamed to `devkitImage` / `devkitImageEnv`** ([#781](https://github.com/vig-os/devcontainer/issues/781))
+  - As part of the `devcontainer` → `devkit` project rename, the Nix flake output
+    attributes are renamed (`devcontainerImage` → `devkitImage`,
+    `devcontainerImageEnv` → `devkitImageEnv`). The **published image name is
+    unchanged** — it remains `ghcr.io/vig-os/devcontainer`: the artifact is a dev
+    container, while `devkit` names the project/repository that builds and ships
+    it. Consumers need **no image-ref change** and keep pulling the same image.
 
 - **Scaffolded `.vig-os` pins under `DEVKIT_VERSION`** ([#781](https://github.com/vig-os/devcontainer/issues/781))
   - The scaffold/release writeback now emits the renamed `DEVKIT_VERSION` key:

--- a/assets/workspace/.devcontainer/docker-compose.yml
+++ b/assets/workspace/.devcontainer/docker-compose.yml
@@ -1,7 +1,7 @@
 ---
 services:
   devcontainer:
-    image: ghcr.io/vig-os/devkit:${DEVCONTAINER_VERSION:-latest}
+    image: ghcr.io/vig-os/devcontainer:${DEVCONTAINER_VERSION:-latest}
     volumes:
       # Mount the project folder to a subdirectory of workspace
       - ..:/workspace/{{SHORT_NAME}}:cached

--- a/assets/workspace/.github/actions/resolve-image/action.yml
+++ b/assets/workspace/.github/actions/resolve-image/action.yml
@@ -90,7 +90,7 @@ runs:
         REGISTRY_USERNAME: ${{ inputs.registry-username }}
       run: |
         set -euo pipefail
-        IMAGE="ghcr.io/vig-os/devkit:${IMAGE_TAG}"
+        IMAGE="ghcr.io/vig-os/devcontainer:${IMAGE_TAG}"
         echo "Validating image availability: $IMAGE"
 
         # Authenticate before the probe when a token is supplied, so private or

--- a/assets/workspace/.github/workflows/ci.yml
+++ b/assets/workspace/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
     needs: [resolve-image]
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/vig-os/devkit:${{ needs.resolve-image.outputs.image-tag }}
+      image: ghcr.io/vig-os/devcontainer:${{ needs.resolve-image.outputs.image-tag }}
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GHCR_PULL_TOKEN || github.token }}
@@ -101,7 +101,7 @@ jobs:
       - name: Verify toolchain (prek present)
         run: |
           if ! command -v prek >/dev/null 2>&1; then
-            echo "::error::'prek' not found in the CI image (ghcr.io/vig-os/devkit). The image pinned by .vig-os DEVKIT_VERSION predates the prek hook runner (#778)."
+            echo "::error::'prek' not found in the CI image (ghcr.io/vig-os/devcontainer). The image pinned by .vig-os DEVKIT_VERSION predates the prek hook runner (#778)."
             echo "Fix: bump .vig-os DEVKIT_VERSION to an image that ships prek, or re-run the devkit installer. See docs/MIGRATION.md."
             exit 1
           fi
@@ -118,7 +118,7 @@ jobs:
     needs: [resolve-image]
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/vig-os/devkit:${{ needs.resolve-image.outputs.image-tag }}
+      image: ghcr.io/vig-os/devcontainer:${{ needs.resolve-image.outputs.image-tag }}
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GHCR_PULL_TOKEN || github.token }}

--- a/assets/workspace/.github/workflows/prepare-release.yml
+++ b/assets/workspace/.github/workflows/prepare-release.yml
@@ -135,7 +135,7 @@ jobs:
     needs: validate
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/vig-os/devkit:${{ needs.validate.outputs.image_tag }}
+      image: ghcr.io/vig-os/devcontainer:${{ needs.validate.outputs.image_tag }}
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GHCR_PULL_TOKEN || github.token }}

--- a/assets/workspace/.github/workflows/promote-release.yml
+++ b/assets/workspace/.github/workflows/promote-release.yml
@@ -53,7 +53,7 @@ jobs:
     needs: [resolve-image]
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/vig-os/devkit:${{ needs.resolve-image.outputs.image-tag }}
+      image: ghcr.io/vig-os/devcontainer:${{ needs.resolve-image.outputs.image-tag }}
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GHCR_PULL_TOKEN || github.token }}
@@ -230,7 +230,7 @@ jobs:
     needs: [resolve-image, validate]
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/vig-os/devkit:${{ needs.resolve-image.outputs.image-tag }}
+      image: ghcr.io/vig-os/devcontainer:${{ needs.resolve-image.outputs.image-tag }}
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GHCR_PULL_TOKEN || github.token }}
@@ -273,7 +273,7 @@ jobs:
     needs: [resolve-image, validate, promote]
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/vig-os/devkit:${{ needs.resolve-image.outputs.image-tag }}
+      image: ghcr.io/vig-os/devcontainer:${{ needs.resolve-image.outputs.image-tag }}
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GHCR_PULL_TOKEN || github.token }}
@@ -394,7 +394,7 @@ jobs:
     needs: [resolve-image, validate, promote, merge]
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/vig-os/devkit:${{ needs.resolve-image.outputs.image-tag }}
+      image: ghcr.io/vig-os/devcontainer:${{ needs.resolve-image.outputs.image-tag }}
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GHCR_PULL_TOKEN || github.token }}

--- a/assets/workspace/.github/workflows/release-core.yml
+++ b/assets/workspace/.github/workflows/release-core.yml
@@ -104,7 +104,7 @@ jobs:
       pull-requests: read
       packages: read
     container:
-      image: ghcr.io/vig-os/devkit:${{ needs.resolve-image.outputs.image-tag }}
+      image: ghcr.io/vig-os/devcontainer:${{ needs.resolve-image.outputs.image-tag }}
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GHCR_PULL_TOKEN || github.token }}
@@ -340,7 +340,7 @@ jobs:
       contents: write
       packages: read
     container:
-      image: ghcr.io/vig-os/devkit:${{ needs.validate.outputs.image_tag }}
+      image: ghcr.io/vig-os/devcontainer:${{ needs.validate.outputs.image_tag }}
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GHCR_PULL_TOKEN || github.token }}
@@ -530,7 +530,7 @@ jobs:
     needs: [validate, finalize]
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/vig-os/devkit:${{ needs.validate.outputs.image_tag }}
+      image: ghcr.io/vig-os/devcontainer:${{ needs.validate.outputs.image_tag }}
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GHCR_PULL_TOKEN || github.token }}

--- a/assets/workspace/.github/workflows/release-publish.yml
+++ b/assets/workspace/.github/workflows/release-publish.yml
@@ -88,7 +88,7 @@ jobs:
     needs: [resolve-image]
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/vig-os/devkit:${{ needs.resolve-image.outputs.image-tag }}
+      image: ghcr.io/vig-os/devcontainer:${{ needs.resolve-image.outputs.image-tag }}
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GHCR_PULL_TOKEN || github.token }}

--- a/assets/workspace/.github/workflows/release.yml
+++ b/assets/workspace/.github/workflows/release.yml
@@ -124,7 +124,7 @@ jobs:
     needs: [resolve-image, core, extension, publish]
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/vig-os/devkit:${{ needs.resolve-image.outputs.image-tag }}
+      image: ghcr.io/vig-os/devcontainer:${{ needs.resolve-image.outputs.image-tag }}
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GHCR_PULL_TOKEN || github.token }}

--- a/assets/workspace/.github/workflows/renovate-changelog-build.yml
+++ b/assets/workspace/.github/workflows/renovate-changelog-build.yml
@@ -52,7 +52,7 @@ jobs:
     needs: [resolve-image]
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/vig-os/devkit:${{ needs.resolve-image.outputs.image-tag }}
+      image: ghcr.io/vig-os/devcontainer:${{ needs.resolve-image.outputs.image-tag }}
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GHCR_PULL_TOKEN || github.token }}

--- a/assets/workspace/.github/workflows/sync-issues.yml
+++ b/assets/workspace/.github/workflows/sync-issues.yml
@@ -67,7 +67,7 @@ jobs:
     needs: [resolve-image]
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/vig-os/devkit:${{ needs.resolve-image.outputs.image-tag }}
+      image: ghcr.io/vig-os/devcontainer:${{ needs.resolve-image.outputs.image-tag }}
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GHCR_PULL_TOKEN || github.token }}

--- a/assets/workspace/.github/workflows/sync-main-to-dev.yml
+++ b/assets/workspace/.github/workflows/sync-main-to-dev.yml
@@ -70,7 +70,7 @@ jobs:
     needs: [resolve-image]
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/vig-os/devkit:${{ needs.resolve-image.outputs.image-tag }}
+      image: ghcr.io/vig-os/devcontainer:${{ needs.resolve-image.outputs.image-tag }}
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GHCR_PULL_TOKEN || github.token }}
@@ -118,7 +118,7 @@ jobs:
     if: needs.check.outputs.up_to_date != 'true'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/vig-os/devkit:${{ needs.resolve-image.outputs.image-tag }}
+      image: ghcr.io/vig-os/devcontainer:${{ needs.resolve-image.outputs.image-tag }}
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GHCR_PULL_TOKEN || github.token }}

--- a/assets/workspace/docs/container-ci-quirks.md
+++ b/assets/workspace/docs/container-ci-quirks.md
@@ -1,7 +1,7 @@
 # Container CI Notes
 
 Behavioral notes for the workspace CI workflow (`.github/workflows/ci.yml`)
-when jobs run inside `ghcr.io/vig-os/devkit:*` via GitHub Actions
+when jobs run inside `ghcr.io/vig-os/devcontainer:*` via GitHub Actions
 `container:`.
 
 ## Tool bootstrap model
@@ -64,7 +64,7 @@ runtime.
 ## Authenticated pulls (private / rate-limited registries)
 
 The shipped container workflows support **authenticated** GHCR pulls, so a
-**private** (or anonymous-rate-limited) `ghcr.io/vig-os/devkit` image works
+**private** (or anonymous-rate-limited) `ghcr.io/vig-os/devcontainer` image works
 without any per-repo YAML edits ([#920](https://github.com/vig-os/devcontainer/issues/920)).
 Public consumers are unaffected: the automatic `GITHUB_TOKEN` performs an
 authenticated pull of a public image, which succeeds unchanged.

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -18,7 +18,7 @@ two ways:
 
 - **Container image** — assembled by `dockerTools.buildLayeredImage` (no base
   distro, no `Dockerfile FROM`), bit-reproducible, and built natively for
-  `amd64` and `arm64`. Published as `ghcr.io/vig-os/devkit`.
+  `amd64` and `arm64`. Published as `ghcr.io/vig-os/devcontainer`.
 - **Bare-nix dev-shell** — the same toolchain via `nix develop` / `direnv`,
   consumed as a flake input (`vigos.url = "github:vig-os/devcontainer"`).
 
@@ -62,7 +62,7 @@ so upgrades never need `--mode` again.
 
 `direnv` (and `bare`) consumers cannot run the container-based CI: with no
 `.devcontainer/`, a `.vig-os`-driven `resolve-image` job hard-fails and bricks
-every workflow that runs `container: ghcr.io/vig-os/devkit:<pin>`. To keep
+every workflow that runs `container: ghcr.io/vig-os/devcontainer:<pin>`. To keep
 the main lane working, `direnv` mode ships a **nix-direct `ci.yml`** overlay
 ([#854](https://github.com/vig-os/devcontainer/issues/854)) that runs on the host
 runner (`install-nix` + Cachix → `nix develop -c just sync|precommit|test`),
@@ -461,12 +461,15 @@ Nix-built. Released images are never deleted, so 0.3.9 remains pullable
 (`DEVCONTAINER_VERSION=0.3.9` in the repo-root `.vig-os`), but the line is
 frozen — it receives no CVE fixes and is not a supported rollback track.
 
-## Upcoming rename: `devcontainer` → `devkit`
+## Upcoming rename: repository `devcontainer` → `devkit`
 
-The repository and image are scheduled to be renamed to **`devkit`** in the
-release cycle after the Nix cutover
-([#781](https://github.com/vig-os/devcontainer/issues/781)). GitHub redirects
-the repository URL, but the image moves to a **new** GHCR package
-(`ghcr.io/vig-os/devkit`) — a one-time `install.sh --force` re-scaffold will
-migrate consumers. Existing `ghcr.io/vig-os/devcontainer` images remain
-pullable indefinitely.
+The **repository** is scheduled to be renamed to **`devkit`** in the release
+cycle after the Nix cutover
+([#781](https://github.com/vig-os/devcontainer/issues/781)). GitHub redirects the
+old repository URL. The **published image is unchanged** — it stays
+`ghcr.io/vig-os/devcontainer` (the artifact is a dev container; `devkit` is the
+project that builds and ships it), so existing `.vig-os` pins and `podman pull`
+commands keep working with no change. A re-scaffold (`install.sh --force`) only
+refreshes the `install.sh` source URL and templated files; it does not change the
+image you pull. The `.vig-os` version-pin key is `DEVKIT_VERSION` (the legacy
+`DEVCONTAINER_VERSION` is still accepted).

--- a/docs/RELEASE_CYCLE.md
+++ b/docs/RELEASE_CYCLE.md
@@ -393,8 +393,8 @@ The `release.yml` workflow performs the entire remaining release process. Behavi
    - Downloads tested images from artifacts
    - Logs in to GitHub Container Registry
    - Pushes images to GHCR with architecture-specific tags
-   - Creates multi-architecture manifest `ghcr.io/vig-os/devkit:<publish-tag>`
-   - Creates/updates `ghcr.io/vig-os/devkit:latest` only in final mode (and only when both architectures are built)
+   - Creates multi-architecture manifest `ghcr.io/vig-os/devcontainer:<publish-tag>`
+   - Creates/updates `ghcr.io/vig-os/devcontainer:latest` only in final mode (and only when both architectures are built)
    - Verifies manifests exist
    - Candidate and final modes: trigger cross-repository validation dispatch with `client_payload[tag]` plus source metadata (`source_repo`, `source_workflow`, `source_run_id`, `source_run_url`, `source_sha`, `correlation_id`)
 
@@ -418,8 +418,8 @@ Release Summary:
   Release Kind: final
   Tag: 1.0.0
   Images:
-    - ghcr.io/vig-os/devkit:1.0.0
-    - ghcr.io/vig-os/devkit:latest
+    - ghcr.io/vig-os/devcontainer:1.0.0
+    - ghcr.io/vig-os/devcontainer:latest
 ```
 
 **Key characteristics:**
@@ -479,11 +479,11 @@ No CHANGELOG reset is needed -- dev already has `## Unreleased` from the prepare
 git tag | grep 1.0.0
 
 # Verify images in registry
-docker pull ghcr.io/vig-os/devkit:1.0.0
-docker pull ghcr.io/vig-os/devkit:latest
+docker pull ghcr.io/vig-os/devcontainer:1.0.0
+docker pull ghcr.io/vig-os/devcontainer:latest
 
 # Check manifests
-docker buildx imagetools inspect ghcr.io/vig-os/devkit:1.0.0
+docker buildx imagetools inspect ghcr.io/vig-os/devcontainer:1.0.0
 ```
 
 ---

--- a/docs/templates/README.md.j2
+++ b/docs/templates/README.md.j2
@@ -72,25 +72,25 @@ curl -sSfL https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh
 1. **Pull the latest image**
 
    ```bash
-   podman pull ghcr.io/vig-os/devkit:latest
+   podman pull ghcr.io/vig-os/devcontainer:latest
    # or
-   docker pull ghcr.io/vig-os/devkit:latest
+   docker pull ghcr.io/vig-os/devcontainer:latest
    ```
 
    To pull a specific version, use the bare semver tag (without `v` prefix):
 
    ```bash
-   podman pull ghcr.io/vig-os/devkit:0.2.1
+   podman pull ghcr.io/vig-os/devcontainer:0.2.1
    ```
 
 2. **Initialize a workspace inside `PATH_TO_PROJECT`**
 
    ```bash
    podman run -it --rm -v "PATH_TO_PROJECT:/workspace" \
-     ghcr.io/vig-os/devkit:latest /root/assets/init-workspace.sh
+     ghcr.io/vig-os/devcontainer:latest /root/assets/init-workspace.sh
    # or with Docker:
    docker run -it --rm -v "PATH_TO_PROJECT:/workspace" \
-     ghcr.io/vig-os/devkit:latest /root/assets/init-workspace.sh
+     ghcr.io/vig-os/devcontainer:latest /root/assets/init-workspace.sh
    ```
 
    The script copies the devcontainer template (`.devcontainer/`), git hooks, README/CHANGELOG, and auth helpers into your project.
@@ -104,7 +104,7 @@ curl -sSfL https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh
 
    ```bash
    podman run -it --rm -v "PATH_TO_PROJECT:/workspace" \
-     ghcr.io/vig-os/devkit:latest /root/assets/init-workspace.sh --force
+     ghcr.io/vig-os/devcontainer:latest /root/assets/init-workspace.sh --force
    ```
 
    You will be prompted to confirm before files are replaced.
@@ -130,7 +130,7 @@ For detailed command descriptions, run `just --list --unsorted` or `just --help`
 ## Image Details
 
 - **Build**: Nix flake via `dockerTools.buildLayeredImage` (no Debian/Docker base image); bit-reproducible
-- **Registry**: `ghcr.io/vig-os/devkit`
+- **Registry**: `ghcr.io/vig-os/devcontainer`
 - **Architecture**: Multi-platform support (AMD64, ARM64)
 - **License**: Apache
 - **Latest Version**: [{{ version }}]({{ release_url }}) - {{ release_date }}

--- a/docs/templates/TESTING.md.j2
+++ b/docs/templates/TESTING.md.j2
@@ -54,7 +54,7 @@ These tests run against an initialized workspace to verify that the container wo
 Image and integration fixtures:
 
 - `container_tag`: Container tag from `TEST_CONTAINER_TAG` environment variable (defaults to "dev")
-- `container_image`: Full image name (e.g. `ghcr.io/vig-os/devkit:dev`)
+- `container_image`: Full image name (e.g. `ghcr.io/vig-os/devcontainer:dev`)
 - `test_container`: Running container instance for testing (session-scoped)
 - `host`: Testinfra host connection to the container (session-scoped)
 - `initialized_workspace`: Temporary workspace initialized with `init-workspace` script (session-scoped)

--- a/flake.nix
+++ b/flake.nix
@@ -1031,9 +1031,9 @@
             in
             pkgs.dockerTools.buildLayeredImage {
               # Name matches the published repo so the portable testinfra
-              # (#635), which targets ghcr.io/vig-os/devkit:<tag>, runs
+              # (#635), which targets ghcr.io/vig-os/devcontainer:<tag>, runs
               # unchanged against the loaded image under a unique tag.
-              name = "ghcr.io/vig-os/devkit";
+              name = "ghcr.io/vig-os/devcontainer";
               # Disposable discovery tag, matching the CI workflow's
               # INDEX_TAG (.github/workflows/nix-image.yml). The versioned
               # / :latest cutover is handled separately (#639).

--- a/install.sh
+++ b/install.sh
@@ -30,7 +30,7 @@
 set -euo pipefail
 
 # Configuration
-REGISTRY="ghcr.io/vig-os/devkit"
+REGISTRY="ghcr.io/vig-os/devcontainer"
 VERSION="latest"
 RUNTIME=""
 FORCE=""

--- a/justfile
+++ b/justfile
@@ -7,7 +7,7 @@
 # ===============================================================================
 # Allow TEST_REGISTRY to override REPO for testing (e.g., localhost:5000/test/)
 
-repo := env("TEST_REGISTRY", "ghcr.io/vig-os/devkit")
+repo := env("TEST_REGISTRY", "ghcr.io/vig-os/devcontainer")
 
 # ===============================================================================
 # INFO

--- a/justfile.gh
+++ b/justfile.gh
@@ -105,4 +105,4 @@ reset-changelog:
 # Pull image from registry (default: latest)
 [group('release')]
 pull version="latest":
-    podman pull "ghcr.io/vig-os/devkit:{{ version }}"
+    podman pull "ghcr.io/vig-os/devcontainer:{{ version }}"

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -10,7 +10,7 @@ if [[ "$VERSION" =~ ^version= ]]; then
 	VERSION="${VERSION#version=}"
 fi
 
-REPO="${2:-${TEST_REGISTRY:-ghcr.io/vig-os/devkit}}"
+REPO="${2:-${TEST_REGISTRY:-ghcr.io/vig-os/devcontainer}}"
 # Strip trailing slash if present
 REPO="${REPO%/}"
 

--- a/tests/bats/clean.bats
+++ b/tests/bats/clean.bats
@@ -63,8 +63,8 @@ setup() {
     assert_success
 }
 
-@test "clean.sh defaults to ghcr.io/vig-os/devkit registry" {
-    run grep 'ghcr.io/vig-os/devkit' "$CLEAN_SH"
+@test "clean.sh defaults to ghcr.io/vig-os/devcontainer registry" {
+    run grep 'ghcr.io/vig-os/devcontainer' "$CLEAN_SH"
     assert_success
 }
 

--- a/tests/bats/install.bats
+++ b/tests/bats/install.bats
@@ -83,7 +83,7 @@ setup() {
 @test "dry-run includes image registry in command" {
     run bash "$INSTALL_SH" --dry-run .
     assert_success
-    assert_output --partial "ghcr.io/vig-os/devkit"
+    assert_output --partial "ghcr.io/vig-os/devcontainer"
 }
 
 @test "dry-run output is shell-quoted for safe copy-paste" {
@@ -92,7 +92,7 @@ setup() {
     # The command is rendered from the real CMD array via printf '%q', so each
     # argument is shell-safe (quoted only when it contains special characters).
     assert_output --regexp '[^ ]+:/workspace'
-    assert_output --regexp 'ghcr\.io/vig-os/devkit:[^ ]+'
+    assert_output --regexp 'ghcr\.io/vig-os/devcontainer:[^ ]+'
 }
 
 # ── version flag ──────────────────────────────────────────────────────────────
@@ -100,13 +100,13 @@ setup() {
 @test "version flag appears in dry-run command" {
     run bash "$INSTALL_SH" --dry-run --version 1.2.3 .
     assert_success
-    assert_output --partial "ghcr.io/vig-os/devkit:1.2.3"
+    assert_output --partial "ghcr.io/vig-os/devcontainer:1.2.3"
 }
 
 @test "default version is latest" {
     run bash "$INSTALL_SH" --dry-run .
     assert_success
-    assert_output --partial "ghcr.io/vig-os/devkit:latest"
+    assert_output --partial "ghcr.io/vig-os/devcontainer:latest"
 }
 
 # ── force flag ────────────────────────────────────────────────────────────────

--- a/tests/bats/just.bats
+++ b/tests/bats/just.bats
@@ -244,7 +244,7 @@ EOF
 }
 
 @test "release workflow rollback resolves container image independently of core outputs" {
-    run bash -lc "grep -Fq -- 'resolve-image:' assets/workspace/.github/workflows/release.yml && grep -Fq -- 'needs: [resolve-image, core, extension, publish]' assets/workspace/.github/workflows/release.yml && grep -Fq -- 'image: ghcr.io/vig-os/devkit:\${{ needs.resolve-image.outputs.image-tag }}' assets/workspace/.github/workflows/release.yml"
+    run bash -lc "grep -Fq -- 'resolve-image:' assets/workspace/.github/workflows/release.yml && grep -Fq -- 'needs: [resolve-image, core, extension, publish]' assets/workspace/.github/workflows/release.yml && grep -Fq -- 'image: ghcr.io/vig-os/devcontainer:\${{ needs.resolve-image.outputs.image-tag }}' assets/workspace/.github/workflows/release.yml"
     assert_success
 }
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -182,7 +182,7 @@ def container_image(container_tag):
     """
     Construct the full container image name and verify it exists.
     """
-    image_name = f"ghcr.io/vig-os/devkit:{container_tag}"
+    image_name = f"ghcr.io/vig-os/devcontainer:{container_tag}"
 
     # Check if image exists
     result = subprocess.run(
@@ -793,7 +793,7 @@ def devcontainer_up(initialized_workspace, container_tag):
     # Run the devcontainer from the image *under test*, not the published
     # DEVCONTAINER_VERSION baked into the scaffolded .vig-os/.env. The
     # scaffolded docker-compose.yml resolves the runtime image as
-    # ghcr.io/vig-os/devkit:${DEVCONTAINER_VERSION:-latest}; compose reads
+    # ghcr.io/vig-os/devcontainer:${DEVCONTAINER_VERSION:-latest}; compose reads
     # the shell environment over the .env file, so exporting DEVCONTAINER_VERSION
     # here pins compose -- and every `devcontainer exec` below, which inherits
     # os.environ -- to TEST_CONTAINER_TAG. Refs #701.

--- a/tests/docker-compose.test.yml
+++ b/tests/docker-compose.test.yml
@@ -8,7 +8,7 @@
 services:
   # Service to initialize a test workspace using init-workspace.sh
   init-workspace:
-    image: ${TEST_IMAGE:-ghcr.io/vig-os/devkit:dev}
+    image: ${TEST_IMAGE:-ghcr.io/vig-os/devcontainer:dev}
     volumes:
       - test-workspace:/workspace
     # Note: TTY is allocated by 'podman compose run -it', not here
@@ -16,7 +16,7 @@ services:
 
   # Service to inspect the initialized workspace (for debugging)
   workspace-inspector:
-    image: ${TEST_IMAGE:-ghcr.io/vig-os/devkit:dev}
+    image: ${TEST_IMAGE:-ghcr.io/vig-os/devcontainer:dev}
     volumes:
       - test-workspace:/workspace
     command: ls -la /workspace

--- a/tests/test_install_script.py
+++ b/tests/test_install_script.py
@@ -1,7 +1,7 @@
 """
 Integration tests for install.sh — full deployment workflow.
 
-These tests require a built container image (ghcr.io/vig-os/devkit:<tag>)
+These tests require a built container image (ghcr.io/vig-os/devcontainer:<tag>)
 and are run by the test-integration CI job, NOT project-checks.
 
 Tests the full install.sh workflow which:
@@ -60,7 +60,7 @@ class TestInstallScriptIntegration:
 
         atexit.register(cleanup)
 
-        # Extract version from container_image (e.g., "ghcr.io/vig-os/devkit:dev" -> "dev")
+        # Extract version from container_image (e.g., "ghcr.io/vig-os/devcontainer:dev" -> "dev")
         version = container_image.split(":")[-1]
 
         # Run install.sh

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -550,7 +550,7 @@ class TestDevContainerDockerCompose:
         assert "image" in service, "devcontainer service missing 'image' field"
 
         # docker-compose now references version from .env / .vig-os
-        expected_image = "ghcr.io/vig-os/devkit:${DEVCONTAINER_VERSION:-latest}"
+        expected_image = "ghcr.io/vig-os/devcontainer:${DEVCONTAINER_VERSION:-latest}"
         assert service["image"] == expected_image, (
             f"Expected image to be {expected_image}, got: {service['image']}"
         )
@@ -1449,7 +1449,7 @@ class TestDevContainerCLI:
         """The running devcontainer must use the freshly-built image under test.
 
         The scaffolded docker-compose.yml pins the runtime image as
-        ``ghcr.io/vig-os/devkit:${DEVCONTAINER_VERSION:-latest}`` and
+        ``ghcr.io/vig-os/devcontainer:${DEVCONTAINER_VERSION:-latest}`` and
         ``initialize.sh`` writes the pinned ``DEVCONTAINER_VERSION`` (from the
         scaffolded ``.vig-os``) into ``.env``. Without an override the suite
         would validate fresh scaffolding running inside an old *published*
@@ -1480,7 +1480,7 @@ class TestDevContainerCLI:
             f"No running devcontainer found for workspace {workspace_path.name}"
         )
 
-        expected_image = f"ghcr.io/vig-os/devkit:{container_tag}"
+        expected_image = f"ghcr.io/vig-os/devcontainer:{container_tag}"
         assert any(expected_image in image for image in images), (
             f"Devcontainer is running from {images}, but the suite must validate "
             f"the image under test ({expected_image}). DEVCONTAINER_VERSION is not "
@@ -2159,7 +2159,7 @@ class TestJustRecipes:
         assert "build/test images" not in content
         assert "GHCR :latest" not in content
         assert 'pull version="latest"' not in content
-        assert "ghcr.io/vig-os/devkit" not in content
+        assert "ghcr.io/vig-os/devcontainer" not in content
 
 
 class TestDockerComposeProjectOverrides:
@@ -3042,7 +3042,7 @@ class TestVersionComparison:
         if compose_file.exists():
             content = compose_file.read_text()
             # Just verify it contains the image reference
-            assert "ghcr.io/vig-os/devkit:" in content
+            assert "ghcr.io/vig-os/devcontainer:" in content
 
 
 class TestVersionCheckJustIntegration:


### PR DESCRIPTION
## Summary

**Course-correction on the rename's scope.** The **project/repository** becomes
`devkit`, but the **published container image stays `ghcr.io/vig-os/devcontainer`**.

Rationale: the artifact *is* a dev container; `devkit` is the project/repo that
builds and ships it (image + installer + scaffold + flake templates). Repo-name ≠
artifact-name is normal, and keeping the image name descriptive means **consumers
never change their image ref** — no new GHCR package, no `--force` re-scaffold to
move registries, no two-package/"frozen old package" story.

This reverts the image-ref flip from **#973** while **keeping** the internal
`devkitImage` / `devkitImageEnv` flake attributes (the devkit project's build
outputs) and the `DEVKIT_VERSION` pin key.

## What changed back to `devcontainer`
Image ref across the flake image name, CI/release workflows, `install.sh`, the
scaffold template (compose + workflows + actions), tests, and regenerated
README/TESTING. `nix eval .#devkitImage.imageName` → `ghcr.io/vig-os/devcontainer`.

## What stays `devkit` (unchanged here)
Repo/project (`pyproject`/`package.json`), the `DEVKIT_*` manifest keys incl.
`DEVKIT_VERSION`, installer branding, `devkit-smoke-test` dispatch targets, and the
`devkitImage*` flake attrs.

## Docs
Rewrote the Unreleased CHANGELOG entry (flake-attr rename, image name unchanged)
and the `MIGRATION.md` rename section (repo-only rename; image + pins keep working).
Immutable released CHANGELOG entries that mention the old plan are left as history.

## Follow-ups (not in this PR)
- The seeded `ghcr.io/vig-os/devkit` package is now unused → delete it (needs
  `delete:packages` / UI).
- The docker-compose `${DEVCONTAINER_VERSION}` var is now consistent by default
  (no rename needed).

## Testing
`install`/`clean`/`just` bats, `test_flake_services` + `test_workflow_cachix`
(attrs kept), and `just precommit` full suite — all green.

Refs: #781