### PR TITLE
ci(actions): bump sigstore/cosign-installer to v4.1.2

### DIFF
--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -137,7 +137,7 @@ jobs:
           done
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003  # v4
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6  # v4.1.2
 
       - name: Verify cosign signature
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1033,7 +1033,7 @@ jobs:
           fi
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003  # v4
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6  # v4.1.2
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0  # v4.4.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Pin `sigstore/cosign-installer` to `v4.1.2` so Renovate can resolve its digest** ([#986](https://github.com/vig-os/devkit/issues/986))
+  - The previous pin's `# v4` comment named a floating tag that `sigstore/cosign-installer` never published, so Renovate's digest lookup failed on the dependency dashboard
+
 ### Security
 
 ## [1.0.1](https://github.com/vig-os/devkit/releases/tag/1.0.1) - 2026-07-11

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Pin `sigstore/cosign-installer` to `v4.1.2` so Renovate can resolve its digest** ([#986](https://github.com/vig-os/devkit/issues/986))
+  - The previous pin's `# v4` comment named a floating tag that `sigstore/cosign-installer` never published, so Renovate's digest lookup failed on the dependency dashboard
+
 ### Security
 
 ## [1.0.1](https://github.com/vig-os/devkit/releases/tag/1.0.1) - 2026-07-11


### PR DESCRIPTION
## Description

Renovate reported on the dependency dashboard that it "Could not determine new digest for update (github-tags package `sigstore/cosign-installer`)". Both release workflows pinned the action to a SHA with the comment `# v4`, but `sigstore/cosign-installer` never published a floating `v4` tag (only exact tags `v4.0.0`–`v4.1.2` and a legacy `v3`). Renovate resolves the comment as the current version via the `github-tags` datasource, so the `refs/tags/v4` lookup 404s and digest updates fail.

Closes #986

## Type of Change

- [x] `ci` -- CI/CD pipeline changes

## Changes Made

- Bump `sigstore/cosign-installer` from `cad07c2e` (`v4.1.1`) to `6f9f1778` (`v4.1.2`) in `.github/workflows/release.yml` and `.github/workflows/promote-release.yml`, with a comment naming the real `v4.1.2` tag so Renovate can resolve future digest updates
- Changelog entry under `## Unreleased` (mirrored to `assets/workspace/.devcontainer/CHANGELOG.md` by the `sync-manifest` hook)

## Changelog Entry

### Fixed
- **Pin `sigstore/cosign-installer` to `v4.1.2` so Renovate can resolve its digest** ([#986](https://github.com/vig-os/devkit/issues/986))
  - The previous pin's `# v4` comment named a floating tag that `sigstore/cosign-installer` never published, so Renovate's digest lookup failed on the dependency dashboard

## Testing

- Verified upstream via the GitHub API: `refs/tags/v4` returns 404; `v4.1.2` resolves to `6f9f17788090df1f26f669e9d70d6ae9567deba6`
- Verified all other digest-pinned actions in the repo use comments that resolve to real tags
- `just precommit` (full `--all-files` suite) green locally, including `check-action-pins`