### PR TITLE
chore(ci): scaffold check-agent-identity and approve the perf commit type

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -244,7 +244,7 @@ repos:
         language: system
         stages: [commit-msg]
         args: [
-          "--types", "feat,fix,docs,chore,refactor,test,ci,build,revert,style",
+          "--types", "feat,fix,docs,chore,refactor,perf,test,ci,build,revert,style",
           "--refs-optional-types", "chore",
           "--blocked-patterns", ".github/agent-blocklist.toml",
         ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **Scaffolded repos reject AI-authored commits** ([#1031](https://github.com/vig-os/devkit/issues/1031))
+  - `check-agent-identity` now reaches the consumer pre-commit config. It is the only hook of the agent-identity pipeline ([#163](https://github.com/vig-os/devkit/issues/163)) that guards the commit **author/committer** — the one that catches `git commit --author="Claude <...>"`. After [#1026](https://github.com/vig-os/devkit/issues/1026) scaffolded repos rejected an AI-attributed commit *message* while accepting an AI-authored *commit*; the `COMMIT_MESSAGE_STANDARD.md` they ship promised the opposite. It runs at the pre-commit stage, so `prek run --all-files` enforces it in the scaffold's lint job too.
+
 ## [1.1.0](https://github.com/vig-os/devkit/releases/tag/1.1.0) - 2026-07-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`perf` is now an approved commit type** ([#1030](https://github.com/vig-os/devkit/issues/1030))
+  - `perf` joins the approved commit-type allowlist in `nix/hooks.nix` (both rendered `.pre-commit-config.yaml` files), `DEFAULT_APPROVED_TYPES` (the default CI's `validate-commit-range` uses), and `docs/COMMIT_MESSAGE_STANDARD.md`. It is a standard [Conventional Commits](https://www.conventionalcommits.org/) type and was already used once in history; before this the live `commit-checks` job would reject the next `perf(...)` commit.
 - **Commit scopes are free-form** ([#1019](https://github.com/vig-os/devkit/issues/1019))
   - The `validate-commit-msg` hook no longer pins an allowlist of commit scopes. The previous five-scope list (`agent,ci,setup,image,vigutils`) rejected 594 of the 1206 scoped commits in history (~49%), including the scopes used by our own bots, and contradicted `docs/COMMIT_MESSAGE_STANDARD.md`, which defines a scope as free-form "alphanumeric and hyphens only". The commit **type**, the `Refs:` line and the agent blocklist remain enforced; only the scope vocabulary is open.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,7 @@ type(scope)!: short description
 Refs: #<issue>
 ```
 
-- **Types:** `feat`, `fix`, `docs`, `chore`, `refactor`, `test`, `ci`, `build`, `revert`, `style`
+- **Types:** `feat`, `fix`, `docs`, `chore`, `refactor`, `perf`, `test`, `ci`, `build`, `revert`, `style`
 - Scope optional; `!` only for breaking changes
 - Imperative mood, no period
 - **Refs line mandatory** (at least one GitHub issue, e.g. `Refs: #36`). Exception: `chore` commits may omit `Refs:` when no issue is related.

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -28,6 +28,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **Scaffolded repos reject AI-authored commits** ([#1031](https://github.com/vig-os/devkit/issues/1031))
+  - `check-agent-identity` now reaches the consumer pre-commit config. It is the only hook of the agent-identity pipeline ([#163](https://github.com/vig-os/devkit/issues/163)) that guards the commit **author/committer** — the one that catches `git commit --author="Claude <...>"`. After [#1026](https://github.com/vig-os/devkit/issues/1026) scaffolded repos rejected an AI-attributed commit *message* while accepting an AI-authored *commit*; the `COMMIT_MESSAGE_STANDARD.md` they ship promised the opposite. It runs at the pre-commit stage, so `prek run --all-files` enforces it in the scaffold's lint job too.
+
 ## [1.1.0](https://github.com/vig-os/devkit/releases/tag/1.1.0) - 2026-07-13
 
 ### Added

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`perf` is now an approved commit type** ([#1030](https://github.com/vig-os/devkit/issues/1030))
+  - `perf` joins the approved commit-type allowlist in `nix/hooks.nix` (both rendered `.pre-commit-config.yaml` files), `DEFAULT_APPROVED_TYPES` (the default CI's `validate-commit-range` uses), and `docs/COMMIT_MESSAGE_STANDARD.md`. It is a standard [Conventional Commits](https://www.conventionalcommits.org/) type and was already used once in history; before this the live `commit-checks` job would reject the next `perf(...)` commit.
 - **Commit scopes are free-form** ([#1019](https://github.com/vig-os/devkit/issues/1019))
   - The `validate-commit-msg` hook no longer pins an allowlist of commit scopes. The previous five-scope list (`agent,ci,setup,image,vigutils`) rejected 594 of the 1206 scoped commits in history (~49%), including the scopes used by our own bots, and contradicted `docs/COMMIT_MESSAGE_STANDARD.md`, which defines a scope as free-form "alphanumeric and hyphens only". The commit **type**, the `Refs:` line and the agent blocklist remain enforced; only the scope vocabulary is open.
 

--- a/assets/workspace/.pre-commit-config.yaml
+++ b/assets/workspace/.pre-commit-config.yaml
@@ -158,7 +158,7 @@ repos:
         language: system
         stages: [commit-msg]
         args: [
-          "--types", "feat,fix,docs,chore,refactor,test,ci,build,revert,style",
+          "--types", "feat,fix,docs,chore,refactor,perf,test,ci,build,revert,style",
           "--refs-optional-types", "chore",
           "--blocked-patterns", ".github/agent-blocklist.toml",
         ]

--- a/assets/workspace/.pre-commit-config.yaml
+++ b/assets/workspace/.pre-commit-config.yaml
@@ -138,6 +138,15 @@ repos:
         stages: [prepare-commit-msg]
         pass_filenames: true
 
+  # AI agent identity: reject author/committer matching blocklist (Refs: #163)
+  - repo: local
+    hooks:
+      - id: check-agent-identity
+        name: check agent identity
+        entry: uv run check-agent-identity
+        language: system
+        pass_filenames: false
+
   # Commit message validation (commit-msg stage). Scope is free-form
   # ("alphanumeric and hyphens only" per docs/COMMIT_MESSAGE_STANDARD.md);
   # only the type, the Refs line and the agent blocklist are enforced.

--- a/assets/workspace/docs/COMMIT_MESSAGE_STANDARD.md
+++ b/assets/workspace/docs/COMMIT_MESSAGE_STANDARD.md
@@ -40,6 +40,7 @@ Only the following types are allowed:
 | `docs`     | Documentation only |
 | `chore`    | Maintenance, tooling, config (no code/docs behavior change) |
 | `refactor` | Code refactoring, no new behavior |
+| `perf`     | Performance improvements, no behavior change |
 | `test`     | Tests, test infrastructure |
 | `ci`       | CI/CD, workflows, automation |
 | `build`    | Commits that affect build components like build scripts and makefiles |

--- a/docs/COMMIT_MESSAGE_STANDARD.md
+++ b/docs/COMMIT_MESSAGE_STANDARD.md
@@ -40,6 +40,7 @@ Only the following types are allowed:
 | `docs`     | Documentation only |
 | `chore`    | Maintenance, tooling, config (no code/docs behavior change) |
 | `refactor` | Code refactoring, no new behavior |
+| `perf`     | Performance improvements, no behavior change |
 | `test`     | Tests, test infrastructure |
 | `ci`       | CI/CD, workflows, automation |
 | `build`    | Commits that affect build components like build scripts and makefiles |

--- a/nix/hooks.nix
+++ b/nix/hooks.nix
@@ -608,7 +608,17 @@ let
         pass_filenames = true;
       };
     };
+    # Scaffolded: the two commit-msg hooks above guard the commit *message*,
+    # but this is the only #163 hook that guards the *author/committer* —
+    # the one that catches `git commit --author="Claude <...>"`. Without it
+    # in the consumer render, a scaffolded repo rejects an AI-attributed
+    # message while accepting an AI-authored commit, the exact false
+    # guarantee its COMMIT_MESSAGE_STANDARD.md warns against. It is
+    # pre-commit-stage, so `prek run --all-files` also enforces it in the
+    # scaffold's lint job. The blocklist it reads (.github/agent-blocklist.toml)
+    # is already manifest-synced into the scaffold. Refs #1031.
     check-agent-identity = {
+      scaffold = true;
       yaml = {
         name = "check agent identity";
         entry = "uv run check-agent-identity";

--- a/nix/hooks.nix
+++ b/nix/hooks.nix
@@ -645,7 +645,7 @@ let
         stages = [ "commit-msg" ];
         args = [
           "--types"
-          "feat,fix,docs,chore,refactor,test,ci,build,revert,style"
+          "feat,fix,docs,chore,refactor,perf,test,ci,build,revert,style"
           "--refs-optional-types"
           "chore"
           "--blocked-patterns"

--- a/packages/vig-utils/src/vig_utils/validate_commit_msg.py
+++ b/packages/vig-utils/src/vig_utils/validate_commit_msg.py
@@ -37,6 +37,7 @@ DEFAULT_APPROVED_TYPES = frozenset[str](
         "docs",
         "chore",
         "refactor",
+        "perf",
         "test",
         "ci",
         "build",
@@ -272,7 +273,7 @@ def main() -> int:
         "--types",
         type=str,
         default=None,
-        help="Comma-separated list of allowed commit types (default: feat,fix,docs,chore,refactor,test,ci,build,revert,style)",
+        help="Comma-separated list of allowed commit types (default: feat,fix,docs,chore,refactor,perf,test,ci,build,revert,style)",
     )
     parser.add_argument(
         "--scopes",

--- a/packages/vig-utils/tests/test_validate_commit_msg.py
+++ b/packages/vig-utils/tests/test_validate_commit_msg.py
@@ -49,6 +49,19 @@ class TestValidateCommitMessage:
             assert valid is True, f"Type {ctype} should be valid: {err}"
             assert err is None
 
+    def test_perf_is_an_approved_type(self):
+        """`perf` is a standard Conventional Commits type. Refs #1030.
+
+        CI's ``validate-commit-range`` runs with no ``--types`` override, so
+        ``DEFAULT_APPROVED_TYPES`` is the effective allowlist there; a
+        ``perf(...)`` commit must validate against it.
+        """
+        assert "perf" in DEFAULT_APPROVED_TYPES
+        msg = "perf(image): speed up manifest bake\n\nRefs: #1030\n"
+        valid, err = validate_commit_message(msg)
+        assert valid is True, f"perf should be valid: {err}"
+        assert err is None
+
     def test_valid_scope_with_hyphens(self):
         msg = "chore(deps): bump pre-commit\n\nRefs: #37\n"
         valid, err = validate_commit_message(msg)

--- a/tests/test_flake_hooks.py
+++ b/tests/test_flake_hooks.py
@@ -240,6 +240,21 @@ class TestCommitMsgHookContract:
         assert "prepare-commit-msg-strip-trailers" in scaffold
         assert scaffold["validate-commit-msg"]["stages"] == ["commit-msg"]
 
+    def test_agent_identity_hook_is_scaffolded(
+        self, rendered_portable: dict[str, Any]
+    ) -> None:
+        """Consumers guard the commit *author*, not only the message. Refs #1031.
+
+        ``check-agent-identity`` is the only hook of the #163 pipeline that
+        catches ``git commit --author="Claude <...>"``; the two commit-msg
+        hooks scaffolded in #1026 guard the message text alone. Without this
+        hook in the consumer render, a scaffolded repo rejects an
+        AI-attributed *message* while accepting an AI-authored *commit* — the
+        exact false guarantee its COMMIT_MESSAGE_STANDARD.md promises against.
+        """
+        scaffold = _normalize(rendered_portable["scaffold"])["hooks"]
+        assert "check-agent-identity" in scaffold
+
 
 @pytest.fixture(scope="module")
 def consumer_config() -> dict[str, Any]:


### PR DESCRIPTION
## Summary

Bundles two small hook-SSoT chores that touch the same files (`nix/hooks.nix` + rendered `.pre-commit-config.yaml`), sharing one CI run.

### #1031 — scaffold the `check-agent-identity` hook
- `scaffold = true;` on the hook in `nix/hooks.nix`; re-rendered `assets/workspace/.pre-commit-config.yaml`.
- Closes the #163 pipeline gap: consumers now guard the commit **author/committer**, not only the message. The blocklist the hook reads (`.github/agent-blocklist.toml`) was already manifest-synced — verified.
- Being pre-commit-stage, it is also enforced by `prek run --all-files` in the scaffold's lint job.

### #1030 — `perf` is now an approved commit type (Option A)
- Added to the SSoT `--types` list in `nix/hooks.nix` (both renders), `DEFAULT_APPROVED_TYPES` in `vig-utils` (the effective CI allowlist — `validate-commit-range` runs with no `--types` override), the type table in `docs/COMMIT_MESSAGE_STANDARD.md` (both copies), and the `CLAUDE.md` summary line.
- Option A per the issue's own suggestion: standard Conventional Commits type, already reached for naturally once in history.

TDD: each change lands as failing-test commit → implementation commit.

### Out of scope (deliberate)
`check-pr-agent-fingerprints` remains dead code. Note for the follow-up decision on #1031: after #1026 the PR **title** is already guarded by `validate-commit-range --title`; the entry point's only unique coverage is the PR **body**. Recommend wiring it into `commit-checks` as a cheap defense-in-depth step, or dropping it — either resolves the documented-but-uncalled-guard shape.

## Test evidence
- `uv run pytest tests/test_flake_hooks.py` → 17 passed (includes both drift gates)
- `uv run pytest packages/vig-utils/tests/test_validate_commit_msg.py tests/test_flake_hooks.py` → 128 passed
- `prek run --all-files` → green (re-verified independently before push)

Closes #1031
Closes #1030
Refs: #163, #1019, #1026