### PR TITLE
fix(flake): wire core.hooksPath to .githooks for direnv consumers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Wire `core.hooksPath` for direnv consumers** ([#1112](https://github.com/vig-os/devkit/issues/1112))
+  - In direnv / `nix develop` mode the dev-shell never set `core.hooksPath`, so
+    commit-time hooks (pre-commit / commit-msg via prek) were silently inactive
+    until the consumer set it by hand — a local commit could bypass the gate with
+    only CI catching it later. Devcontainer mode already wired it in setup.
+  - `mkProjectShell`'s shellHook now sets `core.hooksPath` → `.githooks` on shell
+    entry, mirroring the devcontainer and reinforcing the `.githooks` entry-point
+    invariant (never installing into `.git/hooks`, never unsetting it).
+  - Guarded to a scaffold-shaped repo (a `.githooks/` directory at the git
+    toplevel) and to the main worktree, so it leaves non-scaffold consumers
+    untouched and never fights the worktree flow (which deliberately unsets
+    `core.hooksPath` and installs prek hooks directly); idempotent on re-entry.
 - **Post-promote sync-main-to-dev no longer conflicts on the workspace changelog mirror** ([#1115](https://github.com/vig-os/devkit/issues/1115))
   - The prepare extension's sibling-commit reconcile left the mirror's merge base
     at pre-freeze content, so `assets/workspace/.devcontainer/CHANGELOG.md`

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -28,6 +28,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Wire `core.hooksPath` for direnv consumers** ([#1112](https://github.com/vig-os/devkit/issues/1112))
+  - In direnv / `nix develop` mode the dev-shell never set `core.hooksPath`, so
+    commit-time hooks (pre-commit / commit-msg via prek) were silently inactive
+    until the consumer set it by hand — a local commit could bypass the gate with
+    only CI catching it later. Devcontainer mode already wired it in setup.
+  - `mkProjectShell`'s shellHook now sets `core.hooksPath` → `.githooks` on shell
+    entry, mirroring the devcontainer and reinforcing the `.githooks` entry-point
+    invariant (never installing into `.git/hooks`, never unsetting it).
+  - Guarded to a scaffold-shaped repo (a `.githooks/` directory at the git
+    toplevel) and to the main worktree, so it leaves non-scaffold consumers
+    untouched and never fights the worktree flow (which deliberately unsets
+    `core.hooksPath` and installs prek hooks directly); idempotent on re-entry.
 - **Post-promote sync-main-to-dev no longer conflicts on the workspace changelog mirror** ([#1115](https://github.com/vig-os/devkit/issues/1115))
   - The prepare extension's sibling-commit reconcile left the mirror's merge base
     at pre-freeze content, so `assets/workspace/.devcontainer/CHANGELOG.md`

--- a/assets/workspace/docs/COMMIT_MESSAGE_STANDARD.md
+++ b/assets/workspace/docs/COMMIT_MESSAGE_STANDARD.md
@@ -88,7 +88,7 @@ Additionally, the CI validator skips two classes of commit outright:
 
 ## Where the standard is enforced
 
-- **Locally** — the `commit-msg` hook (via `core.hooksPath` → `.githooks/commit-msg` → `prek run --hook-stage commit-msg`). This guards only a correctly configured working copy: if `core.hooksPath` is unset or stale, git runs no hooks and the guard is silently absent.
+- **Locally** — the `commit-msg` hook (via `core.hooksPath` → `.githooks/commit-msg` → `prek run --hook-stage commit-msg`). Both sanctioned environments wire `core.hooksPath` → `.githooks` automatically: the devcontainer sets it during setup, and the direnv / `nix develop` dev-shell sets it on shell entry (guarded to the main worktree). So once you have entered the dev environment the guard is active. It is only silently absent before you have entered it (or in an ad-hoc checkout outside both modes), where `core.hooksPath` may be unset and git runs no hooks.
 - **In CI** — the `commit-checks` job runs `validate-commit-range`, which re-validates every commit the pull request adds (from the merge-base with the base branch) plus the **pull request title**. The title matters because pull requests merge `--no-ff`, so it becomes the merge commit's subject in the base branch's history.
 
 Because `commit-msg` is a stage-gated hook, `prek run --all-files` does **not** run it — CI enforcement comes from the `commit-checks` job, not from the lint lane.

--- a/docs/COMMIT_MESSAGE_STANDARD.md
+++ b/docs/COMMIT_MESSAGE_STANDARD.md
@@ -85,7 +85,7 @@ Additionally, the CI validator skips two classes of commit outright:
 
 ## Where the standard is enforced
 
-- **Locally** — the `commit-msg` hook (via `core.hooksPath` → `.githooks/commit-msg` → `prek run --hook-stage commit-msg`). This guards only a correctly configured working copy: if `core.hooksPath` is unset or stale, git runs no hooks and the guard is silently absent.
+- **Locally** — the `commit-msg` hook (via `core.hooksPath` → `.githooks/commit-msg` → `prek run --hook-stage commit-msg`). Both sanctioned environments wire `core.hooksPath` → `.githooks` automatically: the devcontainer sets it during setup, and the direnv / `nix develop` dev-shell sets it on shell entry (guarded to the main worktree). So once you have entered the dev environment the guard is active. It is only silently absent before you have entered it (or in an ad-hoc checkout outside both modes), where `core.hooksPath` may be unset and git runs no hooks.
 - **In CI** — the `commit-checks` job runs `validate-commit-range`, which re-validates every commit the pull request adds (from the merge-base with the base branch) plus the **pull request title**. The title matters because pull requests merge `--no-ff`, so it becomes the merge commit's subject in the base branch's history.
 
 Because `commit-msg` is a stage-gated hook, `prek run --all-files` does **not** run it — CI enforcement comes from the `commit-checks` job, not from the lint lane.

--- a/flake.nix
+++ b/flake.nix
@@ -470,6 +470,47 @@
             export NVIM_APPNAME="vigos-dev"
           '';
 
+          # #1112: wire `.githooks` as the git hook entry point for direnv /
+          # `nix develop` consumers. Devcontainer mode runs
+          # `git config core.hooksPath .githooks` from setup-git-conf.sh; a
+          # container-less consumer never got that, so commit-time hooks
+          # (pre-commit / commit-msg via prek) were silently inactive until the
+          # consumer set it by hand — a local commit could bypass the gate with
+          # only CI catching it later. Set it on shell entry, mirroring the
+          # devcontainer, and ALWAYS to `.githooks` (never elsewhere):
+          # `.githooks` is the sanctioned single entry point (#908 —
+          # sanctioned-environment guard, consumer-owned scripts) and its
+          # `prek run` picks up any flake-generated config. This SETS
+          # core.hooksPath but never unsets/resets it or installs into
+          # `.git/hooks`, so the #908 invariant is reinforced, not broken.
+          #
+          # Guards, in order:
+          #   * `.githooks/` must exist at the git toplevel — only a
+          #     scaffold-shaped repo is touched; a bare mkProjectShell consumer
+          #     is left alone.
+          #   * MAIN worktree only (worktree git-dir == common git-dir) — a
+          #     linked worktree is owned by justfile.worktree, which
+          #     deliberately unsets core.hooksPath and installs prek hooks
+          #     directly; guarding here keeps this hook from fighting that flow
+          #     on every shell entry inside a worktree.
+          #   * only when the value differs from `.githooks` — idempotent: no
+          #     redundant write on re-entry when it is already set.
+          #
+          # In the shared base (like the ld/nvim hooks) so the default
+          # `hooks = null` shell and an opted-in shell change identically; the
+          # zero-hooks parity (tests/test_flake_devshell.py,
+          # tests/test_flake_hooks.py) holds.
+          githooksPathHook = ''
+            if _gitTop=$(${pkgs.gitMinimal}/bin/git rev-parse --show-toplevel 2>/dev/null) \
+              && [ -d "$_gitTop/.githooks" ] \
+              && [ "$(${pkgs.gitMinimal}/bin/git rev-parse --absolute-git-dir 2>/dev/null)" \
+                 = "$(${pkgs.gitMinimal}/bin/git rev-parse --path-format=absolute --git-common-dir 2>/dev/null)" ] \
+              && [ "$(${pkgs.gitMinimal}/bin/git -C "$_gitTop" config --get core.hooksPath 2>/dev/null)" != ".githooks" ]; then
+              ${pkgs.gitMinimal}/bin/git -C "$_gitTop" config core.hooksPath .githooks
+            fi
+            unset _gitTop
+          '';
+
           # When the interpreter is overridden (#1038), prepend it to PATH so the
           # bare `python`/`python3` follow the override too — not just uv's
           # `UV_PYTHON` pin. `vig-utils` (a devTools entry) is built against the
@@ -516,6 +557,7 @@
               + nvimIsolationHook
               + "\n"
               + pythonOverrideHook
+              + githooksPathHook
               + moduleShellHook
               + hooksShellHook
               + shellHook;

--- a/tests/test_flake_hooks.py
+++ b/tests/test_flake_hooks.py
@@ -439,12 +439,16 @@ class TestZeroHooksParity:
         the PR #908 defect was git-hooks.nix's stock installation script
         unsetting/resetting ``core.hooksPath`` and installing only the
         pre-commit stage into ``.git/hooks``, silently bypassing ``.githooks``.
-        So every ``core.hooksPath`` reference must be the sanctioned
-        ``.githooks`` set, and nothing may unset/uninstall it.
+        So every ``core.hooksPath`` *write* must set the sanctioned
+        ``.githooks`` value, and nothing may unset/uninstall it. (A
+        ``config --get core.hooksPath`` read is harmless and does not match
+        the ``config core.hooksPath`` write form.)
         """
-        assert opted_in_shellhook.count("core.hooksPath") == opted_in_shellhook.count(
-            "core.hooksPath .githooks"
-        ), "opting in introduced a non-`.githooks` core.hooksPath mutation (#908)"
+        assert opted_in_shellhook.count(
+            "config core.hooksPath"
+        ) == opted_in_shellhook.count("config core.hooksPath .githooks"), (
+            "opting in introduced a non-`.githooks` core.hooksPath write (#908)"
+        )
         assert "--unset" not in opted_in_shellhook
         assert "uninstall" not in opted_in_shellhook
 

--- a/tests/test_flake_hooks.py
+++ b/tests/test_flake_hooks.py
@@ -320,6 +320,14 @@ def consumer_config() -> dict[str, Any]:
 
 
 @pytest.fixture(scope="module")
+def default_shellhook() -> str:
+    """The shellHook of the flake's own default dev-shell (``hooks = null``)."""
+    result = _run_nix(["eval", "--raw", ".#devShells.x86_64-linux.default.shellHook"])
+    assert result.returncode == 0, result.stderr
+    return result.stdout
+
+
+@pytest.fixture(scope="module")
 def opted_in_shellhook() -> str:
     """The shellHook of a minimally opted-in (``hooks = { }``) shell."""
     expr = f"""
@@ -416,18 +424,69 @@ class TestZeroHooksParity:
         assert ".pre-commit-config.yaml" in opted_in_shellhook
         assert "Refusing" in opted_in_shellhook
 
-    def test_opted_in_shellhook_never_rewires_hookspath(
+    def test_opted_in_shellhook_only_sanctions_githooks_path(
         self, opted_in_shellhook: str
     ) -> None:
-        """Opting in must not touch ``core.hooksPath`` or ``.git/hooks``.
+        """Opting in adds no ``core.hooksPath`` mutation beyond the sanctioned set.
 
         The scaffold's ``.githooks`` directory stays the single hook entry
         point (its sanctioned-environment guard and any consumer-owned
         scripts keep running); the generated config is picked up by
         ``.githooks/pre-commit``'s ``prek run`` via the repo-root symlink.
-        PR #908 review defect: git-hooks.nix's stock installation script
-        unset/reset ``core.hooksPath`` and installed only the pre-commit
-        stage into ``.git/hooks``, silently bypassing ``.githooks``.
+        The base dev-shell now wires ``core.hooksPath`` -> ``.githooks`` for
+        direnv consumers (#1112), *reinforcing* that entry point. Opting into
+        the flake-generated config must add no *other* hooksPath mutation:
+        the PR #908 defect was git-hooks.nix's stock installation script
+        unsetting/resetting ``core.hooksPath`` and installing only the
+        pre-commit stage into ``.git/hooks``, silently bypassing ``.githooks``.
+        So every ``core.hooksPath`` reference must be the sanctioned
+        ``.githooks`` set, and nothing may unset/uninstall it.
         """
-        assert "core.hooksPath" not in opted_in_shellhook
+        assert opted_in_shellhook.count("core.hooksPath") == opted_in_shellhook.count(
+            "core.hooksPath .githooks"
+        ), "opting in introduced a non-`.githooks` core.hooksPath mutation (#908)"
+        assert "--unset" not in opted_in_shellhook
         assert "uninstall" not in opted_in_shellhook
+
+
+class TestGithooksPathWiring:
+    """The dev-shell wires ``.githooks`` as core.hooksPath for direnv mode (#1112).
+
+    Devcontainer mode runs ``git config core.hooksPath .githooks`` from
+    ``setup-git-conf.sh``; a direnv / ``nix develop`` consumer never got that,
+    so commit-time hooks (pre-commit / commit-msg via prek) were silently
+    inactive until the consumer set it by hand. The base shellHook now mirrors
+    the devcontainer, guarded so it only touches a scaffold-shaped repo and
+    never fights the worktree flow (justfile.worktree unsets core.hooksPath and
+    installs prek hooks directly in a linked worktree).
+    """
+
+    def test_default_shellhook_sets_core_hookspath_to_githooks(
+        self, default_shellhook: str
+    ) -> None:
+        """direnv mode mirrors the devcontainer: ``config core.hooksPath .githooks``."""
+        assert "config core.hooksPath .githooks" in default_shellhook
+
+    def test_default_shellhook_guards_on_githooks_dir(
+        self, default_shellhook: str
+    ) -> None:
+        """Only a scaffold-shaped repo (a ``.githooks/`` dir at toplevel) is touched."""
+        assert "/.githooks" in default_shellhook
+
+    def test_default_shellhook_guards_on_main_worktree(
+        self, default_shellhook: str
+    ) -> None:
+        """A linked worktree (owned by justfile.worktree) is left alone.
+
+        The guard compares the worktree git-dir with the common git-dir; they
+        differ only in a linked worktree, so the wiring runs solely in the main
+        checkout and never re-fights the worktree's deliberate unset.
+        """
+        assert "--git-common-dir" in default_shellhook
+
+    def test_default_shellhook_never_unsets_hookspath(
+        self, default_shellhook: str
+    ) -> None:
+        """The wiring only ever *sets* ``.githooks``; it never unsets/uninstalls (#908)."""
+        assert "--unset" not in default_shellhook
+        assert "uninstall" not in default_shellhook


### PR DESCRIPTION
## Description

In direnv mode the scaffold never set `core.hooksPath`, so commit-time hooks (pre-commit / commit-msg via prek) were silently inactive until the consumer set it by hand — a local commit could bypass the gate, with only CI catching violations later. Devcontainer mode already wires it (`setup-git-conf.sh` runs `git config core.hooksPath .githooks`). The dev shell now mirrors that: entering the direnv / `nix develop` shell wires `core.hooksPath` → `.githooks` automatically.

Closes #1112

## Type of Change

- [ ] `feat` -- New feature
- [x] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [ ] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- `flake.nix`: new `githooksPathHook` fragment in `mkProjectShell`'s shared base shellHook. Implemented here (not in the scaffolded `.envrc`) so every direnv consumer gets it on the next flake-pin bump without a re-scaffold, and the devkit's own `devShells.default` exercises it. Three guards, each justified in the code comment:
  1. `.githooks/` must exist at the git toplevel — only scaffold-shaped repos are touched;
  2. **main worktree only** (worktree git-dir == common git-dir) — a linked worktree is owned by `justfile.worktree`, which deliberately unsets `core.hooksPath` and installs prek hooks directly; this guard keeps the shellHook from fighting that flow;
  3. only when the value differs from `.githooks` — idempotent on re-entry.
  The hook only ever **sets** `.githooks` — never unsets/resets it or installs into `.git/hooks` — reinforcing the #908 invariant that `.githooks` stays the single entry point.
- `tests/test_flake_hooks.py`: new `TestGithooksPathWiring` suite (wiring present, `.githooks`-dir guard, main-worktree guard, never unsets) + the existing #908 guard test refined to allow the sanctioned `.githooks` write while still rejecting any other `core.hooksPath` mutation.
- `docs/COMMIT_MESSAGE_STANDARD.md` (SSoT; `assets/workspace/` mirror regenerated by `sync-manifest`): updated the "if `core.hooksPath` is unset the guard is silently absent" caveat — both sanctioned environments now wire it automatically.

## Changelog Entry

### Fixed
- **direnv dev-shell wires `core.hooksPath` → `.githooks` automatically** ([#1112](https://github.com/vig-os/devkit/issues/1112))
  - Devcontainer mode set the hook entry point during setup, but a direnv / `nix develop` consumer never got it, so commit-time hooks (pre-commit / commit-msg via prek) were silently inactive until set by hand.
  - `mkProjectShell`'s base shellHook now sets it on shell entry, guarded to scaffold-shaped repos (a `.githooks/` dir), the main worktree (linked worktrees stay owned by `justfile.worktree`'s direct prek install), and idempotent re-entry; it only ever sets the sanctioned `.githooks` value (#908 invariant).

## Testing

- [x] Tests pass locally (`just test`)
- [x] Manual testing performed (describe below)

### Manual Testing Details

- TDD: `test_default_shellhook_sets_core_hookspath_to_githooks` committed failing (RED), turned GREEN by the fix.
- `tests/test_flake_hooks.py` + `tests/test_flake_devshell.py`: 38 passed, 1 skipped (FHS-only leak guard, N/A on NixOS host) — implementation run + independent review run, re-run after merging current `dev` (post podman-DooD flake change).
- End-to-end against temp repos: main worktree + `.githooks` → set; linked worktree → left unset; no `.githooks` → untouched; re-entry → idempotent.
- Tier-0 flake gates `nix run .#nix-fast-build -- --flake ".#checks.x86_64-linux"` → exit 0 (includes treefmt/nixfmt + dev-shell build + git-hooks check). Downstream scaffold-stub `nix flake check ./assets/workspace --override-input vigos "path:$PWD"` → all checks passed.
- `prek run --all-files`: green.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

Part of the commit-action-deployment bug batch. Shared-config semantics note: `core.hooksPath` lives in the repo's shared config, so entering the main-worktree dev shell sets it repo-wide; in a linked worktree the `.githooks` entry point then also runs `prek run`, so hooks stay enforced either way — no functional regression, just an observation.

Refs: #1112
