### PR TITLE
fix(ci): gate scaffolded release-core draft/approval on final only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Candidate releases no longer fail the draft/approval gate** ([#1095](https://github.com/vig-os/devkit/issues/1095))
+  - The scaffolded `release-core.yml` "Find and verify PR" step applied the draft + approval gate to every release kind, so a `release_kind=candidate` dispatch failed against a still-draft PR (`ERROR: PR #N is still in draft`). This was template drift: the #902 fix landed in devkit's own `release.yml` but was never mirrored into the scaffolded template consumers receive. The draft + approval checks are now guarded behind `release_kind=final`; candidates gate on CI only, consistent with `RELEASE_CYCLE.md`.
+
 ### Security
 
 ## [1.2.0](https://github.com/vig-os/devkit/releases/tag/1.2.0) - 2026-07-14

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Candidate releases no longer fail the draft/approval gate** ([#1095](https://github.com/vig-os/devkit/issues/1095))
+  - The scaffolded `release-core.yml` "Find and verify PR" step applied the draft + approval gate to every release kind, so a `release_kind=candidate` dispatch failed against a still-draft PR (`ERROR: PR #N is still in draft`). This was template drift: the #902 fix landed in devkit's own `release.yml` but was never mirrored into the scaffolded template consumers receive. The draft + approval checks are now guarded behind `release_kind=final`; candidates gate on CI only, consistent with `RELEASE_CYCLE.md`.
+
 ### Security
 
 ## [1.2.0](https://github.com/vig-os/devkit/releases/tag/1.2.0) - 2026-07-14

--- a/assets/workspace/.github/workflows/release-core.yml
+++ b/assets/workspace/.github/workflows/release-core.yml
@@ -283,6 +283,7 @@ jobs:
         id: pr
         env:
           VERSION: ${{ steps.vars.outputs.version }}
+          RELEASE_KIND: ${{ steps.vars.outputs.release_kind }}
           GH_TOKEN: ${{ steps.auth.outputs.token }}
         run: |
           set -euo pipefail
@@ -304,26 +305,37 @@ jobs:
           REVIEW_DECISION=$(echo "$PR_JSON" | jq -r '.[0].reviewDecision')
           echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
 
-          if [ "$IS_DRAFT" = "true" ]; then
-            echo "ERROR: PR #$PR_NUMBER is still in draft"
-            exit 1
-          fi
-          if [ "$REVIEW_DECISION" = "APPROVED" ]; then
-            echo "PR #$PR_NUMBER is approved"
-          elif [ "$REVIEW_DECISION" = "null" ] || [ -z "$REVIEW_DECISION" ]; then
-            # Bot approval fallback when gh pr list leaves reviewDecision empty (#438)
-            APPROVED_COUNT=$(retry --retries 3 --backoff 5 --max-backoff 30 -- gh api \
-              --paginate --slurp \
-              "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/reviews" \
-              | jq 'add | map(select(.state == "APPROVED")) | length')
-            if [ "$APPROVED_COUNT" -eq 0 ]; then
-              echo "ERROR: PR #$PR_NUMBER is not approved (reviewDecision: $REVIEW_DECISION, approved reviews: 0)"
+          # The draft + approval gate applies only to the final release, which
+          # burns the immutable X.Y.Z tag. Release candidates are disposable
+          # verification artifacts (auto-incrementing rcN tags, never touch
+          # :latest, no GitHub Release, pruned at promote), so they gate on CI
+          # only and may run against a still-draft, not-yet-approved PR. The
+          # approval that protects `main` is re-enforced by promote-release's
+          # merge job regardless. See #902.
+          if [ "$RELEASE_KIND" = "final" ]; then
+            if [ "$IS_DRAFT" = "true" ]; then
+              echo "ERROR: PR #$PR_NUMBER is still in draft"
               exit 1
             fi
-            echo "reviewDecision='$REVIEW_DECISION' but $APPROVED_COUNT approved review(s) found"
+            if [ "$REVIEW_DECISION" = "APPROVED" ]; then
+              echo "PR #$PR_NUMBER is approved"
+            elif [ "$REVIEW_DECISION" = "null" ] || [ -z "$REVIEW_DECISION" ]; then
+              # Bot approval fallback when gh pr list leaves reviewDecision empty (#438)
+              APPROVED_COUNT=$(retry --retries 3 --backoff 5 --max-backoff 30 -- gh api \
+                --paginate --slurp \
+                "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/reviews" \
+                | jq 'add | map(select(.state == "APPROVED")) | length')
+              if [ "$APPROVED_COUNT" -eq 0 ]; then
+                echo "ERROR: PR #$PR_NUMBER is not approved (reviewDecision: $REVIEW_DECISION, approved reviews: 0)"
+                exit 1
+              fi
+              echo "reviewDecision='$REVIEW_DECISION' but $APPROVED_COUNT approved review(s) found"
+            else
+              echo "ERROR: PR #$PR_NUMBER is not approved (status: $REVIEW_DECISION)"
+              exit 1
+            fi
           else
-            echo "ERROR: PR #$PR_NUMBER is not approved (status: $REVIEW_DECISION)"
-            exit 1
+            echo "Release kind '$RELEASE_KIND': deferring draft/approval gate to the final release (CI checks still enforced below)"
           fi
 
           STATUS_ROLLUP=$(echo "$PR_JSON" | jq -r '.[0].statusCheckRollup // []')


### PR DESCRIPTION
## Description

The scaffolded release template `assets/workspace/.github/workflows/release-core.yml` applied the **draft + approval gate to every release kind**, so a `release_kind=candidate` dispatch failed against a still-draft PR with `ERROR: PR #N is still in draft`. This blocked a real consumer (`vig-os/commit-action`'s 0.3.0 candidate — [run 29396249943](https://github.com/vig-os/commit-action/actions/runs/29396249943/job/87290340861)).

Root cause is **template drift**: #902's fix (gate RC dispatch on CI only) landed in devkit's *own* `.github/workflows/release.yml` but was never mirrored into the scaffolded `release-core.yml` that consumers receive. Devkit dogfoods the fixed copy, so the regression went unnoticed until a downstream repo ran a candidate.

Closes #1095.

## Type of Change

- [x] `fix` -- Bug fix

## Changes Made

- Wrapped the draft (`isDraft`) and approval (`reviewDecision` + #438 bot-approval fallback) checks in the "Find and verify PR" step behind `if [ "$RELEASE_KIND" = "final" ]`, with an `else` branch that logs the deferral — a verbatim port of the guard already in `release.yml:354-380`.
- Added `RELEASE_KIND: ${{ steps.vars.outputs.release_kind }}` to the step env.
- Left the `CI_FAILED` check unconditional: candidates still gate on CI.
- Scope kept minimal — did **not** port `release.yml`'s additional `CI_PENDING`/`CI_SUCCESS` checks (separate divergence, out of scope for this bug).

## Changelog Entry

### Fixed
- **Candidate releases no longer fail the draft/approval gate** ([#1095](https://github.com/vig-os/devkit/issues/1095))
  - The scaffolded `release-core.yml` "Find and verify PR" step applied the draft + approval gate to every release kind, so a `release_kind=candidate` dispatch failed against a still-draft PR (`ERROR: PR #N is still in draft`). This was template drift: the #902 fix landed in devkit's own `release.yml` but was never mirrored into the scaffolded template consumers receive. The draft + approval checks are now guarded behind `release_kind=final`; candidates gate on CI only, consistent with `RELEASE_CYCLE.md`.

## Testing

- [x] Tests pass locally (`prek run --all-files` — fully green)
- [x] Manual testing performed (describe below)

### Manual Testing Details

- Validated YAML (`yaml.safe_load`).
- Full hook suite (`prek run --all-files`) green: actionlint, yamllint, check-yaml, sync-manifest, agent-identity, commit-msg.
- The ported logic is byte-equivalent to the guard already running in devkit's own `release.yml`, which has executed successfully across 1.1.0 and 1.2.0 candidate + final releases.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [x] New and existing unit tests pass locally with my changes
