### PR TITLE
fix(ci): fast-forward dev to the release-branch mirror sync commit

### DIFF
--- a/.github/workflows/prepare-release-extension.yml
+++ b/.github/workflows/prepare-release-extension.yml
@@ -1,4 +1,4 @@
-# Prepare Release Extension (devkit dogfooding of #1059)
+# Prepare Release Extension (devkit dogfooding of #1059, #1115)
 #
 # Devkit's implementation of the scaffolded prepare-release-extension.yml hook.
 # Runs on the freshly cut release/X.Y.Z branch, AFTER the changelog freeze and
@@ -16,30 +16,51 @@
 #    branch the image is built from (tests/test_image.py::test_manifest_files
 #    checksums mirror == root).
 #
-# 2. Dev reconciliation (LAST, and that ordering is load-bearing): the freeze
-#    commit is scaffold-verbatim (root CHANGELOG.md only), so dev's mirror is
-#    stale after every prepare — the sync-manifest pre-commit hook would go red
-#    on every dev PR during the release window. This job therefore re-syncs the
-#    mirror against dev's current head and commits JUST the mirror to dev
-#    (idempotent: skipped when it already matches).
+# 2. Dev reconciliation: the freeze commit is scaffold-verbatim (root
+#    CHANGELOG.md only), so dev's mirror is stale after every prepare — the
+#    sync-manifest pre-commit hook would go red on every dev PR during the
+#    release window. The OLD design (#1059) minted a *sibling* reconcile commit
+#    on dev: same parent+tree as the release-branch sync commit (step 1) but a
+#    distinct object. Because that sibling shared no ancestry with the release
+#    branch, the mirror's merge base at post-promote sync time was the stale
+#    pre-freeze content → a deterministic sync-main-to-dev conflict on the
+#    mirror every release cycle (#1091, #1114).
 #
-# Rollback interplay — why the dev reconciliation MUST be the last step:
+#    The fix (#1115) fast-forwards dev to the release branch's step-1 sync
+#    commit, so the mirror rewrite becomes *shared ancestry* — the same property
+#    that keeps the root changelog conflict-free (the freeze commit is the merge
+#    base). The FF only runs while dev still sits on the freeze commit
+#    (branch_sha); the ref update is non-force and therefore FF-only, so the
+#    server rejects it atomically if dev advanced in the race window. A
+#    dev-advanced race (or any PATCH failure) falls back to the previous
+#    sibling-commit reconcile — that one cycle may conflict, exactly the status
+#    quo, never worse. The FF creates NO commit: the step-1 sync commit is
+#    app-signed API history and the COMMIT_APP token already pushes to dev
+#    directly (same actor), so fast-forwarding dev to it adds no new object and
+#    introduces no new signer.
+#
+# Rollback interplay — why the fallback reconcile MUST stay the last step:
 # prepare-release.yml's rollback job restores root CHANGELOG.md on dev only when
