### PR TITLE
fix(vigutils): raise clear error when finalize re-runs with a changed tag prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,6 +159,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The scaffolded `codeql.yml` and an install-time note now document that this
     advanced config conflicts with GitHub's default code-scanning setup (which
     must be disabled). The installer never changes the code-scanning API setting.
+- **`prepare-changelog finalize` names the heading on a tag-prefix mismatch** ([#1073](https://github.com/vig-os/devkit/issues/1073))
+  - Re-running `finalize` on a reused release branch with a different `--tag-prefix` than the first run raised the generic "Version section not found" ValueError. It now detects the already-finalized heading, names it and the expected prefix in the error, and states that the tag prefix must be stable across re-runs; the docstring records the invariant (re-run idempotency holds only for an unchanged prefix).
 
 ### Security
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -159,6 +159,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The scaffolded `codeql.yml` and an install-time note now document that this
     advanced config conflicts with GitHub's default code-scanning setup (which
     must be disabled). The installer never changes the code-scanning API setting.
+- **`prepare-changelog finalize` names the heading on a tag-prefix mismatch** ([#1073](https://github.com/vig-os/devkit/issues/1073))
+  - Re-running `finalize` on a reused release branch with a different `--tag-prefix` than the first run raised the generic "Version section not found" ValueError. It now detects the already-finalized heading, names it and the expected prefix in the error, and states that the tag prefix must be stable across re-runs; the docstring records the invariant (re-run idempotency holds only for an unchanged prefix).
 
 ### Security
 

--- a/packages/vig-utils/src/vig_utils/prepare_changelog.py
+++ b/packages/vig-utils/src/vig_utils/prepare_changelog.py
@@ -422,6 +422,11 @@ def finalize_release_date(
     - TBD`` placeholder matched in the file stays bare; only the emitted tag name
     and URL carry the prefix. An empty prefix reproduces today's output byte-for-byte.
 
+    Re-run idempotency holds only for an unchanged ``tag_prefix``: re-running
+    against a heading this tool already finalized is a no-op when the prefix is
+    the same, and raises :class:`ValueError` when the prefix differs (#1073).
+    The tag prefix must be stable across re-runs on a reused release branch.
+
     Args:
         version: Semantic version (e.g., "1.0.0")
         release_date: Release date in ISO format (YYYY-MM-DD)
@@ -460,6 +465,24 @@ def finalize_release_date(
     finalized_pattern = rf"## \[{re.escape(tag)}\]\([^)]*\) - \d{{4}}-\d{{2}}-\d{{2}}"
     if re.search(finalized_pattern, content):
         return
+
+    # A heading already finalized for this version but under a *different* tag
+    # prefix (#1073): the re-run no-op above only covers an unchanged prefix, so
+    # name the offending heading instead of falling through to the generic
+    # "TBD not found" error. The lookbehind keeps a longer version (e.g. 11.0.0)
+    # from being mistaken for a prefixed 1.0.0.
+    mismatched_pattern = (
+        rf"## \[[^\]]*?(?<![\d.]){re.escape(version)}\]\([^)]*\) - "
+        rf"\d{{4}}-\d{{2}}-\d{{2}}"
+    )
+    mismatch = re.search(mismatched_pattern, content)
+    if mismatch:
+        raise ValueError(
+            f"Version {version} is already finalized with a different tag prefix: "
+            f"found heading '{mismatch.group(0)}', but tag prefix {tag_prefix!r} "
+            f"expects '## [{tag}](...)'. The tag prefix must be stable across "
+            f"finalize re-runs; re-run with the prefix used originally."
+        )
 
     # Check if version with TBD exists (the placeholder heading stays bare).
     version_pattern = rf"## \[{re.escape(version)}\] - TBD"

--- a/packages/vig-utils/tests/test_prepare_changelog.py
+++ b/packages/vig-utils/tests/test_prepare_changelog.py
@@ -1492,6 +1492,67 @@ class TestFinalizeTagPrefix:
         )
         assert f.read_text() == after_first
 
+    def test_rerun_with_different_prefix_raises_clear_error(self, tmp_path):
+        """Re-running with a changed prefix raises a specific error, not a generic one (#1073)."""
+        f = tmp_path / "CHANGELOG.md"
+        f.write_text(CHANGELOG_WITH_TBD)
+        finalize_release_date(
+            "1.0.0",
+            "2026-02-11",
+            str(f),
+            github_repository=_FINALIZE_TEST_REPO,
+            tag_prefix="",
+        )
+        after_first = f.read_text()
+        with pytest.raises(ValueError) as excinfo:
+            finalize_release_date(
+                "1.0.0",
+                "2026-02-11",
+                str(f),
+                github_repository=_FINALIZE_TEST_REPO,
+                tag_prefix="v",
+            )
+        msg = str(excinfo.value)
+        # Names the heading actually found in the file.
+        assert (
+            f"## [1.0.0](https://github.com/{_FINALIZE_TEST_REPO}/releases/tag/1.0.0) - 2026-02-11"
+            in msg
+        )
+        # Names the expected prefix and states the stability invariant.
+        assert "'v'" in msg
+        assert "stable" in msg
+        # The file is left untouched.
+        assert f.read_text() == after_first
+
+    def test_rerun_dropping_prefix_raises_clear_error(self, tmp_path):
+        """The reverse direction (first 'v', then '') is detected too (#1073)."""
+        f = tmp_path / "CHANGELOG.md"
+        f.write_text(CHANGELOG_WITH_TBD)
+        finalize_release_date(
+            "1.0.0",
+            "2026-02-11",
+            str(f),
+            github_repository=_FINALIZE_TEST_REPO,
+            tag_prefix="v",
+        )
+        after_first = f.read_text()
+        with pytest.raises(ValueError) as excinfo:
+            finalize_release_date(
+                "1.0.0",
+                "2026-02-11",
+                str(f),
+                github_repository=_FINALIZE_TEST_REPO,
+                tag_prefix="",
+            )
+        msg = str(excinfo.value)
+        assert (
+            f"## [v1.0.0](https://github.com/{_FINALIZE_TEST_REPO}/releases/tag/v1.0.0) - 2026-02-11"
+            in msg
+        )
+        assert "''" in msg
+        assert "stable" in msg
+        assert f.read_text() == after_first
+
 
 # ═════════════════════════════════════════════════════════════════════════════
 # Full prepare → finalize cycle


### PR DESCRIPTION
Implements #1073 (review follow-up from #1068).

`prepare-changelog finalize` re-run with a different `--tag-prefix` now raises a specific ValueError naming the already-finalized heading it found, the expected prefix, and the invariant (prefix must be stable across re-runs on a reused release branch) — instead of the generic "TBD not found" error. No auto-re-finalize (per approved plan); the file is left untouched, asserted by tests. Docstring states the invariant. A lookbehind keeps e.g. `11.0.0` from matching as prefixed `1.0.0`.

TDD: RED commit with both prefix directions (`""`→`"v"`, `"v"`→`""`), then the fix. Evidence: `test_prepare_changelog.py` 147 passed; full `just precommit` green. Changelog entry under `## [1.2.0] - TBD` ### Fixed, root + mirror.

Refs: #1073