### PR TITLE
ci: re-enable actionlint shellcheck integration and harden workflow run blocks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,11 +71,13 @@ jobs:
           BUILD_TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
           RELEASE_URL="https://github.com/${GITHUB_REPOSITORY}/commit/${VCS_REF}"
 
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "vcs_ref=$VCS_REF" >> $GITHUB_OUTPUT
-          echo "release_date=$RELEASE_DATE" >> $GITHUB_OUTPUT
-          echo "build_timestamp=$BUILD_TIMESTAMP" >> $GITHUB_OUTPUT
-          echo "release_url=$RELEASE_URL" >> $GITHUB_OUTPUT
+          {
+            echo "version=$VERSION"
+            echo "vcs_ref=$VCS_REF"
+            echo "release_date=$RELEASE_DATE"
+            echo "build_timestamp=$BUILD_TIMESTAMP"
+            echo "release_url=$RELEASE_URL"
+          } >> "$GITHUB_OUTPUT"
           echo "Building dev version: $VERSION"
 
       - name: Build container image
@@ -281,8 +283,8 @@ jobs:
         if: always() && steps.bandit.outcome == 'success'
         run: |
           if [ -f bandit-report.json ]; then
-            echo "## Python Security: Bandit" >> $GITHUB_STEP_SUMMARY
-            python -m json.tool bandit-report.json | head -50 >> $GITHUB_STEP_SUMMARY || true
+            echo "## Python Security: Bandit" >> "$GITHUB_STEP_SUMMARY"
+            python -m json.tool bandit-report.json | head -50 >> "$GITHUB_STEP_SUMMARY" || true
           fi
 
   security-scan:

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -76,8 +76,8 @@ jobs:
           fi
 
           RELEASE_BRANCH="release/$VERSION"
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "release_branch=$RELEASE_BRANCH" >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "release_branch=$RELEASE_BRANCH" >> "$GITHUB_OUTPUT"
           echo "✓ Version format validated: $VERSION"
 
       - name: Verify release branch does not exist
@@ -315,6 +315,7 @@ jobs:
           PR_BODY="${HEADER}${CHANGELOG_CONTENT}"$'\n'
 
           if [ "${#PR_BODY}" -gt "$MAX_BODY" ]; then
