### PR TITLE
feat(setup): generate provenance banners in scaffolded assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Provenance banner in scaffolded assets** ([#1036](https://github.com/vig-os/devkit/issues/1036))
+  - Every comment-capable file scaffolded into a downstream repo now carries a two-line banner stating that devkit manages the file, whether an upgrade overwrites it, and where to file bugs / missing tools. The banner comes in two variants — **managed** (regenerated on upgrade) and **preserved** (seeded once, yours to edit) — chosen automatically from `PRESERVE_FILES` (the SSoT in `init-workspace.sh`) by a new `Banner` transform wired into `sync_manifest.py`, so the classification cannot drift from a hand-typed copy. The `sync-manifest` pre-commit hook regenerates the banners on every commit and fails on any hand-edited or missing one.
+  - The banner carries **no version string** (`.vig-os` remains the version SSoT), so it stays byte-stable across releases and never floods upgrade diffs. Strict-JSON files (`renovate.json`, `.github/renovate-default.json`, `.claude/worktrees.json`, `.pymarkdown`) and a small documented set of other files (JSONC under the strict `check-json` hook, the render-gated `.pre-commit-config.yaml`, changelogs, `.vig-os`, `LICENSE`) are explicitly skipped; coverage is knowingly partial.
+  - The stale `justfile.devc` banner — which pointed at the root `justfile` that an upgrade overwrites — is corrected to point at `justfile.project`.
 - **Opt-in release artifact/bundle step for repos that ship a committed build** ([#1029](https://github.com/vig-os/devkit/issues/1029))
   - `release-core.yml` now detects a `bundle` just recipe via `just --summary` in the finalize job; when present it runs `just bundle` and commits `dist/` alongside `CHANGELOG.md` in the finalization commit, so a JS Action (or any repo shipping a committed `@vercel/ncc` artifact) tags a fresh bundle instead of a stale one. Repos without a `bundle` recipe (e.g. a pure-Python consumer) are unaffected — no new config surface, the recipe's presence is the flag.
 - **Commit messages are validated in CI** ([#1019](https://github.com/vig-os/devkit/issues/1019))

--- a/assets/workspace/.claude/agent-models.toml
+++ b/assets/workspace/.claude/agent-models.toml
@@ -1,3 +1,6 @@
+# Managed by vigOS devkit — regenerated on upgrade; local edits are lost.
+# Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues
+
 # .claude/agent-models.toml
 # Single source of truth for agent model assignments.
 # Referenced by: justfile.worktree (worktree-start) and derive-branch-summary.

--- a/assets/workspace/.claude/skills/branch-naming/SKILL.md
+++ b/assets/workspace/.claude/skills/branch-naming/SKILL.md
@@ -3,6 +3,8 @@ name: branch-naming
 description: Topic branch naming and workflow for starting work on an issue. Use when creating branches, starting work on issues, or checking out branches.
 disable-model-invocation: true
 ---
+<!-- Managed by vigOS devkit — regenerated on upgrade; local edits are lost. -->
+<!-- Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues -->
 
 # Topic Branch Naming and Workflow
 

--- a/assets/workspace/.claude/skills/ci_check/SKILL.md
+++ b/assets/workspace/.claude/skills/ci_check/SKILL.md
@@ -3,6 +3,8 @@ name: ci_check
 description: Checks the CI pipeline status for the current branch or PR.
 disable-model-invocation: true
 ---
+<!-- Managed by vigOS devkit — regenerated on upgrade; local edits are lost. -->
+<!-- Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues -->
 
 # Check CI Status
 

--- a/assets/workspace/.claude/skills/ci_fix/SKILL.md
+++ b/assets/workspace/.claude/skills/ci_fix/SKILL.md
@@ -3,6 +3,8 @@ name: ci_fix
 description: Diagnoses and fixes a failing CI run using systematic debugging.
 disable-model-invocation: true
 ---
+<!-- Managed by vigOS devkit — regenerated on upgrade; local edits are lost. -->
+<!-- Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues -->
 
 # Fix CI Failure
 

--- a/assets/workspace/.claude/skills/code_debug/SKILL.md
+++ b/assets/workspace/.claude/skills/code_debug/SKILL.md
@@ -3,6 +3,8 @@ name: code_debug
 description: Diagnoses bugs, test failures, or unexpected behavior. Root cause first, fix second.
 disable-model-invocation: true
 ---
+<!-- Managed by vigOS devkit — regenerated on upgrade; local edits are lost. -->
+<!-- Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues -->
 
 # Systematic Debugging
 

--- a/assets/workspace/.claude/skills/code_execute/SKILL.md
+++ b/assets/workspace/.claude/skills/code_execute/SKILL.md
@@ -3,6 +3,8 @@ name: code_execute
 description: Works through an implementation plan in batches with human checkpoints.
 disable-model-invocation: true
 ---
+<!-- Managed by vigOS devkit — regenerated on upgrade; local edits are lost. -->
+<!-- Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues -->
 
 # Execute Plan
 

--- a/assets/workspace/.claude/skills/code_review/SKILL.md
+++ b/assets/workspace/.claude/skills/code_review/SKILL.md
@@ -3,6 +3,8 @@ name: code_review
 description: Spawns a fresh-context readonly subagent to review changes before PR.
 disable-model-invocation: true
 ---
+<!-- Managed by vigOS devkit — regenerated on upgrade; local edits are lost. -->
+<!-- Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues -->
 
 # Self-Review
 

--- a/assets/workspace/.claude/skills/code_tdd/SKILL.md
+++ b/assets/workspace/.claude/skills/code_tdd/SKILL.md
@@ -3,6 +3,8 @@ name: code_tdd
 description: Implements changes using strict RED-GREEN-REFACTOR discipline.
 disable-model-invocation: true
 ---
+<!-- Managed by vigOS devkit — regenerated on upgrade; local edits are lost. -->
+<!-- Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues -->
 
 # Test-Driven Development
 

--- a/assets/workspace/.claude/skills/code_verify/SKILL.md
+++ b/assets/workspace/.claude/skills/code_verify/SKILL.md
@@ -3,6 +3,8 @@ name: code_verify
 description: Runs verification and provides evidence before claiming work is done.
 disable-model-invocation: true
 ---
+<!-- Managed by vigOS devkit — regenerated on upgrade; local edits are lost. -->
+<!-- Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues -->
 
 # Verify Before Completion
 

--- a/assets/workspace/.claude/skills/design_brainstorm/SKILL.md
+++ b/assets/workspace/.claude/skills/design_brainstorm/SKILL.md
@@ -3,6 +3,8 @@ name: design_brainstorm
 description: Explores requirements and design before writing any code.
 disable-model-invocation: true
 ---
+<!-- Managed by vigOS devkit — regenerated on upgrade; local edits are lost. -->
+<!-- Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues -->
 
 # Brainstorm
 

--- a/assets/workspace/.claude/skills/design_plan/SKILL.md
+++ b/assets/workspace/.claude/skills/design_plan/SKILL.md
@@ -3,6 +3,8 @@ name: design_plan
 description: Breaks an approved design or issue into bite-sized implementation tasks.
 disable-model-invocation: true
 ---
+<!-- Managed by vigOS devkit — regenerated on upgrade; local edits are lost. -->
+<!-- Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues -->
 
 # Write Implementation Plan
 

--- a/assets/workspace/.claude/skills/git_commit/SKILL.md
+++ b/assets/workspace/.claude/skills/git_commit/SKILL.md
@@ -3,6 +3,8 @@ name: git_commit
 description: Executes the commit workflow following the project's commit message conventions.
 disable-model-invocation: true
 ---
+<!-- Managed by vigOS devkit — regenerated on upgrade; local edits are lost. -->
+<!-- Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues -->
 
 # Git Commit Workflow
 

--- a/assets/workspace/.claude/skills/inception_architect/SKILL.md
+++ b/assets/workspace/.claude/skills/inception_architect/SKILL.md
@@ -3,6 +3,8 @@ name: inception_architect
 description: Architecture evaluation — validate design against established patterns.
 disable-model-invocation: true
 ---
+<!-- Managed by vigOS devkit — regenerated on upgrade; local edits are lost. -->
+<!-- Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues -->
 
 # Inception: Architect
 

--- a/assets/workspace/.claude/skills/inception_explore/README.md
+++ b/assets/workspace/.claude/skills/inception_explore/README.md
@@ -1,3 +1,6 @@
+<!-- Managed by vigOS devkit — regenerated on upgrade; local edits are lost. -->
+<!-- Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues -->
+
 # Inception Skills
 
 Pre-development product-thinking skills that bridge the gap between "I have an idea" and "I have actionable GitHub issues."

--- a/assets/workspace/.claude/skills/inception_explore/SKILL.md
+++ b/assets/workspace/.claude/skills/inception_explore/SKILL.md
@@ -3,6 +3,8 @@ name: inception_explore
 description: Divergent exploration — understand the problem space before jumping to solutions.
 disable-model-invocation: true
 ---
+<!-- Managed by vigOS devkit — regenerated on upgrade; local edits are lost. -->
+<!-- Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues -->
 
 # Inception: Explore
 

--- a/assets/workspace/.claude/skills/inception_plan/SKILL.md
+++ b/assets/workspace/.claude/skills/inception_plan/SKILL.md
@@ -3,6 +3,8 @@ name: inception_plan
 description: Decomposition — turn scoped design into actionable GitHub issues.
 disable-model-invocation: true
 ---
+<!-- Managed by vigOS devkit — regenerated on upgrade; local edits are lost. -->
+<!-- Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues -->
 
 # Inception: Plan
 

--- a/assets/workspace/.claude/skills/inception_scope/SKILL.md
+++ b/assets/workspace/.claude/skills/inception_scope/SKILL.md
@@ -3,6 +3,8 @@ name: inception_scope
 description: Convergent scoping — define what to build and what not to build.
 disable-model-invocation: true
 ---
+<!-- Managed by vigOS devkit — regenerated on upgrade; local edits are lost. -->
+<!-- Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues -->
 
 # Inception: Scope
 

--- a/assets/workspace/.claude/skills/issue_claim/SKILL.md
+++ b/assets/workspace/.claude/skills/issue_claim/SKILL.md
@@ -3,6 +3,8 @@ name: issue_claim
 description: Sets up the local environment to begin working on a GitHub issue, and ensures the issue is assigned.
 disable-model-invocation: true
 ---
+<!-- Managed by vigOS devkit — regenerated on upgrade; local edits are lost. -->
+<!-- Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues -->
 
 # Claim and Start Work on an Issue
 

--- a/assets/workspace/.claude/skills/issue_create/SKILL.md
+++ b/assets/workspace/.claude/skills/issue_create/SKILL.md
@@ -3,6 +3,8 @@ name: issue_create
 description: Creates a new GitHub issue using the appropriate issue template.
 disable-model-invocation: true
 ---
+<!-- Managed by vigOS devkit — regenerated on upgrade; local edits are lost. -->
+<!-- Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues -->
 
 # Create a GitHub Issue
 

--- a/assets/workspace/.claude/skills/issue_triage/SKILL.md
+++ b/assets/workspace/.claude/skills/issue_triage/SKILL.md
@@ -2,6 +2,8 @@
 name: issue_triage
 description: Triage open GitHub issues by analyzing them across priority, area, effort, SemVer impact, dependencies, and release readiness. Groups related issues into parent/sub-issue clusters, suggests milestone assignments, and applies approved changes via gh CLI. Use when the user asks to triage issues, groom the backlog, plan a milestone, or organize open issues.
 ---
+<!-- Managed by vigOS devkit — regenerated on upgrade; local edits are lost. -->
+<!-- Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues -->
 
 # Issue Triage
 

--- a/assets/workspace/.claude/skills/pr_create/SKILL.md
+++ b/assets/workspace/.claude/skills/pr_create/SKILL.md
@@ -3,6 +3,8 @@ name: pr_create
 description: Prepares and submits a pull request for feature or bugfix work.
 disable-model-invocation: true
 ---
+<!-- Managed by vigOS devkit — regenerated on upgrade; local edits are lost. -->
+<!-- Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues -->
 
 # Submit Pull Request
 

--- a/assets/workspace/.claude/skills/pr_post-merge/SKILL.md
+++ b/assets/workspace/.claude/skills/pr_post-merge/SKILL.md
@@ -3,6 +3,8 @@ name: pr_post-merge
 description: Performs cleanup and branch switching after a PR merge.
 disable-model-invocation: true
 ---
+<!-- Managed by vigOS devkit — regenerated on upgrade; local edits are lost. -->
+<!-- Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues -->
 
 # After PR merge: cleanup and switch branch
 

--- a/assets/workspace/.claude/skills/pr_solve/SKILL.md
+++ b/assets/workspace/.claude/skills/pr_solve/SKILL.md
@@ -3,6 +3,8 @@ name: pr_solve
 description: Diagnoses all PR failures (CI, reviews, merge state), plans fixes, executes them.
 disable-model-invocation: true
 ---
+<!-- Managed by vigOS devkit — regenerated on upgrade; local edits are lost. -->
+<!-- Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues -->
 
 # Solve PR Failures
 

--- a/assets/workspace/.claude/skills/solve-and-pr/SKILL.md
+++ b/assets/workspace/.claude/skills/solve-and-pr/SKILL.md
@@ -3,6 +3,8 @@ name: solve-and-pr
 description: Launches the autonomous worktree pipeline for an issue via just worktree-start.
 disable-model-invocation: true
 ---
+<!-- Managed by vigOS devkit — regenerated on upgrade; local edits are lost. -->
+<!-- Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues -->
 
 # Solve and PR (Autonomous Launcher)
 

--- a/assets/workspace/.claude/skills/subagent-delegation/SKILL.md
+++ b/assets/workspace/.claude/skills/subagent-delegation/SKILL.md
@@ -3,6 +3,8 @@ name: subagent-delegation
 description: How to delegate mechanical sub-steps to lightweight subagents when executing skills. Use when running a skill that has data-gathering, formatting, or structured-review sub-steps.
 disable-model-invocation: true
 ---
+<!-- Managed by vigOS devkit — regenerated on upgrade; local edits are lost. -->
+<!-- Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues -->
 
 # Subagent Delegation
 

--- a/assets/workspace/.claude/skills/tdd/SKILL.md
+++ b/assets/workspace/.claude/skills/tdd/SKILL.md
@@ -3,6 +3,8 @@ name: tdd
 description: TDD discipline and test scenario guidance when writing code. Use when implementing features or fixes that have testable behavior.
 disable-model-invocation: true
 ---
+<!-- Managed by vigOS devkit — regenerated on upgrade; local edits are lost. -->
+<!-- Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues -->
 
 # TDD
 

--- a/assets/workspace/.claude/skills/worktree_ask/SKILL.md
+++ b/assets/workspace/.claude/skills/worktree_ask/SKILL.md
@@ -3,6 +3,8 @@ name: worktree_ask
 description: Posts a question to the GitHub issue when the autonomous agent is stuck.
 disable-model-invocation: true
 ---
+<!-- Managed by vigOS devkit — regenerated on upgrade; local edits are lost. -->
+<!-- Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues -->
 
 # Ask for Help
 

--- a/assets/workspace/.claude/skills/worktree_brainstorm/SKILL.md
+++ b/assets/workspace/.claude/skills/worktree_brainstorm/SKILL.md
@@ -3,6 +3,8 @@ name: worktree_brainstorm
 description: Autonomous design — reads full issue, posts design comment, never blocks for feedback.
 disable-model-invocation: true
 ---
+<!-- Managed by vigOS devkit — regenerated on upgrade; local edits are lost. -->
+<!-- Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues -->
 
 # Autonomous Brainstorm
 

--- a/assets/workspace/.claude/skills/worktree_ci-check/SKILL.md
+++ b/assets/workspace/.claude/skills/worktree_ci-check/SKILL.md
@@ -3,6 +3,8 @@ name: worktree_ci-check
 description: Autonomous CI check — polls until CI finishes, invokes worktree_ci-fix on failure.
 disable-model-invocation: true
 ---
+<!-- Managed by vigOS devkit — regenerated on upgrade; local edits are lost. -->
+<!-- Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues -->
 
 # Autonomous CI Check
 

--- a/assets/workspace/.claude/skills/worktree_ci-fix/SKILL.md
+++ b/assets/workspace/.claude/skills/worktree_ci-fix/SKILL.md
@@ -3,6 +3,8 @@ name: worktree_ci-fix
 description: Autonomous CI fix — diagnoses failure, posts diagnosis, fixes, pushes, re-checks.
 disable-model-invocation: true
 ---
+<!-- Managed by vigOS devkit — regenerated on upgrade; local edits are lost. -->
+<!-- Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues -->
 
 # Autonomous CI Fix
 

--- a/assets/workspace/.claude/skills/worktree_execute/SKILL.md
+++ b/assets/workspace/.claude/skills/worktree_execute/SKILL.md
@@ -3,6 +3,8 @@ name: worktree_execute
 description: Autonomous TDD implementation — commits as it goes, no user checkpoints.
 disable-model-invocation: true
 ---
+<!-- Managed by vigOS devkit — regenerated on upgrade; local edits are lost. -->
+<!-- Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues -->
 
 # Autonomous Execute
 

--- a/assets/workspace/.claude/skills/worktree_plan/SKILL.md
+++ b/assets/workspace/.claude/skills/worktree_plan/SKILL.md
@@ -3,6 +3,8 @@ name: worktree_plan
 description: Autonomous planning — reads issue and design, posts implementation plan, never blocks.
 disable-model-invocation: true
 ---
+<!-- Managed by vigOS devkit — regenerated on upgrade; local edits are lost. -->
+<!-- Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues -->
 
 # Autonomous Plan
 

--- a/assets/workspace/.claude/skills/worktree_pr/SKILL.md
+++ b/assets/workspace/.claude/skills/worktree_pr/SKILL.md
@@ -3,6 +3,8 @@ name: worktree_pr
 description: Autonomous PR creation from a worktree branch.
 disable-model-invocation: true
 ---
+<!-- Managed by vigOS devkit — regenerated on upgrade; local edits are lost. -->
+<!-- Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues -->
 
 # Autonomous PR
 

--- a/assets/workspace/.claude/skills/worktree_solve-and-pr/SKILL.md
+++ b/assets/workspace/.claude/skills/worktree_solve-and-pr/SKILL.md
@@ -3,6 +3,8 @@ name: worktree_solve-and-pr
 description: State-aware autonomous pipeline — detect phase from issue, run remaining phases through PR.
 disable-model-invocation: true
 ---
+<!-- Managed by vigOS devkit — regenerated on upgrade; local edits are lost. -->
+<!-- Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues -->
 
 # Solve and PR
 

--- a/assets/workspace/.claude/skills/worktree_verify/SKILL.md
+++ b/assets/workspace/.claude/skills/worktree_verify/SKILL.md
@@ -3,6 +3,8 @@ name: worktree_verify
 description: Autonomous verification — full test suite + lint + precommit, evidence only, loops on failure.
 disable-model-invocation: true
 ---
+<!-- Managed by vigOS devkit — regenerated on upgrade; local edits are lost. -->
+<!-- Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues -->
 
 # Autonomous Verify
 

--- a/assets/workspace/.devcontainer/.gitignore
+++ b/assets/workspace/.devcontainer/.gitignore
@@ -1,3 +1,6 @@
+# Managed by vigOS devkit — regenerated on upgrade; local edits are lost.
+# Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues
+
 # Local configuration (machine-specific, not tracked)
 .local/
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Provenance banner in scaffolded assets** ([#1036](https://github.com/vig-os/devkit/issues/1036))
+  - Every comment-capable file scaffolded into a downstream repo now carries a two-line banner stating that devkit manages the file, whether an upgrade overwrites it, and where to file bugs / missing tools. The banner comes in two variants — **managed** (regenerated on upgrade) and **preserved** (seeded once, yours to edit) — chosen automatically from `PRESERVE_FILES` (the SSoT in `init-workspace.sh`) by a new `Banner` transform wired into `sync_manifest.py`, so the classification cannot drift from a hand-typed copy. The `sync-manifest` pre-commit hook regenerates the banners on every commit and fails on any hand-edited or missing one.
+  - The banner carries **no version string** (`.vig-os` remains the version SSoT), so it stays byte-stable across releases and never floods upgrade diffs. Strict-JSON files (`renovate.json`, `.github/renovate-default.json`, `.claude/worktrees.json`, `.pymarkdown`) and a small documented set of other files (JSONC under the strict `check-json` hook, the render-gated `.pre-commit-config.yaml`, changelogs, `.vig-os`, `LICENSE`) are explicitly skipped; coverage is knowingly partial.
+  - The stale `justfile.devc` banner — which pointed at the root `justfile` that an upgrade overwrites — is corrected to point at `justfile.project`.
 - **Opt-in release artifact/bundle step for repos that ship a committed build** ([#1029](https://github.com/vig-os/devkit/issues/1029))
   - `release-core.yml` now detects a `bundle` just recipe via `just --summary` in the finalize job; when present it runs `just bundle` and commits `dist/` alongside `CHANGELOG.md` in the finalization commit, so a JS Action (or any repo shipping a committed `@vercel/ncc` artifact) tags a fresh bundle instead of a stale one. Repos without a `bundle` recipe (e.g. a pure-Python consumer) are unaffected — no new config surface, the recipe's presence is the flag.
 - **Commit messages are validated in CI** ([#1019](https://github.com/vig-os/devkit/issues/1019))

--- a/assets/workspace/.devcontainer/README.md
+++ b/assets/workspace/.devcontainer/README.md
@@ -1,3 +1,6 @@
+<!-- Managed by vigOS devkit — regenerated on upgrade; local edits are lost. -->
+<!-- Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues -->
+
 # Devcontainer Reference
 
 This folder contains everything VS Code needs to launch the

--- a/assets/workspace/.devcontainer/docker-compose.local.yaml
+++ b/assets/workspace/.devcontainer/docker-compose.local.yaml
@@ -1,3 +1,6 @@
+# Seeded by vigOS devkit — yours to edit; upgrades never overwrite this file.
+# Bugs / missing tools: https://github.com/vig-os/devkit/issues
+
 # docker-compose.local.yaml
 #
 # Personal/user-specific compose overrides.

--- a/assets/workspace/.devcontainer/docker-compose.project.yaml
+++ b/assets/workspace/.devcontainer/docker-compose.project.yaml
@@ -1,3 +1,6 @@
+# Seeded by vigOS devkit — yours to edit; upgrades never overwrite this file.
+# Bugs / missing tools: https://github.com/vig-os/devkit/issues
+
 # docker-compose.project.yaml
 #
 # Project/team-specific compose overrides.

--- a/assets/workspace/.devcontainer/docker-compose.yml
+++ b/assets/workspace/.devcontainer/docker-compose.yml
@@ -1,4 +1,7 @@
 ---
+# Managed by vigOS devkit — regenerated on upgrade; local edits are lost.
+# Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues
+
 services:
   devcontainer:
     image: ghcr.io/vig-os/devcontainer:${DEVCONTAINER_VERSION:-latest}

--- a/assets/workspace/.devcontainer/justfile.devc
+++ b/assets/workspace/.devcontainer/justfile.devc
@@ -1,7 +1,5 @@
-# ===============================================================================
-# DEVCONTAINER RECIPES - DO NOT EDIT
-# Managed by vigOS devcontainer. Customizations go in root justfile.
-# ===============================================================================
+# Managed by vigOS devkit — regenerated on upgrade; local edits are lost.
+# Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues
 
 # Note: `set shell := [...pipefail...]` lives in the root justfile (the SSoT) so
 # it applies in every delivery mode, including direnv/bare which have no

--- a/assets/workspace/.devcontainer/justfile.gh
+++ b/assets/workspace/.devcontainer/justfile.gh
@@ -1,3 +1,6 @@
+# Managed by vigOS devkit — regenerated on upgrade; local edits are lost.
+# Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues
+
 # ===============================================================================
 # GITHUB CLI RECIPES - Issue, PR, and Repository Management
 # ===============================================================================

--- a/assets/workspace/.devcontainer/justfile.worktree
+++ b/assets/workspace/.devcontainer/justfile.worktree
@@ -1,3 +1,6 @@
+# Managed by vigOS devkit — regenerated on upgrade; local edits are lost.
+# Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues
+
 # ===============================================================================
 # WORKTREE RECIPES — CLI-based parallel agent development
 # ===============================================================================

--- a/assets/workspace/.devcontainer/scripts/copy-host-user-conf.sh
+++ b/assets/workspace/.devcontainer/scripts/copy-host-user-conf.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Managed by vigOS devkit — regenerated on upgrade; local edits are lost.
+# Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues
+
 set -euo pipefail
 
 # Check if we're running inside the dev container

--- a/assets/workspace/.devcontainer/scripts/init-git.sh
+++ b/assets/workspace/.devcontainer/scripts/init-git.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# Managed by vigOS devkit — regenerated on upgrade; local edits are lost.
+# Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues
+
 set -euo pipefail
 
 # Change to project root directory ({{SHORT_NAME}} is replaced during template initialization)

--- a/assets/workspace/.devcontainer/scripts/init-precommit.sh
+++ b/assets/workspace/.devcontainer/scripts/init-precommit.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Managed by vigOS devkit — regenerated on upgrade; local edits are lost.
+# Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues
+
 set -euo pipefail
 
 # Derive the project root from this script's own location

--- a/assets/workspace/.devcontainer/scripts/initialize.sh
+++ b/assets/workspace/.devcontainer/scripts/initialize.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Managed by vigOS devkit — regenerated on upgrade; local edits are lost.
+# Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues
 
 # Initialize script - runs on host before container starts
 # This script is called from initializeCommand in devcontainer.json

--- a/assets/workspace/.devcontainer/scripts/post-attach.sh
+++ b/assets/workspace/.devcontainer/scripts/post-attach.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# Managed by vigOS devkit — regenerated on upgrade; local edits are lost.
+# Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues
 
 # Post-attach script - runs each time a tool attaches to the container.
 # This script is called from postAttachCommand in devcontainer.json.

--- a/assets/workspace/.devcontainer/scripts/post-create.sh
+++ b/assets/workspace/.devcontainer/scripts/post-create.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# Managed by vigOS devkit — regenerated on upgrade; local edits are lost.
+# Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues
 
 # Post-create script - runs once when container is created for the first time.
 # This script is called from postCreateCommand in devcontainer.json.

--- a/assets/workspace/.devcontainer/scripts/post-start.sh
+++ b/assets/workspace/.devcontainer/scripts/post-start.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# Managed by vigOS devkit — regenerated on upgrade; local edits are lost.
+# Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues
 
 # Post-start script - runs every time the container starts (create + restart).
 # This script is called from postStartCommand in devcontainer.json.

--- a/assets/workspace/.devcontainer/scripts/setup-gh-repo.sh
+++ b/assets/workspace/.devcontainer/scripts/setup-gh-repo.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# Managed by vigOS devkit — regenerated on upgrade; local edits are lost.
+# Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues
+
 set -euo pipefail
 
 # Configure GitHub repository settings for merge commit compliance and

--- a/assets/workspace/.devcontainer/scripts/setup-git-conf.sh
+++ b/assets/workspace/.devcontainer/scripts/setup-git-conf.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# Managed by vigOS devkit — regenerated on upgrade; local edits are lost.
+# Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues
+
 set -e
 
 # One-time setup of git configuration inside the dev container.

--- a/assets/workspace/.devcontainer/scripts/verify-auth.sh
+++ b/assets/workspace/.devcontainer/scripts/verify-auth.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# Managed by vigOS devkit — regenerated on upgrade; local edits are lost.
+# Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues
+
 set -e
 
 # Verify authentication state inside the dev container.

--- a/assets/workspace/.devcontainer/scripts/version-check.sh
+++ b/assets/workspace/.devcontainer/scripts/version-check.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Managed by vigOS devkit — regenerated on upgrade; local edits are lost.
+# Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues
+
 ###############################################################################
 # version-check.sh - Devcontainer Update Checker
 #

--- a/assets/workspace/.envrc
+++ b/assets/workspace/.envrc
@@ -1,3 +1,6 @@
+# Seeded by vigOS devkit — yours to edit; upgrades never overwrite this file.
+# Bugs / missing tools: https://github.com/vig-os/devkit/issues
+
 # nix-direnv: GC-rooted, cached flake evaluation so re-entry is instant and the
 # dev-shell closure is not garbage-collected. Falls back to bare `use flake`
 # when the nix-direnv library is unavailable.

--- a/assets/workspace/.githooks/commit-msg
+++ b/assets/workspace/.githooks/commit-msg
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Managed by vigOS devkit — regenerated on upgrade; local edits are lost.
+# Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues
+
 # Set error handling, fail on any error during script execution
 set -euo pipefail
 

--- a/assets/workspace/.githooks/pre-commit
+++ b/assets/workspace/.githooks/pre-commit
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Managed by vigOS devkit — regenerated on upgrade; local edits are lost.
+# Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues
+
 # Set error handling, fail on any error during script execution
 set -euo pipefail
 

--- a/assets/workspace/.githooks/prepare-commit-msg
+++ b/assets/workspace/.githooks/prepare-commit-msg
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# Managed by vigOS devkit — regenerated on upgrade; local edits are lost.
+# Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues
+
 # Strip AI agent trailers from commit message before validation.
 # Refs: #163
 set -euo pipefail

--- a/assets/workspace/.github/CODEOWNERS
+++ b/assets/workspace/.github/CODEOWNERS
@@ -1,3 +1,6 @@
+# Seeded by vigOS devkit — yours to edit; upgrades never overwrite this file.
+# Bugs / missing tools: https://github.com/vig-os/devkit/issues
+
 # CODEOWNERS — default reviewers for pull requests
 # Docs: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 #

--- a/assets/workspace/.github/ISSUE_TEMPLATE/bug.yml
+++ b/assets/workspace/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,4 +1,7 @@
 ---
+# Managed by vigOS devkit — regenerated on upgrade; local edits are lost.
+# Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues
+
 name: Bug Report
 description: Report a bug or unexpected behavior
 title: '[BUG] '

--- a/assets/workspace/.github/ISSUE_TEMPLATE/chore.yml
+++ b/assets/workspace/.github/ISSUE_TEMPLATE/chore.yml
@@ -1,4 +1,7 @@
 ---
+# Managed by vigOS devkit — regenerated on upgrade; local edits are lost.
+# Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues
+
 name: Chore
 description: General task, CI/build change, or maintenance work item
 title: '[CHORE] '

--- a/assets/workspace/.github/ISSUE_TEMPLATE/config.yml
+++ b/assets/workspace/.github/ISSUE_TEMPLATE/config.yml
@@ -1,3 +1,6 @@
+# Managed by vigOS devkit — regenerated on upgrade; local edits are lost.
+# Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues
+
 blank_issues_enabled: false
 contact_links:
   - name: Documentation

--- a/assets/workspace/.github/ISSUE_TEMPLATE/discussion.yml
+++ b/assets/workspace/.github/ISSUE_TEMPLATE/discussion.yml
@@ -1,4 +1,7 @@
 ---
+# Managed by vigOS devkit — regenerated on upgrade; local edits are lost.
+# Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues
+
 name: Discussion
 description: Discuss a new idea, approach, or open question
 title: '[DISCUSSION] '

--- a/assets/workspace/.github/ISSUE_TEMPLATE/docs.yml
+++ b/assets/workspace/.github/ISSUE_TEMPLATE/docs.yml
@@ -1,4 +1,7 @@
 ---
+# Managed by vigOS devkit — regenerated on upgrade; local edits are lost.
+# Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues
+
 name: Documentation
 description: Request a documentation update or addition
 title: '[DOCS] '

--- a/assets/workspace/.github/ISSUE_TEMPLATE/feature.yml
+++ b/assets/workspace/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,4 +1,7 @@
 ---
+# Managed by vigOS devkit — regenerated on upgrade; local edits are lost.
+# Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues
+
 name: Feature Request
 description: Suggest a new feature or enhancement
 title: '[FEATURE] '

--- a/assets/workspace/.github/ISSUE_TEMPLATE/refactor.yml
+++ b/assets/workspace/.github/ISSUE_TEMPLATE/refactor.yml
@@ -1,4 +1,7 @@
 ---
+# Managed by vigOS devkit — regenerated on upgrade; local edits are lost.
+# Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues
+
 name: Refactor
 description: Propose a code refactoring (no behavior change)
 title: '[REFACTOR] '

--- a/assets/workspace/.github/actions/resolve-toolchain/action.yml
+++ b/assets/workspace/.github/actions/resolve-toolchain/action.yml
@@ -1,3 +1,6 @@
+# Managed by vigOS devkit — regenerated on upgrade; local edits are lost.
+# Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues
+
 # Resolve devkit toolchain (mode + image)
 #
 # Evolves resolve-image (#994): reads the `.vig-os` manifest and emits the

--- a/assets/workspace/.github/actions/setup-devkit-toolchain/action.yml
+++ b/assets/workspace/.github/actions/setup-devkit-toolchain/action.yml
@@ -1,3 +1,6 @@
+# Managed by vigOS devkit — regenerated on upgrade; local edits are lost.
+# Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues
+
 # Set up the devkit toolchain (mode-aware step-level preamble)
 #
 # The single toolchain preamble for every scaffolded CI/release job (#994).

--- a/assets/workspace/.github/agent-blocklist.toml
+++ b/assets/workspace/.github/agent-blocklist.toml
@@ -1,3 +1,6 @@
+# Managed by vigOS devkit — regenerated on upgrade; local edits are lost.
+# Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues
+
 # Canonical blocklist for AI agent identity fingerprints.
 # Referenced by: validate-commit-msg, pre-commit hooks.
 # Refs: #163

--- a/assets/workspace/.github/label-taxonomy.toml
+++ b/assets/workspace/.github/label-taxonomy.toml
@@ -1,3 +1,6 @@
+# Managed by vigOS devkit — regenerated on upgrade; local edits are lost.
+# Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues
+
 # Canonical repository labels.
 # Single source of truth — referenced by:
 #   - uv run setup-labels                   (provision labels on a repo)

--- a/assets/workspace/.github/pull_request_template.md
+++ b/assets/workspace/.github/pull_request_template.md
@@ -1,3 +1,6 @@
+<!-- Managed by vigOS devkit — regenerated on upgrade; local edits are lost. -->
+<!-- Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues -->
+
 ## Description
 
 <!-- Provide a clear and concise description of what this PR does. -->

--- a/assets/workspace/.github/workflows/ci.yml
+++ b/assets/workspace/.github/workflows/ci.yml
@@ -1,3 +1,6 @@
+# Managed by vigOS devkit — regenerated on upgrade; local edits are lost.
+# Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues
+
 # CI Workflow (mode-aware)
 #
 # One workflow for every DEVKIT_MODE. Toolchain provisioning is split from image

--- a/assets/workspace/.github/workflows/codeql.yml
+++ b/assets/workspace/.github/workflows/codeql.yml
@@ -1,3 +1,6 @@
+# Managed by vigOS devkit — regenerated on upgrade; local edits are lost.
+# Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues
+
 # CodeQL Static Analysis
 #
 # Runs GitHub CodeQL analysis on Python build tooling and GitHub Actions workflows.

--- a/assets/workspace/.github/workflows/prepare-release.yml
+++ b/assets/workspace/.github/workflows/prepare-release.yml
@@ -1,3 +1,6 @@
+# Managed by vigOS devkit — regenerated on upgrade; local edits are lost.
+# Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues
+
 name: Prepare Release
 
 on:  # yamllint disable-line rule:truthy

--- a/assets/workspace/.github/workflows/promote-release.yml
+++ b/assets/workspace/.github/workflows/promote-release.yml
@@ -1,3 +1,6 @@
+# Managed by vigOS devkit — regenerated on upgrade; local edits are lost.
+# Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues
+
 # Promote Release — after final release.yml has created the git tag and draft GitHub Release
 #
 # 1. validate: semver, draft GitHub Release for X.Y.Z, release PR approved and CI green

--- a/assets/workspace/.github/workflows/release-core.yml
+++ b/assets/workspace/.github/workflows/release-core.yml
@@ -1,3 +1,6 @@
+# Managed by vigOS devkit — regenerated on upgrade; local edits are lost.
+# Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues
+
 name: Release Core
 
 on:  # yamllint disable-line rule:truthy

--- a/assets/workspace/.github/workflows/release-extension.yml
+++ b/assets/workspace/.github/workflows/release-extension.yml
@@ -1,3 +1,6 @@
+# Seeded by vigOS devkit — yours to edit; upgrades never overwrite this file.
+# Bugs / missing tools: https://github.com/vig-os/devkit/issues
+
 name: Release Extension
 
 on:  # yamllint disable-line rule:truthy

--- a/assets/workspace/.github/workflows/release-publish.yml
+++ b/assets/workspace/.github/workflows/release-publish.yml
@@ -1,3 +1,6 @@
+# Managed by vigOS devkit — regenerated on upgrade; local edits are lost.
+# Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues
+
 # Publishes git tag and optionally a GitHub Release. Final releases always get a draft release.
 # Candidates get a draft pre-release only when create_release is true (workflow_dispatch input).
 name: Release Publish

--- a/assets/workspace/.github/workflows/release.yml
+++ b/assets/workspace/.github/workflows/release.yml
@@ -1,3 +1,6 @@
+# Managed by vigOS devkit — regenerated on upgrade; local edits are lost.
+# Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues
+
 name: Release
 
 on:  # yamllint disable-line rule:truthy

--- a/assets/workspace/.github/workflows/renovate-changelog-build.yml
+++ b/assets/workspace/.github/workflows/renovate-changelog-build.yml
@@ -1,3 +1,6 @@
+# Managed by vigOS devkit — regenerated on upgrade; local edits are lost.
+# Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues
+
 # Append Keep-a-Changelog Unreleased entries for Renovate dependency PRs (Refs: #506, #562, #863).
 # Read-only build on pull_request; privileged commit runs via workflow_run from default branch.
 # The sender-login guard skips synchronize events raised by the changelog commit bot's own

--- a/assets/workspace/.github/workflows/renovate-changelog-commit.yml
+++ b/assets/workspace/.github/workflows/renovate-changelog-commit.yml
@@ -1,3 +1,6 @@
+# Managed by vigOS devkit — regenerated on upgrade; local edits are lost.
+# Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues
+
 # Privileged commit for Renovate changelog updates (Refs: #506, #562).
 # Runs from default branch via workflow_run; never checks out PR-head code.
 

--- a/assets/workspace/.github/workflows/scorecard.yml
+++ b/assets/workspace/.github/workflows/scorecard.yml
@@ -1,3 +1,6 @@
+# Managed by vigOS devkit — regenerated on upgrade; local edits are lost.
+# Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues
+
 # OpenSSF Scorecard
 #
 # Runs the OpenSSF Scorecard analysis on a weekly schedule and on pushes

--- a/assets/workspace/.github/workflows/sync-issues.yml
+++ b/assets/workspace/.github/workflows/sync-issues.yml
@@ -1,3 +1,6 @@
+# Managed by vigOS devkit — regenerated on upgrade; local edits are lost.
+# Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues
+
 # Workflow to sync issues and PRs to markdown files
 # Uses:
 # - sync-issues action from this public repository (vig-os/sync-issues-action)

--- a/assets/workspace/.github/workflows/sync-main-to-dev.yml
+++ b/assets/workspace/.github/workflows/sync-main-to-dev.yml
@@ -1,3 +1,6 @@
+# Managed by vigOS devkit — regenerated on upgrade; local edits are lost.
+# Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues
+
 # Sync main to dev
 #
 # Keeps dev up to date with main by opening a PR from a disposable sync branch.

--- a/assets/workspace/.gitignore
+++ b/assets/workspace/.gitignore
@@ -1,3 +1,6 @@
+# Managed by vigOS devkit — regenerated on upgrade; local edits are lost.
+# Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues
+
 # Language-neutral base .gitignore
 #
 # This is a MANAGED scaffold file: init-workspace.sh overwrites it on every

--- a/assets/workspace/.pymarkdown.config.md
+++ b/assets/workspace/.pymarkdown.config.md
@@ -1,3 +1,6 @@
+<!-- Managed by vigOS devkit — regenerated on upgrade; local edits are lost. -->
+<!-- Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues -->
+
 # Pymarkdown Configuration
 
 This repository uses `.pymarkdown` (JSON format) to configure markdown linting rules.

--- a/assets/workspace/.typos.toml
+++ b/assets/workspace/.typos.toml
@@ -1,3 +1,6 @@
+# Seeded by vigOS devkit — yours to edit; upgrades never overwrite this file.
+# Bugs / missing tools: https://github.com/vig-os/devkit/issues
+
 # Typos configuration
 # https://github.com/crate-ci/typos
 

--- a/assets/workspace/.yamllint
+++ b/assets/workspace/.yamllint
@@ -1,4 +1,7 @@
 ---
+# Managed by vigOS devkit — regenerated on upgrade; local edits are lost.
+# Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues
+
 extends: default
 
 rules:

--- a/assets/workspace/README.md
+++ b/assets/workspace/README.md
@@ -1,1 +1,4 @@
+<!-- Seeded by vigOS devkit — yours to edit; upgrades never overwrite this file. -->
+<!-- Bugs / missing tools: https://github.com/vig-os/devkit/issues -->
+
 # README

--- a/assets/workspace/SECURITY.md
+++ b/assets/workspace/SECURITY.md
@@ -1,3 +1,6 @@
+<!-- Managed by vigOS devkit — regenerated on upgrade; local edits are lost. -->
+<!-- Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues -->
+
 # Security Policy
 
 ## Supported Versions

--- a/assets/workspace/docs/COMMIT_MESSAGE_STANDARD.md
+++ b/assets/workspace/docs/COMMIT_MESSAGE_STANDARD.md
@@ -1,3 +1,6 @@
+<!-- Managed by vigOS devkit — regenerated on upgrade; local edits are lost. -->
+<!-- Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues -->
+
 # Commit Message Standard
 
 This document defines the commit message format used in this repository. Commit messages are treated as **quality records** and must follow this standard to ensure consistency, traceability, and compliance with QMS expectations (e.g. IEC 62304, ISO 13485, MDR change control).

--- a/assets/workspace/docs/container-ci-quirks.md
+++ b/assets/workspace/docs/container-ci-quirks.md
@@ -1,3 +1,6 @@
+<!-- Managed by vigOS devkit — regenerated on upgrade; local edits are lost. -->
+<!-- Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues -->
+
 # Container CI Notes
 
 Behavioral notes for the workspace CI workflow (`.github/workflows/ci.yml`)

--- a/assets/workspace/justfile
+++ b/assets/workspace/justfile
@@ -1,3 +1,6 @@
+# Managed by vigOS devkit — regenerated on upgrade; local edits are lost.
+# Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues
+
 # ===============================================================================
 # MAIN JUSTFILE - Orchestrates all recipe sources
 # ===============================================================================

--- a/assets/workspace/justfile.project
+++ b/assets/workspace/justfile.project
@@ -1,3 +1,6 @@
+# Seeded by vigOS devkit — yours to edit; upgrades never overwrite this file.
+# Bugs / missing tools: https://github.com/vig-os/devkit/issues
+
 # ===============================================================================
 # PROJECT RECIPES - Team-shared customizations
 # This file is git-tracked and preserved during devcontainer upgrades.

--- a/scripts/sync_manifest.py
+++ b/scripts/sync_manifest.py
@@ -17,6 +17,7 @@ Called by:
 from __future__ import annotations
 
 import argparse
+import re
 import shutil
 import sys
 import tomllib
@@ -27,6 +28,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from transforms import (
+    Banner,
     RemoveBlock,
     RemoveLines,
     RemovePrecommitHooks,
@@ -106,6 +108,111 @@ _MANIFEST_PATH = Path(__file__).resolve().parent / "manifest.toml"
 MANIFEST: list[Entry] = _load_manifest(_MANIFEST_PATH)
 
 
+# ── Provenance banners (issue #1036) ─────────────────────────────────────────
+#
+# Every comment-capable file under assets/workspace/ carries a two-line banner
+# (transforms.Banner). The managed-vs-preserved variant is derived from the
+# PRESERVE_FILES array in assets/init-workspace.sh — the single source of truth
+# for what an upgrade overwrites — so the classification can never drift from a
+# hand-typed copy. Because this runs on every `sync`, the sync-manifest
+# pre-commit hook regenerates the banners and fails the commit on any
+# hand-edited or missing one.
+
+_INIT_WORKSPACE = Path("assets") / "init-workspace.sh"
+
+# Files deliberately left un-bannered, grouped by reason. Coverage is knowingly
+# partial (issue #1036); this list keeps every exclusion explicit.
+_BANNER_SKIP: frozenset[str] = frozenset(
+    {
+        # Strict JSON — no comment syntax exists.
+        "renovate.json",
+        ".github/renovate-default.json",
+        ".claude/worktrees.json",
+        ".pymarkdown",
+        # JSONC: VS Code / the devcontainer CLI accept `//`, but the repo's own
+        # (and the scaffolded) `check-json` hook uses a strict parser with no
+        # exclude for these paths, so a `//` banner would fail check-json both
+        # upstream and downstream. Excluding them means editing the drift-gated
+        # nix/hooks.nix hook set — out of scope for a comment-only change.
+        ".devcontainer/devcontainer.json",
+        ".vscode/settings.json",
+        ".devcontainer/workspace.code-workspace.example",
+        # Rendered from nix/hooks.nix and drift-gated by tests/test_flake_hooks.py;
+        # a post-sync banner would have to be threaded through the Nix render.
+        ".pre-commit-config.yaml",
+        # Changelogs — a banner would churn every release diff; the .devcontainer
+        # copy is a generated mirror of the root CHANGELOG.md.
+        "CHANGELOG.md",
+        ".devcontainer/CHANGELOG.md",
+        # Version SSoT, rewritten in place by init-workspace.sh on every
+        # (re)scaffold; a banner would be churned or duplicated by that write-back.
+        ".vig-os",
+        # Commit-message template: git strips `#` lines, so a banner would only
+        # clutter the editor above the author's message on every commit.
+        ".gitmessage",
+        # No comment syntax.
+        "LICENSE",
+        # Nix source is outside this issue's enumerated comment-capable set;
+        # flake.nix is consumer-owned/preserved and deferred to avoid nix-format
+        # churn on re-sync.
+        "flake.nix",
+        # Personal, gitignored starter whose own header already claims (wrongly)
+        # to be preserved even though it is absent from PRESERVE_FILES;
+        # reclassifying it is a separate decision, so it is skipped rather than
+        # handed a contradictory managed banner.
+        "justfile.local",
+    }
+)
+
+
+def load_preserve_files(script_path: Path) -> set[str]:
+    """Parse the PRESERVE_FILES array from init-workspace.sh (the variant SSoT)."""
+    text = script_path.read_text()
+    match = re.search(r"^PRESERVE_FILES=\(\n(.*?)^\)", text, re.DOTALL | re.MULTILINE)
+    if match is None:
+        raise ValueError(f"PRESERVE_FILES array not found in {script_path}")
+    files: set[str] = set()
+    for line in match.group(1).splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        quoted = re.match(r'"([^"]+)"', stripped)
+        if quoted:
+            files.add(quoted.group(1))
+    return files
+
+
+def _banner_style(rel_path: str) -> str | None:
+    """Return the comment style ("hash" | "html") for a file, or None to skip."""
+    if rel_path in _BANNER_SKIP:
+        return None
+    name = rel_path.rsplit("/", 1)[-1]
+    if name.endswith(".md"):
+        return "html"
+    if (
+        name.endswith((".yml", ".yaml", ".toml", ".sh"))
+        or name == ".yamllint"
+        or name in {".gitignore", ".envrc", "CODEOWNERS"}
+        or name == "justfile"
+        or name.startswith("justfile.")
+        or rel_path.startswith(".githooks/")
+    ):
+        return "hash"
+    return None
+
+
+def apply_banners(dest_base: Path, preserve_files: set[str]) -> None:
+    """Stamp the provenance banner onto every comment-capable synced file."""
+    for path in sorted(dest_base.rglob("*")):
+        if not path.is_file():
+            continue
+        rel_path = path.relative_to(dest_base).as_posix()
+        style = _banner_style(rel_path)
+        if style is None:
+            continue
+        Banner(preserved=rel_path in preserve_files, style=style).apply(path)
+
+
 # ── Sync logic ───────────────────────────────────────────────────────────────
 
 
@@ -149,6 +256,10 @@ def sync(project_root: Path, dest_base: Path) -> None:
     if failed:
         print("Error: Some files could not be synced", file=sys.stderr)
         sys.exit(1)
+
+    # Stamp provenance banners over the whole tree (manifest-synced and
+    # directly-authored assets alike), variant driven by PRESERVE_FILES (#1036).
+    apply_banners(dest_base, load_preserve_files(project_root / _INIT_WORKSPACE))
 
     print("All manifest entries synced successfully.")
 

--- a/scripts/sync_manifest.py
+++ b/scripts/sync_manifest.py
@@ -61,7 +61,17 @@ class Entry:
 
     @property
     def is_transformed(self) -> bool:
-        return len(self.transforms) > 0
+        """Whether the synced dest differs from the src.
+
+        True for entries with manifest transforms, and for entries whose dest
+        the provenance-banner pass (#1036) rewrites — derived from the same
+        banner-eligibility logic (``_banner_style``), so the classification
+        cannot drift from a hand-flagged copy. The image gate
+        (tests/test_image.py::test_manifest_files) checksums every
+        non-transformed entry against its src, so a bannered entry must never
+        claim to be untransformed.
+        """
+        return len(self.transforms) > 0 or _entry_gets_banner(self.src, self.dest)
 
 
 # ── Transform registry (type name -> constructor) ─────────────────────────────
@@ -199,6 +209,26 @@ def _banner_style(rel_path: str) -> str | None:
     ):
         return "hash"
     return None
+
+
+def _entry_gets_banner(src: str, dest: str) -> bool:
+    """Whether the banner pass rewrites this entry's synced dest (#1036).
+
+    Drives ``Entry.is_transformed``. Directory entries are classified by
+    walking the SOURCE tree (this repo's checkout, like sync's default
+    project root): the entry is banner-transformed if any file it syncs
+    would receive a banner at its dest-relative path.
+    """
+    src_path = Path(__file__).resolve().parent.parent / src
+    if src_path.is_dir():
+        dest_root = dest.strip("/")
+        return any(
+            _banner_style(f"{dest_root}/{f.relative_to(src_path).as_posix()}")
+            is not None
+            for f in src_path.rglob("*")
+            if f.is_file()
+        )
+    return _banner_style(dest) is not None
 
 
 def apply_banners(dest_base: Path, preserve_files: set[str]) -> None:

--- a/scripts/transforms.py
+++ b/scripts/transforms.py
@@ -19,6 +19,120 @@ class Transform(Protocol):
     def apply(self, file_path: Path) -> None: ...
 
 
+# ── Provenance banner (issue #1036) ───────────────────────────────────────────
+#
+# Two byte-stable, version-free variants stamped into comment-capable scaffold
+# assets. The managed/preserved choice is derived from PRESERVE_FILES (the SSoT
+# in assets/init-workspace.sh) by sync_manifest.py — never hand-written per file.
+# The version deliberately lives only in .vig-os (DEVKIT_VERSION), so banners do
+# not churn on every release.
+
+MANAGED_BANNER: tuple[str, str] = (
+    "Managed by vigOS devkit — regenerated on upgrade; local edits are lost.",
+    "Customize in justfile.project. "
+    "Bugs / missing tools: https://github.com/vig-os/devkit/issues",
+)
+
+PRESERVED_BANNER: tuple[str, str] = (
+    "Seeded by vigOS devkit — yours to edit; upgrades never overwrite this file.",
+    "Bugs / missing tools: https://github.com/vig-os/devkit/issues",
+)
+
+# Comment styles: (line prefix, line suffix). Strict-JSON files carry no comment
+# syntax and are skip-listed by sync_manifest.py rather than handled here.
+_COMMENT_STYLES: dict[str, tuple[str, str]] = {
+    "hash": ("# ", ""),
+    "html": ("<!-- ", " -->"),
+}
+
+# Every banner sentence, style-independent — used to recognise (and strip) an
+# existing banner so the transform is idempotent and switches variants cleanly.
+_BANNER_TEXTS: frozenset[str] = frozenset(MANAGED_BANNER + PRESERVED_BANNER)
+
+
+def _banner_inner(line: str) -> str | None:
+    """Return a comment line's inner text, or None if it is not a comment."""
+    stripped = line.strip()
+    if stripped.startswith("<!--") and stripped.endswith("-->"):
+        return stripped[4:-3].strip()
+    if stripped.startswith("//"):
+        return stripped[2:].strip()
+    if stripped.startswith("#"):
+        return stripped.lstrip("#").strip()
+    return None
+
+
+def _split_header(lines: list[str], style: str) -> tuple[list[str], list[str]]:
+    """Split off a leading region the banner must sit *after*.
+
+    Shebangs, a YAML document-start marker (``---``) and markdown front matter
+    all carry positional meaning, so the banner goes after them, not before.
+    """
+    if not lines:
+        return [], []
+    if style == "html":
+        if lines[0].strip() == "---":
+            for i in range(1, len(lines)):
+                if lines[i].strip() == "---":
+                    return lines[: i + 1], lines[i + 1 :]
+        return [], lines
+    # hash style
+    idx = 1 if lines[0].startswith("#!") else 0
+    probe = idx
+    while probe < len(lines) and lines[probe].strip() == "":
+        probe += 1
+    if probe < len(lines) and lines[probe].strip() == "---":
+        return lines[: probe + 1], lines[probe + 1 :]
+    return lines[:idx], lines[idx:]
+
+
+def _strip_banner_block(rest: list[str]) -> list[str]:
+    """Drop a leading run of banner lines (any style) plus one trailing blank."""
+    i = 0
+    saw = False
+    while i < len(rest) and _banner_inner(rest[i]) in _BANNER_TEXTS:
+        i += 1
+        saw = True
+    if saw and i < len(rest) and rest[i].strip() == "":
+        i += 1
+    return rest[i:]
+
+
+@dataclass
+class Banner:
+    """Stamp the generated provenance banner (#1036) for the given variant.
+
+    Idempotent: an existing banner (of either variant/style) is stripped before
+    the current one is inserted, so re-running the sync never stacks or drifts.
+    """
+
+    preserved: bool
+    style: str = "hash"
+    target: str = ""
+
+    def apply(self, file_path: Path) -> None:
+        path = _resolve(file_path, self.target)
+        if path is None:
+            return
+        prefix, suffix = _COMMENT_STYLES[self.style]
+        texts = PRESERVED_BANNER if self.preserved else MANAGED_BANNER
+        banner = [f"{prefix}{t}{suffix}\n" for t in texts]
+
+        original = path.read_text()
+        header, rest = _split_header(original.splitlines(keepends=True), self.style)
+        rest = _strip_banner_block(rest)
+        while rest and rest[0].strip() == "":
+            rest.pop(0)
+
+        new_lines = header + banner
+        if rest:
+            new_lines += ["\n", *rest]
+        result = "".join(new_lines)
+        if original.endswith("\n") and not result.endswith("\n"):
+            result += "\n"
+        path.write_text(result)
+
+
 def _resolve(file_path: Path, target: str) -> Path | None:
     """Resolve a transform target path, returning None if it doesn't exist."""
     path = file_path / target if target else file_path

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -120,6 +120,134 @@ class TestRenovateChangelogTemplateNoMirrorLeak:
         assert "FILE_PATHS: CHANGELOG.md\n" in commit
 
 
+class TestBannerTransform:
+    """The Banner transform stamps the generated provenance banner (#1036).
+
+    Two byte-stable, version-free variants (managed vs preserved) are derived
+    from ``PRESERVE_FILES``; the transform inserts them at the correct position
+    for the file's comment style and is idempotent.
+    """
+
+    def test_managed_hash_inserts_two_comment_lines_at_top(self, tmp_path):
+        transforms = _load_transforms()
+        f = tmp_path / "ci.yml"
+        f.write_text("# CI Workflow\non: push\n")
+
+        transforms.Banner(preserved=False, style="hash").apply(f)
+
+        lines = f.read_text().splitlines()
+        assert lines[0] == "# " + transforms.MANAGED_BANNER[0]
+        assert lines[1] == "# " + transforms.MANAGED_BANNER[1]
+        assert lines[2] == ""
+        assert "# CI Workflow" in lines
+        assert "on: push" in f.read_text()
+
+    def test_preserved_hash_uses_preserved_text(self, tmp_path):
+        transforms = _load_transforms()
+        f = tmp_path / "justfile.project"
+        f.write_text("# PROJECT RECIPES\n")
+
+        transforms.Banner(preserved=True, style="hash").apply(f)
+
+        text = f.read_text()
+        assert "# " + transforms.PRESERVED_BANNER[0] in text
+        assert "# " + transforms.PRESERVED_BANNER[1] in text
+        # The managed variant must not leak into a preserved file.
+        assert transforms.MANAGED_BANNER[0] not in text
+
+    def test_banner_carries_no_version_string(self):
+        transforms = _load_transforms()
+        import re
+
+        for variant in (transforms.MANAGED_BANNER, transforms.PRESERVED_BANNER):
+            for line in variant:
+                assert not re.search(r"\d+\.\d+", line), (
+                    f"banner must stay byte-stable across releases: {line!r}"
+                )
+            # A pointer to where issues go, not a policy restatement.
+            assert any("github.com/vig-os/devkit/issues" in line for line in variant)
+
+    def test_html_variant_inserts_after_front_matter(self, tmp_path):
+        transforms = _load_transforms()
+        f = tmp_path / "SKILL.md"
+        f.write_text("---\nname: tdd\ndescription: x\n---\n\n# TDD\n\nbody\n")
+
+        transforms.Banner(preserved=False, style="html").apply(f)
+
+        lines = f.read_text().splitlines()
+        # Front matter must stay first.
+        assert lines[0] == "---"
+        assert lines[3] == "---"
+        assert lines[4] == "<!-- " + transforms.MANAGED_BANNER[0] + " -->"
+        assert lines[5] == "<!-- " + transforms.MANAGED_BANNER[1] + " -->"
+        assert "# TDD" in f.read_text()
+
+    def test_html_variant_no_front_matter_goes_to_top(self, tmp_path):
+        transforms = _load_transforms()
+        f = tmp_path / "README.md"
+        f.write_text("# Title\n\nbody\n")
+
+        transforms.Banner(preserved=True, style="html").apply(f)
+
+        lines = f.read_text().splitlines()
+        assert lines[0] == "<!-- " + transforms.PRESERVED_BANNER[0] + " -->"
+        assert lines[1] == "<!-- " + transforms.PRESERVED_BANNER[1] + " -->"
+        assert lines[2] == ""
+        assert lines[3] == "# Title"
+
+    def test_banner_inserts_after_shebang(self, tmp_path):
+        transforms = _load_transforms()
+        f = tmp_path / "post-create.sh"
+        f.write_text("#!/bin/bash\n\n# real comment\necho hi\n")
+
+        transforms.Banner(preserved=False, style="hash").apply(f)
+
+        lines = f.read_text().splitlines()
+        assert lines[0] == "#!/bin/bash"
+        assert lines[1] == "# " + transforms.MANAGED_BANNER[0]
+        assert lines[2] == "# " + transforms.MANAGED_BANNER[1]
+        assert "# real comment" in lines
+
+    def test_banner_inserts_after_yaml_document_start(self, tmp_path):
+        transforms = _load_transforms()
+        f = tmp_path / "docker-compose.yml"
+        f.write_text("---\nservices:\n  a: {}\n")
+
+        transforms.Banner(preserved=True, style="hash").apply(f)
+
+        lines = f.read_text().splitlines()
+        assert lines[0] == "---"
+        assert lines[1] == "# " + transforms.PRESERVED_BANNER[0]
+        assert lines[2] == "# " + transforms.PRESERVED_BANNER[1]
+        assert "services:" in lines
+
+    def test_banner_is_idempotent(self, tmp_path):
+        transforms = _load_transforms()
+        f = tmp_path / "ci.yml"
+        f.write_text("# CI Workflow\non: push\n")
+
+        transforms.Banner(preserved=False, style="hash").apply(f)
+        once = f.read_text()
+        transforms.Banner(preserved=False, style="hash").apply(f)
+        twice = f.read_text()
+
+        assert once == twice
+
+    def test_banner_replaces_stale_variant(self, tmp_path):
+        transforms = _load_transforms()
+        f = tmp_path / "ci.yml"
+        f.write_text("# CI Workflow\non: push\n")
+
+        transforms.Banner(preserved=True, style="hash").apply(f)
+        transforms.Banner(preserved=False, style="hash").apply(f)
+
+        text = f.read_text()
+        assert "# " + transforms.MANAGED_BANNER[0] in text
+        # The old preserved banner must be gone, not stacked.
+        assert transforms.PRESERVED_BANNER[0] not in text
+        assert text.count("vig-os/devkit/issues") == 1
+
+
 class TestRemovePrecommitHooks:
     """Tests for RemovePrecommitHooks transform."""
 

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -278,3 +278,159 @@ class TestRemovePrecommitHooks:
         assert "keep-me" in result
         assert "# Section A" not in result
         assert "remove-me" not in result
+
+
+class TestPreserveFilesSource:
+    """PRESERVE_FILES (init-workspace.sh) is the banner-variant SSoT (#1036)."""
+
+    def test_load_preserve_files_reads_the_array(self):
+        sync_manifest = _load_sync_manifest()
+        preserve = sync_manifest.load_preserve_files(
+            project_root / "assets" / "init-workspace.sh"
+        )
+        assert "justfile.project" in preserve
+        assert "renovate.json" in preserve
+        assert ".envrc" in preserve
+        assert ".typos.toml" in preserve
+        # Interleaved comment lines are not mistaken for array entries.
+        assert not any(entry.startswith("#") for entry in preserve)
+
+
+class TestBannerApplication:
+    """apply_banners walks the synced tree and stamps the right variant (#1036)."""
+
+    def test_stamps_managed_and_preserved_variants(self, tmp_path):
+        sync_manifest = _load_sync_manifest()
+        transforms = _load_transforms()
+        (tmp_path / ".github" / "workflows").mkdir(parents=True)
+        managed = tmp_path / ".github" / "workflows" / "ci.yml"
+        managed.write_text("# CI\non: push\n")
+        preserved = tmp_path / "justfile.project"
+        preserved.write_text("# recipes\n")
+
+        sync_manifest.apply_banners(tmp_path, {"justfile.project"})
+
+        assert ("# " + transforms.MANAGED_BANNER[0]) in managed.read_text()
+        assert ("# " + transforms.PRESERVED_BANNER[0]) in preserved.read_text()
+
+    def test_skips_strict_json_and_generated_configs(self, tmp_path):
+        sync_manifest = _load_sync_manifest()
+        renovate = tmp_path / "renovate.json"
+        renovate.write_text('{\n  "x": 1\n}\n')
+        (tmp_path / ".claude").mkdir()
+        worktrees = tmp_path / ".claude" / "worktrees.json"
+        worktrees.write_text('{\n  "y": 2\n}\n')
+        precommit = tmp_path / ".pre-commit-config.yaml"
+        precommit.write_text("repos: []\n")
+        changelog = tmp_path / "CHANGELOG.md"
+        changelog.write_text("# Changelog\n")
+
+        sync_manifest.apply_banners(tmp_path, {"renovate.json"})
+
+        assert renovate.read_text() == '{\n  "x": 1\n}\n'
+        assert worktrees.read_text() == '{\n  "y": 2\n}\n'
+        assert "vigOS devkit" not in precommit.read_text()
+        assert "vigOS devkit" not in changelog.read_text()
+
+    def test_skips_contradictory_justfile_local(self, tmp_path):
+        sync_manifest = _load_sync_manifest()
+        local = tmp_path / "justfile.local"
+        local.write_text("# LOCAL RECIPES\n")
+
+        sync_manifest.apply_banners(tmp_path, set())
+
+        assert "vigOS devkit" not in local.read_text()
+
+    def test_apply_banners_is_idempotent(self, tmp_path):
+        sync_manifest = _load_sync_manifest()
+        (tmp_path / ".github" / "workflows").mkdir(parents=True)
+        wf = tmp_path / ".github" / "workflows" / "ci.yml"
+        wf.write_text("# CI\non: push\n")
+
+        sync_manifest.apply_banners(tmp_path, set())
+        once = wf.read_text()
+        sync_manifest.apply_banners(tmp_path, set())
+        assert wf.read_text() == once
+
+    def test_restores_a_deleted_banner(self, tmp_path):
+        """A missing banner is regenerated exactly, so the hook flags the drift."""
+        sync_manifest = _load_sync_manifest()
+        wf = tmp_path / "scorecard.yml"
+        wf.write_text("# Scorecard\non: push\n")
+        sync_manifest.apply_banners(tmp_path, set())
+        clean = wf.read_text()
+
+        # Consumer deletes the banner block entirely.
+        wf.write_text("# Scorecard\non: push\n")
+        assert wf.read_text() != clean
+
+        sync_manifest.apply_banners(tmp_path, set())
+        assert wf.read_text() == clean
+
+    def test_detects_a_hand_edited_banner(self, tmp_path):
+        """A hand-edited banner re-emerges canonically, so re-sync differs from it."""
+        sync_manifest = _load_sync_manifest()
+        transforms = _load_transforms()
+        wf = tmp_path / "scorecard.yml"
+        wf.write_text("# Scorecard\non: push\n")
+        sync_manifest.apply_banners(tmp_path, set())
+
+        tampered = wf.read_text().replace(transforms.MANAGED_BANNER[0], "hand edited")
+        wf.write_text(tampered)
+
+        sync_manifest.apply_banners(tmp_path, set())
+        result = wf.read_text()
+        # The canonical banner is re-stamped at the top and the drift is visible.
+        assert result != tampered
+        assert result.splitlines()[0] == "# " + transforms.MANAGED_BANNER[0]
+        assert result.splitlines()[1] == "# " + transforms.MANAGED_BANNER[1]
+
+
+class TestSyncBannerIntegration:
+    """The full sync applies banners and converges (#1036)."""
+
+    def test_sync_stamps_banner_on_synced_assets(self, tmp_path):
+        sync_manifest = _load_sync_manifest()
+        transforms = _load_transforms()
+        sync_manifest.sync(project_root, tmp_path)
+
+        # .typos.toml is a preserved file (PRESERVE_FILES) -> preserved variant.
+        typos = (tmp_path / ".typos.toml").read_text()
+        assert ("# " + transforms.PRESERVED_BANNER[0]) in typos
+        # A synced workflow is managed.
+        scorecard = (tmp_path / ".github" / "workflows" / "scorecard.yml").read_text()
+        assert ("# " + transforms.MANAGED_BANNER[0]) in scorecard
+
+    def test_sync_converges_on_second_run(self, tmp_path):
+        sync_manifest = _load_sync_manifest()
+        sync_manifest.sync(project_root, tmp_path)
+        first = {
+            p.relative_to(tmp_path).as_posix(): p.read_text()
+            for p in tmp_path.rglob("*")
+            if p.is_file()
+        }
+        sync_manifest.sync(project_root, tmp_path)
+        second = {
+            p.relative_to(tmp_path).as_posix(): p.read_text()
+            for p in tmp_path.rglob("*")
+            if p.is_file()
+        }
+        assert first == second
+
+
+class TestJustfileDevcBanner:
+    """The stale justfile.devc banner is corrected to point at justfile.project (#1036)."""
+
+    def test_devc_banner_points_at_justfile_project(self):
+        transforms = _load_transforms()
+        devc = (
+            project_root / "assets" / "workspace" / ".devcontainer" / "justfile.devc"
+        ).read_text()
+
+        lines = devc.splitlines()
+        assert lines[0] == "# " + transforms.MANAGED_BANNER[0]
+        assert lines[1] == "# " + transforms.MANAGED_BANNER[1]
+        assert "justfile.project" in lines[1]
+        # The stale, actively-wrong banner is gone.
+        assert "DEVCONTAINER RECIPES - DO NOT EDIT" not in devc
+        assert "Managed by vigOS devcontainer" not in devc

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -434,3 +434,55 @@ class TestJustfileDevcBanner:
         # The stale, actively-wrong banner is gone.
         assert "DEVCONTAINER RECIPES - DO NOT EDIT" not in devc
         assert "Managed by vigOS devcontainer" not in devc
+
+
+class TestManifestTransformedFlagCoversBanners:
+    """Entries whose dest gets a banner must be flagged transformed (#1036).
+
+    The image gate (tests/test_image.py::TestFileStructure::test_manifest_files)
+    checksums every NON-transformed manifest entry against its repo-root src;
+    the banner pass rewrites the dest, so a bannered entry that still claims
+    ``is_transformed == False`` fails that gate only once the image is built.
+    These local mirrors catch the mismatch pre-push.
+    """
+
+    def test_non_transformed_entries_stay_byte_identical_after_sync(self, tmp_path):
+        """Local mirror of the image identity check: src == dest byte-for-byte."""
+        sync_manifest = _load_sync_manifest()
+        sync_manifest.sync(project_root, tmp_path)
+
+        for entry in sync_manifest.MANIFEST:
+            if entry.is_transformed:
+                continue
+            src = project_root / entry.src
+            if src.is_file():
+                pairs = [(src, tmp_path / entry.dest)]
+            else:
+                pairs = [
+                    (f, tmp_path / entry.dest / f.relative_to(src))
+                    for f in sorted(src.rglob("*"))
+                    if f.is_file()
+                ]
+            for src_file, dest_file in pairs:
+                assert dest_file.read_bytes() == src_file.read_bytes(), (
+                    f"manifest entry {entry.src!r} is not flagged transformed but "
+                    f"its synced copy {dest_file} differs from {src_file} — "
+                    "flag it (or the banner pass) as a transform"
+                )
+
+    def test_bannered_file_entry_is_flagged_transformed(self):
+        sync_manifest = _load_sync_manifest()
+        by_src = {entry.src: entry for entry in sync_manifest.MANIFEST}
+        # A markdown doc gets an HTML-comment banner -> transformed.
+        assert by_src["docs/COMMIT_MESSAGE_STANDARD.md"].is_transformed
+        # A directory whose files all get banners -> transformed.
+        assert by_src[".github/ISSUE_TEMPLATE/"].is_transformed
+
+    def test_skip_listed_entry_keeps_identity_flag(self):
+        """Genuinely untransformed entries must keep the strict identity check."""
+        sync_manifest = _load_sync_manifest()
+        by_src = {entry.src: entry for entry in sync_manifest.MANIFEST}
+        assert not by_src[".claude/worktrees.json"].is_transformed
+        assert not by_src[".gitmessage"].is_transformed
+        assert not by_src[".vscode/settings.json"].is_transformed
+        assert not by_src["CHANGELOG.md"].is_transformed


### PR DESCRIPTION
## Summary

Implements #1036 as specified: every comment-capable file the scaffold ships now opens with a two-line provenance banner — managed ("regenerated on upgrade; local edits are lost") or preserved ("yours to edit; upgrades never overwrite") — plus the issues-URL pointer. **94 files bannered** (86 managed + 8 preserved).

- **Generated, never hand-written:** a `Banner` transform in `scripts/transforms.py`, applied by `scripts/sync_manifest.py` on every sync. The variant derives from `PRESERVE_FILES` in `init-workspace.sh` (parsed as the SSoT), so classification drift is structurally impossible; the `sync-manifest` pre-commit hook regenerates banners and **fails the commit on a tampered or missing banner** (verified with a tampered `ci.yml` — hook fails, restores).
- **No version string** — banners are byte-stable across releases (`.vig-os` stays the version SSoT).
- **Placement-aware:** after shebangs, YAML `---` document starts, and markdown front-matter (MD041-clean on SKILL.md files); `#` style for yaml/toml/sh/justfiles/githooks/.gitignore/.envrc/CODEOWNERS, HTML comments for markdown.
- **`justfile.devc` banner fixed:** the stale "vigOS devcontainer … customizations go in root justfile" box (which pointed at an overwritten file) is replaced by the generated managed banner pointing at `justfile.project`.
- **Explicit, documented skip-list** in `_BANNER_SKIP`: strict JSON (no comments); **JSONC files** (deviation from the issue text: the active `check-json` hook parses them strictly with no exclude, so a `//` banner fails the suite both upstream and downstream — bannering them requires a `nix/hooks.nix` exclude, flagged as follow-up); `.pre-commit-config.yaml` (rendered from `nix/hooks.nix`, drift-gated); changelogs (release-diff churn); `.vig-os`, `.gitmessage`, `LICENSE`, `flake.nix`, `justfile.local`.

### Follow-up candidates surfaced (not in this diff)
1. JSONC banner coverage via a `check-json` exclude in `nix/hooks.nix`.
2. `justfile.local`'s shipped header claims preservation but the file is absent from `PRESERVE_FILES` — reclassification decision.
3. The #1027 node seed (`assets/justfile.d/node.justfile.project`, PR #1042) lives outside `assets/workspace/`, so consumers seeded from it won't carry the preserved banner — small alignment once both PRs land.

TDD: two failing-test → implementation commit pairs; 25 tests in `tests/test_transforms.py`.

## Test evidence
- `uv run pytest tests/test_transforms.py` → 25 passed; `tests/test_flake_hooks.py` → 17 passed (drift gate green)
- Tamper test: hand-edited banner → `sync-manifest ... Failed / files were modified by this hook`
- Convergence: full `prek run --all-files` twice back-to-back → 0 failures, 0 modifications (re-verified independently after merging dev)

Closes #1036
Refs: #878, #913