-# dev's head still equals the post-freeze SHA (the dev-advanced guard). The
-# reconcile commit always advances dev, so:
-#   * Extension fails BEFORE the reconcile commit lands => dev holds only the
-#     root-only freeze => rollback's guard passes and its root-restore returns
-#     dev to root(pre) == mirror(pre). Consistent.
-#   * The reconcile commit landed => the extension job is already finished
-#     (nothing failable follows), so the only remaining failure domain is
-#     open-pr => rollback's guard sees dev advanced and skips the root-restore,
-#     leaving dev at root(frozen) == mirror(frozen). Also consistent; the freeze
-#     is intentionally NOT auto-reverted on this rare path (restoring root alone
-#     would re-open the inverse drift, and the scaffold-shaped rollback must not
-#     learn devkit-specific mirror paths). Recover by reverting the freeze +
-#     reconcile commits on dev, or re-cutting the release branch manually.
+# dev's head still equals the post-freeze SHA (the dev-advanced guard). Any dev
+# mutation here (the FF, or the fallback reconcile commit) advances dev, so:
+#   * Extension fails BEFORE any dev update => dev still at branch_sha => the
+#     rollback's dev-advanced guard passes and its root-restore returns dev to
+#     root(pre) == mirror(pre). Consistent.
+#   * Once dev advances (the FF landed, or the fallback reconcile commit landed
+#     — each the last failable act on its path; the fallback steps are
+#     if-skipped when the FF succeeded and a skipped step cannot fail), the only
+#     remaining failure domain is open-pr (plus the single GITHUB_OUTPUT write
+#     after the PATCH) => the rollback's guard sees dev advanced and skips the
+#     root-restore, leaving dev at root(frozen) == mirror(frozen). Also
+#     consistent; the freeze is intentionally NOT auto-reverted on this rare
+#     path (restoring root alone would re-open the inverse drift, and the
+#     scaffold-shaped rollback must not learn devkit-specific mirror paths).
+#     After an FF, the deleted release branch's sync commit stays reachable from
+#     dev (no GC risk); recover by re-cutting release/X.Y.Z at dev's head
+#     (identical content) or reverting the freeze + sync commits on dev.
 # Every failure path therefore leaves dev's root+mirror consistent, which is
-# pinned by tests/test_workflow_prepare_extension.py's ordering assertions.
+# pinned by tests/test_workflow_prepare_extension.py's ordering/gating
+# assertions.
 
 name: Prepare Release Extension
 
@@ -114,6 +135,7 @@ jobs:
           echo "✓ Synced workspace manifest on ${{ inputs.release_branch }}"
 
       - name: Commit synced manifest to release branch via API
+        id: release-commit
         uses: vig-os/commit-action@1bc004353d08d9332a0cb54920b148256220c8e0  # v0.2.0
         env:
           GH_TOKEN: ${{ steps.commit-app-token.outputs.token }}
@@ -128,13 +150,49 @@ jobs:
             CHANGELOG.md on the release branch.
           FILE_PATHS: assets/workspace/.devcontainer/CHANGELOG.md
 
-      # ── Dev-side mirror reconciliation ──────────────────────────────────────
-      # Everything below runs against dev's CURRENT head (not the frozen branch
-      # point), so a dev that advanced since the freeze is reconciled against
-      # what it actually contains. The commit step below must stay the LAST step
-      # of this job — see the rollback-interplay analysis in the header.
+      - name: Fast-forward dev to the release-branch sync commit
+        id: dev-ff
+        env:
+          GH_TOKEN: ${{ steps.commit-app-token.outputs.token }}
+          BRANCH_SHA: ${{ inputs.branch_sha }}
+          RELEASE_COMMIT_SHA: ${{ steps.release-commit.outputs.commit-sha }}
+        run: |
+          set -euo pipefail
+          FF_DONE=false
+          # Missing output => no-op PATCH to the branch point; fails safe.
+          RELEASE_SHA="${RELEASE_COMMIT_SHA:-$BRANCH_SHA}"
+          # A read failure here must degrade to the fallback, never fail the
+          # job before any dev mutation (that would roll back the release
+          # branch for nothing).
+          DEV_SHA="$(git ls-remote origin refs/heads/dev | cut -f1 || true)"
+          if [ "$DEV_SHA" = "$BRANCH_SHA" ]; then
+            # Non-force: the server rejects atomically unless this is a
+            # fast-forward, so a dev that advanced in the race window can
+            # never be clobbered. Deliberately not retried — a legitimate
+            # 422 non-FF rejection must not be retried, and a transient
+            # failure degrades to the fallback (status quo).
+            if gh api -X PATCH "repos/${{ github.repository }}/git/refs/heads/dev" \
+                 -f sha="$RELEASE_SHA" -F force=false; then
+              FF_DONE=true
+              echo "✓ Fast-forwarded dev to release sync commit $RELEASE_SHA"
+            else
+              echo "w non-FF rejection or transient failure; falling back to reconcile commit"
+            fi
+          else
+            echo "i dev advanced past the freeze; falling back to reconcile commit"
+          fi
+          echo "ff_done=$FF_DONE" >> "$GITHUB_OUTPUT"
+
+      # ── Dev-side mirror reconciliation (fallback) ───────────────────────────
+      # Reached only when the fast-forward above did NOT land (dev advanced past
+      # the freeze, or the PATCH failed). Everything below runs against dev's
+      # CURRENT head (not the frozen branch point), so a dev that advanced since
+      # the freeze is reconciled against what it actually contains. The commit
+      # step below must stay the LAST step of this job — see the
+      # rollback-interplay analysis in the header.
 
       - name: Check out dev at its current head
