### PR TITLE
fix(init-workspace): durable consumer seam for repo-root ignores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Durable committed home for repo-root ignores (`.gitignore.project`)** ([#1092](https://github.com/vig-os/devkit/issues/1092))
+  - New preserved, consumer-owned `.gitignore.project` (mirroring `justfile.project`): the only committed place git honors for repo-ROOT ignores, since git reads root ignores solely from the managed root `.gitignore` that devkit regenerates on every upgrade. `init-workspace.sh` appends its contents to the regenerated `.gitignore` after the per-language fragments, so root-level consumer ignores survive every upgrade. The base `.gitignore` header and the `flake.nix` opt-in note now point here instead of advising an edit the upgrade destroys.
+
 ### Changed
 
 ### Deprecated
@@ -16,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+
+- **Managed `.gitignore` rewrite no longer drops consumer-required ignores** ([#1092](https://github.com/vig-os/devkit/issues/1092))
+  - When the flake-hooks opt-in installs `.pre-commit-config.yaml` as a `/nix/store` symlink, the ignore for it is now seeded automatically on every (re)scaffold — gated strictly on the store-symlink condition, so a hand-managed consumer that commits a real `.pre-commit-config.yaml` file is never affected.
+  - The Node fragment now ignores the `tsc`/`ncc` declaration byproducts under `dist/src/` (`.d.ts` / `.d.ts.map` files embed absolute `file://` paths regenerated per checkout) while keeping the committed bundle `dist/index.js` and `dist/package.json` tracked — no blanket `dist/` ignore.
 
 ### Security
 

--- a/assets/gitignore.d/node.gitignore
+++ b/assets/gitignore.d/node.gitignore
@@ -12,6 +12,12 @@ node_modules/
 # TypeScript incremental build info
 *.tsbuildinfo
 
+# tsc/ncc emit .d.ts + .d.ts.map declaration byproducts under dist/src/ (#1092);
+# the .d.ts.map files embed absolute file:// paths regenerated per checkout, so
+# ignore them — WITHOUT a blanket dist/ ignore, keeping the committed bundle
+# dist/index.js + dist/package.json tracked.
+dist/src/
+
 # Coverage reports
 coverage/
 .nyc_output/

--- a/assets/init-workspace.sh
+++ b/assets/init-workspace.sh
@@ -102,6 +102,13 @@ PRESERVE_FILES=(
     # terms. Preserved like .pre-commit-config.yaml; the upgrade prints a diff
     # against the template below. (Legacy `_typos.toml` handled at copy time.)
     ".typos.toml"
+    # The consumer owns its repo-ROOT ignores (#1092): the managed root
+    # .gitignore is overwritten on every upgrade, and git honors a repo-root
+    # ignore only from that root .gitignore — so there was no durable committed
+    # home for root-level ignores. .gitignore.project is that home (mirroring
+    # justfile.project): preserved here, and its contents are appended to the
+    # regenerated .gitignore by render_gitignore below so they survive upgrades.
+    ".gitignore.project"
 )
 
 # Base recipes the shipped .github/workflows/ci.yml depends on (sync, precommit,
@@ -612,6 +619,35 @@ render_gitignore() {
             cat "$frag" >>"$gi"
         fi
     done
+
+    # Consumer-owned durable root ignores (#1092): .gitignore.project is a
+    # PRESERVE_FILE — the only committed home git honors for repo-ROOT ignores,
+    # since git reads root ignores solely from this regenerated root .gitignore.
+    # Append its contents LAST so consumer entries survive every regeneration.
+    local proj="$WORKSPACE_DIR/.gitignore.project"
+    if [[ -f "$proj" ]]; then
+        printf '\n' >>"$gi"
+        cat "$proj" >>"$gi"
+    fi
+
+    # flake-hooks opt-in seed (#1092): a consumer that opts into flake-generated
+    # hooks (hooks = { } in flake.nix) gets .pre-commit-config.yaml installed as
+    # a /nix/store symlink, which must be ignored — committing it pushes a
+    # machine-local, broken symlink. Seed the ignore automatically, gated
+    # STRICTLY on the store-symlink condition so a hand-managed consumer who
+    # commits a real .pre-commit-config.yaml file is never affected. Idempotent:
+    # skip when the assembled ignore (incl. .gitignore.project) already lists it.
+    local pcc="$WORKSPACE_DIR/.pre-commit-config.yaml"
+    if [[ -L "$pcc" ]] && readlink "$pcc" | grep -q '/nix/store/'; then
+        if ! grep -qxF '.pre-commit-config.yaml' "$gi"; then
+            {
+                printf '\n# flake-hooks opt-in (#1092): the generated'
+                printf ' .pre-commit-config.yaml is a\n'
+                printf '# /nix/store symlink — never commit it.\n'
+                printf '.pre-commit-config.yaml\n'
+            } >>"$gi"
+        fi
+    fi
 }
 
 # Rewrite the managed CodeQL language matrix to the detected language(s) (#1025):

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Durable committed home for repo-root ignores (`.gitignore.project`)** ([#1092](https://github.com/vig-os/devkit/issues/1092))
+  - New preserved, consumer-owned `.gitignore.project` (mirroring `justfile.project`): the only committed place git honors for repo-ROOT ignores, since git reads root ignores solely from the managed root `.gitignore` that devkit regenerates on every upgrade. `init-workspace.sh` appends its contents to the regenerated `.gitignore` after the per-language fragments, so root-level consumer ignores survive every upgrade. The base `.gitignore` header and the `flake.nix` opt-in note now point here instead of advising an edit the upgrade destroys.
+
 ### Changed
 
 ### Deprecated
@@ -16,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 ### Fixed
+
+- **Managed `.gitignore` rewrite no longer drops consumer-required ignores** ([#1092](https://github.com/vig-os/devkit/issues/1092))
+  - When the flake-hooks opt-in installs `.pre-commit-config.yaml` as a `/nix/store` symlink, the ignore for it is now seeded automatically on every (re)scaffold — gated strictly on the store-symlink condition, so a hand-managed consumer that commits a real `.pre-commit-config.yaml` file is never affected.
+  - The Node fragment now ignores the `tsc`/`ncc` declaration byproducts under `dist/src/` (`.d.ts` / `.d.ts.map` files embed absolute `file://` paths regenerated per checkout) while keeping the committed bundle `dist/index.js` and `dist/package.json` tracked — no blanket `dist/` ignore.
 
 ### Security
 

--- a/assets/workspace/.gitignore
+++ b/assets/workspace/.gitignore
@@ -7,7 +7,8 @@
 # upgrade and appends a per-language fragment (Python / Node / Rust) detected
 # from the repo's marker files (pyproject.toml / package.json / Cargo.toml).
 # Do not hand-edit durable ignores here — they will not survive an upgrade.
-# Put repo-specific ignores in a committed file your team owns instead.
+# Put repo-specific root ignores in .gitignore.project (preserved on upgrade);
+# init-workspace.sh appends its contents here on every regeneration (#1092).
 
 # Environments
 .env

--- a/assets/workspace/.gitignore.project
+++ b/assets/workspace/.gitignore.project
@@ -1,0 +1,10 @@
+# Repo-specific root .gitignore entries — yours to edit; upgrades never
+# overwrite this file. This is the durable committed home for repo-ROOT ignores:
+# git honors a root ignore only from the root .gitignore, which devkit
+# regenerates on every upgrade, so entries added HERE are appended to that
+# regenerated .gitignore and survive. Put durable repo-root ignores below (not
+# in the managed .gitignore, where hand edits are lost).
+#
+# Examples (uncomment / add your own):
+#   /scratch/
+#   /secrets.local.yaml

--- a/assets/workspace/flake.nix
+++ b/assets/workspace/flake.nix
@@ -64,9 +64,11 @@
           # update vigos`, and your customization lives HERE (preserved).
           # Contract + migration steps:
           # https://github.com/vig-os/devkit/blob/main/docs/MIGRATION.md ("Customizing
-          # pre-commit hooks from the project flake"). Uncomment to opt in,
-          # then delete .pre-commit-config.yaml and add it to .gitignore
-          # (the generated config refuses to overwrite an existing file).
+          # pre-commit hooks from the project flake"). Uncomment to opt in, then
+          # delete .pre-commit-config.yaml (the generated config refuses to
+          # overwrite an existing file). The generated store symlink is ignored
+          # automatically on (re)scaffold (#1092); add durable root ignores you
+          # own to .gitignore.project.
           #
           #   hooks = {
           #     typos.enable = false;                    # toggle a base hook

--- a/scripts/sync_manifest.py
+++ b/scripts/sync_manifest.py
@@ -162,6 +162,12 @@ _BANNER_SKIP: frozenset[str] = frozenset(
         # flake.nix is consumer-owned/preserved and deferred to avoid nix-format
         # churn on re-sync.
         "flake.nix",
+        # Consumer-owned durable root ignores (#1092): init-workspace.sh APPENDS
+        # this file's contents into the managed root .gitignore on every
+        # (re)scaffold (like the gitignore.d fragments below), so a preserved
+        # banner would land inside the managed .gitignore and contradict its
+        # managed banner. Its own hand-written header states it is preserved.
+        ".gitignore.project",
     }
 )
 

--- a/tests/bats/init-workspace.bats
+++ b/tests/bats/init-workspace.bats
@@ -2689,3 +2689,106 @@ _RELEASE_RESOLVERS_991=(
     assert_success
     assert_output --partial 'Seeded by vigOS devkit'
 }
+
+# ── consumer-owned durable root ignores: .gitignore.project (#1092) ────────────
+# The managed root .gitignore is overwritten on every upgrade, and git honors a
+# repo-ROOT ignore only from that root .gitignore — so consumers had no durable
+# committed home for root-level ignores. .gitignore.project is a PRESERVE_FILE
+# (mirroring justfile.project) whose contents init-workspace.sh appends to the
+# regenerated .gitignore after the per-language fragments, so root-level consumer
+# ignores survive every regeneration.
+
+@test ".gitignore.project is in PRESERVE_FILES (#1092)" {
+    # shellcheck disable=SC2016
+    run grep -E '"\.gitignore\.project"' "$INIT_WORKSPACE_SH"
+    assert_success
+}
+
+@test "template ships a .gitignore.project (#1092)" {
+    run test -f "$TEMPLATE_DIR/.gitignore.project"
+    assert_success
+}
+
+@test "upgrade preserves a customized .gitignore.project (#1092)" {
+    ws="$BATS_TEST_TMPDIR/e2e-1092-preserve"
+    mkdir -p "$ws"
+    printf '# SENTINEL-1092 consumer root ignores\n/scratch-local/\n' \
+        >"$ws/.gitignore.project"
+    run _upgrade both "$ws"
+    assert_success
+    run grep -q 'SENTINEL-1092' "$ws/.gitignore.project"
+    assert_success
+}
+
+@test "rendered .gitignore appends the consumer .gitignore.project contents (#1092)" {
+    ws="$BATS_TEST_TMPDIR/e2e-1092-append"
+    mkdir -p "$ws"
+    printf '# SENTINEL-1092 consumer root ignores\n/scratch-local/\n' \
+        >"$ws/.gitignore.project"
+    run _scaffold both "$ws"
+    assert_success
+    run cat "$ws/.gitignore"
+    assert_success
+    # The consumer's durable root ignore is folded into the regenerated file.
+    assert_line '/scratch-local/'
+}
+
+@test "scaffold .gitignore ignores dist/src/ byproducts but keeps dist/index.js tracked (#1092)" {
+    ws="$BATS_TEST_TMPDIR/e2e-1092-node-dist"
+    mkdir -p "$ws"
+    printf '{ "name": "probe" }\n' >"$ws/package.json"
+    run _scaffold both "$ws"
+    assert_success
+    run cat "$ws/.gitignore"
+    assert_success
+    # tsc/ncc declaration output under dist/src/ is ignored ...
+    assert_line 'dist/src/'
+    # ... but no blanket dist/ ignore (the committed bundle must stay tracked).
+    refute_line 'dist/'
+    # Behavioral proof: git honors the ignore for dist/src/ output, not the bundle.
+    git -C "$ws" init -q
+    mkdir -p "$ws/dist/src"
+    printf 'x\n' >"$ws/dist/index.js"
+    printf 'x\n' >"$ws/dist/src/index.d.ts"
+    run git -C "$ws" check-ignore dist/src/index.d.ts
+    assert_success
+    run git -C "$ws" check-ignore dist/index.js
+    assert_failure
+}
+
+# ── flake-hooks opt-in seeds the .pre-commit-config.yaml ignore (#1092) ────────
+# A consumer that opts into flake-generated hooks (hooks = { } in flake.nix) gets
+# .pre-commit-config.yaml installed as a /nix/store symlink, which must be
+# gitignored (committing it pushes a machine-local, broken symlink). The seed is
+# gated STRICTLY on the store-symlink condition, so a hand-managed consumer that
+# commits a real .pre-commit-config.yaml file is never affected.
+
+@test "flake-hooks store-symlink seeds the .pre-commit-config.yaml ignore (#1092)" {
+    ws="$BATS_TEST_TMPDIR/e2e-1092-flakehooks"
+    mkdir -p "$ws"
+    # A real /nix/store-shaped target so the preserve exclude keeps the symlink
+    # (the exclude guard uses -e, which follows the link) and readlink sees the
+    # /nix/store/ path the seed gates on.
+    store="$BATS_TEST_TMPDIR/nix/store/abc123-hooks"
+    mkdir -p "$store"
+    printf 'repos: []\n' >"$store/pre-commit-config.yaml"
+    ln -s "$store/pre-commit-config.yaml" "$ws/.pre-commit-config.yaml"
+    run _scaffold both "$ws"
+    assert_success
+    run cat "$ws/.gitignore"
+    assert_success
+    assert_line '.pre-commit-config.yaml'
+}
+
+@test "a hand-managed real .pre-commit-config.yaml is NOT seeded into .gitignore (#1092)" {
+    ws="$BATS_TEST_TMPDIR/e2e-1092-realconfig"
+    mkdir -p "$ws"
+    # A committed regular file (not a store symlink): the consumer owns it and
+    # tracks it, so it must never be auto-ignored.
+    printf 'repos: []\n' >"$ws/.pre-commit-config.yaml"
+    run _scaffold both "$ws"
+    assert_success
+    run cat "$ws/.gitignore"
+    assert_success
+    refute_line '.pre-commit-config.yaml'
+}


### PR DESCRIPTION
Closes #1092. Part of #1096.

## Problem
The managed root `.gitignore` is fully overwritten on every `install.sh --force`, and there was no committed place a consumer could put repo-**root** ignores that survives — git only honors a root ignore from the root `.gitignore`, which devkit regenerates. The file's own advice ("put repo-specific ignores in a committed file your team owns") had no valid form for root paths, and `flake.nix` even *instructed* an edit to the managed `.gitignore` that the next upgrade destroyed.

## Change
- **New preserved `.gitignore.project`** (mirrors `justfile.project`): the durable, consumer-owned home for repo-root ignores. `render_gitignore()` appends its contents to the regenerated `.gitignore` after the per-language fragments, so they survive every upgrade. Added to `PRESERVE_FILES` and to `_BANNER_SKIP` (its content is inlined into the managed file, so it carries a hand-written header, not a preserved banner).
- **Auto-seed** the `.pre-commit-config.yaml` ignore when the flake-hooks opt-in makes it a `/nix/store` symlink — gated strictly on the store-symlink condition, so a hand-managed committed file is never ignored.
- **Node byproducts**: `dist/src/` (`.d.ts`/`.d.ts.map`) is ignored while the committed bundle `dist/index.js`/`dist/package.json` stays tracked — no blanket `dist/`.
- **`flake.nix:68`** no longer tells the opt-in consumer to edit the managed `.gitignore`; it points at the auto-seed / `.gitignore.project`.

## Tests / verification
7 new bats cases in `tests/bats/init-workspace.bats` (preserve, append, dist/src, store-symlink seed vs real-file no-seed). Full `prek run --all-files` green locally; `init-workspace.bats` 184 ok / 0 fail.

## Merge note
Cut from and re-merged onto `dev` (includes the `chore: merge dev` commit; conflict-free). Siblings #1093 and #1099 also touch `CHANGELOG.md` — whichever merges second/third will need a one-click "Update branch" (trivial changelog union).
