### PR TITLE
refactor(image): evict redundant CPython 3.13 via gitMinimal and unwrapped actionlint

### DIFF
--- a/.vulnixignore
+++ b/.vulnixignore
@@ -114,9 +114,10 @@ CVE-2026-5928
 # Remaining lower-reachability components (provenance per note). Specifics
 # unverified offline; medium-near expiry to force re-review.
 Expiration: 2026-08-31
-# perl 5.42.0 — in-closure via git (git's perl-based subcommands: send-email,
-#   instaweb, etc.). Reachable only when those subcommands run, not on the hot
-#   path; specifics unverified offline.
+# perl 5.42.0 — in-closure via neovim → wl-clipboard → xdg-utils (git stopped
+#   anchoring perl in #1107, which swapped the image to gitMinimal). Reachable
+#   only on xdg-utils' desktop-open helper paths, not the hot path; specifics
+#   unverified offline.
 CVE-2026-4176
 # zlib 1.3.2 — ubiquitous compression dep (curl, openssh, git, nix, python).
 #   Reachable on any decompression path; specifics unverified offline.
@@ -328,8 +329,8 @@ CVE-2026-40553
 # ONLY in the perl 5.43.x DEVELOPMENT series (fixed in 5.43.10); stable perl is
 # 5.42.0 in the pinned rev, in nixos-26.05, AND in Debian stable (all still
 # unpatched, no backport) — so the "advance the rev" lever has nowhere to land
-# today. perl is in-closure via git's perl-based subcommands (send-email,
-# instaweb, etc.), same provenance as CVE-2026-4176; it processes
+# today. perl is in-closure via neovim → wl-clipboard → xdg-utils (git stopped
+# anchoring it in #1107), same provenance as CVE-2026-4176; it processes
 # developer/CI-chosen inputs only, with no untrusted-input path in the
 # single-user dev model. Flip to a nixpkgs rev-advance once a patched perl
 # reaches the pinned channel; short expiry to force near-term re-check.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Drop vestigial baked bandit from the image** ([#1105](https://github.com/vig-os/devkit/issues/1105))
   - Hooks already run the venv bandit via `uv run` (pinned `bandit[toml]==1.9.4`); the baked copy was unused.
   - Removes ~74 MiB from the image closure — a stray CPython 3.13 package stack (nixpkgs builds `bandit` on 3.13 while the image toolchain is 3.14) plus a duplicate `git-minimal` pulled in via gitpython.
