### PR TITLE
docs(workspace): document --skip-pull in install.sh usage

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -20,6 +20,8 @@
 #   --prune-devcontainer  In direnv/bare mode, remove a pre-existing .devcontainer/
 #                     (container->direnv/bare migration cleanup; default keeps it)
 #   --skip-preflight  Bypass the upgrade preflight guard (branch + clean-tree checks)
+#   --skip-pull       Use the already-present local image for --version (skip the
+#                     registry pull); e.g. a locally built :dev tag
 #   --dry-run         Show the container command that would run without executing
 #   -h, --help        Show this help message
 #
@@ -93,6 +95,8 @@ OPTIONS:
                       The default is non-destructive and keeps it (#738).
     --skip-preflight  Bypass the upgrade preflight guard (--force refuses on
                       main/dev/release/*/detached HEAD and on a dirty tree)
+    --skip-pull       Use the already-present local image for --version (skip the
+                      registry pull); e.g. a locally built :dev tag
     --dry-run         Show the container command that would run (unlike
                       --preview, no file report is computed)
     -h, --help        Show this help

--- a/tests/bats/install.bats
+++ b/tests/bats/install.bats
@@ -766,3 +766,9 @@ MANIFEST
     assert_success
     assert_output --partial "--prune-devcontainer"
 }
+
+@test "help lists --skip-pull (#1008)" {
+    run bash "$INSTALL_SH" --help
+    assert_success
+    assert_output --partial "--skip-pull"
+}


### PR DESCRIPTION
## What

Document the `--skip-pull` flag at both usage/help sites in `install.sh`: the header usage comment block (top of file) and the `usage()` `--help` OPTIONS output. The flag was already implemented in arg parsing but undocumented.

Wording is consistent with the neighboring `--skip-preflight`/`--preview` entries and placed adjacent to `--skip-preflight`:

> Use the already-present local image for --version (skip the registry pull); e.g. a locally built :dev tag

## Why

`--skip-pull` (use a local image tag without pulling from GHCR, e.g. a locally built `:dev` image) was missing from the usage/help text. Surfaced by the #988 local validation run.

## Test evidence

Strict TDD (RED -> commit test -> GREEN -> commit fix):

- RED (before fix): `not ok 2 help lists --skip-pull (#1008)`
- GREEN (after fix): `ok 2 help lists --skip-pull (#1008)`
- Full file: `nix develop -c bats tests/bats/install.bats` -> 90 passed, 0 failed
- `nix develop -c prek run --all-files` -> all hooks passed

Refs: #1008