### PR TITLE
fix(workspace): mode-filter container-only artifacts out of direnv/bare scaffolds

### DIFF
--- a/.vig-os
+++ b/.vig-os
@@ -1,2 +1,4 @@
 # vig-os devkit configuration
 DEVKIT_VERSION=1.0.1
+# The devkit itself develops via its own flake + .envrc (no .devcontainer/) — #989.
+DEVKIT_MODE=direnv

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **direnv/bare scaffolds no longer ship container-only artifacts** ([#989](https://github.com/vig-os/devkit/issues/989))
+  - `docs/container-ci-quirks.md` (in-image CI notes) is now mode-filtered like
+    `.devcontainer/`: excluded from container-less scaffolds, pruned from a
+    previously scaffolded tree on upgrade, and reflected truthfully in the
+    `--preview` report. The `resolve-image` action and `container:` workflow
+    coupling were already retired by the mode-aware toolchain work
+    ([#991](https://github.com/vig-os/devkit/issues/991)).
+  - The devkit's own `.vig-os` now declares its delivery mode (`direnv`).
+
 - **Pin `sigstore/cosign-installer` to `v4.1.2` so Renovate can resolve its digest** ([#986](https://github.com/vig-os/devkit/issues/986))
   - The previous pin's `# v4` comment named a floating tag that `sigstore/cosign-installer` never published, so Renovate's digest lookup failed on the dependency dashboard
 

--- a/assets/init-workspace.sh
+++ b/assets/init-workspace.sh
@@ -568,6 +568,14 @@ if [[ "$FORCE" == "true" ]]; then
             && "$rel_path" == .devcontainer/* ]]; then
             continue
         fi
+        # Container-only documentation (#989): in-image CI notes are dead
+        # weight (and misleading) in the container-less modes. Devkit-managed
+        # (not in PRESERVE_FILES), so filtered unconditionally — same class as
+        # the .devcontainer/ skip above.
+        if [[ ("$MODE" == "direnv" || "$MODE" == "bare") \
+            && "$rel_path" == "docs/container-ci-quirks.md" ]]; then
+            continue
+        fi
         if [[ "$MODE" == "devcontainer" || "$MODE" == "bare" ]] \
             && [[ "$rel_path" == "flake.nix" || "$rel_path" == ".envrc" ]] \
             && [[ ! -e "$workspace_file" ]]; then
@@ -601,6 +609,12 @@ if [[ "$FORCE" == "true" ]]; then
             # The #738 guard keeps a populated consumer .devcontainer/; say so
             # explicitly instead of leaving it silently absent from the report.
             PRESERVED+=(".devcontainer/ (pre-existing, kept — #738)")
+        fi
+        # Container-only documentation is pruned in the container-less modes
+        # (#989): devkit-managed, so no pre-existence guard — mirrors the copy
+        # filter above.
+        if [[ -f "$WORKSPACE_DIR/docs/container-ci-quirks.md" ]]; then
+            DELETIONS+=("docs/container-ci-quirks.md")
         fi
     else
         # The devcontainer-mode flake.nix/.envrc prune only removes stubs this
@@ -767,6 +781,9 @@ else
     # .devcontainer/ intact.
     if [[ "$MODE" == "direnv" || "$MODE" == "bare" ]]; then
         EXCLUDE_ARGS+=("--exclude=.devcontainer")
+        # Container-only documentation stays out of the container-less modes
+        # (#989); a previously scaffolded copy is pruned after the copy below.
+        EXCLUDE_ARGS+=("--exclude=/docs/container-ci-quirks.md")
     fi
 
     # Legacy typos config (#913): the `typos` tool reads .typos.toml, typos.toml
@@ -874,6 +891,16 @@ case "$MODE" in
         : # keep everything
         ;;
 esac
+
+# Container-only documentation (#989): prune a previously scaffolded
+# docs/container-ci-quirks.md from the container-less modes. Devkit-managed
+# (never in PRESERVE_FILES), so no pre-existence guard — the rsync above
+# already excludes the template copy; this removes an old scaffold's leftover.
+if [[ ("$MODE" == "direnv" || "$MODE" == "bare") \
+    && -f "$WORKSPACE_DIR/docs/container-ci-quirks.md" ]]; then
+    echo "Pruning container-only docs/container-ci-quirks.md (#989)..."
+    rm -f "$WORKSPACE_DIR/docs/container-ci-quirks.md"
+fi
 
 # 0.4.0 retired .devcontainer/justfile.base (recipes relocated to
 # justfile.project), so drop the stale copy an upgraded 0.3.x repo carries —

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -83,6 +83,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **direnv/bare scaffolds no longer ship container-only artifacts** ([#989](https://github.com/vig-os/devkit/issues/989))
+  - `docs/container-ci-quirks.md` (in-image CI notes) is now mode-filtered like
+    `.devcontainer/`: excluded from container-less scaffolds, pruned from a
+    previously scaffolded tree on upgrade, and reflected truthfully in the
+    `--preview` report. The `resolve-image` action and `container:` workflow
+    coupling were already retired by the mode-aware toolchain work
+    ([#991](https://github.com/vig-os/devkit/issues/991)).
+  - The devkit's own `.vig-os` now declares its delivery mode (`direnv`).
+
 - **Pin `sigstore/cosign-installer` to `v4.1.2` so Renovate can resolve its digest** ([#986](https://github.com/vig-os/devkit/issues/986))
   - The previous pin's `# v4` comment named a floating tag that `sigstore/cosign-installer` never published, so Renovate's digest lookup failed on the dependency dashboard
 

--- a/tests/bats/init-workspace.bats
+++ b/tests/bats/init-workspace.bats
@@ -2313,3 +2313,61 @@ _RELEASE_RESOLVERS_991=(
         done
     done
 }
+
+# ── #989: container-only artifacts are mode-filtered out of direnv/bare ────────
+# docs/container-ci-quirks.md documents in-image CI behavior (PREK_HOME cache,
+# GHCR credential quirks) and is dead weight in the container-less modes. The
+# scaffold filters it exactly like .devcontainer/: excluded from the copy,
+# pruned on upgrade, and reflected truthfully in the preview report.
+
+@test "container-ci-quirks.md ships in devcontainer/both but not direnv/bare (#989)" {
+    for mode in devcontainer both; do
+        ws="$BATS_TEST_TMPDIR/e2e-989-$mode"
+        mkdir -p "$ws"
+        run _scaffold "$mode" "$ws"
+        assert_success
+        run test -f "$ws/docs/container-ci-quirks.md"
+        assert_success
+    done
+    for mode in direnv bare; do
+        ws="$BATS_TEST_TMPDIR/e2e-989-$mode"
+        mkdir -p "$ws"
+        run _scaffold "$mode" "$ws"
+        assert_success
+        run test -f "$ws/docs/container-ci-quirks.md"
+        assert_failure
+    done
+}
+
+@test "direnv/bare upgrade prunes a previously scaffolded container-ci-quirks.md (#989)" {
+    for mode in direnv bare; do
+        ws="$BATS_TEST_TMPDIR/e2e-989-prune-$mode"
+        mkdir -p "$ws/docs"
+        printf '# stale container notes\n' >"$ws/docs/container-ci-quirks.md"
+        run _scaffold "$mode" "$ws"
+        assert_success
+        run test -f "$ws/docs/container-ci-quirks.md"
+        assert_failure
+    done
+}
+
+@test "preview lists container-ci-quirks.md as DELETED on a direnv upgrade (#989)" {
+    ws="$BATS_TEST_TMPDIR/e2e-989-preview-del"
+    mkdir -p "$ws/docs"
+    printf '# stale container notes\n' >"$ws/docs/container-ci-quirks.md"
+    run _preview "$ws" --mode direnv
+    assert_success
+    assert_output --partial "DELETED"
+    assert_output --partial "docs/container-ci-quirks.md"
+    # side-effect-free: the preview left the file in place
+    run test -f "$ws/docs/container-ci-quirks.md"
+    assert_success
+}
+
+@test "preview does not list container-ci-quirks.md as ADDED on a fresh direnv scaffold (#989)" {
+    ws="$BATS_TEST_TMPDIR/e2e-989-preview-add"
+    mkdir -p "$ws"
+    run _preview "$ws" --mode direnv
+    assert_success
+    refute_output --partial "docs/container-ci-quirks.md"
+}


### PR DESCRIPTION
## Summary

D1 residual (#989) — most of the issue was absorbed by #991 (resolve-image and
the container: coupling already retired). This filters the remaining
container-only artifact, `docs/container-ci-quirks.md`, out of the
container-less modes exactly like `.devcontainer/`: copy exclusion, upgrade
prune, and truthful `--preview` (DELETED on upgrade, never ADDED on fresh
direnv/bare scaffolds). Also declares the devkit's own delivery mode
(`direnv`: flake + .envrc, no `.devcontainer/`) in its root `.vig-os`.

## Audit of remaining container references in rendered direnv/bare trees

- `justfile` — `import? '.devcontainer/justfile.*'` optional imports: mode-neutral
  by design (documented in the file header), left as is.
- `.devcontainer/CHANGELOG.md` — inside `.devcontainer/`, already filtered.
- No other `ghcr.io/vig-os/devcontainer` / `resolve-image` hits outside
  historical CHANGELOG entries.

## Evidence (local — no automated CI on epic-branch PRs)

- TDD: 4 new bats tests committed failing first, now green
- `bats init-workspace.bats + install.bats`: **246/246 green**
- `nix develop -c prek run --all-files`: green

Refs: #989