### PR TITLE
fix(setup): resolve scaffolded references to unshipped docs and add the scaffold lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Scaffolded references resolve to shipped or absolute docs** ([#1056](https://github.com/vig-os/devkit/issues/1056))
+  - Two more instances of the #1046 dangling-reference class: the scaffolded `ci.yml` header pointed at `docs/rfcs/ADR-conditional-container-toolchain.md`, and the synced `docs/DOWNSTREAM_RELEASE.md` cross-linked `docs/RELEASE_CYCLE.md`, `docs/CROSS_REPO_RELEASE_GATE.md`, `docs/MIGRATION.md`, and the same ADR — none of which the scaffold ships, so every consumer carried dead pointers. These now use absolute `https://github.com/vig-os/devkit/blob/main/docs/...` URLs (rewritten in the root `DOWNSTREAM_RELEASE.md` SSoT, which resolve from both devkit and a consumer checkout); links that resolve within the scaffold stay relative. Structurally guarded by the #1057 scaffold lint.
 - **Scaffold ships `docs/DOWNSTREAM_RELEASE.md`** ([#1046](https://github.com/vig-os/devkit/issues/1046))
   - The scaffolded `promote-release.yml` header points at `docs/DOWNSTREAM_RELEASE.md` — the consumer's primary release-process documentation — but the scaffold never shipped it, leaving every consumer with a dangling reference. The doc is now a manifest-synced managed file (root copy is the SSoT), so the reference resolves inside consumer repos and refreshes on scaffold upgrades.
 - **Interim transitive npm vulnerability coverage via weekly lockfile maintenance** ([#1041](https://github.com/vig-os/devkit/issues/1041))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Merge commits and bot-authored commits (`…[bot]`) are exempt. Renovate and Dependabot emit `build(pip): …` / `ci(actions): …` with no `Refs:` line, so without the exemption the new gate would fail every dependency PR. The exemption is keyed on the author — the same message from a human is still rejected.
 - **Scaffolded repos can enforce the commit standard** ([#1019](https://github.com/vig-os/devkit/issues/1019))
   - `validate-commit-msg` and `prepare-commit-msg-strip-trailers` now reach the consumer pre-commit config. Scaffolded repos already shipped a `.githooks/commit-msg` shim and a `COMMIT_MESSAGE_STANDARD.md`, but had no `commit-msg`-stage hooks for the shim to run — the documented standard was unenforceable in every consumer repo.
+- **Scaffold lint for unshipped references and foreign-ref local actions** ([#1057](https://github.com/vig-os/devkit/issues/1057))
+  - A new `tests/test_scaffold_lint.py` pins two structural invariants in `Project Checks`, no new hook. Rule 1 walks the scaffold and fails if a workflow header comment or a shipped `docs/*.md` cross-link points at a repo path the scaffold does not ship (the #1046/#1056 dangling-reference class). Rule 2 parses every scaffold and devkit workflow and fails if a job checks out a ref foreign to its trigger while invoking a local `uses: ./...` action (the #1034 bootstrap-deadlock shape), with the pre-#1034 pattern covered by a constructed regression fixture.
 
 ### Changed
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -93,6 +93,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Scaffolded references resolve to shipped or absolute docs** ([#1056](https://github.com/vig-os/devkit/issues/1056))
+  - Two more instances of the #1046 dangling-reference class: the scaffolded `ci.yml` header pointed at `docs/rfcs/ADR-conditional-container-toolchain.md`, and the synced `docs/DOWNSTREAM_RELEASE.md` cross-linked `docs/RELEASE_CYCLE.md`, `docs/CROSS_REPO_RELEASE_GATE.md`, `docs/MIGRATION.md`, and the same ADR — none of which the scaffold ships, so every consumer carried dead pointers. These now use absolute `https://github.com/vig-os/devkit/blob/main/docs/...` URLs (rewritten in the root `DOWNSTREAM_RELEASE.md` SSoT, which resolve from both devkit and a consumer checkout); links that resolve within the scaffold stay relative. Structurally guarded by the #1057 scaffold lint.
 - **Scaffold ships `docs/DOWNSTREAM_RELEASE.md`** ([#1046](https://github.com/vig-os/devkit/issues/1046))
   - The scaffolded `promote-release.yml` header points at `docs/DOWNSTREAM_RELEASE.md` — the consumer's primary release-process documentation — but the scaffold never shipped it, leaving every consumer with a dangling reference. The doc is now a manifest-synced managed file (root copy is the SSoT), so the reference resolves inside consumer repos and refreshes on scaffold upgrades.
 - **Interim transitive npm vulnerability coverage via weekly lockfile maintenance** ([#1041](https://github.com/vig-os/devkit/issues/1041))

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -77,6 +77,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Merge commits and bot-authored commits (`…[bot]`) are exempt. Renovate and Dependabot emit `build(pip): …` / `ci(actions): …` with no `Refs:` line, so without the exemption the new gate would fail every dependency PR. The exemption is keyed on the author — the same message from a human is still rejected.
 - **Scaffolded repos can enforce the commit standard** ([#1019](https://github.com/vig-os/devkit/issues/1019))
   - `validate-commit-msg` and `prepare-commit-msg-strip-trailers` now reach the consumer pre-commit config. Scaffolded repos already shipped a `.githooks/commit-msg` shim and a `COMMIT_MESSAGE_STANDARD.md`, but had no `commit-msg`-stage hooks for the shim to run — the documented standard was unenforceable in every consumer repo.
+- **Scaffold lint for unshipped references and foreign-ref local actions** ([#1057](https://github.com/vig-os/devkit/issues/1057))
+  - A new `tests/test_scaffold_lint.py` pins two structural invariants in `Project Checks`, no new hook. Rule 1 walks the scaffold and fails if a workflow header comment or a shipped `docs/*.md` cross-link points at a repo path the scaffold does not ship (the #1046/#1056 dangling-reference class). Rule 2 parses every scaffold and devkit workflow and fails if a job checks out a ref foreign to its trigger while invoking a local `uses: ./...` action (the #1034 bootstrap-deadlock shape), with the pre-#1034 pattern covered by a constructed regression fixture.
 
 ### Changed
 

--- a/assets/workspace/.github/workflows/ci.yml
+++ b/assets/workspace/.github/workflows/ci.yml
@@ -4,7 +4,7 @@
 # CI Workflow (mode-aware)
 #
 # One workflow for every DEVKIT_MODE. Toolchain provisioning is split from image
-# selection per docs/rfcs/ADR-conditional-container-toolchain.md (Option A,
+# selection per https://github.com/vig-os/devkit/blob/main/docs/rfcs/ADR-conditional-container-toolchain.md (Option A,
 # #991): a leading `resolve-toolchain` job reads `.vig-os` and outputs the
 # delivery `mode` and container `image` — the devcontainer image for the
 # container-ish modes, an EXPLICIT EMPTY STRING for direnv/bare (which makes the

--- a/assets/workspace/docs/DOWNSTREAM_RELEASE.md
+++ b/assets/workspace/docs/DOWNSTREAM_RELEASE.md
@@ -3,7 +3,7 @@
 
 # Downstream Release Workflows
 
-This document is the **only** place that describes the release process for **consumer projects** that install workflows from `assets/workspace/`. The upstream devcontainer and smoke-test validation flow is documented in [`docs/RELEASE_CYCLE.md`](RELEASE_CYCLE.md) and [`docs/CROSS_REPO_RELEASE_GATE.md`](CROSS_REPO_RELEASE_GATE.md).
+This document is the **only** place that describes the release process for **consumer projects** that install workflows from `assets/workspace/`. The upstream devcontainer and smoke-test validation flow is documented in [`docs/RELEASE_CYCLE.md`](https://github.com/vig-os/devkit/blob/main/docs/RELEASE_CYCLE.md) and [`docs/CROSS_REPO_RELEASE_GATE.md`](https://github.com/vig-os/devkit/blob/main/docs/CROSS_REPO_RELEASE_GATE.md).
 
 ## Overview
 
@@ -31,7 +31,7 @@ Candidate mode keeps release branch content unchanged (no CHANGELOG date finaliz
 
 ## Immutable releases, tag rulesets, and forward-fix policy (downstream)
 
-- **Candidate (`X.Y.Z-rcN`)**: By default only the git tag is created. With **`create-release: true`**, `release-publish.yml` creates a **draft** GitHub **pre-release** (`gh release create --draft --prerelease`). Promote-time validation uses `gh api .../releases/tags/<tag>` and inspects `.draft` to ensure the expected draft pre-release exists; see [Cross-repo gate](CROSS_REPO_RELEASE_GATE.md) for upstream enforcement status. With **immutable releases** enabled, **publishing** a pre-release locks the **linked** tag and assets (see [upstream policy](RELEASE_CYCLE.md#immutable-releases-tag-rulesets-and-forward-fix-policy)); iterate with a **new** RC tag.
+- **Candidate (`X.Y.Z-rcN`)**: By default only the git tag is created. With **`create-release: true`**, `release-publish.yml` creates a **draft** GitHub **pre-release** (`gh release create --draft --prerelease`). Promote-time validation uses `gh api .../releases/tags/<tag>` and inspects `.draft` to ensure the expected draft pre-release exists; see [Cross-repo gate](https://github.com/vig-os/devkit/blob/main/docs/CROSS_REPO_RELEASE_GATE.md) for upstream enforcement status. With **immutable releases** enabled, **publishing** a pre-release locks the **linked** tag and assets (see [upstream policy](https://github.com/vig-os/devkit/blob/main/docs/RELEASE_CYCLE.md#immutable-releases-tag-rulesets-and-forward-fix-policy)); iterate with a **new** RC tag.
 - **Final (`X.Y.Z`)**: Automation creates a **draft** GitHub Release; **publishing** it (UI or `promote-release.yml`) applies immutable-release lock-in for the linked tag and assets when that setting is enabled. Enable **immutable releases** and **tag rulesets** on each consumer repository (and org policy) as needed; see [Preventing changes to your releases](https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/preventing-changes-to-your-releases).
 - **Rollback**: The orchestrator resets the release branch and does **not** delete tags (forward-fix policy); recover with a new RC or a careful final retry per workflow logs.
 
@@ -44,7 +44,7 @@ After final `release.yml` has pushed tag `X.Y.Z` and created a **draft** GitHub 
 3. **Merge** — merge `release/X.Y.Z` → `main` (triggers `sync-main-to-dev` when configured)
 4. **Cleanup** (best-effort, does not fail the workflow) — delete remote git tags matching `${VERSION}-rc*` that have **no** GitHub Release
 
-**Upstream (`vig-os/devcontainer`) only:** Root `promote-release.yml` also prunes GHCR RC package versions via the org Packages API using **`GITHUB_TOKEN`** with **repo Admin** on the `devcontainer` package (one-time **Manage Actions access** grant). See [GitHub App Configuration](RELEASE_CYCLE.md#github-app-configuration) and [Registry and cleanup tokens](RELEASE_CYCLE.md#registry-and-cleanup-tokens-upstream) in `docs/RELEASE_CYCLE.md`.
+**Upstream (`vig-os/devcontainer`) only:** Root `promote-release.yml` also prunes GHCR RC package versions via the org Packages API using **`GITHUB_TOKEN`** with **repo Admin** on the `devcontainer` package (one-time **Manage Actions access** grant). See [GitHub App Configuration](https://github.com/vig-os/devkit/blob/main/docs/RELEASE_CYCLE.md#github-app-configuration) and [Registry and cleanup tokens](https://github.com/vig-os/devkit/blob/main/docs/RELEASE_CYCLE.md#registry-and-cleanup-tokens-upstream) in `docs/RELEASE_CYCLE.md`.
 
 This template does **not** implement upstream-only steps (GHCR `:latest`, cosign, cross-repo smoke-test gate). Projects that need registry or deploy promotion after merge should run separate automation or extend their `release-extension.yml` / own workflows; see [Extension Hook](#extension-hook).
 
@@ -65,7 +65,7 @@ There is no separate contract-version handshake; compatibility is defined by the
 Since [#991](https://github.com/vig-os/devkit/issues/991), the whole
 release/automation set provisions its toolchain per `DEVKIT_MODE`
 (`.vig-os`), following the conditional-`container:` pattern in
-[`docs/rfcs/ADR-conditional-container-toolchain.md`](rfcs/ADR-conditional-container-toolchain.md):
+[`docs/rfcs/ADR-conditional-container-toolchain.md`](https://github.com/vig-os/devkit/blob/main/docs/rfcs/ADR-conditional-container-toolchain.md):
 
 - Each `workflow_dispatch`/event-triggered workflow (`release.yml`,
   `prepare-release.yml`, `promote-release.yml`, `sync-issues.yml`,
@@ -94,7 +94,7 @@ choreography's bare `run:` invocations are identical in every mode. In `bare`
 mode the composite pins `vig-utils` to the `.vig-os` `DEVKIT_VERSION`
 (`renovate-changelog-pr` in `renovate-changelog-build.yml`, `prepare-changelog`
 in `prepare-release.yml` / `release-core.yml`); see
-[`docs/MIGRATION.md`](MIGRATION.md#bare-mode-vig-utils-release-console-scripts).
+[`docs/MIGRATION.md`](https://github.com/vig-os/devkit/blob/main/docs/MIGRATION.md#bare-mode-vig-utils-release-console-scripts).
 
 ## Required App Secrets
 

--- a/docs/DOWNSTREAM_RELEASE.md
+++ b/docs/DOWNSTREAM_RELEASE.md
@@ -1,6 +1,6 @@
 # Downstream Release Workflows
 
-This document is the **only** place that describes the release process for **consumer projects** that install workflows from `assets/workspace/`. The upstream devcontainer and smoke-test validation flow is documented in [`docs/RELEASE_CYCLE.md`](RELEASE_CYCLE.md) and [`docs/CROSS_REPO_RELEASE_GATE.md`](CROSS_REPO_RELEASE_GATE.md).
+This document is the **only** place that describes the release process for **consumer projects** that install workflows from `assets/workspace/`. The upstream devcontainer and smoke-test validation flow is documented in [`docs/RELEASE_CYCLE.md`](https://github.com/vig-os/devkit/blob/main/docs/RELEASE_CYCLE.md) and [`docs/CROSS_REPO_RELEASE_GATE.md`](https://github.com/vig-os/devkit/blob/main/docs/CROSS_REPO_RELEASE_GATE.md).
 
 ## Overview
 
@@ -28,7 +28,7 @@ Candidate mode keeps release branch content unchanged (no CHANGELOG date finaliz
 
 ## Immutable releases, tag rulesets, and forward-fix policy (downstream)
 
-- **Candidate (`X.Y.Z-rcN`)**: By default only the git tag is created. With **`create-release: true`**, `release-publish.yml` creates a **draft** GitHub **pre-release** (`gh release create --draft --prerelease`). Promote-time validation uses `gh api .../releases/tags/<tag>` and inspects `.draft` to ensure the expected draft pre-release exists; see [Cross-repo gate](CROSS_REPO_RELEASE_GATE.md) for upstream enforcement status. With **immutable releases** enabled, **publishing** a pre-release locks the **linked** tag and assets (see [upstream policy](RELEASE_CYCLE.md#immutable-releases-tag-rulesets-and-forward-fix-policy)); iterate with a **new** RC tag.
+- **Candidate (`X.Y.Z-rcN`)**: By default only the git tag is created. With **`create-release: true`**, `release-publish.yml` creates a **draft** GitHub **pre-release** (`gh release create --draft --prerelease`). Promote-time validation uses `gh api .../releases/tags/<tag>` and inspects `.draft` to ensure the expected draft pre-release exists; see [Cross-repo gate](https://github.com/vig-os/devkit/blob/main/docs/CROSS_REPO_RELEASE_GATE.md) for upstream enforcement status. With **immutable releases** enabled, **publishing** a pre-release locks the **linked** tag and assets (see [upstream policy](https://github.com/vig-os/devkit/blob/main/docs/RELEASE_CYCLE.md#immutable-releases-tag-rulesets-and-forward-fix-policy)); iterate with a **new** RC tag.
 - **Final (`X.Y.Z`)**: Automation creates a **draft** GitHub Release; **publishing** it (UI or `promote-release.yml`) applies immutable-release lock-in for the linked tag and assets when that setting is enabled. Enable **immutable releases** and **tag rulesets** on each consumer repository (and org policy) as needed; see [Preventing changes to your releases](https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/preventing-changes-to-your-releases).
 - **Rollback**: The orchestrator resets the release branch and does **not** delete tags (forward-fix policy); recover with a new RC or a careful final retry per workflow logs.
 
@@ -41,7 +41,7 @@ After final `release.yml` has pushed tag `X.Y.Z` and created a **draft** GitHub 
 3. **Merge** — merge `release/X.Y.Z` → `main` (triggers `sync-main-to-dev` when configured)
 4. **Cleanup** (best-effort, does not fail the workflow) — delete remote git tags matching `${VERSION}-rc*` that have **no** GitHub Release
 
-**Upstream (`vig-os/devcontainer`) only:** Root `promote-release.yml` also prunes GHCR RC package versions via the org Packages API using **`GITHUB_TOKEN`** with **repo Admin** on the `devcontainer` package (one-time **Manage Actions access** grant). See [GitHub App Configuration](RELEASE_CYCLE.md#github-app-configuration) and [Registry and cleanup tokens](RELEASE_CYCLE.md#registry-and-cleanup-tokens-upstream) in `docs/RELEASE_CYCLE.md`.
+**Upstream (`vig-os/devcontainer`) only:** Root `promote-release.yml` also prunes GHCR RC package versions via the org Packages API using **`GITHUB_TOKEN`** with **repo Admin** on the `devcontainer` package (one-time **Manage Actions access** grant). See [GitHub App Configuration](https://github.com/vig-os/devkit/blob/main/docs/RELEASE_CYCLE.md#github-app-configuration) and [Registry and cleanup tokens](https://github.com/vig-os/devkit/blob/main/docs/RELEASE_CYCLE.md#registry-and-cleanup-tokens-upstream) in `docs/RELEASE_CYCLE.md`.
 
 This template does **not** implement upstream-only steps (GHCR `:latest`, cosign, cross-repo smoke-test gate). Projects that need registry or deploy promotion after merge should run separate automation or extend their `release-extension.yml` / own workflows; see [Extension Hook](#extension-hook).
 
@@ -62,7 +62,7 @@ There is no separate contract-version handshake; compatibility is defined by the
 Since [#991](https://github.com/vig-os/devkit/issues/991), the whole
 release/automation set provisions its toolchain per `DEVKIT_MODE`
 (`.vig-os`), following the conditional-`container:` pattern in
-[`docs/rfcs/ADR-conditional-container-toolchain.md`](rfcs/ADR-conditional-container-toolchain.md):
+[`docs/rfcs/ADR-conditional-container-toolchain.md`](https://github.com/vig-os/devkit/blob/main/docs/rfcs/ADR-conditional-container-toolchain.md):
 
 - Each `workflow_dispatch`/event-triggered workflow (`release.yml`,
   `prepare-release.yml`, `promote-release.yml`, `sync-issues.yml`,
@@ -91,7 +91,7 @@ choreography's bare `run:` invocations are identical in every mode. In `bare`
 mode the composite pins `vig-utils` to the `.vig-os` `DEVKIT_VERSION`
 (`renovate-changelog-pr` in `renovate-changelog-build.yml`, `prepare-changelog`
 in `prepare-release.yml` / `release-core.yml`); see
-[`docs/MIGRATION.md`](MIGRATION.md#bare-mode-vig-utils-release-console-scripts).
+[`docs/MIGRATION.md`](https://github.com/vig-os/devkit/blob/main/docs/MIGRATION.md#bare-mode-vig-utils-release-console-scripts).
 
 ## Required App Secrets
 

--- a/tests/test_scaffold_lint.py
+++ b/tests/test_scaffold_lint.py
@@ -1,0 +1,235 @@
+"""Scaffold-lint tests: two structural regressions the scaffold must never reship.
+
+**Rule 1 — unshipped-path references** (#1046, #1056): a file scaffolded into a
+consumer repo must not point at a repo path the scaffold does not ship, or every
+consumer carries a dead pointer. Two deliberately conservative extractors, one
+per shape these bugs took:
+
+* **workflow header comments** — the bare ``docs/<path>.md`` tokens in
+  ``assets/workspace/.github/workflows/*.yml`` (e.g. ci.yml's ADR pointer,
+  #1056); each must resolve inside the scaffold tree.
+* **documentation cross-links** — the relative Markdown link targets in the
+  shipped ``assets/workspace/docs/*.md`` set (e.g. DOWNSTREAM_RELEASE.md's
+  devkit-internal links, #1056); each must resolve inside the scaffold tree.
+
+Extraction is intentionally narrow — #1057: "few false positives beat exhaustive
+coverage." Absolute URLs and pure anchors are exempt; ``docs/...`` mentions in
+prose that a consumer legitimately never receives (changelog history, agent
+skill files that point at repo-root/devkit-only docs) are out of scope by
+construction, not by suppression. ``RULE1_ALLOWLIST`` is the documented escape
+hatch for a deliberate exception and is empty by design.
+
+**Rule 2 — non-default-ref checkout + local action** (#1034): a workflow job
+that checks out a ref other than the one it was triggered on must not invoke a
+local (``uses: ./...``) action. GitHub resolves local actions against the
+*checked-out* workspace, so a job that pins a foreign branch may run against a
+tree that does not carry the action yet — the sync-main-to-dev bootstrap
+deadlock. Every current scaffold + devkit workflow is asserted clean, and the
+rule predicate is unit-tested against the pre-#1034 pattern as a constructed
+regression fixture.
+
+Refs: #1057
+"""
+
+from __future__ import annotations
+
+import re
+from fnmatch import fnmatch
+from pathlib import Path
+
+import pytest
+import yaml
+
+# Repository root (tests/ -> repo root) and the consumer scaffold tree.
+REPO_ROOT = Path(__file__).resolve().parent.parent
+WORKSPACE = REPO_ROOT / "assets" / "workspace"
+
+
+# --------------------------------------------------------------------------- #
+# Rule 1 — unshipped-path references
+# --------------------------------------------------------------------------- #
+
+# Deliberate, documented exceptions to Rule 1, keyed by the exact reference
+# string. Empty by design: the fix (#1056) resolves the only known instances.
+RULE1_ALLOWLIST: dict[str, str] = {}
+
+_ABSOLUTE_URL = re.compile(r"^[a-zA-Z][a-zA-Z0-9+.-]*://")
+# A bare repo-relative ``docs/....md`` path token, as written in a workflow
+# comment. The negative lookbehind keeps it from matching the same substring
+# embedded in an absolute URL (``.../blob/main/docs/....md``) or a longer path.
+_DOCS_TOKEN = re.compile(r"(?<![\w./-])docs/[A-Za-z0-9_./-]+\.md")
+_MD_LINK = re.compile(r"\]\(([^)]+)\)")
+
+
+def _scaffold_workflows() -> list[Path]:
+    base = WORKSPACE / ".github" / "workflows"
+    return sorted([*base.glob("*.yml"), *base.glob("*.yaml")])
+
+
+def _scaffold_docs() -> list[Path]:
+    return sorted((WORKSPACE / "docs").glob("*.md"))
+
+
+def _workflow_comment_violations() -> list[tuple[Path, str]]:
+    """``docs/....md`` tokens in scaffold workflows that do not resolve."""
+    out: list[tuple[Path, str]] = []
+    for wf in _scaffold_workflows():
+        for token in _DOCS_TOKEN.findall(wf.read_text(encoding="utf-8")):
+            if token in RULE1_ALLOWLIST:
+                continue
+            if not (WORKSPACE / token).exists():
+                out.append((wf, token))
+    return out
+
+
+def _doc_crosslink_violations() -> list[tuple[Path, str]]:
+    """Relative Markdown links in shipped docs that do not resolve."""
+    out: list[tuple[Path, str]] = []
+    for doc in _scaffold_docs():
+        for target in _MD_LINK.findall(doc.read_text(encoding="utf-8")):
+            target = target.strip()
+            base = target.split("#", 1)[0]
+            if base == "" or target.startswith(("#", "mailto:")):
+                continue
+            if _ABSOLUTE_URL.match(target) or target in RULE1_ALLOWLIST:
+                continue
+            if not (doc.parent / base).exists():
+                out.append((doc, target))
+    return out
+
+
+def test_scaffold_has_no_unshipped_path_references() -> None:
+    """No scaffolded file points at a repo path the scaffold does not ship."""
+    violations = _workflow_comment_violations() + _doc_crosslink_violations()
+    assert not violations, (
+        "scaffolded files reference paths absent from the scaffold "
+        "(rewrite to an absolute https://github.com/vig-os/devkit/... URL, or "
+        "add to RULE1_ALLOWLIST with a reason):\n"
+        + "\n".join(f"  {p.relative_to(REPO_ROOT)} -> {ref}" for p, ref in violations)
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Rule 2 — non-default-ref checkout + local action
+# --------------------------------------------------------------------------- #
+
+ALL_WORKFLOWS = [
+    p
+    for base in (
+        REPO_ROOT / ".github" / "workflows",
+        WORKSPACE / ".github" / "workflows",
+    )
+    for p in sorted([*base.glob("*.yml"), *base.glob("*.yaml")])
+]
+
+
+def _load(path: Path) -> dict:
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def _on(doc: dict) -> object:
+    # YAML 1.1 parses the bare ``on:`` key as the boolean ``True``.
+    return doc.get("on", doc.get(True))
+
+
+def _job_uses_local_action(job: dict) -> bool:
+    return any(
+        isinstance(s, dict) and str(s.get("uses", "")).startswith("./")
+        for s in job.get("steps", []) or []
+    )
+
+
+def _checkout_refs(job: dict) -> list[str | None]:
+    refs: list[str | None] = []
+    for s in job.get("steps", []) or []:
+        if isinstance(s, dict) and "actions/checkout" in str(s.get("uses", "")):
+            refs.append((s.get("with") or {}).get("ref"))
+    return refs
+
+
+def _push_branches(on: object) -> set[str] | None:
+    """Literal branch filters of a ``push`` trigger, else ``None``.
+
+    ``None`` means the run's ref cannot be pinned statically (dispatch, PR,
+    schedule, ``workflow_call``), so a static checkout ref cannot be proven
+    foreign and is not flagged.
+    """
+    if not isinstance(on, dict):
+        return None
+    push = on.get("push")
+    if not isinstance(push, dict):
+        return None
+    branches = push.get("branches")
+    if not isinstance(branches, list):
+        return None
+    return {str(b) for b in branches}
+
+
+def job_checks_out_foreign_ref_with_local_action(on: object, job: dict) -> bool:
+    """True if a job runs a local action against a ref foreign to its trigger.
+
+    The pre-#1034 shape: a ``push``-triggered job that pins a static branch ref
+    other than the pushed branch and then invokes a local ``uses: ./...``
+    action. Dynamic ``${{ ... }}`` refs (the run's own ref/SHA) are safe, as is
+    the absence of an explicit ref (the triggering SHA).
+    """
+    if not _job_uses_local_action(job):
+        return False
+    branches = _push_branches(on)
+    if branches is None:
+        return False
+    for ref in _checkout_refs(job):
+        if ref is None or "${{" in ref:
+            continue
+        if not any(fnmatch(ref, pattern) for pattern in branches):
+            return True
+    return False
+
+
+@pytest.mark.parametrize(
+    "path", ALL_WORKFLOWS, ids=lambda p: str(p.relative_to(REPO_ROOT))
+)
+def test_no_local_action_on_foreign_ref(path: Path) -> None:
+    """No current workflow job runs a local action on a foreign checkout ref."""
+    doc = _load(path)
+    if not isinstance(doc, dict):
+        return
+    on = _on(doc)
+    jobs = doc.get("jobs") or {}
+    offending = [
+        name
+        for name, job in jobs.items()
+        if isinstance(job, dict)
+        and job_checks_out_foreign_ref_with_local_action(on, job)
+    ]
+    assert not offending, (
+        f"{path.relative_to(REPO_ROOT)} jobs {offending} check out a ref foreign "
+        "to the trigger while invoking a local `uses: ./...` action (#1034): a "
+        "local action resolves against the checked-out workspace, which may not "
+        "carry it yet. Check out the triggering ref (drop `ref:` or use a "
+        "run-scoped `${{ ... }}` expression)."
+    )
+
+
+def test_rule2_predicate_catches_pre_1034_pattern() -> None:
+    """Regression fixture: the exact pre-#1034 sync-main-to-dev job shape."""
+    on = {"push": {"branches": ["main"]}}
+    job = {
+        "steps": [
+            {"uses": "actions/checkout@v4", "with": {"ref": "dev"}},
+            {"uses": "./.github/actions/setup-env"},
+        ]
+    }
+    assert job_checks_out_foreign_ref_with_local_action(on, job) is True
+
+
+def test_rule2_predicate_allows_triggering_ref_checkout() -> None:
+    """The #1034 fix: no explicit ref (triggering SHA) + local action is safe."""
+    on = {"push": {"branches": ["main"]}}
+    job = {
+        "steps": [
+            {"uses": "actions/checkout@v4"},
+            {"uses": "./.github/actions/setup-env"},
+        ]
+    }
+    assert job_checks_out_foreign_ref_with_local_action(on, job) is False


### PR DESCRIPTION
## Summary

Fix+lint pair, designed as one PR: the #1057 lint's rule 1 is the failing test that the #1056 fix turns green.

### #1057 — scaffold lint (`tests/test_scaffold_lint.py`)
- **Rule 1 — unshipped-path references:** conservative extractors (workflow header comments matching bare `docs/<path>.md` tokens; file-relative markdown links in scaffold docs) assert every referenced target exists inside the scaffold tree. Tuned until RED flagged **exactly** the two known instances and nothing else; the allowlist is empty. A lookbehind prevents re-matching the `docs/…` substring inside rewritten absolute URLs.
- **Rule 2 — non-default-ref checkout + local action** (the #1034 class): a push-triggered job pinning a static foreign ref while invoking `uses: ./…` is a violation. All current workflows (both trees) pass; the exact pre-#1034 sync-main-to-dev shape is covered as a constructed regression fixture, and the fixed shape is asserted safe.

### #1056 — fix the current instances
- Scaffold `ci.yml` header: ADR reference → absolute devkit URL (root ci.yml has no such reference — independent copy, unchanged).
- Root `docs/DOWNSTREAM_RELEASE.md` (SSoT): 8 internal link targets (RELEASE_CYCLE, CROSS_REPO_RELEASE_GATE, MIGRATION, the ADR) → absolute URLs; the manifest-synced scaffold copy follows.

### Surfaced while tuning (filed, not fixed here)
- Broader same-class refs outside the lint's conservative scope → #1062.
- `test_scaffold_doc_matches_root_sssot` already fails on the base commit (banner-unaware byte-identity, pre-existing from the #1043×#1051 interaction) → #1060; and the reason nobody noticed — CI never runs these shape-test suites → #1061. Both being fixed in a follow-up PR.

## Test evidence
- `uv run pytest tests/test_scaffold_lint.py` → 32 passed (RED first: rule 1 listed exactly the two known files)
- `prek run --all-files` → green (re-verified independently before push)

Closes #1056
Closes #1057
Refs: #1034, #1046