### PR TITLE
docs(workspace): document Banner.apply dropping leading blank lines

### DIFF
--- a/scripts/transforms.py
+++ b/scripts/transforms.py
@@ -137,6 +137,10 @@ class Banner:
         original = path.read_text()
         header, rest = _split_header(original.splitlines(keepends=True), self.style)
         rest = _strip_banner_block(rest)
+        # Intentional one-shot normalization (#1077): drop the source's leading
+        # blank lines so the banner is always followed by exactly one blank
+        # line. Only visible when diffing the initial sync of a source that
+        # opens with blanks; idempotent thereafter (no ongoing drift).
         while rest and rest[0].strip() == "":
             rest.pop(0)
 


### PR DESCRIPTION
Implements #1077 (review follow-up from #1068).

Comment-only: documents the leading-blank-line drop in `Banner.apply` as an intentional one-shot normalization (banner always followed by exactly one blank line; visible only when diffing the initial sync; idempotent thereafter). Note: the issue cites `sync_manifest.py:180`, but the loop lives in `scripts/transforms.py` (`Banner.apply`) since the transforms extraction — comment placed there. No behavior change, no changelog (internal comment).

Full `just precommit` green.

Refs: #1077