### PR TITLE
fix(ci): bound sync-issues re-sync on cache miss

### DIFF
--- a/.github/workflows/sync-issues.yml
+++ b/.github/workflows/sync-issues.yml
@@ -123,6 +123,29 @@ jobs:
             echo "No cache found with key: $CACHE_KEY (this is OK for first run)"
           fi
 
+      - name: Compute incremental cutoff (self-heal on cache miss)
+        id: cutoff
+        if: github.event.inputs.force-update != 'true'
+        env:
+          CACHE_HIT: ${{ steps.restore-state.outputs.cache-hit }}
+        run: |
+          set -euo pipefail
+          if [ "$CACHE_HIT" = "true" ]; then
+            # State restored from cache: let the action read the state file.
+            echo "updated-since=" >> "$GITHUB_OUTPUT"
+            echo "Cache hit: incremental sync from the restored state file."
+          else
+            # Cache miss (a repository rename, or the routine 7-day cache
+            # eviction). Without state the action would re-sync the entire
+            # issue/PR history from epoch and exhaust the GitHub API rate limit
+            # (#980). Fall back to a bounded look-back that safely covers the
+            # eviction gap; older items are already in the committed archives,
+            # and force-update still forces a full rebuild.
+            SINCE="$(date -u -d '14 days ago' '+%Y-%m-%dT%H:%M:%SZ')"
+            echo "updated-since=$SINCE" >> "$GITHUB_OUTPUT"
+            echo "Cache miss: bounded incremental sync since $SINCE (14-day look-back)."
+          fi
+
       - name: Sync Issues and PRs
         id: sync
         uses: vig-os/sync-issues-action@bad447d330526a7313ffddae084010c39b335fc1  # v0.2.2
@@ -134,7 +157,7 @@ jobs:
           sync-prs: 'true'
           include-closed: 'true'
           state-file: '.sync-state/last-sync.txt'
-          updated-since: ${{ (github.event.inputs.force-update == 'true' && '1970-01-01T00:00:00Z') || '' }}
+          updated-since: ${{ (github.event.inputs.force-update == 'true' && '1970-01-01T00:00:00Z') || steps.cutoff.outputs.updated-since }}
 
       - name: Commit and push changes via API
         id: commit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`sync-issues` no longer full-re-syncs on a cache miss** ([#980](https://github.com/vig-os/devkit/issues/980))
+  - The scaffolded `sync-issues` workflow keyed its incremental-state cache by
+    repository name, so a repository rename (or the routine 7-day cache eviction)
+    orphaned the state and made it re-fetch the **entire** issue/PR history from
+    epoch — exhausting the GitHub API rate limit before it could save state, so it
+    failed every run. On a cache miss it now falls back to a bounded **14-day
+    look-back** (safely covering the eviction gap; older items already live in the
+    committed archives), then saves state and self-heals to incremental.
+    `force-update` still performs a full rebuild.
+
 ### Security
 
 ## [1.0.0](https://github.com/vig-os/devcontainer/releases/tag/1.0.0) - 2026-07-10

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -26,6 +26,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`sync-issues` no longer full-re-syncs on a cache miss** ([#980](https://github.com/vig-os/devkit/issues/980))
+  - The scaffolded `sync-issues` workflow keyed its incremental-state cache by
+    repository name, so a repository rename (or the routine 7-day cache eviction)
+    orphaned the state and made it re-fetch the **entire** issue/PR history from
+    epoch — exhausting the GitHub API rate limit before it could save state, so it
+    failed every run. On a cache miss it now falls back to a bounded **14-day
+    look-back** (safely covering the eviction gap; older items already live in the
+    committed archives), then saves state and self-heals to incremental.
+    `force-update` still performs a full rebuild.
+
 ### Security
 
 ## [1.0.0](https://github.com/vig-os/devcontainer/releases/tag/1.0.0) - 2026-07-10

--- a/assets/workspace/.github/workflows/sync-issues.yml
+++ b/assets/workspace/.github/workflows/sync-issues.yml
@@ -127,6 +127,29 @@ jobs:
             echo "No cache found with key: $CACHE_KEY (this is OK for first run)"
           fi
 
+      - name: Compute incremental cutoff (self-heal on cache miss)
+        id: cutoff
+        if: github.event.inputs.force-update != 'true'
+        env:
+          CACHE_HIT: ${{ steps.restore-state.outputs.cache-hit }}
+        run: |
+          set -euo pipefail
+          if [ "$CACHE_HIT" = "true" ]; then
+            # State restored from cache: let the action read the state file.
+            echo "updated-since=" >> "$GITHUB_OUTPUT"
+            echo "Cache hit: incremental sync from the restored state file."
+          else
+            # Cache miss (a repository rename, or the routine 7-day cache
+            # eviction). Without state the action would re-sync the entire
+            # issue/PR history from epoch and exhaust the GitHub API rate limit.
+            # Fall back to a bounded look-back that safely covers the eviction
+            # gap; older items are already in the committed archives, and
+            # force-update still forces a full rebuild.
+            SINCE="$(date -u -d '14 days ago' '+%Y-%m-%dT%H:%M:%SZ')"
+            echo "updated-since=$SINCE" >> "$GITHUB_OUTPUT"
+            echo "Cache miss: bounded incremental sync since $SINCE (14-day look-back)."
+          fi
+
       - name: Sync Issues and PRs
         id: sync
         uses: vig-os/sync-issues-action@bad447d330526a7313ffddae084010c39b335fc1  # v0.2.2
@@ -138,7 +161,7 @@ jobs:
           sync-prs: 'true'
           include-closed: 'true'
           state-file: '.sync-state/last-sync.txt'
-          updated-since: ${{ (github.event.inputs.force-update == 'true' && '1970-01-01T00:00:00Z') || '' }}
+          updated-since: ${{ (github.event.inputs.force-update == 'true' && '1970-01-01T00:00:00Z') || steps.cutoff.outputs.updated-since }}
 
       - name: Commit and push changes via API
         id: commit


### PR DESCRIPTION
## Summary

Fixes **#980**: the scaffolded `sync-issues` workflow re-synced the **entire** issue/PR history from epoch on any cache miss, exhausting the GitHub API rate limit and failing every run. Hit in production right after the `vig-os/devcontainer` → `vig-os/devkit` rename (#781) orphaned the repo-name-keyed state cache.

## Fix
On a cache miss, compute a bounded **14-day look-back** and pass it as `updated-since` instead of epoch:
- Sync stays small → completes under the rate limit → **saves state → self-heals** to incremental thereafter.
- Covers the 7-day cache-eviction gap with margin; older items already live in the committed archives.
- **Cache hit** → still reads the restored state file (unchanged). **`force-update`** → still a full rebuild (unchanged).

Applied to both `.github/workflows/sync-issues.yml` and the scaffold template `assets/workspace/.github/workflows/sync-issues.yml`, so **every consumer** gets it (this is a general cache-miss fragility, not rename-specific).

## Not in scope
Defense-in-depth rate-limit-aware checkpointing belongs in `vig-os/sync-issues-action` — a separate, lower-priority issue there.

## Testing
`just precommit` (full suite incl. actionlint / yamllint) — green. Logic: `force-update ? epoch : (cache-hit ? '' (use state file) : 14d-lookback)`.

Refs: #980