### PR TITLE
fix(security): except perl 5.42.0 CVE batch pending upstream stable fix

### DIFF
--- a/.vulnixignore
+++ b/.vulnixignore
@@ -318,3 +318,36 @@ CVE-2026-40467
 #   reachable when the opt-in readdir extension is loaded (`-l readdir`) on a
 #   crafted directory tree — not used by any tooling here.
 CVE-2026-40553
+
+# ============================================================================
+# Triage 2026-07-15 — perl 5.42.0 CPANSec batch (release-cycle fix, #1094).
+# Surfaced in the vulnix feed 2026-07-15 and failed the nightly vulnix gate
+# (security-scan run 29396607272). Verified ONLINE against NVD/MITRE/CPANSec,
+# the Debian security tracker, and the upstream perl release on 2026-07-15.
+# Real product match (perl the interpreter, no CPE collision). Both fixes exist
+# ONLY in the perl 5.43.x DEVELOPMENT series (fixed in 5.43.10); stable perl is
+# 5.42.0 in the pinned rev, in nixos-26.05, AND in Debian stable (all still
+# unpatched, no backport) — so the "advance the rev" lever has nowhere to land
+# today. perl is in-closure via git's perl-based subcommands (send-email,
+# instaweb, etc.), same provenance as CVE-2026-4176; it processes
+# developer/CI-chosen inputs only, with no untrusted-input path in the
+# single-user dev model. Flip to a nixpkgs rev-advance once a patched perl
+# reaches the pinned channel; short expiry to force near-term re-check.
+# ============================================================================
+
+Expiration: 2026-08-14
+# perl 5.42.0 — CVE-2026-13221 (9.1): a 16-bit trie-delta field overflows in
+#   Perl_study_chunk when a regex alternation of >65535 fixed-string branches
+#   is compiled into a trie, silently truncating the match table (false
+#   positive/negative matches). Correctness bug; dangerous only when a regex
+#   gates access/filtering, and needs a pathological developer-authored
+#   pattern — no untrusted-regex path here. Fixed upstream in perl 5.43.10
+#   (dev series); not in any stable branch.
+CVE-2026-13221
+# perl 5.42.0 — CVE-2026-57432 (8.4): integer overflow in S_measure_struct
+#   wraps the signed size total negative, so a pack/unpack template with a huge
+#   repeat count drives an out-of-bounds heap read (info disclosure) when the
+#   template derives from untrusted input. No such path here (developer/CI-
+#   chosen templates only). Fixed in the perl 5.43.x dev series; not in any
+#   stable branch.
+CVE-2026-57432


### PR DESCRIPTION
## Summary

The nightly vulnix gate ([run 29396607272](https://github.com/vig-os/devkit/actions/runs/29396607272)) went red on two **new** HIGH/CRITICAL findings in `perl 5.42.0`. Running the real `vulnix-gate` against the run's `vulnix-findings.json` with the live register confirmed these are the **only** blocking findings — every other reported CVE (curl, gawk, openssh, glibc, openssl, …) is still masked by a non-expired exception.

| CVE | CVSS | Description |
|-----|------|-------------|
| CVE-2026-13221 | 9.1 | 16-bit trie-delta overflow in `Perl_study_chunk`; regex alternations of >65535 fixed branches silently miscompile (false pos/neg matches). Correctness bug; needs a pathological developer-authored pattern. |
| CVE-2026-57432 | 8.4 | Integer overflow in `S_measure_struct` → OOB heap read in `pack`/`unpack` when the template derives from untrusted input (info disclosure). |

## Remediation

Both fixes exist **only in the perl 5.43.x development series** (fixed in 5.43.10). Stable perl is 5.42.0 in the pinned rev, `nixos-26.05`, **and** Debian stable — all unpatched, no backport — so the "advance the rev" lever has nowhere to land today. `perl` is in-closure via git's perl-based subcommands (send-email/instaweb), same provenance as the existing CVE-2026-4176 entry, and processes developer/CI-chosen inputs only (no untrusted-input path in the single-user dev model).

This PR adds a **time-boxed `.vulnixignore` exception** (`Expiration: 2026-08-14`) with a verified rationale, mirroring the #1071/#1072 gawk triage. Flip to a nixpkgs rev-advance once a patched perl reaches the pinned channel.

## Verification

- `vulnix-gate` against the run's artifact with the edited register: **0 blocking findings** (was 2).
- `check-expirations`: all 60 exceptions validated.
- `just precommit` (full suite, `--all-files`): green.

Closes #1094