### PR TITLE
fix(workspace): preserve .pymarkdown / .yamllint lint configs on upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Preserve customized `.yamllint` / `.pymarkdown.config.md` on upgrade** ([#1099](https://github.com/vig-os/devkit/issues/1099))
+  - Promoted both lint configs to `PRESERVE_FILES`, so repo-specific `ignore:`
+    globs and rule disables survive `install.sh --force` instead of being
+    silently overwritten (same class as `.pre-commit-config.yaml` #878 and
+    `.typos.toml` #913).
+  - The upgrade now prints a template diff against each preserved file so
+    lint-rule evolution stays visible, and both templates render the preserved
+    provenance banner.
+
 ### Security
 
 ## [1.2.0](https://github.com/vig-os/devkit/releases/tag/1.2.0) - 2026-07-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,14 +17,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Preserve customized `.yamllint` / `.pymarkdown.config.md` on upgrade** ([#1099](https://github.com/vig-os/devkit/issues/1099))
-  - Promoted both lint configs to `PRESERVE_FILES`, so repo-specific `ignore:`
-    globs and rule disables survive `install.sh --force` instead of being
-    silently overwritten (same class as `.pre-commit-config.yaml` #878 and
-    `.typos.toml` #913).
+- **Preserve customized lint configs `.pymarkdown` / `.yamllint` on upgrade** ([#1099](https://github.com/vig-os/devkit/issues/1099))
+  - Promoted the markdown-lint config `.pymarkdown` (the JSON pymarkdown reads),
+    the `.yamllint` config, and the `.pymarkdown.config.md` doc companion to
+    `PRESERVE_FILES`, so repo-specific `ignore:` globs and rule disables survive
+    `install.sh --force` instead of being silently overwritten (same class as
+    `.pre-commit-config.yaml` #878 and `.typos.toml` #913).
   - The upgrade now prints a template diff against each preserved file so
-    lint-rule evolution stays visible, and both templates render the preserved
-    provenance banner.
+    lint-rule evolution stays visible. The comment-capable `.yamllint` /
+    `.pymarkdown.config.md` templates render the preserved provenance banner;
+    `.pymarkdown` is strict JSON and stays un-bannered, like `renovate.json`.
 
 ### Security
 

--- a/assets/init-workspace.sh
+++ b/assets/init-workspace.sh
@@ -102,6 +102,13 @@ PRESERVE_FILES=(
     # terms. Preserved like .pre-commit-config.yaml; the upgrade prints a diff
     # against the template below. (Legacy `_typos.toml` handled at copy time.)
     ".typos.toml"
+    # The consumer owns its lint-rule exceptions (#1099): repos add repo-specific
+    # yamllint `ignore:` globs / rule disables and pymarkdown rule tweaks that a
+    # template overwrite silently destroyed, so the hook then flagged legitimate
+    # content. Preserved like .typos.toml; the upgrade prints a diff against the
+    # template below so lint-rule evolution stays visible.
+    ".yamllint"
+    ".pymarkdown.config.md"
 )
 
 # Base recipes the shipped .github/workflows/ci.yml depends on (sync, precommit,
@@ -552,6 +559,13 @@ PRECOMMIT_CONFIG_PREEXISTED=false
 # record it so the post-scaffold guard can surface template divergence.
 TYPOS_CONFIG_PREEXISTED=false
 [[ -f "$WORKSPACE_DIR/.typos.toml" ]] && TYPOS_CONFIG_PREEXISTED=true
+
+# Preserved lint configs are the consumer's rule exceptions (#1099); record them
+# so the post-scaffold guard can surface template divergence.
+YAMLLINT_CONFIG_PREEXISTED=false
+[[ -f "$WORKSPACE_DIR/.yamllint" ]] && YAMLLINT_CONFIG_PREEXISTED=true
+PYMARKDOWN_CONFIG_PREEXISTED=false
+[[ -f "$WORKSPACE_DIR/.pymarkdown.config.md" ]] && PYMARKDOWN_CONFIG_PREEXISTED=true
 
 # ── consumer language detection (#1024/#1025) ─────────────────────────────────
 # Managed scaffold statics (.gitignore, .github/workflows/codeql.yml) are
@@ -1204,6 +1218,17 @@ fi
 # can fold in what they need deliberately. Non-fatal, like the #878 guard.
 if [[ "$TYPOS_CONFIG_PREEXISTED" == "true" ]]; then
     print_preserved_template_diff ".typos.toml" || true
+fi
+
+# Preserved lint configs are the consumer's (#1099) — never overwritten, so
+# their yamllint/pymarkdown rule exceptions survive; the cost is that template
+# rule evolution no longer arrives automatically. Print the divergence so
+# consumers can fold in what they need deliberately. Non-fatal, like the #913 guard.
+if [[ "$YAMLLINT_CONFIG_PREEXISTED" == "true" ]]; then
+    print_preserved_template_diff ".yamllint" || true
+fi
+if [[ "$PYMARKDOWN_CONFIG_PREEXISTED" == "true" ]]; then
+    print_preserved_template_diff ".pymarkdown.config.md" || true
 fi
 
 # The retired `pre-commit` binary (#778) exits 127 at first use: a preserved

--- a/assets/init-workspace.sh
+++ b/assets/init-workspace.sh
@@ -106,8 +106,12 @@ PRESERVE_FILES=(
     # yamllint `ignore:` globs / rule disables and pymarkdown rule tweaks that a
     # template overwrite silently destroyed, so the hook then flagged legitimate
     # content. Preserved like .typos.toml; the upgrade prints a diff against the
-    # template below so lint-rule evolution stays visible.
+    # template below so lint-rule evolution stays visible. `.pymarkdown` is the
+    # strict-JSON config pymarkdown actually reads (md0xx rule settings); like
+    # renovate.json it carries no banner but is preserved all the same, while
+    # `.pymarkdown.config.md` is its human-readable doc companion.
     ".yamllint"
+    ".pymarkdown"
     ".pymarkdown.config.md"
 )
 
@@ -565,7 +569,9 @@ TYPOS_CONFIG_PREEXISTED=false
 YAMLLINT_CONFIG_PREEXISTED=false
 [[ -f "$WORKSPACE_DIR/.yamllint" ]] && YAMLLINT_CONFIG_PREEXISTED=true
 PYMARKDOWN_CONFIG_PREEXISTED=false
-[[ -f "$WORKSPACE_DIR/.pymarkdown.config.md" ]] && PYMARKDOWN_CONFIG_PREEXISTED=true
+[[ -f "$WORKSPACE_DIR/.pymarkdown" ]] && PYMARKDOWN_CONFIG_PREEXISTED=true
+PYMARKDOWN_DOC_PREEXISTED=false
+[[ -f "$WORKSPACE_DIR/.pymarkdown.config.md" ]] && PYMARKDOWN_DOC_PREEXISTED=true
 
 # ── consumer language detection (#1024/#1025) ─────────────────────────────────
 # Managed scaffold statics (.gitignore, .github/workflows/codeql.yml) are
@@ -1228,6 +1234,9 @@ if [[ "$YAMLLINT_CONFIG_PREEXISTED" == "true" ]]; then
     print_preserved_template_diff ".yamllint" || true
 fi
 if [[ "$PYMARKDOWN_CONFIG_PREEXISTED" == "true" ]]; then
+    print_preserved_template_diff ".pymarkdown" || true
+fi
+if [[ "$PYMARKDOWN_DOC_PREEXISTED" == "true" ]]; then
     print_preserved_template_diff ".pymarkdown.config.md" || true
 fi
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -17,6 +17,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Preserve customized `.yamllint` / `.pymarkdown.config.md` on upgrade** ([#1099](https://github.com/vig-os/devkit/issues/1099))
+  - Promoted both lint configs to `PRESERVE_FILES`, so repo-specific `ignore:`
+    globs and rule disables survive `install.sh --force` instead of being
+    silently overwritten (same class as `.pre-commit-config.yaml` #878 and
+    `.typos.toml` #913).
+  - The upgrade now prints a template diff against each preserved file so
+    lint-rule evolution stays visible, and both templates render the preserved
+    provenance banner.
+
 ### Security
 
 ## [1.2.0](https://github.com/vig-os/devkit/releases/tag/1.2.0) - 2026-07-14

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -17,14 +17,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Preserve customized `.yamllint` / `.pymarkdown.config.md` on upgrade** ([#1099](https://github.com/vig-os/devkit/issues/1099))
-  - Promoted both lint configs to `PRESERVE_FILES`, so repo-specific `ignore:`
-    globs and rule disables survive `install.sh --force` instead of being
-    silently overwritten (same class as `.pre-commit-config.yaml` #878 and
-    `.typos.toml` #913).
+- **Preserve customized lint configs `.pymarkdown` / `.yamllint` on upgrade** ([#1099](https://github.com/vig-os/devkit/issues/1099))
+  - Promoted the markdown-lint config `.pymarkdown` (the JSON pymarkdown reads),
+    the `.yamllint` config, and the `.pymarkdown.config.md` doc companion to
+    `PRESERVE_FILES`, so repo-specific `ignore:` globs and rule disables survive
+    `install.sh --force` instead of being silently overwritten (same class as
+    `.pre-commit-config.yaml` #878 and `.typos.toml` #913).
   - The upgrade now prints a template diff against each preserved file so
-    lint-rule evolution stays visible, and both templates render the preserved
-    provenance banner.
+    lint-rule evolution stays visible. The comment-capable `.yamllint` /
+    `.pymarkdown.config.md` templates render the preserved provenance banner;
+    `.pymarkdown` is strict JSON and stays un-bannered, like `renovate.json`.
 
 ### Security
 

--- a/assets/workspace/.pymarkdown.config.md
+++ b/assets/workspace/.pymarkdown.config.md
@@ -1,5 +1,5 @@
-<!-- Managed by vigOS devkit — regenerated on upgrade; local edits are lost. -->
-<!-- Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues -->
+<!-- Seeded by vigOS devkit — yours to edit; upgrades never overwrite this file. -->
+<!-- Bugs / missing tools: https://github.com/vig-os/devkit/issues -->
 
 # Pymarkdown Configuration
 

--- a/assets/workspace/.yamllint
+++ b/assets/workspace/.yamllint
@@ -1,6 +1,6 @@
 ---
-# Managed by vigOS devkit — regenerated on upgrade; local edits are lost.
-# Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues
+# Seeded by vigOS devkit — yours to edit; upgrades never overwrite this file.
+# Bugs / missing tools: https://github.com/vig-os/devkit/issues
 
 extends: default
 

--- a/tests/bats/init-workspace.bats
+++ b/tests/bats/init-workspace.bats
@@ -1401,6 +1401,41 @@ EOF
     assert_output --partial 'MD013'
 }
 
+# .pymarkdown is the JSON config pymarkdown actually reads (md0xx rule settings)
+# — the file a consumer really customizes. Like renovate.json it is strict JSON
+# and carries no banner (it stays in _BANNER_SKIP), but it is preserved on
+# upgrade all the same, with a template diff on divergence.
+
+@test ".pymarkdown is preserved on --force upgrade (#1099)" {
+    # shellcheck disable=SC2016
+    run grep -E '"\.pymarkdown"' "$INIT_WORKSPACE_SH"
+    assert_success
+}
+
+@test "upgrade preserves a customized .pymarkdown (#1099)" {
+    ws="$BATS_TEST_TMPDIR/e2e-1099-pymarkdown-json-preserve"
+    mkdir -p "$ws"
+    printf '{ "SENTINEL-1099": true, "plugins": { "md013": { "line_length": 999 } } }\n' \
+        >"$ws/.pymarkdown"
+    run _upgrade both "$ws"
+    assert_success
+    run grep -q 'SENTINEL-1099' "$ws/.pymarkdown"
+    assert_success
+}
+
+@test "upgrade prints a template diff hint for a preserved .pymarkdown (#1099)" {
+    ws="$BATS_TEST_TMPDIR/e2e-1099-pymarkdown-json-diff"
+    mkdir -p "$ws"
+    # a config lacking the template's rule set
+    printf '{ "SENTINEL-1099": true }\n' >"$ws/.pymarkdown"
+    run _upgrade both "$ws"
+    assert_success
+    refute_output --partial 'command not found'
+    assert_output --partial 'Preserved .pymarkdown differs from the template'
+    # a template rule the preserved file lacks shows in the diff
+    assert_output --partial 'siblings_only'
+}
+
 # ── justfile.local must be preserved on upgrade (#1054) ───────────────────────
 # The scaffolded justfile.local (personal, gitignored recipes) claims in its
 # header to be preserved on upgrade, but it was absent from PRESERVE_FILES, so a

--- a/tests/bats/init-workspace.bats
+++ b/tests/bats/init-workspace.bats
@@ -1333,6 +1333,74 @@ EOF
     assert_failure
 }
 
+# ── upgrade must preserve customized lint configs .yamllint / .pymarkdown (#1099) ─
+# Same class as #878/#913: these are fully-managed scaffold files, yet lint
+# CONFIGS a consumer legitimately customizes (repo-specific `ignore:` globs, rule
+# disables). A template overwrite silently destroyed those edits and the hook
+# then flagged legitimate content. Preserve them like .typos.toml (#913) and
+# print the template diff so hook-rule evolution stays visible.
+
+@test ".yamllint is preserved on --force upgrade (#1099)" {
+    # shellcheck disable=SC2016
+    run grep -E '"\.yamllint"' "$INIT_WORKSPACE_SH"
+    assert_success
+}
+
+@test "upgrade preserves a customized .yamllint (#1099)" {
+    ws="$BATS_TEST_TMPDIR/e2e-1099-yamllint-preserve"
+    mkdir -p "$ws"
+    printf '# SENTINEL-1099 consumer yamllint config\nrules:\n  line-length: enable\n' \
+        >"$ws/.yamllint"
+    run _upgrade both "$ws"
+    assert_success
+    run grep -q 'SENTINEL-1099' "$ws/.yamllint"
+    assert_success
+}
+
+@test "upgrade prints a template diff hint for a preserved .yamllint (#1099)" {
+    ws="$BATS_TEST_TMPDIR/e2e-1099-yamllint-diff"
+    mkdir -p "$ws"
+    # a config lacking the template's rule set
+    printf '# SENTINEL-1099 minimal consumer yamllint config\n' >"$ws/.yamllint"
+    run _upgrade both "$ws"
+    assert_success
+    refute_output --partial 'command not found'
+    assert_output --partial 'Preserved .yamllint differs from the template'
+    # a template rule the preserved file lacks shows in the diff
+    assert_output --partial 'comments-indentation'
+}
+
+@test ".pymarkdown.config.md is preserved on --force upgrade (#1099)" {
+    # shellcheck disable=SC2016
+    run grep -E '"\.pymarkdown\.config\.md"' "$INIT_WORKSPACE_SH"
+    assert_success
+}
+
+@test "upgrade preserves a customized .pymarkdown.config.md (#1099)" {
+    ws="$BATS_TEST_TMPDIR/e2e-1099-pymarkdown-preserve"
+    mkdir -p "$ws"
+    printf '# SENTINEL-1099 consumer pymarkdown notes\n\nMy repo-specific rules.\n' \
+        >"$ws/.pymarkdown.config.md"
+    run _upgrade both "$ws"
+    assert_success
+    run grep -q 'SENTINEL-1099' "$ws/.pymarkdown.config.md"
+    assert_success
+}
+
+@test "upgrade prints a template diff hint for a preserved .pymarkdown.config.md (#1099)" {
+    ws="$BATS_TEST_TMPDIR/e2e-1099-pymarkdown-diff"
+    mkdir -p "$ws"
+    # a doc lacking the template's rule descriptions
+    printf '# SENTINEL-1099 minimal consumer pymarkdown notes\n' \
+        >"$ws/.pymarkdown.config.md"
+    run _upgrade both "$ws"
+    assert_success
+    refute_output --partial 'command not found'
+    assert_output --partial 'Preserved .pymarkdown.config.md differs from the template'
+    # a template rule the preserved file lacks shows in the diff
+    assert_output --partial 'MD013'
+}
+
 # ── justfile.local must be preserved on upgrade (#1054) ───────────────────────
 # The scaffolded justfile.local (personal, gitignored recipes) claims in its
 # header to be preserved on upgrade, but it was absent from PRESERVE_FILES, so a

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -341,6 +341,8 @@ class TestPreserveFilesSource:
         assert ".typos.toml" in preserve
         # Lint configs are preserved now (#1099): consumers customize them.
         assert ".yamllint" in preserve
+        # .pymarkdown is the strict-JSON config (banner-skipped like renovate.json).
+        assert ".pymarkdown" in preserve
         assert ".pymarkdown.config.md" in preserve
         # justfile.local is preserved now (#1054): its header's claim is real.
         assert "justfile.local" in preserve

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -339,6 +339,9 @@ class TestPreserveFilesSource:
         assert "renovate.json" in preserve
         assert ".envrc" in preserve
         assert ".typos.toml" in preserve
+        # Lint configs are preserved now (#1099): consumers customize them.
+        assert ".yamllint" in preserve
+        assert ".pymarkdown.config.md" in preserve
         # justfile.local is preserved now (#1054): its header's claim is real.
         assert "justfile.local" in preserve
         # Interleaved comment lines are not mistaken for array entries.
@@ -412,6 +415,34 @@ class TestBannerApplication:
 
         text = local.read_text()
         assert ("# " + transforms.PRESERVED_BANNER[0]) in text
+        # The managed variant must not leak into this preserved file.
+        assert transforms.MANAGED_BANNER[0] not in text
+
+    def test_stamps_preserved_banner_on_yamllint(self, tmp_path):
+        """.yamllint is a PRESERVE_FILE now (#1099): preserved banner (hash style)."""
+        sync_manifest = _load_sync_manifest()
+        transforms = _load_transforms()
+        cfg = tmp_path / ".yamllint"
+        cfg.write_text("---\nextends: default\n")
+
+        sync_manifest.apply_banners(tmp_path, {".yamllint"})
+
+        text = cfg.read_text()
+        assert ("# " + transforms.PRESERVED_BANNER[0]) in text
+        # The managed variant must not leak into this preserved file.
+        assert transforms.MANAGED_BANNER[0] not in text
+
+    def test_stamps_preserved_banner_on_pymarkdown_config_md(self, tmp_path):
+        """.pymarkdown.config.md is a PRESERVE_FILE now (#1099): preserved banner (html)."""
+        sync_manifest = _load_sync_manifest()
+        transforms = _load_transforms()
+        doc = tmp_path / ".pymarkdown.config.md"
+        doc.write_text("# Pymarkdown Configuration\n")
+
+        sync_manifest.apply_banners(tmp_path, {".pymarkdown.config.md"})
+
+        text = doc.read_text()
+        assert ("<!-- " + transforms.PRESERVED_BANNER[0] + " -->") in text
         # The managed variant must not leak into this preserved file.
         assert transforms.MANAGED_BANNER[0] not in text
 


### PR DESCRIPTION
Closes #1099. Part of #1096.

## Problem
`.pymarkdown` (the JSON config pymarkdown reads), `.yamllint`, and the `.pymarkdown.config.md` doc were fully-managed and overwritten on every `install.sh --force`, silently destroying repo-specific `ignore:` globs and rule disables — the exact defect fixed for `.pre-commit-config.yaml` (#878) and `.typos.toml` (#913) by promoting them to `PRESERVE_FILES`. That reasoning was never applied here.

## Change
- Promote **`.pymarkdown`**, **`.yamllint`**, and **`.pymarkdown.config.md`** to `PRESERVE_FILES`, mirroring the `.typos.toml` (#913) change set: `*_PREEXISTED` captures + `print_preserved_template_diff` so template evolution stays visible.
- `.yamllint` / `.pymarkdown.config.md` (comment-capable) render the **preserved** banner; `.pymarkdown` is strict JSON and stays un-bannered in `_BANNER_SKIP`, exactly like the already-preserved `renovate.json`.

> Scope note: the original issue named only `.pymarkdown.config.md` (it carried the managed banner); the actual config a consumer customizes is `.pymarkdown` (comment-less JSON, banner-skip-listed, missed by a banner-keyed grep). Corrected to preserve the real config plus its doc companion.

## Tests / verification
6 new bats cases (preserve + customized-survives + diff-hint for `.pymarkdown` and `.yamllint`) + `test_transforms.py` `PRESERVE_FILES` membership and preserved-banner coverage. `init-workspace.bats` 186 ok / 0 fail; `test_transforms.py` 37 passed; full `prek run --all-files` green locally.

## Merge note
Re-merged onto `dev` (changelog union resolved). Siblings #1092 and #1093 also touch `CHANGELOG.md` — a later merge may need "Update branch".
