### PR TITLE
refactor(workspace): make strip_banner style argument required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `perf` joins the approved commit-type allowlist in `nix/hooks.nix` (both rendered `.pre-commit-config.yaml` files), `DEFAULT_APPROVED_TYPES` (the default CI's `validate-commit-range` uses), and `docs/COMMIT_MESSAGE_STANDARD.md`. It is a standard [Conventional Commits](https://www.conventionalcommits.org/) type and was already used once in history; before this the live `commit-checks` job would reject the next `perf(...)` commit.
 - **Commit scopes are free-form** ([#1019](https://github.com/vig-os/devkit/issues/1019))
   - The `validate-commit-msg` hook no longer pins an allowlist of commit scopes. The previous five-scope list (`agent,ci,setup,image,vigutils`) rejected 594 of the 1206 scoped commits in history (~49%), including the scopes used by our own bots, and contradicted `docs/COMMIT_MESSAGE_STANDARD.md`, which defines a scope as free-form "alphanumeric and hyphens only". The commit **type**, the `Refs:` line and the agent blocklist remain enforced; only the scope vocabulary is open.
+- **`strip_banner` requires an explicit comment style** ([#1076](https://github.com/vig-os/devkit/issues/1076))
+  - The helper in `scripts/transforms.py` defaulted `style` to `"html"`, so a future caller stripping a hash-style file that forgot the kwarg would get the wrong header split (no shebang / YAML doc-start handling) and could corrupt the file. The default is removed — omitting `style` now raises `TypeError` — and all callers pass it explicitly.
 
 ### Fixed
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -107,6 +107,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `perf` joins the approved commit-type allowlist in `nix/hooks.nix` (both rendered `.pre-commit-config.yaml` files), `DEFAULT_APPROVED_TYPES` (the default CI's `validate-commit-range` uses), and `docs/COMMIT_MESSAGE_STANDARD.md`. It is a standard [Conventional Commits](https://www.conventionalcommits.org/) type and was already used once in history; before this the live `commit-checks` job would reject the next `perf(...)` commit.
 - **Commit scopes are free-form** ([#1019](https://github.com/vig-os/devkit/issues/1019))
   - The `validate-commit-msg` hook no longer pins an allowlist of commit scopes. The previous five-scope list (`agent,ci,setup,image,vigutils`) rejected 594 of the 1206 scoped commits in history (~49%), including the scopes used by our own bots, and contradicted `docs/COMMIT_MESSAGE_STANDARD.md`, which defines a scope as free-form "alphanumeric and hyphens only". The commit **type**, the `Refs:` line and the agent blocklist remain enforced; only the scope vocabulary is open.
+- **`strip_banner` requires an explicit comment style** ([#1076](https://github.com/vig-os/devkit/issues/1076))
+  - The helper in `scripts/transforms.py` defaulted `style` to `"html"`, so a future caller stripping a hash-style file that forgot the kwarg would get the wrong header split (no shebang / YAML doc-start handling) and could corrupt the file. The default is removed — omitting `style` now raises `TypeError` — and all callers pass it explicitly.
 
 ### Fixed
 

--- a/scripts/transforms.py
+++ b/scripts/transforms.py
@@ -102,7 +102,7 @@ def _strip_banner_block(rest: list[str]) -> list[str]:
     return rest[i:]
 
 
-def strip_banner(text: str, style: str = "html") -> str:
+def strip_banner(text: str, style: str) -> str:
     """Return ``text`` with any provenance banner (either variant) removed.
 
     The inverse of :class:`Banner`: it locates the banner after the same leading

--- a/tests/test_scaffold_downstream_release_doc.py
+++ b/tests/test_scaffold_downstream_release_doc.py
@@ -58,4 +58,4 @@ def test_scaffold_doc_matches_root_sssot() -> None:
     root = (REPO_ROOT / DOC_RELPATH).read_text(encoding="utf-8")
     scaffold = (WORKSPACE / DOC_RELPATH).read_text(encoding="utf-8")
     strip_banner = _load_transforms().strip_banner
-    assert strip_banner(scaffold) == root
+    assert strip_banner(scaffold, style="html") == root

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -7,6 +7,8 @@ import json
 import sys
 from pathlib import Path
 
+import pytest
+
 scripts_dir = Path(__file__).parent.parent / "scripts"
 project_root = scripts_dir.parent
 sys.path.insert(0, str(project_root))
@@ -277,6 +279,20 @@ class TestBannerTransform:
         # The old preserved banner must be gone, not stacked.
         assert transforms.PRESERVED_BANNER[0] not in text
         assert text.count("vig-os/devkit/issues") == 1
+
+
+class TestStripBanner:
+    """``strip_banner`` (#1076): header splitting depends on the comment style.
+
+    A defaulted ``style="html"`` would silently split hash-style files wrong
+    (no shebang / YAML doc-start handling) for callers that forget the kwarg,
+    so the argument must be explicit.
+    """
+
+    def test_style_argument_is_required(self):
+        transforms = _load_transforms()
+        with pytest.raises(TypeError):
+            transforms.strip_banner("<!-- banner -->\n\nbody\n")
 
 
 class TestRemovePrecommitHooks:


### PR DESCRIPTION
Implements #1076 (review follow-up from #1068).

`strip_banner(text, style)` no longer defaults `style` to `"html"` — a hash-style caller forgetting the kwarg would get wrong header splitting (no shebang / YAML doc-start handling) and could corrupt a file. The single external caller (`test_scaffold_downstream_release_doc.py`) now passes `style="html"` explicitly; internal callers already did.

TDD: RED test asserting TypeError on omitted style, then the change. Evidence: 38 passed across the two affected test files; full `just precommit` green (sync-manifest/generate-docs exercise the real callers). Changelog entry under `## [1.2.0] - TBD` ### Changed, root + mirror.

Refs: #1076