### PR TITLE
fix(ci): roll back prepare-release when a phase job is cancelled

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -412,10 +412,14 @@ jobs:
   # pre-prepare state, and every commit the extension makes lives on the branch
   # this job deletes.
   rollback:
-    name: Roll Back Prepare Release on Failure
+    name: Roll Back Prepare Release on Failure or Cancellation
     needs: [validate, prepare, extension, open-pr]
     runs-on: ubuntu-24.04
     timeout-minutes: 10
+    # `always()` (not `!cancelled()`) is load-bearing: it is what keeps this job
+    # eligible to run after the run itself is cancelled, and each phase guard
+    # also matches `cancelled` so a cancellation after the freeze commit rolls
+    # back exactly like a failure (#1078).
     if: >-
       ${{
         always() &&
@@ -423,8 +427,11 @@ jobs:
         needs.validate.result == 'success' &&
         (
           needs.prepare.result == 'failure' ||
+          needs.prepare.result == 'cancelled' ||
           needs.extension.result == 'failure' ||
-          needs.open-pr.result == 'failure'
+          needs.extension.result == 'cancelled' ||
+          needs.open-pr.result == 'failure' ||
+          needs.open-pr.result == 'cancelled'
         )
       }}
     permissions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,6 +159,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The scaffolded `codeql.yml` and an install-time note now document that this
     advanced config conflicts with GitHub's default code-scanning setup (which
     must be disabled). The installer never changes the code-scanning API setting.
