### PR TITLE
feat(nix): expose vig-utils console scripts in the dev-shell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`vig-utils` console scripts available in the dev-shell** ([#993](https://github.com/vig-os/devkit/issues/993))
+  - `prepare-changelog`, `renovate-changelog-pr`, and the other
+    `packages/vig-utils` console scripts are now on the toolchain SSoT
+    (`nix/devtools.nix`), so every `nix develop` shell — the devkit's own and any
+    consumer `mkProjectShell` (direnv mode) — exposes them on PATH, matching the
+    image. This unblocks mode-aware release workflows for the container-less
+    modes.
+  - Bare mode (no flake) gets a documented, version-pinned host-native install
+    path: `uv tool install "vig-utils @ git+https://github.com/vig-os/devkit@<DEVKIT_VERSION>#subdirectory=packages/vig-utils"`
+    (see `docs/MIGRATION.md`).
+
 ### Changed
 
 - **Renovate: update `cachix/install-nix-action` from `v31.10.6` to `v31.10.7`** ([#984](https://github.com/vig-os/devkit/pull/984))

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`vig-utils` console scripts available in the dev-shell** ([#993](https://github.com/vig-os/devkit/issues/993))
+  - `prepare-changelog`, `renovate-changelog-pr`, and the other
+    `packages/vig-utils` console scripts are now on the toolchain SSoT
+    (`nix/devtools.nix`), so every `nix develop` shell — the devkit's own and any
+    consumer `mkProjectShell` (direnv mode) — exposes them on PATH, matching the
+    image. This unblocks mode-aware release workflows for the container-less
+    modes.
+  - Bare mode (no flake) gets a documented, version-pinned host-native install
+    path: `uv tool install "vig-utils @ git+https://github.com/vig-os/devkit@<DEVKIT_VERSION>#subdirectory=packages/vig-utils"`
+    (see `docs/MIGRATION.md`).
+
 ### Changed
 
 - **Renovate: update `cachix/install-nix-action` from `v31.10.6` to `v31.10.7`** ([#984](https://github.com/vig-os/devkit/pull/984))

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -58,6 +58,26 @@ one of four modes:
 The chosen mode is persisted as `DEVKIT_MODE` in the `.vig-os` manifest (below),
 so upgrades never need `--mode` again.
 
+### Bare mode: `vig-utils` release console scripts
+
+The release workflows invoke `prepare-changelog` and `renovate-changelog-pr`
+(console scripts of `packages/vig-utils`). In `devcontainer`/`both` mode they
+ship in the image; in `direnv` mode the flake dev-shell provides them (they are
+on the toolchain SSoT, [#993](https://github.com/vig-os/devkit/issues/993)).
+Bare mode has no flake and no image, so install them host-native with `uv`,
+pinned to the same devkit version as `.vig-os`
+(`DEVKIT_VERSION`/`DEVCONTAINER_VERSION`):
+
+```bash
+uv tool install "vig-utils @ git+https://github.com/vig-os/devkit@<DEVKIT_VERSION>#subdirectory=packages/vig-utils"
+```
+
+This puts `prepare-changelog`, `renovate-changelog-pr`, and the other
+`vig-utils` scripts on PATH. Pin `<DEVKIT_VERSION>` to a release tag so the
+tooling matches your `.vig-os` pin; the `setup-devkit-toolchain` composite
+([#994](https://github.com/vig-os/devkit/issues/994)) runs this step for you in
+bare-mode CI.
+
 ### direnv-mode CI
 
 `direnv` (and `bare`) consumers cannot run the container-based CI: with no

--- a/flake.nix
+++ b/flake.nix
@@ -90,10 +90,33 @@
           }) fastMovers
         );
 
+      # vig-utils exposed on the overlay so `pkgs.vig-utils` resolves for the
+      # toolchain SSoT (nix/devtools.nix) and for downstream consumers that
+      # apply `overlays.default`. A pure-Python hatchling package (single
+      # runtime dep `rich`) built from THIS flake's `packages/vig-utils`, so its
+      # console scripts (prepare-changelog, renovate-changelog-pr, …) reach the
+      # dev-shell, the image, and the home module from one list. The devkit pin
+      # in a consumer's `.vig-os` governs the version. Refs #993, #666.
+      vigUtilsOverlay = final: _prev: {
+        vig-utils = final.python314.pkgs.buildPythonPackage {
+          pname = "vig-utils";
+          version = "0.1.0";
+          pyproject = true;
+          src = ./packages/vig-utils;
+          build-system = [ final.python314.pkgs.hatchling ];
+          dependencies = [ final.python314.pkgs.rich ];
+          pythonImportsCheck = [ "vig_utils" ];
+          # The package's own tests need pytest + the repo; CI covers them.
+          doCheck = false;
+        };
+      };
+
       # System-independent overlay for downstream consumers (overlays.default).
       # No concrete system is known here, so it imports unstable inside the
       # fixpoint; the in-flake path below uses the hoisted importUnstable.
-      overlay = final: prev: mkFastMoverOverlay (importUnstable final.system) final prev;
+      overlay =
+        final: prev:
+        (mkFastMoverOverlay (importUnstable final.system) final prev) // (vigUtilsOverlay final prev);
 
       # ---------------------------------------------------------------------
       # vigos home environment (#819): self-pkgs + the ci homeConfigurations.
@@ -106,7 +129,10 @@
         system:
         import nixpkgs {
           inherit system;
-          overlays = [ (mkFastMoverOverlay (importUnstable system)) ];
+          overlays = [
+            (mkFastMoverOverlay (importUnstable system))
+            vigUtilsOverlay
+          ];
           config.allowUnfree = true;
         };
 
@@ -490,7 +516,10 @@
         unstable = importUnstable system;
         pkgs = import nixpkgs {
           inherit system;
-          overlays = [ (mkFastMoverOverlay unstable) ];
+          overlays = [
+            (mkFastMoverOverlay unstable)
+            vigUtilsOverlay
+          ];
           config.allowUnfree = true;
         };
 
@@ -517,17 +546,10 @@
         # package (single runtime dep `rich`) built by Nix, so `import vig_utils`
         # and its console scripts (check-expirations, vulnix-gate, …) are present
         # without a network-populated uv venv (impossible in a hermetic build).
-        vigUtils = python.pkgs.buildPythonPackage {
-          pname = "vig-utils";
-          version = "0.1.0";
-          pyproject = true;
-          src = ./packages/vig-utils;
-          build-system = [ python.pkgs.hatchling ];
-          dependencies = [ python.pkgs.rich ];
-          pythonImportsCheck = [ "vig_utils" ];
-          # The package's own tests need pytest + the repo; CI covers them.
-          doCheck = false;
-        };
+        # Defined once on the overlay (`vigUtilsOverlay`) and consumed here for
+        # `pythonEnv` and the sandbox-pure hook check; the same `pkgs.vig-utils`
+        # reaches the dev-shell/image/home module via `devTools`. Refs #993, #666.
+        vigUtils = pkgs.vig-utils;
 
         # pip-licenses is not packaged in nixpkgs, so install it from its PyPI
         # wheel (pinned to the project's locked version + hash). Using the wheel

--- a/nix/devtools.nix
+++ b/nix/devtools.nix
@@ -25,6 +25,16 @@ with pkgs;
   # Python tooling (uv from unstable via overlay)
   uv
 
+  # vig-utils console scripts (prepare-changelog, renovate-changelog-pr,
+  # validate-commit-msg, …) from THIS flake's packages/vig-utils, exposed on
+  # the overlay (vigUtilsOverlay in flake.nix). Delivered here so the dev-shell
+  # — including a consumer mkProjectShell (direnv-mode CI) — has them on PATH,
+  # matching the image, which also bakes them via `pythonEnv`. lowPrio so this
+  # devTools copy yields to `pythonEnv`'s identical console scripts in the image
+  # buildEnv (the same collision-avoidance the wrapped neovim uses below).
+  # Refs #993.
+  (pkgs.lib.lowPrio vig-utils)
+
   # Node.js (devcontainer CLI via npm)
   nodejs
 

--- a/tests/test_flake_devshell.py
+++ b/tests/test_flake_devshell.py
@@ -48,6 +48,11 @@ VERSION_FLAG_OVERRIDES: dict[str, list[str]] = {
     # argument"); it is a subcommand CLI. `--help` exits 0 and proves the binary
     # is runnable in the dev-shell, which is what this parity check asserts.
     "statix": ["--help"],
+    # vig-utils is a subcommand CLI (its `main` requires a subcommand, so
+    # `--version` exits 2); `--help` exits 0 and proves the binary runs. The
+    # release console scripts it ships (prepare-changelog,
+    # renovate-changelog-pr) get their own dedicated PATH test above. Refs #993.
+    "vig-utils": ["--help"],
 }
 
 pytestmark = pytest.mark.skipif(

--- a/tests/test_flake_devshell.py
+++ b/tests/test_flake_devshell.py
@@ -416,6 +416,47 @@ def test_devshell_exposes_python3_and_precommit(binary: str) -> None:
     )
 
 
+@pytest.mark.parametrize("script", ["prepare-changelog", "renovate-changelog-pr"])
+def test_devshell_exposes_vig_utils_console_scripts(script: str) -> None:
+    """The dev-shell must expose vig-utils' release console scripts on PATH (#993).
+
+    ``prepare-changelog`` and ``renovate-changelog-pr`` are console scripts of
+    ``packages/vig-utils``. They are baked into the image's Python env
+    (``pythonEnv``) but were historically absent from the ``devTools`` SSoT, so a
+    consumer ``mkProjectShell`` dev-shell (direnv mode) lacked them — blocking
+    the mode-aware release workflows (#991) for the container-less modes. Adding
+    ``vig-utils`` to ``devTools`` delivers the scripts to the dev-shell as well.
+
+    The check runs under ``nix develop --ignore-environment`` so it asserts the
+    dev-shell's *own* PATH contribution and is not satisfied by a host script
+    leaking through the inherited environment.
+    """
+    cmd = [
+        "nix",
+        "develop",
+        "--ignore-environment",
+        "--keep",
+        "HOME",
+        str(REPO_ROOT),
+        "-c",
+        "bash",
+        "-c",
+        f"command -v {script}",
+    ]
+    proc = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        env=_nix_env(),
+        timeout=900,
+    )
+    assert proc.returncode == 0, (
+        f"{script} must be on the dev-shell's own PATH (#993): "
+        f"rc={proc.returncode} stdout={proc.stdout.strip()!r} "
+        f"stderr={proc.stderr.strip()[:200]}"
+    )
+
+
 def test_each_tool_runs_in_devshell(dev_shell_tools: list[str]) -> None:
     """Every tool in ``devTools`` is runnable inside ``nix develop``."""
     failures: list[str] = []


### PR DESCRIPTION
## What

Expose the `packages/vig-utils` console scripts (`prepare-changelog`,
`renovate-changelog-pr`, and siblings) host-side:

- **Dev-shell (direnv mode):** `vig-utils` is now on the vigOS overlay
  (`pkgs.vig-utils`) and in the `devTools` SSoT (`nix/devtools.nix`), so every
  `nix develop` shell — the devkit's own and any consumer `mkProjectShell` —
  exposes the scripts on PATH, matching the image. Defined once on the overlay
  (`vigUtilsOverlay`) and reused by `pythonEnv`/the hook check (no duplicate
  builder). `lowPrio` in `devTools` yields to `pythonEnv`'s identical scripts in
  the image `buildEnv`, mirroring the wrapped-neovim collision guard.
- **Bare mode (no flake):** documented, version-pinned host-native install path
  in `docs/MIGRATION.md`, consumed later by the #994 `setup-devkit-toolchain`
  composite.

## Why

`prepare-changelog` / `renovate-changelog-pr` are invoked bare by the scaffolded
release workflows but were only in the image, not `devTools` — blocking
mode-aware release workflows (#991) for container-less modes. Part of #988.

## Evidence (local — PRs into the epic branch get no automated CI)

Devkit's own dev-shell:
```
$ nix develop --ignore-environment --keep HOME -c command -v prepare-changelog renovate-changelog-pr vig-utils
/nix/store/…-python3.14-vig-utils-0.1.0/bin/prepare-changelog
/nix/store/…-python3.14-vig-utils-0.1.0/bin/renovate-changelog-pr
/nix/store/…-python3.14-vig-utils-0.1.0/bin/vig-utils
```

Consumer `mkProjectShell` (downstream stub, `vigos` overridden to this branch):
```
$ nix develop path:assets/workspace --override-input vigos path:. -c command -v prepare-changelog renovate-changelog-pr
/nix/store/…-python3.14-vig-utils-0.1.0/bin/prepare-changelog
/nix/store/…-python3.14-vig-utils-0.1.0/bin/renovate-changelog-pr
```

Tests:
- `tests/test_flake_devshell.py::test_devshell_exposes_vig_utils_console_scripts[prepare-changelog|renovate-changelog-pr]` — new, RED→GREEN.
- `test_each_tool_runs_in_devshell` (vig-utils added to `VERSION_FLAG_OVERRIDES`) and `test_downstream_flake.py` — pass.
- `nix build .#devkitImage` — succeeds (no `buildEnv` collision; `lowPrio` resolves it).
- `prek run --all-files` — green.

Verified bare-mode install command (tested locally from both the local path and the git subdirectory):
```
uv tool install "vig-utils @ git+https://github.com/vig-os/devkit@<DEVKIT_VERSION>#subdirectory=packages/vig-utils"
```

## Follow-up for #994

The composite runs the bare-mode `uv tool install` above; pin `<DEVKIT_VERSION>`
to the release tag from `.vig-os` so the host toolchain matches the pin.

Refs: #993