### PR TITLE
docs(vigutils): document title Refs exemption for merge-commit subjects

### DIFF
--- a/packages/vig-utils/src/vig_utils/validate_commit_range.py
+++ b/packages/vig-utils/src/vig_utils/validate_commit_range.py
@@ -145,6 +145,13 @@ def validate_title(
     valid, error = validate_commit_message(
         title,
         approved_types=approved_types,
+        # Deliberately looser than full commit validation, where only
+        # DEFAULT_REFS_OPTIONAL_TYPES ({chore}) may omit Refs: every approved
+        # type is Refs-optional for a title. This is safe because the merge
+        # commit the title becomes on dev is exempt from Refs enforcement
+        # downstream -- validate_commits() skips merges (`commit.is_merge`),
+        # CI's commit-checks job is the only re-validator of history, and the
+        # commit-msg hook never fires on GitHub's server-side merges.
         refs_optional_types=approved_types,
         blocked_patterns=blocked_patterns,
     )

--- a/packages/vig-utils/tests/test_validate_commit_range.py
+++ b/packages/vig-utils/tests/test_validate_commit_range.py
@@ -154,6 +154,21 @@ class TestValidateTitle:
     def test_title_does_not_require_refs(self) -> None:
         assert validate_title("feat(ci): add a lane") is None
 
+    def test_refs_requiring_type_is_exempt_end_to_end(self) -> None:
+        """A Refs-requiring type is safe as a title (#1074).
+
+        ``docs`` is not in DEFAULT_REFS_OPTIONAL_TYPES, yet a bare ``docs:``
+        title must pass: the --no-ff merge commit it becomes on dev is skipped
+        by validate_commits (``is_merge``), so it never faces the Refs rule.
+        The same subject as a plain human commit still fails -- the exemption
+        reaches merge commits only.
+        """
+        title = "docs: update readme"
+        assert validate_title(title) is None
+        merge = _commit(message=title, parents=("b" * 40, "c" * 40))
+        assert validate_commits([merge]) == []
+        assert len(validate_commits([_commit(message=title)])) == 1
+
 
 class TestParseGitLog:
     """The %H/%an/%P/%B record parser feeding validate_commits from CI."""


### PR DESCRIPTION
Implements #1074 (review follow-up from #1068).

**Investigation verdict: merge-commit subjects are exempt from Refs enforcement downstream**, so the looser `refs_optional_types=approved_types` in `validate_title` is safe and now documented rather than changed:
- `validate_commits()` skips merges (`commit.is_merge`) — the --no-ff merge subject a PR title becomes never faces the Refs rule.
- CI's `commit-checks` job is the only re-validator of history and is pull_request-only; ranges are merge-base..head with merges skipped.
- The `validate-commit-msg` hook is commit-msg-stage: fires on local commits only, never on GitHub's server-side merges.

Change: call-site comment explaining the mechanism + end-to-end regression test (`docs: update readme` passes as title, passes as merge subject, still fails as a plain commit). No behavior change, hence single commit (TDD note in body) and no changelog entry.

Evidence: `test_validate_commit_range.py` 34 passed; full `just precommit` green.

Refs: #1074