### PR TITLE
docs(ci): comment why sync-main-to-dev checkout drops ref: dev

### DIFF
--- a/.github/workflows/sync-main-to-dev.yml
+++ b/.github/workflows/sync-main-to-dev.yml
@@ -107,6 +107,8 @@ jobs:
           client-id: ${{ secrets.COMMIT_APP_CLIENT_ID }}
           private-key: ${{ secrets.COMMIT_APP_PRIVATE_KEY }}
 
+      # No `ref:` needed — checkout only resolves ./.github/actions/setup-env;
+      # every later git op targets origin/main / origin/dev explicitly (#1081).
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:


### PR DESCRIPTION
Implements #1081 (review follow-up from #1068).

Comment-only: two-line YAML comment on the sync job's checkout step — no `ref:` needed because the checkout exists solely to resolve `./.github/actions/setup-env`, and every later git op targets `origin/main`/`origin/dev` explicitly. The scaffolded twin (`assets/workspace/.github/workflows/sync-main-to-dev.yml`) is intentionally decoupled (own header says so, different composite) and was left untouched. No changelog (internal comment).

Full `just precommit` green (actionlint, sync-manifest pass).

Refs: #1081