### PR TITLE
chore(testing): adopt actionlint for authored and rendered workflows

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -95,6 +95,21 @@ repos:
         args: ["-x"]
         exclude: (^|/)\.envrc$
 
+  # GitHub Actions workflow linting (actionlint from the flake dev-shell). Lints
+  # THIS repo's own .github/workflows/ via auto-discovery; shellcheck integration
+  # is disabled (its run-block findings are a separate concern, and the
+  # shellcheck hook above covers .sh scripts). Devkit-only: not scaffolded to
+  # consumers — the per-mode rendered templates are validated in tests/bats.
+  # Refs #995.
+  - repo: local
+    hooks:
+      - id: actionlint
+        name: actionlint (lint GitHub Actions workflows)
+        entry: actionlint -shellcheck=
+        language: system
+        files: ^\.github/workflows/.*\.ya?ml$
+        pass_filenames: false
+
   # Markdown Linting (excludes auto-generated docs)
   - repo: https://github.com/jackdewinter/pymarkdown
     rev: f93643d339dfee2a1022e7b05e8b5a281bfac553  # v0.9.23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`actionlint` GitHub Actions workflow linter adopted** ([#995](https://github.com/vig-os/devkit/issues/995))
+  - `actionlint` joins the vigOS toolchain (dev-shell, image, and `vigos.packages` home module), so it is available in every consumer environment.
+  - The devkit lints its own `.github/workflows/` through a pre-commit hook, and its bats suite runs `actionlint` over the per-mode scaffold output (devcontainer, direnv, bare, both) plus the smoke-test template — a semantically broken rendered workflow now fails in the devkit instead of silently in a consumer repo.
+
 ### Changed
 
 - **Renovate: update `cachix/install-nix-action` from `v31.10.6` to `v31.10.7`** ([#984](https://github.com/vig-os/devkit/pull/984))

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`actionlint` GitHub Actions workflow linter adopted** ([#995](https://github.com/vig-os/devkit/issues/995))
+  - `actionlint` joins the vigOS toolchain (dev-shell, image, and `vigos.packages` home module), so it is available in every consumer environment.
+  - The devkit lints its own `.github/workflows/` through a pre-commit hook, and its bats suite runs `actionlint` over the per-mode scaffold output (devcontainer, direnv, bare, both) plus the smoke-test template — a semantically broken rendered workflow now fails in the devkit instead of silently in a consumer repo.
+
 ### Changed
 
 - **Renovate: update `cachix/install-nix-action` from `v31.10.6` to `v31.10.7`** ([#984](https://github.com/vig-os/devkit/pull/984))

--- a/nix/devtools.nix
+++ b/nix/devtools.nix
@@ -44,6 +44,7 @@ with pkgs;
   typos # source typo checker (pre-commit typos hook)
   deadnix # dead-Nix-code linter (flake `checks.deadnix`)
   statix # nix anti-pattern linter (flake `checks.statix`)
+  actionlint # GitHub Actions workflow linter (pre-commit hook, #995)
 
   # Container runtime
   podman

--- a/nix/hooks.nix
+++ b/nix/hooks.nix
@@ -373,6 +373,25 @@ let
         excludes = [ shellcheckExclude ];
       };
     };
+    # GitHub Actions workflow linter (#995). Runner-only and devkit-only: it
+    # lints THIS repo's own .github/workflows/ via actionlint's auto-discovery
+    # (pass_filenames = false). Not scaffolded to consumers and not in the
+    # sandbox gate — the per-mode RENDERED consumer templates are validated in
+    # tests/bats instead, because linting them in-place resolves the
+    # reusable-workflow siblings against the wrong root (the devkit itself).
+    # shellcheck integration
+    # is disabled (-shellcheck=): its run-block findings on the authored
+    # workflows are a separate hardening concern, and the shellcheck hook above
+    # already covers .sh scripts.
+    actionlint = {
+      yaml = {
+        name = "actionlint (lint GitHub Actions workflows)";
+        entry = "actionlint -shellcheck=";
+        language = "system";
+        files = "^\\.github/workflows/.*\\.ya?ml$";
+        pass_filenames = false;
+      };
+    };
     # Markdown lint — runner-only everywhere: pymarkdown is not in nixpkgs,
     # so neither the sandbox gate nor the consumer generation can resolve
     # it (documented residual, docs/NIX.md).

--- a/tests/bats/init-workspace.bats
+++ b/tests/bats/init-workspace.bats
@@ -1942,3 +1942,63 @@ _upgrade_legacy() {
         assert_failure
     done
 }
+
+# ── actionlint over the per-mode RENDERED workflows (#995) ─────────────────────
+# Each mode scaffolds a full .github/workflows/ tree (reusable release
+# choreography + the mode-specific ci.yml). actionlint validates the rendered
+# YAML semantically — job/needs/outputs wiring, expression syntax, action
+# inputs — so a broken render fails here in the devkit, not silently in a
+# consumer repo. Linting the templates in-place is impossible (actionlint
+# resolves `./.github/workflows/<reusable>` against the devkit root, where the
+# reusable release files do not exist); the faithful check is over the fully
+# rendered tree, which is what these fixtures do.
+#
+# The invocation disables actionlint's bundled shellcheck (`-shellcheck=`): its
+# run-block findings on the authored templates are pre-existing info/style/
+# warning noise, tracked for a separate hardening pass — the dedicated
+# shell-lint hook already covers `.sh` scripts. The reusable release workflows
+# read secrets (GHCR_PULL_TOKEN, *_APP_CLIENT_ID/PRIVATE_KEY) passed by the
+# caller via `secrets: inherit`, which actionlint cannot see statically; those
+# false positives are ignored by message.
+ACTIONLINT_INHERITED_SECRETS='property "(ghcr_pull_token|release_app_client_id|release_app_private_key|commit_app_client_id|commit_app_private_key)" is not defined'
+
+_actionlint_rendered() {
+    local mode="$1" ws="$2"
+    mkdir -p "$ws"
+    _scaffold "$mode" "$ws" || return 1
+    # actionlint locates the project root (for reusable-workflow resolution)
+    # via git; a scaffolded consumer repo is a git repo, so mirror that.
+    (
+        cd "$ws" &&
+            git init -q &&
+            actionlint -shellcheck= -ignore "$ACTIONLINT_INHERITED_SECRETS"
+    )
+}
+
+@test "actionlint passes over the devcontainer-mode rendered workflows (#995)" {
+    run _actionlint_rendered devcontainer "$BATS_TEST_TMPDIR/al-devcontainer"
+    assert_success
+}
+
+@test "actionlint passes over the direnv-mode rendered workflows (#995)" {
+    run _actionlint_rendered direnv "$BATS_TEST_TMPDIR/al-direnv"
+    assert_success
+}
+
+@test "actionlint passes over the bare-mode rendered workflows (#995)" {
+    run _actionlint_rendered bare "$BATS_TEST_TMPDIR/al-bare"
+    assert_success
+}
+
+@test "actionlint passes over the both-mode rendered workflows (#995)" {
+    run _actionlint_rendered both "$BATS_TEST_TMPDIR/al-both"
+    assert_success
+}
+
+@test "actionlint passes over the smoke-test workflow template (#995)" {
+    # The smoke-test template ships a single, standalone workflow (no reusable
+    # siblings), so it is linted in-place by explicit path from the repo root.
+    run actionlint -shellcheck= \
+        "$PROJECT_ROOT/assets/smoke-test/.github/workflows/repository-dispatch.yml"
+    assert_success
+}


### PR DESCRIPTION
## Summary

Adopts `actionlint` (nixpkgs `1.7.12`) so GitHub Actions workflows — both the
devkit's own authored workflows and the per-mode **rendered** scaffold output —
are validated semantically, not just yamllint/grep-checked. Closes a gap where a
broken `needs`/`outputs` wiring or invalid expression in a rendered workflow
would ship silently and only fail in a consumer repo.

Part of #988. Supports #991/#994 verification.

## What changed

- **Toolchain** (`nix/devtools.nix`): `actionlint` added to the vigOS toolchain
  SSoT — available in the dev-shell, the Nix-built image, and the
  `vigos.packages` home module (so consumers get the binary too).
- **Pre-commit hook** (`nix/hooks.nix` → rendered into `.pre-commit-config.yaml`):
  an `actionlint` hook that auto-discovers and lints the devkit's **own**
  `.github/workflows/`, with the bundled shellcheck disabled (`-shellcheck=`).
- **bats** (`tests/bats/init-workspace.bats`): five new tests that scaffold each
  delivery mode (devcontainer / direnv / bare / both) into a temp workspace via
  the real `init-workspace.sh`, `git init` it, and run `actionlint` over the
  rendered `.github/workflows/` tree asserting exit 0 — plus the standalone
  smoke-test workflow template.
- **CHANGELOG**: `Added` entry (the `actionlint` binary ships to consumers via
  the toolchain SSoT).

## Hook-placement decision

**Devkit-only, runner-only.** The hook lives in the devkit's own
`.pre-commit-config.yaml` (not scaffolded to consumers, not in the flake sandbox
gate). It lints the devkit's own workflows only.

The per-mode consumer templates are **not** linted in-place by the hook and are
covered by the bats suite instead. This is forced, not just preferred: the
reusable release workflows reference `./.github/workflows/release-core.yml`
(etc.), which actionlint resolves against the **project root**. Linting the
templates where they live (`assets/workspace/.github/workflows/`) resolves those
siblings against the devkit repo root — where those files do not exist —
producing false "reusable workflow not found" errors. Validating the **rendered**
tree (where the siblings sit together) is the faithful check, so that is what the
bats fixtures do. Consumers therefore get no actionlint hook; their rendered
workflows are guaranteed valid by the devkit's bats suite.

## actionlint sweep triage

Ran actionlint over every target tree. Findings:

| Class | Where | Count | Disposition |
|-------|-------|-------|-------------|
| shellcheck-in-`run:` (SC2086/2129/2016/2295/2207/2076/2015/2034 — all info/style/warning) | devkit-own + all templates | 41 | **Suppressed** — `-shellcheck=` disables actionlint's bundled shellcheck. All are pre-existing info/style/warning noise in established `run:` blocks; the standalone shellcheck hook already covers `.sh` scripts. Hardening `run:` blocks + re-enabling is a **deferred** follow-up. |
| `secrets.*` "not defined in object type" | `assets/workspace` `release-core.yml`, `release-publish.yml` | 16 | **Suppressed** in the bats sweep via `-ignore` (scoped to the exact inherited secret names). The caller passes them with `secrets: inherit`, which actionlint cannot see statically — a known false positive, not a defect. |
| `workflow-call` "could not read reusable workflow file" | `assets/workspace` `release.yml` | 3 | **False positive from out-of-tree linting** (see decision above). Does not occur in the rendered tree, so no suppression needed — the bats fixtures pass cleanly. |
| genuine syntax/expression/wiring defects | anywhere | 0 | None found. **Nothing fixed, nothing deferred.** |

No workflows were rewritten. No `.github/actionlint.yaml` was added (the only
real false positive — inherited secrets — is scoped narrowly in the bats
invocation; a shipped config would belong with a future consumer-facing
actionlint hook, out of scope here).

## CI wiring

No CI edit needed. The `project-checks` lane (`.github/actions/test-project`)
already runs `prek run --all-files` (covers the new hook) and `bats tests/bats/`
(covers the rendered-tree fixtures).

## Evidence (local — the epic branch has no automated CI on sub-PRs)

- `actionlint --version` from the dev-shell: `1.7.12`
- `prek run --all-files`: green
- `bats tests/bats/init-workspace.bats`: **132/132** pass (5 new #995 tests)
- `pytest tests/test_flake_hooks.py` (hook drift gate): 13 passed — render matches committed config

Refs: #995
