### PR TITLE
refactor(image): drop vestigial baked bandit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     (`allLocales = false; locales = [ "en_US.UTF-8/UTF-8" ]`), so exactly one
     small (~3 MiB) locale path lands in the closure — a ~220 MiB uncompressed
     reduction with zero functional change.
+- **Drop vestigial baked bandit from the image** ([#1105](https://github.com/vig-os/devkit/issues/1105))
+  - Hooks already run the venv bandit via `uv run` (pinned `bandit[toml]==1.9.4`); the baked copy was unused.
+  - Removes ~74 MiB from the image closure — a stray CPython 3.13 package stack (nixpkgs builds `bandit` on 3.13 while the image toolchain is 3.14) plus a duplicate `git-minimal` pulled in via gitpython.
 
 ### Deprecated
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     (`allLocales = false; locales = [ "en_US.UTF-8/UTF-8" ]`), so exactly one
     small (~3 MiB) locale path lands in the closure — a ~220 MiB uncompressed
     reduction with zero functional change.
+- **Drop vestigial baked bandit from the image** ([#1105](https://github.com/vig-os/devkit/issues/1105))
+  - Hooks already run the venv bandit via `uv run` (pinned `bandit[toml]==1.9.4`); the baked copy was unused.
+  - Removes ~74 MiB from the image closure — a stray CPython 3.13 package stack (nixpkgs builds `bandit` on 3.13 while the image toolchain is 3.14) plus a duplicate `git-minimal` pulled in via gitpython.
 
 ### Deprecated
 

--- a/docs/NIX.md
+++ b/docs/NIX.md
@@ -286,7 +286,7 @@ pin wins and no download happens; the URL matters only on the CI runner.
   bare layered image lacks (an FHS base distro would otherwise supply it): the
   Nix evaluator (`nix`, `direnv`, `nix-direnv`), `glibcLocales` for locale
   support, the project Python env (`vig-utils` + `pip-licenses` baked via
-  `python314.withPackages`), the `prek` hook runner (via `devTools`) + `bandit`,
+  `python314.withPackages`), the `prek` hook runner (via `devTools`),
   Rust/just tooling
   (`cargo-binstall`, `just-lsp`, `typstyle`), core GNU utilities, `cacert`,
   `openssh`, and `dockerTools.fakeNss` (a root uid-0 user database, without which

--- a/flake.nix
+++ b/flake.nix
@@ -702,7 +702,6 @@
             # The git-hook runner is `prek` (via devTools); the standalone
             # Python `pre-commit` that used to sit here is dropped (#778).
             pythonEnv
-            bandit
 
             # Rust/cargo + just LSP/formatter tools. The Debian image installed
             # these via cargo-binstall; Nix-native from nixpkgs here (#666).

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -31,7 +31,6 @@ EXPECTED_VERSIONS = {
     "uv": "0.11.",  # uv (fast-mover overlaid from nixpkgs-unstable)
     "python": "3.14",  # interpreter major.minor (pinned to python314)
     "ruff": "0.15.",  # nixpkgs-26.05
-    "bandit": "1.9.",  # nixpkgs-26.05
     "pip_licenses": "5.",  # PyPI wheel pinned in flake.nix
     "taplo": "0.10.",  # nixpkgs-26.05
     "vig_utils": "0.1.",  # our package version
@@ -659,16 +658,6 @@ class TestDevelopmentTools:
         expected = EXPECTED_VERSIONS["ruff"]
         assert expected in result.stdout, (
             f"Expected ruff {expected}, got: {result.stdout}"
-        )
-
-    def test_bandit_installed(self, host):
-        """Test that bandit is installed."""
-        result = host.run("bandit --version")
-        assert result.rc == 0, "bandit --version failed"
-        assert "bandit" in result.stdout.lower()
-        expected = EXPECTED_VERSIONS["bandit"]
-        assert expected in result.stdout, (
-            f"Expected bandit {expected}, got: {result.stdout}"
         )
 
     def test_pip_licenses_installed(self, host):


### PR DESCRIPTION
## Summary

Removes `bandit` from `imageTools`. The baked copy was vestigial: the committed
`.pre-commit-config.yaml` runs `uv run bandit` (the venv bandit, pinned in
`pyproject.toml` as `bandit[toml]==1.9.4`), and the only Nix-bandit consumer is
the sandbox `checks.pre-commit` profile in `nix/hooks.nix` — outside the image
closure and untouched here.

nixpkgs builds `bandit` against CPython 3.13 while the image toolchain is 3.14,
so this one entry dragged in a stray 3.13 package stack (ddt, stevedore, pyyaml,
rich, pygments, gitpython, …) **plus a duplicate `git-minimal` (52 MiB)** via
gitpython.

## Evidence

- `.#devkitImageEnv` closure: **−78,095,400 bytes (74.5 MiB)**
- `nix path-info -r | grep -E 'python3.13-|git-minimal|bandit'` → only
  `python3.13-pyflakes` remains, anchored solely by `actionlint` (verified with
  `nix why-depends`) — that is #1107's target, not part of the bandit stack
- `checks.pre-commit` still evaluates (`nix eval …pre-commit.drvPath` clean);
  `uv run bandit --version` → `bandit 1.9.4, python 3.14.4`
- Baked-bandit test assertions removed (`test_bandit_installed`,
  `EXPECTED_VERSIONS` entry) — removal is the intended behavior
- Full hook suite green (`prek run --all-files`, exit 0), including the
  surviving venv bandit hook

Part of epic #1103 (sub-issue 2/5). One of the four anchors of the redundant
CPython 3.13 interpreter; the interpreter itself falls in #1107.

Closes #1105