### PR TITLE
chore(ci): wire check-pr-agent-fingerprints into commit-checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -281,6 +281,17 @@ jobs:
             --title "${PR_TITLE}" \
             --blocked-patterns .github/agent-blocklist.toml
 
+      # The PR title and body are attacker-controlled text visible in the UI and
+      # notifications even though the body never enters git history, so they reach
+      # the guard as environment variables — never interpolated into the shell
+      # command. validate-commit-range already covers the title; this adds the
+      # body as cheap defense-in-depth against the agent blocklist.
+      - name: Check PR title and body for agent fingerprints
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: uv run check-pr-agent-fingerprints
+
   python-security:
     name: Python Security Scan
     runs-on: ubuntu-24.04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **PR body guarded against AI agent fingerprints** ([#1052](https://github.com/vig-os/devkit/issues/1052))
+  - The `commit-checks` job (both ci.yml copies) now runs `check-pr-agent-fingerprints`, wiring a previously dead entry point into CI. After [#1026](https://github.com/vig-os/devkit/issues/1026) the job already validated the PR **title** via `validate-commit-range --title`; this closes the remaining gap by greping the PR **body** against `.github/agent-blocklist.toml` ([#163](https://github.com/vig-os/devkit/issues/163)). The body is attacker-controlled text visible in the UI and notifications even though it never enters git history, so title and body reach the guard via `env:` (`PR_TITLE`/`PR_BODY`), never interpolated into the shell command.
 - **Scaffolded repos reject AI-authored commits** ([#1031](https://github.com/vig-os/devkit/issues/1031))
   - `check-agent-identity` now reaches the consumer pre-commit config. It is the only hook of the agent-identity pipeline ([#163](https://github.com/vig-os/devkit/issues/163)) that guards the commit **author/committer** — the one that catches `git commit --author="Claude <...>"`. After [#1026](https://github.com/vig-os/devkit/issues/1026) scaffolded repos rejected an AI-attributed commit *message* while accepting an AI-authored *commit*; the `COMMIT_MESSAGE_STANDARD.md` they ship promised the opposite. It runs at the pre-commit stage, so `prek run --all-files` enforces it in the scaffold's lint job too.
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -128,6 +128,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **PR body guarded against AI agent fingerprints** ([#1052](https://github.com/vig-os/devkit/issues/1052))
+  - The `commit-checks` job (both ci.yml copies) now runs `check-pr-agent-fingerprints`, wiring a previously dead entry point into CI. After [#1026](https://github.com/vig-os/devkit/issues/1026) the job already validated the PR **title** via `validate-commit-range --title`; this closes the remaining gap by greping the PR **body** against `.github/agent-blocklist.toml` ([#163](https://github.com/vig-os/devkit/issues/163)). The body is attacker-controlled text visible in the UI and notifications even though it never enters git history, so title and body reach the guard via `env:` (`PR_TITLE`/`PR_BODY`), never interpolated into the shell command.
 - **Scaffolded repos reject AI-authored commits** ([#1031](https://github.com/vig-os/devkit/issues/1031))
   - `check-agent-identity` now reaches the consumer pre-commit config. It is the only hook of the agent-identity pipeline ([#163](https://github.com/vig-os/devkit/issues/163)) that guards the commit **author/committer** — the one that catches `git commit --author="Claude <...>"`. After [#1026](https://github.com/vig-os/devkit/issues/1026) scaffolded repos rejected an AI-attributed commit *message* while accepting an AI-authored *commit*; the `COMMIT_MESSAGE_STANDARD.md` they ship promised the opposite. It runs at the pre-commit stage, so `prek run --all-files` enforces it in the scaffold's lint job too.
 

--- a/assets/workspace/.github/workflows/ci.yml
+++ b/assets/workspace/.github/workflows/ci.yml
@@ -212,6 +212,17 @@ jobs:
             --title "${PR_TITLE}" \
             --blocked-patterns .github/agent-blocklist.toml
 
+      # The PR title and body are attacker-controlled text visible in the UI and
+      # notifications even though the body never enters git history, so they reach
+      # the guard as environment variables — never interpolated into the shell
+      # command. validate-commit-range already covers the title; this adds the
+      # body as cheap defense-in-depth against the agent blocklist.
+      - name: Check PR title and body for agent fingerprints
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: uv run check-pr-agent-fingerprints
+
   summary:
     name: CI Summary
     runs-on: ubuntu-24.04

--- a/tests/test_workflow_pr_agent_fingerprints.py
+++ b/tests/test_workflow_pr_agent_fingerprints.py
@@ -1,0 +1,84 @@
+"""Workflow-shape tests: commit-checks must guard the PR body for agent fingerprints.
+
+Issue #1052: the ``check-pr-agent-fingerprints`` entry point exists in
+``vig_utils`` but no workflow invoked it — a guard nothing calls is not a guard.
+After #1026 the ``commit-checks`` job already validates the PR **title** via
+``validate-commit-range --title``; this entry point's unique coverage is the PR
+**body** (it reads ``PR_TITLE``/``PR_BODY`` from env and greps them against
+``.github/agent-blocklist.toml``). The body is attacker-controlled text visible
+in the UI and notifications even though it never enters git history.
+
+The fix wires ``check-pr-agent-fingerprints`` into the ``commit-checks`` job of
+both ci.yml copies as a cheap defense-in-depth step, passing ``PR_TITLE`` and
+``PR_BODY`` via ``env:`` (never interpolated into the ``run:`` script) so the
+attacker-controlled body cannot inject shell.
+
+These assertions pin that invariant for both copies: the devkit's own workflow
+and the independent scaffold copy shipped to consumers.
+
+Refs: #1052
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+# Repository root (tests/ -> repo root).
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+ENTRY_POINT = "check-pr-agent-fingerprints"
+
+# Both ci.yml copies are independent (not manifest-synced); each must guard the
+# PR body. The devkit's own workflow and the scaffold copy under assets/workspace/.
+CI_WORKFLOWS = [
+    REPO_ROOT / ".github" / "workflows" / "ci.yml",
+    REPO_ROOT / "assets" / "workspace" / ".github" / "workflows" / "ci.yml",
+]
+
+
+def _load(path: Path) -> dict:
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def _fingerprint_step(steps: list[dict]) -> dict | None:
+    for step in steps:
+        if ENTRY_POINT in str(step.get("run", "")):
+            return step
+    return None
+
+
+@pytest.mark.parametrize(
+    "path", CI_WORKFLOWS, ids=lambda p: str(p.relative_to(REPO_ROOT))
+)
+def test_commit_checks_guards_pr_body(path: Path) -> None:
+    """commit-checks runs check-pr-agent-fingerprints with PR_TITLE/PR_BODY via env."""
+    workflow = _load(path)
+    assert "commit-checks" in workflow["jobs"], f"{path} has no `commit-checks` job"
+    steps = workflow["jobs"]["commit-checks"]["steps"]
+
+    step = _fingerprint_step(steps)
+    assert step is not None, (
+        f"{path} commit-checks job must run `{ENTRY_POINT}` to guard the PR body "
+        f"(#1052)"
+    )
+
+    env = step.get("env", {})
+    # Attacker-controlled text must arrive via env, never inline in the run script.
+    assert env.get("PR_BODY") == "${{ github.event.pull_request.body }}", (
+        f"{path} `{ENTRY_POINT}` step must pass PR_BODY via env from "
+        f"github.event.pull_request.body; found {env.get('PR_BODY')!r}"
+    )
+    assert env.get("PR_TITLE") == "${{ github.event.pull_request.title }}", (
+        f"{path} `{ENTRY_POINT}` step must pass PR_TITLE via env from "
+        f"github.event.pull_request.title; found {env.get('PR_TITLE')!r}"
+    )
+    # Injection safety: the attacker-controlled values must not be interpolated
+    # into the shell command text.
+    run = str(step.get("run", ""))
+    assert "github.event.pull_request.body" not in run, (
+        f"{path} `{ENTRY_POINT}` step must not interpolate the PR body into the "
+        f"run script — pass it via env only"
+    )


### PR DESCRIPTION
## Summary

Implements #1052 per the decision recorded there: the previously dead `check-pr-agent-fingerprints` entry point now runs as a step in the `commit-checks` job — devkit's `ci.yml` and the scaffold's (independent copies, both edited; verified not manifest-linked).

- The step passes the PR title and body via `env:` only — never interpolated into the `run:` script — mirroring the injection-safe pattern of the sibling `validate-commit-range` step, and reusing its exact toolchain invocation so vig-utils resolves in both devkit and scaffolded consumers.
- `validate-commit-range` already guards the title (which becomes the merge-commit subject); this adds the body as defense-in-depth — it is visible in the UI and notifications even though it never enters git history.
- Entry point unchanged; it already reads the env vars and greps the blocklist.
- This closes the last documented-but-uncalled guard in the #163 pipeline.

TDD: new workflow-shape test (parametrized over both copies), RED then GREEN.

## Test evidence
- `uv run pytest tests/test_workflow_pr_agent_fingerprints.py` → 2 passed (9 passed combined with the entry-point suite)
- actionlint clean; `prek run --all-files` → green (re-verified independently before push)
- This PR's own CI exercises the new step live

Closes #1052
Refs: #163