+            # shellcheck disable=SC2016  # backticks are literal Markdown code spans, not command substitution
             NOTE=$(printf '\n\n_Changelog truncated to fit GitHub'"'"'s %s-char PR-body limit; see `CHANGELOG.md` on `%s` for the full entry._' "$MAX_BODY" "$RELEASE_BRANCH")
             budget=$(( MAX_BODY - ${#HEADER} - ${#NOTE} ))
             TRUNCATED="${CHANGELOG_CONTENT:0:budget}"
@@ -331,8 +332,8 @@ jobs:
             --draft)
 
           PR_NUMBER=$(echo "$PR_URL" | grep -oE '[0-9]+$')
-          echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
-          echo "pr_url=$PR_URL" >> $GITHUB_OUTPUT
+          echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+          echo "pr_url=$PR_URL" >> "$GITHUB_OUTPUT"
           echo "✓ Draft PR created: $PR_URL (#$PR_NUMBER)"
 
       - name: Roll back prepare-release side effects on failure

--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -77,6 +77,7 @@ jobs:
           VALIDATED_ARCHS=()
           for arch in "${ARCH_ARRAY[@]}"; do
             [ -z "$arch" ] && continue
+            # shellcheck disable=SC2076  # literal substring match against the space-padded whitelist is intentional
             if [[ " $VALID_ARCHS " =~ " $arch " ]]; then
               VALIDATED_ARCHS+=("$arch")
             else
@@ -84,6 +85,7 @@ jobs:
               exit 1
             fi
           done
+          # shellcheck disable=SC2207  # deliberate word-splitting of the space-free arch tokens; mapfile is overkill
           UNIQUE_ARCHS=($(echo "${VALIDATED_ARCHS[@]}" | tr ' ' '\n' | sort -u))
           if [ ${#UNIQUE_ARCHS[@]} -ne ${#VALIDATED_ARCHS[@]} ]; then
             echo "ERROR: Duplicate architectures found"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,11 +116,13 @@ jobs:
           RELEASE_DATE=$(date -u +%Y-%m-%d)
           BUILD_TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "release_kind=$RELEASE_KIND" >> $GITHUB_OUTPUT
-          echo "release_date=$RELEASE_DATE" >> $GITHUB_OUTPUT
-          echo "build_timestamp=$BUILD_TIMESTAMP" >> $GITHUB_OUTPUT
-          echo "release_branch=$RELEASE_BRANCH" >> $GITHUB_OUTPUT
+          {
+            echo "version=$VERSION"
+            echo "release_kind=$RELEASE_KIND"
+            echo "release_date=$RELEASE_DATE"
+            echo "build_timestamp=$BUILD_TIMESTAMP"
+            echo "release_branch=$RELEASE_BRANCH"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Checkout release branch
         env:
@@ -138,7 +140,7 @@ jobs:
         id: pre_sha
         run: |
           PRE_FINALIZE_SHA=$(git rev-parse HEAD)
-          echo "pre_finalize_sha=$PRE_FINALIZE_SHA" >> $GITHUB_OUTPUT
+          echo "pre_finalize_sha=$PRE_FINALIZE_SHA" >> "$GITHUB_OUTPUT"
           echo "Pre-finalization SHA: $PRE_FINALIZE_SHA"
 
       - name: Compute publish version
@@ -186,9 +188,11 @@ jobs:
           fi
 
           RELEASE_URL="https://github.com/${GITHUB_REPOSITORY}/releases/tag/${PUBLISH_VERSION}"
-          echo "publish_version=$PUBLISH_VERSION" >> $GITHUB_OUTPUT
-          echo "next_rc=$NEXT_RC" >> $GITHUB_OUTPUT
-          echo "release_url=$RELEASE_URL" >> $GITHUB_OUTPUT
+          {
+            echo "publish_version=$PUBLISH_VERSION"
+            echo "next_rc=$NEXT_RC"
+            echo "release_url=$RELEASE_URL"
+          } >> "$GITHUB_OUTPUT"
           echo "Publish version: $PUBLISH_VERSION"
 
       - name: Find latest RC tag
@@ -338,7 +342,7 @@ jobs:
           IS_DRAFT=$(echo "$PR_JSON" | jq -r '.[0].isDraft')
           REVIEW_DECISION=$(echo "$PR_JSON" | jq -r '.[0].reviewDecision')
 
-          echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
+          echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
 
           # The draft + approval gate applies only to the final release, which
           # burns the immutable X.Y.Z tag. Release candidates are disposable
@@ -427,6 +431,7 @@ jobs:
           VALIDATED_ARCHS=()
 
           for arch in "${ARCH_ARRAY[@]}"; do
+            # shellcheck disable=SC2076  # literal substring match against the space-padded whitelist is intentional
             if [[ " $VALID_ARCHS " =~ " $arch " ]]; then
               VALIDATED_ARCHS+=("$arch")
               echo "✓ Valid architecture: $arch"
@@ -437,6 +442,7 @@ jobs:
           done
 
           # Check for duplicates
+          # shellcheck disable=SC2207  # deliberate word-splitting of the space-free arch tokens; mapfile is overkill
           UNIQUE_ARCHS=($(echo "${VALIDATED_ARCHS[@]}" | tr ' ' '\n' | sort -u))
           if [ ${#UNIQUE_ARCHS[@]} -ne ${#VALIDATED_ARCHS[@]} ]; then
             echo "ERROR: Duplicate architectures found"
@@ -446,8 +452,8 @@ jobs:
           # Generate matrix JSON
           MATRIX_JSON=$(printf '%s\n' "${VALIDATED_ARCHS[@]}" | jq -R . | jq -s -c '{arch: .}')
 
-          echo "architectures=${VALIDATED_ARCHS[*]}" >> $GITHUB_OUTPUT
-          echo "matrix=$MATRIX_JSON" >> $GITHUB_OUTPUT
+          echo "architectures=${VALIDATED_ARCHS[*]}" >> "$GITHUB_OUTPUT"
+          echo "matrix=$MATRIX_JSON" >> "$GITHUB_OUTPUT"
 
       - name: Summary
         env:
@@ -652,6 +658,7 @@ jobs:
           PR_BODY="${HEADER}${CHANGELOG_CONTENT}"$'\n'
 
           if [ "${#PR_BODY}" -gt "$MAX_BODY" ]; then
+            # shellcheck disable=SC2016  # backticks are literal Markdown code spans, not command substitution
             NOTE=$(printf '\n\n_Changelog truncated to fit GitHub'"'"'s %s-char PR-body limit; see `CHANGELOG.md` on `%s` for the full entry._' "$MAX_BODY" "$RELEASE_BRANCH")
             budget=$(( MAX_BODY - ${#HEADER} - ${#NOTE} ))
             TRUNCATED="${CHANGELOG_CONTENT:0:budget}"
@@ -679,7 +686,7 @@ jobs:
             FINALIZE_SHA=$(retry --retries 3 --backoff 5 --max-backoff 30 -- \
               gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/release/$VERSION" --jq '.object.sha')
           fi
-          echo "finalize_sha=$FINALIZE_SHA" >> $GITHUB_OUTPUT
+          echo "finalize_sha=$FINALIZE_SHA" >> "$GITHUB_OUTPUT"
           echo "Release kind: $RELEASE_KIND — SHA: $FINALIZE_SHA"
 
       - name: Check if publish tag already exists at finalize SHA
@@ -913,6 +920,7 @@ jobs:
               sleep $((60 * attempt))
             fi
           done
+          # shellcheck disable=SC2015  # the error branch is meant to fire whenever the scan-ok check fails, not as if-then-else
           [ "$rc" -le 2 ] && jq -e . vulnix-findings.json > /dev/null 2>&1 \
             || { echo "::error::vulnix scan failed after 3 attempts (exit $rc)"; exit 1; }
 
@@ -1109,12 +1117,9 @@ jobs:
       - name: Verify manifests
         env:
           PUBLISH_VERSION: ${{ needs.validate.outputs.publish_version }}
-          ARCHS: ${{ needs.validate.outputs.architectures }}
         run: |
           set -euo pipefail
           REPO="ghcr.io/vig-os/devcontainer"
-
-          IFS=' ' read -ra ARCH_ARRAY <<< "$ARCHS"
 
           echo "Verifying version manifest: $REPO:$PUBLISH_VERSION"
           RETRIES=5
@@ -1123,7 +1128,7 @@ jobs:
               echo "✓ Version manifest verified"
               break
             else
-              if [ $i -lt $RETRIES ]; then
+              if [ "$i" -lt "$RETRIES" ]; then
                 echo "Verification failed, retrying ($i/$RETRIES)..."
                 sleep 5
               else
@@ -1189,7 +1194,7 @@ jobs:
           REPO="ghcr.io/vig-os/devcontainer"
           DIGEST=$(retry --retries 3 --backoff 5 --max-backoff 30 -- \
             docker buildx imagetools inspect "$REPO:$PUBLISH_VERSION" --format '{{json .Manifest.Digest}}' | tr -d '"')
-          echo "digest=$DIGEST" >> $GITHUB_OUTPUT
+          echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
           echo "Image digest: $DIGEST"
 
       - name: Attest build provenance (attempt 1)
@@ -1602,6 +1607,7 @@ jobs:
           PR_BODY="${HEADER}${CHANGELOG_CONTENT}"$'\n'
 
           if [ "${#PR_BODY}" -gt "$MAX_BODY" ]; then
+            # shellcheck disable=SC2016  # backticks are literal Markdown code spans, not command substitution
             NOTE=$(printf '\n\n_Changelog truncated to fit GitHub'"'"'s %s-char PR-body limit; see `CHANGELOG.md` on `%s` for the full entry._' "$MAX_BODY" "$RELEASE_BRANCH")
             budget=$(( MAX_BODY - ${#HEADER} - ${#NOTE} ))
             TRUNCATED="${CHANGELOG_CONTENT:0:budget}"

--- a/.github/workflows/renovate-changelog-commit.yml
+++ b/.github/workflows/renovate-changelog-commit.yml
@@ -48,9 +48,11 @@ jobs:
           set -euo pipefail
           # shellcheck disable=SC1091
           source metadata.env
-          echo "modified=${MODIFIED}" >> "$GITHUB_OUTPUT"
-          echo "pr_number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
-          echo "head_ref=${HEAD_REF}" >> "$GITHUB_OUTPUT"
+          {
+            echo "modified=${MODIFIED}"
+            echo "pr_number=${PR_NUMBER}"
+            echo "head_ref=${HEAD_REF}"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Commit changelog via API
         if: steps.metadata.outputs.modified == 'true'

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -126,6 +126,7 @@ jobs:
               sleep $((60 * attempt))
             fi
           done
+          # shellcheck disable=SC2015  # the error branch is meant to fire whenever the scan-ok check fails, not as if-then-else
           [ "$rc" -le 2 ] && jq -e . vulnix-findings.json > /dev/null 2>&1 \
             || { echo "::error::vulnix scan failed after 3 attempts (exit $rc)"; exit 1; }
           rc=0

--- a/.github/workflows/sync-issues.yml
+++ b/.github/workflows/sync-issues.yml
@@ -118,7 +118,7 @@ jobs:
           if [ -n "$CACHE_ID" ]; then
             echo "Found cache ID: $CACHE_ID, attempting deletion..."
             retry --retries 3 --backoff 3 --max-backoff 15 -- \
-              gh api repos/${{ github.repository }}/actions/caches/$CACHE_ID -X DELETE && echo "Cache deleted successfully" || echo "Cache deletion failed (may be locked or already deleted)"
+              gh api repos/${{ github.repository }}/actions/caches/"$CACHE_ID" -X DELETE && echo "Cache deleted successfully" || echo "Cache deletion failed (may be locked or already deleted)"
           else
             echo "No cache found with key: $CACHE_KEY (this is OK for first run)"
           fi

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -96,16 +96,16 @@ repos:
         exclude: (^|/)\.envrc$
 
   # GitHub Actions workflow linting (actionlint from the flake dev-shell). Lints
-  # THIS repo's own .github/workflows/ via auto-discovery; shellcheck integration
-  # is disabled (its run-block findings are a separate concern, and the
-  # shellcheck hook above covers .sh scripts). Devkit-only: not scaffolded to
-  # consumers — the per-mode rendered templates are validated in tests/bats.
+  # THIS repo's own .github/workflows/ via auto-discovery; actionlint's bundled
+  # shellcheck pass over run-block scripts is enabled (#1003, the standalone
+  # shellcheck hook above still covers .sh scripts). Devkit-only: not scaffolded
+  # to consumers — the per-mode rendered templates are validated in tests/bats.
   # Refs #995.
   - repo: local
     hooks:
       - id: actionlint
         name: actionlint (lint GitHub Actions workflows)
-        entry: actionlint -shellcheck=
+        entry: actionlint
         language: system
         files: ^\.github/workflows/.*\.ya?ml$
         pass_filenames: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     choreography (step logic, ordering, inputs/outputs, rollback semantics) is
     unchanged.
 - **Renovate: update `cachix/install-nix-action` from `v31.10.6` to `v31.10.7`** ([#984](https://github.com/vig-os/devkit/pull/984))
+- **`actionlint` shellcheck integration re-enabled; workflow `run:` blocks hardened** ([#1003](https://github.com/vig-os/devkit/issues/1003))
+  - The bundled `shellcheck` pass that #995 deferred is now active in both the
+    devkit's own `actionlint` pre-commit hook and the bats fixtures that lint the
+    per-mode scaffold output. The scaffolded template workflows shipped to
+    consumers had their `run:` blocks hardened to pass it — quoting redirect
+    targets and shell variables, grouping consecutive `>> "$GITHUB_OUTPUT"`
+    writes, and quoting pattern expansions — so a consumer's rendered workflows
+    now lint clean under `actionlint`'s shellcheck. A handful of intentional
+    patterns (literal Markdown backticks, whitelist substring matches, deliberate
+    word-splitting) carry justified `# shellcheck disable` directives.
 
 ### Deprecated
 

--- a/assets/smoke-test/.github/workflows/repository-dispatch.yml
+++ b/assets/smoke-test/.github/workflows/repository-dispatch.yml
@@ -127,16 +127,18 @@ jobs:
             EFFECTIVE_SOURCE_RUN_URL="${GITHUB_SERVER_URL}/${SOURCE_REPO}/actions/runs/${SOURCE_RUN_ID}"
           fi
 
-          echo "tag=${TAG}" >> "${GITHUB_OUTPUT}"
-          echo "base_version=${BASE_VERSION}" >> "${GITHUB_OUTPUT}"
-          echo "rc_number=${RC_NUMBER}" >> "${GITHUB_OUTPUT}"
-          echo "release_kind=${EFFECTIVE_RELEASE_KIND}" >> "${GITHUB_OUTPUT}"
-          echo "source_repo=${SOURCE_REPO}" >> "${GITHUB_OUTPUT}"
-          echo "source_workflow=${SOURCE_WORKFLOW}" >> "${GITHUB_OUTPUT}"
-          echo "source_run_id=${SOURCE_RUN_ID}" >> "${GITHUB_OUTPUT}"
-          echo "source_run_url=${EFFECTIVE_SOURCE_RUN_URL}" >> "${GITHUB_OUTPUT}"
-          echo "source_sha=${SOURCE_SHA}" >> "${GITHUB_OUTPUT}"
-          echo "correlation_id=${CORRELATION_ID}" >> "${GITHUB_OUTPUT}"
+          {
+            echo "tag=${TAG}"
+            echo "base_version=${BASE_VERSION}"
+            echo "rc_number=${RC_NUMBER}"
+            echo "release_kind=${EFFECTIVE_RELEASE_KIND}"
+            echo "source_repo=${SOURCE_REPO}"
+            echo "source_workflow=${SOURCE_WORKFLOW}"
+            echo "source_run_id=${SOURCE_RUN_ID}"
+            echo "source_run_url=${EFFECTIVE_SOURCE_RUN_URL}"
+            echo "source_sha=${SOURCE_SHA}"
+            echo "correlation_id=${CORRELATION_ID}"
+          } >> "${GITHUB_OUTPUT}"
 
   deploy:
     name: Deploy tag and open PR to dev

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -76,6 +76,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     choreography (step logic, ordering, inputs/outputs, rollback semantics) is
     unchanged.
 - **Renovate: update `cachix/install-nix-action` from `v31.10.6` to `v31.10.7`** ([#984](https://github.com/vig-os/devkit/pull/984))
+- **`actionlint` shellcheck integration re-enabled; workflow `run:` blocks hardened** ([#1003](https://github.com/vig-os/devkit/issues/1003))
+  - The bundled `shellcheck` pass that #995 deferred is now active in both the
+    devkit's own `actionlint` pre-commit hook and the bats fixtures that lint the
+    per-mode scaffold output. The scaffolded template workflows shipped to
+    consumers had their `run:` blocks hardened to pass it — quoting redirect
+    targets and shell variables, grouping consecutive `>> "$GITHUB_OUTPUT"`
+    writes, and quoting pattern expansions — so a consumer's rendered workflows
+    now lint clean under `actionlint`'s shellcheck. A handful of intentional
+    patterns (literal Markdown backticks, whitelist substring matches, deliberate
+    word-splitting) carry justified `# shellcheck disable` directives.
 
 ### Deprecated
 

--- a/assets/workspace/.github/workflows/prepare-release.yml
+++ b/assets/workspace/.github/workflows/prepare-release.yml
@@ -312,6 +312,7 @@ jobs:
           PR_BODY="${HEADER}${CHANGELOG_CONTENT}"$'\n'
 
           if [ "${#PR_BODY}" -gt "$MAX_BODY" ]; then
+            # shellcheck disable=SC2016  # backticks are literal Markdown code spans, not command substitution
             NOTE=$(printf '\n\n_Changelog truncated to fit GitHub'"'"'s %s-char PR-body limit; see `CHANGELOG.md` on `%s` for the full entry._' "$MAX_BODY" "$RELEASE_BRANCH")
             budget=$(( MAX_BODY - ${#HEADER} - ${#NOTE} ))
             TRUNCATED="${CHANGELOG_CONTENT:0:budget}"

--- a/assets/workspace/.github/workflows/release-core.yml
+++ b/assets/workspace/.github/workflows/release-core.yml
@@ -157,9 +157,11 @@ jobs:
           fi
 
           RELEASE_DATE=$(date -u +%Y-%m-%d)
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "release_kind=$RELEASE_KIND" >> "$GITHUB_OUTPUT"
-          echo "release_date=$RELEASE_DATE" >> "$GITHUB_OUTPUT"
+          {
+            echo "version=$VERSION"
+            echo "release_kind=$RELEASE_KIND"
+            echo "release_date=$RELEASE_DATE"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Checkout release branch
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
@@ -220,12 +222,12 @@ jobs:
               if [ -n "$EXISTING_TAGS" ]; then
                 while IFS= read -r tag; do
                   [ -z "$tag" ] && continue
-                  if [ "${tag#${VERSION}-rc}" = "$tag" ]; then
+                  if [ "${tag#"${VERSION}"-rc}" = "$tag" ]; then
                     echo "ERROR: Malformed candidate tag detected: $tag"
                     echo "Expected format: ${VERSION}-rcN"
                     exit 1
                   fi
-                  rc_num="${tag#${VERSION}-rc}"
+                  rc_num="${tag#"${VERSION}"-rc}"
                   if ! echo "$rc_num" | grep -qE '^[0-9]+$'; then
                     echo "ERROR: Malformed candidate tag detected: $tag"
                     echo "Expected format: ${VERSION}-rcN"

--- a/assets/workspace/.github/workflows/renovate-changelog-commit.yml
+++ b/assets/workspace/.github/workflows/renovate-changelog-commit.yml
@@ -48,9 +48,11 @@ jobs:
           set -euo pipefail
           # shellcheck disable=SC1091
           source metadata.env
-          echo "modified=${MODIFIED}" >> "$GITHUB_OUTPUT"
-          echo "pr_number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
-          echo "head_ref=${HEAD_REF}" >> "$GITHUB_OUTPUT"
+          {
+            echo "modified=${MODIFIED}"
+            echo "pr_number=${PR_NUMBER}"
+            echo "head_ref=${HEAD_REF}"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Commit changelog via API
         if: steps.metadata.outputs.modified == 'true'

--- a/assets/workspace/.github/workflows/sync-issues.yml
+++ b/assets/workspace/.github/workflows/sync-issues.yml
@@ -130,7 +130,7 @@ jobs:
           if [ -n "$CACHE_ID" ]; then
             echo "Found cache ID: $CACHE_ID, attempting deletion..."
             retry --retries 3 --backoff 3 --max-backoff 15 -- \
-              gh api repos/${{ github.repository }}/actions/caches/$CACHE_ID -X DELETE && echo "Cache deleted successfully" || echo "Cache deletion failed (may be locked or already deleted)"
+              gh api repos/${{ github.repository }}/actions/caches/"$CACHE_ID" -X DELETE && echo "Cache deleted successfully" || echo "Cache deletion failed (may be locked or already deleted)"
           else
             echo "No cache found with key: $CACHE_KEY (this is OK for first run)"
           fi

--- a/nix/hooks.nix
+++ b/nix/hooks.nix
@@ -379,14 +379,12 @@ let
     # sandbox gate — the per-mode RENDERED consumer templates are validated in
     # tests/bats instead, because linting them in-place resolves the
     # reusable-workflow siblings against the wrong root (the devkit itself).
-    # shellcheck integration
-    # is disabled (-shellcheck=): its run-block findings on the authored
-    # workflows are a separate hardening concern, and the shellcheck hook above
-    # already covers .sh scripts.
+    # actionlint's bundled shellcheck pass over run-block scripts is enabled
+    # (#1003); the standalone shellcheck hook above still covers .sh scripts.
     actionlint = {
       yaml = {
         name = "actionlint (lint GitHub Actions workflows)";
-        entry = "actionlint -shellcheck=";
+        entry = "actionlint";
         language = "system";
         files = "^\\.github/workflows/.*\\.ya?ml$";
         pass_filenames = false;

--- a/tests/bats/init-workspace.bats
+++ b/tests/bats/init-workspace.bats
@@ -2035,12 +2035,10 @@ _upgrade_legacy() {
 # reusable release files do not exist); the faithful check is over the fully
 # rendered tree, which is what these fixtures do.
 #
-# The invocation disables actionlint's bundled shellcheck (`-shellcheck=`): its
-# run-block findings on the authored templates are pre-existing info/style/
-# warning noise, tracked for a separate hardening pass — the dedicated
-# shell-lint hook already covers `.sh` scripts. The reusable release workflows
-# read secrets (GHCR_PULL_TOKEN, *_APP_CLIENT_ID/PRIVATE_KEY) passed by the
-# caller via `secrets: inherit`, which actionlint cannot see statically; those
+# The invocation runs actionlint's bundled shellcheck over the run-block scripts
+# (#1003); the template run blocks are hardened to pass it. The reusable release
+# workflows read secrets (GHCR_PULL_TOKEN, *_APP_CLIENT_ID/PRIVATE_KEY) passed by
+# the caller via `secrets: inherit`, which actionlint cannot see statically; those
 # false positives are ignored by message.
 ACTIONLINT_INHERITED_SECRETS='property "(ghcr_pull_token|release_app_client_id|release_app_private_key|commit_app_client_id|commit_app_private_key)" is not defined'
 
@@ -2053,7 +2051,7 @@ _actionlint_rendered() {
     (
         cd "$ws" &&
             git init -q &&
-            actionlint -shellcheck= -ignore "$ACTIONLINT_INHERITED_SECRETS"
+            actionlint -ignore "$ACTIONLINT_INHERITED_SECRETS"
     )
 }
 
@@ -2080,7 +2078,7 @@ _actionlint_rendered() {
 @test "actionlint passes over the smoke-test workflow template (#995)" {
     # The smoke-test template ships a single, standalone workflow (no reusable
     # siblings), so it is linted in-place by explicit path from the repo root.
-    run actionlint -shellcheck= \
+    run actionlint \
         "$PROJECT_ROOT/assets/smoke-test/.github/workflows/repository-dispatch.yml"
     assert_success
 }


### PR DESCRIPTION
## Summary

Re-enables `actionlint`'s bundled shellcheck integration (removes the
`-shellcheck=` opt-out) in the devkit's own pre-commit hook and the bats
fixtures, and hardens every workflow `run:` block — the devkit's own
`.github/workflows/`, the per-mode scaffold templates under
`assets/workspace/`, and the smoke-test template — until the shellcheck pass is
clean. Follow-up to #995 (which deferred the 41 info/style/warning findings).

Every commit stays green: commit 1 hardens the run blocks (hook still opted
out); commit 2 removes the opt-outs with shellcheck now active and the gate
proving clean.

## Findings and fixes

`actionlint` with shellcheck over the devkit's own workflows surfaced the same
**41** findings #995 recorded, plus a handful in the rendered/template trees.
All are `SC2086` quoting-style noise except the intentional patterns noted
below. No correctness defects. Locations are `run:`-block start lines.

### Devkit-own `.github/workflows/`

| File | Block | SC code(s) | Fix |
|------|-------|-----------|-----|
| ci.yml | @67 | SC2086 x5, SC2129 | grouped consecutive `>> "$GITHUB_OUTPUT"` writes into one `{ ... } >> "$GITHUB_OUTPUT"` |
| ci.yml | @282 | SC2086 x2 | quoted `"$GITHUB_STEP_SUMMARY"` |
| prepare-release.yml | @67 | SC2086 x2 | quoted `"$GITHUB_OUTPUT"` |
| prepare-release.yml | @303 | SC2016; SC2086 x2 | SC2016 **suppressed** (literal Markdown backticks); quoted `"$GITHUB_OUTPUT"` |
| promote-release.yml | @65 | SC2076; SC2207 | both **suppressed** (see reasons) |
| release.yml | @97 | SC2086 x5, SC2129 | grouped `>> "$GITHUB_OUTPUT"` |
| release.yml | @139 | SC2086 | quoted `"$GITHUB_OUTPUT"` |
| release.yml | @149 | SC2086 x3, SC2129 | grouped `>> "$GITHUB_OUTPUT"` |
| release.yml | @314 | SC2086 | quoted `"$GITHUB_OUTPUT"` |
| release.yml | @415 | SC2076; SC2207; SC2086 x2 | SC2076/SC2207 **suppressed**; quoted `"$GITHUB_OUTPUT"` |
| release.yml | @629 | SC2016 | **suppressed** (literal Markdown backticks) |
| release.yml | @674 | SC2086 | quoted `"$GITHUB_OUTPUT"` |
| release.yml | @899 | SC2015 | **suppressed** (intentional `&&`/`||` guard) |
| release.yml | @1113 | SC2034; SC2086 | removed dead `ARCH_ARRAY` parse + its now-unused `ARCHS:` env; quoted `"$i"`/`"$RETRIES"` |
| release.yml | @1187 | SC2086 | quoted `"$GITHUB_OUTPUT"` |
| release.yml | @1573 | SC2016 | **suppressed** (literal Markdown backticks) |
| renovate-changelog-commit.yml | @47 | SC2129 | grouped `>> "$GITHUB_OUTPUT"` (synced -> template) |
| security-scan.yml | @112 | SC2015 | **suppressed** (intentional `&&`/`||` guard) |
| sync-issues.yml | @110 | SC2086 | quoted `"$CACHE_ID"` (minimal, coordinating with #996) |

### Scaffold templates (`assets/workspace/.github/workflows/`)

| File | Block | SC code(s) | Fix |
|------|-------|-----------|-----|
| prepare-release.yml | @299 | SC2016 | **suppressed** (literal Markdown backticks) |
| release-core.yml | @143 | SC2129 | grouped `>> "$GITHUB_OUTPUT"` |
| release-core.yml | @199 | SC2295 x2 | quoted the pattern: `${tag#"${VERSION}"-rc}` |
| sync-issues.yml | @122 | SC2086 | quoted `"$CACHE_ID"` |

### Smoke-test template

| File | Block | SC code(s) | Fix |
|------|-------|-----------|-----|
| assets/smoke-test/.github/workflows/repository-dispatch.yml | @72 | SC2129 | grouped 10 `>> "${GITHUB_OUTPUT}"` writes |

## Suppressions (each carries an inline justification comment)

| SC | Where | Reason |
|----|-------|--------|
| SC2016 | prepare-release.yml (root + template), release.yml x2 | The `` `CHANGELOG.md` `` backticks in the truncation-note `printf` are literal Markdown code spans, not command substitution. |
| SC2076 | promote-release.yml, release.yml | `[[ " $VALID_ARCHS " =~ " $arch " ]]` is a deliberate literal substring match against the space-padded whitelist, not a regex. |
| SC2207 | promote-release.yml, release.yml | `UNIQUE_ARCHS=($(... \| sort -u))` deliberately word-splits the space-free arch tokens; `mapfile` is overkill. |
| SC2015 | release.yml, security-scan.yml | The `... && ... \|\| { error; exit; }` guard is meant to run the error branch whenever the combined scan-ok check fails, not an if-then-else. |

The inherited-secrets `-ignore` regex in the bats fixtures is retained — that is
a separate, legitimate suppression (`secrets: inherit` values actionlint cannot
resolve statically).

## Evidence

- `actionlint` (shellcheck active) over the devkit's own workflows, all four
  rendered mode trees (devcontainer/direnv/bare/both), and the smoke-test
  template: **0 findings**.
- `nix develop -c prek run --all-files`: green (shellcheck active).
- `nix develop -c bats tests/bats/init-workspace.bats`: full file green (157 tests).
- `uv run pytest tests/test_flake_hooks.py tests/test_transforms.py -q`: green
  (hook-config drift gate + manifest transforms).

Refs: #1003