+- **Evict the redundant CPython 3.13 interpreter from the image** ([#1107](https://github.com/vig-os/devkit/issues/1107))
+  - The image carried a second CPython interpreter (`python3-3.13.13`, 127 MiB)
+    that the chosen toolchain (`python3.14`, `UV_PYTHON`, `vig-utils`) never
+    uses. It was held by four independent anchors, all of which had to fall:
+    `bandit` ([#1105](https://github.com/vig-os/devkit/issues/1105)), `criu` via
+    the podman runtime ([#1106](https://github.com/vig-os/devkit/issues/1106)),
+    full `git` (git-p4/python helpers), and `actionlint` (its optional
+    `python3.13-pyflakes` lint wrapper) — the last two removed here.
+  - The image now ships `gitMinimal` (`perlSupport`/`pythonSupport`/
+    `guiSupport`/`withManual` all off) instead of full `git`, and an
+    `overrideAttrs`'d `actionlint` whose wrapper drops `pyflakes` (keeping
+    `shellcheck`). Together this evicts the 3.13 interpreter and full git's
+    `git-doc`, measuring **~149 MiB** off the uncompressed closure beyond the
+    bandit/criu cuts.
+  - Contract (declared non-contract in
+    [#1103](https://github.com/vig-os/devkit/issues/1103), `semver:minor`): the
+    image loses `git send-email`/`svn`/`p4`/`gitk`/`git gui` and built-in
+    `git help <cmd>` man pages, and actionlint's inline-python lint on workflow
+    `run:` steps. Builtin-C porcelain (`log`, `commit`, `rebase -i`, `add -p`,
+    worktrees) and SSH commit signing are unaffected; `gettext` stays (still
+    linked by gitMinimal for i18n).
+  - Dev-shell behavior is unchanged: `devTools` still ships full `git` and stock
+    `actionlint`; the swaps are scoped to the image only.
 - **Replace in-image podman runtime with DooD-only client** ([#1106](https://github.com/vig-os/devkit/issues/1106))
   - The image now ships a client-only podman: its local-runtime helpers
     (`crun`, `criu`, `conmon`, `netavark`, `passt`, `libkrun`/`libkrunfw`,

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -21,6 +21,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Drop vestigial baked bandit from the image** ([#1105](https://github.com/vig-os/devkit/issues/1105))
   - Hooks already run the venv bandit via `uv run` (pinned `bandit[toml]==1.9.4`); the baked copy was unused.
   - Removes ~74 MiB from the image closure — a stray CPython 3.13 package stack (nixpkgs builds `bandit` on 3.13 while the image toolchain is 3.14) plus a duplicate `git-minimal` pulled in via gitpython.
+- **Evict the redundant CPython 3.13 interpreter from the image** ([#1107](https://github.com/vig-os/devkit/issues/1107))
+  - The image carried a second CPython interpreter (`python3-3.13.13`, 127 MiB)
+    that the chosen toolchain (`python3.14`, `UV_PYTHON`, `vig-utils`) never
+    uses. It was held by four independent anchors, all of which had to fall:
+    `bandit` ([#1105](https://github.com/vig-os/devkit/issues/1105)), `criu` via
+    the podman runtime ([#1106](https://github.com/vig-os/devkit/issues/1106)),
+    full `git` (git-p4/python helpers), and `actionlint` (its optional
+    `python3.13-pyflakes` lint wrapper) — the last two removed here.
+  - The image now ships `gitMinimal` (`perlSupport`/`pythonSupport`/
+    `guiSupport`/`withManual` all off) instead of full `git`, and an
+    `overrideAttrs`'d `actionlint` whose wrapper drops `pyflakes` (keeping
+    `shellcheck`). Together this evicts the 3.13 interpreter and full git's
+    `git-doc`, measuring **~149 MiB** off the uncompressed closure beyond the
+    bandit/criu cuts.
+  - Contract (declared non-contract in
+    [#1103](https://github.com/vig-os/devkit/issues/1103), `semver:minor`): the
+    image loses `git send-email`/`svn`/`p4`/`gitk`/`git gui` and built-in
+    `git help <cmd>` man pages, and actionlint's inline-python lint on workflow
+    `run:` steps. Builtin-C porcelain (`log`, `commit`, `rebase -i`, `add -p`,
+    worktrees) and SSH commit signing are unaffected; `gettext` stays (still
+    linked by gitMinimal for i18n).
+  - Dev-shell behavior is unchanged: `devTools` still ships full `git` and stock
+    `actionlint`; the swaps are scoped to the image only.
 - **Replace in-image podman runtime with DooD-only client** ([#1106](https://github.com/vig-os/devkit/issues/1106))
   - The image now ships a client-only podman: its local-runtime helpers
     (`crun`, `criu`, `conmon`, `netavark`, `passt`, `libkrun`/`libkrunfw`,

--- a/flake.nix
+++ b/flake.nix
@@ -723,16 +723,51 @@
           extraRuntimes = [ ];
         };
 
+        # actionlint for the IMAGE without its optional `pyflakes` runtime dep
+        # (#1107). Stock actionlint wraps its binary with `pyflakes` + `shellcheck`
+        # on PATH (pkgs/by-name/ac/actionlint/package.nix postInstall). `pyflakes`
+        # only lints inline `python` in workflow `run:` steps — unused in this
+        # gh-driven repo — and it is `python3.13-pyflakes`, one of the two
+        # remaining anchors dragging the redundant CPython 3.13 interpreter into
+        # the image (full `git` → gitMinimal drops the other; #1105/#1106 dropped
+        # bandit/criu). `.override` exposes only `python3Packages`, not `pyflakes`,
+        # so a clean single-dep drop needs `overrideAttrs`: we rewrite postInstall
+        # to wrap with `shellcheck` ONLY, evicting `pyflakes` (and thus
+        # python3.13) from the closure while keeping the shellcheck-backed `run:`
+        # shell lint and the man page. Scoped to the IMAGE — the dev-shell keeps
+        # stock actionlint via devTools. Refs #1107, #1103.
+        actionlintImage = pkgs.actionlint.overrideAttrs (_: {
+          postInstall = ''
+            ronn --roff man/actionlint.1.ronn
+            installManPage man/actionlint.1
+            wrapProgram "$out/bin/actionlint" \
+              --prefix PATH : ${pkgs.lib.makeBinPath [ pkgs.shellcheck ]}
+          '';
+        });
+
         # The toolchain SSoT plus the runtime substrate a bare layered image
         # lacks (an FHS base distro would provide these; here we add them
         # explicitly — this is the discovery surface for FHS gaps). Shared by
         # the image (`devkitImage`) and its vulnix scan target
-        # (`devkitImageEnv`, #637). The full podman from devTools is swapped for
-        # the client-only build above (#1106) — filtered out here, not in the
-        # SSoT, so the dev-shell keeps its daemonless runtime.
+        # (`devkitImageEnv`, #637). Three devTools entries are swapped for
+        # slimmer image-only builds — filtered out here, not in the SSoT, so the
+        # dev-shell keeps the full tools:
+        #   - full `podman` → `podmanClient` (client-only, #1106).
+        #   - full `git` → `gitMinimal` (no perl/python/gui/man; drops the
+        #     git-p4/python-helper anchor of CPython 3.13, plus git-doc; gettext
+        #     stays, still linked by gitMinimal for i18n; loses
+        #     send-email/svn/p4/gitk/`git help` — non-contract per #1103).
+        #   - stock `actionlint` → `actionlintImage` (no `python3.13-pyflakes`
+        #     wrapper — the other CPython 3.13 anchor).
+        # Together with #1105 (bandit) and #1106 (criu) this evicts the redundant
+        # CPython 3.13 interpreter from the image. Refs #1107, #1103.
         imageTools =
-          (builtins.filter (p: p != pkgs.podman) (devTools pkgs))
-          ++ [ podmanClient ]
+          (builtins.filter (p: p != pkgs.podman && p != pkgs.git && p != pkgs.actionlint) (devTools pkgs))
+          ++ [
+            podmanClient
+            pkgs.gitMinimal
+            actionlintImage
+          ]
           ++ (with pkgs; [
             # Nix package manager in the closure (CppNix).
             nix


### PR DESCRIPTION
## Summary

The image carried a second CPython interpreter (`python3-3.13.13`, 127 MiB) that
the chosen 3.14 toolchain never uses, held by four anchors. #1105 (bandit) and
#1106 (criu) removed two; this PR removes the last two and completes the
eviction:

- **full `git` → `gitMinimal`** (stock nixpkgs attr, cached — the exact
  derivation bandit's gitpython used to pull). Drops the git-p4/python-helper
  anchor plus `git-doc`. Loses `send-email`/`svn`/`p4`/`gitk`/`git help` man
  pages — declared non-contract in #1103 (`semver:minor`). Builtin-C porcelain
  (`log`, `commit`, `rebase -i`, `add -p`, worktrees) and SSH signing unaffected.
- **`actionlint` → `overrideAttrs` without the `pyflakes` wrapper** (`.override`
  only exposes `python3Packages`, so the wrapper's `postInstall` is rewritten to
  wrap with `shellcheck` only). Loses inline-python lint on workflow `run:`
  steps; shellcheck-backed lint and the man page stay.

Both swaps follow the image-scoped filter pattern from #1106 — `devTools` (the
SSoT) is untouched, so the dev-shell keeps full git and stock actionlint.

Also fixes the now-false provenance notes in `.vulnixignore`: the perl 5.42
entries claimed perl is in-closure "via git's perl-based subcommands"; after this
PR its sole anchor is `neovim → wl-clipboard → xdg-utils` (the #1108 chain). CVE
ignore lines themselves unchanged (perl is still present until #1108).

## Evidence (independently re-verified)

- Closure: 1,914,744,512 → 1,758,754,952 bytes (**−148.8 MiB**, 395 → 378 paths)
- **`nix path-info -r | grep -E 'python3-3.13|python3.13-'` → EMPTY** — the
  issue's hard gate
- git: only `git-minimal-2.54.0` in the closure; `git version 2.54.0`;
  `git-p4` present only as the upstream "not built with python" stub
- actionlint 1.7.12 runs; lints `.github/workflows/ci.yml` clean; its closure
  contains `shellcheck` and **zero** python paths
- `gettext` stays (still linked by gitMinimal for i18n) — the changelog states
  this honestly rather than claiming it dropped
- No test changes needed: `test_image.py` asserts only `git version` (identical
  string for gitMinimal); no send-email/pyflakes assertions exist
- Full hook suite green (`prek run --all-files`, exit 0)

Part of epic #1103 (sub-issue 4/5). Unblocks #1108 (perl eviction — git no
longer anchors perl; only the neovim chain remains).

Closes #1107