### PR TITLE
feat(image): add node capability module with first-scaffold npm recipes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`node` capability module with selectable Node version** ([#1027](https://github.com/vig-os/devkit/issues/1027))
+  - `mkProjectShell` gains a `node` capability module: `modules = [ "node" ]`
+    puts `nodejs` (which bundles `npm`) in the dev-shell, replacing the
+    hand-wired `extraPackages = [ pkgs.nodejs ]` every TS-action consumer copied.
+  - Lands the per-module-options mechanism the capability-modules ADR deferred:
+    a `modules` entry may now be an attrset `{ name = "node"; version = 22; }`
+    (selecting `pkgs.nodejs_<major>`) alongside the plain `"node"` string;
+    unknown option keys and unavailable/insecure majors fail at eval time. A
+    pinned version is prepended on PATH so it wins over the `nodejs` the
+    toolchain SSoT already ships. `modules = [ ]` is byte-identical to before.
+  - Node-detected repos get npm-mapped `justfile.project` recipes seeded at
+    their first scaffold (`sync` = `npm ci`, plus `lint`/`test`/`build`/`bundle`)
+    instead of the uv template, so `just sync` / `just test` work under Node; an
+    existing `justfile.project` is never touched. The module ships shell packages
+    only — eslint/prettier hooks and the codeql language stay out of scope.
 - **Commit messages are validated in CI** ([#1019](https://github.com/vig-os/devkit/issues/1019))
   - New `commit-checks` job (devkit and scaffolded repos) runs `validate-commit-range` over every commit a pull request adds, plus the **pull request title** — which becomes the merge commit's subject under `--no-ff`. `validate-commit-msg` is a `commit-msg`-stage hook, so `prek run --all-files` never ran it: until now the standard was enforced only by a local hook, and only on a machine whose `core.hooksPath` was intact.
   - Merge commits and bot-authored commits (`…[bot]`) are exempt. Renovate and Dependabot emit `build(pip): …` / `ci(actions): …` with no `Refs:` line, so without the exemption the new gate would fail every dependency PR. The exemption is keyed on the author — the same message from a human is still rejected.

--- a/assets/init-workspace.sh
+++ b/assets/init-workspace.sh
@@ -558,6 +558,35 @@ DETECTED_LANGUAGES=()
 [[ -f "$WORKSPACE_DIR/package.json" ]] && DETECTED_LANGUAGES+=("node")
 [[ -f "$WORKSPACE_DIR/Cargo.toml" ]] && DETECTED_LANGUAGES+=("rust")
 
+# Seed npm-mapped justfile.project recipes on the FIRST scaffold of a Node
+# consumer (#1027). justfile.project is a PRESERVE_FILE: the stock template
+# ships uv/pyproject recipes, so a Node repo's `just sync` / `just test` (which
+# ci.yml calls in every mode) would no-op against `uv`. When `node` is detected
+# AND the consumer had no justfile.project before this scaffold (the template
+# copy above just placed the default), replace that fresh default with the Node
+# seed — `sync` = `npm ci`, plus lint/test/build (tsc)/bundle (ncc). Guarded on
+# JUSTFILE_PROJECT_PREEXISTED so an EXISTING consumer-owned justfile.project is
+# NEVER touched (same preserve semantics as the #877 repair path). The seed
+# lives beside init-workspace.sh in the image ($SCRIPT_DIR), so it is an
+# install-time input; it carries the same {{SHORT_NAME}} token the template
+# does and is placed BEFORE the substitution pass so that pass resolves it. A
+# full replacement (not an append like the .gitignore fragments): appending npm
+# recipes onto the uv template would redeclare recipe names and break `just`.
+seed_node_justfile_project() {
+    local seed="$SCRIPT_DIR/justfile.d/node.justfile.project"
+    local dst="$WORKSPACE_DIR/justfile.project"
+    # Only on a first scaffold (never over a consumer-owned file) of a Node repo.
+    [[ "$JUSTFILE_PROJECT_PREEXISTED" == "true" ]] && return 0
+    [[ -f "$seed" && -f "$dst" ]] || return 0
+    local lang is_node=false
+    for lang in ${DETECTED_LANGUAGES[@]+"${DETECTED_LANGUAGES[@]}"}; do
+        [[ "$lang" == "node" ]] && is_node=true
+    done
+    [[ "$is_node" == "true" ]] || return 0
+    echo "Seeding npm-mapped justfile.project recipes for the Node consumer (#1027)..."
+    cp "$seed" "$dst"
+}
+
 # Render the managed .gitignore as the language-neutral base (already copied
 # from the template) plus one appended fragment per detected language (#1024).
 # The fragments live beside init-workspace.sh in the image ($SCRIPT_DIR), never
@@ -1018,6 +1047,13 @@ fi
 if [[ "$NO_PROMPTS" != "true" ]]; then
     resolve_github_repository
 fi
+
+# Seed the Node justfile.project on a first scaffold BEFORE the substitution
+# pass below, so the seed's {{SHORT_NAME}} token is resolved like every other
+# managed file (the seed replaces the freshly-copied template at the same path,
+# which the manifest already lists as carrying the token). No-op for non-Node
+# consumers and for an existing (preserved) justfile.project. Refs #1027.
+seed_node_justfile_project
 
 # Replace placeholders in files (using pre-built manifest from image)
 echo "Replacing placeholders in files..."

--- a/assets/justfile.d/node.justfile.project
+++ b/assets/justfile.d/node.justfile.project
@@ -1,0 +1,121 @@
+# ===============================================================================
+# PROJECT RECIPES - Team-shared customizations (Node / TypeScript)
+# This file is git-tracked and preserved during devcontainer upgrades.
+# Add team-shared recipes here that everyone on the project should use.
+#
+# Seeded by init-workspace.sh on the FIRST scaffold of a Node consumer (a
+# package.json was detected). It maps the CI-contract recipe names the base
+# justfile and ci.yml expect (sync/lint/test/…) onto npm, so `just sync` and
+# `just test` work in a Node repo the same way they do in a Python one. The
+# bodies use `npm run <script>` (and `npm ci`/`npm test`) — ADAPT the script
+# names to your package.json. An EXISTING justfile.project is never replaced.
+# ===============================================================================
+# ===============================================================================
+# PROJECT VARIABLES
+# ===============================================================================
+
+project := "{{SHORT_NAME}}"
+# ===============================================================================
+# INFO
+# ===============================================================================
+
+# Show project information
+[group('info')]
+info:
+    @echo "Project: {{ project }}"
+
+# -------------------------------------------------------------------------------
+# CODE QUALITY
+# -------------------------------------------------------------------------------
+
+# Run all linters (adapt to your package.json "lint" script, e.g. eslint)
+[group('quality')]
+lint:
+    @if [ -f package.json ]; then npm run lint; fi
+
+# Format code (adapt to your package.json "format" script, e.g. prettier)
+[group('quality')]
+format:
+    @if [ -f package.json ]; then npm run format; fi
+
+# Run pre-commit hooks on all files
+[group('quality')]
+precommit:
+    prek run --all-files
+
+# -------------------------------------------------------------------------------
+# TESTING
+# -------------------------------------------------------------------------------
+
+# Run tests (npm test -> package.json "test" script, e.g. jest)
+[group('test')]
+test *args:
+    @if [ -f package.json ]; then npm test -- {{ args }}; fi
+
+# Run tests with coverage (adapt to your package.json "test:cov" script)
+[group('test')]
+test-cov *args:
+    @if [ -f package.json ]; then npm run test:cov -- {{ args }}; fi
+
+# -------------------------------------------------------------------------------
+# DEPENDENCIES
+# -------------------------------------------------------------------------------
+
+# Sync dependencies (clean, lockfile-faithful install)
+[group('deps')]
+sync *args:
+    @if [ -f package.json ]; then npm ci {{ args }}; fi
+
+# Update all dependencies (refreshes package-lock.json)
+[group('deps')]
+update:
+    npm update
+
+# -------------------------------------------------------------------------------
+# BUILD
+# -------------------------------------------------------------------------------
+
+# Compile TypeScript (adapt to your package.json "build" script, e.g. tsc)
+[group('build')]
+build:
+    @if [ -f package.json ]; then npm run build; fi
+
+# Bundle the action entrypoint into dist/ (adapt to your "bundle" script, e.g. ncc)
+[group('build')]
+bundle:
+    @if [ -f package.json ]; then npm run bundle; fi
+
+# Clean build artifacts
+[group('build')]
+clean-artifacts:
+    rm -rf dist coverage .nyc_output *.tsbuildinfo
+
+# ===============================================================================
+# PROJECT-SPECIFIC RECIPES
+# ===============================================================================
+# Uncomment and customize for your project:
+# # Run the application
+# [group('app')]
+# run *args:
+#     node dist/index.js {{args}}
+#
+# # Boot the local dev services declared in flake.nix (mkProjectServices,
+# # #795): daemonless process-compose stack, state in ./data (gitignore it).
+# [group('services')]
+# services *args:
+#     nix run .#services -- {{args}}
+#
+# # Prepare release branch (manual workflow dispatch helper)
+# [group('release')]
+# prepare-release version:
+#     gh workflow run prepare-release.yml --ref dev -f "version={{ version }}"
+#
+# # Finalize and publish release (manual workflow dispatch helper)
+# [group('release')]
+# finalize-release version:
+#     gh workflow run release.yml --ref release/{{ version }} -f "version={{ version }}" -f "release-kind=final" -f "dry-run=false"
+#
+# # Publish candidate release (manual workflow dispatch helper)
+# [group('release')]
+# publish-candidate version:
+#     gh workflow run release.yml --ref release/{{ version }} -f "version={{ version }}" -f "release-kind=candidate" -f "dry-run=false"

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`node` capability module with selectable Node version** ([#1027](https://github.com/vig-os/devkit/issues/1027))
+  - `mkProjectShell` gains a `node` capability module: `modules = [ "node" ]`
+    puts `nodejs` (which bundles `npm`) in the dev-shell, replacing the
+    hand-wired `extraPackages = [ pkgs.nodejs ]` every TS-action consumer copied.
+  - Lands the per-module-options mechanism the capability-modules ADR deferred:
+    a `modules` entry may now be an attrset `{ name = "node"; version = 22; }`
+    (selecting `pkgs.nodejs_<major>`) alongside the plain `"node"` string;
+    unknown option keys and unavailable/insecure majors fail at eval time. A
+    pinned version is prepended on PATH so it wins over the `nodejs` the
+    toolchain SSoT already ships. `modules = [ ]` is byte-identical to before.
+  - Node-detected repos get npm-mapped `justfile.project` recipes seeded at
+    their first scaffold (`sync` = `npm ci`, plus `lint`/`test`/`build`/`bundle`)
+    instead of the uv template, so `just sync` / `just test` work under Node; an
+    existing `justfile.project` is never touched. The module ships shell packages
+    only — eslint/prettier hooks and the codeql language stay out of scope.
 - **Commit messages are validated in CI** ([#1019](https://github.com/vig-os/devkit/issues/1019))
   - New `commit-checks` job (devkit and scaffolded repos) runs `validate-commit-range` over every commit a pull request adds, plus the **pull request title** — which becomes the merge commit's subject under `--no-ff`. `validate-commit-msg` is a `commit-msg`-stage hook, so `prek run --all-files` never ran it: until now the standard was enforced only by a local hook, and only on a machine whose `core.hooksPath` was intact.
   - Merge commits and bot-authored commits (`…[bot]`) are exempt. Renovate and Dependabot emit `build(pip): …` / `ci(actions): …` with no `Refs:` line, so without the exemption the new gate would fail every dependency PR. The exemption is keyed on the author — the same message from a human is still rejected.

--- a/docs/NIX.md
+++ b/docs/NIX.md
@@ -98,14 +98,44 @@ devShells.default = vigos.lib.mkProjectShell {
   byte-identical to the pre-module builder — pure-Python consumers are
   untouched, and the **published image stays base-only** (modules are a
   direnv-mode/devshell feature).
-- **Shipped:** `native` — `stdenv.cc`, `cmake`, `gnumake`, `pkg-config` plus
-  generic `CC=cc`/`CXX=c++` exports; the curated form of the
-  [native-build contract](./MIGRATION.md#the-native-build-contract)'s
-  preferred tier. **Candidates (ask-gated, not shipped):** `geant4`, `rust`,
-  `fortran`/`f2py`, `root`.
+- **Shipped:**
+  - `native` — `stdenv.cc`, `cmake`, `gnumake`, `pkg-config` plus generic
+    `CC=cc`/`CXX=c++` exports; the curated form of the
+    [native-build contract](./MIGRATION.md#the-native-build-contract)'s
+    preferred tier.
+  - `node` ([#1027](https://github.com/vig-os/devkit/issues/1027)) — the
+    Node/TypeScript capability: `nodejs` (which bundles `npm`) in the shell,
+    for consumers who previously hand-wired `extraPackages = [ pkgs.nodejs ]`.
+  - **Candidates (ask-gated, not shipped):** `geant4`, `rust`, `fortran`/`f2py`,
+    `root`.
+- **Per-module options (the `node` version).** A `modules` entry is either a
+  plain name string or an attrset `{ name = "<name>"; <options> }` — additive,
+  the string form is unchanged. `node` takes one option, `version` (a Node
+  major), selecting `pkgs.nodejs_<major>`; omitted, it uses the nixpkgs default:
+
+  ```nix
+  modules = [ { name = "node"; version = 22; } ]; # pin Node 22; plain "node" = default
+  ```
+
+  Unknown option keys and unavailable majors throw at eval time. Note the
+  toolchain SSoT (`nix/devtools.nix`) already ships `nodejs` for the
+  `@devcontainers/cli`, and the composition orders devTools before module
+  packages — so a pinned `version` is prepended in the module's shellHook to
+  actually win `node`/`npm` on PATH. An **EOL major** nixpkgs marks insecure
+  (e.g. `nodejs_20`) throws unless the consumer opts into
+  `permittedInsecurePackages`; prefer a maintained LTS for local dev.
+- **What `node` does NOT do (v1 contract):** it contributes shell packages
+  only — no eslint/prettier pre-commit hooks (that is the #883 consumer-hooks
+  seam), no `.gitignore`/`codeql` language (those are the language-aware
+  scaffold, [#1024](https://github.com/vig-os/devkit/issues/1024)/[#1025](https://github.com/vig-os/devkit/issues/1025)).
+  Separately, a repo whose `package.json` is detected at its **first** scaffold
+  gets npm-mapped `justfile.project` recipes seeded (`sync` = `npm ci`, plus
+  `lint`/`test`/`build`/`bundle`) instead of the uv template, so `just sync` /
+  `just test` work under Node; an existing `justfile.project` is never touched.
 - Each shipped module gets a `checks.<system>.module-<name>` devshell build
-  and, for `native`, the uv C-extension sdist smoke test in
-  `tests/test_flake_modules.py`.
+  and a `tests/test_flake_modules.py` smoke test (for `native`, the uv
+  C-extension sdist; for `node`, that `node`/`npm` resolve and the versioned
+  form pins the major).
 
 ## Home-manager modules — versioning & release policy
 

--- a/flake.nix
+++ b/flake.nix
@@ -256,15 +256,46 @@
           # pre-#884 builder (parity: tests/test_flake_devshell.py). Kept as
           # one self-contained block so #883's `hooks` argument can land
           # beside it without conflict.
+          #
+          # Per-module options (#1027, the ADR's deferred migration path): a
+          # `modules` entry is EITHER a plain name string (no options) OR an
+          # attrset `{ name = "<name>"; <options> }` — additive, no break for
+          # the string form. Each module is a function `pkgs -> options ->
+          # contribution`; the options attrset is the entry minus `name`
+          # (empty for the string form). A module validates its own option
+          # keys (unknown keys throw), so the general mechanism here stays
+          # minimal: normalize the entry, resolve the name, apply.
           # ------------------------------------------------------------------
+          normalizeModuleEntry =
+            entry:
+            if builtins.isString entry then
+              {
+                name = entry;
+                options = { };
+              }
+            else if builtins.isAttrs entry && entry ? name then
+              {
+                inherit (entry) name;
+                options = builtins.removeAttrs entry [ "name" ];
+              }
+            else
+              throw (
+                "mkProjectShell: a `modules` entry must be a module name string or an "
+                + "attrset with a `name` field; got: "
+                + builtins.toJSON entry
+              );
           moduleDefs = map (
-            name:
-            (capabilityModules.${name} or (throw (
-              "mkProjectShell: unknown capability module '${name}'; available: "
+            entry:
+            let
+              parsed = normalizeModuleEntry entry;
+            in
+            (capabilityModules.${parsed.name} or (throw (
+              "mkProjectShell: unknown capability module '${parsed.name}'; available: "
               + pkgs.lib.concatStringsSep ", " (builtins.attrNames capabilityModules)
             ))
             )
               pkgs
+              parsed.options
           ) modules;
           # Appended AFTER extraPackages: earlier entries win PATH lookup, so
           # the per-repo escape hatch overrides a module's tool choice.

--- a/nix/modules/default.nix
+++ b/nix/modules/default.nix
@@ -2,8 +2,10 @@
 #
 # Maps a module name (the string consumers pass in mkProjectShell's
 # `modules = [ "<name>" … ]`) to its definition: a function
-# `pkgs -> { packages, env, shellHook }` (all fields optional — the v1
-# contract). mkProjectShell resolves names against this attrset and the
+# `pkgs -> options -> { packages, env, shellHook }` (contribution fields all
+# optional — the v1 contract). `options` is the per-entry attrset a consumer
+# passes via `{ name = "<name>"; … }` minus `name` (empty `{}` for the plain
+# string form). mkProjectShell resolves names against this attrset and the
 # flake generates a per-system `checks.<system>.module-<name>` devshell
 # build for every entry, so a module cannot ship without its check.
 #
@@ -11,4 +13,5 @@
 # NOT defined until a concrete consumer asks (YAGNI; see the ADR).
 {
   native = import ./native.nix;
+  node = import ./node.nix;
 }

--- a/nix/modules/native.nix
+++ b/nix/modules/native.nix
@@ -6,7 +6,11 @@
 # and this module provides that PATH. Field-validated need: hyrr/pycatima
 # (#639). Third-party libraries (Geant4, ROOT, OCCT, …) stay per-project
 # `extraPackages` — or a future ask-gated module.
-pkgs: {
+#
+# Takes no options (`_options`): the module calling convention is uniformly
+# `pkgs -> options -> contribution` since #1027 landed per-module options; the
+# native capability has nothing to configure.
+pkgs: _options: {
   packages = with pkgs; [
     # C/C++ compiler wrapper: puts cc/c++ (and gcc/g++) on PATH and links
     # against the same Nix C++ runtime the toolchain SSoT already exposes.

--- a/nix/modules/node.nix
+++ b/nix/modules/node.nix
@@ -1,0 +1,64 @@
+# `node` capability module (#1027): the Node/TypeScript dev-shell capability.
+# v1 contract (packages only, per docs/rfcs/ADR-capability-modules.md): puts
+# `nodejs` — which bundles `npm` — on the dev-shell PATH so a consumer opts in
+# with `modules = [ "node" ]` instead of hand-wiring `extraPackages = [
+# pkgs.nodejs ]`. It deliberately does NOT provide the npm justfile recipes,
+# the .gitignore fragment, the pre-commit hooks or the CodeQL language — those
+# are scaffold concerns (the language-aware scaffold, #1024/#1025, and the
+# first-scaffold npm recipe seeding in init-workspace.sh), not shell
+# contributions.
+#
+# This is the first module that needs configuration, so it also exercises the
+# per-module-options mechanism the ADR deferred: mkProjectShell calls a module
+# as `pkgs -> options -> contribution`, where `options` is the attrset entry's
+# fields minus `name`. The only recognized option is `version` (a Node major,
+# e.g. 20), mapping to `pkgs.nodejs_<major>`; omitted, it uses the nixpkgs
+# default `pkgs.nodejs`. Unknown option keys and unavailable versions fail at
+# eval time with a clear message.
+pkgs:
+{
+  version ? null,
+  ...
+}@options:
+let
+  # Only `version` is a recognized option — reject anything else loudly so a
+  # typo (or an unsupported knob) is a hard eval error, never a silent no-op.
+  knownOptions = [ "version" ];
+  unknownOptions = builtins.filter (k: !builtins.elem k knownOptions) (builtins.attrNames options);
+
+  # Resolve the Node package: a `version` major selects `pkgs.nodejs_<major>`;
+  # null uses the nixpkgs default. An unavailable major (not packaged in the
+  # pinned nixpkgs) fails at eval time rather than silently degrading.
+  nodeAttr = "nodejs_${toString version}";
+  nodePkg =
+    if version == null then
+      pkgs.nodejs
+    else
+      pkgs.${nodeAttr} or (throw (
+        "node module: unavailable Node version '${toString version}' "
+        + "(pkgs.${nodeAttr} is not in the pinned nixpkgs)"
+      ));
+in
+if unknownOptions != [ ] then
+  throw (
+    "node module: unknown option(s): "
+    + pkgs.lib.concatStringsSep ", " unknownOptions
+    + "; the only recognized option is 'version'"
+  )
+else
+  {
+    # nodejs bundles npm, so a single package covers both `node` and `npm`.
+    packages = [ nodePkg ];
+
+    # The toolchain SSoT (nix/devtools.nix) already ships `nodejs` for the
+    # @devcontainers/cli, and the ADR composition orders devTools BEFORE module
+    # packages — so an appended module/extraPackages node is shadowed on PATH by
+    # that default. When a consumer pins a specific `version`, prepend it in the
+    # shellHook (a v1-contract fragment, exactly how the native module exports
+    # CC/CXX) so the pinned major actually wins `node`/`npm` lookup. Fires ONLY
+    # for an explicit version: the default form is a pure package contribution
+    # (same major as the SSoT node, so nothing to override).
+    shellHook = pkgs.lib.optionalString (version != null) ''
+      export PATH="${nodePkg}/bin:$PATH"
+    '';
+  }

--- a/tests/bats/init-workspace.bats
+++ b/tests/bats/init-workspace.bats
@@ -2524,3 +2524,84 @@ _RELEASE_RESOLVERS_991=(
     assert_success
     assert_output --partial "default code-scanning setup"
 }
+
+# ── first-scaffold npm justfile.project recipes for Node consumers (#1027) ─────
+# justfile.project is a PRESERVE_FILE: the stock template ships uv/pyproject
+# recipes, which no-op for a Node repo whose CI still calls `just sync|test`.
+# On the FIRST scaffold of a Node consumer (package.json present, no existing
+# justfile.project) init-workspace.sh seeds npm-mapped recipes instead of the
+# default template, so `just sync` = `npm ci`, plus lint/test/build/bundle. An
+# EXISTING justfile.project is consumer-owned and never touched.
+
+@test "first scaffold of a Node consumer seeds npm justfile.project recipes (#1027)" {
+    ws="$BATS_TEST_TMPDIR/e2e-1027-node-seed"
+    mkdir -p "$ws"
+    printf '{ "name": "probe" }\n' >"$ws/package.json"
+    run _scaffold both "$ws"
+    assert_success
+    run cat "$ws/justfile.project"
+    assert_success
+    # sync = npm ci (the CI contract recipe every mode calls).
+    assert_output --partial 'npm ci'
+    # The npm-mapped quality/build recipes are present by name.
+    assert_output --partial 'sync'
+    assert_output --partial 'test'
+    assert_output --partial 'build'
+    assert_output --partial 'bundle'
+    # ncc (bundle) and tsc (build) are the Action-runtime mappings.
+    assert_output --partial 'ncc'
+    # The Python default template must NOT have been used.
+    refute_output --partial 'uv sync'
+}
+
+@test "first scaffold of a Node consumer substitutes the project placeholder (#1027)" {
+    ws="$BATS_TEST_TMPDIR/e2e-1027-node-subst"
+    mkdir -p "$ws"
+    printf '{ "name": "probe" }\n' >"$ws/package.json"
+    run _scaffold both "$ws"
+    assert_success
+    run cat "$ws/justfile.project"
+    assert_success
+    # The seed carries the {{SHORT_NAME}} token, resolved by the substitution
+    # pass like every managed file (SHORT_NAME=testproj in the _scaffold helper).
+    assert_output --partial 'testproj'
+    refute_output --partial '{{SHORT_NAME}}'
+}
+
+@test "an existing justfile.project is never replaced by the Node seed (#1027)" {
+    ws="$BATS_TEST_TMPDIR/e2e-1027-node-preserve"
+    mkdir -p "$ws"
+    printf '{ "name": "probe" }\n' >"$ws/package.json"
+    printf '# consumer-owned recipes\nmy-custom-recipe:\n\t@echo mine\n' \
+        >"$ws/justfile.project"
+    run _scaffold both "$ws"
+    assert_success
+    run cat "$ws/justfile.project"
+    assert_success
+    # The consumer file is preserved verbatim — the seed must not clobber it.
+    assert_output --partial 'my-custom-recipe'
+    refute_output --partial 'npm ci'
+}
+
+@test "first scaffold of a Python consumer keeps the uv template, not npm (#1027)" {
+    ws="$BATS_TEST_TMPDIR/e2e-1027-py-notseeded"
+    mkdir -p "$ws"
+    printf '[project]\nname = "probe"\n' >"$ws/pyproject.toml"
+    run _scaffold both "$ws"
+    assert_success
+    run cat "$ws/justfile.project"
+    assert_success
+    # No package.json marker, so the Node seed must not apply.
+    assert_output --partial 'uv sync'
+    refute_output --partial 'npm ci'
+}
+
+@test "first scaffold of a language-neutral consumer keeps the default template (#1027)" {
+    ws="$BATS_TEST_TMPDIR/e2e-1027-neutral-notseeded"
+    mkdir -p "$ws"
+    run _scaffold both "$ws"
+    assert_success
+    run cat "$ws/justfile.project"
+    assert_success
+    refute_output --partial 'npm ci'
+}

--- a/tests/test_flake_modules.py
+++ b/tests/test_flake_modules.py
@@ -171,7 +171,7 @@ def test_native_module_builds_c_extension_sdist_with_uv(
 # node module (#1027) — the Node/TypeScript capability. v1 contract (packages
 # only): `nodejs` (which bundles npm) in the dev-shell, with a selectable major
 # version via the ADR's per-module-options migration path — a `modules` entry
-# may be `{ name = "node"; version = 20; }` (attrset) alongside the plain
+# may be `{ name = "node"; version = 22; }` (attrset) alongside the plain
 # `"node"` string (nixpkgs default). See docs/rfcs/ADR-capability-modules.md.
 # ---------------------------------------------------------------------------
 
@@ -258,12 +258,17 @@ def test_node_module_provides_node_and_npm(current_system: str) -> None:
 
 
 def test_node_module_version_option_pins_major(current_system: str) -> None:
-    """``{ name = "node"; version = 20; }`` selects ``pkgs.nodejs_20`` (#1027).
+    """``{ name = "node"; version = 22; }`` selects ``pkgs.nodejs_22`` (#1027).
 
     The per-module-options migration path the ADR deferred: an attrset entry
     carries a ``version`` that maps to ``pkgs.nodejs_<major>``. Build that shell
     directly (the registry check only covers the default form) and assert the
     running interpreter is the pinned major.
+
+    A maintained LTS major (22) is used deliberately: the pinned nixpkgs marks
+    EOL majors (e.g. nodejs_20) insecure, so pinning one throws unless the
+    consumer opts into ``permittedInsecurePackages`` — a nixpkgs policy the
+    module surfaces rather than masks (documented in docs/NIX.md).
     """
     expr = f"""
     let
@@ -276,7 +281,7 @@ def test_node_module_version_option_pins_major(current_system: str) -> None:
       }};
     in flake.lib.mkProjectShell {{
       inherit pkgs;
-      modules = [ {{ name = "node"; version = 20; }} ];
+      modules = [ {{ name = "node"; version = 22; }} ];
     }}
     """
     proc = _develop_expr(expr, "node --version")
@@ -284,8 +289,8 @@ def test_node_module_version_option_pins_major(current_system: str) -> None:
         f"failed to build/enter the versioned node devshell: {proc.stderr[-500:]}"
     )
     got = proc.stdout.strip().splitlines()[-1] if proc.stdout else ""
-    assert got.startswith("v20."), (
-        f"node module version=20 must run Node 20.x; got {got!r}"
+    assert got.startswith("v22."), (
+        f"node module version=22 must run Node 22.x; got {got!r}"
     )
 
 

--- a/tests/test_flake_modules.py
+++ b/tests/test_flake_modules.py
@@ -4,10 +4,12 @@
 (see ``docs/rfcs/ADR-capability-modules.md``). Each shipped module is exposed
 as a per-system flake check ``checks.<system>.module-<name>`` (generated from
 the ``nix/modules/`` registry), which doubles as the entry point here: these
-tests ``nix develop`` the ``native`` module's shell and assert its contract —
-the C/C++ toolchain is on the shell's own PATH, generic ``CC``/``CXX`` are
-exported, and a trivial setuptools C-extension sdist builds and installs with
-``uv`` (the pycatima-class scenario from #639/#879 that motivated the module).
+tests ``nix develop`` a module's shell and assert its contract. For ``native``
+(#884): the C/C++ toolchain is on the shell's own PATH, generic ``CC``/``CXX``
+are exported, and a trivial setuptools C-extension sdist builds and installs
+with ``uv`` (the pycatima-class scenario from #639/#879). For ``node`` (#1027):
+``node`` + bundled ``npm`` resolve, and the ``{ name = "node"; version = …; }``
+per-module-options form pins the Node major (the mechanism the ADR deferred).
 
 The zero-module parity guarantee (the default dev-shell is byte-identical to
 the pre-module builder) is covered by ``tests/test_flake_devshell.py`` staying
@@ -162,4 +164,160 @@ def test_native_module_builds_c_extension_sdist_with_uv(
     assert proc.returncode == 0 and "sdist-ok" in proc.stdout, (
         "uv sdist build/install failed inside the native-module devshell: "
         f"rc={proc.returncode}\nstdout:\n{proc.stdout}\nstderr:\n{proc.stderr[-2000:]}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# node module (#1027) — the Node/TypeScript capability. v1 contract (packages
+# only): `nodejs` (which bundles npm) in the dev-shell, with a selectable major
+# version via the ADR's per-module-options migration path — a `modules` entry
+# may be `{ name = "node"; version = 20; }` (attrset) alongside the plain
+# `"node"` string (nixpkgs default). See docs/rfcs/ADR-capability-modules.md.
+# ---------------------------------------------------------------------------
+
+
+def _develop_module(
+    current_system: str, module: str, script: str, *, timeout: int = 1800
+) -> subprocess.CompletedProcess[str]:
+    """Run a bash script inside the generated ``module-<module>`` devshell.
+
+    Purity guard (``--ignore-environment``, keeping only HOME) as in
+    ``_develop_native``: the assertions must exercise the module's OWN PATH
+    contribution and never be satisfied by a host toolchain leaking through.
+    """
+    return subprocess.run(
+        [
+            "nix",
+            "develop",
+            "--ignore-environment",
+            "--keep",
+            "HOME",
+            f"{REPO_ROOT}#checks.{current_system}.module-{module}",
+            "-c",
+            "bash",
+            "-c",
+            script,
+        ],
+        capture_output=True,
+        text=True,
+        env=_nix_env(),
+        timeout=timeout,
+    )
+
+
+def _develop_expr(
+    expr: str, script: str, *, timeout: int = 1800
+) -> subprocess.CompletedProcess[str]:
+    """Run a bash script inside an ad-hoc devshell built from a Nix expression.
+
+    Used for the versioned module form, which the registry-generated
+    ``module-node`` check (plain-string default) cannot express: it builds
+    ``flake.lib.mkProjectShell`` directly with an attrset ``modules`` entry.
+    ``--impure`` is required for ``builtins.getFlake`` on the local path.
+    """
+    return subprocess.run(
+        [
+            "nix",
+            "develop",
+            "--impure",
+            "--ignore-environment",
+            "--keep",
+            "HOME",
+            "--expr",
+            expr,
+            "-c",
+            "bash",
+            "-c",
+            script,
+        ],
+        capture_output=True,
+        text=True,
+        env=_nix_env(),
+        timeout=timeout,
+    )
+
+
+def test_node_module_provides_node_and_npm(current_system: str) -> None:
+    """The ``node`` module puts ``node`` and its bundled ``npm`` on PATH (#1027).
+
+    The plain-string ``modules = [ "node" ]`` form (exercised through the
+    registry-generated ``module-node`` check) contributes the nixpkgs-default
+    ``nodejs``, which bundles ``npm`` — both must resolve from the shell's own
+    PATH, not the host's.
+    """
+    proc = _develop_module(
+        current_system,
+        "node",
+        "command -v node && command -v npm && node --version && npm --version",
+    )
+    assert proc.returncode == 0, (
+        "node-module devshell is missing node/npm: "
+        f"rc={proc.returncode} stdout={proc.stdout.strip()!r} "
+        f"stderr={proc.stderr.strip()[:300]}"
+    )
+
+
+def test_node_module_version_option_pins_major(current_system: str) -> None:
+    """``{ name = "node"; version = 20; }`` selects ``pkgs.nodejs_20`` (#1027).
+
+    The per-module-options migration path the ADR deferred: an attrset entry
+    carries a ``version`` that maps to ``pkgs.nodejs_<major>``. Build that shell
+    directly (the registry check only covers the default form) and assert the
+    running interpreter is the pinned major.
+    """
+    expr = f"""
+    let
+      flake = builtins.getFlake "path:{REPO_ROOT}";
+      system = builtins.currentSystem;
+      pkgs = import flake.inputs.nixpkgs {{
+        inherit system;
+        overlays = [ flake.overlays.default ];
+        config.allowUnfree = true;
+      }};
+    in flake.lib.mkProjectShell {{
+      inherit pkgs;
+      modules = [ {{ name = "node"; version = 20; }} ];
+    }}
+    """
+    proc = _develop_expr(expr, "node --version")
+    assert proc.returncode == 0, (
+        f"failed to build/enter the versioned node devshell: {proc.stderr[-500:]}"
+    )
+    got = proc.stdout.strip().splitlines()[-1] if proc.stdout else ""
+    assert got.startswith("v20."), (
+        f"node module version=20 must run Node 20.x; got {got!r}"
+    )
+
+
+def test_node_module_rejects_unknown_option(current_system: str) -> None:
+    """An unrecognized module option fails at eval time with a clear message (#1027).
+
+    The options mechanism is intentionally strict: only keys the module declares
+    are accepted, so a mistyped or unsupported knob (here ``channel``) is a hard
+    eval error, never a silently-ignored no-op.
+    """
+    expr = f"""
+    let
+      flake = builtins.getFlake "path:{REPO_ROOT}";
+      system = builtins.currentSystem;
+      pkgs = import flake.inputs.nixpkgs {{
+        inherit system;
+        overlays = [ flake.overlays.default ];
+        config.allowUnfree = true;
+      }};
+    in (flake.lib.mkProjectShell {{
+      inherit pkgs;
+      modules = [ {{ name = "node"; channel = 20; }} ];
+    }}).drvPath
+    """
+    result = subprocess.run(
+        ["nix", "eval", "--impure", "--expr", expr],
+        capture_output=True,
+        text=True,
+        env=_nix_env(),
+        timeout=300,
+    )
+    assert result.returncode != 0, "unknown node option must fail eval, not pass"
+    assert "channel" in result.stderr and "node" in result.stderr, (
+        f"error must name the offending option and module; got: {result.stderr[-500:]}"
     )


### PR DESCRIPTION
## Summary

Implements the node/typescript capability module per the design decision recorded on the issue (module = v1 shell contract; scaffold statics via #1024/#1025; release bundling via #1029).

### `node` capability module (v1 contract)
- `modules = [ "node" ]` puts `nodejs` (bundles npm) in the dev shell — replaces the hand-wired `extraPackages = [ pkgs.nodejs ]` every TS-action consumer copied.
- **Lands the per-module-options mechanism the ADR deferred** (this is "the first module that needs it"): a `modules` entry may be `{ name = "node"; version = 22; }` alongside plain strings — additive, no break for the string form. Modules are now uniformly `pkgs -> options -> contribution`; unknown option names, malformed entries, and unavailable Node majors all fail at eval time with clear messages.
- **PATH nuance (flagged for review):** the toolchain SSoT (`nix/devtools.nix`) already ships `nodejs` for `@devcontainers/cli`, and the ADR orders devTools before module packages — so a pinned module node would be shadowed. When (and only when) an explicit `version` is given, the module prepends its node in `shellHook` (a v1-contract fragment, same pattern as `native`'s CC/CXX exports). Documented in the module and `docs/NIX.md`.
- `nodejs_20` (the Actions runtime major the issue mentions) is EOL/insecure in the pinned nixpkgs — pinning it surfaces nixpkgs' own error unless the consumer opts into `permittedInsecurePackages`; the versioned test uses maintained LTS 22.
- Zero-module invariant intact: `modules = [ ]` drvPath byte-identity and the parity suite pass untouched. `checks.<system>.module-node` is registry-generated.

### First-scaffold npm recipes
Node-detected consumers (`package.json`, via #1024's `DETECTED_LANGUAGES`) get `justfile.project` seeded from `assets/justfile.d/node.justfile.project` at **first scaffold only** — `sync`=`npm ci`, `lint`/`format`/`test`/`test-cov`, `build` (tsc), `bundle` (ncc) — so the CI contract (`just sync`/`just test`) and the #1029 release bundle probe work out of the box. Guarded on `JUSTFILE_PROJECT_PREEXISTED`: an existing consumer-owned file is never touched. Full replacement, not append (appending would redeclare recipe names).

### Out of scope (per the recorded decision)
eslint/prettier hooks (#883 seam), gitignore/codeql (landed via #1035), release bundle step (landed via #1033).

TDD: two failing-test → implementation commit pairs + a docs commit.

## Test evidence
- `uv run pytest tests/test_flake_modules.py` → 6 passed (node/npm resolve; `version = 22` pins 22.x; unknown option rejected)
- `bats tests/bats/init-workspace.bats` → 174 ok / 0 failed (5 new seeding tests; re-run after merging dev)
- Zero-module drvPath parity → passed; flake checks `module-node`, `deadnix`, `statix` build
- `prek run --all-files` → green (re-verified independently before push)

Closes #1027
Refs: #884, #1024, #1029