### PR TITLE
feat(workspace): opt-in .devcontainer/ prune on container-less mode upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Opt-in `--prune-devcontainer` for container → direnv/bare migrations** ([#990](https://github.com/vig-os/devkit/issues/990))
+  - Switching a container repo to `direnv`/`bare` keeps a populated pre-existing
+    `.devcontainer/` by default (non-destructive, [#738](https://github.com/vig-os/devkit/issues/738)).
+    On a real migration that strands the stale container next to the new flake,
+    so `install.sh` / `init-workspace.sh` now accept `--prune-devcontainer` to
+    remove it. The flag is rejected in `devcontainer`/`both` modes; `--preview`
+    lists the `.devcontainer/` under `DELETED` when it is set; and interactive
+    runs prompt once (`Prune existing .devcontainer/? (y/N)`, default No) when a
+    populated pre-existing `.devcontainer/` is detected in a container-less mode.
+    `docs/MIGRATION.md` documents the preview-then-apply cleanup runbook.
+
 ### Changed
 
 - **Renovate: update `cachix/install-nix-action` from `v31.10.6` to `v31.10.7`** ([#984](https://github.com/vig-os/devkit/pull/984))

--- a/assets/init-workspace.sh
+++ b/assets/init-workspace.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Initialize workspace by copying template files
 #
-# Usage: init-workspace [--force] [--no-prompts] [--smoke-test] [--preview] [--mode MODE]
+# Usage: init-workspace [--force] [--no-prompts] [--smoke-test] [--preview] [--mode MODE] [--prune-devcontainer]
 #
 # Options:
 #   --force       Overwrite existing files (for upgrades)
@@ -9,6 +9,12 @@
 #   --smoke-test  Deploy smoke-test-specific assets
 #   --preview     Print the add/overwrite/preserve/delete report an upgrade
 #                 would produce, then exit 0 without touching the tree (#886)
+#   --prune-devcontainer
+#                 In direnv/bare mode, also remove a PRE-EXISTING .devcontainer/
+#                 (a container→direnv/bare migration cleanup, #990). Without it
+#                 the #738 default is non-destructive and keeps it. Interactive
+#                 runs prompt once when a populated .devcontainer/ is detected.
+#                 Rejected in devcontainer/both modes.
 #   --mode MODE   Delivery mode: devcontainer | direnv | both | bare
 #                 devcontainer  scaffold .devcontainer/ only (no flake.nix/.envrc)
 #                 direnv        scaffold flake.nix + .envrc only (no .devcontainer/)
@@ -48,6 +54,8 @@ FORCE=false
 NO_PROMPTS=false
 SMOKE_TEST=false
 PREVIEW=false
+# Opt-in removal of a PRE-EXISTING .devcontainer/ in direnv/bare mode (#990).
+PRUNE_DEVCONTAINER=false
 # Delivery mode: devcontainer | direnv | both | bare. Empty = manifest, prompt, or "both".
 MODE=""
 
@@ -121,6 +129,10 @@ while [[ $# -gt 0 ]]; do
             PREVIEW=true
             shift
             ;;
+        --prune-devcontainer)
+            PRUNE_DEVCONTAINER=true
+            shift
+            ;;
         --mode)
             MODE="$2"
             shift 2
@@ -131,7 +143,7 @@ while [[ $# -gt 0 ]]; do
             ;;
         *)
             echo "Unknown option: $1" >&2
-            echo "Usage: init-workspace [--force] [--no-prompts] [--smoke-test] [--preview] [--mode MODE]" >&2
+            echo "Usage: init-workspace [--force] [--no-prompts] [--smoke-test] [--preview] [--mode MODE] [--prune-devcontainer]" >&2
             exit 1
             ;;
     esac
@@ -424,6 +436,15 @@ if [[ -z "$MODE" ]]; then
 fi
 echo "Delivery mode set to: $MODE"
 
+# --prune-devcontainer is only meaningful where the scaffold owns no container
+# (#990). In devcontainer/both mode a .devcontainer/ is a first-class deliverable,
+# so reject the flag loudly rather than silently ignore it — same failure shape
+# as an invalid --mode above.
+if [[ "$PRUNE_DEVCONTAINER" == "true" && "$MODE" != "direnv" && "$MODE" != "bare" ]]; then
+    echo "Error: --prune-devcontainer only applies to direnv/bare modes (got: $MODE)" >&2
+    exit 1
+fi
+
 # Print one recipe block from the template justfile.project: the immediately
 # preceding comment/attribute lines, the recipe header, and the indented body.
 # Used to repair a preserved pre-0.4.0 justfile.project that lacks the
@@ -481,6 +502,22 @@ DEVCONTAINER_PREEXISTED=false
 if [[ -d "$WORKSPACE_DIR/.devcontainer" ]] \
     && [[ -n "$(ls -A "$WORKSPACE_DIR/.devcontainer" 2>/dev/null)" ]]; then
     DEVCONTAINER_PREEXISTED=true
+fi
+
+# Interactive prune offer (#990): on a container→direnv/bare (re)scaffold a
+# populated pre-existing .devcontainer/ is kept by default (#738). When the
+# operator did not pass --prune-devcontainer, ask once — default No preserves
+# the #738 behavior. Resolved here (before the file report below) so the DELETED
+# listing mirrors the choice. Skipped under --no-prompts and --preview (a preview
+# must stay side-effect-free and decide purely from the flag).
+if [[ "$PRUNE_DEVCONTAINER" != "true" && "$DEVCONTAINER_PREEXISTED" == "true" \
+    && ( "$MODE" == "direnv" || "$MODE" == "bare" ) \
+    && "$NO_PROMPTS" != "true" && "$PREVIEW" != "true" ]]; then
+    read -rp "Prune existing .devcontainer/? (y/N): " -n 1 -r
+    echo
+    if [[ $REPLY =~ ^[Yy]$ ]]; then
+        PRUNE_DEVCONTAINER=true
+    fi
 fi
 
 # Same guard for the consumer's own nix-direnv files (#859): the
@@ -556,6 +593,10 @@ if [[ "$FORCE" == "true" ]]; then
     if [[ "$MODE" == "direnv" || "$MODE" == "bare" ]]; then
         if [[ -e "$WORKSPACE_DIR/.devcontainer" && "$DEVCONTAINER_PREEXISTED" != "true" ]]; then
             DELETIONS+=(".devcontainer/")
+        elif [[ "$DEVCONTAINER_PREEXISTED" == "true" && "$PRUNE_DEVCONTAINER" == "true" ]]; then
+            # --prune-devcontainer opts into removing a pre-existing container
+            # on a container→direnv/bare migration (#990).
+            DELETIONS+=(".devcontainer/ (pre-existing, pruned — #990)")
         elif [[ "$DEVCONTAINER_PREEXISTED" == "true" ]]; then
             # The #738 guard keeps a populated consumer .devcontainer/; say so
             # explicitly instead of leaving it silently absent from the report.
@@ -801,10 +842,14 @@ case "$MODE" in
         # Standards-only scaffold (#885): prune every container/flake
         # artifact, with the same pre-existence guards as the other modes —
         # consumer-owned files always survive (#738/#859).
-        if [[ "$DEVCONTAINER_PREEXISTED" == "true" ]]; then
+        if [[ "$DEVCONTAINER_PREEXISTED" == "true" && "$PRUNE_DEVCONTAINER" != "true" ]]; then
             echo "bare mode: preserving existing .devcontainer/ (#738)"
         else
-            echo "Pruning to 'bare' mode: removing .devcontainer/..."
+            if [[ "$DEVCONTAINER_PREEXISTED" == "true" ]]; then
+                echo "bare mode: pruning pre-existing .devcontainer/ (--prune-devcontainer, #990)..."
+            else
+                echo "Pruning to 'bare' mode: removing .devcontainer/..."
+            fi
             rm -rf "$WORKSPACE_DIR/.devcontainer"
         fi
         if [[ "$FLAKE_PREEXISTED" == "true" ]]; then
@@ -839,10 +884,14 @@ case "$MODE" in
     direnv)
         # Only drop a .devcontainer/ that this scaffold created; never delete a
         # populated consumer .devcontainer/ that predates the (re)scaffold (#738).
-        if [[ "$DEVCONTAINER_PREEXISTED" == "true" ]]; then
+        if [[ "$DEVCONTAINER_PREEXISTED" == "true" && "$PRUNE_DEVCONTAINER" != "true" ]]; then
             echo "direnv mode: preserving existing .devcontainer/ (#738)"
         else
-            echo "Pruning to 'direnv' mode: removing .devcontainer/..."
+            if [[ "$DEVCONTAINER_PREEXISTED" == "true" ]]; then
+                echo "direnv mode: pruning pre-existing .devcontainer/ (--prune-devcontainer, #990)..."
+            else
+                echo "Pruning to 'direnv' mode: removing .devcontainer/..."
+            fi
             rm -rf "$WORKSPACE_DIR/.devcontainer"
         fi
         ;;

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Opt-in `--prune-devcontainer` for container → direnv/bare migrations** ([#990](https://github.com/vig-os/devkit/issues/990))
+  - Switching a container repo to `direnv`/`bare` keeps a populated pre-existing
+    `.devcontainer/` by default (non-destructive, [#738](https://github.com/vig-os/devkit/issues/738)).
+    On a real migration that strands the stale container next to the new flake,
+    so `install.sh` / `init-workspace.sh` now accept `--prune-devcontainer` to
+    remove it. The flag is rejected in `devcontainer`/`both` modes; `--preview`
+    lists the `.devcontainer/` under `DELETED` when it is set; and interactive
+    runs prompt once (`Prune existing .devcontainer/? (y/N)`, default No) when a
+    populated pre-existing `.devcontainer/` is detected in a container-less mode.
+    `docs/MIGRATION.md` documents the preview-then-apply cleanup runbook.
+
 ### Changed
 
 - **Renovate: update `cachix/install-nix-action` from `v31.10.6` to `v31.10.7`** ([#984](https://github.com/vig-os/devkit/pull/984))

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -385,6 +385,41 @@ It prints the add/overwrite/preserve/delete file report and exits without
 touching the tree (unlike `--dry-run`, which only prints the container command
 and computes no file report).
 
+### Migrating a `devcontainer`/`both` repo to `direnv` or `bare`
+
+By default a mode switch is **non-destructive** toward a populated pre-existing
+`.devcontainer/`: switching a container repo to `direnv`/`bare` keeps the old
+container next to the new flake ([#738](https://github.com/vig-os/devkit/issues/738)).
+That is right for coexistence, but on a genuine **container → direnv/bare
+migration** it strands a now-stale container. `--prune-devcontainer` opts into
+removing it (`direnv`/`bare` modes only; rejected in `devcontainer`/`both`).
+
+Because a mode switch never happens implicitly (see
+[the `.vig-os` manifest](#the-vig-os-project-manifest) above), the migration is a
+deliberate, reviewable branch:
+
+1. On a clean upgrade branch, set `DEVKIT_MODE=direnv` (or `bare`) in `.vig-os`
+   and commit it.
+2. **Preview the cleanup first** — confirm the `.devcontainer/` moves into the
+   `DELETED` listing (and nothing else you rely on does):
+
+   ```bash
+   curl -sSfL https://raw.githubusercontent.com/vig-os/devkit/main/install.sh \
+     | bash -s -- --force --preview --mode direnv --prune-devcontainer .
+   ```
+
+3. Run the upgrade with the flag to apply it:
+
+   ```bash
+   curl -sSfL https://raw.githubusercontent.com/vig-os/devkit/main/install.sh \
+     | bash -s -- --force --mode direnv --prune-devcontainer .
+   ```
+
+Interactive runs (no `--no-prompts`) that detect a populated pre-existing
+`.devcontainer/` in a container-less mode prompt once
+(`Prune existing .devcontainer/? (y/N)`, default No). Omit the flag entirely to
+keep the #738 default and preserve the container.
+
 ## Upgrading an existing 0.3.x consumer — manual steps
 
 `install.sh --version <X> --force` refreshes the scaffold and pins `<X>` in

--- a/install.sh
+++ b/install.sh
@@ -17,6 +17,8 @@
 #   --smoke-test      Deploy smoke-test-specific assets
 #   --preview         Print the add/overwrite/preserve/delete file report for an
 #                     upgrade and exit without changing anything
+#   --prune-devcontainer  In direnv/bare mode, remove a pre-existing .devcontainer/
+#                     (container->direnv/bare migration cleanup; default keeps it)
 #   --skip-preflight  Bypass the upgrade preflight guard (branch + clean-tree checks)
 #   --dry-run         Show the container command that would run without executing
 #   -h, --help        Show this help message
@@ -44,6 +46,7 @@ GITHUB_REPO_OVERRIDE=""
 MODE=""
 SMOKE_TEST=""
 PREVIEW=""
+PRUNE_DEVCONTAINER=""
 SKIP_PREFLIGHT=false
 
 # Colors (disabled if not a tty)
@@ -84,6 +87,10 @@ OPTIONS:
     --smoke-test      Deploy smoke-test-specific assets
     --preview         Preview an upgrade: print the add/overwrite/preserve/delete
                       file report and exit without changing any files
+    --prune-devcontainer
+                      In direnv/bare mode, also remove a pre-existing
+                      .devcontainer/ (a container->direnv/bare migration cleanup).
+                      The default is non-destructive and keeps it (#738).
     --skip-preflight  Bypass the upgrade preflight guard (--force refuses on
                       main/dev/release/*/detached HEAD and on a dirty tree)
     --dry-run         Show the container command that would run (unlike
@@ -442,6 +449,10 @@ while [ $# -gt 0 ]; do
             PREVIEW="--preview"
             shift
             ;;
+        --prune-devcontainer)
+            PRUNE_DEVCONTAINER="--prune-devcontainer"
+            shift
+            ;;
         --skip-preflight)
             SKIP_PREFLIGHT=true
             shift
@@ -697,6 +708,10 @@ fi
 
 if [ -n "$MODE" ]; then
     CMD+=(--mode "$MODE")
+fi
+
+if [ -n "$PRUNE_DEVCONTAINER" ]; then
+    CMD+=(--prune-devcontainer)
 fi
 
 if [ "$DRY_RUN" = true ]; then

--- a/tests/bats/init-workspace.bats
+++ b/tests/bats/init-workspace.bats
@@ -330,6 +330,109 @@ _scaffold() {
     assert_success
 }
 
+# ── opt-in .devcontainer/ prune on container-less mode upgrade (#990) ──────────
+# The #738 default is non-destructive: a container→direnv/bare re-scaffold keeps
+# a populated pre-existing .devcontainer/. On a real container→direnv migration
+# that strands a stale container next to the new flake, so `--prune-devcontainer`
+# opts into removing it. The flag applies only to direnv/bare modes; in
+# devcontainer/both it is rejected loudly. The default (no flag) stays #738.
+
+# Like _scaffold, but forwards extra args (e.g. --prune-devcontainer).
+_scaffold_ex() {
+    local mode="$1" ws="$2"
+    shift 2
+    local stub="$BATS_TEST_TMPDIR/stub-bin"
+    mkdir -p "$stub"
+    printf '#!/usr/bin/env bash\nexit 0\n' >"$stub/just"
+    chmod +x "$stub/just"
+    env PATH="$stub:$PATH" \
+        TEMPLATE_DIR="$PROJECT_ROOT/assets/workspace" \
+        WORKSPACE_DIR="$ws" \
+        SHORT_NAME=testproj \
+        GITHUB_REPOSITORY=test/repo \
+        bash "$INIT_WORKSPACE_SH" --force --no-prompts --mode "$mode" "$@"
+}
+
+@test "init-workspace --mode=direnv --prune-devcontainer removes a pre-existing .devcontainer/ (#990)" {
+    ws="$BATS_TEST_TMPDIR/e2e-990-direnv-prune"
+    mkdir -p "$ws/.devcontainer"
+    printf '{ "name": "stale devcontainer" }\n' >"$ws/.devcontainer/devcontainer.json"
+    run _scaffold_ex direnv "$ws" --prune-devcontainer
+    assert_success
+    run test -e "$ws/.devcontainer"
+    assert_failure
+    # ...and the direnv stub was still scaffolded.
+    run test -f "$ws/flake.nix"
+    assert_success
+}
+
+@test "init-workspace --mode=bare --prune-devcontainer removes a pre-existing .devcontainer/ (#990)" {
+    ws="$BATS_TEST_TMPDIR/e2e-990-bare-prune"
+    mkdir -p "$ws/.devcontainer"
+    printf '{ "name": "stale devcontainer" }\n' >"$ws/.devcontainer/devcontainer.json"
+    run _scaffold_ex bare "$ws" --prune-devcontainer
+    assert_success
+    run test -e "$ws/.devcontainer"
+    assert_failure
+}
+
+@test "init-workspace --mode=direnv without the flag still preserves .devcontainer/ (#990 keeps #738)" {
+    ws="$BATS_TEST_TMPDIR/e2e-990-direnv-keep"
+    mkdir -p "$ws/.devcontainer"
+    printf '{ "name": "SENTINEL-990 kept" }\n' >"$ws/.devcontainer/devcontainer.json"
+    run _scaffold direnv "$ws"
+    assert_success
+    run grep -q 'SENTINEL-990 kept' "$ws/.devcontainer/devcontainer.json"
+    assert_success
+}
+
+@test "init-workspace --prune-devcontainer is rejected in devcontainer mode (#990)" {
+    ws="$BATS_TEST_TMPDIR/e2e-990-reject-devc"
+    mkdir -p "$ws"
+    run _scaffold_ex devcontainer "$ws" --prune-devcontainer
+    assert_failure
+    assert_output --partial "--prune-devcontainer only applies to direnv/bare modes"
+}
+
+@test "init-workspace --prune-devcontainer is rejected in both mode (#990)" {
+    ws="$BATS_TEST_TMPDIR/e2e-990-reject-both"
+    mkdir -p "$ws"
+    run _scaffold_ex both "$ws" --prune-devcontainer
+    assert_failure
+    assert_output --partial "--prune-devcontainer only applies to direnv/bare modes"
+}
+
+@test "init-workspace prompts to prune a pre-existing .devcontainer/ in a container-less mode (#990)" {
+    # Interactive runs (no --no-prompts) prompt once, default No = preserve; the
+    # prompt is guarded to direnv/bare, a pre-existing .devcontainer/, and no
+    # explicit flag. Asserted structurally (the suite has no pty harness).
+    run grep -q 'Prune existing .devcontainer/? (y/N)' "$INIT_WORKSPACE_SH"
+    assert_success
+}
+
+@test "init-workspace --preview --prune-devcontainer lists .devcontainer/ as DELETED without deleting (#990)" {
+    ws="$BATS_TEST_TMPDIR/e2e-990-preview-prune"
+    mkdir -p "$ws/.devcontainer"
+    printf '{ "name": "stale devcontainer" }\n' >"$ws/.devcontainer/devcontainer.json"
+    run _preview "$ws" --mode direnv --prune-devcontainer
+    assert_success
+    assert_output --partial "DELETED"
+    assert_output --partial ".devcontainer/"
+    # side-effect-free: the preview left the dir in place
+    run test -d "$ws/.devcontainer"
+    assert_success
+}
+
+@test "init-workspace --preview without the flag lists a pre-existing .devcontainer/ as PRESERVED (#990)" {
+    ws="$BATS_TEST_TMPDIR/e2e-990-preview-keep"
+    mkdir -p "$ws/.devcontainer"
+    printf '{ "name": "stale devcontainer" }\n' >"$ws/.devcontainer/devcontainer.json"
+    run _preview "$ws" --mode direnv
+    assert_success
+    assert_output --partial "PRESERVED"
+    assert_output --partial "pre-existing, kept"
+}
+
 # ── upgrade preview/report follows template symlinks (#949) ───────────────────
 # The Nix image bakes assets/workspace as a tree of symlinks into the nix store,
 # so the --preview/--force classifier's `find -type f` matched ZERO files and the

--- a/tests/bats/install.bats
+++ b/tests/bats/install.bats
@@ -750,3 +750,19 @@ MANIFEST
     run grep -E 'MODE" = "direnv" \] \|\| \[ "\$MODE" = "bare"' "$INSTALL_SH"
     assert_success
 }
+
+# ── opt-in .devcontainer/ prune forwarding (#990) ─────────────────────────────
+
+@test "install.sh forwards --prune-devcontainer to init-workspace.sh (#990)" {
+    repo="$BATS_TEST_TMPDIR/prune-forward"
+    _make_manifest_repo "$repo" direnv
+    run bash "$INSTALL_SH" --dry-run --force --prune-devcontainer "$repo" </dev/null
+    assert_success
+    assert_output --partial "--prune-devcontainer"
+}
+
+@test "help lists --prune-devcontainer (#990)" {
+    run bash "$INSTALL_SH" --help
+    assert_success
+    assert_output --partial "--prune-devcontainer"
+}


### PR DESCRIPTION
## What

Add an opt-in `--prune-devcontainer` flag to `assets/init-workspace.sh` (forwarded
by `install.sh`) that removes a **pre-existing** `.devcontainer/` when
(re)scaffolding in a container-less mode (`direnv` or `bare`).

## Why

Mode switching is deliberately non-destructive toward a pre-existing
`.devcontainer/` (#738), which is correct for coexistence but strands a stale,
broken container on a real container → direnv migration (concrete case:
`vig-os/commit-action`'s old apt/Debian `.devcontainer/`). This gives operators a
supported, explicit way to prune it while keeping the #738 default intact.

## Behavior

- **`--prune-devcontainer`** (direnv/bare only): a populated pre-existing
  `.devcontainer/` is removed. Without it, #738 behavior is unchanged (preserved).
- **Rejected loudly** in `devcontainer`/`both` modes:
  `Error: --prune-devcontainer only applies to direnv/bare modes (got: <mode>)`,
  exit 1 — same failure shape as an invalid `--mode`.
- **Interactive runs** (no `--no-prompts`) prompt once when a populated
  pre-existing `.devcontainer/` is detected in a container-less mode:
  `Prune existing .devcontainer/? (y/N)`, default No = preserve. Skipped under
  `--no-prompts` and `--preview` (preview decides purely from the flag and stays
  side-effect-free).
- **`--preview`**: with the flag the `.devcontainer/` moves from the PRESERVED
  listing to the DELETED listing; the tree is not touched.
- `install.sh` forwards the flag (parse → CMD array), documented in `--help`.
- `docs/MIGRATION.md`: new "Migrating a devcontainer/both repo to direnv/bare"
  subsection with the preview-then-apply runbook.

## Test evidence

`bats tests/bats/init-workspace.bats tests/bats/install.bats` → **224 passed, 0 failed**
(no automated CI on PRs into the epic branch — local evidence).

New tests (all green):

- init-workspace `--mode=direnv --prune-devcontainer` removes a pre-existing `.devcontainer/` (#990)
- init-workspace `--mode=bare --prune-devcontainer` removes a pre-existing `.devcontainer/` (#990)
- init-workspace `--mode=direnv` without the flag still preserves `.devcontainer/` (#990 keeps #738)
- init-workspace `--prune-devcontainer` is rejected in devcontainer mode (#990)
- init-workspace `--prune-devcontainer` is rejected in both mode (#990)
- init-workspace prompts to prune a pre-existing `.devcontainer/` in a container-less mode (#990)
- init-workspace `--preview --prune-devcontainer` lists `.devcontainer/` as DELETED without deleting (#990)
- init-workspace `--preview` without the flag lists a pre-existing `.devcontainer/` as PRESERVED (#990)
- install.sh forwards `--prune-devcontainer` to init-workspace.sh (#990)
- help lists `--prune-devcontainer` (#990)

Full `prek run --all-files` green (sync-manifest mirrored the CHANGELOG entry into
`assets/workspace/.devcontainer/CHANGELOG.md`; re-staged and re-run clean).

Refs: #990
