### PR TITLE
fix: resolve the 1.1.0-rc1 validation follow-ups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`install.sh` next-steps message is mode-aware** ([#1015](https://github.com/vig-os/devkit/issues/1015))
+  - A `direnv` deploy printed *"Open in VS Code — it will detect `.devcontainer/`"*,
+    pointing at a directory the direnv scaffold never creates (and that
+    `--prune-devcontainer` may have just removed). The message now branches over
+    every validated mode: `direnv` points at `direnv allow` (with `nix develop` as
+    the hook-free fallback), `both` offers each entrypoint, and `bare`/`devcontainer`
+    are unchanged.
+
+- **Scaffolded `workflow_call` workflows declare the secrets they inherit** ([#1016](https://github.com/vig-os/devkit/issues/1016))
+  - `release-core.yml` and `release-publish.yml` read `GHCR_PULL_TOKEN`,
+    `RELEASE_APP_*` and `COMMIT_APP_*` without declaring them in their
+    `workflow_call: secrets:` block. A reusable workflow has a *closed* secrets set,
+    so `actionlint` correctly reported each one as undefined and every scaffolded
+    consumer inherited a dirty lint run. The secrets are now declared (`required:`
+    set from real usage), and the bats suite no longer suppresses the diagnostic —
+    it asserts that every referenced secret is declared.
+
+- **Dev-shell entry is warning-free** ([#1017](https://github.com/vig-os/devkit/issues/1017))
+  - `nix develop` emitted two upstream rename warnings (`nixfmt-rfc-style` →
+    `nixfmt`, and home-manager's `programs.neovim.extraLuaConfig` → `initLua`).
+    Both are pure aliases: the dev-shell and home-manager activation derivations
+    are byte-identical before and after.
+
 - **Scaffolded flake stub references the renamed `github:vig-os/devkit` input** ([#1009](https://github.com/vig-os/devkit/issues/1009))
   - The preserved `assets/workspace/flake.nix` stub (active input and pin-example
     comment) still pointed at `github:vig-os/devcontainer`, which only resolved

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -103,6 +103,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`install.sh` next-steps message is mode-aware** ([#1015](https://github.com/vig-os/devkit/issues/1015))
+  - A `direnv` deploy printed *"Open in VS Code — it will detect `.devcontainer/`"*,
+    pointing at a directory the direnv scaffold never creates (and that
+    `--prune-devcontainer` may have just removed). The message now branches over
+    every validated mode: `direnv` points at `direnv allow` (with `nix develop` as
+    the hook-free fallback), `both` offers each entrypoint, and `bare`/`devcontainer`
+    are unchanged.
+
+- **Scaffolded `workflow_call` workflows declare the secrets they inherit** ([#1016](https://github.com/vig-os/devkit/issues/1016))
+  - `release-core.yml` and `release-publish.yml` read `GHCR_PULL_TOKEN`,
+    `RELEASE_APP_*` and `COMMIT_APP_*` without declaring them in their
+    `workflow_call: secrets:` block. A reusable workflow has a *closed* secrets set,
+    so `actionlint` correctly reported each one as undefined and every scaffolded
+    consumer inherited a dirty lint run. The secrets are now declared (`required:`
+    set from real usage), and the bats suite no longer suppresses the diagnostic —
+    it asserts that every referenced secret is declared.
+
+- **Dev-shell entry is warning-free** ([#1017](https://github.com/vig-os/devkit/issues/1017))
+  - `nix develop` emitted two upstream rename warnings (`nixfmt-rfc-style` →
+    `nixfmt`, and home-manager's `programs.neovim.extraLuaConfig` → `initLua`).
+    Both are pure aliases: the dev-shell and home-manager activation derivations
+    are byte-identical before and after.
+
 - **Scaffolded flake stub references the renamed `github:vig-os/devkit` input** ([#1009](https://github.com/vig-os/devkit/issues/1009))
   - The preserved `assets/workspace/flake.nix` stub (active input and pin-example
     comment) still pointed at `github:vig-os/devcontainer`, which only resolved

--- a/assets/workspace/.github/workflows/release-core.yml
+++ b/assets/workspace/.github/workflows/release-core.yml
@@ -49,6 +49,23 @@ on:  # yamllint disable-line rule:truthy
     secrets:
       token:
         required: false
+      # Passed by the caller via `secrets: inherit`; a workflow_call workflow has
+      # a closed secrets set, so every secret it reads must be declared here.
+      GHCR_PULL_TOKEN:
+        description: "GHCR read token for the container image (falls back to github.token)"
+        required: false
+      RELEASE_APP_CLIENT_ID:
+        description: "GitHub App client ID used to mint the release token"
+        required: true
+      RELEASE_APP_PRIVATE_KEY:
+        description: "GitHub App private key used to mint the release token"
+        required: true
+      COMMIT_APP_CLIENT_ID:
+        description: "GitHub App client ID used to mint the verified-commit token"
+        required: true
+      COMMIT_APP_PRIVATE_KEY:
+        description: "GitHub App private key used to mint the verified-commit token"
+        required: true
     outputs:
       version:
         description: "Resolved release version"

--- a/assets/workspace/.github/workflows/release-publish.yml
+++ b/assets/workspace/.github/workflows/release-publish.yml
@@ -62,6 +62,17 @@ on:  # yamllint disable-line rule:truthy
     secrets:
       token:
         required: false
+      # Passed by the caller via `secrets: inherit`; a workflow_call workflow has
+      # a closed secrets set, so every secret it reads must be declared here.
+      GHCR_PULL_TOKEN:
+        description: "GHCR read token for the container image (falls back to github.token)"
+        required: false
+      RELEASE_APP_CLIENT_ID:
+        description: "GitHub App client ID used to mint the release token"
+        required: true
+      RELEASE_APP_PRIVATE_KEY:
+        description: "GitHub App private key used to mint the release token"
+        required: true
     outputs:
       tag:
         description: "Published tag"

--- a/flake.nix
+++ b/flake.nix
@@ -525,7 +525,7 @@
 
         # treefmt-nix: one `nix fmt` entrypoint + a `checks.formatting` gate over
         # the whole repo. The enabled programs mirror the pre-commit formatters —
-        # nixfmt-rfc-style (same package as devTools/the hook), ruff-format, and
+        # nixfmt (same package as devTools/the hook), ruff-format, and
         # taplo — so the editor `nix fmt`, the hooks, and the flake check all
         # agree on one formatting. Refs #777.
         treefmtEval = treefmt-nix.lib.evalModule pkgs {
@@ -533,7 +533,7 @@
           programs = {
             nixfmt = {
               enable = true;
-              package = pkgs.nixfmt-rfc-style;
+              package = pkgs.nixfmt;
             };
             ruff-format.enable = true;
             taplo.enable = true;

--- a/install.sh
+++ b/install.sh
@@ -889,9 +889,22 @@ success "Devcontainer deployed to $PROJECT_PATH"
 echo ""
 echo "Next steps:"
 echo "  1. cd $PROJECT_PATH"
-if [ "$MODE" = "bare" ]; then
-    echo "  2. Run 'just help' to list the shipped recipes (host-native: no container)"
-else
-    echo "  2. Open in VS Code - it will detect .devcontainer/ and offer to reopen in container"
-fi
+# The next step is mode-specific: only the container modes scaffold a
+# .devcontainer/ for VS Code to detect, so direnv (which scaffolds only the
+# flake + .envrc) must be pointed at its own entrypoint instead (#1015).
+case "$MODE" in
+    bare)
+        echo "  2. Run 'just help' to list the shipped recipes (host-native: no container)"
+        ;;
+    direnv)
+        echo "  2. Run 'direnv allow' to load the flake dev-shell (or 'nix develop' without direnv)"
+        ;;
+    both)
+        echo "  2. Open in VS Code - it will detect .devcontainer/ and offer to reopen in container"
+        echo "     (or run 'direnv allow' on the host to load the flake dev-shell)"
+        ;;
+    *)
+        echo "  2. Open in VS Code - it will detect .devcontainer/ and offer to reopen in container"
+        ;;
+esac
 echo ""

--- a/nix/devtools.nix
+++ b/nix/devtools.nix
@@ -49,7 +49,7 @@ with pkgs;
 
   # Linting
   taplo
-  nixfmt-rfc-style # nix file formatter (treefmt `nix fmt`, pre-commit hook)
+  nixfmt # nix file formatter, RFC style (treefmt `nix fmt`, pre-commit hook)
   ruff # python linter/formatter (pre-commit ruff/ruff-format hooks)
   typos # source typo checker (pre-commit typos hook)
   deadnix # dead-Nix-code linter (flake `checks.deadnix`)

--- a/nix/home/editor.nix
+++ b/nix/home/editor.nix
@@ -18,7 +18,7 @@
       viAlias = lib.mkDefault true;
       vimAlias = lib.mkDefault true;
       plugins = [ pkgs.vimPlugins.claudecode-nvim ];
-      extraLuaConfig = lib.mkAfter ''
+      initLua = lib.mkAfter ''
         -- claudecode.nvim: :ClaudeCode toggles a Claude terminal; visual
         -- selections go over with :ClaudeCodeSend.
         require("claudecode").setup({})

--- a/nix/hooks.nix
+++ b/nix/hooks.nix
@@ -450,7 +450,7 @@ let
       consumer = pkgs: {
         enable = true;
         name = "nixfmt";
-        entry = "${pkgs.nixfmt-rfc-style}/bin/nixfmt --check";
+        entry = "${pkgs.nixfmt}/bin/nixfmt --check";
         language = "system";
         files = "\\.nix$";
       };

--- a/tests/bats/init-workspace.bats
+++ b/tests/bats/init-workspace.bats
@@ -2048,12 +2048,11 @@ _upgrade_legacy() {
 # rendered tree, which is what these fixtures do.
 #
 # The invocation runs actionlint's bundled shellcheck over the run-block scripts
-# (#1003); the template run blocks are hardened to pass it. The reusable release
-# workflows read secrets (GHCR_PULL_TOKEN, *_APP_CLIENT_ID/PRIVATE_KEY) passed by
-# the caller via `secrets: inherit`, which actionlint cannot see statically; those
-# false positives are ignored by message.
-ACTIONLINT_INHERITED_SECRETS='property "(ghcr_pull_token|release_app_client_id|release_app_private_key|commit_app_client_id|commit_app_private_key)" is not defined'
-
+# (#1003); the template run blocks are hardened to pass it. A `workflow_call`
+# workflow has a CLOSED secrets set: every `secrets.X` it reads must appear in
+# its `on.workflow_call.secrets:` block, otherwise actionlint reports
+# `property "x" is not defined` — and a scaffolded consumer inherits that dirty
+# lint. So the run is unsuppressed (#1016): no `-ignore`.
 _actionlint_rendered() {
     local mode="$1" ws="$2"
     mkdir -p "$ws"
@@ -2063,8 +2062,39 @@ _actionlint_rendered() {
     (
         cd "$ws" &&
             git init -q &&
-            actionlint -ignore "$ACTIONLINT_INHERITED_SECRETS"
+            actionlint
     )
+}
+
+# Secret names declared under a workflow's `on.workflow_call.secrets:` block.
+_declared_call_secrets() {
+    awk '
+        /^    secrets:[[:space:]]*$/ { in_s = 1; next }
+        in_s && /^      [A-Za-z_][A-Za-z0-9_-]*:[[:space:]]*$/ {
+            sub(/:[[:space:]]*$/, ""); gsub(/^[[:space:]]+/, ""); print; next
+        }
+        in_s && /^    [A-Za-z]/ { in_s = 0 }
+    ' "$1"
+}
+
+# Secret names a workflow reads via ${{ secrets.X }} (GITHUB_TOKEN is automatic).
+_referenced_secrets() {
+    grep -oE 'secrets\.[A-Za-z_][A-Za-z0-9_-]*' "$1" |
+        sed 's/^secrets\.//' | grep -vx 'GITHUB_TOKEN' | sort -u
+}
+
+@test "scaffolded workflow_call workflows declare every secret they reference (#1016)" {
+    local wf declared ref missing=""
+    for wf in "$TEMPLATE_DIR"/.github/workflows/*.yml; do
+        grep -qE '^  workflow_call:[[:space:]]*$' "$wf" || continue
+        declared="$(_declared_call_secrets "$wf")"
+        while IFS= read -r ref; do
+            [ -n "$ref" ] || continue
+            printf '%s\n' "$declared" | grep -Fqx -- "$ref" ||
+                missing+="  $(basename "$wf"): secrets.$ref is read but not declared"$'\n'
+        done < <(_referenced_secrets "$wf")
+    done
+    [ -z "$missing" ] || fail "undeclared workflow_call secrets:"$'\n'"$missing"
 }
 
 @test "actionlint passes over the devcontainer-mode rendered workflows (#995)" {

--- a/tests/bats/install.bats
+++ b/tests/bats/install.bats
@@ -772,3 +772,48 @@ MANIFEST
     assert_success
     assert_output --partial "--skip-pull"
 }
+
+# ── mode-aware "Next steps" (#1015) ───────────────────────────────────────────
+# The printed next step must match the delivery mode: only the container modes
+# scaffold a .devcontainer/ for VS Code to detect, so direnv must be pointed at
+# the direnv entrypoint instead. Exercised end to end against a stub runtime
+# (`docker` on PATH, exit 0 for info/inspect/run) so nothing is pulled or
+# scaffolded and the run still reaches the final message.
+_run_install_stubbed() {
+    local dir="$1" mode="$2"
+    local stub="$BATS_TEST_TMPDIR/stub-bin"
+    mkdir -p "$stub"
+    printf '#!/usr/bin/env bash\nexit 0\n' >"$stub/docker"
+    chmod +x "$stub/docker"
+    _make_repo "$dir"
+    run env PATH="$stub:$PATH" bash "$INSTALL_SH" \
+        --docker --skip-pull --mode "$mode" "$dir" </dev/null
+}
+
+@test "direnv install points at the direnv entrypoint, not VS Code (#1015)" {
+    _run_install_stubbed "$BATS_TEST_TMPDIR/next-direnv" direnv
+    assert_success
+    refute_output --partial "Open in VS Code"
+    assert_output --partial "direnv allow"
+    assert_output --partial "nix develop"
+}
+
+@test "bare install still points at 'just help' (#1015)" {
+    _run_install_stubbed "$BATS_TEST_TMPDIR/next-bare" bare
+    assert_success
+    refute_output --partial "Open in VS Code"
+    assert_output --partial "just help"
+}
+
+@test "devcontainer install still points at VS Code (#1015)" {
+    _run_install_stubbed "$BATS_TEST_TMPDIR/next-devcontainer" devcontainer
+    assert_success
+    assert_output --partial "Open in VS Code"
+}
+
+@test "both install points at VS Code and mentions direnv (#1015)" {
+    _run_install_stubbed "$BATS_TEST_TMPDIR/next-both" both
+    assert_success
+    assert_output --partial "Open in VS Code"
+    assert_output --partial "direnv allow"
+}


### PR DESCRIPTION
Follow-ups found by the `1.1.0-rc1` validation run on #1014. All three were reported as minor/non-blocking; landing them on the release branch means `1.1.0` ships with them fixed, at the cost of re-cutting a candidate (`rc2`) and re-validating.

Targets `release/1.1.0` (not `dev`) — these are release-branch fixes. They reach `dev` via the normal main→dev sync after promotion.

## Fixes

### #1015 — `install.sh` next-steps message was not mode-filtered
A `direnv` deploy printed *"Open in VS Code — it will detect `.devcontainer/`"*, pointing at a directory the direnv scaffold never creates (and that `--prune-devcontainer` may have just deleted). The two-branch `if` only special-cased `bare`, so every non-bare mode fell through to the container message.

Now a `case` over all validated modes: `direnv` → `direnv allow` (with `nix develop` as the hook-free fallback), `both` → both entrypoints, `bare`/`devcontainer` unchanged (byte-identical).

Note the existing tests only exercised `--dry-run`, which exits *before* the next-steps block — so this message had no behavioural coverage at all. The new bats tests drive `install.sh` end-to-end with a stubbed `docker`.

### #1016 — scaffolded `workflow_call` workflows did not declare inherited secrets
`release-core.yml` and `release-publish.yml` read `GHCR_PULL_TOKEN`, `RELEASE_APP_*` and `COMMIT_APP_*` while declaring only `token:`.

**This was being actively suppressed.** The bats actionlint tests passed `-ignore 'property "(ghcr_pull_token|...)" is not defined'`, with a comment calling them false positives that actionlint "cannot see statically". That reasoning is wrong: a reusable workflow has a **closed** secrets set, so actionlint was correct and the suppression hid a real defect that every scaffolded consumer inherited as a dirty lint run. The `-ignore` is removed and replaced with a structural test asserting every referenced secret is declared.

Callers use `secrets: inherit`, so no call-site change was needed. `required:` is set from real usage (`GHCR_PULL_TOKEN` false — it falls back to `github.token`; the App credentials true — they feed `create-github-app-token` with no fallback).

Out of scope and untouched: `promote-release.yml`, `release.yml`, `sync-issues.yml`, `sync-main-to-dev.yml` are `workflow_dispatch`/`push`/`schedule`, where secrets are ambient and need no declaration.

### #1017 — dev-shell emitted two upstream rename warnings
`nixfmt-rfc-style` → `nixfmt`, and home-manager's `programs.neovim.extraLuaConfig` → `initLua`.

Both are pure aliases, verified rather than assumed: the `devShells.default` and `homeConfigurations.*.activationPackage` **derivation paths are byte-identical** before and after. No nixpkgs bump, no `flake.lock` change.

Correction to the original report: it described the second warning as a `'system'` rename. Cold evaluation of every flake output found no such warning — it was the neovim option rename, paraphrased from memory.

## Verification
- Full hook suite (`just precommit`) green.
- `bats tests/bats/install.bats` — 94 passed.
- `bats tests/bats/init-workspace.bats` — 159 passed, 0 failures.
- `nix flake check` — all checks passed; `nix develop` enters warning-free.
- The 9 `tests/bats/githooks.bats` failures on a host checkout are **pre-existing** — they reproduce identically on untouched `4ec4e4a` and are host-vs-container environment guards.

Refs: #1015, #1016, #1017