### PR TITLE
fix(init-workspace): read flake pin from the real input line, not the doc comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     banner + its `check-json` exclude) and must move together, else strict hooks
     reject files the new scaffold wrote.
   - Non-fatal; a floating (unpinned) input or a matching pin stays silent.
+  - The pinned ref is read from the real `vigos.url` input line only, not the
+    `?ref=<tag>` doc-comment example that ships above it in the standard-layout
+    `flake.nix`; previously the extractor matched the comment first, reported the
+    literal `<tag>`, and false-fired even on an aligned pin ([#1110](https://github.com/vig-os/devkit/issues/1110)).
 
 ### Fixed
 

--- a/assets/init-workspace.sh
+++ b/assets/init-workspace.sh
@@ -1117,7 +1117,12 @@ if [[ -n "${VIG_OS_VERSION:-}" && -f "$WORKSPACE_DIR/.vig-os" ]]; then
         # `|| true`: a floating input yields no grep match (exit 1), which would
         # abort under `set -o pipefail`; an empty pinned_ref is the intended
         # "unpinned, no warning" signal.
-        pinned_ref="$(grep -oE 'vigos\.url[[:space:]]*=[[:space:]]*"github:vig-os/devkit\?ref=[^"]+"' \
+        # Anchor on `^[[:space:]]*vigos\.url` so we read the REAL input line only:
+        # the standard-layout flake.nix ships a doc-comment EXAMPLE line
+        # (`#   vigos.url = "github:vig-os/devkit?ref=<tag>";`) above it, and an
+        # unanchored match picked that comment first, reporting the literal
+        # `<tag>` and false-firing even on an aligned pin (#1110).
+        pinned_ref="$(grep -oE '^[[:space:]]*vigos\.url[[:space:]]*=[[:space:]]*"github:vig-os/devkit\?ref=[^"]+"' \
             "$WORKSPACE_DIR/flake.nix" 2>/dev/null \
             | sed -E 's/.*\?ref=([^"]+)".*/\1/' | head -n1 || true)"
         if [[ -n "$pinned_ref" && "$pinned_ref" != "$VIG_OS_VERSION" ]]; then

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -32,6 +32,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     banner + its `check-json` exclude) and must move together, else strict hooks
     reject files the new scaffold wrote.
   - Non-fatal; a floating (unpinned) input or a matching pin stays silent.
+  - The pinned ref is read from the real `vigos.url` input line only, not the
+    `?ref=<tag>` doc-comment example that ships above it in the standard-layout
+    `flake.nix`; previously the extractor matched the comment first, reported the
+    literal `<tag>`, and false-fired even on an aligned pin ([#1110](https://github.com/vig-os/devkit/issues/1110)).
 
 ### Fixed
 

--- a/tests/bats/init-workspace.bats
+++ b/tests/bats/init-workspace.bats
@@ -917,6 +917,47 @@ EOF
     refute_output --partial "pinned vigos flake input is still"
 }
 
+# ── skew warning reads the real pin, not the doc-comment (#1110) ──────────────
+# The standard-layout scaffold flake.nix ships a doc-comment EXAMPLE line
+# (`#   vigos.url = "github:vig-os/devkit?ref=<tag>";`) ABOVE the real input
+# line. The #1093 extractor must read the real pin, not the comment: reading the
+# comment reports the literal `<tag>` and false-fires even on an aligned pin.
+
+# Pre-seed $ws/flake.nix carrying the doc-comment example line AND a real $url
+# vigos input (mirroring the real template shape), then --force upgrade the
+# direnv scaffold to $target.
+_upgrade_direnv_with_documented_flake_url() {
+    local ws="$1" target="$2" url="$3"
+    mkdir -p "$ws"
+    cat >"$ws/flake.nix" <<EOF
+{
+  inputs = {
+    # This scaffold deliberately FLOATS on the default branch. Once you depend
+    # on stability, pin a release tag instead and bump deliberately:
+    #   vigos.url = "github:vig-os/devkit?ref=<tag>";
+    vigos.url = "$url";
+    nixpkgs.follows = "vigos/nixpkgs";
+  };
+}
+EOF
+    local verfile="$BATS_TEST_TMPDIR/VERSION-1110-$RANDOM"
+    printf '%s\n' "$target" >"$verfile"
+    _scaffold_with_version_file direnv "$ws" "$verfile"
+}
+
+@test "init-workspace reports the real pin, not the <tag> doc-comment, when it lags (#1110)" {
+    run _upgrade_direnv_with_documented_flake_url "$BATS_TEST_TMPDIR/e2e-1110-skew" 1.2.0 "github:vig-os/devkit?ref=1.1.0"
+    assert_success
+    assert_output --partial "pinned vigos flake input is still 1.1.0"
+    refute_output --partial "pinned vigos flake input is still <tag>"
+}
+
+@test "init-workspace is silent on an aligned pin despite the <tag> doc-comment (#1110)" {
+    run _upgrade_direnv_with_documented_flake_url "$BATS_TEST_TMPDIR/e2e-1110-match" 1.2.0 "github:vig-os/devkit?ref=1.2.0"
+    assert_success
+    refute_output --partial "pinned vigos flake input is still"
+}
+
 @test "template ships .typos.toml alongside the typos hook (#855)" {
     # The scaffold's .pre-commit-config.yaml runs the typos hook; without the
     # exception config, scaffold-shipped content (version-check.sh's Nd


### PR DESCRIPTION
## rc1 finding

Found during **1.2.1-rc1 verification** on the `commit-action` consumer: the #1093 flake-pin / `DEVKIT_VERSION` skew warning (new in 1.2.1) read the pinned `vigos` ref from the wrong line of the consumer `flake.nix`.

The standard-layout `flake.nix` ships a doc-comment example line
(`#   vigos.url = "github:vig-os/devkit?ref=<tag>";`) above the real input line. The unanchored extractor matched the comment first, and `head -n1` picked it. Consequences:

- (a) the warning always reported the current pin as the literal `<tag>` instead of the real value;
- (b) because `<tag>` never equals a real `DEVKIT_VERSION`, the warning **false-fired even when the consumer's pin already matched the target** — violating the changelog contract "a floating (unpinned) input or a matching pin stays silent". It never wrongly stays silent, so severity is quality/noise, but it defeats the feature's contract.

## Fix

Anchor the grep on `^[[:space:]]*vigos\.url` so only the real (non-comment) input line is read (the doc-comment starts with `#`, so the anchor skips it). One-line change in `assets/init-workspace.sh`.

## Test evidence (TDD)

New fixture flake.nix carries BOTH the `?ref=<tag>` doc-comment and a real pin, mirroring the shipped template:

- Failing (before fix): both #1110 tests red — `pinned vigos flake input is still <tag>` reported; aligned-pin case false-fired.
- Passing (after fix): all 5 tests green (3 existing #1093 + 2 new #1110), real pin `1.1.0` reported, aligned pin `1.2.0` stays silent.

## Changelog

Amends the frozen `## [1.2.1] - TBD` #1093 entry with a sub-bullet noting the pin is now read from the real input line, not the doc comment.

## Issue closure

`Refs: #1110`. `Closes #` only auto-fires on default-branch (main) merges here, so **#1110 will be closed manually after rc2 verification**.

Refs: #1110