+        if: ${{ steps.dev-ff.outputs.ff_done != 'true' }}
         run: |
           set -euo pipefail
           # The release-branch sync above left local modifications (the API
@@ -146,6 +204,7 @@ jobs:
 
       - name: Sync workspace manifest against dev
         id: dev-sync
+        if: ${{ steps.dev-ff.outputs.ff_done != 'true' }}
         run: |
           set -euo pipefail
           uv run python scripts/sync_manifest.py sync assets/workspace/
@@ -158,7 +217,7 @@ jobs:
           fi
 
       - name: Commit reconciled mirror to dev via API
-        if: ${{ steps.dev-sync.outputs.mirror_dirty == 'true' }}
+        if: ${{ steps.dev-ff.outputs.ff_done != 'true' && steps.dev-sync.outputs.mirror_dirty == 'true' }}
         uses: vig-os/commit-action@1bc004353d08d9332a0cb54920b148256220c8e0  # v0.2.0
         env:
           GH_TOKEN: ${{ steps.commit-app-token.outputs.token }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Post-promote sync-main-to-dev no longer conflicts on the workspace changelog mirror** ([#1115](https://github.com/vig-os/devkit/issues/1115))
+  - The prepare extension's sibling-commit reconcile left the mirror's merge base
+    at pre-freeze content, so `assets/workspace/.devcontainer/CHANGELOG.md`
+    conflicted in the post-promote sync-main-to-dev merge every release cycle
+    ([#1091](https://github.com/vig-os/devkit/issues/1091),
+    [#1114](https://github.com/vig-os/devkit/issues/1114)).
+  - The extension now fast-forwards dev to the release branch's mirror-sync
+    commit (a non-force app ref update, taken only while dev still sits on the
+    freeze commit) so the mirror rewrite is shared ancestry — the same property
+    that keeps the root changelog conflict-free.
+  - A dev-advanced race (or any ref-update failure) falls back to the previous
+    sibling-commit reconcile, exactly the status quo.
+
 ### Security
 
 ## [1.2.1](https://github.com/vig-os/devkit/releases/tag/1.2.1) - 2026-07-15

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -17,6 +17,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Post-promote sync-main-to-dev no longer conflicts on the workspace changelog mirror** ([#1115](https://github.com/vig-os/devkit/issues/1115))
+  - The prepare extension's sibling-commit reconcile left the mirror's merge base
+    at pre-freeze content, so `assets/workspace/.devcontainer/CHANGELOG.md`
+    conflicted in the post-promote sync-main-to-dev merge every release cycle
+    ([#1091](https://github.com/vig-os/devkit/issues/1091),
+    [#1114](https://github.com/vig-os/devkit/issues/1114)).
+  - The extension now fast-forwards dev to the release branch's mirror-sync
+    commit (a non-force app ref update, taken only while dev still sits on the
+    freeze commit) so the mirror rewrite is shared ancestry — the same property
+    that keeps the root changelog conflict-free.
+  - A dev-advanced race (or any ref-update failure) falls back to the previous
+    sibling-commit reconcile, exactly the status quo.
+
 ### Security
 
 ## [1.2.1](https://github.com/vig-os/devkit/releases/tag/1.2.1) - 2026-07-15

--- a/tests/test_workflow_prepare_extension.py
+++ b/tests/test_workflow_prepare_extension.py
@@ -298,21 +298,39 @@ def test_devkit_extension_implements_manifest_sync() -> None:
 
 
 # --------------------------------------------------------------------------- #
-# Devkit dogfooding: dev-side mirror reconciliation (#1059)
+# Devkit dogfooding: dev-side mirror reconciliation via fast-forward (#1115)
 #
 # The freeze commit is scaffold-verbatim (root CHANGELOG.md only), so after
 # every prepare, dev's synced mirror (assets/workspace/.devcontainer/CHANGELOG.md)
 # is stale until reconciled — a red sync-manifest hook on every dev PR during
-# the release window. Devkit's extension closes that drift by committing the
-# reconciled mirror to dev, and its ORDERING is load-bearing for the rollback:
+# the release window. The old design (#1059) minted a *sibling* reconcile commit
+# on dev (same parent+tree as the release-branch sync commit, but a distinct
+# object), so the mirror's merge base at post-promote sync time was pre-freeze
+# content → a deterministic sync-main-to-dev conflict every cycle (#1091, #1114).
 #
-# * The dev-reconcile commit must be the LAST step of the job. Any extension
-#   failure then implies the reconcile did NOT land, dev holds only the
-#   root-only freeze, and the scaffold-shaped rollback's root-restore returns
-#   dev to root(pre) == mirror(pre).
-# * If the reconcile landed, the only remaining failure domain is open-pr; the
-#   rollback's dev-advanced guard skips the root-restore, leaving dev at
-#   root(frozen) == mirror(frozen) — also consistent.
+# The fix (#1115) fast-forwards dev to the release branch's sync commit, making
+# the mirror rewrite *shared ancestry* — the same property that keeps the root
+# changelog conflict-free (the freeze commit is the merge base). The FF is a
+# non-force, FF-only ref update (git/refs/heads/dev, -X PATCH, -F force=false)
+# taken ONLY while dev still sits on the freeze commit (branch_sha), and it
+# targets the release-commit's commit-sha *output* rather than a fresh ref read
+# (avoids GitHub read-after-write ref lag, #617). A dev-advanced race — or any
+# PATCH failure — falls back to the previous sibling-commit reconcile; that
+# cycle may conflict, exactly the status quo. The ordering/gating stays
+# load-bearing for the rollback:
+#
+# * Every step after the FF is gated on `ff_done != 'true'`: nothing failable
+#   runs after a successful FF, and the sibling-commit fallback is reached only
+#   when the FF did not land.
+# * FF not taken → the fallback reconcile commit must be the LAST step of the
+#   job. Any extension failure then implies neither the FF nor the reconcile
+#   landed, dev holds only the root-only freeze, and the scaffold-shaped
+#   rollback's root-restore returns dev to root(pre) == mirror(pre).
+# * Once dev advances (FF landed, or the fallback reconcile commit landed — each
+#   the last failable act on its path; the fallback steps are if-skipped when the
+#   FF succeeded, and a skipped step cannot fail), the only remaining failure
+#   domain is open-pr; the rollback's dev-advanced guard skips the root-restore,
+#   leaving dev at root(frozen) == mirror(frozen) — also consistent.
 #
 # Either way, every failure path leaves dev's root+mirror consistent.
 # --------------------------------------------------------------------------- #
@@ -332,6 +350,14 @@ def _commit_action_steps(job: dict) -> list[tuple[int, dict]]:
         for i, s in enumerate(job.get("steps") or [])
         if isinstance(s, dict) and "vig-os/commit-action" in str(s.get("uses", ""))
     ]
+
+
+def _step_by_id(job: dict, step_id: str) -> tuple[int, dict]:
+    """(index, step) of the job's step with the given ``id`` (asserts it exists)."""
+    for i, s in enumerate(job.get("steps") or []):
+        if isinstance(s, dict) and s.get("id") == step_id:
+            return i, s
+    raise AssertionError(f"no step with id={step_id!r} in the devkit extension job")
 
 
 def test_devkit_extension_reconciles_dev_mirror() -> None:
@@ -358,15 +384,90 @@ def test_devkit_extension_reconciles_dev_mirror() -> None:
     assert "dry_run" in str(job.get("if", "")), (
         "the job holding the dev reconciliation must be gated on dry_run"
     )
+    step_if = str(step.get("if", ""))
+    assert "steps.dev-ff.outputs.ff_done != 'true'" in step_if, (
+        "the fallback dev reconcile commit must be gated on the FF not having "
+        "been taken (#1115)"
+    )
+    assert "steps.dev-sync.outputs.mirror_dirty == 'true'" in step_if, (
+        "the fallback dev reconcile commit must still be gated on a dirty mirror"
+    )
+
+
+def test_devkit_extension_fast_forwards_dev_to_release_sync_commit() -> None:
+    """Dev is fast-forwarded to the release-branch sync commit, not a sibling (#1115).
+
+    The old design minted a sibling reconcile commit on dev (same parent+tree as
+    the release-branch sync commit, distinct object), so the mirror's merge base
+    at post-promote sync time was pre-freeze content → a deterministic
+    sync-main-to-dev conflict every cycle. Fast-forwarding dev to the release
+    branch's sync commit makes the rewrite shared ancestry. The FF is a
+    non-force, FF-only ref update pinned to the release-commit *output* (not a
+    fresh ref read — avoids GitHub read-after-write ref lag, #617), taken only
+    while dev still equals branch_sha.
+    """
+    job = _devkit_extension_job()
+    ff_idx, ff_step = _step_by_id(job, "dev-ff")
+
+    run = str(ff_step.get("run", ""))
+    assert "git/refs/heads/dev" in run, "the FF must PATCH refs/heads/dev"
+    assert "-X PATCH" in run, "the FF must use an HTTP PATCH ref update"
+    assert "-F force=false" in run, (
+        "the FF must pin force=false so the server only accepts a fast-forward"
+    )
+
+    env = ff_step.get("env") or {}
+    assert env.get("BRANCH_SHA") == "${{ inputs.branch_sha }}", (
+        "the FF must read the freeze SHA from inputs.branch_sha"
+    )
+    assert '"$DEV_SHA" = "$BRANCH_SHA"' in run, (
+        "the FF must only proceed while dev still sits on the freeze commit"
+    )
+
+    # The FF target is the release-commit's output, not a ref read (read lag, #617).
+    release_idx, release_step = next(
+        (i, s)
+        for i, s in _commit_action_steps(job)
+        if "release_branch" in str((s.get("env") or {}).get("TARGET_BRANCH", ""))
+    )
+    assert release_step.get("id") == "release-commit", (
+        "the release-branch commit step must carry id: release-commit"
+    )
+    assert "steps.release-commit.outputs.commit-sha" in str(env), (
+        "the FF target must be the release-commit's commit-sha output, not a "
+        "fresh ref read (avoids GitHub read-after-write ref lag, #617)"
+    )
+    assert release_idx < ff_idx, (
+        "the release-branch commit must precede the dev fast-forward"
+    )
+
+
+def test_devkit_extension_ff_short_circuits_fallback() -> None:
+    """Every step after the FF is gated on the FF not having been taken (#1115).
+
+    Nothing failable may run after a successful FF, and the sibling-commit
+    fallback must be reached only when the FF did not land.
+    """
+    job = _devkit_extension_job()
+    ff_idx, _ = _step_by_id(job, "dev-ff")
+    for i, s in enumerate(job.get("steps") or []):
+        if i <= ff_idx or not isinstance(s, dict):
+            continue
+        assert "steps.dev-ff.outputs.ff_done != 'true'" in str(s.get("if", "")), (
+            f"step #{i} ({s.get('name')!r}) after the FF must be gated on "
+            "steps.dev-ff.outputs.ff_done != 'true'"
+        )
 
 
 def test_devkit_extension_dev_reconcile_is_last_step() -> None:
-    """Ordering invariant the rollback analysis relies on (#1059).
+    """Ordering invariant the rollback analysis relies on (#1115).
 
-    The dev reconciliation commit runs AFTER the release-branch commit and is
-    the LAST step of the job: nothing failable follows it, so a rollback with
-    the reconcile landed can only come from open-pr — the one path where
-    skipping the root-restore is exactly what keeps dev consistent.
+    With the FF-first mechanism, the sibling-commit fallback reconcile stays the
+    LAST step of the job and still runs AFTER the release-branch commit: nothing
+    failable follows it, so a rollback with the reconcile landed can only come
+    from open-pr — the one path where skipping the root-restore is exactly what
+    keeps dev consistent. (A successful FF if-skips every fallback step, and a
+    skipped step cannot fail, so the invariant holds on both paths.)
     """
     job = _devkit_extension_job()
     steps = job.get("steps") or []


### PR DESCRIPTION
## Summary

Every release cycle the post-promote `sync-main-to-dev` PR conflicted on exactly one file: the workspace changelog mirror `assets/workspace/.devcontainer/CHANGELOG.md` (#1091, #1114). Root cause, verified on the 1.2.1 cycle: the prepare extension minted the mirror reconcile as a **sibling commit** on `dev` (`11ff0e1c`) — same parent (freeze `849b324a`) and same tree (`d5b4f190`) as the release-branch sync commit (`e727daf0`), but a distinct object. Dev's copy was never an ancestor of the release branch, so the mirror's merge base at sync time was the stale pre-freeze content → deterministic overlap conflict. The root changelog merges clean precisely because the freeze commit *is* shared ancestry.

## Fix

After the extension commits the mirror sync to the release branch, **fast-forward `dev` to that commit** (non-force ref `PATCH` via the COMMIT_APP token) — but only while dev still sits on the freeze commit (`inputs.branch_sha`). Both branches then share the literal commit object, giving the mirror the same shared-ancestry property that already keeps the root changelog conflict-free.

- FF target is the release commit-action step's `commit-sha` **output**, not a fresh ref read (avoids the read-after-write ref lag documented in #617).
- `force=false` makes the update FF-only and atomic: a dev that advanced in the race window can never be clobbered. Deliberately not retried — a legitimate non-FF rejection must not be retried; transient failures degrade to the fallback.
- Dev-advanced race or any PATCH failure → fall back to the previous sibling-commit reconcile (status quo, never worse; that one cycle may conflict).
- Rollback interplay preserved: every step after the FF is gated on `ff_done != 'true'`, and the fallback reconcile commit stays the job's last step — every failure path still leaves dev's root+mirror consistent under prepare-release.yml's dev-advanced guard. Header comment rewritten with the full analysis.

Devkit-local change only: `prepare-release.yml` stays scaffold-verbatim; the consumer no-op scaffold extension is untouched.

## Verification

- TDD: `5f991fa2` pins the new invariants (3 red structural tests), `71dc5d79` turns them green — `tests/test_workflow_prepare_extension.py`: 18 passed.
- Full pre-commit suite green locally (actionlint validates the new step's `steps.*.outputs` references and `if` expressions).
- Scratch-repo ancestry proof: root-only freeze → sibling mirror commits on both branches → `git merge-tree --write-tree` conflicts on the mirror (reproduces #1114); dev fast-forwarded to the release-branch sync commit instead → same merge is clean.
- Real end-to-end proof lands next release cycle: the sync PR should come out titled without "(conflicts)" and auto-merge.

Closes #1115
