### PR TITLE
fix(init-workspace): preserve dangling store pre-commit symlink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Preserve a flake-hooks `.pre-commit-config.yaml` store symlink on upgrade** ([#1117](https://github.com/vig-os/devkit/issues/1117))
+  - In direnv mode a flake with `hooks = { }` generates `.pre-commit-config.yaml`
+    as a symlink into the host `/nix/store`, which is not mounted inside the image
+    where `init-workspace.sh` runs — so the symlink is dangling from the
+    container's view. The preserve/exclude and report gates tested presence with
+    `-e`/`-f`, which follow the link and reported it absent, so `rsync -avL`
+    overwrote the symlink with the ~6 KB template config and the
+    [#1092](https://github.com/vig-os/devkit/issues/1092) ignore auto-seed never
+    fired — leaving a committed, non-ignored template shadowing the generated
+    config (observed on `commit-action` 1.2.0→1.2.1).
+  - A new `path_present` helper treats a symlink of any kind (including a dangling
+    one) as present at all three gates — the rsync exclude builder, the
+    add/preserve report classification (`--preview` now lists it as PRESERVED),
+    and the `PRECOMMIT_CONFIG_PREEXISTED` divergence guard — so the symlink
+    survives untouched and the ignore seed still runs.
 - **Post-promote sync-main-to-dev no longer conflicts on the workspace changelog mirror** ([#1115](https://github.com/vig-os/devkit/issues/1115))
   - The prepare extension's sibling-commit reconcile left the mirror's merge base
     at pre-freeze content, so `assets/workspace/.devcontainer/CHANGELOG.md`

--- a/assets/init-workspace.sh
+++ b/assets/init-workspace.sh
@@ -487,6 +487,18 @@ extract_template_recipe() {
     ' "$TEMPLATE_DIR/justfile.project"
 }
 
+# Helper: a path is "present" in the workspace if it exists as a resolvable
+# target OR is a symlink of any kind — including a DANGLING one (#1117). In
+# direnv mode a flake-hooks consumer's .pre-commit-config.yaml is a symlink into
+# the HOST /nix/store, which is not mounted inside the image where this script
+# runs, so `-e` alone (it follows the link) reports the symlink absent. Every
+# presence gate that decides whether to preserve/classify/track such a file must
+# see the symlink itself, so the rsync copy never clobbers it and the #1092
+# ignore seed (which reads the still-present symlink's target) still fires.
+path_present() {
+    [[ -e "$1" || -L "$1" ]]
+}
+
 # Helper: check if a file is in the preserve list
 is_preserved_file() {
     local file="$1"
@@ -564,7 +576,9 @@ JUSTFILE_PROJECT_PREEXISTED=false
 # A preserved .pre-commit-config.yaml may lag the template hook stack (#878);
 # record it so the post-scaffold guard can surface the divergence.
 PRECOMMIT_CONFIG_PREEXISTED=false
-[[ -f "$WORKSPACE_DIR/.pre-commit-config.yaml" ]] && PRECOMMIT_CONFIG_PREEXISTED=true
+# path_present, not -f: a flake-hooks consumer's config is a dangling store
+# symlink (#1117), which -f (it follows the link) would miss.
+path_present "$WORKSPACE_DIR/.pre-commit-config.yaml" && PRECOMMIT_CONFIG_PREEXISTED=true
 
 # A preserved .typos.toml is the consumer's spell-check exception set (#913);
 # record it so the post-scaffold guard can surface template divergence.
@@ -742,7 +756,9 @@ if [[ "$FORCE" == "true" ]]; then
             continue
         fi
 
-        if [[ -e "$workspace_file" ]]; then
+        # path_present, not -e: a dangling store symlink (#1117) at a preserved
+        # path exists in the tree and must classify as PRESERVED, not ADDED.
+        if path_present "$workspace_file"; then
             if is_preserved_file "$rel_path"; then
                 PRESERVED+=("$rel_path")
             else
@@ -928,9 +944,12 @@ else
     # (.devcontainer/README.md, .claude/skills/*/README.md), which the preview
     # (is_preserved_file, exact rel-path) still promised as ADDED. The anchor
     # matches is_preserved_file's exact-path semantics.
+    # path_present, not -e: a preserved path that is a symlink of any kind —
+    # including a dangling store symlink (#1117) — must be excluded from the
+    # copy, or `rsync -avL` dereferences and writes a real template file over it.
     EXCLUDE_ARGS=()
     for preserved in "${PRESERVE_FILES[@]}"; do
-        if [[ -e "$WORKSPACE_DIR/$preserved" ]]; then
+        if path_present "$WORKSPACE_DIR/$preserved"; then
             EXCLUDE_ARGS+=("--exclude=/$preserved")
         fi
     done

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -28,6 +28,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Preserve a flake-hooks `.pre-commit-config.yaml` store symlink on upgrade** ([#1117](https://github.com/vig-os/devkit/issues/1117))
+  - In direnv mode a flake with `hooks = { }` generates `.pre-commit-config.yaml`
+    as a symlink into the host `/nix/store`, which is not mounted inside the image
+    where `init-workspace.sh` runs — so the symlink is dangling from the
+    container's view. The preserve/exclude and report gates tested presence with
+    `-e`/`-f`, which follow the link and reported it absent, so `rsync -avL`
+    overwrote the symlink with the ~6 KB template config and the
+    [#1092](https://github.com/vig-os/devkit/issues/1092) ignore auto-seed never
+    fired — leaving a committed, non-ignored template shadowing the generated
+    config (observed on `commit-action` 1.2.0→1.2.1).
+  - A new `path_present` helper treats a symlink of any kind (including a dangling
+    one) as present at all three gates — the rsync exclude builder, the
+    add/preserve report classification (`--preview` now lists it as PRESERVED),
+    and the `PRECOMMIT_CONFIG_PREEXISTED` divergence guard — so the symlink
+    survives untouched and the ignore seed still runs.
 - **Post-promote sync-main-to-dev no longer conflicts on the workspace changelog mirror** ([#1115](https://github.com/vig-os/devkit/issues/1115))
   - The prepare extension's sibling-commit reconcile left the mirror's merge base
     at pre-freeze content, so `assets/workspace/.devcontainer/CHANGELOG.md`

--- a/tests/bats/init-workspace.bats
+++ b/tests/bats/init-workspace.bats
@@ -595,8 +595,9 @@ _preview_symlinked_template_venv() {
     # shellcheck disable=SC2016
     run grep -A3 'for preserved in "${PRESERVE_FILES\[@\]}"' "$INIT_WORKSPACE_SH"
     assert_success
+    # path_present (not -e) so a dangling store symlink is still excluded (#1117).
     # shellcheck disable=SC2016
-    assert_output --partial 'if [[ -e "$WORKSPACE_DIR/$preserved" ]]; then'
+    assert_output --partial 'if path_present "$WORKSPACE_DIR/$preserved"; then'
     # shellcheck disable=SC2016
     assert_output --partial 'EXCLUDE_ARGS+=("--exclude=/$preserved")'
 }

--- a/tests/bats/init-workspace.bats
+++ b/tests/bats/init-workspace.bats
@@ -2981,3 +2981,52 @@ _RELEASE_RESOLVERS_991=(
     assert_success
     refute_line '.pre-commit-config.yaml'
 }
+
+# ── dangling /nix/store symlink is preserved and seeds the ignore (#1117) ──────
+# In direnv mode the flake generates .pre-commit-config.yaml as a symlink into
+# the HOST /nix/store, which is NOT mounted inside the devcontainer image where
+# init-workspace runs. So the symlink is DANGLING from the container's view: `-e`
+# (which follows the link) reports it absent, the preserve/exclude gate emits no
+# --exclude, and `rsync -avL` copies the template over it — destroying the
+# flake-generated config AND skipping the #1092 ignore seed. The presence gates
+# must treat a symlink of any kind (even dangling) as present.
+
+@test "a dangling /nix/store .pre-commit-config.yaml symlink survives upgrade and seeds the ignore (#1117)" {
+    ws="$BATS_TEST_TMPDIR/e2e-1117-dangling"
+    mkdir -p "$ws"
+    # A /nix/store-shaped target that does NOT exist (the host store is not
+    # mounted): the symlink is dangling from the container's viewpoint.
+    target="/nix/store/0000000000000000000000000000000-hooks/pre-commit-config.yaml"
+    ln -s "$target" "$ws/.pre-commit-config.yaml"
+    run _scaffold both "$ws"
+    assert_success
+    # (1) The symlink survives untouched — the template was NOT written over it.
+    run test -L "$ws/.pre-commit-config.yaml"
+    assert_success
+    run readlink "$ws/.pre-commit-config.yaml"
+    assert_success
+    assert_output "$target"
+    # (2) The #1092 ignore seed still fires (the symlink was present at seed time).
+    run cat "$ws/.gitignore"
+    assert_success
+    assert_line '.pre-commit-config.yaml'
+}
+
+@test "--preview classifies a dangling /nix/store .pre-commit-config.yaml symlink as PRESERVED (#1117)" {
+    ws="$BATS_TEST_TMPDIR/e2e-1117-dangling-preview"
+    mkdir -p "$ws"
+    target="/nix/store/0000000000000000000000000000000-hooks/pre-commit-config.yaml"
+    ln -s "$target" "$ws/.pre-commit-config.yaml"
+    local stub="$BATS_TEST_TMPDIR/stub-bin"
+    mkdir -p "$stub"
+    printf '#!/usr/bin/env bash\nexit 0\n' >"$stub/just"
+    chmod +x "$stub/just"
+    run env PATH="$stub:$PATH" \
+        TEMPLATE_DIR="$PROJECT_ROOT/assets/workspace" \
+        WORKSPACE_DIR="$ws" \
+        SHORT_NAME=testproj \
+        GITHUB_REPOSITORY=test/repo \
+        bash "$INIT_WORKSPACE_SH" --preview --no-prompts --mode both
+    assert_success
+    assert_line '  ✓  .pre-commit-config.yaml'
+}


### PR DESCRIPTION
## Description

In direnv mode a flake-hooks consumer's `.pre-commit-config.yaml` is a symlink into the **host** `/nix/store`. `install.sh` runs `init-workspace.sh` inside the devcontainer image where that store is not mounted, so the symlink is dangling from the container's viewpoint. The preserve/exclude gate used `[[ -e ]]` (which follows the link), reported the file absent, and `rsync -avL` wrote the real ~6 KB template over the symlink — which in turn prevented the #1092 ignore auto-seed (its gate is correctly target-based, but the symlink no longer existed when it ran). Net result on every direnv-mode flake-hooks upgrade: a committed, non-ignored template shadowing the flake-generated config. Observed on the `vig-os/commit-action` 1.2.0 → 1.2.1 upgrade (vig-os/commit-action#80).

Closes #1117

## Type of Change

- [ ] `feat` -- New feature
- [x] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [ ] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- `assets/init-workspace.sh`: new `path_present()` helper (`[[ -e || -L ]]` — a symlink of any kind, even dangling, is present) routed through all three presence gates:
  1. the rsync preserve/exclude builder (the critical clobber fix — the symlink is now excluded from the template copy),
  2. the `--preview` classification loop (a dangling store symlink now reports PRESERVED, not ADDED),
  3. `PRECOMMIT_CONFIG_PREEXISTED` (was `-f`; the #878 divergence guard is no longer silently skipped).
  The #1092 ignore-seed gate itself is unchanged — it was already target-based (`readlink | grep /nix/store/`); the fix is that the symlink still exists when it runs.
- `tests/bats/init-workspace.bats`: two regression tests reproducing the exact direnv-in-container scenario (dangling `/nix/store/...` target): symlink survives upgrade untouched + ignore seeded; `--preview` classifies PRESERVED. Also updated the existing whitebox exclude-gate assertion that pinned the old literal `-e` line.

## Changelog Entry

### Fixed
- **Preserve a dangling flake-hooks store symlink through direnv-mode upgrades** ([#1117](https://github.com/vig-os/devkit/issues/1117))
  - In direnv mode `init-workspace.sh` runs inside the image where the host `/nix/store` is not mounted, so a flake-generated `.pre-commit-config.yaml` symlink is dangling; the `-e`/`-f` presence gates followed the link, reported it absent, and the template rsync overwrote it — also silencing the #1092 ignore auto-seed.
  - All presence gates now treat a symlink of any kind (including dangling) as present via a shared `path_present()` helper: the symlink survives the copy, the ignore is seeded, `--preview` classifies it as PRESERVED, and the #878 divergence guard sees the pre-existing config.

## Testing

- [x] Tests pass locally (`just test`)
- [x] Manual testing performed (describe below)

### Manual Testing Details

- TDD: both regression tests committed failing (RED — symlink clobbered into a regular file; `--preview` misclassified as ADDED), turned GREEN by the fix.
- Full `tests/bats/init-workspace.bats`: 200 tests, 0 failures, exit 0 (implementation run + independent review run).
- `prek run --all-files`: green.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

Part of the commit-action-deployment bug batch. Known adjacent, deliberately not fixed here: `print_preserved_template_diff` still gates on `-f`, so the #878 divergence *diff* is not printed for a dangling symlink — harmless (a store symlink has no meaningful template diff and cannot be validated while unmounted). #1111 (root-`.gitignore` migration, same function) follows in a separate PR after this one merges.

Refs: #1117
