### PR TITLE
fix(init-workspace): preserve tag-scheme keys across upgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Preserve tag-scheme keys across `--force` upgrades** ([#1116](https://github.com/vig-os/devkit/issues/1116))
+  - `init-workspace.sh` read back `DEVKIT_MODE`/identity/`DEVKIT_MODULES` before
+    the managed-template overwrite of `.vig-os`, but not `DEVKIT_TAG_PREFIX` or
+    `DEVKIT_FLOATING_TAGS`, so an upgrade silently reset a consumer's release
+    tag scheme to the empty template defaults (observed cutting bare tags and
+    stalling floating tags on the commit-action 1.2.0 → 1.2.1 upgrade).
+  - Both keys are now read before the overwrite and written back (bare, matching
+    the template's unquoted form) when the consumer set them.
 - **Post-promote sync-main-to-dev no longer conflicts on the workspace changelog mirror** ([#1115](https://github.com/vig-os/devkit/issues/1115))
   - The prepare extension's sibling-commit reconcile left the mirror's merge base
     at pre-freeze content, so `assets/workspace/.devcontainer/CHANGELOG.md`

--- a/assets/init-workspace.sh
+++ b/assets/init-workspace.sh
@@ -292,6 +292,8 @@ MANIFEST_PROJECT="$(read_manifest_value "$VIG_OS_MANIFEST" DEVKIT_PROJECT || tru
 MANIFEST_ORG="$(read_manifest_value "$VIG_OS_MANIFEST" DEVKIT_ORG || true)"
 MANIFEST_REPO="$(read_manifest_value "$VIG_OS_MANIFEST" DEVKIT_REPO || true)"
 MANIFEST_MODULES="$(read_manifest_value "$VIG_OS_MANIFEST" DEVKIT_MODULES || true)"
+MANIFEST_TAG_PREFIX="$(read_manifest_value "$VIG_OS_MANIFEST" DEVKIT_TAG_PREFIX || true)"
+MANIFEST_FLOATING_TAGS="$(read_manifest_value "$VIG_OS_MANIFEST" DEVKIT_FLOATING_TAGS || true)"
 
 # The OWNER/REPO placeholder (written when no origin was resolvable) must not
 # mask a now-detectable git origin on a later upgrade.
@@ -1195,7 +1197,10 @@ render_codeql_matrix
 # file (template-overwritten on upgrade), so the resolved delivery mode and
 # identity are written back on every (re)scaffold — the next upgrade then
 # needs no mode/identity flags at all. A consumer's DEVKIT_MODULES
-# declaration (#884, read before the template overwrite) is restored too.
+# declaration (#884, read before the template overwrite) is restored too, as
+# are the DEVKIT_TAG_PREFIX / DEVKIT_FLOATING_TAGS release tag-scheme keys
+# (#1116, read before the overwrite) — the template ships them empty, so
+# without a write-back an upgrade would silently reset a consumer's tag scheme.
 if [[ -f "$VIG_OS_MANIFEST" ]]; then
     echo "Persisting resolved manifest values in .vig-os..."
     write_manifest_value DEVKIT_MODE "$MODE"
@@ -1204,6 +1209,14 @@ if [[ -f "$VIG_OS_MANIFEST" ]]; then
     write_manifest_value DEVKIT_REPO "$GITHUB_REPOSITORY"
     if [[ -n "$MANIFEST_MODULES" ]]; then
         write_manifest_value DEVKIT_MODULES "\"$MANIFEST_MODULES\""
+    fi
+    # Bare in the template (DEVKIT_TAG_PREFIX= / DEVKIT_FLOATING_TAGS=), so
+    # written back bare — matching the template's unquoted form.
+    if [[ -n "$MANIFEST_TAG_PREFIX" ]]; then
+        write_manifest_value DEVKIT_TAG_PREFIX "$MANIFEST_TAG_PREFIX"
+    fi
+    if [[ -n "$MANIFEST_FLOATING_TAGS" ]]; then
+        write_manifest_value DEVKIT_FLOATING_TAGS "$MANIFEST_FLOATING_TAGS"
     fi
 fi
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -28,6 +28,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Preserve tag-scheme keys across `--force` upgrades** ([#1116](https://github.com/vig-os/devkit/issues/1116))
+  - `init-workspace.sh` read back `DEVKIT_MODE`/identity/`DEVKIT_MODULES` before
+    the managed-template overwrite of `.vig-os`, but not `DEVKIT_TAG_PREFIX` or
+    `DEVKIT_FLOATING_TAGS`, so an upgrade silently reset a consumer's release
+    tag scheme to the empty template defaults (observed cutting bare tags and
+    stalling floating tags on the commit-action 1.2.0 → 1.2.1 upgrade).
+  - Both keys are now read before the overwrite and written back (bare, matching
+    the template's unquoted form) when the consumer set them.
 - **Post-promote sync-main-to-dev no longer conflicts on the workspace changelog mirror** ([#1115](https://github.com/vig-os/devkit/issues/1115))
   - The prepare extension's sibling-commit reconcile left the mirror's merge base
     at pre-freeze content, so `assets/workspace/.devcontainer/CHANGELOG.md`

--- a/tests/bats/init-workspace.bats
+++ b/tests/bats/init-workspace.bats
@@ -1928,6 +1928,25 @@ _upgrade_no_flags() {
     assert_success
 }
 
+@test "upgrade preserves persisted tag-scheme keys (#1116)" {
+    # .vig-os is a managed file, so a consumer's DEVKIT_TAG_PREFIX /
+    # DEVKIT_FLOATING_TAGS must be read before the template overwrite and
+    # written back — else an upgrade silently resets bare tags / stops moving
+    # floating tags (release-integrity regression observed 1.2.0 -> 1.2.1).
+    ws="$BATS_TEST_TMPDIR/e2e-1116-tagscheme"
+    mkdir -p "$ws"
+    run _scaffold both "$ws"
+    assert_success
+    sed -i 's/^DEVKIT_TAG_PREFIX=.*/DEVKIT_TAG_PREFIX=v/' "$ws/.vig-os"
+    sed -i 's/^DEVKIT_FLOATING_TAGS=.*/DEVKIT_FLOATING_TAGS=major,minor/' "$ws/.vig-os"
+    run _upgrade_no_flags "$ws"
+    assert_success
+    run grep -x 'DEVKIT_TAG_PREFIX=v' "$ws/.vig-os"
+    assert_success
+    run grep -x 'DEVKIT_FLOATING_TAGS=major,minor' "$ws/.vig-os"
+    assert_success
+}
+
 # ── legacy mode inference (#885) ──────────────────────────────────────────────
 # Consumers scaffolded before the manifest carry a version-only .vig-os (or
 # none): an upgrade without --mode must infer the delivery mode from the tree


### PR DESCRIPTION
## Description

An `install.sh --force` upgrade reset `DEVKIT_TAG_PREFIX` and `DEVKIT_FLOATING_TAGS` in a consumer's `.vig-os` manifest back to the empty template defaults, silently discarding consumer-set values. Action-publishing consumers set `DEVKIT_TAG_PREFIX=v` / `DEVKIT_FLOATING_TAGS=major,minor`; after an upgrade the next release cut bare `X.Y.Z` tags and stopped moving floating tags — a silent release-integrity regression, observed on the `vig-os/commit-action` 1.2.0 → 1.2.1 upgrade (vig-os/commit-action#80).

Closes #1116

## Type of Change

- [ ] `feat` -- New feature
- [x] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [ ] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- `assets/init-workspace.sh`: read `DEVKIT_TAG_PREFIX` / `DEVKIT_FLOATING_TAGS` from the consumer's `.vig-os` **before** the template rsync overwrite (alongside the existing MODE/identity/`DEVKIT_MODULES` reads) and conditionally write them back in the final persist block, mirroring the `DEVKIT_MODULES` preservation pattern (#884). Written back bare, matching the template's unquoted form. Persist-block comment updated.
- `tests/bats/init-workspace.bats`: new regression test — scaffold, seed both keys, `--force` upgrade, assert both survive (the preservation gap had no coverage, which is how this regressed).

## Changelog Entry

### Fixed
- **Preserve tag-scheme keys across `--force` upgrades** ([#1116](https://github.com/vig-os/devkit/issues/1116))
  - `init-workspace.sh` read back `DEVKIT_MODE`/identity/`DEVKIT_MODULES` before the managed-template overwrite of `.vig-os`, but not `DEVKIT_TAG_PREFIX` or `DEVKIT_FLOATING_TAGS`, so an upgrade silently reset a consumer's release tag scheme to the empty template defaults (observed cutting bare tags and stalling floating tags on the commit-action 1.2.0 → 1.2.1 upgrade).
  - Both keys are now read before the overwrite and written back (bare, matching the template's unquoted form) when the consumer set them.

## Testing

- [x] Tests pass locally (`just test`)
- [x] Manual testing performed (describe below)

### Manual Testing Details

- TDD: the new bats test was committed failing (RED — `DEVKIT_TAG_PREFIX` reset to empty after upgrade), then the fix turned it GREEN.
- Full `tests/bats/init-workspace.bats`: 199 tests, 0 failures, exit 0 (verified twice — implementation run and an independent review run).
- `uv run pytest tests/test_release_tag_prefix.py tests/test_floating_tags.py`: 9 passed.
- `prek run --all-files`: green.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

Part of the commit-action-deployment bug batch (#1116, #1117, #1118, plus #1111/#1112). Merge order: this PR first (priority high), the others rebase on top.

Refs: #1116
