### PR TITLE
fix(ci): group npm updates and enable lockfile maintenance in the Renovate preset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Renovate preset groups npm updates instead of one PR per package** ([#1047](https://github.com/vig-os/devkit/issues/1047))
+  - The scaffolded `renovate-default.json` gave `github-actions` and `pep621` a `groupName` but left `npm` ungrouped, so npm consumers got one PR per package — each touching `package-lock.json` and `CHANGELOG.md`, so they conflicted pairwise and were effectively unlandable serially. npm now gets two grouping rules matching the other managers' style: `devDependencies` group across all update types ("npm dev dependencies"), and runtime `dependencies` minor/patch ("npm (minor and patch)") with majors staying as individual PRs. The existing `build(npm)` semantic-commit rule still applies to every npm PR (Renovate merges matching `packageRules` in order).
+
 - **`sync-main-to-dev` no longer deadlocks on new local actions** ([#1034](https://github.com/vig-os/devkit/issues/1034))
   - The `sync` job checked out `ref: dev` and then invoked a local `uses: ./.github/actions/...` composite, which GitHub resolves against the checked-out workspace. When `main` added or renamed a local action absent from `dev`, the job died on its first run — and the only PR that would carry the action onto `dev` was the very sync PR the job could no longer open. Dropping `ref: dev` builds against the triggering `main` SHA, where the action is guaranteed to exist; every downstream step already operates on `origin/main`/`origin/dev` or the API, so behavior is otherwise unchanged.
 - **`setup-devkit-toolchain` no longer forces Python/uv env on non-Python consumers** ([#1028](https://github.com/vig-os/devkit/issues/1028))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Interim transitive npm vulnerability coverage via weekly lockfile maintenance** ([#1041](https://github.com/vig-os/devkit/issues/1041))
+  - The Renovate preset never touched transitive npm dependencies, so vulnerabilities in packages only reachable through a parent (12 of 21 alerts in the `commit-action` pilot, including the only critical) were neither reported nor remediated. The preset now enables `lockFileMaintenance` (weekly, same Monday cadence), which regenerates the lockfile and picks up in-range fixes for indirect dependencies. This is an **interim** mechanism, not a full fix: alert-driven transitive remediation is unimplemented upstream ([renovatebot/renovate#41825](https://github.com/renovatebot/renovate/discussions/41825)) and the former `transitiveRemediation` option was removed from Renovate. devkit's own `renovate.json` drops its now-duplicated `lockFileMaintenance` block and inherits it from the preset.
+
 - **Renovate preset groups npm updates instead of one PR per package** ([#1047](https://github.com/vig-os/devkit/issues/1047))
   - The scaffolded `renovate-default.json` gave `github-actions` and `pep621` a `groupName` but left `npm` ungrouped, so npm consumers got one PR per package — each touching `package-lock.json` and `CHANGELOG.md`, so they conflicted pairwise and were effectively unlandable serially. npm now gets two grouping rules matching the other managers' style: `devDependencies` group across all update types ("npm dev dependencies"), and runtime `dependencies` minor/patch ("npm (minor and patch)") with majors staying as individual PRs. The existing `build(npm)` semantic-commit rule still applies to every npm PR (Renovate merges matching `packageRules` in order).
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -45,6 +45,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Renovate preset groups npm updates instead of one PR per package** ([#1047](https://github.com/vig-os/devkit/issues/1047))
+  - The scaffolded `renovate-default.json` gave `github-actions` and `pep621` a `groupName` but left `npm` ungrouped, so npm consumers got one PR per package — each touching `package-lock.json` and `CHANGELOG.md`, so they conflicted pairwise and were effectively unlandable serially. npm now gets two grouping rules matching the other managers' style: `devDependencies` group across all update types ("npm dev dependencies"), and runtime `dependencies` minor/patch ("npm (minor and patch)") with majors staying as individual PRs. The existing `build(npm)` semantic-commit rule still applies to every npm PR (Renovate merges matching `packageRules` in order).
+
 - **`sync-main-to-dev` no longer deadlocks on new local actions** ([#1034](https://github.com/vig-os/devkit/issues/1034))
   - The `sync` job checked out `ref: dev` and then invoked a local `uses: ./.github/actions/...` composite, which GitHub resolves against the checked-out workspace. When `main` added or renamed a local action absent from `dev`, the job died on its first run — and the only PR that would carry the action onto `dev` was the very sync PR the job could no longer open. Dropping `ref: dev` builds against the triggering `main` SHA, where the action is guaranteed to exist; every downstream step already operates on `origin/main`/`origin/dev` or the API, so behavior is otherwise unchanged.
 - **`setup-devkit-toolchain` no longer forces Python/uv env on non-Python consumers** ([#1028](https://github.com/vig-os/devkit/issues/1028))

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -45,6 +45,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Interim transitive npm vulnerability coverage via weekly lockfile maintenance** ([#1041](https://github.com/vig-os/devkit/issues/1041))
+  - The Renovate preset never touched transitive npm dependencies, so vulnerabilities in packages only reachable through a parent (12 of 21 alerts in the `commit-action` pilot, including the only critical) were neither reported nor remediated. The preset now enables `lockFileMaintenance` (weekly, same Monday cadence), which regenerates the lockfile and picks up in-range fixes for indirect dependencies. This is an **interim** mechanism, not a full fix: alert-driven transitive remediation is unimplemented upstream ([renovatebot/renovate#41825](https://github.com/renovatebot/renovate/discussions/41825)) and the former `transitiveRemediation` option was removed from Renovate. devkit's own `renovate.json` drops its now-duplicated `lockFileMaintenance` block and inherits it from the preset.
+
 - **Renovate preset groups npm updates instead of one PR per package** ([#1047](https://github.com/vig-os/devkit/issues/1047))
   - The scaffolded `renovate-default.json` gave `github-actions` and `pep621` a `groupName` but left `npm` ungrouped, so npm consumers got one PR per package — each touching `package-lock.json` and `CHANGELOG.md`, so they conflicted pairwise and were effectively unlandable serially. npm now gets two grouping rules matching the other managers' style: `devDependencies` group across all update types ("npm dev dependencies"), and runtime `dependencies` minor/patch ("npm (minor and patch)") with majors staying as individual PRs. The existing `build(npm)` semantic-commit rule still applies to every npm PR (Renovate merges matching `packageRules` in order).
 

--- a/assets/workspace/.github/renovate-default.json
+++ b/assets/workspace/.github/renovate-default.json
@@ -46,6 +46,19 @@
       "matchManagers": ["npm"],
       "semanticCommitType": "build",
       "semanticCommitScope": "npm"
+    },
+    {
+      "description": "npm — group dev dependencies (they never ship in the bundle)",
+      "matchManagers": ["npm"],
+      "matchDepTypes": ["devDependencies"],
+      "groupName": "npm dev dependencies"
+    },
+    {
+      "description": "npm — group runtime minor/patch; majors stay separate",
+      "matchManagers": ["npm"],
+      "matchDepTypes": ["dependencies"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "npm (minor and patch)"
     }
   ]
 }

--- a/assets/workspace/.github/renovate-default.json
+++ b/assets/workspace/.github/renovate-default.json
@@ -5,6 +5,11 @@
   "schedule": ["before 9am on monday"],
   "baseBranchPatterns": ["dev"],
   "rebaseWhen": "conflicted",
+  "lockFileMaintenance": {
+    "description": "Interim mechanism for transitive npm vulnerability coverage: a weekly lockfile regeneration picks up in-range fixes for indirect dependencies that never appear in package.json. Alert-driven transitive remediation is unimplemented upstream (renovatebot/renovate#41825) and the former transitiveRemediation option was removed from Renovate. Refs #1041.",
+    "enabled": true,
+    "schedule": ["before 9am on monday"]
+  },
   "gitIgnoredAuthors": ["41898282+github-actions[bot]@users.noreply.github.com"],
   "packageRules": [
     {

--- a/renovate.json
+++ b/renovate.json
@@ -4,10 +4,6 @@
     "github>vig-os/devcontainer//assets/workspace/.github/renovate-default"
   ],
   "enabledManagers": ["github-actions", "pep621", "npm", "nix", "custom.regex"],
-  "lockFileMaintenance": {
-    "enabled": true,
-    "schedule": ["before 9am on monday"]
-  },
   "customManagers": [
     {
       "customType": "regex",


### PR DESCRIPTION
## Summary

Two Renovate-preset fixes from the commit-action pilot's first Renovate run, bundled per #1047's own suggestion (same file).

### #1047 — npm update grouping (fixed as specified)
The preset grouped `github-actions` and `pep621` minor/patch but fanned npm out one PR per package — and because every npm PR touches `package-lock.json` + `CHANGELOG.md`, the set was pairwise-conflicting (commit-action got 11 mutually unlandable PRs). Now, matching the existing style:
- `devDependencies` grouped across ALL update types ("npm dev dependencies") — they never ship in the bundle;
- runtime `dependencies` minor/patch grouped ("npm (minor and patch)"); runtime **majors stay individual** (the `@actions/*` ESM-only majors showed why).
Renovate packageRules merge in order, so the existing `build(npm)` semantic-commit rule still applies to every npm PR.

### #1041 — transitive npm vulnerabilities (interim; issue stays open)
The issue's proposed `transitiveRemediation: true` is **impossible on current Renovate**: the option is in `removedProperties` and absent from the options schema of the validator-pinned version (43.262.3) — adding it fails `renovate-validate.yml` (`--strict` migration warning → exit 1) and would be silently discarded anyway. There is no drop-in replacement; alert-driven transitive remediation is upstream-unimplemented (renovatebot/renovate#41825).
Interim shipped instead: **weekly `lockFileMaintenance` in the shared preset** — the mechanism devkit's own root `renovate.json` already used — which regenerates lockfiles and picks up in-range transitive fixes. The root copy's now-duplicate block is removed (SSoT: root extends the preset). The preset block's `description` documents the interim status and the upstream pointer. #1041 will be re-scoped to track the upstream feature, not closed.

Known small window (accepted): the preset resolves from `main`, so between this dev-merge and the next promotion devkit itself skips at most a weekly maintenance run; consumers are unaffected.

No preset test idiom exists; `renovate-config-validator --strict` over all 3 tracked configs is the evidence (exit 0), per the repo's `renovate-validate.yml` convention.

## Evidence
- `renovate-config-validator --strict`: "Config validated successfully against 3 file(s)", exit 0
- `prek run --all-files` → green (re-verified independently before push)

Closes #1047
Refs: #1041