### PR TITLE
feat(ci): add resolve-toolchain and setup-devkit-toolchain composite actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Mode-aware toolchain composite actions** ([#994](https://github.com/vig-os/devkit/issues/994))
+  - New scaffolded `resolve-toolchain` composite action (evolves
+    `resolve-image`): reads `.vig-os` and emits `mode`, `image`, and `image-tag`.
+    Container-ish modes (`devcontainer`/`both`) get the `ghcr.io/vig-os/devcontainer`
+    image and keep the `docker manifest inspect` accessibility probe; the host
+    modes (`direnv`/`bare`) get an explicit empty `image` so the downstream job
+    runs on the host runner (Option A, `docs/rfcs/ADR-conditional-container-toolchain.md`).
+  - New scaffolded `setup-devkit-toolchain` composite action: the single
+    step-level toolchain preamble for every mode. Branches on `DEVKIT_MODE` —
+    in-container jobs export the image-relative env (`UV_PROJECT_ENVIRONMENT`,
+    `PREK_HOME`) + `safe.directory` fix; `direnv` provisions the repo flake
+    dev-shell via Nix + Cachix; `bare` installs the pinned toolchain (`just`,
+    `prek`, `vig-utils`) with `uv`. Both host modes install a self-contained
+    `retry` shim. Preserves the per-mode `prek` version-skew guards (#854).
 - **`vig-utils` console scripts available in the dev-shell** ([#993](https://github.com/vig-os/devkit/issues/993))
   - `prepare-changelog`, `renovate-changelog-pr`, and the other
     `packages/vig-utils` console scripts are now on the toolchain SSoT

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Mode-aware toolchain composite actions** ([#994](https://github.com/vig-os/devkit/issues/994))
+  - New scaffolded `resolve-toolchain` composite action (evolves
+    `resolve-image`): reads `.vig-os` and emits `mode`, `image`, and `image-tag`.
+    Container-ish modes (`devcontainer`/`both`) get the `ghcr.io/vig-os/devcontainer`
+    image and keep the `docker manifest inspect` accessibility probe; the host
+    modes (`direnv`/`bare`) get an explicit empty `image` so the downstream job
+    runs on the host runner (Option A, `docs/rfcs/ADR-conditional-container-toolchain.md`).
+  - New scaffolded `setup-devkit-toolchain` composite action: the single
+    step-level toolchain preamble for every mode. Branches on `DEVKIT_MODE` —
+    in-container jobs export the image-relative env (`UV_PROJECT_ENVIRONMENT`,
+    `PREK_HOME`) + `safe.directory` fix; `direnv` provisions the repo flake
+    dev-shell via Nix + Cachix; `bare` installs the pinned toolchain (`just`,
+    `prek`, `vig-utils`) with `uv`. Both host modes install a self-contained
+    `retry` shim. Preserves the per-mode `prek` version-skew guards (#854).
 - **`vig-utils` console scripts available in the dev-shell** ([#993](https://github.com/vig-os/devkit/issues/993))
   - `prepare-changelog`, `renovate-changelog-pr`, and the other
     `packages/vig-utils` console scripts are now on the toolchain SSoT

--- a/assets/workspace/.github/actions/resolve-toolchain/action.yml
+++ b/assets/workspace/.github/actions/resolve-toolchain/action.yml
@@ -1,0 +1,165 @@
+# Resolve devkit toolchain (mode + image)
+#
+# Evolves resolve-image (#994): reads the `.vig-os` manifest and emits the
+# delivery mode alongside the container image, so a leading `resolve-toolchain`
+# job can drive the Option-A conditional-`container:` pattern
+# (docs/rfcs/ADR-conditional-container-toolchain.md). The `resolve-image` action
+# stays in place for now; it is retired by #991/#989.
+#
+# Outputs:
+#   mode       devcontainer | direnv | both | bare. A manifest-bearing repo with
+#              no DEVKIT_MODE key defaults to `both` — today's container
+#              behavior — so un-migrated pins keep resolving.
+#   image      ghcr.io/vig-os/devcontainer:<tag> for the container-ish modes
+#              (devcontainer/both); an EXPLICIT EMPTY STRING for the host modes
+#              (direnv/bare). Per the ADR the output is ALWAYS emitted, never
+#              omitted: an empty container image makes the downstream job run on
+#              the host runner.
+#   image-tag  the bare resolved version tag (for logging/compat, and doubles as
+#              the devkit-version to plumb into setup-devkit-toolchain's bare
+#              branch).
+
+name: Resolve devkit toolchain
+description: Resolve the delivery mode + devcontainer image tag from .vig-os for mode-aware CI jobs
+
+inputs:
+  image-tag:
+    description: Optional image tag override
+    required: false
+    default: ''
+  registry-token:
+    description: >-
+      Optional GHCR token for authenticated manifest probes (private or
+      rate-limited images). When empty, the probe runs anonymously (public
+      images). Only used for the container-ish modes.
+    required: false
+    default: ''
+  registry-username:
+    description: Username paired with registry-token for docker login
+    required: false
+    default: ''
+
+outputs:
+  mode:
+    description: Delivery mode (devcontainer|direnv|both|bare)
+    value: ${{ steps.resolve.outputs.mode }}
+  image:
+    description: Container image (ghcr.io/... for container modes, empty string for host modes)
+    value: ${{ steps.resolve.outputs.image }}
+  image-tag:
+    description: Resolved image/version tag
+    value: ${{ steps.resolve.outputs.tag }}
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve mode + image tag
+      id: resolve
+      shell: bash
+      env:
+        INPUT_IMAGE_TAG: ${{ inputs.image-tag }}
+      run: |
+        set -euo pipefail
+
+        MODE=""
+        DEVKIT_VERSION=""
+        LEGACY_VERSION=""
+
+        if [[ -f .vig-os ]]; then
+          # Tolerant KEY=VALUE parsing shared with resolve-image (#781): capture
+          # DEVKIT_MODE and both version keys, preferring the renamed
+          # DEVKIT_VERSION over the legacy DEVCONTAINER_VERSION after the read so
+          # line order never matters.
+          while IFS= read -r line || [[ -n "${line:-}" ]]; do
+            [[ -z "${line//[[:space:]]/}" ]] && continue
+            [[ "$line" =~ ^[[:space:]]*# ]] && continue
+
+            case "$line" in
+              DEVKIT_MODE=*|DEVKIT_VERSION=*|DEVCONTAINER_VERSION=*)
+                key="${line%%=*}"
+                value="${line#*=}"
+                value="${value#"${value%%[![:space:]]*}"}"
+                value="${value%"${value##*[![:space:]]}"}"
+
+                if [[ "$value" =~ ^\".*\"$ ]]; then
+                  value="${value:1:-1}"
+                elif [[ "$value" =~ ^\'.*\'$ ]]; then
+                  value="${value:1:-1}"
+                fi
+
+                case "$key" in
+                  DEVKIT_MODE) MODE="$value" ;;
+                  DEVKIT_VERSION) DEVKIT_VERSION="$value" ;;
+                  DEVCONTAINER_VERSION) LEGACY_VERSION="$value" ;;
+                esac
+                ;;
+            esac
+          done < .vig-os
+        fi
+
+        # Missing DEVKIT_MODE defaults to `both` (today's container behavior).
+        MODE="${MODE:-both}"
+        echo "mode=$MODE" >> "$GITHUB_OUTPUT"
+
+        # Resolve the version tag: explicit override wins, else DEVKIT_VERSION,
+        # else the legacy DEVCONTAINER_VERSION.
+        TAG="$INPUT_IMAGE_TAG"
+        if [[ -z "$TAG" ]]; then
+          TAG="${DEVKIT_VERSION:-$LEGACY_VERSION}"
+        fi
+        echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+        case "$MODE" in
+          devcontainer|both)
+            # Container-ish modes need a resolvable tag to build the image ref.
+            if [[ -z "$TAG" ]]; then
+              echo "::error::Could not resolve DEVKIT_VERSION (or legacy DEVCONTAINER_VERSION) from .vig-os and no image-tag override was provided (mode=$MODE)."
+              exit 1
+            fi
+            IMAGE="ghcr.io/vig-os/devcontainer:${TAG}"
+            ;;
+          *)
+            # Host modes (direnv/bare): no container image. Emit an EXPLICIT
+            # empty string (never omit) so the downstream `container:` runs on
+            # the host (ADR Option A).
+            IMAGE=""
+            ;;
+        esac
+        echo "image=$IMAGE" >> "$GITHUB_OUTPUT"
+        echo "Resolved mode=$MODE tag=${TAG:-<none>} image=${IMAGE:-<host>}"
+
+    - name: Validate image accessibility
+      # Only the container-ish modes emit a non-empty image; host modes skip the
+      # probe entirely (no image needed).
+      if: steps.resolve.outputs.image != ''
+      shell: bash
+      env:
+        IMAGE: ${{ steps.resolve.outputs.image }}
+        REGISTRY_TOKEN: ${{ inputs.registry-token }}
+        REGISTRY_USERNAME: ${{ inputs.registry-username }}
+      run: |
+        set -euo pipefail
+        echo "Validating image availability: $IMAGE"
+
+        # Authenticate before the probe when a token is supplied, so private or
+        # rate-limited images resolve. The anonymous path is kept for public
+        # images (empty token).
+        if [[ -n "$REGISTRY_TOKEN" ]]; then
+          echo "Authenticating to ghcr.io as '${REGISTRY_USERNAME}'"
+          if ! echo "$REGISTRY_TOKEN" | docker login ghcr.io -u "$REGISTRY_USERNAME" --password-stdin; then
+            echo "::error::Failed to authenticate to ghcr.io as '${REGISTRY_USERNAME}'. Check the GHCR_PULL_TOKEN secret and that it grants packages:read."
+            exit 1
+          fi
+        fi
+
+        # Do not swallow stderr: capture it so an auth/denied failure can be
+        # distinguished from a genuinely missing tag.
+        if ! PROBE_ERR="$(docker manifest inspect "$IMAGE" 2>&1 >/dev/null)"; then
+          echo "$PROBE_ERR"
+          if echo "$PROBE_ERR" | grep -qiE 'unauthorized|denied|authentication|forbidden|toomanyrequests|rate limit'; then
+            echo "::error::Cannot access image manifest: ${IMAGE} — authentication required or denied. Set the GHCR_PULL_TOKEN secret (or grant the workflow token packages:read) and pass it to this action."
+          else
+            echo "::error::Cannot access image manifest: ${IMAGE} — the tag does not exist or is not readable. Check that DEVKIT_VERSION (or legacy DEVCONTAINER_VERSION) in .vig-os points at a published image tag."
+          fi
+          exit 1
+        fi

--- a/assets/workspace/.github/actions/resolve-toolchain/action.yml
+++ b/assets/workspace/.github/actions/resolve-toolchain/action.yml
@@ -99,6 +99,18 @@ runs:
 
         # Missing DEVKIT_MODE defaults to `both` (today's container behavior).
         MODE="${MODE:-both}"
+
+        # Refuse an unknown/corrupt mode loudly (mirrors the init-workspace.sh
+        # persisted-mode guard): a typo'd value must never be silently
+        # classified as a host mode and flip a container repo's CI onto host
+        # runners.
+        case "$MODE" in
+          devcontainer|direnv|both|bare) ;;
+          *)
+            echo "::error::Invalid DEVKIT_MODE in .vig-os: $MODE (expected: devcontainer | direnv | both | bare)"
+            exit 1
+            ;;
+        esac
         echo "mode=$MODE" >> "$GITHUB_OUTPUT"
 
         # Resolve the version tag: explicit override wins, else DEVKIT_VERSION,
@@ -118,10 +130,11 @@ runs:
             fi
             IMAGE="ghcr.io/vig-os/devcontainer:${TAG}"
             ;;
-          *)
-            # Host modes (direnv/bare): no container image. Emit an EXPLICIT
-            # empty string (never omit) so the downstream `container:` runs on
-            # the host (ADR Option A).
+          direnv|bare)
+            # Host modes: no container image. Emit an EXPLICIT empty string
+            # (never omit) so the downstream `container:` runs on the host
+            # (ADR Option A). Explicit arm — unknown modes were rejected above,
+            # so the statement is closed.
             IMAGE=""
             ;;
         esac

--- a/assets/workspace/.github/actions/setup-devkit-toolchain/action.yml
+++ b/assets/workspace/.github/actions/setup-devkit-toolchain/action.yml
@@ -1,0 +1,246 @@
+# Set up the devkit toolchain (mode-aware step-level preamble)
+#
+# The single toolchain preamble for every scaffolded CI/release job (#994).
+# Safe to call as the FIRST step after checkout in every job: it branches on the
+# delivery `mode` (resolved by the resolve-toolchain job) so container and host
+# jobs share one call site (docs/rfcs/ADR-conditional-container-toolchain.md).
+# After it runs, plain `run: just sync` / `just precommit` / `gh` steps work
+# identically in every mode.
+#
+# Branches (gated by `if:` on the mode input):
+#   devcontainer / both  in-container: the toolchain is already baked into the
+#                        image, so this only exports the image-relative env
+#                        (UV_PROJECT_ENVIRONMENT, PREK_HOME), applies the git
+#                        safe.directory fix, and runs the prek version-skew guard
+#                        (#854). The image ships the `retry` binary, so no shim.
+#   direnv               host: install Nix + the vig-os Cachix substituter, build
+#                        the repo's OWN flake dev-shell once, prepend its bin
+#                        dirs to PATH (mirrors the devkit's setup-env), then the
+#                        skew guard resolves prek off that PATH.
+#   bare                 host: astral-sh/setup-uv + pinned `uv tool install`
+#                        (just, prek, and the vig-utils release scripts pinned to
+#                        the devkit-version), prepend the uv tool bin dir to PATH.
+#   direnv + bare        both host modes additionally install a self-contained
+#                        `retry` shim via BASH_ENV (the scaffold cannot source a
+#                        devkit-internal script, so the function is embedded).
+
+name: Setup devkit toolchain
+description: Mode-aware step-level toolchain preamble (container in-image env, direnv Nix dev-shell, bare uv install)
+
+inputs:
+  mode:
+    description: Delivery mode (devcontainer|direnv|both|bare) — pass needs.resolve-toolchain.outputs.mode
+    required: true
+  devkit-version:
+    description: >-
+      Devkit version pin for the bare-mode vig-utils install — pass
+      needs.resolve-toolchain.outputs.image-tag. Ignored in the other modes.
+    required: false
+    default: ''
+  cachix-cache:
+    description: Optional consumer-owned Cachix cache name (direnv mode; pulls need no token)
+    required: false
+    default: ''
+  cachix-auth-token:
+    description: Optional Cachix auth token for pushing to cachix-cache (direnv mode)
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    # ── devcontainer / both — in-container, toolchain baked into the image ────
+    - name: Configure in-container toolchain env
+      if: inputs.mode == 'devcontainer' || inputs.mode == 'both'
+      shell: bash
+      run: |
+        set -euo pipefail
+        # Reuse the venv already present in the image instead of creating a new
+        # one, and use the image-baked prek cache. These paths only exist inside
+        # the devcontainer image.
+        echo "UV_PROJECT_ENVIRONMENT=/root/assets/workspace/.venv" >> "$GITHUB_ENV"
+        echo "PREK_HOME=/opt/prek-cache" >> "$GITHUB_ENV"
+        # The workspace is bind-mounted with a different owner than the image
+        # root user; mark it safe so git operations do not abort.
+        git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+        # Version-skew guard (#854): fail with an actionable message if the CI
+        # image predates the prek hook runner (#778), instead of an opaque
+        # `just precommit` exit 127 deep in the log.
+        if ! command -v prek >/dev/null 2>&1; then
+          echo "::error::'prek' not found in the CI image (ghcr.io/vig-os/devcontainer). The image pinned by .vig-os DEVKIT_VERSION predates the prek hook runner (#778)."
+          echo "Fix: bump .vig-os DEVKIT_VERSION to an image that ships prek, or re-run the devkit installer. See docs/MIGRATION.md."
+          exit 1
+        fi
+        echo "prek present: $(command -v prek)"
+
+    # ── direnv — host, provision from the repo's own Nix flake dev-shell ──────
+    # Nix installer SHA-pinned to match the vig-os toolchain. The vig-os public
+    # Cachix substituter (pull-only, no token) makes the dev-shell a fast
+    # binary-cache pull; accept-flake-config lets the pinned vigos input
+    # contribute its own substituters.
+    - name: Install Nix (upstream CppNix)
+      if: inputs.mode == 'direnv'
+      uses: cachix/install-nix-action@a49548c11d9846ad46ecc0115273879b045f001c  # v31.10.7
+      with:
+        extra_nix_config: |
+          experimental-features = nix-command flakes
+          accept-flake-config = true
+          extra-substituters = https://vig-os.cachix.org
+          extra-trusted-public-keys = vig-os.cachix.org-1:yoOYRi3bvnM6ThxO0joLt7vtzhTfkq3r6jykeUMg7Bk=
+
+    # Optional: push this repo's own closure to a consumer-owned Cachix cache.
+    # Skipped unless the repo passes cachix-cache; pulls need no token, so the
+    # vig-os substituter above already warms the dev-shell.
+    - name: Configure Cachix
+      if: inputs.mode == 'direnv' && inputs.cachix-cache != ''
+      uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71  # v17
+      with:
+        name: ${{ inputs.cachix-cache }}
+        authToken: ${{ inputs.cachix-auth-token }}
+
+    - name: Build repo flake dev-shell and export PATH
+      if: inputs.mode == 'direnv'
+      shell: bash
+      run: |
+        set -euo pipefail
+        # Build the consumer repo's own dev-shell (repo root flake) into a gcroot
+        # profile — a warm Cachix pull — then prepend its nix-store bin dirs to
+        # GITHUB_PATH so every following step runs as if inside `nix develop`.
+        # Mirrors the devkit's setup-env action (adapted: the consumer flake at
+        # the repo root, not the devkit's).
+        nix develop --profile "$RUNNER_TEMP/devkit-dev-profile" --command true
+
+        SHELL_PATH="$(nix develop --profile "$RUNNER_TEMP/devkit-dev-profile" \
+          --command bash -c 'printf "%s" "$PATH"')"
+
+        # Exclude the flake's podman (rootless podman on GitHub runners needs the
+        # host's setuid newuidmap/newgidmap, which the nix-store podman cannot
+        # see) and its bare CPython (`uv sync` must keep building the venv from a
+        # downloaded manylinux CPython, not the Nix loader — the #698/#703/#729
+        # libstdc++ regression). Library pkgs (python3.<ver>-<pkg>) are unaffected.
+        printf '%s' "$SHELL_PATH" | tr ':' '\n' \
+          | grep '^/nix/store' \
+          | grep -v '/nix/store/[^/]*-podman[^/]*/bin' \
+          | grep -Ev '/nix/store/[^/]*-python3-[0-9][^/]*/bin' >> "$GITHUB_PATH"
+
+        # Forward the dev-shell's uv Python-download metadata URL (GITHUB_PATH
+        # carries PATH only): `uv sync` needs it to fetch the project's pinned
+        # CPython, which nixpkgs does not package.
+        UV_DL_JSON_URL="$(nix develop --profile "$RUNNER_TEMP/devkit-dev-profile" \
+          --command bash -c 'printf "UV_PYTHON_DOWNLOADS_JSON_URL=%s\n" "${UV_PYTHON_DOWNLOADS_JSON_URL:-}"' \
+          | grep '^UV_PYTHON_DOWNLOADS_JSON_URL=' | tail -n1 | cut -d= -f2-)"
+        if [ -n "$UV_DL_JSON_URL" ]; then
+          echo "UV_PYTHON_DOWNLOADS_JSON_URL=$UV_DL_JSON_URL" >> "$GITHUB_ENV"
+        fi
+        echo "Repo flake dev-shell provisioned; tools added to PATH."
+
+    - name: Verify toolchain (prek present in dev-shell)
+      if: inputs.mode == 'direnv'
+      shell: bash
+      run: |
+        set -euo pipefail
+        # Skew guard (#854): prek must resolve off the PATH exported above.
+        if ! command -v prek >/dev/null 2>&1; then
+          echo "::error::'prek' is not provided by the repo flake dev-shell — the vigos flake input likely predates the prek hook runner (#778), or the dev-shell failed to build (see logs above)."
+          echo "Fix: 'nix flake update vigos' to a devkit generation that ships prek. See docs/MIGRATION.md."
+          exit 1
+        fi
+        echo "prek present: $(command -v prek)"
+
+    # ── bare — host, provision the pinned toolchain with uv ───────────────────
+    - name: Set up uv
+      if: inputs.mode == 'bare'
+      uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990  # v8.3.2
+
+    - name: Install host toolchain (just, prek, vig-utils)
+      if: inputs.mode == 'bare'
+      shell: bash
+      env:
+        DEVKIT_VERSION: ${{ inputs.devkit-version }}
+      run: |
+        set -euo pipefail
+        if [[ -z "$DEVKIT_VERSION" ]]; then
+          echo "::error::setup-devkit-toolchain (bare mode) requires 'devkit-version' — pass needs.resolve-toolchain.outputs.image-tag so vig-utils installs at the pinned devkit version."
+          exit 1
+        fi
+        # Pinned to the versions the vig-os toolchain ships; bump via Renovate or
+        # alongside a devkit upgrade. vig-utils supplies the release console
+        # scripts (prepare-changelog, renovate-changelog-pr) that the image bakes
+        # in the other modes — pinned to the same devkit version as .vig-os
+        # (#993, see docs/MIGRATION.md).
+        uv tool install rust-just==1.51.0
+        uv tool install prek==0.3.11
+        uv tool install "vig-utils @ git+https://github.com/vig-os/devkit@${DEVKIT_VERSION}#subdirectory=packages/vig-utils"
+        uv tool dir --bin >> "$GITHUB_PATH"
+        echo "Host toolchain installed (just, prek, vig-utils@${DEVKIT_VERSION})."
+
+    # ── host modes (direnv + bare) — embed the retry() shim via BASH_ENV ──────
+    # In-container jobs use the image-baked `retry` binary, so this is skipped
+    # there. The scaffold cannot source the devkit-internal retry.sh, so the
+    # function is embedded self-contained (mirrors setup-env's BASH_ENV wiring).
+    - name: Install retry shell helper (host modes)
+      if: inputs.mode == 'direnv' || inputs.mode == 'bare'
+      shell: bash
+      run: |
+        set -euo pipefail
+        RETRY_HELPER="$RUNNER_TEMP/devkit-retry.sh"
+        PREV_BASH_ENV="${BASH_ENV:-}"
+
+        cat > "$RETRY_HELPER" <<'RETRY_EOF'
+        # shellcheck shell=bash
+        retry() {
+          local retries=3
+          local backoff=1
+          local max_backoff=60
+          local rc=1
+
+          while [ "$#" -gt 0 ]; do
+            case "$1" in
+              --retries) retries="$2"; shift 2 ;;
+              --backoff) backoff="$2"; shift 2 ;;
+              --max-backoff) max_backoff="$2"; shift 2 ;;
+              --) shift; break ;;
+              *) echo "ERROR: Unknown retry option '$1'"; return 2 ;;
+            esac
+          done
+
+          if [ "$#" -eq 0 ]; then
+            echo "ERROR: retry requires a command after '--'"
+            return 2
+          fi
+
+          local attempt=1
+          local current_backoff="$backoff"
+          while [ "$attempt" -le "$retries" ]; do
+            "$@" && return 0
+            rc=$?
+            if [ "$attempt" -lt "$retries" ]; then
+              local wait="$current_backoff"
+              if [ "$wait" -gt "$max_backoff" ]; then
+                wait="$max_backoff"
+              fi
+              echo "Retry $attempt/$retries failed (exit $rc), waiting ${wait}s..."
+              sleep "$wait"
+              current_backoff=$((current_backoff * 2))
+            fi
+            attempt=$((attempt + 1))
+          done
+
+          echo "ERROR: Command failed after $retries attempts: $*"
+          return "$rc"
+        }
+        export -f retry
+        RETRY_EOF
+
+        # Chain any pre-existing BASH_ENV so this shim adds to it rather than
+        # replacing it.
+        if [ -n "$PREV_BASH_ENV" ] && [ -f "$PREV_BASH_ENV" ] && [ "$PREV_BASH_ENV" != "$RETRY_HELPER" ]; then
+          {
+            echo "source \"$PREV_BASH_ENV\""
+            cat "$RETRY_HELPER"
+          } > "${RETRY_HELPER}.merged"
+          mv "${RETRY_HELPER}.merged" "$RETRY_HELPER"
+        fi
+
+        echo "BASH_ENV=$RETRY_HELPER" >> "$GITHUB_ENV"

--- a/tests/bats/init-workspace.bats
+++ b/tests/bats/init-workspace.bats
@@ -1942,3 +1942,110 @@ _upgrade_legacy() {
         assert_failure
     done
 }
+
+# ── #994: shared resolve-toolchain + setup-devkit-toolchain composites ─────────
+# Two mode-aware composite actions ship (managed) in
+# assets/workspace/.github/actions/ for EVERY delivery mode. resolve-toolchain
+# evolves resolve-image: it emits `mode` + `image` (empty string for the host
+# modes per the Option-A ADR) + `image-tag`. setup-devkit-toolchain is the
+# step-level toolchain preamble branching on DEVKIT_MODE. These are structural
+# render assertions only — the host branches are exercised on real runners by
+# #991; here we prove the files ship, are SHA-pinned, and wire each mode branch.
+
+@test "resolve-toolchain and setup-devkit-toolchain ship in every mode (#994)" {
+    for mode in devcontainer direnv both bare; do
+        ws="$BATS_TEST_TMPDIR/e2e-994-$mode"
+        mkdir -p "$ws"
+        run _scaffold "$mode" "$ws"
+        assert_success
+        run test -f "$ws/.github/actions/resolve-toolchain/action.yml"
+        assert_success
+        run test -f "$ws/.github/actions/setup-devkit-toolchain/action.yml"
+        assert_success
+    done
+}
+
+@test "composite toolchain actions SHA-pin every action reference (#994)" {
+    # scorecard/check-action-pins conform: no floating `uses:` in either file.
+    for f in resolve-toolchain setup-devkit-toolchain; do
+        af="$TEMPLATE_DIR/.github/actions/$f/action.yml"
+        run bash -c "grep 'uses:' '$af' | grep -vE '@[0-9a-f]{40}'"
+        assert_failure
+    done
+}
+
+@test "resolve-toolchain emits an explicit empty image for direnv/bare (#994)" {
+    f="$TEMPLATE_DIR/.github/actions/resolve-toolchain/action.yml"
+    # host modes get an explicit empty-string image (ADR Option A: always emit,
+    # never omit — an empty container image makes the job run on the host).
+    run grep -Eq 'IMAGE=""' "$f"
+    assert_success
+    # container-ish modes get the ghcr devcontainer image.
+    run grep -q 'ghcr.io/vig-os/devcontainer:' "$f"
+    assert_success
+    # emits mode + image + image-tag outputs.
+    for o in 'mode:' 'image:' 'image-tag:'; do
+        run grep -q "$o" "$f"
+        assert_success
+    done
+}
+
+@test "resolve-toolchain retains the manifest-inspect accessibility probe (#994)" {
+    f="$TEMPLATE_DIR/.github/actions/resolve-toolchain/action.yml"
+    run grep -q 'docker manifest inspect' "$f"
+    assert_success
+    # tolerant .vig-os parsing preserved: DEVKIT_VERSION with legacy fallback.
+    run grep -q 'DEVCONTAINER_VERSION' "$f"
+    assert_success
+}
+
+@test "setup-devkit-toolchain gates every branch on the mode input (#994)" {
+    f="$TEMPLATE_DIR/.github/actions/setup-devkit-toolchain/action.yml"
+    run grep -q "inputs.mode == 'devcontainer'" "$f"
+    assert_success
+    run grep -q "inputs.mode == 'direnv'" "$f"
+    assert_success
+    run grep -q "inputs.mode == 'bare'" "$f"
+    assert_success
+}
+
+@test "setup-devkit-toolchain container branch reproduces the in-image env (#994)" {
+    f="$TEMPLATE_DIR/.github/actions/setup-devkit-toolchain/action.yml"
+    run grep -q 'PREK_HOME' "$f"
+    assert_success
+    run grep -q 'UV_PROJECT_ENVIRONMENT' "$f"
+    assert_success
+    run grep -q 'safe.directory' "$f"
+    assert_success
+}
+
+@test "setup-devkit-toolchain direnv branch uses Nix + the repo dev-shell (#994)" {
+    f="$TEMPLATE_DIR/.github/actions/setup-devkit-toolchain/action.yml"
+    run grep -q 'cachix/install-nix-action' "$f"
+    assert_success
+    run grep -q 'nix develop' "$f"
+    assert_success
+    # host-side prek version-skew guard points at `nix flake update vigos` (#854).
+    run grep -q 'nix flake update vigos' "$f"
+    assert_success
+}
+
+@test "setup-devkit-toolchain bare branch installs the host toolchain incl vig-utils (#994)" {
+    f="$TEMPLATE_DIR/.github/actions/setup-devkit-toolchain/action.yml"
+    run grep -q 'astral-sh/setup-uv' "$f"
+    assert_success
+    run grep -q 'uv tool install' "$f"
+    assert_success
+    run grep -q 'vig-utils' "$f"
+    assert_success
+}
+
+@test "setup-devkit-toolchain embeds a self-contained retry shim for host modes (#994)" {
+    f="$TEMPLATE_DIR/.github/actions/setup-devkit-toolchain/action.yml"
+    # BASH_ENV mechanism replicated inline (the scaffold cannot source a
+    # devkit-internal script), gated to the host modes only.
+    run grep -q 'BASH_ENV' "$f"
+    assert_success
+    run grep -q 'retry()' "$f"
+    assert_success
+}

--- a/tests/bats/init-workspace.bats
+++ b/tests/bats/init-workspace.bats
@@ -2049,3 +2049,18 @@ _upgrade_legacy() {
     run grep -q 'retry()' "$f"
     assert_success
 }
+
+@test "resolve-toolchain rejects an unknown DEVKIT_MODE loudly (#994)" {
+    # A typo'd manifest value (e.g. a misspelled `container`) must fail the
+    # resolve step, not
+    # silently fall through to the host branch (empty image) and flip a
+    # container repo's CI onto host runners. Mirrors the init-workspace.sh
+    # corrupt-persisted-mode guard.
+    f="$TEMPLATE_DIR/.github/actions/resolve-toolchain/action.yml"
+    run grep -q 'Invalid DEVKIT_MODE' "$f"
+    assert_success
+    # the image case statement is closed: an explicit direnv|bare arm, no
+    # catch-all that would classify unknown modes as host.
+    run grep -q 'direnv|bare)' "$f"
+    assert_success
+}


### PR DESCRIPTION
## Summary

Adds the two shared mode-aware composite actions from #994, scaffolded (managed)
into every workspace mode under `assets/workspace/.github/actions/`. Provisioning
is separated from image selection per the #992 spike verdict
(`docs/rfcs/ADR-conditional-container-toolchain.md`, Option A adopted): a
workflow-level `resolve-toolchain` job selects the image; the step-level
`setup-devkit-toolchain` composite handles the toolchain preamble.

`resolve-image` is left untouched (retired later by #991/#989). No workflow is
converted here — that is #991.

## How each mode branch works

**`resolve-toolchain/action.yml`** — reads `.vig-os` with the same tolerant
`KEY=VALUE` parsing as `resolve-image` (DEVKIT_MODE + DEVKIT_VERSION with legacy
DEVCONTAINER_VERSION fallback). Outputs:

- `mode` — `devcontainer|direnv|both|bare`; a manifest-bearing repo with no
  `DEVKIT_MODE` defaults to `both` (today's container behavior).
- `image` — `ghcr.io/vig-os/devcontainer:<tag>` for container-ish modes; an
  **explicit empty string** for `direnv`/`bare` (always emitted, never omitted,
  per the ADR — empty image makes the downstream job run on the host).
- `image-tag` — the bare resolved version tag (logging/compat; doubles as the
  `devkit-version` to plumb into the bare branch).

Container-ish modes keep the `docker manifest inspect` accessibility probe
(auth-vs-missing classification preserved); host modes skip it via
`if: steps.resolve.outputs.image != ''`.

**`setup-devkit-toolchain/action.yml`** — single step-level preamble, gated per
`mode` input, safe as the first step after checkout in every job:

- **devcontainer/both (in-container):** export `UV_PROJECT_ENVIRONMENT` +
  `PREK_HOME` to `$GITHUB_ENV`, `git config --global --add safe.directory`, and
  the #854 prek version-skew guard. No retry shim (image-baked `retry` binary).
- **direnv (host):** `install-nix-action` + vig-os Cachix substituter (verbatim
  from the direnv `ci.yml`), optional consumer `cachix-action`, then build the
  **repo's own** flake dev-shell once via `nix develop --profile` and prepend
  its bin dirs to `$GITHUB_PATH` (mirrors this repo's `setup-env`: filters
  podman/python3, forwards `UV_PYTHON_DOWNLOADS_JSON_URL`). Skew guard resolves
  `prek` off the exported PATH and points at `nix flake update vigos`.
- **bare (host):** `setup-uv` + `uv tool install rust-just==1.51.0`,
  `prek==0.3.11`, and `vig-utils @ git+…@${DEVKIT_VERSION}#subdirectory=packages/vig-utils`
  (#993); `uv tool dir --bin >> $GITHUB_PATH`.
- **host modes (direnv + bare):** embed a self-contained `retry` shim via
  `BASH_ENV` (the scaffold cannot source the devkit-internal `retry.sh`, so the
  function is inlined).

## Design decisions

- **Version plumbing into the bare branch:** `resolve-toolchain` resolves the
  `.vig-os` version pin into `image-tag` in **all** modes (not just container),
  so #991 passes `devkit-version: ${{ needs.resolve-toolchain.outputs.image-tag }}`
  to `setup-devkit-toolchain`. The bare install step fails fast with an
  actionable message if `devkit-version` is empty.
- **Retry shim:** embedded verbatim as a self-contained function (from
  `.github/scripts/retry.sh`) rather than referenced, because scaffolded
  consumer repos have no access to devkit-internal scripts. Chains any
  pre-existing `BASH_ENV`. Validated end-to-end (heredoc de-indents correctly and
  the function is callable).

## Evidence

- `bats tests/bats/init-workspace.bats` — **136 tests pass**, including 9 new
  `#994` render/structural assertions (both actions ship in every mode tree,
  every `uses:` SHA-pinned, per-mode branch wiring, explicit empty host image).
- `prek run --all-files` — **all hooks green** (yamllint, shellcheck,
  check-action-pins, sync-manifest all pass; CHANGELOG synced to
  `.devcontainer/CHANGELOG.md`).
- Embedded `retry()` shim executed in a simulated runner env — defined and
  functional.
- `actionlint` does **not** lint standalone composite `action.yml` metadata
  (it parses them as workflows and mis-reports); the permanent hook lands in
  #995. Run scripts were shellchecked ad hoc — only intentional `SC2016` (info)
  on the `nix develop --command bash -c 'printf … $PATH'` idiom, identical to the
  existing `setup-env` action.

## Open questions for #991 (workflow conversion)

- Which release/automation jobs should carry `devkit-version` (all that touch
  vig-utils scripts, i.e. the changelog jobs)?
- Confirm the GHCR `credentials:` block stays unconditional on scaffolded jobs
  (proven inert on empty image by the #992 spike) when threading
  `needs.resolve-toolchain.outputs.image`.
- Whether `ci.yml`'s three per-mode overlays collapse to one file in this epic
  or a follow-up.

## How #991 consumes the two actions

```yaml
jobs:
  resolve-toolchain:
    name: Resolve toolchain
    runs-on: ubuntu-24.04
    outputs:
      mode: ${{ steps.resolve.outputs.mode }}
      image: ${{ steps.resolve.outputs.image }}
      image-tag: ${{ steps.resolve.outputs.image-tag }}
    steps:
      - uses: actions/checkout@<sha>  # sparse: .vig-os + .github/actions/resolve-toolchain
      - id: resolve
        uses: ./.github/actions/resolve-toolchain
        with:
          registry-token: ${{ secrets.GHCR_PULL_TOKEN || github.token }}
          registry-username: ${{ github.actor }}

  lint:
    needs: [resolve-toolchain]
    runs-on: ubuntu-24.04
    # Empty image (host modes) => runs on host; non-empty => runs in container.
    container:
      image: ${{ needs.resolve-toolchain.outputs.image }}
      credentials:               # inert when image is empty (#992 spike)
        username: ${{ github.actor }}
        password: ${{ secrets.GHCR_PULL_TOKEN || github.token }}
    steps:
      - uses: actions/checkout@<sha>
      - uses: ./.github/actions/setup-devkit-toolchain
        with:
          mode: ${{ needs.resolve-toolchain.outputs.mode }}
          devkit-version: ${{ needs.resolve-toolchain.outputs.image-tag }}
          cachix-cache: ${{ vars.CACHIX_CACHE }}
          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
      - run: just sync
      - run: just precommit
```

No automated CI runs on PRs into the epic branch; evidence is local (above).

Refs: #994
