### PR TITLE
refactor(image): restrict glibc locales to en_US.UTF-8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Restrict image locales to en_US.UTF-8** ([#1104](https://github.com/vig-os/devkit/issues/1104))
+  - The image shipped the full 222 MiB upstream `glibcLocales` archive but only
+    ever uses `en_US.UTF-8`. The `imageTools` entry and the `LOCALE_ARCHIVE`
+    OCI-config env now share one overridden derivation
+    (`allLocales = false; locales = [ "en_US.UTF-8/UTF-8" ]`), so exactly one
+    small (~3 MiB) locale path lands in the closure — a ~220 MiB uncompressed
+    reduction with zero functional change.
+
 ### Deprecated
 
 ### Removed

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Restrict image locales to en_US.UTF-8** ([#1104](https://github.com/vig-os/devkit/issues/1104))
+  - The image shipped the full 222 MiB upstream `glibcLocales` archive but only
+    ever uses `en_US.UTF-8`. The `imageTools` entry and the `LOCALE_ARCHIVE`
+    OCI-config env now share one overridden derivation
+    (`allLocales = false; locales = [ "en_US.UTF-8/UTF-8" ]`), so exactly one
+    small (~3 MiB) locale path lands in the closure — a ~220 MiB uncompressed
+    reduction with zero functional change.
+
 ### Deprecated
 
 ### Removed

--- a/flake.nix
+++ b/flake.nix
@@ -668,6 +668,17 @@
           }
         );
 
+        # Locale support without locale-gen. The image only ever sets
+        # en_US.UTF-8 (LANG/LC_ALL/LANGUAGE below), so we ship just that one
+        # locale instead of the full 222 MiB upstream archive. Bound once and
+        # used in BOTH image references — the imageTools entry AND the
+        # LOCALE_ARCHIVE Env store-path interpolation — so a single small
+        # derivation lands in the closure. Refs #1104.
+        glibcLocalesEnUS = pkgs.glibcLocales.override {
+          allLocales = false;
+          locales = [ "en_US.UTF-8/UTF-8" ];
+        };
+
         # The toolchain SSoT plus the runtime substrate a bare layered image
         # lacks (an FHS base distro would provide these; here we add them
         # explicitly — this is the discovery surface for FHS gaps). Shared by
@@ -681,8 +692,9 @@
             direnv
             nix-direnv
 
-            # Locale support without locale-gen.
-            glibcLocales
+            # Locale support without locale-gen (en_US.UTF-8 only; see
+            # glibcLocalesEnUS above). Refs #1104.
+            glibcLocalesEnUS
 
             # Python (with vig-utils baked) + the project Python toolchain.
             # The Debian image installed these via `uv pip install` at build;
@@ -1199,7 +1211,7 @@
                   "LANG=en_US.UTF-8"
                   "LANGUAGE=en_US:en"
                   "LC_ALL=en_US.UTF-8"
-                  "LOCALE_ARCHIVE=${pkgs.glibcLocales}/lib/locale/locale-archive"
+                  "LOCALE_ARCHIVE=${glibcLocalesEnUS}/lib/locale/locale-archive"
                   # Expose the Nix C++/compression runtime on the loader path
                   # for runtime-installed manylinux wheels (see manylinuxLibPath
                   # above). Required for the C-extension .so files the baked Nix


### PR DESCRIPTION
## Summary

The image shipped the full 222 MiB `glibcLocales` archive while only ever setting
`en_US.UTF-8`. This binds one overridden derivation
(`allLocales = false; locales = [ "en_US.UTF-8/UTF-8" ]`) and points **both**
image references at it — the `imageTools` entry **and** the `LOCALE_ARCHIVE`
OCI-config Env interpolation. Fixing only one of the two would have kept the full
archive in the closure via the Env store-path reference (the trap #1104 exists to
avoid).

## Evidence

- `.#devkitImageEnv` closure: **2.1 GiB → 1.9 GiB**
- `nix path-info -r | grep glibc-locales` → exactly one path, **2.9 MiB**
  (was 222.4 MiB)
- Full hook suite green (`prek run --all-files`, exit 0)
- No other `glibcLocales` reference exists repo-wide (dev-shell/home module
  unaffected); `tests/` locale matches concern dev-shell glibc ABI, not image
  locales — no test changes needed

Part of epic #1103 (sub-issue 1/5). Zero functional change; the overridden
derivation was even substitutable from cache.nixos.org.

Closes #1104