+- **`prepare-release` rolls back on workflow cancellation** ([#1078](https://github.com/vig-os/devkit/issues/1078))
+  - The `rollback` job's guard only matched `needs.<job>.result == 'failure'` for the `prepare`, `extension` and `open-pr` phases, so cancelling a run after the freeze commit landed skipped the rollback and stranded the partial `release/X.Y.Z` branch plus the freeze commit on `dev`. Each phase guard now also matches `result == 'cancelled'` (the job already used `always()`, which keeps it eligible to run after a cancellation), in both the devkit workflow and the scaffolded consumer copy.
 
 ### Security
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -159,6 +159,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The scaffolded `codeql.yml` and an install-time note now document that this
     advanced config conflicts with GitHub's default code-scanning setup (which
     must be disabled). The installer never changes the code-scanning API setting.
+- **`prepare-release` rolls back on workflow cancellation** ([#1078](https://github.com/vig-os/devkit/issues/1078))
+  - The `rollback` job's guard only matched `needs.<job>.result == 'failure'` for the `prepare`, `extension` and `open-pr` phases, so cancelling a run after the freeze commit landed skipped the rollback and stranded the partial `release/X.Y.Z` branch plus the freeze commit on `dev`. Each phase guard now also matches `result == 'cancelled'` (the job already used `always()`, which keeps it eligible to run after a cancellation), in both the devkit workflow and the scaffolded consumer copy.
 
 ### Security
 

--- a/assets/workspace/.github/workflows/prepare-release.yml
+++ b/assets/workspace/.github/workflows/prepare-release.yml
@@ -407,7 +407,7 @@ jobs:
   # erases the extension's work too, so an extension failure needs no new
   # machinery beyond listing `extension` in `needs`.
   rollback:
-    name: Roll Back Prepare Release on Failure
+    name: Roll Back Prepare Release on Failure or Cancellation
     needs: [validate, prepare, extension, open-pr]
     runs-on: ubuntu-24.04
     container:
@@ -419,6 +419,10 @@ jobs:
     defaults:
       run:
         shell: bash
+    # `always()` (not `!cancelled()`) is load-bearing: it is what keeps this job
+    # eligible to run after the run itself is cancelled, and each phase guard
+    # also matches `cancelled` so a cancellation after the freeze commit rolls
+    # back exactly like a failure (#1078).
     if: >-
       ${{
         always() &&
@@ -426,8 +430,11 @@ jobs:
         needs.validate.result == 'success' &&
         (
           needs.prepare.result == 'failure' ||
+          needs.prepare.result == 'cancelled' ||
           needs.extension.result == 'failure' ||
-          needs.open-pr.result == 'failure'
+          needs.extension.result == 'cancelled' ||
+          needs.open-pr.result == 'failure' ||
+          needs.open-pr.result == 'cancelled'
         )
       }}
     permissions:

--- a/tests/bats/just.bats
+++ b/tests/bats/just.bats
@@ -123,11 +123,13 @@ EOF
     assert_success
 }
 
-@test "prepare-release workflow defines rollback job on failure" {
+@test "prepare-release workflow defines rollback job on failure or cancellation" {
     # #1059 moved the inline `if: failure()` rollback step into a dedicated
     # `rollback` job so it also covers the extension and open-pr jobs. Same
     # guard, new shape: the rollback exists and triggers on any phase failure.
-    run bash -lc "grep -Eq -- '^  rollback:' .github/workflows/prepare-release.yml && grep -Fq -- 'name: Roll back prepare-release side effects' .github/workflows/prepare-release.yml && grep -Fq -- \"needs.prepare.result == 'failure'\" .github/workflows/prepare-release.yml && grep -Fq -- \"needs.extension.result == 'failure'\" .github/workflows/prepare-release.yml && grep -Fq -- \"needs.open-pr.result == 'failure'\" .github/workflows/prepare-release.yml"
+    # #1078: a run cancelled after the freeze commit must roll back too, so
+    # each phase's guard also matches `result == 'cancelled'`.
+    run bash -lc "grep -Eq -- '^  rollback:' .github/workflows/prepare-release.yml && grep -Fq -- 'name: Roll back prepare-release side effects' .github/workflows/prepare-release.yml && grep -Fq -- \"needs.prepare.result == 'failure'\" .github/workflows/prepare-release.yml && grep -Fq -- \"needs.extension.result == 'failure'\" .github/workflows/prepare-release.yml && grep -Fq -- \"needs.open-pr.result == 'failure'\" .github/workflows/prepare-release.yml && grep -Fq -- \"needs.prepare.result == 'cancelled'\" .github/workflows/prepare-release.yml && grep -Fq -- \"needs.extension.result == 'cancelled'\" .github/workflows/prepare-release.yml && grep -Fq -- \"needs.open-pr.result == 'cancelled'\" .github/workflows/prepare-release.yml"
     assert_success
 }
 

--- a/tests/test_workflow_prepare_extension.py
+++ b/tests/test_workflow_prepare_extension.py
@@ -200,6 +200,45 @@ def test_extension_failure_is_covered_by_rollback(path: Path) -> None:
     )
 
 
+@pytest.mark.parametrize(
+    "path", CALLER_WORKFLOWS, ids=lambda p: str(p.relative_to(REPO_ROOT))
+)
+def test_rollback_fires_on_phase_cancellation(path: Path) -> None:
+    """Cancelling a run after the freeze commit rolls back like a failure (#1078).
+
+    ``needs.<job>.result == 'failure'`` alone skips the rollback when the run is
+    CANCELLED mid-phase, stranding the partial ``release/X.Y.Z`` branch and the
+    freeze commit on dev. The guard must (a) keep ``always()`` so GitHub even
+    evaluates the job after a cancellation, and (b) match
+    ``result == 'cancelled'`` for every phase job it watches.
+    """
+    doc = _load(path)
+    ext_name, _ = _extension_job(doc)
+    branch_name, _ = _job_with_step_run(doc, "git/refs")
+    pr_name, _ = _job_with_step_run(doc, "gh pr create")
+    assert ext_name and branch_name and pr_name
+
+    rollback_ifs = [
+        str(job.get("if", ""))
+        for job in _jobs(doc).values()
+        if isinstance(job, dict)
+        and ext_name in _needs(job)
+        and "failure" in str(job.get("if", ""))
+    ]
+    assert rollback_ifs, "could not locate the rollback job"
+    cond = rollback_ifs[0]
+    assert "always()" in cond, (
+        "the rollback guard needs always() to be evaluated at all after a "
+        "workflow cancellation"
+    )
+    for phase in (branch_name, ext_name, pr_name):
+        assert f"needs.{phase}.result == 'cancelled'" in cond, (
+            f"the rollback guard must also fire when the `{phase}` job is "
+            "cancelled, or a cancelled run strands the partial release branch "
+            "and the freeze commit on dev (#1078)"
+        )
+
+
 # --------------------------------------------------------------------------- #
 # Devkit dogfooding: the sync_manifest step moves into devkit's own hook
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
Implements #1078 (review follow-up from #1068).

The rollback job's guard now matches `cancelled` for each phase (`prepare`/`extension`/`open-pr`) alongside `failure`, so cancelling a run after the freeze commit lands rolls back the partial release branch and dev freeze exactly like a failure. `always()` is kept (and documented as load-bearing — it's what keeps the job eligible after a run-level cancel); `validate.result == 'success'` is kept deliberately (a cancelled validate means no freeze commit exists to roll back).

Scope note: the scaffolded twin (`assets/workspace/.github/workflows/prepare-release.yml`) is independently authored (not manifest-synced, per #996/#991) and had the identical gap — both copies fixed, and the shape tests are parametrized over both.

TDD: RED (2 pytest + 1 bats failures) → GREEN (`test_workflow_prepare_extension.py` 15 passed, bats rollback filter 3 ok); full `just precommit` green (actionlint). Runtime path exercises at the next prepare-release run. Changelog under `## [1.2.0] - TBD` ### Fixed, root + mirror.

Refs: #1078