### PR TITLE
refactor(image): replace podman runtime with DooD-only client

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -8,3 +8,5 @@ ba = "ba"
 unexcepted = "unexcepted"
 # version-check.sh duration placeholder (#759): 'Nd' = N days (cf. Nw/Nh/Nm)
 Nd = "Nd"
+# podman rootless-networking helper package name (#1106), not a misspelling
+passt = "passt"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Drop vestigial baked bandit from the image** ([#1105](https://github.com/vig-os/devkit/issues/1105))
   - Hooks already run the venv bandit via `uv run` (pinned `bandit[toml]==1.9.4`); the baked copy was unused.
   - Removes ~74 MiB from the image closure — a stray CPython 3.13 package stack (nixpkgs builds `bandit` on 3.13 while the image toolchain is 3.14) plus a duplicate `git-minimal` pulled in via gitpython.
+- **Replace in-image podman runtime with DooD-only client** ([#1106](https://github.com/vig-os/devkit/issues/1106))
+  - The image now ships a client-only podman: its local-runtime helpers
+    (`crun`, `criu`, `conmon`, `netavark`, `passt`, `libkrun`/`libkrunfw`,
+    `aardvark-dns`, `fuse-overlayfs`, `runc`) are `.override`n with an empty
+    stub, dropping ~67 MiB of uncompressed image closure. The epic's ~254 MiB
+    estimate assumed removing podman entirely; retaining the client binary
+    (~54 MiB) and `systemd` (rpath-linked into it; `systemdMinimal` breaks
+    `podman logs` per the nixpkgs pin) reduces the net saving to ~67 MiB.
+  - In-container isolated (nested) container execution is removed — the retired
+    podman-in-podman sidecar model, declared non-contract in
+    [#1103](https://github.com/vig-os/devkit/issues/1103).
+  - Docker-out-of-Docker against the host's rootless podman socket (the
+    consumer scaffold's existing `DOCKER_HOST` wiring) is unchanged.
+  - The `docker -> podman` shim is retained and now execs the client-only
+    podman.
+  - Dev-shell behavior is unchanged: `devTools` still ships the full podman
+    runtime for daemonless `podman run` on a real host; the swap is scoped to
+    the image only.
 
 ### Deprecated
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -21,6 +21,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Drop vestigial baked bandit from the image** ([#1105](https://github.com/vig-os/devkit/issues/1105))
   - Hooks already run the venv bandit via `uv run` (pinned `bandit[toml]==1.9.4`); the baked copy was unused.
   - Removes ~74 MiB from the image closure — a stray CPython 3.13 package stack (nixpkgs builds `bandit` on 3.13 while the image toolchain is 3.14) plus a duplicate `git-minimal` pulled in via gitpython.
+- **Replace in-image podman runtime with DooD-only client** ([#1106](https://github.com/vig-os/devkit/issues/1106))
+  - The image now ships a client-only podman: its local-runtime helpers
+    (`crun`, `criu`, `conmon`, `netavark`, `passt`, `libkrun`/`libkrunfw`,
+    `aardvark-dns`, `fuse-overlayfs`, `runc`) are `.override`n with an empty
+    stub, dropping ~67 MiB of uncompressed image closure. The epic's ~254 MiB
+    estimate assumed removing podman entirely; retaining the client binary
+    (~54 MiB) and `systemd` (rpath-linked into it; `systemdMinimal` breaks
+    `podman logs` per the nixpkgs pin) reduces the net saving to ~67 MiB.
+  - In-container isolated (nested) container execution is removed — the retired
+    podman-in-podman sidecar model, declared non-contract in
+    [#1103](https://github.com/vig-os/devkit/issues/1103).
+  - Docker-out-of-Docker against the host's rootless podman socket (the
+    consumer scaffold's existing `DOCKER_HOST` wiring) is unchanged.
+  - The `docker -> podman` shim is retained and now execs the client-only
+    podman.
+  - Dev-shell behavior is unchanged: `devTools` still ships the full podman
+    runtime for daemonless `podman run` on a real host; the swap is scoped to
+    the image only.
 
 ### Deprecated
 

--- a/assets/workspace/.typos.toml
+++ b/assets/workspace/.typos.toml
@@ -11,3 +11,5 @@ ba = "ba"
 unexcepted = "unexcepted"
 # version-check.sh duration placeholder (#759): 'Nd' = N days (cf. Nw/Nh/Nm)
 Nd = "Nd"
+# podman rootless-networking helper package name (#1106), not a misspelling
+passt = "passt"

--- a/flake.nix
+++ b/flake.nix
@@ -679,13 +679,60 @@
           locales = [ "en_US.UTF-8/UTF-8" ];
         };
 
+        # Client-only podman for the IMAGE (Docker-out-of-Docker, #1106).
+        #
+        # `devTools` (nix/devtools.nix) ships the FULL local podman runtime —
+        # crun/criu/conmon/netavark/passt/libkrun(fw)/aardvark-dns/
+        # fuse-overlayfs/runc — because dev-shell users on a real host run
+        # daemonless `podman run` and need those helpers. The IMAGE never does:
+        # the consumer scaffold mounts the host's rootless podman socket as
+        # /var/run/docker.sock and sets DOCKER_HOST
+        # (assets/workspace/.devcontainer/scripts/initialize.sh), so every
+        # `podman`/`docker` call forwards to the host daemon — the container is
+        # a thin CLIENT. The in-image runtime (the retired podman-in-podman
+        # sidecar model, declared non-contract in epic #1103) is dead weight;
+        # stubbing the helpers nets ~67 MiB (the epic's ~254 MiB estimate
+        # assumed dropping podman entirely — the retained client binary and
+        # its rpath-linked systemd account for the difference).
+        #
+        # This pin has no `podman-remote` attribute, and the wrapper hardcodes
+        # its helper set (passthru.helpersBin / binPath in
+        # pkgs/by-name/po/podman/package.nix). We therefore keep the real
+        # podman client and .override its helper INPUTS with an empty stub
+        # (option 1 of #1106): the helpers are only wrap-time PATH suffixes and
+        # a store path substituted into the OCI-runtime config
+        # (hardcode-paths.patch) — pointing them at an empty $out/bin drops the
+        # helper closures while leaving the `podman` binary, `podman --version`,
+        # and shell completions intact. Daemonless `podman run` then fails
+        # gracefully (no local runtime), which is exactly the DooD contract.
+        # `extraRuntimes = []` drops runc; catatonit (tiny, pause-image init)
+        # is left real so the installPhase `ln -s helpersBin/bin/*` glob is
+        # non-empty. systemd stays: it is a buildInput linked into the podman
+        # binary (rpath), not a helper, and the pin warns systemdMinimal breaks
+        # `podman logs`. Scoped to the IMAGE only — the dev-shell keeps the
+        # full runtime via devTools. Refs #1106, #1103.
+        podmanHelperStub = pkgs.runCommand "podman-helper-stub" { } "mkdir -p $out/bin";
+        podmanClient = pkgs.podman.override {
+          crun = podmanHelperStub;
+          conmon = podmanHelperStub;
+          netavark = podmanHelperStub;
+          passt = podmanHelperStub;
+          aardvark-dns = podmanHelperStub;
+          fuse-overlayfs = podmanHelperStub;
+          runc = podmanHelperStub;
+          extraRuntimes = [ ];
+        };
+
         # The toolchain SSoT plus the runtime substrate a bare layered image
         # lacks (an FHS base distro would provide these; here we add them
         # explicitly — this is the discovery surface for FHS gaps). Shared by
         # the image (`devkitImage`) and its vulnix scan target
-        # (`devkitImageEnv`, #637).
+        # (`devkitImageEnv`, #637). The full podman from devTools is swapped for
+        # the client-only build above (#1106) — filtered out here, not in the
+        # SSoT, so the dev-shell keeps its daemonless runtime.
         imageTools =
-          (devTools pkgs)
+          (builtins.filter (p: p != pkgs.podman) (devTools pkgs))
+          ++ [ podmanClient ]
           ++ (with pkgs; [
             # Nix package manager in the closure (CppNix).
             nix
@@ -1061,9 +1108,12 @@
                     # working binary without pulling in the Docker engine. The
                     # heredoc is quoted so `$@` is written verbatim; the store
                     # paths are interpolated by Nix at eval time. Refs #740.
+                    # Points at `podmanClient` (the image's client-only podman,
+                    # #1106) — NOT `pkgs.podman` — so the shim does not silently
+                    # re-pull the full local runtime into the image closure.
                     cat > "$out/usr/local/bin/docker" <<'DOCKERSHIM'
                     #!${pkgs.runtimeShell}
-                    exec ${pkgs.podman}/bin/podman "$@"
+                    exec ${podmanClient}/bin/podman "$@"
                     DOCKERSHIM
                     chmod +x "$out/usr/local/bin/docker"
 


### PR DESCRIPTION
## Summary

The image shipped podman's full local runtime for the retired podman-in-podman
sidecar model. Everything the scaffold actually does is **Docker-out-of-Docker**
against the host's rootless podman socket (`initialize.sh` mounts it as
`/var/run/docker.sock`), so the image now ships a **client-only podman**:
`pkgs.podman.override` with the helper inputs (`crun`, `conmon`, `netavark`,
`passt`, `aardvark-dns`, `fuse-overlayfs`, `runc`) stubbed and
`extraRuntimes = []`. `catatonit` stays (tiny; keeps the installPhase glob
non-empty). The `docker → podman` shim is retained and repointed at the client
build so it cannot silently re-pull the full runtime.

**Scope guard:** the swap is image-only — `devTools` (the SSoT) still ships the
full runtime, so dev-shell users keep daemonless `podman run` on real hosts.

**Contract:** in-container *isolated* (nested) container execution is removed —
declared non-contract in #1103 (`semver:minor`).

## Honest size correction

Net closure reduction is **~67 MiB, not the epic's ~254 MiB estimate**. The
estimate assumed dropping podman entirely; keeping the client binary (~54 MiB)
and `systemd` (rpath-linked into podman; `systemdMinimal` breaks `podman logs`
per the nixpkgs pin) accounts for the difference. The strategic goal is fully
met regardless: **`criu` is gone**, which removes one of the four anchors of the
redundant CPython 3.13 interpreter (unblocks #1107). Changelog and flake comment
carry the corrected figure. Epic table will be updated.

## Evidence

- Closure: 2,293,215,224 → 2,222,999,680 bytes (**−67 MiB**, 424 → 408 paths)
- `grep -E 'crun|criu|conmon|netavark|passt|libkrun|aardvark|fuse-overlayfs|runc-'`
  over the new closure → **empty** (verified independently, including `gvproxy`,
  which the pin already excludes on this platform)
- `podman --version` → `podman version 5.8.2`; bash/zsh/fish completions present
- No test changes needed: `test_image.py` asserts only client-level behavior
  (`podman --version`, docker shim); no test asserts in-image runtime helpers
- `.vulnixignore`: no stranded entries (the `podman` CVE entry stays valid —
  client still ships; systemd-transitive entries persist since systemd stays)
- Full hook suite green (`prek run --all-files`, exit 0)
- `.typos.toml`: allowlist `passt` (real package name)

Part of epic #1103 (sub-issue 3/5).

Closes #1106