### PR TITLE
feat(ci): per-repo release tag prefix and promote-time floating tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Scaffold ships `docs/DOWNSTREAM_RELEASE.md`** ([#1046](https://github.com/vig-os/devkit/issues/1046))
+  - The scaffolded `promote-release.yml` header points at `docs/DOWNSTREAM_RELEASE.md` — the consumer's primary release-process documentation — but the scaffold never shipped it, leaving every consumer with a dangling reference. The doc is now a manifest-synced managed file (root copy is the SSoT), so the reference resolves inside consumer repos and refreshes on scaffold upgrades.
 - **`sync-main-to-dev` no longer deadlocks on new local actions** ([#1034](https://github.com/vig-os/devkit/issues/1034))
   - The `sync` job checked out `ref: dev` and then invoked a local `uses: ./.github/actions/...` composite, which GitHub resolves against the checked-out workspace. When `main` added or renamed a local action absent from `dev`, the job died on its first run — and the only PR that would carry the action onto `dev` was the very sync PR the job could no longer open. Dropping `ref: dev` builds against the triggering `main` SHA, where the action is guaranteed to exist; every downstream step already operates on `origin/main`/`origin/dev` or the API, so behavior is otherwise unchanged.
 - **`setup-devkit-toolchain` no longer forces Python/uv env on non-Python consumers** ([#1028](https://github.com/vig-os/devkit/issues/1028))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Per-repo release tag prefix (`DEVKIT_TAG_PREFIX`)** ([#1044](https://github.com/vig-os/devkit/issues/1044))
+  - New optional `.vig-os` key threads a tag prefix through the scaffolded release
+    pipeline, applied **only at the publishing edge** — the pushed git tag name and
+    the changelog release link. Absent/empty reproduces today's bare `X.Y.Z` tags
+    byte-for-byte (no change for devkit or existing consumers); Action-publishing
+    repos set `v` for the `actions/checkout@v5` ecosystem convention.
+  - `resolve-toolchain` reads the key and emits a `tag-prefix` output; `release.yml`
+    threads it into `release-core.yml`/`release-publish.yml`, and it composes into
+    the RC-discovery pattern, publish tag, `tag_state` check, `gh release create`,
+    the `prepare-release` tag-existence guard, and the `promote-release` release/RC
+    validation and cleanup. The `version` input, `release/X.Y.Z` branch name, and
+    `## [X.Y.Z]` freeze heading stay bare everywhere.
+  - `prepare-changelog finalize` gains `--tag-prefix`, prefixing both the release
+    link URL and the displayed heading (`## [v0.3.0](…/tag/v0.3.0) - DATE`); an
+    empty prefix is byte-identical to prior output.
 - **`mkProjectShell` accepts an overridable Python interpreter** ([#1038](https://github.com/vig-os/devkit/issues/1038))
   - New opt-in `python ? pkgs.python314` argument: `UV_PYTHON` and the bare
     `python`/`python3` on PATH now follow the override, so a consumer whose

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Opt-in floating major/minor tags at promote (`DEVKIT_FLOATING_TAGS`)** ([#1045](https://github.com/vig-os/devkit/issues/1045))
+  - New optional `.vig-os` key (comma-separated subset of `major,minor`; empty =
+    off) makes the scaffolded `promote-release.yml` force-move `<prefix>X` and/or
+    `<prefix>X.Y` to the promoted final-release commit, giving Action consumers the
+    standard `uses: owner/repo@v0` pinning contract with promote-gated moves.
+  - A new `floating-tags` job runs only after the Release is published and the
+    release PR is merged (the post-acceptance gate); it is idempotent (skips when a
+    tag already points at the release commit), final-only, composes with
+    `DEVKIT_TAG_PREFIX`, and pushes with the RELEASE_APP token so a tag ruleset can
+    make floating-tag moves app-exclusive. Off by default — no change for devkit or
+    existing consumers.
 - **Per-repo release tag prefix (`DEVKIT_TAG_PREFIX`)** ([#1044](https://github.com/vig-os/devkit/issues/1044))
   - New optional `.vig-os` key threads a tag prefix through the scaffolded release
     pipeline, applied **only at the publishing edge** — the pushed git tag name and

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -78,6 +78,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Scaffold ships `docs/DOWNSTREAM_RELEASE.md`** ([#1046](https://github.com/vig-os/devkit/issues/1046))
+  - The scaffolded `promote-release.yml` header points at `docs/DOWNSTREAM_RELEASE.md` — the consumer's primary release-process documentation — but the scaffold never shipped it, leaving every consumer with a dangling reference. The doc is now a manifest-synced managed file (root copy is the SSoT), so the reference resolves inside consumer repos and refreshes on scaffold upgrades.
 - **`sync-main-to-dev` no longer deadlocks on new local actions** ([#1034](https://github.com/vig-os/devkit/issues/1034))
   - The `sync` job checked out `ref: dev` and then invoked a local `uses: ./.github/actions/...` composite, which GitHub resolves against the checked-out workspace. When `main` added or renamed a local action absent from `dev`, the job died on its first run — and the only PR that would carry the action onto `dev` was the very sync PR the job could no longer open. Dropping `ref: dev` builds against the triggering `main` SHA, where the action is guaranteed to exist; every downstream step already operates on `origin/main`/`origin/dev` or the API, so behavior is otherwise unchanged.
 - **`setup-devkit-toolchain` no longer forces Python/uv env on non-Python consumers** ([#1028](https://github.com/vig-os/devkit/issues/1028))

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Per-repo release tag prefix (`DEVKIT_TAG_PREFIX`)** ([#1044](https://github.com/vig-os/devkit/issues/1044))
+  - New optional `.vig-os` key threads a tag prefix through the scaffolded release
+    pipeline, applied **only at the publishing edge** — the pushed git tag name and
+    the changelog release link. Absent/empty reproduces today's bare `X.Y.Z` tags
+    byte-for-byte (no change for devkit or existing consumers); Action-publishing
+    repos set `v` for the `actions/checkout@v5` ecosystem convention.
+  - `resolve-toolchain` reads the key and emits a `tag-prefix` output; `release.yml`
+    threads it into `release-core.yml`/`release-publish.yml`, and it composes into
+    the RC-discovery pattern, publish tag, `tag_state` check, `gh release create`,
+    the `prepare-release` tag-existence guard, and the `promote-release` release/RC
+    validation and cleanup. The `version` input, `release/X.Y.Z` branch name, and
+    `## [X.Y.Z]` freeze heading stay bare everywhere.
+  - `prepare-changelog finalize` gains `--tag-prefix`, prefixing both the release
+    link URL and the displayed heading (`## [v0.3.0](…/tag/v0.3.0) - DATE`); an
+    empty prefix is byte-identical to prior output.
 - **`mkProjectShell` accepts an overridable Python interpreter** ([#1038](https://github.com/vig-os/devkit/issues/1038))
   - New opt-in `python ? pkgs.python314` argument: `UV_PYTHON` and the bare
     `python`/`python3` on PATH now follow the override, so a consumer whose

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Opt-in floating major/minor tags at promote (`DEVKIT_FLOATING_TAGS`)** ([#1045](https://github.com/vig-os/devkit/issues/1045))
+  - New optional `.vig-os` key (comma-separated subset of `major,minor`; empty =
+    off) makes the scaffolded `promote-release.yml` force-move `<prefix>X` and/or
+    `<prefix>X.Y` to the promoted final-release commit, giving Action consumers the
+    standard `uses: owner/repo@v0` pinning contract with promote-gated moves.
+  - A new `floating-tags` job runs only after the Release is published and the
+    release PR is merged (the post-acceptance gate); it is idempotent (skips when a
+    tag already points at the release commit), final-only, composes with
+    `DEVKIT_TAG_PREFIX`, and pushes with the RELEASE_APP token so a tag ruleset can
+    make floating-tag moves app-exclusive. Off by default — no change for devkit or
+    existing consumers.
 - **Per-repo release tag prefix (`DEVKIT_TAG_PREFIX`)** ([#1044](https://github.com/vig-os/devkit/issues/1044))
   - New optional `.vig-os` key threads a tag prefix through the scaffolded release
     pipeline, applied **only at the publishing edge** — the pushed git tag name and

--- a/assets/workspace/.github/actions/resolve-toolchain/action.yml
+++ b/assets/workspace/.github/actions/resolve-toolchain/action.yml
@@ -49,6 +49,9 @@ outputs:
   image-tag:
     description: Resolved image/version tag
     value: ${{ steps.resolve.outputs.tag }}
+  tag-prefix:
+    description: Release tag prefix from DEVKIT_TAG_PREFIX (empty string => bare tags)
+    value: ${{ steps.resolve.outputs.tag-prefix }}
 
 runs:
   using: composite
@@ -64,6 +67,7 @@ runs:
         MODE=""
         DEVKIT_VERSION=""
         LEGACY_VERSION=""
+        TAG_PREFIX=""
 
         if [[ -f .vig-os ]]; then
           # Tolerant KEY=VALUE parsing shared with resolve-image (#781): capture
@@ -75,7 +79,7 @@ runs:
             [[ "$line" =~ ^[[:space:]]*# ]] && continue
 
             case "$line" in
-              DEVKIT_MODE=*|DEVKIT_VERSION=*|DEVCONTAINER_VERSION=*)
+              DEVKIT_MODE=*|DEVKIT_VERSION=*|DEVCONTAINER_VERSION=*|DEVKIT_TAG_PREFIX=*)
                 key="${line%%=*}"
                 value="${line#*=}"
                 value="${value#"${value%%[![:space:]]*}"}"
@@ -91,6 +95,7 @@ runs:
                   DEVKIT_MODE) MODE="$value" ;;
                   DEVKIT_VERSION) DEVKIT_VERSION="$value" ;;
                   DEVCONTAINER_VERSION) LEGACY_VERSION="$value" ;;
+                  DEVKIT_TAG_PREFIX) TAG_PREFIX="$value" ;;
                 esac
                 ;;
             esac
@@ -112,6 +117,11 @@ runs:
             ;;
         esac
         echo "mode=$MODE" >> "$GITHUB_OUTPUT"
+
+        # Release tag prefix (#1044): freeform, empty by default (= bare tags).
+        # Emitted for every mode; only the release/promote workflows consume it,
+        # composing it onto tag names/URLs at the publishing edge.
+        echo "tag-prefix=$TAG_PREFIX" >> "$GITHUB_OUTPUT"
 
         # Resolve the version tag: explicit override wins, else DEVKIT_VERSION,
         # else the legacy DEVCONTAINER_VERSION.

--- a/assets/workspace/.github/actions/resolve-toolchain/action.yml
+++ b/assets/workspace/.github/actions/resolve-toolchain/action.yml
@@ -52,6 +52,9 @@ outputs:
   tag-prefix:
     description: Release tag prefix from DEVKIT_TAG_PREFIX (empty string => bare tags)
     value: ${{ steps.resolve.outputs.tag-prefix }}
+  floating-tags:
+    description: Floating tag levels from DEVKIT_FLOATING_TAGS (subset of major,minor; empty => off)
+    value: ${{ steps.resolve.outputs.floating-tags }}
 
 runs:
   using: composite
@@ -68,6 +71,7 @@ runs:
         DEVKIT_VERSION=""
         LEGACY_VERSION=""
         TAG_PREFIX=""
+        FLOATING_TAGS=""
 
         if [[ -f .vig-os ]]; then
           # Tolerant KEY=VALUE parsing shared with resolve-image (#781): capture
@@ -79,7 +83,7 @@ runs:
             [[ "$line" =~ ^[[:space:]]*# ]] && continue
 
             case "$line" in
-              DEVKIT_MODE=*|DEVKIT_VERSION=*|DEVCONTAINER_VERSION=*|DEVKIT_TAG_PREFIX=*)
+              DEVKIT_MODE=*|DEVKIT_VERSION=*|DEVCONTAINER_VERSION=*|DEVKIT_TAG_PREFIX=*|DEVKIT_FLOATING_TAGS=*)
                 key="${line%%=*}"
                 value="${line#*=}"
                 value="${value#"${value%%[![:space:]]*}"}"
@@ -96,6 +100,7 @@ runs:
                   DEVKIT_VERSION) DEVKIT_VERSION="$value" ;;
                   DEVCONTAINER_VERSION) LEGACY_VERSION="$value" ;;
                   DEVKIT_TAG_PREFIX) TAG_PREFIX="$value" ;;
+                  DEVKIT_FLOATING_TAGS) FLOATING_TAGS="$value" ;;
                 esac
                 ;;
             esac
@@ -122,6 +127,11 @@ runs:
         # Emitted for every mode; only the release/promote workflows consume it,
         # composing it onto tag names/URLs at the publishing edge.
         echo "tag-prefix=$TAG_PREFIX" >> "$GITHUB_OUTPUT"
+
+        # Floating tag levels (#1045): comma-separated subset of major,minor;
+        # empty by default (= off). Only promote-release consumes it, force-moving
+        # <prefix>X / <prefix>X.Y at the final release commit.
+        echo "floating-tags=$FLOATING_TAGS" >> "$GITHUB_OUTPUT"
 
         # Resolve the version tag: explicit override wins, else DEVKIT_VERSION,
         # else the legacy DEVCONTAINER_VERSION.

--- a/assets/workspace/.github/workflows/prepare-release.yml
+++ b/assets/workspace/.github/workflows/prepare-release.yml
@@ -92,14 +92,18 @@ jobs:
       - name: Verify tag does not exist
         env:
           VERSION: ${{ steps.vars.outputs.version }}
+          TAG_PREFIX: ${{ steps.resolve.outputs.tag-prefix }}
         run: |
           set -euo pipefail
-          if git rev-parse -q --verify "refs/tags/$VERSION" > /dev/null; then
-            echo "ERROR: Tag $VERSION already exists"
+          # The release will publish the prefixed tag name (#1044); validate that,
+          # not the bare version. Empty prefix => bare tag (today's behavior).
+          PUBLISH_TAG="${TAG_PREFIX}${VERSION}"
+          if git rev-parse -q --verify "refs/tags/$PUBLISH_TAG" > /dev/null; then
+            echo "ERROR: Tag $PUBLISH_TAG already exists"
             exit 1
           fi
-          if git ls-remote --exit-code --tags --refs origin "refs/tags/$VERSION" > /dev/null 2>&1; then
-            echo "ERROR: Tag $VERSION already exists on remote"
+          if git ls-remote --exit-code --tags --refs origin "refs/tags/$PUBLISH_TAG" > /dev/null 2>&1; then
+            echo "ERROR: Tag $PUBLISH_TAG already exists on remote"
             exit 1
           fi
 

--- a/assets/workspace/.github/workflows/promote-release.yml
+++ b/assets/workspace/.github/workflows/promote-release.yml
@@ -35,6 +35,7 @@ jobs:
       image: ${{ steps.resolve.outputs.image }}
       image-tag: ${{ steps.resolve.outputs.image-tag }}
       tag-prefix: ${{ steps.resolve.outputs.tag-prefix }}
+      floating-tags: ${{ steps.resolve.outputs.floating-tags }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
@@ -539,3 +540,112 @@ jobs:
             exit 1
           fi
           echo "✓ RC draft pre-release and git RC tag cleanup complete for $VERSION"
+
+  floating-tags:
+    # Opt-in floating major/minor tags (#1045). Runs at the post-acceptance gate
+    # — after the GitHub Release is published (promote) AND the release PR is
+    # merged to main (merge) — mirroring where the upstream image moves GHCR
+    # `:latest`. RC candidates never reach promote, so this is final-only. Off
+    # unless DEVKIT_FLOATING_TAGS is set; the tag ruleset can then deny tag
+    # update/delete to everyone but the RELEASE_APP, making moves app-exclusive.
+    name: Move floating tags
+    needs: [resolve-toolchain, validate, promote, merge]
+    runs-on: ubuntu-24.04
+    container:
+      image: ${{ needs.resolve-toolchain.outputs.image }}
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GHCR_PULL_TOKEN || github.token }}
+    timeout-minutes: 10
+    if: ${{ needs.merge.result == 'success' && needs.resolve-toolchain.outputs.floating-tags != '' }}
+    permissions:
+      contents: write
+      packages: read
+    defaults:
+      run:
+        shell: bash
+    env:
+      GH_REPO: ${{ github.repository }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+
+      - name: Set up devkit toolchain
+        uses: ./.github/actions/setup-devkit-toolchain
+        with:
+          mode: ${{ needs.resolve-toolchain.outputs.mode }}
+          devkit-version: ${{ needs.resolve-toolchain.outputs.image-tag }}
+
+      - name: Generate release app token
+        id: release_app_token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3
+        with:
+          client-id: ${{ secrets.RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
+      - name: Move floating major/minor tags
+        env:
+          GH_TOKEN: ${{ steps.release_app_token.outputs.token }}
+          VERSION: ${{ needs.validate.outputs.version }}
+          TAG_PREFIX: ${{ needs.resolve-toolchain.outputs.tag-prefix }}
+          FLOATING_TAGS: ${{ needs.resolve-toolchain.outputs.floating-tags }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          RELEASE_TAG="${TAG_PREFIX}${VERSION}"
+
+          # Resolve the commit the release tag points at. release-publish.yml
+          # creates an ANNOTATED tag, so peel it (object.type == "tag") to the
+          # underlying commit; floating tags then point straight at the commit.
+          REF_JSON=$(retry --retries 3 --backoff 5 --max-backoff 30 -- \
+            gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${RELEASE_TAG}")
+          TARGET_SHA=$(printf '%s' "$REF_JSON" | jq -r '.object.sha')
+          OBJ_TYPE=$(printf '%s' "$REF_JSON" | jq -r '.object.type')
+          if [ "$OBJ_TYPE" = "tag" ]; then
+            TARGET_SHA=$(retry --retries 3 --backoff 5 --max-backoff 30 -- \
+              gh api "repos/${GITHUB_REPOSITORY}/git/tags/${TARGET_SHA}" --jq '.object.sha')
+          fi
+          if [ -z "$TARGET_SHA" ] || [ "$TARGET_SHA" = "null" ]; then
+            echo "ERROR: Could not resolve commit for release tag ${RELEASE_TAG}"
+            exit 1
+          fi
+
+          MAJOR="${VERSION%%.*}"
+          REST="${VERSION#*.}"
+          MINOR="${REST%%.*}"
+
+          # Create-or-update a lightweight floating tag at the release commit,
+          # idempotently (skip when it already points there). Force is required
+          # because a floating tag is mutable by design (#1045).
+          move_tag() {
+            name="$1"
+            current=$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${name}" --jq '.object.sha' 2>/dev/null || echo "")
+            if [ "$current" = "$TARGET_SHA" ]; then
+              echo "Floating tag ${name} already at ${TARGET_SHA}; skipping"
+              return 0
+            fi
+            if [ -n "$current" ]; then
+              retry --retries 3 --backoff 5 --max-backoff 30 -- \
+                gh api -X PATCH "repos/${GITHUB_REPOSITORY}/git/refs/tags/${name}" \
+                -f sha="$TARGET_SHA" -F force=true >/dev/null
+              echo "Moved floating tag ${name} -> ${TARGET_SHA}"
+            else
+              retry --retries 3 --backoff 5 --max-backoff 30 -- \
+                gh api "repos/${GITHUB_REPOSITORY}/git/refs" \
+                -f ref="refs/tags/${name}" -f sha="$TARGET_SHA" >/dev/null
+              echo "Created floating tag ${name} -> ${TARGET_SHA}"
+            fi
+          }
+
+          IFS=',' read -ra LEVELS <<< "$FLOATING_TAGS"
+          for level in "${LEVELS[@]}"; do
+            level="${level//[[:space:]]/}"
+            case "$level" in
+              major) move_tag "${TAG_PREFIX}${MAJOR}" ;;
+              minor) move_tag "${TAG_PREFIX}${MAJOR}.${MINOR}" ;;
+              "") ;;
+              *) echo "::warning::Unknown DEVKIT_FLOATING_TAGS level '$level' (expected major or minor); skipping" ;;
+            esac
+          done
+          echo "✓ Floating tag move complete for ${RELEASE_TAG}"

--- a/assets/workspace/.github/workflows/promote-release.yml
+++ b/assets/workspace/.github/workflows/promote-release.yml
@@ -34,6 +34,7 @@ jobs:
       mode: ${{ steps.resolve.outputs.mode }}
       image: ${{ steps.resolve.outputs.image }}
       image-tag: ${{ steps.resolve.outputs.image-tag }}
+      tag-prefix: ${{ steps.resolve.outputs.tag-prefix }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
@@ -109,8 +110,11 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ steps.vars.outputs.version }}
+          TAG_PREFIX: ${{ needs.resolve-toolchain.outputs.tag-prefix }}
         run: |
           set -euo pipefail
+          # The Release/tag published by release.yml carries the prefix (#1044).
+          PROMOTE_TAG="${TAG_PREFIX}${VERSION}"
           RETRIES=5
           LAST_ERROR=""
           RELEASE_JSON=""
@@ -118,12 +122,12 @@ jobs:
             API_OUTPUT=""
             if API_OUTPUT=$(gh api "repos/${GITHUB_REPOSITORY}/releases" --paginate 2>&1); then
               MATCHED=$(printf '%s' "$API_OUTPUT" | \
-                jq -s --arg tag "$VERSION" 'flatten | map(select(.tag_name == $tag)) | .[0] // empty' 2>/dev/null)
+                jq -s --arg tag "$PROMOTE_TAG" 'flatten | map(select(.tag_name == $tag)) | .[0] // empty' 2>/dev/null)
               if printf '%s' "$MATCHED" | jq -e 'type == "object"' >/dev/null 2>&1; then
                 RELEASE_JSON="$MATCHED"
                 break
               fi
-              LAST_ERROR="No release found for tag $VERSION (not in releases list yet)"
+              LAST_ERROR="No release found for tag $PROMOTE_TAG (not in releases list yet)"
               if [ "$i" -lt "$RETRIES" ]; then
                 sleep $((i * 5))
                 continue
@@ -148,12 +152,12 @@ jobs:
                 continue
               fi
             fi
-            echo "ERROR: Unexpected response querying release for tag $VERSION"
+            echo "ERROR: Unexpected response querying release for tag $PROMOTE_TAG"
             echo "$API_OUTPUT"
             exit 1
           done
           if [ -z "$RELEASE_JSON" ]; then
-            echo "ERROR: No GitHub Release for tag $VERSION"
+            echo "ERROR: No GitHub Release for tag $PROMOTE_TAG"
             if [ -n "$LAST_ERROR" ]; then
               echo "$LAST_ERROR"
             fi
@@ -161,10 +165,10 @@ jobs:
           fi
           IS_DRAFT=$(printf '%s' "$RELEASE_JSON" | jq -r '.draft')
           if [ "$IS_DRAFT" != "true" ]; then
-            echo "ERROR: GitHub Release for $VERSION must still be a draft (got draft=$IS_DRAFT)"
+            echo "ERROR: GitHub Release for $PROMOTE_TAG must still be a draft (got draft=$IS_DRAFT)"
             exit 1
           fi
-          echo "✓ Draft GitHub Release exists for $VERSION"
+          echo "✓ Draft GitHub Release exists for $PROMOTE_TAG"
 
       - name: Find and verify release PR
         env:
@@ -276,11 +280,14 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.release_app_token.outputs.token }}
           VERSION: ${{ needs.validate.outputs.version }}
+          TAG_PREFIX: ${{ needs.resolve-toolchain.outputs.tag-prefix }}
         run: |
           set -euo pipefail
+          # The GitHub Release is keyed on the prefixed tag name (#1044).
+          PROMOTE_TAG="${TAG_PREFIX}${VERSION}"
           retry --retries 3 --backoff 5 --max-backoff 30 -- \
-            gh release edit "$VERSION" --draft=false
-          echo "✓ GitHub Release $VERSION published (no longer draft)"
+            gh release edit "$PROMOTE_TAG" --draft=false
+          echo "✓ GitHub Release $PROMOTE_TAG published (no longer draft)"
 
       - name: Summary
         env:
@@ -458,9 +465,13 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.release_app_token.outputs.token }}
           VERSION: ${{ needs.validate.outputs.version }}
+          TAG_PREFIX: ${{ needs.resolve-toolchain.outputs.tag-prefix }}
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
           set -euo pipefail
+          # RC tags carry the prefix (#1044): <prefix>X.Y.Z-rcN. Empty prefix
+          # reproduces the bare X.Y.Z-rc* pattern (today's behavior).
+          RC_BASE="${TAG_PREFIX}${VERSION}"
           TMP=$(mktemp)
           trap 'rm -f "$TMP"' EXIT
 
@@ -470,7 +481,7 @@ jobs:
           # releases — not git tags — reclaims drafts whose RC tag was already
           # removed by an earlier partial run.
           select_rc_draft_releases() {
-            jq -r -s --arg base "$VERSION" '
+            jq -r -s --arg base "$RC_BASE" '
               ( "^" + ($base | gsub("\\.";"\\.")) + "-rc[0-9]+$" ) as $rc
               | (add // [])[]
               | select(.draft == true and .prerelease == true and (.tag_name | test($rc)))
@@ -501,7 +512,7 @@ jobs:
           # tag that still has a GitHub Release attached — a published pre-release,
           # or a draft whose deletion failed above so it stays discoverable.
           TAGS=$(retry --retries 3 --backoff 5 --max-backoff 30 -- \
-            git ls-remote --tags --refs "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "${VERSION}-rc*" \
+            git ls-remote --tags --refs "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "${RC_BASE}-rc*" \
             | awk '{print $2}' | sed 's#refs/tags/##' || true)
           while IFS= read -r tag; do
             [ -z "$tag" ] && continue

--- a/assets/workspace/.github/workflows/release-core.yml
+++ b/assets/workspace/.github/workflows/release-core.yml
@@ -46,6 +46,11 @@ on:  # yamllint disable-line rule:truthy
         required: false
         default: ""
         type: string
+      tag_prefix:
+        description: "Release tag prefix (DEVKIT_TAG_PREFIX); empty => bare X.Y.Z tags"
+        required: false
+        default: ""
+        type: string
     secrets:
       token:
         required: false
@@ -215,8 +220,11 @@ jobs:
           VERSION: ${{ steps.vars.outputs.version }}
           RELEASE_KIND: ${{ steps.vars.outputs.release_kind }}
           INPUT_RC_NUMBER: ${{ inputs.rc_number }}
+          TAG_PREFIX: ${{ inputs.tag_prefix }}
         run: |
           set -euo pipefail
+          # publish_version stays BARE (X.Y.Z / X.Y.Z-rcN); the tag prefix is
+          # composed only when discovering/emitting a tag NAME (#1044).
           NEXT_RC=""
           if [ "$RELEASE_KIND" = "candidate" ]; then
             if [ -n "${INPUT_RC_NUMBER}" ]; then
@@ -232,22 +240,23 @@ jobs:
               PUBLISH_VERSION="${VERSION}-rc${NEXT_RC}"
               echo "Using explicit rc_number=$NEXT_RC -> publish_version=$PUBLISH_VERSION"
             else
-              TAG_PATTERN="${VERSION}-rc*"
+              # Discover existing RC tags under the prefixed tag name, e.g. v1.2.3-rc*.
+              TAG_PATTERN="${TAG_PREFIX}${VERSION}-rc*"
               EXISTING_TAGS=$(git ls-remote --tags --refs origin "$TAG_PATTERN" | awk '{print $2}' | sed 's#refs/tags/##')
 
               MAX_RC=0
               if [ -n "$EXISTING_TAGS" ]; then
                 while IFS= read -r tag; do
                   [ -z "$tag" ] && continue
-                  if [ "${tag#"${VERSION}"-rc}" = "$tag" ]; then
+                  if [ "${tag#"${TAG_PREFIX}${VERSION}"-rc}" = "$tag" ]; then
                     echo "ERROR: Malformed candidate tag detected: $tag"
-                    echo "Expected format: ${VERSION}-rcN"
+                    echo "Expected format: ${TAG_PREFIX}${VERSION}-rcN"
                     exit 1
                   fi
-                  rc_num="${tag#"${VERSION}"-rc}"
+                  rc_num="${tag#"${TAG_PREFIX}${VERSION}"-rc}"
                   if ! echo "$rc_num" | grep -qE '^[0-9]+$'; then
                     echo "ERROR: Malformed candidate tag detected: $tag"
-                    echo "Expected format: ${VERSION}-rcN"
+                    echo "Expected format: ${TAG_PREFIX}${VERSION}-rcN"
                     exit 1
                   fi
                   if [ "$rc_num" -gt "$MAX_RC" ]; then
@@ -414,9 +423,12 @@ jobs:
         env:
           VERSION: ${{ needs.validate.outputs.version }}
           RELEASE_DATE: ${{ needs.validate.outputs.release_date }}
+          TAG_PREFIX: ${{ inputs.tag_prefix }}
         run: |
           set -euo pipefail
-          prepare-changelog finalize "$VERSION" "$RELEASE_DATE" CHANGELOG.md
+          # Prefix composes into the release heading + link only; an empty
+          # prefix reproduces today's bare heading byte-for-byte (#1044).
+          prepare-changelog finalize "$VERSION" "$RELEASE_DATE" CHANGELOG.md --tag-prefix "$TAG_PREFIX"
 
       # Language-neutral, opt-in release artifact. A repo that ships a committed
       # build artifact (e.g. a JS Action's @vercel/ncc `dist/`) exposes a
@@ -546,16 +558,19 @@ jobs:
         id: tag_state
         env:
           PUBLISH_VERSION: ${{ needs.validate.outputs.publish_version }}
+          TAG_PREFIX: ${{ inputs.tag_prefix }}
           FINALIZE_SHA: ${{ steps.finalize.outputs.finalize_sha }}
         run: |
           set -euo pipefail
-          REMOTE_LINE=$(git ls-remote origin "refs/tags/${PUBLISH_VERSION}^{}" || true)
+          # Compose the actual tag name (prefix + bare publish version) (#1044).
+          PUBLISH_TAG="${TAG_PREFIX}${PUBLISH_VERSION}"
+          REMOTE_LINE=$(git ls-remote origin "refs/tags/${PUBLISH_TAG}^{}" || true)
           if [ -z "$REMOTE_LINE" ]; then
-            REMOTE_LINE=$(git ls-remote origin "refs/tags/${PUBLISH_VERSION}" || true)
+            REMOTE_LINE=$(git ls-remote origin "refs/tags/${PUBLISH_TAG}" || true)
           fi
           if [ -z "$REMOTE_LINE" ]; then
             echo "tag_already_exists=false" >> "$GITHUB_OUTPUT"
-            echo "No remote tag ${PUBLISH_VERSION} yet"
+            echo "No remote tag ${PUBLISH_TAG} yet"
             exit 0
           fi
           REMOTE_TARGET_SHA=$(printf '%s\n' "$REMOTE_LINE" | awk '{print $1}')
@@ -564,11 +579,11 @@ jobs:
             exit 0
           fi
           if [ "$REMOTE_TARGET_SHA" != "$FINALIZE_SHA" ]; then
-            echo "ERROR: Tag $PUBLISH_VERSION exists but target commit is $REMOTE_TARGET_SHA; expected $FINALIZE_SHA (finalize SHA)"
+            echo "ERROR: Tag $PUBLISH_TAG exists but target commit is $REMOTE_TARGET_SHA; expected $FINALIZE_SHA (finalize SHA)"
             exit 1
           fi
           echo "tag_already_exists=true" >> "$GITHUB_OUTPUT"
-          echo "Remote tag $PUBLISH_VERSION already points to finalize SHA; publish will skip tag create/push"
+          echo "Remote tag $PUBLISH_TAG already points to finalize SHA; publish will skip tag create/push"
 
   test:
     name: Test Finalized Release

--- a/assets/workspace/.github/workflows/release-publish.yml
+++ b/assets/workspace/.github/workflows/release-publish.yml
@@ -59,6 +59,11 @@ on:  # yamllint disable-line rule:truthy
         required: false
         default: ""
         type: string
+      tag_prefix:
+        description: "Release tag prefix (DEVKIT_TAG_PREFIX); empty => bare X.Y.Z tags"
+        required: false
+        default: ""
+        type: string
     secrets:
       token:
         required: false
@@ -164,29 +169,32 @@ jobs:
         if: ${{ !inputs.tag_already_exists }}
         env:
           PUBLISH_VERSION: ${{ inputs.publish_version }}
+          TAG_PREFIX: ${{ inputs.tag_prefix }}
         run: |
           set -euo pipefail
-          git tag -a "$PUBLISH_VERSION" -m "Release $PUBLISH_VERSION"
-          if ! retry --retries 3 --backoff 5 --max-backoff 30 -- git push origin "$PUBLISH_VERSION"; then
-            if retry --retries 3 --backoff 5 --max-backoff 30 -- git ls-remote --tags --refs origin "$PUBLISH_VERSION" | grep -q "refs/tags/$PUBLISH_VERSION$"; then
-              LOCAL_TAG_TARGET_SHA=$(git rev-parse "$PUBLISH_VERSION^{}")
-              REMOTE_TAG_TARGET_SHA=$(retry --retries 3 --backoff 5 --max-backoff 30 -- git ls-remote --tags origin "refs/tags/$PUBLISH_VERSION^{}" | awk '{print $1}')
+          # Compose the actual tag name (prefix + bare publish version) (#1044).
+          PUBLISH_TAG="${TAG_PREFIX}${PUBLISH_VERSION}"
+          git tag -a "$PUBLISH_TAG" -m "Release $PUBLISH_TAG"
+          if ! retry --retries 3 --backoff 5 --max-backoff 30 -- git push origin "$PUBLISH_TAG"; then
+            if retry --retries 3 --backoff 5 --max-backoff 30 -- git ls-remote --tags --refs origin "$PUBLISH_TAG" | grep -q "refs/tags/$PUBLISH_TAG$"; then
+              LOCAL_TAG_TARGET_SHA=$(git rev-parse "$PUBLISH_TAG^{}")
+              REMOTE_TAG_TARGET_SHA=$(retry --retries 3 --backoff 5 --max-backoff 30 -- git ls-remote --tags origin "refs/tags/$PUBLISH_TAG^{}" | awk '{print $1}')
               if [ -z "$REMOTE_TAG_TARGET_SHA" ]; then
-                REMOTE_TAG_TARGET_SHA=$(retry --retries 3 --backoff 5 --max-backoff 30 -- git ls-remote --tags origin "refs/tags/$PUBLISH_VERSION" | awk '{print $1}')
+                REMOTE_TAG_TARGET_SHA=$(retry --retries 3 --backoff 5 --max-backoff 30 -- git ls-remote --tags origin "refs/tags/$PUBLISH_TAG" | awk '{print $1}')
               fi
               if [ -z "$REMOTE_TAG_TARGET_SHA" ]; then
-                echo "ERROR: Remote tag exists but target SHA could not be resolved: $PUBLISH_VERSION"
+                echo "ERROR: Remote tag exists but target SHA could not be resolved: $PUBLISH_TAG"
                 exit 1
               fi
               if [ "$REMOTE_TAG_TARGET_SHA" != "$LOCAL_TAG_TARGET_SHA" ]; then
-                echo "ERROR: Remote tag target SHA mismatch for $PUBLISH_VERSION"
+                echo "ERROR: Remote tag target SHA mismatch for $PUBLISH_TAG"
                 echo "Local tag target:  $LOCAL_TAG_TARGET_SHA"
                 echo "Remote tag target: $REMOTE_TAG_TARGET_SHA"
                 exit 1
               fi
-              echo "Tag already present on origin with matching target SHA: $PUBLISH_VERSION"
+              echo "Tag already present on origin with matching target SHA: $PUBLISH_TAG"
             else
-              echo "ERROR: Failed to push tag $PUBLISH_VERSION"
+              echo "ERROR: Failed to push tag $PUBLISH_TAG"
               exit 1
             fi
           fi
@@ -209,36 +217,39 @@ jobs:
         if: ${{ inputs.release_kind == 'final' || (inputs.release_kind == 'candidate' && inputs.create_release) }}
         env:
           PUBLISH_VERSION: ${{ inputs.publish_version }}
+          TAG_PREFIX: ${{ inputs.tag_prefix }}
           RELEASE_KIND: ${{ inputs.release_kind }}
           GH_TOKEN: ${{ steps.auth.outputs.token }}
         run: |
           set -euo pipefail
-          if RELEASE_JSON=$(retry --retries 2 --backoff 5 --max-backoff 20 -- gh release view "$PUBLISH_VERSION" --json isDraft,isPrerelease 2>/dev/null); then
+          # Release object is keyed on the actual (prefixed) tag name (#1044).
+          PUBLISH_TAG="${TAG_PREFIX}${PUBLISH_VERSION}"
+          if RELEASE_JSON=$(retry --retries 2 --backoff 5 --max-backoff 20 -- gh release view "$PUBLISH_TAG" --json isDraft,isPrerelease 2>/dev/null); then
             IS_DRAFT=$(printf '%s' "$RELEASE_JSON" | jq -r '.isDraft')
             if [ "$IS_DRAFT" = "true" ]; then
-              echo "Draft GitHub Release already exists for $PUBLISH_VERSION; skipping create (retry path)."
+              echo "Draft GitHub Release already exists for $PUBLISH_TAG; skipping create (retry path)."
               exit 0
             fi
             if [ "$RELEASE_KIND" = "candidate" ]; then
               IS_PRERELEASE=$(printf '%s' "$RELEASE_JSON" | jq -r '.isPrerelease')
               if [ "$IS_PRERELEASE" = "true" ]; then
-                echo "Pre-release already exists for $PUBLISH_VERSION; skipping create (candidate retry path)."
+                echo "Pre-release already exists for $PUBLISH_TAG; skipping create (candidate retry path)."
                 exit 0
               fi
             fi
-            echo "ERROR: Published (non-draft) GitHub Release already exists for tag $PUBLISH_VERSION"
+            echo "ERROR: Published (non-draft) GitHub Release already exists for tag $PUBLISH_TAG"
             exit 1
           fi
           if [ "$RELEASE_KIND" = "candidate" ]; then
-            retry --retries 3 --backoff 5 --max-backoff 30 -- gh release create "$PUBLISH_VERSION" \
-              --title "$PUBLISH_VERSION" \
+            retry --retries 3 --backoff 5 --max-backoff 30 -- gh release create "$PUBLISH_TAG" \
+              --title "$PUBLISH_TAG" \
               --notes-file /tmp/release-notes.md \
               --verify-tag \
               --draft \
               --prerelease
           else
-            retry --retries 3 --backoff 5 --max-backoff 30 -- gh release create "$PUBLISH_VERSION" \
-              --title "$PUBLISH_VERSION" \
+            retry --retries 3 --backoff 5 --max-backoff 30 -- gh release create "$PUBLISH_TAG" \
+              --title "$PUBLISH_TAG" \
               --notes-file /tmp/release-notes.md \
               --verify-tag \
               --draft
@@ -249,7 +260,10 @@ jobs:
         id: out
         env:
           PUBLISH_VERSION: ${{ inputs.publish_version }}
-          RELEASE_URL: ${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ inputs.publish_version }}
+          TAG_PREFIX: ${{ inputs.tag_prefix }}
+          RELEASE_BASE: ${{ github.server_url }}/${{ github.repository }}
         run: |
-          echo "tag=$PUBLISH_VERSION" >> "$GITHUB_OUTPUT"
-          echo "release_url=$RELEASE_URL" >> "$GITHUB_OUTPUT"
+          # Published tag and its release URL both carry the prefix (#1044).
+          PUBLISH_TAG="${TAG_PREFIX}${PUBLISH_VERSION}"
+          echo "tag=$PUBLISH_TAG" >> "$GITHUB_OUTPUT"
+          echo "release_url=${RELEASE_BASE}/releases/tag/${PUBLISH_TAG}" >> "$GITHUB_OUTPUT"

--- a/assets/workspace/.github/workflows/release.yml
+++ b/assets/workspace/.github/workflows/release.yml
@@ -58,6 +58,7 @@ jobs:
       mode: ${{ steps.resolve.outputs.mode }}
       image: ${{ steps.resolve.outputs.image }}
       image-tag: ${{ steps.resolve.outputs.image-tag }}
+      tag-prefix: ${{ steps.resolve.outputs.tag-prefix }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
@@ -93,6 +94,7 @@ jobs:
       toolchain_mode: ${{ needs.resolve-toolchain.outputs.mode }}
       toolchain_image: ${{ needs.resolve-toolchain.outputs.image }}
       devkit_version: ${{ needs.resolve-toolchain.outputs.image-tag }}
+      tag_prefix: ${{ needs.resolve-toolchain.outputs.tag-prefix }}
     secrets: inherit
 
   extension:
@@ -129,6 +131,7 @@ jobs:
       toolchain_mode: ${{ needs.resolve-toolchain.outputs.mode }}
       toolchain_image: ${{ needs.resolve-toolchain.outputs.image }}
       devkit_version: ${{ needs.resolve-toolchain.outputs.image-tag }}
+      tag_prefix: ${{ needs.resolve-toolchain.outputs.tag-prefix }}
     secrets: inherit
 
   rollback:

--- a/assets/workspace/.vig-os
+++ b/assets/workspace/.vig-os
@@ -23,3 +23,10 @@ DEVKIT_REPO=
 # Reserved: space-separated capability modules for the project dev-shell,
 # mirroring mkProjectShell's `modules = [ ... ]` in flake.nix (#884).
 DEVKIT_MODULES=""
+
+# Release tag prefix applied ONLY at the publishing edge — the pushed tag name
+# and the changelog release link. Empty (default) => bare X.Y.Z tags (no change
+# for devkit or existing consumers). Action-publishing repos set `v` for the
+# `actions/checkout@v5` ecosystem convention (#1044). The `version` input, the
+# `release/X.Y.Z` branch name, and the `## [X.Y.Z]` freeze heading stay bare.
+DEVKIT_TAG_PREFIX=

--- a/assets/workspace/.vig-os
+++ b/assets/workspace/.vig-os
@@ -30,3 +30,9 @@ DEVKIT_MODULES=""
 # `actions/checkout@v5` ecosystem convention (#1044). The `version` input, the
 # `release/X.Y.Z` branch name, and the `## [X.Y.Z]` freeze heading stay bare.
 DEVKIT_TAG_PREFIX=
+
+# Opt-in floating major/minor tags, force-moved at promote to the final release
+# commit (comma-separated subset of `major,minor`; empty/absent => off). e.g.
+# `major,minor` moves <prefix>X and <prefix>X.Y so consumers can pin
+# `uses: owner/repo@v0`. Composes with DEVKIT_TAG_PREFIX; final releases only (#1045).
+DEVKIT_FLOATING_TAGS=

--- a/assets/workspace/docs/DOWNSTREAM_RELEASE.md
+++ b/assets/workspace/docs/DOWNSTREAM_RELEASE.md
@@ -1,0 +1,202 @@
+# Downstream Release Workflows
+
+This document is the **only** place that describes the release process for **consumer projects** that install workflows from `assets/workspace/`. The upstream devcontainer and smoke-test validation flow is documented in [`docs/RELEASE_CYCLE.md`](RELEASE_CYCLE.md) and [`docs/CROSS_REPO_RELEASE_GATE.md`](CROSS_REPO_RELEASE_GATE.md).
+
+## Overview
+
+The downstream template uses a split release architecture:
+
+- `prepare-release.yml` (`workflow_dispatch`) prepares `release/X.Y.Z`
+- `release.yml` (`workflow_dispatch`) orchestrates:
+  - `release-core.yml` (`workflow_call`)
+  - `release-extension.yml` (`workflow_call`, project-owned)
+  - `release-publish.yml` (`workflow_call`)
+- `promote-release.yml` (`workflow_dispatch`) runs **after** a successful final `release.yml`: validates draft GitHub Release and release PR state, publishes the release, merges `release/X.Y.Z` to `main`, and best-effort cleans up remote git RC tags without a GitHub Release (no GHCR/cosign; see [Promote release (final)](#promote-release-final))
+
+All files are deployed from `assets/workspace/` by `init-workspace.sh`.
+
+On failure, the orchestrator runs a single consolidated rollback that resets the release branch (best-effort), does **not** delete tags (forward-fix policy), and opens a failure issue with forward-fix guidance.
+
+## Release Modes
+
+`release.yml` supports two release modes via `release_kind`:
+
+- `candidate` (default): computes and publishes the next `X.Y.Z-rcN` git tag; optional workflow input **`create-release`** (default `false`) also creates a **draft** GitHub **pre-release**. Use optional `rc-number` to pin `N` when orchestrating from an upstream dispatch (see `docs/CROSS_REPO_RELEASE_GATE.md`). The smoke-test template passes `create-release=true` when it runs the workspace `release.yml` for a candidate.
+- `final`: publishes `X.Y.Z`, finalizes `CHANGELOG.md` release date, runs `sync-issues`, and creates a **draft** GitHub Release (publish from the UI when review is complete; aligns with GitHub’s [immutable releases](https://docs.github.com/en/code-security/concepts/supply-chain-security/immutable-releases) and [draft-first guidance](https://docs.github.com/en/code-security/concepts/supply-chain-security/immutable-releases#best-practices-for-publishing-immutable-releases))
+
+Candidate mode keeps release branch content unchanged (no CHANGELOG date finalization). Final mode performs changelog finalization before publish.
+
+## Immutable releases, tag rulesets, and forward-fix policy (downstream)
+
+- **Candidate (`X.Y.Z-rcN`)**: By default only the git tag is created. With **`create-release: true`**, `release-publish.yml` creates a **draft** GitHub **pre-release** (`gh release create --draft --prerelease`). Promote-time validation uses `gh api .../releases/tags/<tag>` and inspects `.draft` to ensure the expected draft pre-release exists; see [Cross-repo gate](CROSS_REPO_RELEASE_GATE.md) for upstream enforcement status. With **immutable releases** enabled, **publishing** a pre-release locks the **linked** tag and assets (see [upstream policy](RELEASE_CYCLE.md#immutable-releases-tag-rulesets-and-forward-fix-policy)); iterate with a **new** RC tag.
+- **Final (`X.Y.Z`)**: Automation creates a **draft** GitHub Release; **publishing** it (UI or `promote-release.yml`) applies immutable-release lock-in for the linked tag and assets when that setting is enabled. Enable **immutable releases** and **tag rulesets** on each consumer repository (and org policy) as needed; see [Preventing changes to your releases](https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/preventing-changes-to-your-releases).
+- **Rollback**: The orchestrator resets the release branch and does **not** delete tags (forward-fix policy); recover with a new RC or a careful final retry per workflow logs.
+
+## Promote release (final)
+
+After final `release.yml` has pushed tag `X.Y.Z` and created a **draft** GitHub Release, run **`promote-release.yml`** (or `just promote-release X.Y.Z` from the devcontainer; dispatches on `release/X.Y.Z` by default) to:
+
+1. **Validate** — semver, draft release for `X.Y.Z`, release PR not draft / approved / CI green
+2. **Promote** — `gh release edit --draft=false`
+3. **Merge** — merge `release/X.Y.Z` → `main` (triggers `sync-main-to-dev` when configured)
+4. **Cleanup** (best-effort, does not fail the workflow) — delete remote git tags matching `${VERSION}-rc*` that have **no** GitHub Release
+
+**Upstream (`vig-os/devcontainer`) only:** Root `promote-release.yml` also prunes GHCR RC package versions via the org Packages API using **`GITHUB_TOKEN`** with **repo Admin** on the `devcontainer` package (one-time **Manage Actions access** grant). See [GitHub App Configuration](RELEASE_CYCLE.md#github-app-configuration) and [Registry and cleanup tokens](RELEASE_CYCLE.md#registry-and-cleanup-tokens-upstream) in `docs/RELEASE_CYCLE.md`.
+
+This template does **not** implement upstream-only steps (GHCR `:latest`, cosign, cross-repo smoke-test gate). Projects that need registry or deploy promotion after merge should run separate automation or extend their `release-extension.yml` / own workflows; see [Extension Hook](#extension-hook).
+
+## Workflow Interface
+
+The orchestrator `release.yml` passes release context directly to the called reusable workflows:
+
+- `.github/workflows/release-core.yml`
+- `.github/workflows/release-extension.yml`
+- `.github/workflows/release-publish.yml`
+
+There is no separate contract-version handshake; compatibility is defined by the `workflow_call` input schema in each workflow file.
+
+`promote-release.yml` is a standalone `workflow_dispatch` workflow (input: `version`); it does not call the reusable workflows above.
+
+## Toolchain provisioning is mode-aware
+
+Since [#991](https://github.com/vig-os/devkit/issues/991), the whole
+release/automation set provisions its toolchain per `DEVKIT_MODE`
+(`.vig-os`), following the conditional-`container:` pattern in
+[`docs/rfcs/ADR-conditional-container-toolchain.md`](rfcs/ADR-conditional-container-toolchain.md):
+
+- Each `workflow_dispatch`/event-triggered workflow (`release.yml`,
+  `prepare-release.yml`, `promote-release.yml`, `sync-issues.yml`,
+  `renovate-changelog-build.yml`, `sync-main-to-dev.yml`) runs a leading
+  **`resolve-toolchain`** job that reads `.vig-os` and emits `mode`, `image`, and
+  `image-tag`. The `image` is the devcontainer image in the container modes
+  (`devcontainer`/`both`) and an **explicit empty string** in the host modes
+  (`direnv`/`bare`), which makes each downstream `container:` job run directly on
+  the runner. `prepare-release.yml` runs the same composite **inline** in its host
+  `validate` job and exposes the outputs to the `prepare` job.
+- Every job then runs the **`setup-devkit-toolchain`** composite as its first
+  step after checkout: it is a no-op-friendly preamble that exports the in-image
+  env in the container modes, builds the repo's flake dev-shell in `direnv`, or
+  `uv tool install`s the pinned host toolchain (incl. `vig-utils`) in `bare`.
+- The orchestrator `release.yml` **resolves once** and threads the result into
+  the reusable workflows via the `toolchain_mode`, `toolchain_image`, and
+  `devkit_version` `workflow_call` inputs; `release-core.yml` /
+  `release-publish.yml` do **not** re-resolve.
+
+This is a toolchain-provisioning change only — the release **choreography** (step
+logic, ordering, `workflow_call` inputs/outputs, and rollback semantics) is
+unchanged across all modes. Host-mode runners already provide `git`, `gh`, and
+`jq`; `just`, `uv`, `prek`, `retry`, and the `vig-utils` release scripts
+(`prepare-changelog`, `renovate-changelog-pr`) come from the composite, so the
+choreography's bare `run:` invocations are identical in every mode. In `bare`
+mode the composite pins `vig-utils` to the `.vig-os` `DEVKIT_VERSION`
+(`renovate-changelog-pr` in `renovate-changelog-build.yml`, `prepare-changelog`
+in `prepare-release.yml` / `release-core.yml`); see
+[`docs/MIGRATION.md`](MIGRATION.md#bare-mode-vig-utils-release-console-scripts).
+
+## Required App Secrets
+
+Downstream repositories are expected to provide both app credentials:
+
+- `COMMIT_APP_ID` (required by `vig-os/sync-issues-action` in `sync-issues.yml`)
+- `COMMIT_APP_CLIENT_ID`
+- `COMMIT_APP_PRIVATE_KEY`
+- `RELEASE_APP_CLIENT_ID`
+- `RELEASE_APP_PRIVATE_KEY`
+
+Template behavior relies on explicit app-token generation for release operations:
+
+- use **Commit App** token for protected branch/ref writes (`commit-action`, branch/tag mutation)
+- use **Release App** token for release orchestration and PR/release API operations
+
+`github.token` is intentionally not used as a fallback for these release write paths.
+
+## Input Naming Convention
+
+All `workflow_call` inputs use underscores (e.g. `release_kind`, `dry_run`, `git_user_name`). The orchestrator `release.yml` translates its own `workflow_dispatch` hyphenated inputs at each call site.
+
+## Extension Hook
+
+Project-specific release behavior belongs in `.github/workflows/release-extension.yml`.
+
+Default template behavior is no-op. Projects can customize this workflow for tasks such as:
+
+- package publishing
+- container publishing
+- signing and attestations
+- release artifact upload
+
+Extension contract inputs include both `release_kind` and `publish_version`, so custom logic can branch on candidate vs final behavior.
+
+`release.yml` requires extension success before publish, so extension failures block release publication.
+
+## Cross-Repo Validation Gate
+
+Cross-repository validation gate details are documented in `docs/CROSS_REPO_RELEASE_GATE.md`.
+
+### Example: GHCR Publishing
+
+The following shows how a downstream project could customize `release-extension.yml` to build and push a container image to GHCR:
+
+```yaml
+name: Release Extension
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        required: true
+        type: string
+      finalize_sha:
+        required: true
+        type: string
+      release_date:
+        required: true
+        type: string
+      release_kind:
+        required: true
+        type: string
+      publish_version:
+        required: true
+        type: string
+jobs:
+  ghcr-publish:
+    name: Publish Container Image
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout finalized commit
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.finalize_sha }}
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}:${{ inputs.publish_version }}
+            ${{ inputs.release_kind == 'final' && format('ghcr.io/{0}:latest', github.repository) || '' }}
+```
+
+## Upgrade Path
+
+1. Upgrade downstream devcontainer version (which redeploys `assets/workspace` templates).
+2. Keep project-owned `release-extension.yml` (preserved on force upgrades).
+3. Ensure project-owned `release-extension.yml` matches the current `workflow_call` inputs used by `release.yml`.
+4. Run `prepare-release` / `release` in `--dry-run` mode to validate integration.
+
+## Pinning and Drift
+
+Release workflow logic is centralized in shipped local reusable workflows (`release-core.yml`, `release-publish.yml`) while extension logic remains project-owned (`release-extension.yml`).
+
+This reduces drift in release safety checks while preserving downstream customization boundaries.

--- a/packages/vig-utils/src/vig_utils/prepare_changelog.py
+++ b/packages/vig-utils/src/vig_utils/prepare_changelog.py
@@ -407,6 +407,7 @@ def finalize_release_date(
     filepath="CHANGELOG.md",
     *,
     github_repository: str | None = None,
+    tag_prefix: str = "",
 ):
     """
     Replace TBD date with actual release date for a version.
@@ -415,11 +416,18 @@ def finalize_release_date(
     for this repository (``owner/repo`` from ``github_repository`` or the
     ``GITHUB_REPOSITORY`` environment variable).
 
+    ``tag_prefix`` composes the published tag name onto the ``version`` for the
+    displayed heading and the release link (e.g. ``v`` → ``## [v0.3.0](…/tag/v0.3.0)``),
+    matching ``DEVKIT_TAG_PREFIX`` in the release pipeline (#1044). The ``## [X.Y.Z]
+    - TBD`` placeholder matched in the file stays bare; only the emitted tag name
+    and URL carry the prefix. An empty prefix reproduces today's output byte-for-byte.
+
     Args:
         version: Semantic version (e.g., "1.0.0")
         release_date: Release date in ISO format (YYYY-MM-DD)
         filepath: Path to CHANGELOG.md
         github_repository: ``owner/repo`` slug; when omitted, ``GITHUB_REPOSITORY`` is used
+        tag_prefix: Optional tag-name prefix (default empty = bare ``X.Y.Z`` tags)
 
     Raises:
         ValueError: If version format is invalid, date format is invalid,
@@ -441,18 +449,19 @@ def finalize_release_date(
 
     content = path.read_text()
 
+    # Published tag name = prefix + bare version (empty prefix ⇒ bare tag).
+    tag = f"{tag_prefix}{version}"
+
     # Idempotency (#612): a reused release branch can re-run finalize against a
     # heading this tool already dated. Detect the linked-and-dated form finalize
-    # itself writes (## [X.Y.Z](…) - YYYY-MM-DD) and treat a re-run as a no-op so
+    # itself writes (## [<tag>](…) - YYYY-MM-DD) and treat a re-run as a no-op so
     # candidate→final on one base version stays idempotent. A plain dated heading
     # with no release link (a historical entry) is still rejected below.
-    finalized_pattern = (
-        rf"## \[{re.escape(version)}\]\([^)]*\) - \d{{4}}-\d{{2}}-\d{{2}}"
-    )
+    finalized_pattern = rf"## \[{re.escape(tag)}\]\([^)]*\) - \d{{4}}-\d{{2}}-\d{{2}}"
     if re.search(finalized_pattern, content):
         return
 
-    # Check if version with TBD exists
+    # Check if version with TBD exists (the placeholder heading stays bare).
     version_pattern = rf"## \[{re.escape(version)}\] - TBD"
     if not re.search(version_pattern, content):
         raise ValueError(
@@ -460,8 +469,8 @@ def finalize_release_date(
         )
 
     repo_slug = _resolve_github_repository(github_repository)
-    tag_url = f"https://github.com/{repo_slug}/releases/tag/{version}"
-    replacement = f"## [{version}]({tag_url}) - {release_date}"
+    tag_url = f"https://github.com/{repo_slug}/releases/tag/{tag}"
+    replacement = f"## [{tag}]({tag_url}) - {release_date}"
     new_content = re.sub(version_pattern, replacement, content)
 
     # Write back
@@ -525,6 +534,7 @@ def cmd_finalize(args):
         args.date,
         args.file,
         github_repository=args.github_repository,
+        tag_prefix=args.tag_prefix,
     )
 
     print(f"✓ Set release date for version {args.version}")
@@ -666,6 +676,16 @@ Examples:
         help=(
             "Repository slug for the release tag link "
             "(default: GITHUB_REPOSITORY environment variable)"
+        ),
+    )
+    finalize_parser.add_argument(
+        "--tag-prefix",
+        dest="tag_prefix",
+        default="",
+        metavar="PREFIX",
+        help=(
+            "Tag-name prefix composed onto the release heading and link "
+            "(e.g. 'v'; default empty = bare X.Y.Z tags)"
         ),
     )
     finalize_parser.set_defaults(func=cmd_finalize)

--- a/packages/vig-utils/tests/test_prepare_changelog.py
+++ b/packages/vig-utils/tests/test_prepare_changelog.py
@@ -1410,6 +1410,90 @@ class TestFinalizeReleaseDate:
 
 
 # ═════════════════════════════════════════════════════════════════════════════
+# Tag prefix (#1044): finalize composes DEVKIT_TAG_PREFIX into the heading + URL
+# ═════════════════════════════════════════════════════════════════════════════
+
+
+class TestFinalizeTagPrefix:
+    """finalize_release_date(..., tag_prefix=...) for Action-publishing repos."""
+
+    def test_empty_prefix_is_byte_identical(self, tmp_path):
+        """An explicit empty prefix reproduces today's output byte-for-byte."""
+        default = tmp_path / "default.md"
+        empty = tmp_path / "empty.md"
+        default.write_text(CHANGELOG_WITH_TBD)
+        empty.write_text(CHANGELOG_WITH_TBD)
+        finalize_release_date(
+            "1.0.0", "2026-02-11", str(default), github_repository=_FINALIZE_TEST_REPO
+        )
+        finalize_release_date(
+            "1.0.0",
+            "2026-02-11",
+            str(empty),
+            github_repository=_FINALIZE_TEST_REPO,
+            tag_prefix="",
+        )
+        assert empty.read_text() == default.read_text()
+
+    def test_prefix_applies_to_heading_and_url(self, tmp_path):
+        """A non-empty prefix prefixes both the displayed heading and the tag URL."""
+        f = tmp_path / "CHANGELOG.md"
+        f.write_text(CHANGELOG_WITH_TBD)
+        finalize_release_date(
+            "1.0.0",
+            "2026-02-11",
+            str(f),
+            github_repository=_FINALIZE_TEST_REPO,
+            tag_prefix="v",
+        )
+        content = f.read_text()
+        assert (
+            f"## [v1.0.0](https://github.com/{_FINALIZE_TEST_REPO}/releases/tag/v1.0.0) - 2026-02-11"
+            in content
+        )
+        # The bare TBD heading is consumed; no bare release link is emitted.
+        assert "## [1.0.0] - TBD" not in content
+        assert "releases/tag/1.0.0)" not in content
+
+    def test_version_input_stays_bare(self, tmp_path):
+        """Only the tag name/URL is prefixed; other version headings are untouched."""
+        f = tmp_path / "CHANGELOG.md"
+        f.write_text(CHANGELOG_WITH_TBD)
+        finalize_release_date(
+            "1.0.0",
+            "2026-02-11",
+            str(f),
+            github_repository=_FINALIZE_TEST_REPO,
+            tag_prefix="v",
+        )
+        content = f.read_text()
+        # A historical release heading is not rewritten by the prefix.
+        assert "## [0.2.0] - 2026-01-01" in content
+        assert "## Unreleased" in content
+
+    def test_idempotent_with_prefix(self, tmp_path):
+        """Re-running finalize with the same prefix is a no-op on the dated heading."""
+        f = tmp_path / "CHANGELOG.md"
+        f.write_text(CHANGELOG_WITH_TBD)
+        finalize_release_date(
+            "1.0.0",
+            "2026-02-11",
+            str(f),
+            github_repository=_FINALIZE_TEST_REPO,
+            tag_prefix="v",
+        )
+        after_first = f.read_text()
+        finalize_release_date(
+            "1.0.0",
+            "2026-03-01",
+            str(f),
+            github_repository=_FINALIZE_TEST_REPO,
+            tag_prefix="v",
+        )
+        assert f.read_text() == after_first
+
+
+# ═════════════════════════════════════════════════════════════════════════════
 # Full prepare → finalize cycle
 # ═════════════════════════════════════════════════════════════════════════════
 
@@ -1583,7 +1667,12 @@ class TestCmdFinalize:
     """Tests for cmd_finalize handler."""
 
     def _make_args(
-        self, version, date, filepath, github_repository=_FINALIZE_TEST_REPO
+        self,
+        version,
+        date,
+        filepath,
+        github_repository=_FINALIZE_TEST_REPO,
+        tag_prefix="",
     ):
         from argparse import Namespace
 
@@ -1592,6 +1681,7 @@ class TestCmdFinalize:
             date=date,
             file=filepath,
             github_repository=github_repository,
+            tag_prefix=tag_prefix,
         )
 
     def test_success_output(self, tmp_path, capsys):
@@ -1602,6 +1692,16 @@ class TestCmdFinalize:
         out = capsys.readouterr().out
         assert "1.0.0" in out
         assert "2026-02-11" in out
+
+    def test_applies_tag_prefix(self, tmp_path):
+        """cmd_finalize threads the tag prefix into the heading/URL."""
+        f = tmp_path / "CHANGELOG.md"
+        f.write_text(CHANGELOG_WITH_TBD)
+        cmd_finalize(self._make_args("1.0.0", "2026-02-11", str(f), tag_prefix="v"))
+        assert (
+            f"## [v1.0.0](https://github.com/{_FINALIZE_TEST_REPO}/releases/tag/v1.0.0) - 2026-02-11"
+            in f.read_text()
+        )
 
 
 # ═════════════════════════════════════════════════════════════════════════════
@@ -1669,6 +1769,30 @@ class TestMainCLI:
             main()
         assert (
             f"## [1.0.0](https://github.com/{_FINALIZE_TEST_REPO}/releases/tag/1.0.0) - 2026-02-11"
+            in f.read_text()
+        )
+
+    def test_finalize_tag_prefix_via_main(self, tmp_path):
+        """main() 'finalize --tag-prefix v' prefixes the heading and release link."""
+        f = tmp_path / "CHANGELOG.md"
+        f.write_text(CHANGELOG_WITH_TBD)
+        with patch(
+            "sys.argv",
+            [
+                "prog",
+                "finalize",
+                "1.0.0",
+                "2026-02-11",
+                str(f),
+                "--github-repository",
+                _FINALIZE_TEST_REPO,
+                "--tag-prefix",
+                "v",
+            ],
+        ):
+            main()
+        assert (
+            f"## [v1.0.0](https://github.com/{_FINALIZE_TEST_REPO}/releases/tag/v1.0.0) - 2026-02-11"
             in f.read_text()
         )
 

--- a/scripts/manifest.toml
+++ b/scripts/manifest.toml
@@ -9,6 +9,12 @@
 [[entries]]
 src = "docs/COMMIT_MESSAGE_STANDARD.md"
 
+# The downstream release contract referenced by the scaffolded promote-release.yml
+# header ("See docs/DOWNSTREAM_RELEASE.md"). Managed file: the root doc is the
+# SSoT, synced verbatim into the consumer scaffold so the reference resolves (#1046).
+[[entries]]
+src = "docs/DOWNSTREAM_RELEASE.md"
+
 # Agent skills/config live in .claude/ (SSoT, #626). They sync into the
 # downstream template under assets/workspace/.claude/. Workflow rules became
 # skills (synced below) and static principles moved into CLAUDE.md. The template

--- a/tests/test_floating_tags.py
+++ b/tests/test_floating_tags.py
@@ -1,0 +1,71 @@
+"""Workflow-shape tests: DEVKIT_FLOATING_TAGS moved by scaffold promote-release.
+
+Issue #1045: an opt-in ``.vig-os`` key (comma-separated subset of ``major,minor``)
+makes the scaffolded ``promote-release.yml`` force-move floating ``<prefix>X`` /
+``<prefix>X.Y`` tags to the promoted release commit — but only after the Release
+is published and the release PR is merged (the post-acceptance gate).
+
+These assertions pin the wiring: resolve-toolchain emits ``floating-tags``, the
+promote workflow threads it, and the move job is gated on merge success and the
+opt-in being set. The tag-move choreography itself is bash and not unit-testable
+here.
+
+Refs: #1045
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+WORKSPACE = REPO_ROOT / "assets" / "workspace"
+WORKFLOWS = WORKSPACE / ".github" / "workflows"
+
+
+def _load(path: Path) -> dict:
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def test_vig_os_declares_floating_tags_key() -> None:
+    """The scaffold manifest ships the opt-in key (default empty)."""
+    text = (WORKSPACE / ".vig-os").read_text(encoding="utf-8")
+    assert "DEVKIT_FLOATING_TAGS=" in text
+
+
+def test_resolve_toolchain_emits_floating_tags_output() -> None:
+    """resolve-toolchain declares a floating-tags output."""
+    action = _load(WORKFLOWS.parent / "actions" / "resolve-toolchain" / "action.yml")
+    assert "floating-tags" in action["outputs"]
+
+
+def test_promote_resolve_job_exposes_floating_tags() -> None:
+    """promote-release's resolve-toolchain job re-exposes the floating-tags output."""
+    workflow = _load(WORKFLOWS / "promote-release.yml")
+    resolve_out = workflow["jobs"]["resolve-toolchain"]["outputs"]
+    assert "floating-tags" in resolve_out
+
+
+def test_promote_has_floating_tags_job_gated_after_merge() -> None:
+    """A dedicated move job runs only after merge success and when the opt-in is set."""
+    workflow = _load(WORKFLOWS / "promote-release.yml")
+    jobs = workflow["jobs"]
+    assert "floating-tags" in jobs
+    job = jobs["floating-tags"]
+    # Runs after the acceptance gate: Release published (promote) + PR merged.
+    assert "merge" in job["needs"]
+    guard = job["if"]
+    assert "needs.merge.result == 'success'" in guard
+    assert "floating-tags" in guard  # off unless DEVKIT_FLOATING_TAGS is set
+
+
+def test_floating_tags_job_threads_prefix_and_version() -> None:
+    """The move step consumes the tag prefix, floating levels, and the version."""
+    workflow = _load(WORKFLOWS / "promote-release.yml")
+    steps = workflow["jobs"]["floating-tags"]["steps"]
+    move = next(s for s in steps if "floating" in str(s.get("name", "")).lower())
+    env = move["env"]
+    assert "TAG_PREFIX" in env
+    assert "FLOATING_TAGS" in env
+    assert "VERSION" in env

--- a/tests/test_release_tag_prefix.py
+++ b/tests/test_release_tag_prefix.py
@@ -1,0 +1,57 @@
+"""Workflow-shape tests: DEVKIT_TAG_PREFIX threading in the scaffold release set.
+
+Issue #1044: an Action-publishing consumer declares ``DEVKIT_TAG_PREFIX`` in
+``.vig-os``; ``resolve-toolchain`` reads it and emits a ``tag-prefix`` output,
+which ``release.yml`` threads into the reusable ``release-core.yml`` /
+``release-publish.yml`` children as a ``tag_prefix`` ``workflow_call`` input.
+
+These assertions pin the wiring (the composition itself lives in bash ``run:``
+blocks, covered by prepare_changelog unit tests and not shape-testable here).
+
+Refs: #1044
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+# Repository root (tests/ -> repo root).
+REPO_ROOT = Path(__file__).resolve().parent.parent
+WORKSPACE = REPO_ROOT / "assets" / "workspace"
+WORKFLOWS = WORKSPACE / ".github" / "workflows"
+
+
+def _load(path: Path) -> dict:
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def test_vig_os_declares_tag_prefix_key() -> None:
+    """The scaffold manifest ships the opt-in key (default empty)."""
+    text = (WORKSPACE / ".vig-os").read_text(encoding="utf-8")
+    assert "DEVKIT_TAG_PREFIX=" in text
+
+
+def test_resolve_toolchain_emits_tag_prefix_output() -> None:
+    """resolve-toolchain declares a tag-prefix output for callers to consume."""
+    action = _load(WORKFLOWS.parent / "actions" / "resolve-toolchain" / "action.yml")
+    assert "tag-prefix" in action["outputs"]
+
+
+def test_release_orchestrator_threads_tag_prefix() -> None:
+    """release.yml passes tag_prefix into the tag-emitting children."""
+    workflow = _load(WORKFLOWS / "release.yml")
+    resolve_out = workflow["jobs"]["resolve-toolchain"]["outputs"]
+    assert "tag-prefix" in resolve_out
+    for job in ("core", "publish"):
+        assert "tag_prefix" in workflow["jobs"][job]["with"]
+
+
+def test_reusable_children_declare_tag_prefix_input() -> None:
+    """release-core.yml and release-publish.yml accept the tag_prefix input."""
+    for name in ("release-core.yml", "release-publish.yml"):
+        workflow = _load(WORKFLOWS / name)
+        # PyYAML parses the bare ``on`` key as the boolean True.
+        call_inputs = workflow[True]["workflow_call"]["inputs"]
+        assert "tag_prefix" in call_inputs

--- a/tests/test_scaffold_downstream_release_doc.py
+++ b/tests/test_scaffold_downstream_release_doc.py
@@ -1,0 +1,43 @@
+"""Scaffold-shape test: the DOWNSTREAM_RELEASE.md reference must resolve.
+
+Issue #1046: the scaffolded ``promote-release.yml`` header tells consumers to
+"See ``docs/DOWNSTREAM_RELEASE.md``", but the scaffold shipped only
+``COMMIT_MESSAGE_STANDARD.md`` and ``container-ci-quirks.md`` under
+``assets/workspace/docs/`` — so every consumer carried a dangling reference to
+its primary release documentation.
+
+Option 1 (managed file): the doc is manifest-synced from the devkit root
+(SSoT) into the scaffold, exactly like COMMIT_MESSAGE_STANDARD.md. These
+assertions pin that the reference now resolves inside the scaffold.
+
+Refs: #1046
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+WORKSPACE = REPO_ROOT / "assets" / "workspace"
+DOC_RELPATH = "docs/DOWNSTREAM_RELEASE.md"
+
+
+def test_scaffold_ships_downstream_release_doc() -> None:
+    """The scaffold ships the doc the promote workflow points at."""
+    assert (WORKSPACE / DOC_RELPATH).is_file()
+
+
+def test_promote_reference_resolves_in_scaffold() -> None:
+    """The 'See docs/DOWNSTREAM_RELEASE.md' reference resolves from the consumer repo."""
+    workflow = (WORKSPACE / ".github" / "workflows" / "promote-release.yml").read_text(
+        encoding="utf-8"
+    )
+    assert DOC_RELPATH in workflow  # the reference exists...
+    assert (WORKSPACE / DOC_RELPATH).exists()  # ...and now points at a shipped file
+
+
+def test_scaffold_doc_matches_root_sssot() -> None:
+    """The synced copy is byte-identical to the devkit root SSoT (managed file)."""
+    root = (REPO_ROOT / DOC_RELPATH).read_text(encoding="utf-8")
+    scaffold = (WORKSPACE / DOC_RELPATH).read_text(encoding="utf-8")
+    assert scaffold == root


### PR DESCRIPTION
## Summary

Three-issue release-tagging bundle from the commit-action release-stack audit — all touch the same release-workflow family, so they share one PR and CI run.

### #1044 — `DEVKIT_TAG_PREFIX`
New optional `.vig-os` key (default empty = today's bare tags, byte-identical). Threaded per the issue's plan: `resolve-toolchain` emits `tag-prefix` → `release.yml` passes it to the `workflow_call` children → mechanical `${TAG_PREFIX}${VERSION}` composition at every tag-emitting call site (release-core RC discovery/publish tag/tag-state, release-publish tag create + `gh release create` + outputs, prepare-release tag-exists validation, promote-release release validation + RC cleanup). `prepare-changelog finalize` gains `--tag-prefix` (link URL + displayed heading); the empty prefix reproduces today's output byte-for-byte (dedicated test + all 145 pre-existing prepare_changelog tests unchanged). **Invariant held:** `version` input, `release/X.Y.Z` branches, and freeze headings stay bare everywhere.

### #1045 — `DEVKIT_FLOATING_TAGS` (composes with the prefix)
New optional `.vig-os` key (`major,minor` subset, default off). A new `floating-tags` promote job runs only after Release publication AND the main-merge succeed (the same post-acceptance gate that moves GHCR `:latest`), derives `X`/`X.Y` from the promoted version, composes with the prefix, and force-moves the tags idempotently — final releases only, pushed with the RELEASE_APP token so a tag ruleset can make moves app-exclusive. Documented in `docs/DOWNSTREAM_RELEASE.md` (floating tags are mutable by design; no Release object).

### #1046 — ship `docs/DOWNSTREAM_RELEASE.md` (Option 1, per decision)
The doc is now a managed, manifest-synced scaffold file (root copy stays the SSoT, same mechanism as `COMMIT_MESSAGE_STANDARD.md`), resolving the dangling reference in scaffolded `promote-release.yml`.

### Follow-up candidates surfaced (not in this diff)
- `DOWNSTREAM_RELEASE.md` cross-links devkit-internal docs (`RELEASE_CYCLE.md`, `CROSS_REPO_RELEASE_GATE.md`, `MIGRATION.md`, one ADR) that consumers don't ship — same dangling-reference class as #1046; a follow-up could rewrite them to absolute devkit URLs.
- Pre-existing: scaffolded `ci.yml:4` references `docs/rfcs/ADR-conditional-container-toolchain.md`, also not shipped — separate issue candidate.

TDD: one failing-test → implementation pair per issue, in dependency order 1044 → 1045 → 1046.

## Test evidence
- 157 targeted tests pass post-dev-merge (145 prepare_changelog incl. byte-identity, 4 tag-prefix shape, 5 floating-tags shape, 3 scaffold-doc)
- actionlint clean on all five release workflows
- `prek run --all-files` → green (re-verified independently before push)

Closes #1044
Closes #1045
Closes #1046