### PR TITLE
feat(ci): skip codeql and scorecard scans on private repos

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -19,6 +19,16 @@
 # devkit renders the `language:` matrix below to match the repo (Python ->
 # python, Node -> javascript-typescript, Rust omits its leg; `actions` is
 # always analyzed) but never changes the code-scanning API setting for you.
+#
+# NOTE — private repositories: CodeQL requires GitHub Advanced Security, which
+# is unavailable on Free-plan private repos, so the analysis can never succeed
+# there. The `analyze` job is therefore guarded with
+# `if: ${{ !github.event.repository.private }}`: private repos get a skipped
+# (neutral) run instead of a permanently red one, and a repo later flipped
+# public starts scanning automatically with no re-scaffold. The guard is valid
+# on every trigger this workflow declares — `github.event.repository.private` is
+# populated for `pull_request`, `push`, and (since GitHub's 2022-09-27 change
+# adding repository info to scheduled-run payloads) `schedule`.
 
 name: CodeQL
 
@@ -42,6 +52,9 @@ permissions: {}  # restrict default; job declares its own
 jobs:
   analyze:
     name: CodeQL Analysis
+    # Skip on private repos: CodeQL needs GHAS (unavailable on Free-plan private
+    # repos), so it would fail permanently. See the header note for details.
+    if: ${{ !github.event.repository.private }}
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     permissions:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -6,6 +6,15 @@
 #
 # Docs: https://securityscorecards.dev/
 # Action: https://github.com/ossf/scorecard-action
+#
+# NOTE — private repositories: OpenSSF Scorecard only supports public repos, so
+# the analysis can never succeed on a private one. The `analysis` job is guarded
+# with `if: ${{ !github.event.repository.private }}`: private repos get a skipped
+# (neutral) run instead of a permanently red one, and a repo later flipped public
+# starts scanning automatically with no re-scaffold. The guard is valid on every
+# trigger this workflow declares — `github.event.repository.private` is populated
+# for `push` and (since GitHub's 2022-09-27 change adding repository info to
+# scheduled-run payloads) `schedule`.
 
 name: Scorecard
 
@@ -23,6 +32,9 @@ permissions: {}  # restrict default; job declares its own
 jobs:
   analysis:
     name: Scorecard Analysis
