### PR TITLE
feat(image): allow overriding the mkProjectShell python interpreter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`mkProjectShell` accepts an overridable Python interpreter** ([#1038](https://github.com/vig-os/devkit/issues/1038))
+  - New opt-in `python ? pkgs.python314` argument: `UV_PYTHON` and the bare
+    `python`/`python3` on PATH now follow the override, so a consumer whose
+    nixpkgs C-extension dependency is built against a different CPython ABI
+    (e.g. `pkgs.freecad`, built against the nixpkgs default 3.13) can align the
+    interpreter `uv` pins — `mkProjectShell { python = pkgs.python313; extraPackages = [ pkgs.freecad ]; }`.
+    Omitting the argument is byte-identical to the pinned-3.14 default.
 - **`node` capability module with selectable Node version** ([#1027](https://github.com/vig-os/devkit/issues/1027))
   - `mkProjectShell` gains a `node` capability module: `modules = [ "node" ]`
     puts `nodejs` (which bundles `npm`) in the dev-shell, replacing the

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`mkProjectShell` accepts an overridable Python interpreter** ([#1038](https://github.com/vig-os/devkit/issues/1038))
+  - New opt-in `python ? pkgs.python314` argument: `UV_PYTHON` and the bare
+    `python`/`python3` on PATH now follow the override, so a consumer whose
+    nixpkgs C-extension dependency is built against a different CPython ABI
+    (e.g. `pkgs.freecad`, built against the nixpkgs default 3.13) can align the
+    interpreter `uv` pins — `mkProjectShell { python = pkgs.python313; extraPackages = [ pkgs.freecad ]; }`.
+    Omitting the argument is byte-identical to the pinned-3.14 default.
 - **`node` capability module with selectable Node version** ([#1027](https://github.com/vig-os/devkit/issues/1027))
   - `mkProjectShell` gains a `node` capability module: `modules = [ "node" ]`
     puts `nodejs` (which bundles `npm`) in the dev-shell, replacing the

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -308,6 +308,31 @@ pinned by the project's `flake.lock`. This is why the answer to "the build
 needs gcc" is the flake, not the image: the same mechanism scales from a bare
 compiler to a full scientific stack.
 
+#### Overriding the Python interpreter for ABI alignment
+
+`mkProjectShell` pins CPython 3.14 by default. A nixpkgs-provided package with a
+compiled Python binding is built against **nixpkgs' own default CPython**, not
+the devkit's 3.14 — so importing it from the 3.14 interpreter fails with an ABI
+mismatch, and `extraPackages` alone cannot fix it (it adds the package to the
+shell but cannot change the interpreter `uv` pins). Pass the matching
+interpreter as `python` to align them
+([#1038](https://github.com/vig-os/devkit/issues/1038)):
+
+```nix
+devShells.default = vigos.lib.mkProjectShell {
+  inherit pkgs;
+  python = pkgs.python313; # match freecad's ABI (nixpkgs default CPython)
+  extraPackages = [ pkgs.freecad ];
+};
+```
+
+The override flows through the whole shell: `UV_PYTHON` (so `uv sync` builds the
+venv against 3.13), and the bare `python`/`python3` on PATH. `pkgs.freecad`'s
+`import FreeCAD` then works from the project venv. Omit the argument and the
+shell is byte-identical to the pinned-3.14 default — this is a per-project escape
+hatch for compiled nixpkgs bindings (FreeCAD today; Geant4/ROOT Python bindings
+later), not a general downgrade knob.
+
 #### Non-goal: a C/C++ toolchain in the base image
 
 The published image will **not** ship gcc/cmake:

--- a/flake.nix
+++ b/flake.nix
@@ -235,6 +235,7 @@
       #     modules = [ "native" ];           # opt-in capability modules (#884)
       #     extraPackages = [ pkgs.foo ];
       #     hooks = { pymarkdown.enable = false; };  # opt-in generated hooks (#883)
+      #     python = pkgs.python313;          # override the pinned interpreter (#1038)
       #   };
       mkProjectShell =
         {
@@ -244,6 +245,14 @@
           hooks ? null,
           hooksExcludes ? [ ],
           shellHook ? ''echo "devcontainer dev environment loaded (nix)"'',
+          # Overridable CPython (#1038). Defaults to the pinned 3.14 so the
+          # zero-argument shell is byte-identical to the pre-#1038 builder
+          # (parity: tests/test_flake_devshell.py). A consumer whose nixpkgs
+          # C-extension dependency is built against a different CPython ABI
+          # (e.g. `pkgs.freecad`, built against the nixpkgs default Python 3.13)
+          # overrides it so uv pins the matching interpreter — see the UV_PYTHON
+          # derivation below, which follows this argument.
+          python ? pkgs.python314,
         }:
         let
           # ------------------------------------------------------------------
@@ -408,16 +417,17 @@
           # uv and cannot drift from a literal pin. Refs #632, #666, #683, #774.
           uvPythonDownloadsJsonUrl = "https://raw.githubusercontent.com/astral-sh/uv/${pkgs.uv.version}/crates/uv-python/download-metadata.json";
 
-          # CPython matching `requires-python` (>=3.14,<3.15). The dev-shell
-          # carries no Python on PATH (the project venv is uv-managed). Pin a
-          # Nix store CPython via UV_PYTHON and forbid downloads
-          # (UV_PYTHON_DOWNLOADS=never): the nixpkgs uv would otherwise fetch a
-          # generic, dynamically-linked managed CPython a NixOS host cannot
-          # execute out of the box (no FHS ld-linux), so `uv sync` (`just init`)
-          # aborted there (#683). A store interpreter is patched to the store
-          # loader and runs in the dev-shell on both NixOS and FHS hosts. The
-          # IMAGE path sets the same two vars (baking pythonEnv). Refs #666, #683.
-          python = pkgs.python314;
+          # The interpreter (default 3.14, matching `requires-python`
+          # >=3.14,<3.15; overridable via the `python` argument, #1038) is
+          # pinned into the shell: the dev-shell carries no Python on PATH other
+          # than this one (the project venv is uv-managed). Pin the store CPython
+          # via UV_PYTHON and forbid downloads (UV_PYTHON_DOWNLOADS=never): the
+          # nixpkgs uv would otherwise fetch a generic, dynamically-linked
+          # managed CPython a NixOS host cannot execute out of the box (no FHS
+          # ld-linux), so `uv sync` (`just init`) aborted there (#683). A store
+          # interpreter is patched to the store loader and runs in the dev-shell
+          # on both NixOS and FHS hosts. The IMAGE path sets the same two vars
+          # (baking pythonEnv). Refs #666, #683.
 
           # The C++ runtime (libstdc++.so.6). The `pymarkdown` pre-commit hook
           # runs from pre-commit's OWN manylinux-wheel Python env (not the project
@@ -459,6 +469,20 @@
           nvimIsolationHook = ''
             export NVIM_APPNAME="vigos-dev"
           '';
+
+          # When the interpreter is overridden (#1038), prepend it to PATH so the
+          # bare `python`/`python3` follow the override too — not just uv's
+          # `UV_PYTHON` pin. `vig-utils` (a devTools entry) is built against the
+          # devkit's own pinned 3.14 and propagates that interpreter onto PATH,
+          # which would otherwise shadow the overridden `python3`. `vig-utils`
+          # must stay on 3.14 (its own code targets the pinned interpreter), so
+          # the override wins by PATH order rather than by rebuilding the tool.
+          # Empty for the default interpreter, so the zero-override shellHook is
+          # byte-identical to the pre-#1038 builder (parity:
+          # tests/test_flake_devshell.py).
+          pythonOverrideHook = pkgs.lib.optionalString (python != pkgs.python314) ''
+            export PATH="${python}/bin:$PATH"
+          '';
         in
         pkgs.mkShell (
           # Module env first: the builder's attrset below wins any collision,
@@ -487,9 +511,20 @@
               ++ extraPackages
               ++ modulePackages;
             shellHook =
-              ldLibraryPathHook + "\n" + nvimIsolationHook + "\n" + moduleShellHook + hooksShellHook + shellHook;
+              ldLibraryPathHook
+              + "\n"
+              + nvimIsolationHook
+              + "\n"
+              + pythonOverrideHook
+              + moduleShellHook
+              + hooksShellHook
+              + shellHook;
 
-            UV_PYTHON = "${python}/bin/python3.14";
+            # `python.executable` is the interpreter's own binary name
+            # (`python3.14` for the default, `python3.13` under an override), so
+            # UV_PYTHON follows the `python` argument (#1038) instead of a
+            # hardcoded 3.14 string.
+            UV_PYTHON = "${python}/bin/${python.executable}";
             UV_PYTHON_DOWNLOADS = "never";
 
             # Resolve the bats helper libraries from the Nix store. The wrapper

--- a/tests/test_flake_devshell.py
+++ b/tests/test_flake_devshell.py
@@ -481,3 +481,120 @@ def test_each_tool_runs_in_devshell(dev_shell_tools: list[str]) -> None:
                 f"{proc.stderr.strip()[:200]}"
             )
     assert not failures, "Tools failed inside nix develop:\n" + "\n".join(failures)
+
+
+# ---------------------------------------------------------------------------
+# Overridable Python interpreter (#1038) — `mkProjectShell` accepts an opt-in
+# `python ? pkgs.python314` argument so a consumer whose nixpkgs C-extension
+# dependency is built against a different CPython ABI (e.g. `pkgs.freecad`,
+# built against the nixpkgs default Python 3.13) can align the interpreter uv
+# pins. The default stays byte-identical to the pinned-3.14 builder.
+# ---------------------------------------------------------------------------
+
+
+def _mkprojectshell_expr(system: str, args: str) -> str:
+    """A Nix expression building ``flake.lib.mkProjectShell`` with ``args``.
+
+    Mirrors the ``test_flake_modules`` / ``test_flake_hooks`` idiom: import the
+    pinned nixpkgs with the flake's overlay so ``pkgs`` matches the flake's own
+    dev-shell, then apply ``mkProjectShell``. ``--impure`` is required for the
+    ``builtins.getFlake`` on the local path.
+    """
+    return f"""
+    let
+      flake = builtins.getFlake "path:{REPO_ROOT}";
+      system = "{system}";
+      pkgs = import flake.inputs.nixpkgs {{
+        inherit system;
+        overlays = [ flake.overlays.default ];
+        config.allowUnfree = true;
+      }};
+    in flake.lib.mkProjectShell {{ inherit pkgs; {args} }}
+    """
+
+
+def test_devshell_python_default_is_byte_identical(current_system: str) -> None:
+    """Passing the explicit default ``python`` is byte-identical to no argument (#1038).
+
+    The parity guard for the new argument (same pattern as the ``modules`` /
+    ``hooks`` opt-ins): building ``mkProjectShell { python = pkgs.python314; }``
+    must produce the exact same derivation as the flake's own default dev-shell,
+    so adding the knob cannot silently change the pinned-3.14 shell.
+    """
+    expr = f"""
+    let
+      flake = builtins.getFlake "path:{REPO_ROOT}";
+      system = "{current_system}";
+      pkgs = import flake.inputs.nixpkgs {{
+        inherit system;
+        overlays = [ flake.overlays.default ];
+        config.allowUnfree = true;
+      }};
+    in {{
+      default = flake.devShells.${{system}}.default.drvPath;
+      explicitDefault =
+        (flake.lib.mkProjectShell {{ inherit pkgs; python = pkgs.python314; }}).drvPath;
+    }}
+    """
+    result = subprocess.run(
+        ["nix", "eval", "--impure", "--json", "--expr", expr],
+        capture_output=True,
+        text=True,
+        env=_nix_env(),
+        timeout=300,
+    )
+    assert result.returncode == 0, result.stderr
+    paths = json.loads(result.stdout)
+    assert paths["default"] == paths["explicitDefault"], (
+        "explicit python=python314 must match the default dev-shell drv byte-for-byte; "
+        f"got {paths!r}"
+    )
+
+
+def test_devshell_python_override_switches_interpreter(current_system: str) -> None:
+    """``python = pkgs.python313`` makes UV_PYTHON and ``python3`` follow it (#1038).
+
+    The ABI-alignment knob for nixpkgs C-extension deps (freecad-class): the
+    overridden interpreter must be the one uv pins (``UV_PYTHON``) and the one on
+    the shell's own PATH (``python3``). Exercised with 3.13 (the nixpkgs default,
+    reliably cached) rather than building/pulling FreeCAD, which is far too heavy
+    for CI — the FreeCAD acceptance case is covered by the cad2gdml onboarding
+    spike (#1040 Phase 0), not here.
+    """
+    expr = _mkprojectshell_expr(current_system, "python = pkgs.python313;")
+    script = 'printf "\\nUV_PYTHON=%s\\n" "$UV_PYTHON"; python3 --version'
+    proc = subprocess.run(
+        [
+            "nix",
+            "develop",
+            "--impure",
+            "--ignore-environment",
+            "--keep",
+            "HOME",
+            "--expr",
+            expr,
+            "-c",
+            "bash",
+            "-c",
+            script,
+        ],
+        capture_output=True,
+        text=True,
+        env=_nix_env(),
+        timeout=1800,
+    )
+    assert proc.returncode == 0, (
+        f"failed to build/enter the python=python313 dev-shell: {proc.stderr[-500:]}"
+    )
+    lines = proc.stdout.splitlines()
+    uv_python = next(
+        (ln.partition("=")[2] for ln in lines if ln.startswith("UV_PYTHON=")), ""
+    )
+    assert uv_python.startswith("/nix/store/") and uv_python.endswith("python3.13"), (
+        f"UV_PYTHON must follow the override to a store python3.13; got {uv_python!r}"
+    )
+    version_line = lines[-1] if lines else ""
+    assert "3.13" in version_line, (
+        f"python3 on the shell PATH must report 3.13 under the override; got {version_line!r} "
+        f"(full stdout: {proc.stdout!r})"
+    )


### PR DESCRIPTION
## Summary

Implements #1038 — the ABI-alignment knob blocking the cad2gdml onboarding (#1040 Phase 0).

- `mkProjectShell` gains `python ? pkgs.python314` (same additive pattern as `modules`/`hooks`); `UV_PYTHON` derives from `${python}/bin/${python.executable}` instead of the hardcoded `python3.14` string, so uv pins whatever interpreter the consumer selects.
- **Second interpreter assumption found and fixed during testing:** `vig-utils` (a devTools entry, built against the devkit's pinned 3.14) propagates its interpreter onto PATH, shadowing an overridden `python3`. A conditional hook prepends the override's `bin` to PATH — only when `python != pkgs.python314`, so the hook is the empty string by default and the zero-argument shell stays **byte-identical** (drvPath parity test added alongside the override test).
- Deliberately left: the image-build path's own `python314` pins — the published image is devkit's toolchain, not consumer-overridable; the issue scopes to the dev-shell builder.
- No FreeCAD-import test: pulling FreeCAD is far too heavy for CI. The FreeCAD acceptance case is exercised by the cad2gdml onboarding spike (#1040 Phase 0); Python 3.13 (the reliably-cached nixpkgs default) stands in as the ABI probe here.
- Documented in `docs/MIGRATION.md` with the issue's FreeCAD snippet (`mkProjectShell { python = pkgs.python313; extraPackages = [ pkgs.freecad ]; }`).

TDD: failing-test commit (RED: `unexpected argument 'python'`) → implementation → docs.

## Test evidence
- `uv run pytest tests/test_flake_devshell.py tests/test_flake_modules.py` → 21 passed, 1 skipped (NixOS-only test on an FHS host)
- New: default-drvPath parity with explicit `python = pkgs.python314`, and override test asserting `UV_PYTHON` → store `python3.13` + `python3 --version` reports 3.13
- `prek run --all-files` → green (re-verified independently before push)

Closes #1038
Refs: #1040