### PR TITLE
fix(init-workspace): make post-scaffold dependency sync mode-aware and non-fatal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Post-scaffold dependency sync is mode-aware and no longer aborts a successful upgrade** ([#1118](https://github.com/vig-os/devkit/issues/1118))
+  - In `direnv` and `bare` modes the container-side `just sync` is now skipped
+    entirely: the consumer's host nix/direnv shell owns dependency install, and a
+    container-side `npm ci`/`uv sync` would write wrong-platform, wrong-owner
+    artifacts into the bind-mounted workspace. An informational line notes the skip.
+  - In `devcontainer`/`both` modes the sync still runs but is non-fatal — a failure
+    (e.g. `npm error Exit handler never called!`) now warns and continues instead of
+    aborting init with a misleading "Failed to initialize workspace", since the
+    scaffold itself is already complete.
+
 - **Post-promote sync-main-to-dev no longer conflicts on the workspace changelog mirror** ([#1115](https://github.com/vig-os/devkit/issues/1115))
   - The prepare extension's sibling-commit reconcile left the mirror's merge base
     at pre-freeze content, so `assets/workspace/.devcontainer/CHANGELOG.md`

--- a/assets/init-workspace.sh
+++ b/assets/init-workspace.sh
@@ -1350,16 +1350,28 @@ if [[ -n "$PRECOMMIT_REF_HITS" ]]; then
 fi
 
 # Sync dependencies: resolves uv.lock for the new project name and installs the
-# project. Non-fatal (#859): a preserved old-generation justfile.project may not
-# define `sync` yet — the scaffold itself is complete at this point, so warn and
-# let the consumer sync after migrating their recipes.
-echo "Syncing dependencies..."
-cd "$WORKSPACE_DIR"
-if just --show sync > /dev/null 2>&1; then
-    just sync
+# project. Two mode-aware behaviors (#1118):
+#   * direnv/bare: skip entirely — the consumer's host nix/direnv shell owns
+#     dependency install; a container-side `just sync` (e.g. `npm ci`) would
+#     write wrong-platform, wrong-owner artifacts into the bind-mounted workspace.
+#   * devcontainer/both: run it, but non-fatally — the scaffold is already
+#     complete, so a sync failure warns and continues rather than aborting init
+#     with a misleading "Failed to initialize workspace".
+# Also non-fatal (#859): a preserved old-generation justfile.project may not
+# define `sync` yet — warn and let the consumer sync after migrating recipes.
+if [[ "$MODE" == "direnv" || "$MODE" == "bare" ]]; then
+    echo "Skipping dependency sync for $MODE mode; your nix/direnv shell installs" \
+         "dependencies (a container-side 'just sync' would write wrong-platform" \
+         "node_modules into the bind mount)."
 else
-    echo "Warning: no 'sync' recipe found (preserved pre-0.4.0 justfile.project?)." >&2
-    echo "         Run 'uv sync' manually after migrating your recipes (see MIGRATION.md)." >&2
+    echo "Syncing dependencies..."
+    cd "$WORKSPACE_DIR"
+    if just --show sync > /dev/null 2>&1; then
+        just sync || echo "Warning: dependency sync failed; the scaffold itself is complete — run 'just sync' manually." >&2
+    else
+        echo "Warning: no 'sync' recipe found (preserved pre-0.4.0 justfile.project?)." >&2
+        echo "         Run 'uv sync' manually after migrating your recipes (see MIGRATION.md)." >&2
+    fi
 fi
 
 echo "Workspace initialized successfully!"

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -28,6 +28,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Post-scaffold dependency sync is mode-aware and no longer aborts a successful upgrade** ([#1118](https://github.com/vig-os/devkit/issues/1118))
+  - In `direnv` and `bare` modes the container-side `just sync` is now skipped
+    entirely: the consumer's host nix/direnv shell owns dependency install, and a
+    container-side `npm ci`/`uv sync` would write wrong-platform, wrong-owner
+    artifacts into the bind-mounted workspace. An informational line notes the skip.
+  - In `devcontainer`/`both` modes the sync still runs but is non-fatal — a failure
+    (e.g. `npm error Exit handler never called!`) now warns and continues instead of
+    aborting init with a misleading "Failed to initialize workspace", since the
+    scaffold itself is already complete.
+
 - **Post-promote sync-main-to-dev no longer conflicts on the workspace changelog mirror** ([#1115](https://github.com/vig-os/devkit/issues/1115))
   - The prepare extension's sibling-commit reconcile left the mirror's merge base
     at pre-freeze content, so `assets/workspace/.devcontainer/CHANGELOG.md`

--- a/tests/bats/init-workspace.bats
+++ b/tests/bats/init-workspace.bats
@@ -1026,6 +1026,63 @@ EOF
     assert_success
 }
 
+# ── post-scaffold dependency sync is mode-aware and non-fatal (#1118) ──────────
+# The trailing `just sync` runs AFTER the scaffold is complete. In direnv/bare
+# mode the consumer's host nix/direnv shell owns dependency install, so a
+# container-side sync must be skipped entirely (it would write wrong-platform,
+# wrong-owner node_modules into the bind mount). Where it does run
+# (devcontainer/both), a failure must warn-and-continue so a misleading "Failed
+# to initialize workspace" no longer masks a successful scaffold.
+
+# Scaffold in $mode into $ws with a `just` stub that logs every invocation to
+# $BATS_TEST_TMPDIR/just.log and exits $3 when run as `just sync`.
+_scaffold_synclog() {
+    local mode="$1" ws="$2" sync_exit="$3"
+    local stub="$BATS_TEST_TMPDIR/stub-bin"
+    local log="$BATS_TEST_TMPDIR/just.log"
+    mkdir -p "$stub"
+    : > "$log"
+    {
+        printf '#!/usr/bin/env bash\n'
+        # $* and $1 are literals for the generated stub, not this shell (SC2016).
+        # shellcheck disable=SC2016
+        printf 'printf "%%s\\n" "$*" >> %q\n' "$log"
+        # shellcheck disable=SC2016
+        printf 'if [[ "$1" == sync ]]; then exit %s; fi\n' "$sync_exit"
+        printf 'exit 0\n'
+    } >"$stub/just"
+    chmod +x "$stub/just"
+    env PATH="$stub:$PATH" \
+        TEMPLATE_DIR="$PROJECT_ROOT/assets/workspace" \
+        WORKSPACE_DIR="$ws" \
+        SHORT_NAME=testproj \
+        GITHUB_REPOSITORY=test/repo \
+        bash "$INIT_WORKSPACE_SH" --force --no-prompts --mode "$mode"
+}
+
+@test "init-workspace --mode=direnv skips the container-side dependency sync (#1118)" {
+    ws="$BATS_TEST_TMPDIR/e2e-1118-direnv"
+    mkdir -p "$ws"
+    run _scaffold_synclog direnv "$ws" 0
+    assert_success
+    assert_output --partial "Skipping dependency sync"
+    # `just sync` must never be invoked in direnv mode.
+    run grep -Fxq 'sync' "$BATS_TEST_TMPDIR/just.log"
+    assert_failure
+}
+
+@test "init-workspace warns and continues when 'just sync' fails (#1118)" {
+    ws="$BATS_TEST_TMPDIR/e2e-1118-syncfail"
+    mkdir -p "$ws"
+    # devcontainer mode DOES run sync; a failing recipe must not abort init.
+    run _scaffold_synclog devcontainer "$ws" 1
+    assert_success
+    assert_output --partial "Warning: dependency sync failed"
+    # sync was actually attempted (guards against silently skipping it too).
+    run grep -Fxq 'sync' "$BATS_TEST_TMPDIR/just.log"
+    assert_success
+}
+
 @test "typos hook passes --force-exclude in repo and template configs (#859)" {
     # prek passes staged filenames explicitly; without --force-exclude, typos
     # ignores [files] extend-exclude and scans binary artifacts (three


### PR DESCRIPTION
## Description

During a direnv-mode `install.sh --force` upgrade, after all scaffold files were written successfully, `init-workspace.sh` ran `just sync` (npm ci) inside the container; under `set -euo pipefail` a sync failure (observed: `npm error Exit handler never called!`) aborted the whole init and `install.sh` reported a misleading "Failed to initialize workspace". Two fixes, per the issue's two questions: the container-side sync is now skipped entirely in direnv/bare modes (the consumer's host nix/direnv shell owns dependency install; a container-side `npm ci` writes wrong-platform, wrong-owner artifacts into the bind-mounted workspace), and where it does run (devcontainer/both) a failure warns and continues so the exit status reflects the scaffold result. Observed on the `vig-os/commit-action` 1.2.1 upgrade (vig-os/commit-action#80).

Closes #1118

## Type of Change

- [ ] `feat` -- New feature
- [x] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [ ] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- `assets/init-workspace.sh` (post-scaffold sync block): mode gate — `direnv`/`bare` skip the sync with an informational line; `devcontainer`/`both` run it as `just sync || echo "Warning: …" >&2` (warn-and-continue, reusing the established non-fatal post-scaffold idiom). The existing #859 "no `sync` recipe" warn-and-continue branch is preserved. Comment block updated to document both behaviors.
- `tests/bats/init-workspace.bats`: `_scaffold_synclog` helper (a `just` stub that logs invocations and controls the `sync` exit code) + two regression tests: direnv mode never invokes `just sync` and prints the skip message; devcontainer mode with a failing `sync` recipe exits 0 with the warning (and asserts sync was actually attempted).

## Changelog Entry

### Fixed
- **Post-scaffold dependency sync is mode-aware and no longer aborts a successful upgrade** ([#1118](https://github.com/vig-os/devkit/issues/1118))
  - In `direnv` and `bare` modes the container-side `just sync` is now skipped entirely: the consumer's host nix/direnv shell owns dependency install, and a container-side `npm ci`/`uv sync` would write wrong-platform, wrong-owner artifacts into the bind-mounted workspace. An informational line notes the skip.
  - In `devcontainer`/`both` modes the sync still runs but is non-fatal — a failure (e.g. `npm error Exit handler never called!`) now warns and continues instead of aborting init with a misleading "Failed to initialize workspace", since the scaffold itself is already complete.

## Testing

- [x] Tests pass locally (`just test`)
- [x] Manual testing performed (describe below)

### Manual Testing Details

- TDD: both regression tests committed failing (RED — direnv mode still synced; failing sync aborted init), turned GREEN by the fix.
- Full `tests/bats/init-workspace.bats`: 200 tests, 0 failures, exit 0 (implementation run + independent review run).
- `prek run --all-files`: green.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

Part of the commit-action-deployment bug batch. The image-side root cause of `npm error Exit handler never called!` is out of scope here (this PR only removes its blast radius); worth a separate look if it recurs.

Refs: #1118
