### PR TITLE
fix(init-workspace): warn on scaffold/flake-pin version skew

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Warn on flake pin / `DEVKIT_VERSION` skew** ([#1093](https://github.com/vig-os/devkit/issues/1093))
+  - A `--force` direnv/both upgrade that advances the scaffold now warns when the
+    consumer's pinned `vigos` flake `ref` lags the `DEVKIT_VERSION` being
+    written — the two ship coupled halves of the same change (e.g. #1053's JSONC
+    banner + its `check-json` exclude) and must move together, else strict hooks
+    reject files the new scaffold wrote.
+  - Non-fatal; a floating (unpinned) input or a matching pin stays silent.
+
 ### Changed
 
 ### Deprecated

--- a/assets/init-workspace.sh
+++ b/assets/init-workspace.sh
@@ -1046,6 +1046,34 @@ if [[ -n "${VIG_OS_VERSION:-}" && -f "$WORKSPACE_DIR/.vig-os" ]]; then
     # DEVKIT_VERSION, so a stray legacy DEVCONTAINER_VERSION line is migrated
     # rather than left stale (#781).
     sed -i -E "s/^(DEVKIT_VERSION|DEVCONTAINER_VERSION)=.*/DEVKIT_VERSION=${VIG_OS_VERSION}/" "$WORKSPACE_DIR/.vig-os"
+
+    # Flake pin / DEVKIT_VERSION lockstep skew warning (#1093). For direnv/flake
+    # consumers the scaffold and the pinned `vigos` flake input deliver coupled
+    # halves of the same change (e.g. #1053's JSONC banner is written by the
+    # scaffold, but its compensating check-json exclude lives in nix/hooks.nix,
+    # delivered through the flake input). Bumping only the scaffold while a pinned
+    # `vigos` ref lags behind silently breaks every commit. We cannot fix it for
+    # the consumer — flake.nix is a PRESERVE_FILE they own — but we can warn.
+    # A FLOATING input (no ?ref=) is intentionally unpinned, so it never warns;
+    # only a pin that differs from the target does.
+    if [[ "$FORCE" == "true" && ( "$MODE" == "direnv" || "$MODE" == "both" ) \
+        && -f "$WORKSPACE_DIR/flake.nix" ]]; then
+        # `|| true`: a floating input yields no grep match (exit 1), which would
+        # abort under `set -o pipefail`; an empty pinned_ref is the intended
+        # "unpinned, no warning" signal.
+        pinned_ref="$(grep -oE 'vigos\.url[[:space:]]*=[[:space:]]*"github:vig-os/devkit\?ref=[^"]+"' \
+            "$WORKSPACE_DIR/flake.nix" 2>/dev/null \
+            | sed -E 's/.*\?ref=([^"]+)".*/\1/' | head -n1 || true)"
+        if [[ -n "$pinned_ref" && "$pinned_ref" != "$VIG_OS_VERSION" ]]; then
+            echo "" >&2
+            echo "WARNING: scaffold upgraded to ${VIG_OS_VERSION}, but the pinned vigos flake input is still ${pinned_ref}." >&2
+            echo "         The two must move together — they deliver coupled halves of the same" >&2
+            echo "         change (e.g. #1053's JSONC banner + its check-json exclude). Update your" >&2
+            echo "         flake.nix to 'vigos.url = \"github:vig-os/devkit?ref=${VIG_OS_VERSION}\";' and run" >&2
+            echo "         'nix flake update vigos', else strict hooks may reject files this scaffold wrote." >&2
+            echo "" >&2
+        fi
+    fi
 fi
 
 # Interactive origin resolution (the renovate.json owner/repo prompt) runs here,

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Warn on flake pin / `DEVKIT_VERSION` skew** ([#1093](https://github.com/vig-os/devkit/issues/1093))
+  - A `--force` direnv/both upgrade that advances the scaffold now warns when the
+    consumer's pinned `vigos` flake `ref` lags the `DEVKIT_VERSION` being
+    written — the two ship coupled halves of the same change (e.g. #1053's JSONC
+    banner + its `check-json` exclude) and must move together, else strict hooks
+    reject files the new scaffold wrote.
+  - Non-fatal; a floating (unpinned) input or a matching pin stays silent.
+
 ### Changed
 
 ### Deprecated

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -588,3 +588,34 @@ to match, then `nix flake update vigos`:
 ```nix
 vigos.url = "github:vig-os/devkit"; # was github:vig-os/devcontainer
 ```
+
+### `DEVKIT_VERSION` and the pinned flake `ref` move in lockstep
+
+If you **pin** the flake input to a release
+(`vigos.url = "github:vig-os/devkit?ref=<tag>"`), the pinned `<tag>` and the
+`DEVKIT_VERSION` written into `.vig-os` by the scaffold must stay on the **same
+version**. They deliver **coupled halves of the same change**: the scaffold
+(keyed to `DEVKIT_VERSION`, delivered by `install.sh --force`) writes files,
+while the pinned flake input (`nix/hooks.nix`) delivers the matching hook
+behavior. For example, the JSONC provenance banner
+([#1053](https://github.com/vig-os/devkit/issues/1053)) is written by the
+scaffold, but its compensating `check-json` exclude lives in the flake input —
+bump only the scaffold and the strict `check-json` hook rejects the banner,
+failing **every** commit
+([#1093](https://github.com/vig-os/devkit/issues/1093)).
+
+Keep them aligned: whenever a `--force` upgrade advances `DEVKIT_VERSION`, bump
+the pinned `ref` to the same version and re-resolve the input:
+
+```nix
+vigos.url = "github:vig-os/devkit?ref=<new-DEVKIT_VERSION>";
+```
+
+```console
+nix flake update vigos
+```
+
+A `--force` upgrade whose scaffold version differs from a pinned `vigos` ref now
+prints a warning to that effect. A **floating** input
+(`vigos.url = "github:vig-os/devkit"`, no `?ref=`) tracks the branch and needs no
+manual bump — it is exempt.

--- a/tests/bats/init-workspace.bats
+++ b/tests/bats/init-workspace.bats
@@ -872,6 +872,51 @@ _scaffold_with_version_file() {
     assert_output "DEVKIT_VERSION=1.2.3"
 }
 
+# ── flake pin / DEVKIT_VERSION lockstep skew warning (#1093) ──────────────────
+# The scaffold (keyed to DEVKIT_VERSION) and the pinned `vigos` flake input ship
+# coupled halves of a change (e.g. #1053's JSONC banner + its check-json exclude).
+# A --force upgrade that advances the scaffold but leaves a stale pinned flake ref
+# behind silently breaks every commit for a direnv/flake consumer. init warns when
+# a pinned vigos ref in the consumer's flake.nix differs from the DEVKIT_VERSION
+# being written. A floating (unpinned) input is intentional and never warns.
+
+# Pre-seed $ws/flake.nix carrying a $url vigos input, then --force upgrade the
+# direnv scaffold to $target (via the image built-tag record).
+_upgrade_direnv_with_flake_url() {
+    local ws="$1" target="$2" url="$3"
+    mkdir -p "$ws"
+    cat >"$ws/flake.nix" <<EOF
+{
+  inputs = {
+    vigos.url = "$url";
+    nixpkgs.follows = "vigos/nixpkgs";
+  };
+}
+EOF
+    local verfile="$BATS_TEST_TMPDIR/VERSION-1093-$RANDOM"
+    printf '%s\n' "$target" >"$verfile"
+    _scaffold_with_version_file direnv "$ws" "$verfile"
+}
+
+@test "init-workspace warns when a pinned vigos flake ref lags the DEVKIT_VERSION target (#1093)" {
+    run _upgrade_direnv_with_flake_url "$BATS_TEST_TMPDIR/e2e-1093-skew" 1.2.0 "github:vig-os/devkit?ref=1.1.0"
+    assert_success
+    assert_output --partial "pinned vigos flake input is still 1.1.0"
+    assert_output --partial "nix flake update vigos"
+}
+
+@test "init-workspace is silent when the pinned vigos flake ref matches the target (#1093)" {
+    run _upgrade_direnv_with_flake_url "$BATS_TEST_TMPDIR/e2e-1093-match" 1.2.0 "github:vig-os/devkit?ref=1.2.0"
+    assert_success
+    refute_output --partial "pinned vigos flake input is still"
+}
+
+@test "init-workspace is silent when the vigos flake input floats unpinned (#1093)" {
+    run _upgrade_direnv_with_flake_url "$BATS_TEST_TMPDIR/e2e-1093-float" 1.2.0 "github:vig-os/devkit"
+    assert_success
+    refute_output --partial "pinned vigos flake input is still"
+}
+
 @test "template ships .typos.toml alongside the typos hook (#855)" {
     # The scaffold's .pre-commit-config.yaml runs the typos hook; without the
     # exception config, scaffold-shipped content (version-check.sh's Nd


### PR DESCRIPTION
Closes #1093. Part of #1096.

## Problem
For direnv/flake consumers, two coupled halves of a change ship from different version vehicles: the **scaffold** (`.vig-os` `DEVKIT_VERSION`) writes files, while the pinned **`vigos` flake input** delivers the hook behavior in `nix/hooks.nix` that acts on them (e.g. the #1053 `check-json` exclude paired with a scaffold-written JSONC banner). A consumer who bumps only the scaffold but leaves the pinned flake `ref` behind gets, e.g., the banner without its exclude → every commit fails, with nothing warning about the skew.

## Change (warn-only — no auto-edit of the preserved `flake.nix`)
- `install.sh --force` now **detects and warns** when the pinned `vigos.url = "…?ref=<X>"` in `flake.nix` differs from the target `DEVKIT_VERSION`, telling the user to update the pin and run `nix flake update vigos`. Gated on force + direnv/both + a pin that exists and differs; a **floating** (unpinned) input and a **matching** pin are both silent. Non-fatal.
- **`docs/MIGRATION.md`**: new subsection documenting the lockstep invariant (why the two must move together, and how).

## Tests / verification
3 new bats cases (skew warns; match silent; floating silent) — RED before, GREEN after. Handles the `set -euo pipefail` grep-exit-1 trap. Full `prek run --all-files` green locally.

## Merge note
Re-merged onto `dev` (conflict-free; its changelog `Added` entry auto-merged). Siblings #1092 and #1099 also touch `CHANGELOG.md` — a later merge may need "Update branch".
