### PR TITLE
fix: read stdenv.hostPlatform.system in the consumer overlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     Both are pure aliases: the dev-shell and home-manager activation derivations
     are byte-identical before and after.
 
+- **A scaffolded consumer's `nix develop` is warning-free too** ([#1021](https://github.com/vig-os/devkit/issues/1021))
+  - The shared consumer overlay (`vigos.overlays.default`) still read the
+    renamed-away `final.system`, so every consumer that applied it and forced a
+    fast-mover package saw the `'system' has been renamed to/replaced by
+    'stdenv.hostPlatform.system'` warning that [#1017](https://github.com/vig-os/devkit/issues/1017)
+    had already cleared from the devkit's own dev-shell. The overlay now reads
+    `final.stdenv.hostPlatform.system`; the resolved derivations are unchanged.
+
 - **Scaffolded flake stub references the renamed `github:vig-os/devkit` input** ([#1009](https://github.com/vig-os/devkit/issues/1009))
   - The preserved `assets/workspace/flake.nix` stub (active input and pin-example
     comment) still pointed at `github:vig-os/devcontainer`, which only resolved

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -126,6 +126,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     Both are pure aliases: the dev-shell and home-manager activation derivations
     are byte-identical before and after.
 
+- **A scaffolded consumer's `nix develop` is warning-free too** ([#1021](https://github.com/vig-os/devkit/issues/1021))
+  - The shared consumer overlay (`vigos.overlays.default`) still read the
+    renamed-away `final.system`, so every consumer that applied it and forced a
+    fast-mover package saw the `'system' has been renamed to/replaced by
+    'stdenv.hostPlatform.system'` warning that [#1017](https://github.com/vig-os/devkit/issues/1017)
+    had already cleared from the devkit's own dev-shell. The overlay now reads
+    `final.stdenv.hostPlatform.system`; the resolved derivations are unchanged.
+
 - **Scaffolded flake stub references the renamed `github:vig-os/devkit` input** ([#1009](https://github.com/vig-os/devkit/issues/1009))
   - The preserved `assets/workspace/flake.nix` stub (active input and pin-example
     comment) still pointed at `github:vig-os/devcontainer`, which only resolved

--- a/flake.nix
+++ b/flake.nix
@@ -116,7 +116,8 @@
       # fixpoint; the in-flake path below uses the hoisted importUnstable.
       overlay =
         final: prev:
-        (mkFastMoverOverlay (importUnstable final.system) final prev) // (vigUtilsOverlay final prev);
+        (mkFastMoverOverlay (importUnstable final.stdenv.hostPlatform.system) final prev)
+        // (vigUtilsOverlay final prev);
 
       # ---------------------------------------------------------------------
       # vigos home environment (#819): self-pkgs + the ci homeConfigurations.


### PR DESCRIPTION
## Summary

Follow-up to #1017. The `'system' has been renamed to/replaced by 'stdenv.hostPlatform.system'` nixpkgs eval warning was cleared from the devkit's **own** dev-shell, but survived for a **scaffolded consumer's** `nix develop`.

The residual was the shared consumer overlay (`vigos.overlays.default`), the one code path #1017 never exercised: it reads `final.system` inside the fixpoint, so any consumer that applies the overlay and forces a fast-mover package (`uv`, `gh`, `claude-code`) evaluates the renamed-away attribute and gets the warning. The devkit itself takes the hoisted `importUnstable system` path with a concrete system, which is why it looked fully fixed.

`flake.nix:119` now reads `final.stdenv.hostPlatform.system` — the idiom already used at `flake.nix:314`.

## Verification

Evaluated the consumer path directly (plain nixpkgs + `overlays.default`, forcing `claude-code`, exactly as `mkProjectShell` does), with and without the fix:

| | eval output |
|---|---|
| before | `evaluation warning: 'system' has been renamed to/replaced by 'stdenv.hostPlatform.system'` |
| after | *(no warning)* |

Both resolve to the **same** derivation, `/nix/store/h09svv06fs1qx8argj6mz7lz7mzwsqn8-claude-code-2.1.206.drv` — a pure alias, no rebuild, no behaviour change.

The devkit's own dev-shell stays clean: `nix eval .#devShells.x86_64-linux.default.drvPath` emits no warning.

Full local hook suite (`just precommit`) green.

No test commit: a Nix attribute rename has no unit-testable surface, so the before/after eval above is the evidence — same approach as #1017.

## Acceptance criteria

- [x] A scaffolded consumer's `nix develop` emits no `'system' has been renamed` warning.
- [x] Devkit's own dev-shell remains clean.

Refs: #1021