+    # Skip on private repos: OpenSSF Scorecard is public-only, so it would fail
+    # permanently. See the header note for details.
+    if: ${{ !github.event.repository.private }}
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Scaffolded security-scan workflows skip on private repos** ([#1039](https://github.com/vig-os/devkit/issues/1039))
+  - `codeql.yml` and `scorecard.yml` now guard their analysis job with
+    `if: ${{ !github.event.repository.private }}`. Neither scan can ever succeed
+    on a private repo — CodeQL needs GitHub Advanced Security (unavailable on
+    Free-plan private repos) and OpenSSF Scorecard is public-only — so a private
+    consumer previously scaffolded two permanently red workflows. Private repos
+    now get a skipped (neutral) run; a repo later flipped public starts scanning
+    automatically with no re-scaffold. Public consumers are unaffected. The guard
+    is valid on every declared trigger (`pull_request`, `push`, `schedule`).
 - **`mkProjectShell` accepts an overridable Python interpreter** ([#1038](https://github.com/vig-os/devkit/issues/1038))
   - New opt-in `python ? pkgs.python314` argument: `UV_PYTHON` and the bare
     `python`/`python3` on PATH now follow the override, so a consumer whose

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Scaffolded security-scan workflows skip on private repos** ([#1039](https://github.com/vig-os/devkit/issues/1039))
+  - `codeql.yml` and `scorecard.yml` now guard their analysis job with
+    `if: ${{ !github.event.repository.private }}`. Neither scan can ever succeed
+    on a private repo — CodeQL needs GitHub Advanced Security (unavailable on
+    Free-plan private repos) and OpenSSF Scorecard is public-only — so a private
+    consumer previously scaffolded two permanently red workflows. Private repos
+    now get a skipped (neutral) run; a repo later flipped public starts scanning
+    automatically with no re-scaffold. Public consumers are unaffected. The guard
+    is valid on every declared trigger (`pull_request`, `push`, `schedule`).
 - **`mkProjectShell` accepts an overridable Python interpreter** ([#1038](https://github.com/vig-os/devkit/issues/1038))
   - New opt-in `python ? pkgs.python314` argument: `UV_PYTHON` and the bare
     `python`/`python3` on PATH now follow the override, so a consumer whose

--- a/assets/workspace/.github/workflows/codeql.yml
+++ b/assets/workspace/.github/workflows/codeql.yml
@@ -19,6 +19,16 @@
 # devkit renders the `language:` matrix below to match the repo (Python ->
 # python, Node -> javascript-typescript, Rust omits its leg; `actions` is
 # always analyzed) but never changes the code-scanning API setting for you.
+#
+# NOTE — private repositories: CodeQL requires GitHub Advanced Security, which
+# is unavailable on Free-plan private repos, so the analysis can never succeed
+# there. The `analyze` job is therefore guarded with
+# `if: ${{ !github.event.repository.private }}`: private repos get a skipped
+# (neutral) run instead of a permanently red one, and a repo later flipped
+# public starts scanning automatically with no re-scaffold. The guard is valid
+# on every trigger this workflow declares — `github.event.repository.private` is
+# populated for `pull_request`, `push`, and (since GitHub's 2022-09-27 change
+# adding repository info to scheduled-run payloads) `schedule`.
 
 name: CodeQL
 
@@ -42,6 +52,9 @@ permissions: {}  # restrict default; job declares its own
 jobs:
   analyze:
     name: CodeQL Analysis
+    # Skip on private repos: CodeQL needs GHAS (unavailable on Free-plan private
+    # repos), so it would fail permanently. See the header note for details.
+    if: ${{ !github.event.repository.private }}
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     permissions:

--- a/assets/workspace/.github/workflows/scorecard.yml
+++ b/assets/workspace/.github/workflows/scorecard.yml
@@ -6,6 +6,15 @@
 #
 # Docs: https://securityscorecards.dev/
 # Action: https://github.com/ossf/scorecard-action
+#
+# NOTE — private repositories: OpenSSF Scorecard only supports public repos, so
+# the analysis can never succeed on a private one. The `analysis` job is guarded
+# with `if: ${{ !github.event.repository.private }}`: private repos get a skipped
+# (neutral) run instead of a permanently red one, and a repo later flipped public
+# starts scanning automatically with no re-scaffold. The guard is valid on every
+# trigger this workflow declares — `github.event.repository.private` is populated
+# for `push` and (since GitHub's 2022-09-27 change adding repository info to
+# scheduled-run payloads) `schedule`.
 
 name: Scorecard
 
@@ -23,6 +32,9 @@ permissions: {}  # restrict default; job declares its own
 jobs:
   analysis:
     name: Scorecard Analysis
+    # Skip on private repos: OpenSSF Scorecard is public-only, so it would fail
+    # permanently. See the header note for details.
+    if: ${{ !github.event.repository.private }}
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -117,6 +117,14 @@ Container-independent workflows keep working in every mode: `codeql.yml`,
 `scorecard.yml`, `renovate-changelog-commit.yml`, and the project-owned,
 host-native `release-extension.yml`.
 
+`codeql.yml` and `scorecard.yml` additionally guard their analysis job with
+`if: ${{ !github.event.repository.private }}`
+([#1039](https://github.com/vig-os/devkit/issues/1039)): neither scan can succeed
+on a private repo (CodeQL needs GitHub Advanced Security, unavailable on
+Free-plan private repos; OpenSSF Scorecard is public-only), so private consumers
+get a skipped (neutral) run instead of a permanently red one. A repo later
+flipped public starts scanning automatically, with no re-scaffold.
+
 ## The `.vig-os` project manifest
 
 Since [#885](https://github.com/vig-os/devkit/issues/885), `.vig-os` is

--- a/tests/test_workflow_private_repo_guard.py
+++ b/tests/test_workflow_private_repo_guard.py
@@ -1,0 +1,69 @@
+"""Workflow-shape tests: security-scan jobs must skip on private repositories.
+
+Issue #1039: the scaffold ships ``codeql.yml`` and ``scorecard.yml``
+unconditionally. On a **private** repo neither can ever succeed — CodeQL needs
+GitHub Advanced Security (unavailable on Free-plan private repos) and OpenSSF
+Scorecard is public-only — so the first private consumer would scaffold two
+permanently red workflows.
+
+The fix gates each analysis job with ``if: ${{ !github.event.repository.private
+}}`` at the *job* level, so a private repo yields a skipped (neutral) run rather
+than a failing one, and a repo later flipped public starts scanning
+automatically with no re-scaffold. ``github.event.repository`` (and its
+``private`` field) is populated on every trigger these workflows declare —
+``pull_request``, ``push``, and (since the 2022-09-27 Actions change that added
+repository info to scheduled-run payloads) ``schedule`` — so the guard is valid
+and meaningful on all of them.
+
+These assertions pin that invariant for both copies of each workflow: the
+devkit's own (a public no-op) and the manifest-synced scaffold shipped to
+consumers.
+
+Refs: #1039
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+# Repository root (tests/ -> repo root).
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# The guard skips the job whenever the repository is private.
+EXPECTED_GUARD = "${{ !github.event.repository.private }}"
+
+# (workflow path, analysis job key); each is checked in both the devkit's own
+# copy and the manifest-synced scaffold copy under assets/workspace/.
+_WORKFLOWS = [
+    (".github/workflows/codeql.yml", "analyze"),
+    (".github/workflows/scorecard.yml", "analysis"),
+]
+GUARDED_JOBS = [
+    (REPO_ROOT / prefix / rel, job)
+    for rel, job in _WORKFLOWS
+    for prefix in (".", "assets/workspace")
+]
+
+
+def _load(path: Path) -> dict:
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+@pytest.mark.parametrize(
+    ("path", "job"),
+    GUARDED_JOBS,
+    ids=lambda v: str(v.relative_to(REPO_ROOT)) if isinstance(v, Path) else v,
+)
+def test_scan_job_skips_on_private_repo(path: Path, job: str) -> None:
+    """The analysis job is gated so private repos get a neutral (skipped) run."""
+    workflow = _load(path)
+    assert job in workflow["jobs"], f"{path} has no `{job}` job"
+    guard = workflow["jobs"][job].get("if")
+    assert guard == EXPECTED_GUARD, (
+        f"{path} job `{job}` must be guarded with `if: {EXPECTED_GUARD}` so it "
+        f"is skipped on private repos (CodeQL/Scorecard cannot succeed there); "
+        f"found {guard!r}"
+    )


### PR DESCRIPTION
## Summary

Implements #1039 via the issue's recommended Option 1 — a runtime guard, so the scaffold stays uniform and a repo later flipped public starts scanning automatically with no re-scaffold.

- Job-level `if: ${{ !github.event.repository.private }}` on `codeql.yml`'s `analyze` and `scorecard.yml`'s `analysis` jobs. Private repos get skipped (neutral) runs instead of two permanently red workflows (CodeQL needs GHAS — unavailable on Free-plan private repos; Scorecard is public-only).
- Both files are manifest-synced: the guard lands in the root SSoT copies (a no-op for the public devkit) and the scaffold copies are regenerated byte-identical.
- Trigger-payload correctness researched explicitly: `github.event.repository.private` is populated on `pull_request`, `push`, and — since GitHub's 2022-09-27 change adding repository info to scheduled-run payloads — `schedule`, covering every trigger both workflows declare. Reasoning recorded in each workflow header.
- Documented in `docs/MIGRATION.md` at the existing codeql/scorecard description.

Unblocks the second cad2gdml Phase-0 prerequisite (#1040); the last one (#1038) merged in #1048.

TDD: new `tests/test_workflow_private_repo_guard.py` (YAML-parses all 4 copies, asserts the job guard) — RED 4 failed → GREEN 4 passed.

## Test evidence
- `uv run pytest tests/test_workflow_private_repo_guard.py` → 4 passed
- `actionlint` clean on all 4 workflow files
- `prek run --all-files` → green (re-verified independently before push)

Closes #1039
Refs: #1040