### PR TITLE
refactor(workspace): friendlier eval error for invalid node module version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `perf` joins the approved commit-type allowlist in `nix/hooks.nix` (both rendered `.pre-commit-config.yaml` files), `DEFAULT_APPROVED_TYPES` (the default CI's `validate-commit-range` uses), and `docs/COMMIT_MESSAGE_STANDARD.md`. It is a standard [Conventional Commits](https://www.conventionalcommits.org/) type and was already used once in history; before this the live `commit-checks` job would reject the next `perf(...)` commit.
 - **Commit scopes are free-form** ([#1019](https://github.com/vig-os/devkit/issues/1019))
   - The `validate-commit-msg` hook no longer pins an allowlist of commit scopes. The previous five-scope list (`agent,ci,setup,image,vigutils`) rejected 594 of the 1206 scoped commits in history (~49%), including the scopes used by our own bots, and contradicted `docs/COMMIT_MESSAGE_STANDARD.md`, which defines a scope as free-form "alphanumeric and hyphens only". The commit **type**, the `Refs:` line and the agent blocklist remain enforced; only the scope vocabulary is open.
+- **Friendlier eval error for an invalid `node` module version** ([#1080](https://github.com/vig-os/devkit/issues/1080))
+  - The `node` capability module now validates that the `version` option is an integer (`builtins.isInt`) before interpolating it into `pkgs.nodejs_<major>`, so a string, path, derivation or other non-int fails eval with the module-scoped message `node module: invalid Node version of type '…' (the 'version' option must be an integer major, e.g. 22)` instead of Nix's generic "cannot coerce to string" (or, for strings, being silently accepted) — consistent with the module's existing throws for unknown option keys and unavailable majors.
 
 ### Fixed
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -107,6 +107,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `perf` joins the approved commit-type allowlist in `nix/hooks.nix` (both rendered `.pre-commit-config.yaml` files), `DEFAULT_APPROVED_TYPES` (the default CI's `validate-commit-range` uses), and `docs/COMMIT_MESSAGE_STANDARD.md`. It is a standard [Conventional Commits](https://www.conventionalcommits.org/) type and was already used once in history; before this the live `commit-checks` job would reject the next `perf(...)` commit.
 - **Commit scopes are free-form** ([#1019](https://github.com/vig-os/devkit/issues/1019))
   - The `validate-commit-msg` hook no longer pins an allowlist of commit scopes. The previous five-scope list (`agent,ci,setup,image,vigutils`) rejected 594 of the 1206 scoped commits in history (~49%), including the scopes used by our own bots, and contradicted `docs/COMMIT_MESSAGE_STANDARD.md`, which defines a scope as free-form "alphanumeric and hyphens only". The commit **type**, the `Refs:` line and the agent blocklist remain enforced; only the scope vocabulary is open.
+- **Friendlier eval error for an invalid `node` module version** ([#1080](https://github.com/vig-os/devkit/issues/1080))
+  - The `node` capability module now validates that the `version` option is an integer (`builtins.isInt`) before interpolating it into `pkgs.nodejs_<major>`, so a string, path, derivation or other non-int fails eval with the module-scoped message `node module: invalid Node version of type '…' (the 'version' option must be an integer major, e.g. 22)` instead of Nix's generic "cannot coerce to string" (or, for strings, being silently accepted) — consistent with the module's existing throws for unknown option keys and unavailable majors.
 
 ### Fixed
 

--- a/nix/modules/node.nix
+++ b/nix/modules/node.nix
@@ -13,8 +13,8 @@
 # as `pkgs -> options -> contribution`, where `options` is the attrset entry's
 # fields minus `name`. The only recognized option is `version` (a Node major,
 # e.g. 20), mapping to `pkgs.nodejs_<major>`; omitted, it uses the nixpkgs
-# default `pkgs.nodejs`. Unknown option keys and unavailable versions fail at
-# eval time with a clear message.
+# default `pkgs.nodejs`. Unknown option keys, non-integer versions and
+# unavailable versions fail at eval time with a clear message.
 pkgs:
 {
   version ? null,
@@ -27,12 +27,20 @@ let
   unknownOptions = builtins.filter (k: !builtins.elem k knownOptions) (builtins.attrNames options);
 
   # Resolve the Node package: a `version` major selects `pkgs.nodejs_<major>`;
-  # null uses the nixpkgs default. An unavailable major (not packaged in the
-  # pinned nixpkgs) fails at eval time rather than silently degrading.
+  # null uses the nixpkgs default. A non-integer `version` (string, path,
+  # derivation, …) is rejected before the interpolation below so the eval error
+  # is this module's own message, not Nix's generic "cannot coerce to string".
+  # An unavailable major (not packaged in the pinned nixpkgs) likewise fails at
+  # eval time rather than silently degrading.
   nodeAttr = "nodejs_${toString version}";
   nodePkg =
     if version == null then
       pkgs.nodejs
+    else if !builtins.isInt version then
+      throw (
+        "node module: invalid Node version of type '${builtins.typeOf version}' "
+        + "(the 'version' option must be an integer major, e.g. 22)"
+      )
     else
       pkgs.${nodeAttr} or (throw (
         "node module: unavailable Node version '${toString version}' "

--- a/tests/test_flake_modules.py
+++ b/tests/test_flake_modules.py
@@ -326,3 +326,49 @@ def test_node_module_rejects_unknown_option(current_system: str) -> None:
     assert "channel" in result.stderr and "node" in result.stderr, (
         f"error must name the offending option and module; got: {result.stderr[-500:]}"
     )
+
+
+@pytest.mark.parametrize(
+    "bad_version",
+    ['"22"', "{ }"],
+    ids=["string", "attrset"],
+)
+def test_node_module_rejects_non_int_version(
+    current_system: str, bad_version: str
+) -> None:
+    """A non-integer ``version`` fails at eval time with a clear message (#1080).
+
+    ``version`` must be an integer Node major. Before the ``builtins.isInt``
+    guard, a non-int slipped into the ``nodejs_${toString version}``
+    interpolation: a string was silently accepted and a set/path/derivation
+    surfaced Nix's generic "cannot coerce to string" error instead of the
+    module-scoped throw the other invalid inputs (unknown option keys,
+    unavailable majors) already get.
+    """
+    expr = f"""
+    let
+      flake = builtins.getFlake "path:{REPO_ROOT}";
+      system = builtins.currentSystem;
+      pkgs = import flake.inputs.nixpkgs {{
+        inherit system;
+        overlays = [ flake.overlays.default ];
+        config.allowUnfree = true;
+      }};
+    in (flake.lib.mkProjectShell {{
+      inherit pkgs;
+      modules = [ {{ name = "node"; version = {bad_version}; }} ];
+    }}).drvPath
+    """
+    result = subprocess.run(
+        ["nix", "eval", "--impure", "--expr", expr],
+        capture_output=True,
+        text=True,
+        env=_nix_env(),
+        timeout=300,
+    )
+    assert result.returncode != 0, "non-int node version must fail eval, not pass"
+    assert (
+        "invalid Node version" in result.stderr and "integer major" in result.stderr
+    ), (
+        f"error must be the module-scoped invalid-version throw; got: {result.stderr[-500:]}"
+    )


### PR DESCRIPTION
Implements #1080 (review follow-up from #1068).

A non-integer `version` in the node capability module (`{ name = "node"; version = ...; }`) is now rejected by a `builtins.isInt` guard **before** the `nodejs_${toString version}` interpolation, throwing the module-scoped message `node module: invalid Node version of type '<type>' (the 'version' option must be an integer major, e.g. 22)` — consistent with the existing unknown-key and unavailable-major throws — instead of Nix's generic "cannot coerce to string".

Review note: the RED test exposed that a *string* major (`"22"`) was previously silently accepted by coercion; the guard now enforces the documented int contract for that case too (tightening, covered by the parametrized test).

TDD: RED (string silently accepted, attrset → generic coerce error) → GREEN (3 passed incl. the existing unknown-option test); `version = 22` regression-probed as still evaluating. Full `just precommit` green (nixfmt, sync-manifest). Changelog under `## [1.2.0] - TBD` ### Changed, root + mirror.

Refs: #1080