### PR TITLE
fix(workspace): point scaffolded flake stub at github:vig-os/devkit (#1009)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Scaffolded flake stub references the renamed `github:vig-os/devkit` input** ([#1009](https://github.com/vig-os/devkit/issues/1009))
+  - The preserved `assets/workspace/flake.nix` stub (active input and pin-example
+    comment) still pointed at `github:vig-os/devcontainer`, which only resolved
+    via GitHub's post-rename redirect; new consumers now scaffold the canonical
+    `github:vig-os/devkit`. `docs/MIGRATION.md` documents the by-hand update for
+    existing `direnv`/`both` consumers, whose stub is never overwritten on upgrade.
+
 - **direnv/bare scaffolds no longer ship container-only artifacts** ([#989](https://github.com/vig-os/devkit/issues/989))
   - `docs/container-ci-quirks.md` (in-image CI notes) is now mode-filtered like
     `.devcontainer/`: excluded from container-less scaffolds, pruned from a

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -83,6 +83,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Scaffolded flake stub references the renamed `github:vig-os/devkit` input** ([#1009](https://github.com/vig-os/devkit/issues/1009))
+  - The preserved `assets/workspace/flake.nix` stub (active input and pin-example
+    comment) still pointed at `github:vig-os/devcontainer`, which only resolved
+    via GitHub's post-rename redirect; new consumers now scaffold the canonical
+    `github:vig-os/devkit`. `docs/MIGRATION.md` documents the by-hand update for
+    existing `direnv`/`both` consumers, whose stub is never overwritten on upgrade.
+
 - **direnv/bare scaffolds no longer ship container-only artifacts** ([#989](https://github.com/vig-os/devkit/issues/989))
   - `docs/container-ci-quirks.md` (in-image CI notes) is now mode-filtered like
     `.devcontainer/`: excluded from container-less scaffolds, pruned from a

--- a/assets/workspace/flake.nix
+++ b/assets/workspace/flake.nix
@@ -10,9 +10,9 @@
     # project works before its first pin. Once you depend on stability
     # (especially the vigos.* home-manager module options), pin a release
     # tag instead and bump deliberately:
-    #   vigos.url = "github:vig-os/devcontainer?ref=<tag>";
+    #   vigos.url = "github:vig-os/devkit?ref=<tag>";
     # Policy: docs/NIX.md "Home-manager modules - versioning & release policy".
-    vigos.url = "github:vig-os/devcontainer";
+    vigos.url = "github:vig-os/devkit";
     # Follow vigos's pinned nixpkgs + flake-utils so your tools match the
     # toolchain exactly (one resolved nixpkgs, no drift).
     nixpkgs.follows = "vigos/nixpkgs";

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -20,7 +20,7 @@ two ways:
   distro, no `Dockerfile FROM`), bit-reproducible, and built natively for
   `amd64` and `arm64`. Published as `ghcr.io/vig-os/devcontainer`.
 - **Bare-nix dev-shell** — the same toolchain via `nix develop` / `direnv`,
-  consumed as a flake input (`vigos.url = "github:vig-os/devcontainer"`).
+  consumed as a flake input (`vigos.url = "github:vig-os/devkit"`).
 
 The toolchain is defined once, in `flake.nix`'s `devTools` list. A parity test
 guarantees the dev-shell and the image never drift. There is no second
@@ -543,3 +543,15 @@ commands keep working with no change. A re-scaffold (`install.sh --force`) only
 refreshes the `install.sh` source URL and templated files; it does not change the
 image you pull. The `.vig-os` version-pin key is `DEVKIT_VERSION` (the legacy
 `DEVCONTAINER_VERSION` is still accepted).
+
+**Existing `direnv`/`both` consumers: update the flake input by hand.** The
+scaffolded `flake.nix` is a preserved file — a re-scaffold never overwrites it —
+so a repo scaffolded before the rename keeps
+`vigos.url = "github:vig-os/devcontainer"`. That URL keeps resolving via
+GitHub's repository redirect, so nothing breaks, but new stubs now reference the
+canonical `github:vig-os/devkit`. Update your input (and any pin-example comment)
+to match, then `nix flake update vigos`:
+
+```nix
+vigos.url = "github:vig-os/devkit"; # was github:vig-os/devcontainer
+```

--- a/tests/bats/init-workspace.bats
+++ b/tests/bats/init-workspace.bats
@@ -63,6 +63,18 @@ setup() {
     assert_success
 }
 
+@test "downstream flake stub references the renamed github:vig-os/devkit input (#1009)" {
+    # #781 renamed the repo devcontainer -> devkit; the old URL only works via
+    # GitHub's redirect, so the scaffolded stub (a preserved file) must point new
+    # consumers at the canonical name — both the active input and the pin example.
+    run grep -q 'vigos.url = "github:vig-os/devkit"' "$TEMPLATE_DIR/flake.nix"
+    assert_success
+    run grep -q 'github:vig-os/devkit?ref=<tag>' "$TEMPLATE_DIR/flake.nix"
+    assert_success
+    run grep -q 'github:vig-os/devcontainer' "$TEMPLATE_DIR/flake.nix"
+    assert_failure
+}
+
 @test "flake.nix and .envrc are preserved on --force upgrade (#640)" {
     # shellcheck disable=SC2016
     run grep -E '"flake\.nix"' "$INIT_WORKSPACE_SH"

--- a/tests/test_downstream_flake.py
+++ b/tests/test_downstream_flake.py
@@ -1,7 +1,7 @@
 """Downstream flake-stub quality gate (issue #640).
 
 The scaffolded ``assets/workspace/flake.nix`` consumes the shared toolchain as a
-flake input (``vigos.url = github:vig-os/devcontainer``). A change to the vigOS
+flake input (``vigos.url = github:vig-os/devkit``). A change to the vigOS
 flake API (e.g. ``lib.mkProjectShell`` or ``overlays.default``) can silently
 break a downstream repo's ``direnv allow`` even while this repo's own
 ``nix flake check`` stays green, because the stub resolves ``vigos`` from the


### PR DESCRIPTION
## Summary

Fixes #1009. The scaffolded `assets/workspace/flake.nix` stub — a **preserved**
(never-overwritten) file — still set `vigos.url = "github:vig-os/devcontainer"`,
which now only resolves via GitHub's post-rename redirect (#781 renamed the repo
`devcontainer` → `devkit`). New consumers should reference the canonical
`vig-os/devkit` directly.

Surfaced by a commit-action migration dry-run against the #988 epic branch.

## Changes

- **`assets/workspace/flake.nix`** — active `vigos.url` input **and** its pin-example
  comment now reference `github:vig-os/devkit`.
- **`docs/MIGRATION.md`** — corrects the `vigos.url` example in "What changed" and
  adds a note under "Upcoming rename" telling existing `direnv`/`both` consumers to
  update their preserved stub by hand (the old URL keeps working via redirect).
- **`tests/test_downstream_flake.py`** — docstring reference to the input URL updated.
- **`CHANGELOG.md`** (+ synced `.devcontainer/` mirror) — Fixed entry.

## Acceptance criteria

- [x] Stub (and its pin-example comment) reference `github:vig-os/devkit`
- [x] MIGRATION.md notes the URL rename for existing direnv consumers

## Testing

TDD: added a RED guard to `tests/bats/init-workspace.bats` asserting the stub uses
`github:vig-os/devkit` (active input + pin example) and no longer references
`github:vig-os/devcontainer`.

- `bats tests/bats/init-workspace.bats -f flake` — 15/15 pass
- `prek run --all-files` — all green

Refs: #1009
