### PR TITLE
refactor(ci): drop full setup-env from prepare-release open-pr job

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -324,18 +324,15 @@ jobs:
           client-id: ${{ secrets.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
+      # Bare shallow checkout only (#1079): the job's single piece of work is
+      # `gh pr create` — gh ships preinstalled on GitHub-hosted runners, and
+      # retries come from sourcing the canonical bash helper below, so the full
+      # setup-env composite (Nix + uv sync) has nothing to contribute here and
+      # only stretched the release critical path.
       - name: Checkout dev branch
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
           ref: dev
-          fetch-depth: 0
-
-      - name: Set up environment
-        uses: ./.github/actions/setup-env
-        with:
-          sync-dependencies: 'true'
-          cachix-cache: ${{ vars.CACHIX_CACHE }}
-          cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
       - name: Create draft PR to main
         id: pr
@@ -346,6 +343,8 @@ jobs:
           CHANGELOG_CONTENT: ${{ needs.prepare.outputs.changelog }}
         run: |
           set -euo pipefail
+          # shellcheck source=/dev/null  # canonical retry() helper from the checkout
+          source .github/scripts/retry.sh
 
           # GitHub caps PR bodies at 65536 chars; a large frozen release
           # changelog can overflow it (#810). Truncate at a line boundary and
@@ -367,7 +366,7 @@ jobs:
             PR_BODY="${HEADER}${TRUNCATED}${NOTE}"
           fi
 
-          PR_URL=$(uv run retry --retries 3 --backoff 5 --max-backoff 60 -- \
+          PR_URL=$(retry --retries 3 --backoff 5 --max-backoff 60 -- \
             gh pr create \
             --base main \
             --head "$RELEASE_BRANCH" \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `perf` joins the approved commit-type allowlist in `nix/hooks.nix` (both rendered `.pre-commit-config.yaml` files), `DEFAULT_APPROVED_TYPES` (the default CI's `validate-commit-range` uses), and `docs/COMMIT_MESSAGE_STANDARD.md`. It is a standard [Conventional Commits](https://www.conventionalcommits.org/) type and was already used once in history; before this the live `commit-checks` job would reject the next `perf(...)` commit.
 - **Commit scopes are free-form** ([#1019](https://github.com/vig-os/devkit/issues/1019))
   - The `validate-commit-msg` hook no longer pins an allowlist of commit scopes. The previous five-scope list (`agent,ci,setup,image,vigutils`) rejected 594 of the 1206 scoped commits in history (~49%), including the scopes used by our own bots, and contradicted `docs/COMMIT_MESSAGE_STANDARD.md`, which defines a scope as free-form "alphanumeric and hyphens only". The commit **type**, the `Refs:` line and the agent blocklist remain enforced; only the scope vocabulary is open.
+- **`prepare-release`'s `open-pr` job runs on a bare checkout** ([#1079](https://github.com/vig-os/devkit/issues/1079))
+  - The job's only real work is `gh pr create` (gh is preinstalled on GitHub-hosted runners), yet it stood up the full `setup-env` composite (Nix + `uv sync`) on the release critical path just to reach the `uv run retry` wrapper. It now uses a bare shallow checkout and sources the canonical bash `retry()` helper (`.github/scripts/retry.sh`) instead, keeping the same retry semantics while shaving minutes off every prepare run.
 
 ### Fixed
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -107,6 +107,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `perf` joins the approved commit-type allowlist in `nix/hooks.nix` (both rendered `.pre-commit-config.yaml` files), `DEFAULT_APPROVED_TYPES` (the default CI's `validate-commit-range` uses), and `docs/COMMIT_MESSAGE_STANDARD.md`. It is a standard [Conventional Commits](https://www.conventionalcommits.org/) type and was already used once in history; before this the live `commit-checks` job would reject the next `perf(...)` commit.
 - **Commit scopes are free-form** ([#1019](https://github.com/vig-os/devkit/issues/1019))
   - The `validate-commit-msg` hook no longer pins an allowlist of commit scopes. The previous five-scope list (`agent,ci,setup,image,vigutils`) rejected 594 of the 1206 scoped commits in history (~49%), including the scopes used by our own bots, and contradicted `docs/COMMIT_MESSAGE_STANDARD.md`, which defines a scope as free-form "alphanumeric and hyphens only". The commit **type**, the `Refs:` line and the agent blocklist remain enforced; only the scope vocabulary is open.
+- **`prepare-release`'s `open-pr` job runs on a bare checkout** ([#1079](https://github.com/vig-os/devkit/issues/1079))
+  - The job's only real work is `gh pr create` (gh is preinstalled on GitHub-hosted runners), yet it stood up the full `setup-env` composite (Nix + `uv sync`) on the release critical path just to reach the `uv run retry` wrapper. It now uses a bare shallow checkout and sources the canonical bash `retry()` helper (`.github/scripts/retry.sh`) instead, keeping the same retry semantics while shaving minutes off every prepare run.
 
 ### Fixed
 

--- a/tests/test_workflow_prepare_extension.py
+++ b/tests/test_workflow_prepare_extension.py
@@ -205,6 +205,41 @@ def test_extension_failure_is_covered_by_rollback(path: Path) -> None:
 # --------------------------------------------------------------------------- #
 
 
+def test_devkit_open_pr_needs_no_toolchain() -> None:
+    """Devkit's open-pr job runs on a bare checkout — no setup-env (#1079).
+
+    The job's only real work is `gh pr create` (gh ships preinstalled on
+    GitHub-hosted runners), yet it stood up the full setup-env composite
+    (Nix + `uv sync`) on the release critical path just to reach the
+    `uv run retry` wrapper. Retries come from sourcing the canonical bash
+    helper (.github/scripts/retry.sh) instead, so the job must invoke no
+    local action and no `uv run`.
+    """
+    doc = _load(DEVKIT_PREPARE)
+    pr_name, pr_job = _job_with_step_run(doc, "gh pr create")
+    assert pr_name is not None, "could not locate the draft-PR-opening job"
+
+    local_actions = [
+        str(s.get("uses"))
+        for s in (pr_job.get("steps") or [])
+        if isinstance(s, dict) and str(s.get("uses", "")).startswith("./")
+    ]
+    assert not local_actions, (
+        f"devkit's `{pr_name}` job must not invoke local composite actions "
+        f"(found {local_actions}): a bare checkout plus the preinstalled gh "
+        "CLI suffices to open the draft PR (#1079)"
+    )
+    steps_text = _job_steps_text(pr_job)
+    assert "uv run" not in steps_text, (
+        f"devkit's `{pr_name}` job must not depend on the uv environment; "
+        "source .github/scripts/retry.sh for retries instead (#1079)"
+    )
+    assert "retry" in steps_text, (
+        f"devkit's `{pr_name}` job must keep retrying the gh call "
+        "(canonical bash retry helper)"
+    )
+
+
 def test_devkit_prepare_release_no_longer_syncs_manifest_inline() -> None:
     """Devkit's prepare-release.yml is scaffold-shaped: no hardcoded sync step."""
     assert "sync_manifest.py" not in DEVKIT_PREPARE.read_text(encoding="utf-8"), (


### PR DESCRIPTION
Implements #1079 (review follow-up from #1068).

The `open-pr` job no longer runs the `setup-env` composite (Nix + uv sync) — audit showed its only consumer was the `uv run retry` wrapper around `gh pr create`. Now: bare shallow checkout (`fetch-depth: 0` also dropped — no history use), `gh` from the runner image, and retries via `source .github/scripts/retry.sh` (the canonical bash helper with identical flags: `--retries 3 --backoff 5 --max-backoff 60`). Cuts minutes of Nix/uv setup from the release critical path.

Scope note: devkit's workflow only. The scaffolded twin's `open-pr` is architecturally different (runs in the consumer's devkit container where `retry` comes from the toolchain) — slimming it would be a separate issue. The new shape test (`test_devkit_open_pr_needs_no_toolchain`) is scoped to the devkit copy.

TDD: RED → GREEN (`test_workflow_prepare_extension.py` 14 passed); full `just precommit` green. Runtime path exercises at the next prepare-release run. Changelog under `## [1.2.0] - TBD` ### Changed, root + mirror.

Refs: #1079