### PR TITLE
refactor(rename): point source-repo references at vig-os/devkit

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Documentation
-    url: https://github.com/vig-os/devcontainer/tree/dev/docs
+    url: https://github.com/vig-os/devkit/tree/dev/docs
     about: Browse project documentation before opening an issue

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -31,7 +31,7 @@
      If no changelog update is needed, write "No changelog needed" and explain why.
      Example:
      ### Added
-     - **SSH agent forwarding** ([#42](https://github.com/vig-os/devcontainer/issues/42))
+     - **SSH agent forwarding** ([#42](https://github.com/vig-os/devkit/issues/42))
        - Forward host SSH agent into devcontainer for seamless git authentication
 -->
 

--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -147,7 +147,7 @@ jobs:
           REPO="ghcr.io/vig-os/devcontainer"
           retry --retries 3 --backoff 10 --max-backoff 30 -- \
             cosign verify "$REPO:$VERSION" \
-              --certificate-identity-regexp='https://github.com/vig-os/devcontainer/.github/workflows/release.yml@refs/heads/release/' \
+              --certificate-identity-regexp='https://github.com/vig-os/devkit/.github/workflows/release.yml@refs/heads/release/' \
               --certificate-oidc-issuer='https://token.actions.githubusercontent.com'
           echo "✓ Cosign verification passed for $REPO:$VERSION"
 
@@ -593,7 +593,7 @@ jobs:
             if [ ${#UNIQUE_LEFT[@]} -gt 0 ]; then
               echo "ERROR: RC tags still present for $VERSION: ${UNIQUE_LEFT[*]}"
             fi
-            echo "See https://github.com/vig-os/devcontainer/issues/583"
+            echo "See https://github.com/vig-os/devkit/issues/583"
             exit 1
           fi
 

--- a/.trivyignore
+++ b/.trivyignore
@@ -5,7 +5,7 @@
 # 3. Have acceptable risk for devcontainer usage
 #
 # Each entry requires an Expiration date. Expired entries cause CI to fail,
-# forcing periodic review. Tracking: https://github.com/vig-os/devcontainer/issues/512
+# forcing periodic review. Tracking: https://github.com/vig-os/devkit/issues/512
 
 # CVE-2026-42504: Go stdlib MIME header DoS in gh binary
 # Risk Assessment: LOW (devcontainer context)
@@ -13,7 +13,7 @@
 # - Requires maliciously-crafted MIME headers; gh validates GitHub API responses only
 # - Latest gh v2.93.0 (2026-05-27) still embeds Go 1.26.3; fix requires Go 1.26.4 rebuild
 # - Fresh image build (gh 2.93.0, uv 0.11.19) cleared all other bundled-tool HIGH findings
-# - Tracking: https://github.com/vig-os/devcontainer/issues/512, #564
+# - Tracking: https://github.com/vig-os/devkit/issues/512, #564
 Expiration: 2026-09-01
 CVE-2026-42504
 
@@ -21,7 +21,7 @@ CVE-2026-42504
 # Risk Assessment: N/A (not a vulnerability)
 # - JWT-like string in typos crate test fixtures under /opt/pre-commit-cache
 # - Not a live credential; embedded test data only
-# - Tracking: https://github.com/vig-os/devcontainer/issues/512
+# - Tracking: https://github.com/vig-os/devkit/issues/512
 Expiration: 2026-09-01
 jwt-token
 
@@ -32,7 +32,7 @@ jwt-token
 #   path was decommissioned (#642), so :latest cannot be rebuilt to pull deb12u2.
 #   Time-box the ignore until the Nix image ships.
 # - jq processes trusted local JSON in devcontainer workflows, not untrusted input
-# - Tracking: https://github.com/vig-os/devcontainer/issues/805, #512
+# - Tracking: https://github.com/vig-os/devkit/issues/805, #512
 Expiration: 2026-09-01
 CVE-2026-32316
 CVE-2026-40164

--- a/.vulnixignore
+++ b/.vulnixignore
@@ -20,7 +20,7 @@
 # Each accepted entry should record WHY (patched-in-nixpkgs / not-exploitable /
 # awaiting-upstream) per docs/CONTAINER_SECURITY.md.
 #
-# Tracking: https://github.com/vig-os/devcontainer/issues/637
+# Tracking: https://github.com/vig-os/devkit/issues/637
 
 # ============================================================================
 # Triage for the nixos-26.05 baseline (#639 publish-cutover prep), 2026-06-23.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Repository renamed `vig-os/devcontainer` → `vig-os/devkit`** ([#781](https://github.com/vig-os/devkit/issues/781))
+  - The source repository is renamed to `devkit`; GitHub redirects the old URLs.
+    All source-repo references now point at `vig-os/devkit`: clone/raw/API URLs,
+    the documented `install.sh` one-liners, the `devc-upgrade` recipe, the release
+    workflow's cosign signing identity (`--certificate-identity-regexp`), and the
+    image's OCI `source` label. The **published image is unchanged** —
+    `ghcr.io/vig-os/devcontainer` — so existing pins and `podman pull` commands
+    keep working with no change; a re-scaffold only refreshes the source URLs.
+
 ### Deprecated
 
 ### Removed

--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -51,7 +51,7 @@ build, so the first `direnv allow` completes in seconds.
 3. **Clone and allow direnv:**
 
    ```bash
-   git clone git@github.com:vig-os/devcontainer.git
+   git clone git@github.com:vig-os/devkit.git
    cd devcontainer
    direnv allow        # first allow fetches the closure from Cachix (seconds on a warm cache)
    ```
@@ -83,7 +83,7 @@ the two (or both) via the delivery mode: `--mode devcontainer|direnv|both`
 Clone this repository, enter the Nix dev shell, then bootstrap the project:
 
 ```bash
-git clone git@github.com:vig-os/devcontainer.git
+git clone git@github.com:vig-os/devkit.git
 cd devcontainer
 direnv allow        # (recommended) loads the flake toolchain — or run `nix develop`
 just init           # Gate prerequisites and bootstrap the project (venv, git hooks, pre-commit)
@@ -98,7 +98,7 @@ template, pre-commit). It is safe to re-run.
 When contributing to this project, follow this workflow:
 
 1. **Create an issue** to report a bug or request a feature
-   - Use [GitHub Issues](https://github.com/vig-os/devcontainer/issues) to document the problem or feature request
+   - Use [GitHub Issues](https://github.com/vig-os/devkit/issues) to document the problem or feature request
    - This helps track work and provides context for reviewers
 
 2. **Create a branch from `dev` branch**
@@ -124,7 +124,7 @@ When contributing to this project, follow this workflow:
    - Update the [CHANGELOG](CHANGELOG.md) with your changes in the `[Unreleased]` section
      - Add entries under appropriate categories (Added, Changed, Fixed, etc.)
      - Use clear, concise descriptions
-     - Reference related [issues](https://github.com/vig-os/devcontainer/issues) and [PRs](https://github.com/vig-os/devcontainer/pulls) when applicable
+     - Reference related [issues](https://github.com/vig-os/devkit/issues) and [PRs](https://github.com/vig-os/devkit/pulls) when applicable
    - Keep documentation in sync with code changes
 
 5. **Verify tests pass**
@@ -141,8 +141,8 @@ When contributing to this project, follow this workflow:
    ```
 
 6. **Create a pull request**
-   - Create a [pull request](https://github.com/vig-os/devcontainer/pulls) targeting the `dev` branch
-   - Link the PR to the related [issue(s)](https://github.com/vig-os/devcontainer/issues)
+   - Create a [pull request](https://github.com/vig-os/devkit/pulls) targeting the `dev` branch
+   - Link the PR to the related [issue(s)](https://github.com/vig-os/devkit/issues)
    - Provide a clear description of your changes
 
 7. **Accepted contributions will be merged into `dev` branch**

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ That's it! All development tools (Python, git, pre-commit, just, etc.) are inclu
 ### One-Line Install
 
 ```bash
-curl -sSfL https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh | bash -s -- ~/my-project
+curl -sSfL https://raw.githubusercontent.com/vig-os/devkit/main/install.sh | bash -s -- ~/my-project
 ```
 
 This will:
@@ -42,26 +42,26 @@ also `both`. `devcontainer` scaffolds `.devcontainer/` only; `direnv` scaffolds
 
 ```bash
 # Use specific version
-curl -sSfL https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh | bash -s -- --version 0.2.1 ~/my-project
+curl -sSfL https://raw.githubusercontent.com/vig-os/devkit/main/install.sh | bash -s -- --version 0.2.1 ~/my-project
 
 # Upgrade existing project (overwrites template files)
-curl -sSfL https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh | bash -s -- --force ~/my-project
+curl -sSfL https://raw.githubusercontent.com/vig-os/devkit/main/install.sh | bash -s -- --force ~/my-project
 
 # Override project name
-curl -sSfL https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh | bash -s -- --name my_custom_name ~/my-project
+curl -sSfL https://raw.githubusercontent.com/vig-os/devkit/main/install.sh | bash -s -- --name my_custom_name ~/my-project
 
 # Override organization name (default: vigOS)
-curl -sSfL https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh | bash -s -- --org MyOrg ~/my-project
+curl -sSfL https://raw.githubusercontent.com/vig-os/devkit/main/install.sh | bash -s -- --org MyOrg ~/my-project
 
 # Choose the delivery mode: devcontainer | direnv | both (default: both)
-curl -sSfL https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh | bash -s -- --mode direnv ~/my-project
+curl -sSfL https://raw.githubusercontent.com/vig-os/devkit/main/install.sh | bash -s -- --mode direnv ~/my-project
 
 # Preview without executing
-curl -sSfL https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh | bash -s -- --dry-run ~/my-project
+curl -sSfL https://raw.githubusercontent.com/vig-os/devkit/main/install.sh | bash -s -- --dry-run ~/my-project
 
 # Force specific runtime
-curl -sSfL https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh | bash -s -- --docker ~/my-project
-curl -sSfL https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh | bash -s -- --podman ~/my-project
+curl -sSfL https://raw.githubusercontent.com/vig-os/devkit/main/install.sh | bash -s -- --docker ~/my-project
+curl -sSfL https://raw.githubusercontent.com/vig-os/devkit/main/install.sh | bash -s -- --podman ~/my-project
 ```
 
 > **Note:** If podman or docker is not installed, the script provides OS-specific installation instructions for macOS, Ubuntu/Debian, Fedora, Arch Linux, and Windows.
@@ -199,7 +199,7 @@ For detailed command descriptions, run `just --list --unsorted` or `just --help`
 - **Registry**: `ghcr.io/vig-os/devcontainer`
 - **Architecture**: Multi-platform support (AMD64, ARM64)
 - **License**: Apache
-- **Latest Version**: [1.0.0](https://github.com/vig-os/devcontainer/releases/tag/1.0.0) - 2026-07-10
+- **Latest Version**: [1.0.0](https://github.com/vig-os/devkit/releases/tag/1.0.0) - 2026-07-10
 - **Image tags**: bare semver (`0.2.1`, `latest`) — git tags use `v` prefix (`v0.2.1`) but image tags do not
 
 ## Features

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -15,7 +15,7 @@ Older versions are not maintained.
 **Do not open a public GitHub issue for security vulnerabilities.**
 
 To report a vulnerability, use
-[GitHub Private Vulnerability Reporting](https://github.com/vig-os/devcontainer/security/advisories/new).
+[GitHub Private Vulnerability Reporting](https://github.com/vig-os/devkit/security/advisories/new).
 
 When reporting, please include:
 

--- a/assets/smoke-test/.github/workflows/repository-dispatch.yml
+++ b/assets/smoke-test/.github/workflows/repository-dispatch.yml
@@ -198,7 +198,7 @@ jobs:
           TAG: ${{ needs.validate.outputs.tag }}
         run: |
           set -euo pipefail
-          INSTALL_URL="https://raw.githubusercontent.com/vig-os/devcontainer/${TAG}/install.sh"
+          INSTALL_URL="https://raw.githubusercontent.com/vig-os/devkit/${TAG}/install.sh"
           ATTEMPT=1
           MAX_ATTEMPTS=3
           until [ "${ATTEMPT}" -gt "${MAX_ATTEMPTS}" ]; do
@@ -1069,7 +1069,7 @@ jobs:
           )"
 
           gh issue create \
-            --repo vig-os/devcontainer \
+            --repo vig-os/devkit \
             --title "Smoke-test dispatch failed for ${TAG:-unknown}" \
             --label bug \
             --body "${ISSUE_BODY}"

--- a/assets/smoke-test/README.md
+++ b/assets/smoke-test/README.md
@@ -1,7 +1,7 @@
 # devcontainer Smoke Test
 
 This repository is a smoke-test workspace for the
-[vig-os/devcontainer](https://github.com/vig-os/devcontainer) project.
+[vig-os/devcontainer](https://github.com/vig-os/devkit) project.
 
 Its purpose is to verify that the devcontainer template and the shipped CI
 workflow run successfully on real GitHub-hosted runners, not only in local or
@@ -35,7 +35,7 @@ This repository is intentionally minimal. It is used to:
 - **Execution/verification target**: this repository
 
 Template or workflow changes should be made in
-[`vig-os/devcontainer`](https://github.com/vig-os/devcontainer), then validated
+[`vig-os/devcontainer`](https://github.com/vig-os/devkit), then validated
 here through a normal PR run.
 
 ## Automated deploy-and-test flow
@@ -89,7 +89,7 @@ If this repository is lost or needs to be rebuilt, recreate it from the
 2. Clone it locally and run the installer with smoke-test assets enabled:
 
    ```bash
-   curl -sSfL https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh | bash -s -- --smoke-test .
+   curl -sSfL https://raw.githubusercontent.com/vig-os/devkit/main/install.sh | bash -s -- --smoke-test .
    ```
 
 3. Commit the generated files and push to `main`.

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -11,6 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Repository renamed `vig-os/devcontainer` → `vig-os/devkit`** ([#781](https://github.com/vig-os/devkit/issues/781))
+  - The source repository is renamed to `devkit`; GitHub redirects the old URLs.
+    All source-repo references now point at `vig-os/devkit`: clone/raw/API URLs,
+    the documented `install.sh` one-liners, the `devc-upgrade` recipe, the release
+    workflow's cosign signing identity (`--certificate-identity-regexp`), and the
+    image's OCI `source` label. The **published image is unchanged** —
+    `ghcr.io/vig-os/devcontainer` — so existing pins and `podman pull` commands
+    keep working with no change; a re-scaffold only refreshes the source URLs.
+
 ### Deprecated
 
 ### Removed

--- a/assets/workspace/.devcontainer/README.md
+++ b/assets/workspace/.devcontainer/README.md
@@ -1,7 +1,7 @@
 # Devcontainer Reference
 
 This folder contains everything VS Code needs to launch the
-[vigOS development container](https://github.com/vig-os/devcontainer) inside your project.
+[vigOS development container](https://github.com/vig-os/devkit) inside your project.
 
 - **Version**: This is an unreleased development version
 

--- a/assets/workspace/.devcontainer/justfile.devc
+++ b/assets/workspace/.devcontainer/justfile.devc
@@ -67,7 +67,7 @@ devc-upgrade:
         echo ""
         echo "Or use the curl method:"
         echo ""
-        echo "    curl -sSf https://raw.githubusercontent.com/vig-os/devcontainer/${REF}/install.sh | bash -s -- --force ${PIN_ARGS[*]} ."
+        echo "    curl -sSf https://raw.githubusercontent.com/vig-os/devkit/${REF}/install.sh | bash -s -- --force ${PIN_ARGS[*]} ."
         echo ""
         exit 1
     fi
@@ -94,11 +94,11 @@ devc-upgrade:
     echo "✓ Using $RUNTIME"
     echo ""
     echo "Note: the installer refuses upgrades on main/dev/release/* or a dirty tree."
-    echo "      Preview first:  curl -sSf https://raw.githubusercontent.com/vig-os/devcontainer/${REF}/install.sh | bash -s -- --force ${PIN_ARGS[*]} --preview ."
-    echo "      Bypass guard:   curl -sSf https://raw.githubusercontent.com/vig-os/devcontainer/${REF}/install.sh | bash -s -- --force ${PIN_ARGS[*]} --skip-preflight ."
+    echo "      Preview first:  curl -sSf https://raw.githubusercontent.com/vig-os/devkit/${REF}/install.sh | bash -s -- --force ${PIN_ARGS[*]} --preview ."
+    echo "      Bypass guard:   curl -sSf https://raw.githubusercontent.com/vig-os/devkit/${REF}/install.sh | bash -s -- --force ${PIN_ARGS[*]} --skip-preflight ."
     echo ""
     echo "Downloading and running install script..."
-    curl -sSf "https://raw.githubusercontent.com/vig-os/devcontainer/${REF}/install.sh" | bash -s -- --force "${PIN_ARGS[@]}" .
+    curl -sSf "https://raw.githubusercontent.com/vig-os/devkit/${REF}/install.sh" | bash -s -- --force "${PIN_ARGS[@]}" .
 
 # -------------------------------------------------------------------------------
 # DEVCONTAINER (host-side only)

--- a/assets/workspace/.devcontainer/scripts/version-check.sh
+++ b/assets/workspace/.devcontainer/scripts/version-check.sh
@@ -37,7 +37,7 @@ MUTED_UNTIL_FILE="$LOCAL_DIR/.muted-until"
 CACHE_FILE="$LOCAL_DIR/.latest-version"
 
 # API endpoint
-GITHUB_API="https://api.github.com/repos/vig-os/devcontainer/releases/latest"
+GITHUB_API="https://api.github.com/repos/vig-os/devkit/releases/latest"
 
 # Defaults
 DEFAULT_CHECK_INTERVAL=86400  # 24 hours in seconds
@@ -297,7 +297,7 @@ notify_update() {
     echo ""
     echo -e "  Or without just:"
     echo ""
-    echo -e "    curl -sSfL https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh | bash -s -- --force ."
+    echo -e "    curl -sSfL https://raw.githubusercontent.com/vig-os/devkit/main/install.sh | bash -s -- --force ."
     echo ""
     echo -e "  After upgrading, rebuild the container in VS Code."
     echo ""

--- a/assets/workspace/.github/ISSUE_TEMPLATE/config.yml
+++ b/assets/workspace/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Documentation
-    url: https://github.com/vig-os/devcontainer/tree/dev/docs
+    url: https://github.com/vig-os/devkit/tree/dev/docs
     about: Browse project documentation before opening an issue

--- a/assets/workspace/.github/pull_request_template.md
+++ b/assets/workspace/.github/pull_request_template.md
@@ -31,7 +31,7 @@
      If no changelog update is needed, write "No changelog needed" and explain why.
      Example:
      ### Added
-     - **SSH agent forwarding** ([#42](https://github.com/vig-os/devcontainer/issues/42))
+     - **SSH agent forwarding** ([#42](https://github.com/vig-os/devkit/issues/42))
        - Forward host SSH agent into devcontainer for seamless git authentication
 -->
 

--- a/assets/workspace/docs/container-ci-quirks.md
+++ b/assets/workspace/docs/container-ci-quirks.md
@@ -65,7 +65,7 @@ runtime.
 
 The shipped container workflows support **authenticated** GHCR pulls, so a
 **private** (or anonymous-rate-limited) `ghcr.io/vig-os/devcontainer` image works
-without any per-repo YAML edits ([#920](https://github.com/vig-os/devcontainer/issues/920)).
+without any per-repo YAML edits ([#920](https://github.com/vig-os/devkit/issues/920)).
 Public consumers are unaffected: the automatic `GITHUB_TOKEN` performs an
 authenticated pull of a public image, which succeeds unchanged.
 
@@ -109,5 +109,5 @@ set the GHCR_PULL_TOKEN secret / grant packages:read") from a **missing tag**
 public images when no token is provided.
 
 The broader workflow audit that this fix rides is tracked in
-[#781](https://github.com/vig-os/devcontainer/issues/781) and
-[#854](https://github.com/vig-os/devcontainer/issues/854).
+[#781](https://github.com/vig-os/devkit/issues/781) and
+[#854](https://github.com/vig-os/devkit/issues/854).

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -40,14 +40,14 @@ one of four modes:
   `nix develop`) drops you into the shared toolchain on the host, no container.
   The stub is never overwritten on re-scaffold; update with `nix flake update`.
   The shipped `ci.yml` is a **nix-direct** variant
-  ([#854](https://github.com/vig-os/devcontainer/issues/854)): no image
+  ([#854](https://github.com/vig-os/devkit/issues/854)): no image
   resolution and no in-container jobs — the runner installs Nix (with the vig-os
   Cachix substituter) and drives the same `just sync` / `just precommit` /
   `just test` contract inside the flake dev-shell via `nix develop -c`. See
   [direnv-mode CI](#direnv-mode-ci) for the supported boundary.
 - **`both`** — everything above (the default).
 - **`bare`** — the standards layer only
-  ([#885](https://github.com/vig-os/devcontainer/issues/885)): justfiles,
+  ([#885](https://github.com/vig-os/devkit/issues/885)): justfiles,
   `.pre-commit-config.yaml`, `.github/` CI, and `.vig-os` — no `.devcontainer/`,
   no `flake.nix`/`.envrc`. The tools come from
   the host (`uv`, `just`, `prek`), and the shipped `ci.yml` is a host-native
@@ -64,12 +64,12 @@ so upgrades never need `--mode` again.
 `.devcontainer/`, a `.vig-os`-driven `resolve-image` job hard-fails and bricks
 every workflow that runs `container: ghcr.io/vig-os/devcontainer:<pin>`. To keep
 the main lane working, `direnv` mode ships a **nix-direct `ci.yml`** overlay
-([#854](https://github.com/vig-os/devcontainer/issues/854)) that runs on the host
+([#854](https://github.com/vig-os/devkit/issues/854)) that runs on the host
 runner (`install-nix` + Cachix → `nix develop -c just sync|precommit|test`),
 mirroring this repo's own project-checks job.
 
 **Supported boundary (until the devkit rename cycle,
-[#781](https://github.com/vig-os/devcontainer/issues/781), completes the full
+[#781](https://github.com/vig-os/devkit/issues/781), completes the full
 workflow audit):** only `ci.yml` is converted for direnv mode. These shipped
 workflows stay **container-based and devcontainer-mode-only**, so a direnv-only
 consumer should delete or disable them (they still work unchanged in
@@ -84,19 +84,19 @@ Container-independent workflows keep working in every mode: `codeql.yml`,
 
 ## The `.vig-os` project manifest
 
-Since [#885](https://github.com/vig-os/devcontainer/issues/885), `.vig-os` is
+Since [#885](https://github.com/vig-os/devkit/issues/885), `.vig-os` is
 the project's declarative manifest, not just a version pin. Flat `KEY=VALUE`
 lines with `#` comments; every consumer parses it line-based and ignores
 unknown keys:
 
 | Key | Meaning |
 |-----|---------|
-| `DEVCONTAINER_VERSION` | Scaffold/image version pin (managed by release automation; keeps its legacy name until the devkit rename, [#781](https://github.com/vig-os/devcontainer/issues/781)) |
+| `DEVCONTAINER_VERSION` | Scaffold/image version pin (managed by release automation; keeps its legacy name until the devkit rename, [#781](https://github.com/vig-os/devkit/issues/781)) |
 | `DEVKIT_MODE` | Delivery mode: `devcontainer` \| `direnv` \| `both` \| `bare` |
 | `DEVKIT_PROJECT` | Persisted project short name (`SHORT_NAME`) |
 | `DEVKIT_ORG` | Persisted organization name (`ORG_NAME`) |
 | `DEVKIT_REPO` | Persisted GitHub `owner/repo` (Renovate preset) |
-| `DEVKIT_MODULES` | Reserved: space-separated capability modules mirroring `mkProjectShell`'s `modules = [ … ]` ([#884](https://github.com/vig-os/devcontainer/issues/884)) |
+| `DEVKIT_MODULES` | Reserved: space-separated capability modules mirroring `mkProjectShell`'s `modules = [ … ]` ([#884](https://github.com/vig-os/devkit/issues/884)) |
 
 How it behaves:
 
@@ -120,7 +120,7 @@ How it behaves:
   preflight-guard flow below) and re-run the upgrade.
 - **Future flags live here.** The manifest is the home for upcoming per-project
   devkit switches (e.g. the raw-YAML hook opt-out planned in
-  [#883](https://github.com/vig-os/devcontainer/issues/883)). `.vig-os` is a
+  [#883](https://github.com/vig-os/devkit/issues/883)). `.vig-os` is a
   managed file: the devkit-known keys are re-read and written back on upgrade —
   do not park unrelated custom keys in it.
 
@@ -145,10 +145,10 @@ image:
 - **Python is CPython 3.14, uv-managed — but opt-in.** The image provides
   Python and `uv`, yet the scaffold itself is **language-neutral** and ships no
   `pyproject.toml`
-  ([#929](https://github.com/vig-os/devcontainer/issues/929)); the `just`
+  ([#929](https://github.com/vig-os/devkit/issues/929)); the `just`
   lint/format/test recipes no-op until one exists. Add a Python package layout
   with `nix flake init -t github:vig-os/devcontainer#python`
-  ([#930](https://github.com/vig-os/devcontainer/issues/930)) or `uv init`. Once
+  ([#930](https://github.com/vig-os/devkit/issues/930)) or `uv init`. Once
   present, the project venv lives at `/root/assets/workspace/.venv` and is
   populated by `just sync` (`uv sync`).
   Pin `requires-python` as a **range** (`>=3.14,<3.15`), never an exact patch —
@@ -202,7 +202,7 @@ tiered contract:
 
 2. **Native deps, `direnv` mode (preferred).** Enable the curated `native`
    capability module in the project flake
-   ([#884](https://github.com/vig-os/devcontainer/issues/884), contract in
+   ([#884](https://github.com/vig-os/devkit/issues/884), contract in
    [`docs/rfcs/ADR-capability-modules.md`](rfcs/ADR-capability-modules.md)):
 
    ```nix
@@ -220,9 +220,9 @@ tiered contract:
    find a real compiler regardless of what the image's baked interpreter
    recorded at image-build time (the image's sysconfig records are sanitized
    to the same generic names —
-   [#879](https://github.com/vig-os/devcontainer/issues/879)). This path is
+   [#879](https://github.com/vig-os/devkit/issues/879)). This path is
    field-validated by the 0.4.0 downstream runs
-   ([#639](https://github.com/vig-os/devcontainer/issues/639)).
+   ([#639](https://github.com/vig-os/devkit/issues/639)).
 
    Capability modules are a **dev-shell / direnv-mode feature only**: enabling
    one changes nothing about the published image, which stays base-only.
@@ -245,7 +245,7 @@ tiered contract:
    This is the supported interim answer for devcontainer-mode repos whose
    dependencies lack `cp314` wheels. The pinned `nix develop -c` form also
    works in CI until the nix-direct CI lane
-   ([#854](https://github.com/vig-os/devcontainer/issues/854)) lands; #854
+   ([#854](https://github.com/vig-os/devkit/issues/854)) lands; #854
    tracks running consumer CI inside the project devshell so the contract is
    enforced in CI, not just locally.
 
@@ -284,12 +284,12 @@ The published image will **not** ship gcc/cmake:
   only a pinned project flake provides reproducibly.
 
 The in-image behavior when no toolchain is provided is tracked in
-[#879](https://github.com/vig-os/devcontainer/issues/879); the toolchain
+[#879](https://github.com/vig-os/devkit/issues/879); the toolchain
 itself always comes from one of the tiers above.
 
 ## Customizing pre-commit hooks from the project flake (opt-in)
 
-Since [#883](https://github.com/vig-os/devcontainer/issues/883) the shared
+Since [#883](https://github.com/vig-os/devkit/issues/883) the shared
 hook set is defined once in the vigOS flake, and a consumer can compose it
 from the **preserved** project `flake.nix` instead of hand-editing the
 scaffolded `.pre-commit-config.yaml`:
@@ -316,7 +316,7 @@ The contract:
 
 - **Opt-in only.** Without a `hooks`/`hooksExcludes` argument nothing changes:
   the dev-shell is byte-identical to before and your (preserved,
-  [#878](https://github.com/vig-os/devcontainer/issues/878))
+  [#878](https://github.com/vig-os/devkit/issues/878))
   `.pre-commit-config.yaml` stays the runner config, hand-managed by you.
 - **Opting in makes the flake the generator.** On shell entry (a
   config-only snippet inside the `shellHook`) the rendered
@@ -342,7 +342,7 @@ The contract:
   base set does not include it (the scaffolded YAML runs it from its upstream
   pre-commit repo). Add it as a custom hook if you need it under generation.
 - The planned declarative `.vig-os` manifest
-  ([#885](https://github.com/vig-os/devcontainer/issues/885)) will carry an
+  ([#885](https://github.com/vig-os/devkit/issues/885)) will carry an
   explicit raw-YAML opt-out flag so the choice is recorded per-repo rather
   than inferred from the file state.
 
@@ -360,7 +360,7 @@ The contract:
 An upgrade (`just devc-upgrade`, or `install.sh --force`) rewrites and deletes
 files across the consumer tree, so the installer requires it to land on a
 dedicated working branch as a single reviewable, revertible diff
-([#886](https://github.com/vig-os/devcontainer/issues/886)):
+([#886](https://github.com/vig-os/devkit/issues/886)):
 
 - **Protected branches refuse** — `main`, `dev`, `release/*` (prefix), and a
   detached `HEAD`. On a protected branch with a clean tree the installer
@@ -377,7 +377,7 @@ dedicated working branch as a single reviewable, revertible diff
 To see what an upgrade would change before running it, use `--preview`:
 
 ```bash
-curl -sSfL https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh \
+curl -sSfL https://raw.githubusercontent.com/vig-os/devkit/main/install.sh \
   | bash -s -- --force --preview .
 ```
 
@@ -389,7 +389,7 @@ and computes no file report).
 
 `install.sh --version <X> --force` refreshes the scaffold and pins `<X>` in
 `.vig-os`, but files you own are **preserved, not migrated**. Field-validated
-checklist ([#859](https://github.com/vig-os/devcontainer/issues/859)) after the
+checklist ([#859](https://github.com/vig-os/devkit/issues/859)) after the
 re-scaffold:
 
 1. **Base recipes moved into `justfile.project`** — 0.4.0 retired
@@ -398,7 +398,7 @@ re-scaffold:
    preserved on upgrade. The shipped `ci.yml` calls `just sync` /
    `just precommit` / `just test`, so the installer appends any of these
    recipes your preserved file does not already resolve (a clearly marked
-   block, [#877](https://github.com/vig-os/devcontainer/issues/877)) and
+   block, [#877](https://github.com/vig-os/devkit/issues/877)) and
    removes the stale `.devcontainer/justfile.base`. Review the appended
    block and fold it into your own recipes; also verify the root `justfile`
    still carries the scaffold `import?` lines — without them no layered
@@ -406,7 +406,7 @@ re-scaffold:
 2. **`.pre-commit-config.yaml` is preserved on upgrade** — earlier upgrades
    replaced it wholesale, silently dropping repo-specific global and per-hook
    `exclude:` patterns (the autofix hooks then rewrote data files they must
-   never touch, [#878](https://github.com/vig-os/devcontainer/issues/878)).
+   never touch, [#878](https://github.com/vig-os/devkit/issues/878)).
    The installer now keeps your file and prints a diff against the incoming
    template — review it and fold in the template evolution you want (e.g.
    `default_language_version`, runner-compat fixes, new hooks). It also warns
@@ -414,17 +414,17 @@ re-scaffold:
    with `prek validate-config .pre-commit-config.yaml`.
 3. **`pre-commit` invocations → `prek`** — the `pre-commit` binary is gone
    from the 0.4.0 image and venv; the hook runner is `prek` (a drop-in for
-   `run`-style invocations, [#778](https://github.com/vig-os/devcontainer/issues/778)).
+   `run`-style invocations, [#778](https://github.com/vig-os/devkit/issues/778)).
    Rename every invocation in files the upgrade preserves or your repo owns:
    the `justfile.project` `precommit` recipe (`uv run pre-commit run
    --all-files` → `prek run --all-files`), repo-managed `.githooks/` scripts
    beyond the scaffold-shipped three (e.g. a `pre-push` hook), hook `entry:`
    lines in `.pre-commit-config.yaml`, and CI configs. The installer scans
    the preserved surfaces and warns with `file:line`
-   ([#881](https://github.com/vig-os/devcontainer/issues/881)). As a bridge,
+   ([#881](https://github.com/vig-os/devkit/issues/881)). As a bridge,
    0.4.x images shipped a deprecated `pre-commit → prek` shim that printed a
    stderr notice; the one-cycle window is over and **0.5 images carry no
-   `pre-commit` binary at all** ([#897](https://github.com/vig-os/devcontainer/issues/897))
+   `pre-commit` binary at all** ([#897](https://github.com/vig-os/devkit/issues/897))
    — unrenamed invocations now fail with exit 127, so act on the installer's
    scan warnings before committing. While editing old `.githooks`
    scripts, also change `#!/bin/bash` shebangs to `#!/usr/bin/env bash`:
@@ -433,7 +433,7 @@ re-scaffold:
    still calling `pre-commit` against a new image, or a new scaffold on an image
    too old to ship `prek`) now surfaces as a one-line `::error::` from the
    `Verify toolchain (prek present)` guard step in the shipped `ci.yml` lint job
-   ([#854](https://github.com/vig-os/devcontainer/issues/854)), instead of an
+   ([#854](https://github.com/vig-os/devkit/issues/854)), instead of an
    opaque `exit 127` deep in the `just precommit` log.
 4. **Recipe renames** — the managed base recipes are now `devc-*`-namespaced
    and the template test recipe is `just test` (formerly `just test-pytest`).
@@ -455,7 +455,7 @@ re-scaffold:
 ## The retired Debian line (historical)
 
 The Debian build path was decommissioned in
-[#642](https://github.com/vig-os/devcontainer/issues/642): the final
+[#642](https://github.com/vig-os/devkit/issues/642): the final
 Debian-built release is **0.3.9**, and every release from 0.4.0 onward is
 Nix-built. Released images are never deleted, so 0.3.9 remains pullable
 (`DEVCONTAINER_VERSION=0.3.9` in the repo-root `.vig-os`), but the line is
@@ -465,7 +465,7 @@ frozen — it receives no CVE fixes and is not a supported rollback track.
 
 The **repository** is scheduled to be renamed to **`devkit`** in the release
 cycle after the Nix cutover
-([#781](https://github.com/vig-os/devcontainer/issues/781)). GitHub redirects the
+([#781](https://github.com/vig-os/devkit/issues/781)). GitHub redirects the
 old repository URL. The **published image is unchanged** — it stays
 `ghcr.io/vig-os/devcontainer` (the artifact is a dev container; `devkit` is the
 project that builds and ships it), so existing `.vig-os` pins and `podman pull`

--- a/docs/NIX.md
+++ b/docs/NIX.md
@@ -78,7 +78,7 @@ on `PATH` (e.g. the podman image CI lane).
 ## Capability modules (`mkProjectShell` `modules`)
 
 `mkProjectShell` composes opt-in **capability modules**
-([#884](https://github.com/vig-os/devcontainer/issues/884); contract and
+([#884](https://github.com/vig-os/devkit/issues/884); contract and
 composition rules in
 [ADR-capability-modules](rfcs/ADR-capability-modules.md)): a consumer
 declares a capability by name instead of hand-picking packages:
@@ -418,7 +418,7 @@ Pulling from the public `vig-os` cache needs no token (`cachix use vig-os` write
 the same lines). Then:
 
 ```bash
-git clone git@github.com:vig-os/devcontainer.git
+git clone git@github.com:vig-os/devkit.git
 cd devcontainer
 direnv allow        # first allow fetches the closure from Cachix
 ```

--- a/docs/RELEASE_CYCLE.md
+++ b/docs/RELEASE_CYCLE.md
@@ -136,7 +136,7 @@ graph TB
 3. **Candidate Publish** (`publish-candidate`): Build/test/publish `X.Y.Z-rcN` and dispatch cross-repo validation workflow
 4. **Cross-Repo Validation**: Smoke-test runs asynchronously after candidate and final publish; see `docs/CROSS_REPO_RELEASE_GATE.md`. Before promotion, **`promote-release.yml`** requires a published **final** (non-draft, non-prerelease) GitHub Release for the version tag on `devkit-smoke-test` so human acceptance downstream is reflected before `:latest` and the draft release are published.
 5. **Finalization & Post-Release**: Publish final image/tag, open a **draft** GitHub Release for human review, then merge PR to `main` and let sync automation update `dev`
-6. **Promote & cleanup**: `promote-release.yml` updates `:latest`, publishes the draft release, merges the release PR, then runs a **best-effort** cleanup job (Refs [#463](https://github.com/vig-os/devcontainer/issues/463), [#583](https://github.com/vig-os/devcontainer/issues/583)): deletes GHCR RC image versions for `${VERSION}-rc*` (per-arch tags included) and matching RC cosign signatures, and deletes remote git RC tags for that base version when **no** GitHub Release is linked. GHCR deletes use **`GITHUB_TOKEN`** with **repo Admin** on the `devcontainer` package (see [Registry and cleanup tokens](#registry-and-cleanup-tokens-upstream)); the cleanup step fails loudly when RC tags remain. The cleanup job uses `continue-on-error`, so promote still completes. **Before this cleanup runs, migrate any consumers still pinned to an RC tag** (via `DEVCONTAINER_VERSION` in their `.vig-os` file) **to the final tag** — see [Phase 5](#phase-5-post-release-cleanup) ([#880](https://github.com/vig-os/devcontainer/issues/880)).
+6. **Promote & cleanup**: `promote-release.yml` updates `:latest`, publishes the draft release, merges the release PR, then runs a **best-effort** cleanup job (Refs [#463](https://github.com/vig-os/devkit/issues/463), [#583](https://github.com/vig-os/devkit/issues/583)): deletes GHCR RC image versions for `${VERSION}-rc*` (per-arch tags included) and matching RC cosign signatures, and deletes remote git RC tags for that base version when **no** GitHub Release is linked. GHCR deletes use **`GITHUB_TOKEN`** with **repo Admin** on the `devcontainer` package (see [Registry and cleanup tokens](#registry-and-cleanup-tokens-upstream)); the cleanup step fails loudly when RC tags remain. The cleanup job uses `continue-on-error`, so promote still completes. **Before this cleanup runs, migrate any consumers still pinned to an RC tag** (via `DEVCONTAINER_VERSION` in their `.vig-os` file) **to the final tag** — see [Phase 5](#phase-5-post-release-cleanup) ([#880](https://github.com/vig-os/devkit/issues/880)).
 
 ## Immutable releases, tag rulesets, and forward-fix policy
 
@@ -187,14 +187,14 @@ The `prepare-release.yml` workflow freezes the CHANGELOG on dev and creates the 
 2. ✅ **Prepare** job (skipped if --dry-run)
    - Runs `prepare-changelog prepare` → moves Unreleased content to `## [X.Y.Z] - TBD` + creates fresh empty Unreleased section
    - Commits prepared CHANGELOG to `dev` via API (single atomic commit — dev never loses `## Unreleased`)
-   - Creates `release/X.Y.Z` branch from that dev commit (the empty Unreleased is kept — see [#590](https://github.com/vig-os/devcontainer/issues/590))
+   - Creates `release/X.Y.Z` branch from that dev commit (the empty Unreleased is kept — see [#590](https://github.com/vig-os/devkit/issues/590))
    - Creates draft PR to `main` with CHANGELOG content as body
 
 **CHANGELOG state after prepare-release:**
 - `dev`: `## Unreleased` (empty) + `## [X.Y.Z] - TBD` (with content)
 - `release/X.Y.Z`: `## Unreleased` (empty) + `## [X.Y.Z] - TBD` (with content)
 
-The empty `## Unreleased` is never stripped ([#590](https://github.com/vig-os/devcontainer/issues/590)): it is present on both dev and release/main as stable common context in the freeze commit that becomes the main↔dev merge base, so the sync merge keeps `## Unreleased` instead of silently dropping it.
+The empty `## Unreleased` is never stripped ([#590](https://github.com/vig-os/devkit/issues/590)): it is present on both dev and release/main as stable common context in the freeze commit that becomes the main↔dev merge base, so the sync merge keeps `## Unreleased` instead of silently dropping it.
 
 **Output example:**
 
@@ -272,7 +272,7 @@ This is the main quality gate. The release branch and draft PR serve as the coor
    ```
 
    Candidate dispatch gates on **CI only** — the PR may stay a draft and need
-   not be approved yet ([#902](https://github.com/vig-os/devcontainer/issues/902)).
+   not be approved yet ([#902](https://github.com/vig-os/devkit/issues/902)).
    RCs are disposable: auto-incrementing `rcN` tags that never touch `:latest`,
    create no GitHub Release, and are pruned at promote. Iterate freely until the
    image behaves as intended.
@@ -371,7 +371,7 @@ The `release.yml` workflow performs the entire remaining release process. Behavi
    - Checks release branch exists
    - Verifies CHANGELOG has `## [X.Y.Z] - TBD`
    - For **final**: allows an existing **draft** GitHub Release for the publish tag (retry path); rejects a **published** (non-draft) release for the same tag
-   - Confirms PR exists and CI passed; for **final** also requires it to be not draft and approved (candidates skip the draft/approval gate — [#902](https://github.com/vig-os/devcontainer/issues/902))
+   - Confirms PR exists and CI passed; for **final** also requires it to be not draft and approved (candidates skip the draft/approval gate — [#902](https://github.com/vig-os/devkit/issues/902))
    - Records pre-finalization commit for rollback
 
 2. ✅ **Finalize** job (skipped if --dry-run)
@@ -439,7 +439,7 @@ Cross-repository validation gate rationale, mechanics, payload contract, and pas
 **This repository (`vig-os/devcontainer`) — manual promote path:**
 
 1. Verify the workflow run succeeded and smoke-test dispatch completed as expected.
-2. **Migrate RC-pinned consumers to the final tag** ([#880](https://github.com/vig-os/devcontainer/issues/880)): consumers pin the devcontainer image via their `.vig-os` file (`DEVCONTAINER_VERSION=X.Y.Z-rcN`). The **`cleanup`** job ("Cleanup RC artifacts") in `promote-release.yml` deletes all `X.Y.Z-rc*` git tags and GHCR image versions, so any consumer still pinned to an RC (e.g. field-validation repos) can no longer pull its image. Bump those pins to `DEVCONTAINER_VERSION=X.Y.Z` before running promote (preferred), or immediately after — the RC images and tags are gone once the cleanup job has run.
+2. **Migrate RC-pinned consumers to the final tag** ([#880](https://github.com/vig-os/devkit/issues/880)): consumers pin the devcontainer image via their `.vig-os` file (`DEVCONTAINER_VERSION=X.Y.Z-rcN`). The **`cleanup`** job ("Cleanup RC artifacts") in `promote-release.yml` deletes all `X.Y.Z-rc*` git tags and GHCR image versions, so any consumer still pinned to an RC (e.g. field-validation repos) can no longer pull its image. Bump those pins to `DEVCONTAINER_VERSION=X.Y.Z` before running promote (preferred), or immediately after — the RC images and tags are gone once the cleanup job has run.
 3. After smoke-test has published its **final** GitHub Release for `X.Y.Z`, run **`promote-release.yml`** (e.g. `just promote-release X.Y.Z`), which updates GHCR `:latest`, publishes the draft release, merges the release PR, and runs best-effort RC cleanup. See [Release Phases](#release-phases) step 6 and [`docs/CROSS_REPO_RELEASE_GATE.md`](CROSS_REPO_RELEASE_GATE.md).
 
 **Consumer projects** using templates from `assets/workspace/` follow [Downstream release workflows](DOWNSTREAM_RELEASE.md): final `release.yml` leaves a **draft** GitHub Release; run **`promote-release.yml`** (or `just promote-release X.Y.Z`) to publish the release and merge to `main` (no upstream GHCR/smoke-test gate in that template).
@@ -596,7 +596,7 @@ Additional requirement:
 2. **prepare** (skipped if dry-run) - Freezes CHANGELOG and creates release branch
    - Runs `prepare-changelog prepare` (Unreleased → [X.Y.Z] - TBD + fresh empty Unreleased)
    - Commits prepared CHANGELOG to `dev` via API
-   - Creates `release/X.Y.Z` branch from that dev commit (the empty Unreleased is kept, [#590](https://github.com/vig-os/devcontainer/issues/590))
+   - Creates `release/X.Y.Z` branch from that dev commit (the empty Unreleased is kept, [#590](https://github.com/vig-os/devkit/issues/590))
    - Creates draft PR to `main` with release content
 
 **Manual trigger (for testing):**
@@ -631,7 +631,7 @@ gh workflow run prepare-release.yml --ref dev -f "version=1.0.0" -f "dry-run=tru
    - Verifies release branch exists
    - Checks CHANGELOG has `[X.Y.Z] - TBD`
    - For **final**: rejects a **published** GitHub Release for the publish tag; allows an existing **draft** (retry path)
-   - Verifies PR: CI passed (both kinds); for **final** also not draft and approved (candidates defer the draft/approval gate — [#902](https://github.com/vig-os/devcontainer/issues/902))
+   - Verifies PR: CI passed (both kinds); for **final** also not draft and approved (candidates defer the draft/approval gate — [#902](https://github.com/vig-os/devkit/issues/902))
    - Records pre-finalization commit for rollback
    - Outputs: PR number, release date, pre-finalization SHA, publish tag metadata
 
@@ -832,7 +832,7 @@ just finalize-release X.Y.Z
 
 #### "PR is still in draft status"
 
-**Cause:** The **final** release PR hasn't been marked as ready for review. (Candidates don't hit this — they defer the draft/approval gate; see [#902](https://github.com/vig-os/devcontainer/issues/902).)
+**Cause:** The **final** release PR hasn't been marked as ready for review. (Candidates don't hit this — they defer the draft/approval gate; see [#902](https://github.com/vig-os/devkit/issues/902).)
 
 **Solution:**
 
@@ -846,7 +846,7 @@ gh pr ready <PR_NUMBER>
 
 #### "PR has not been approved"
 
-**Cause:** The **final** release PR needs at least one approval. (Candidates don't require approval; see [#902](https://github.com/vig-os/devcontainer/issues/902).)
+**Cause:** The **final** release PR needs at least one approval. (Candidates don't require approval; see [#902](https://github.com/vig-os/devkit/issues/902).)
 
 **Solution:**
 

--- a/docs/generate.py
+++ b/docs/generate.py
@@ -197,7 +197,7 @@ def generate_docs() -> bool:
         "just_help_output": get_just_help(),
         "version": get_version_from_changelog(),
         "release_date": get_release_date_from_changelog(),
-        "release_url": f"https://github.com/vig-os/devcontainer/releases/tag/{get_version_from_changelog()}",
+        "release_url": f"https://github.com/vig-os/devkit/releases/tag/{get_version_from_changelog()}",
         # Skill data
         "skill_groups": group_skills(skills),
     }

--- a/docs/security/ADR-secrets-management.md
+++ b/docs/security/ADR-secrets-management.md
@@ -1,9 +1,9 @@
 # ADR: Secrets-management pattern — sops-nix/age + OIDC
 
 - **Status:** Accepted (pattern / design record; not a migration)
-- **Issue:** [#780](https://github.com/vig-os/devcontainer/issues/780)
-- **Source:** PR [#670](https://github.com/vig-os/devcontainer/pull/670) roadmap, thread D
-- **Related:** [#786](https://github.com/vig-os/devcontainer/issues/786) — agent
+- **Issue:** [#780](https://github.com/vig-os/devkit/issues/780)
+- **Source:** PR [#670](https://github.com/vig-os/devkit/pull/670) roadmap, thread D
+- **Related:** [#786](https://github.com/vig-os/devkit/issues/786) — agent
   secret-management *behaviour* standard (complementary, see
   [Relationship to #786](#relationship-to-786))
 
@@ -148,7 +148,7 @@ image, or any release path and must never be. See its
 ## Relationship to #786
 
 This ADR is the **plumbing** layer (how secrets are stored/delivered);
-[#786](https://github.com/vig-os/devcontainer/issues/786) is the **agent-behaviour
+[#786](https://github.com/vig-os/devkit/issues/786) is the **agent-behaviour
 / governance** layer (how an agent must behave around a secret once it exists —
 discovery, redaction, exfiltration guardrails, never committing key material).
 They **compose and do not overlap**:

--- a/docs/security/examples/sops-nix/README.md
+++ b/docs/security/examples/sops-nix/README.md
@@ -2,7 +2,7 @@
 
 > **This is an illustrative, non-functional example.** It is documentation for
 > the pattern recorded in [`../../ADR-secrets-management.md`](../../ADR-secrets-management.md)
-> (issue [#780](https://github.com/vig-os/devcontainer/issues/780)). It is **not**
+> (issue [#780](https://github.com/vig-os/devkit/issues/780)). It is **not**
 > imported by `flake.nix`, the image build, or any release/CI path, and it must
 > **never** be wired into a live path.
 >

--- a/docs/templates/CONTRIBUTE.md.j2
+++ b/docs/templates/CONTRIBUTE.md.j2
@@ -53,7 +53,7 @@ build, so the first `direnv allow` completes in seconds.
 3. **Clone and allow direnv:**
 
    ```bash
-   git clone git@github.com:vig-os/devcontainer.git
+   git clone git@github.com:vig-os/devkit.git
    cd devcontainer
    direnv allow        # first allow fetches the closure from Cachix (seconds on a warm cache)
    ```
@@ -85,7 +85,7 @@ the two (or both) via the delivery mode: `--mode devcontainer|direnv|both`
 Clone this repository, enter the Nix dev shell, then bootstrap the project:
 
 ```bash
-git clone git@github.com:vig-os/devcontainer.git
+git clone git@github.com:vig-os/devkit.git
 cd devcontainer
 direnv allow        # (recommended) loads the flake toolchain — or run `nix develop`
 just init           # Gate prerequisites and bootstrap the project (venv, git hooks, pre-commit)
@@ -100,7 +100,7 @@ template, pre-commit). It is safe to re-run.
 When contributing to this project, follow this workflow:
 
 1. **Create an issue** to report a bug or request a feature
-   - Use [GitHub Issues](https://github.com/vig-os/devcontainer/issues) to document the problem or feature request
+   - Use [GitHub Issues](https://github.com/vig-os/devkit/issues) to document the problem or feature request
    - This helps track work and provides context for reviewers
 
 2. **Create a branch from `dev` branch**
@@ -126,7 +126,7 @@ When contributing to this project, follow this workflow:
    - Update the [CHANGELOG](CHANGELOG.md) with your changes in the `[Unreleased]` section
      - Add entries under appropriate categories (Added, Changed, Fixed, etc.)
      - Use clear, concise descriptions
-     - Reference related [issues](https://github.com/vig-os/devcontainer/issues) and [PRs](https://github.com/vig-os/devcontainer/pulls) when applicable
+     - Reference related [issues](https://github.com/vig-os/devkit/issues) and [PRs](https://github.com/vig-os/devkit/pulls) when applicable
    - Keep documentation in sync with code changes
 
 5. **Verify tests pass**
@@ -143,8 +143,8 @@ When contributing to this project, follow this workflow:
    ```
 
 6. **Create a pull request**
-   - Create a [pull request](https://github.com/vig-os/devcontainer/pulls) targeting the `dev` branch
-   - Link the PR to the related [issue(s)](https://github.com/vig-os/devcontainer/issues)
+   - Create a [pull request](https://github.com/vig-os/devkit/pulls) targeting the `dev` branch
+   - Link the PR to the related [issue(s)](https://github.com/vig-os/devkit/issues)
    - Provide a clear description of your changes
 
 7. **Accepted contributions will be merged into `dev` branch**

--- a/docs/templates/README.md.j2
+++ b/docs/templates/README.md.j2
@@ -20,7 +20,7 @@ That's it! All development tools (Python, git, pre-commit, just, etc.) are inclu
 ### One-Line Install
 
 ```bash
-curl -sSfL https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh | bash -s -- ~/my-project
+curl -sSfL https://raw.githubusercontent.com/vig-os/devkit/main/install.sh | bash -s -- ~/my-project
 ```
 
 This will:
@@ -40,26 +40,26 @@ also `both`. `devcontainer` scaffolds `.devcontainer/` only; `direnv` scaffolds
 
 ```bash
 # Use specific version
-curl -sSfL https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh | bash -s -- --version 0.2.1 ~/my-project
+curl -sSfL https://raw.githubusercontent.com/vig-os/devkit/main/install.sh | bash -s -- --version 0.2.1 ~/my-project
 
 # Upgrade existing project (overwrites template files)
-curl -sSfL https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh | bash -s -- --force ~/my-project
+curl -sSfL https://raw.githubusercontent.com/vig-os/devkit/main/install.sh | bash -s -- --force ~/my-project
 
 # Override project name
-curl -sSfL https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh | bash -s -- --name my_custom_name ~/my-project
+curl -sSfL https://raw.githubusercontent.com/vig-os/devkit/main/install.sh | bash -s -- --name my_custom_name ~/my-project
 
 # Override organization name (default: vigOS)
-curl -sSfL https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh | bash -s -- --org MyOrg ~/my-project
+curl -sSfL https://raw.githubusercontent.com/vig-os/devkit/main/install.sh | bash -s -- --org MyOrg ~/my-project
 
 # Choose the delivery mode: devcontainer | direnv | both (default: both)
-curl -sSfL https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh | bash -s -- --mode direnv ~/my-project
+curl -sSfL https://raw.githubusercontent.com/vig-os/devkit/main/install.sh | bash -s -- --mode direnv ~/my-project
 
 # Preview without executing
-curl -sSfL https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh | bash -s -- --dry-run ~/my-project
+curl -sSfL https://raw.githubusercontent.com/vig-os/devkit/main/install.sh | bash -s -- --dry-run ~/my-project
 
 # Force specific runtime
-curl -sSfL https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh | bash -s -- --docker ~/my-project
-curl -sSfL https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh | bash -s -- --podman ~/my-project
+curl -sSfL https://raw.githubusercontent.com/vig-os/devkit/main/install.sh | bash -s -- --docker ~/my-project
+curl -sSfL https://raw.githubusercontent.com/vig-os/devkit/main/install.sh | bash -s -- --podman ~/my-project
 ```
 
 > **Note:** If podman or docker is not installed, the script provides OS-specific installation instructions for macOS, Ubuntu/Debian, Fedora, Arch Linux, and Windows.

--- a/flake.nix
+++ b/flake.nix
@@ -1138,7 +1138,7 @@
                 ];
                 Labels = {
                   "org.opencontainers.image.title" = "vigOS development environment";
-                  "org.opencontainers.image.source" = "https://github.com/vig-os/devcontainer";
+                  "org.opencontainers.image.source" = "https://github.com/vig-os/devkit";
                   "org.opencontainers.image.licenses" = "MIT";
                 };
               };

--- a/install.sh
+++ b/install.sh
@@ -2,8 +2,8 @@
 # vigOS devcontainer quick install script
 #
 # Usage:
-#   curl -sSfL https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh | bash
-#   curl -sSfL https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh | bash -s -- [OPTIONS] [PATH]
+#   curl -sSfL https://raw.githubusercontent.com/vig-os/devkit/main/install.sh | bash
+#   curl -sSfL https://raw.githubusercontent.com/vig-os/devkit/main/install.sh | bash -s -- [OPTIONS] [PATH]
 #
 # Options:
 #   --force           Overwrite existing files (for upgrades)
@@ -22,7 +22,7 @@
 #   -h, --help        Show this help message
 #
 # Examples:
-#   curl -sSfL https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh | bash
+#   curl -sSfL https://raw.githubusercontent.com/vig-os/devkit/main/install.sh | bash
 #   curl -sSfL ... | bash -s -- ~/Projects/my-project
 #   curl -sSfL ... | bash -s -- --version 0.2.1 --force ./my-project
 #   curl -sSfL ... | bash -s -- --org MyOrg ./my-project
@@ -67,7 +67,7 @@ usage() {
 vigOS Devcontainer Install Script
 
 USAGE:
-    curl -sSfL https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh | bash
+    curl -sSfL https://raw.githubusercontent.com/vig-os/devkit/main/install.sh | bash
     curl -sSfL ... | bash -s -- [OPTIONS] [PATH]
 
 OPTIONS:
@@ -92,7 +92,7 @@ OPTIONS:
 
 EXAMPLES:
     # Initialize current directory with latest version
-    curl -sSfL https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh | bash
+    curl -sSfL https://raw.githubusercontent.com/vig-os/devkit/main/install.sh | bash
 
     # Initialize specific directory
     curl -sSfL ... | bash -s -- ~/Projects/my-new-project
@@ -726,7 +726,7 @@ if [ ! -t 0 ]; then
         err "This script requires an interactive terminal"
         echo ""
         echo "Try running directly instead of piping:"
-        echo "  curl -sSfL https://raw.githubusercontent.com/vig-os/devcontainer/main/install.sh -o install.sh"
+        echo "  curl -sSfL https://raw.githubusercontent.com/vig-os/devkit/main/install.sh -o install.sh"
         echo "  bash install.sh $PROJECT_PATH"
         exit 1
     fi

--- a/packages/vig-utils/README.md
+++ b/packages/vig-utils/README.md
@@ -193,8 +193,8 @@ Examples:
 
 ```bash
 setup-labels --dry-run
-setup-labels --repo vig-os/devcontainer
-setup-labels --repo vig-os/devcontainer --prune
+setup-labels --repo vig-os/devkit
+setup-labels --repo vig-os/devkit --prune
 ```
 
 ### `vig-utils` (utility helper)

--- a/tests/bats/just.bats
+++ b/tests/bats/just.bats
@@ -90,7 +90,7 @@ EOF
     # The functional upgrade curl must interpolate the resolved ref (${REF}),
     # and no install.sh curl in the recipe may be pinned literally to /main/.
     # shellcheck disable=SC2016  # grepping for the LITERAL '${REF}' in the recipe
-    run grep -q 'githubusercontent.com/vig-os/devcontainer/${REF}/install.sh' \
+    run grep -q 'githubusercontent.com/vig-os/devkit/${REF}/install.sh' \
         assets/workspace/.devcontainer/justfile.devc
     assert_success
     run grep -F 'vig-os/devcontainer/main/install.sh' \
@@ -234,7 +234,7 @@ EOF
 }
 
 @test "smoke-test dispatch notifies upstream on orchestration failure" {
-    run bash -lc "grep -Fq -- 'notify-failure:' assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- 'gh issue create \\' assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- '--repo vig-os/devcontainer' assets/smoke-test/.github/workflows/repository-dispatch.yml"
+    run bash -lc "grep -Fq -- 'notify-failure:' assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- 'gh issue create \\' assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- '--repo vig-os/devkit' assets/smoke-test/.github/workflows/repository-dispatch.yml"
     assert_success
 }
 


### PR DESCRIPTION
## Summary

Stage 3 follow-up: the source repository has been **renamed `vig-os/devcontainer` → `vig-os/devkit`** (done). This flips all **source-repo references** to the new name.

## Changed → `vig-os/devkit`
- Clone/raw/API URLs, the documented `install.sh` one-liners, the `devc-upgrade` recipe.
- Docs: templates (`README.md.j2`, `CONTRIBUTE.md.j2`) + regenerated `README/CONTRIBUTE/TESTING`, `MIGRATION.md`, `NIX.md`, sub-READMEs, `generate.py` release-link base.
- **Release workflow cosign `--certificate-identity-regexp`** and the image's **OCI `source` label**.

## ⚠️ Merge ordering
The cosign identity flip **must merge before the next release (1.0.1+)** — otherwise that release's promote-time cosign-verify fails against the old repo path. (1.0.0 already shipped signed under the old identity; unaffected.)

## Deliberately unchanged
- **The published image** stays `ghcr.io/vig-os/devcontainer` (course-correction) — **no `ghcr.io` ref touched** (verified: no live `ghcr.io/vig-os/devkit`).
- Immutable released `CHANGELOG` entries and the `docs/issues/` + `docs/pull-requests/` archives keep their old links (GitHub redirects them).

## Testing
`just precommit` (full suite incl. `generate-docs`, `actionlint`, `sync-manifest`) — green. `just.bats` devc-upgrade assertion realigned to the new raw URL.

## Companion (separate)
A lockstep PR in `devkit-smoke-test` flips *its* back-references to the source repo (`install.sh` raw URL, `notify-failure`) — doing that next.

Refs: #781