### PR TITLE
refactor(image): evict perl via neovim without wl-clipboard

### DIFF
--- a/.vulnixignore
+++ b/.vulnixignore
@@ -114,11 +114,6 @@ CVE-2026-5928
 # Remaining lower-reachability components (provenance per note). Specifics
 # unverified offline; medium-near expiry to force re-review.
 Expiration: 2026-08-31
-# perl 5.42.0 — in-closure via neovim → wl-clipboard → xdg-utils (git stopped
-#   anchoring perl in #1107, which swapped the image to gitMinimal). Reachable
-#   only on xdg-utils' desktop-open helper paths, not the hot path; specifics
-#   unverified offline.
-CVE-2026-4176
 # zlib 1.3.2 — ubiquitous compression dep (curl, openssh, git, nix, python).
 #   Reachable on any decompression path; specifics unverified offline.
 CVE-2026-27820
@@ -319,36 +314,3 @@ CVE-2026-40467
 #   reachable when the opt-in readdir extension is loaded (`-l readdir`) on a
 #   crafted directory tree — not used by any tooling here.
 CVE-2026-40553
-
-# ============================================================================
-# Triage 2026-07-15 — perl 5.42.0 CPANSec batch (release-cycle fix, #1094).
-# Surfaced in the vulnix feed 2026-07-15 and failed the nightly vulnix gate
-# (security-scan run 29396607272). Verified ONLINE against NVD/MITRE/CPANSec,
-# the Debian security tracker, and the upstream perl release on 2026-07-15.
-# Real product match (perl the interpreter, no CPE collision). Both fixes exist
-# ONLY in the perl 5.43.x DEVELOPMENT series (fixed in 5.43.10); stable perl is
-# 5.42.0 in the pinned rev, in nixos-26.05, AND in Debian stable (all still
-# unpatched, no backport) — so the "advance the rev" lever has nowhere to land
-# today. perl is in-closure via neovim → wl-clipboard → xdg-utils (git stopped
-# anchoring it in #1107), same provenance as CVE-2026-4176; it processes
-# developer/CI-chosen inputs only, with no untrusted-input path in the
-# single-user dev model. Flip to a nixpkgs rev-advance once a patched perl
-# reaches the pinned channel; short expiry to force near-term re-check.
-# ============================================================================
-
-Expiration: 2026-08-14
-# perl 5.42.0 — CVE-2026-13221 (9.1): a 16-bit trie-delta field overflows in
-#   Perl_study_chunk when a regex alternation of >65535 fixed-string branches
-#   is compiled into a trie, silently truncating the match table (false
-#   positive/negative matches). Correctness bug; dangerous only when a regex
-#   gates access/filtering, and needs a pathological developer-authored
-#   pattern — no untrusted-regex path here. Fixed upstream in perl 5.43.10
-#   (dev series); not in any stable branch.
-CVE-2026-13221
-# perl 5.42.0 — CVE-2026-57432 (8.4): integer overflow in S_measure_struct
-#   wraps the signed size total negative, so a pack/unpack template with a huge
-#   repeat count drives an out-of-bounds heap read (info disclosure) when the
-#   template derives from untrusted input. No such path here (developer/CI-
-#   chosen templates only). Fixed in the perl 5.43.x dev series; not in any
-#   stable branch.
-CVE-2026-57432

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Evict perl from the image (neovim without wl-clipboard)** ([#1108](https://github.com/vig-os/devkit/issues/1108))
+  - perl 5.42.0 and its module stack (libwww-perl, XML-Twig, File-MimeInfo,
+    X11-Protocol, …) had one remaining anchor after
+    [#1107](https://github.com/vig-os/devkit/issues/1107) swapped full `git` for
+    `gitMinimal`: `neovim → wl-clipboard → xdg-utils → perl`. The nixpkgs neovim
+    wrapper suffixes `wl-clipboard` onto the wrapped binary's PATH as the Wayland
+    clipboard provider (`waylandSupport`, on by default on Linux), and
+    wl-clipboard drags xdg-utils, which drags perl.
+  - In a headless container this provider is dead code — there is no Wayland
+    socket, so `wl-copy`/`wl-paste` never run. The clipboard path that actually
+    works over VS Code remote / SSH is OSC52, which nvim >= 0.10 uses natively
+    when no display clipboard tool is on PATH.
+  - The image now re-wraps `neovim-unwrapped` with `wrapNeovimUnstable`
+    (replicating the stock legacy wrap — empty rc, providers disabled — but with
+    `waylandSupport = false`), evicting the wl-clipboard → xdg-utils → perl
+    subtree. Measured **~108 MiB** off the uncompressed closure
+    (1,758,754,952 → 1,645,235,648 bytes).
+  - Dev-shell behavior is unchanged: `devTools` still ships the stock wrapped
+    neovim (which keeps wl-clipboard for real Wayland hosts); the swap is scoped
+    to the image only.
 - **Restrict image locales to en_US.UTF-8** ([#1104](https://github.com/vig-os/devkit/issues/1104))
   - The image shipped the full 222 MiB upstream `glibcLocales` archive but only
     ever uses `en_US.UTF-8`. The `imageTools` entry and the `LOCALE_ARCHIVE`
@@ -91,6 +111,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     sibling-commit reconcile, exactly the status quo.
 
 ### Security
+
+- **Retire the perl 5.42.0 CVE exception batch** ([#1108](https://github.com/vig-os/devkit/issues/1108))
+  - With perl gone from the image closure (neovim no longer anchors it via
+    wl-clipboard → xdg-utils), the perl 5.42.0 CVE exceptions in `.vulnixignore`
+    are **deleted** rather than maintained: CVE-2026-4176, and the CPANSec batch
+    CVE-2026-13221 / CVE-2026-57432 (accepted "pending upstream stable fix" in
+    [#1097](https://github.com/vig-os/devkit/issues/1097)/[#1098](https://github.com/vig-os/devkit/issues/1098),
+    fixed only in the perl 5.43.x development series). Fewer packages, fewer
+    exceptions to babysit; the nightly vulnix scan no longer needs them.
 
 ## [1.2.1](https://github.com/vig-os/devkit/releases/tag/1.2.1) - 2026-07-15
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -11,6 +11,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Evict perl from the image (neovim without wl-clipboard)** ([#1108](https://github.com/vig-os/devkit/issues/1108))
+  - perl 5.42.0 and its module stack (libwww-perl, XML-Twig, File-MimeInfo,
+    X11-Protocol, …) had one remaining anchor after
+    [#1107](https://github.com/vig-os/devkit/issues/1107) swapped full `git` for
+    `gitMinimal`: `neovim → wl-clipboard → xdg-utils → perl`. The nixpkgs neovim
+    wrapper suffixes `wl-clipboard` onto the wrapped binary's PATH as the Wayland
+    clipboard provider (`waylandSupport`, on by default on Linux), and
+    wl-clipboard drags xdg-utils, which drags perl.
+  - In a headless container this provider is dead code — there is no Wayland
+    socket, so `wl-copy`/`wl-paste` never run. The clipboard path that actually
+    works over VS Code remote / SSH is OSC52, which nvim >= 0.10 uses natively
+    when no display clipboard tool is on PATH.
+  - The image now re-wraps `neovim-unwrapped` with `wrapNeovimUnstable`
+    (replicating the stock legacy wrap — empty rc, providers disabled — but with
+    `waylandSupport = false`), evicting the wl-clipboard → xdg-utils → perl
+    subtree. Measured **~108 MiB** off the uncompressed closure
+    (1,758,754,952 → 1,645,235,648 bytes).
+  - Dev-shell behavior is unchanged: `devTools` still ships the stock wrapped
+    neovim (which keeps wl-clipboard for real Wayland hosts); the swap is scoped
+    to the image only.
 - **Restrict image locales to en_US.UTF-8** ([#1104](https://github.com/vig-os/devkit/issues/1104))
   - The image shipped the full 222 MiB upstream `glibcLocales` archive but only
     ever uses `en_US.UTF-8`. The `imageTools` entry and the `LOCALE_ARCHIVE`
@@ -91,6 +111,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     sibling-commit reconcile, exactly the status quo.
 
 ### Security
+
+- **Retire the perl 5.42.0 CVE exception batch** ([#1108](https://github.com/vig-os/devkit/issues/1108))
+  - With perl gone from the image closure (neovim no longer anchors it via
+    wl-clipboard → xdg-utils), the perl 5.42.0 CVE exceptions in `.vulnixignore`
+    are **deleted** rather than maintained: CVE-2026-4176, and the CPANSec batch
+    CVE-2026-13221 / CVE-2026-57432 (accepted "pending upstream stable fix" in
+    [#1097](https://github.com/vig-os/devkit/issues/1097)/[#1098](https://github.com/vig-os/devkit/issues/1098),
+    fixed only in the perl 5.43.x development series). Fewer packages, fewer
+    exceptions to babysit; the nightly vulnix scan no longer needs them.
 
 ## [1.2.1](https://github.com/vig-os/devkit/releases/tag/1.2.1) - 2026-07-15
 

--- a/flake.nix
+++ b/flake.nix
@@ -745,11 +745,50 @@
           '';
         });
 
+        # neovim for the IMAGE without the wl-clipboard clipboard provider
+        # (#1108). The stock nixpkgs neovim wrapper suffixes `wl-clipboard` onto
+        # the wrapped binary's runtime PATH as the Wayland clipboard provider:
+        # `runtimeDeps` gains `wl-clipboard` whenever `waylandSupport` is true,
+        # which defaults ON on Linux (pkgs/applications/editors/neovim/
+        # wrapper.nix). wl-clipboard drags in `xdg-utils`, and xdg-utils drags
+        # the entire perl 5.42.0 module stack (File-MimeInfo, X11-Protocol,
+        # XML-Twig, libwww-perl, File-DesktopEntry, …) — perl's SOLE remaining
+        # anchor in the image after #1107 swapped full `git` for gitMinimal. In
+        # a HEADLESS container this provider is dead code: there is no Wayland
+        # socket, so `wl-copy`/`wl-paste` never run. The clipboard path that
+        # actually works over VS Code remote / SSH is OSC52, which nvim >= 0.10
+        # uses natively when no display clipboard tool is on PATH. Evicting
+        # wl-clipboard therefore drops perl — and lets us retire its live CVE
+        # exception batch (#1097/#1098) instead of babysitting it — with zero
+        # functional loss in this usage.
+        #
+        # The pinned wrapped `neovim` is `wrapNeovim neovim-unwrapped {}`
+        # (= neovimUtils.legacyWrapper), whose `.override` exposes only
+        # `{ configure, extraMakeWrapperArgs }` — there is NO `waylandSupport`
+        # knob to flip. We therefore re-wrap `neovim-unwrapped` directly with the
+        # lower-level `wrapNeovimUnstable`, replicating the legacy wrap's defaults
+        # (empty rc, no plugins, `wrapRc = false`, and `legacyWrapper = true` so
+        # the provider-disabling lua rc — `vim.g.loaded_{perl,ruby,python3,node}
+        # _provider = 0` — matches stock `neovim`) but with
+        # `waylandSupport = false`. The result is a behaviour-equivalent `nvim`
+        # minus the wl-clipboard -> xdg-utils -> perl subtree. Scoped to the
+        # IMAGE — the dev-shell keeps the stock wrapped neovim via devTools.
+        # Refs #1108, #1103.
+        neovimImage = pkgs.wrapNeovimUnstable pkgs.neovim-unwrapped {
+          neovimRcContent = "";
+          luaRcContent = "";
+          plugins = [ ];
+          wrapperArgs = [ ];
+          wrapRc = false;
+          legacyWrapper = true;
+          waylandSupport = false;
+        };
+
         # The toolchain SSoT plus the runtime substrate a bare layered image
         # lacks (an FHS base distro would provide these; here we add them
         # explicitly — this is the discovery surface for FHS gaps). Shared by
         # the image (`devkitImage`) and its vulnix scan target
-        # (`devkitImageEnv`, #637). Three devTools entries are swapped for
+        # (`devkitImageEnv`, #637). Four devTools entries are swapped for
         # slimmer image-only builds — filtered out here, not in the SSoT, so the
         # dev-shell keeps the full tools:
         #   - full `podman` → `podmanClient` (client-only, #1106).
@@ -759,14 +798,21 @@
         #     send-email/svn/p4/gitk/`git help` — non-contract per #1103).
         #   - stock `actionlint` → `actionlintImage` (no `python3.13-pyflakes`
         #     wrapper — the other CPython 3.13 anchor).
+        #   - stock `neovim` → `neovimImage` (no wl-clipboard clipboard provider
+        #     — drops the wl-clipboard → xdg-utils → perl anchor; OSC52 replaces
+        #     it in the headless container; #1108).
         # Together with #1105 (bandit) and #1106 (criu) this evicts the redundant
-        # CPython 3.13 interpreter from the image. Refs #1107, #1103.
+        # CPython 3.13 interpreter (#1107) and perl (#1108) from the image.
+        # Refs #1108, #1107, #1103.
         imageTools =
-          (builtins.filter (p: p != pkgs.podman && p != pkgs.git && p != pkgs.actionlint) (devTools pkgs))
+          (builtins.filter (
+            p: p != pkgs.podman && p != pkgs.git && p != pkgs.actionlint && p != pkgs.neovim
+          ) (devTools pkgs))
           ++ [
             podmanClient
             pkgs.gitMinimal
             actionlintImage
+            (pkgs.lib.lowPrio neovimImage)
           ]
           ++ (with pkgs; [
             # Nix package manager in the closure (CppNix).


### PR DESCRIPTION
## Summary

Final cut of epic #1103. After #1107 swapped full git for `gitMinimal`, perl
5.42.0's **sole** remaining anchor was `neovim → wl-clipboard → xdg-utils →
perl` — the nixpkgs neovim wrapper suffixes `wl-clipboard` as the Wayland
clipboard provider, dead code in a headless container (no Wayland socket; the
clipboard that actually works over VS Code remote / SSH is OSC52, native in
nvim ≥ 0.10).

The stock wrapper exposes no `waylandSupport` knob via `.override`, so the image
gets a `wrapNeovimUnstable pkgs.neovim-unwrapped` rewrap replicating the legacy
defaults (`legacyWrapper = true` keeps the stock provider-disabling rc) with
`waylandSupport = false`. Image-scoped via the established filter pattern —
`devTools`/dev-shell keep the stock wrapped neovim, including its `lowPrio`
(replicated, since devTools relies on it for the `vigos.editor` collision rule,
#824).

**Security payoff:** with perl out of the closure, the perl 5.42.0 CVE
exception batch in `.vulnixignore` (#1097/#1098, "pending upstream stable fix")
is **deleted** (38 lines: `CVE-2026-4176`, and the perl-only triage block with
`CVE-2026-13221`/`CVE-2026-57432`) instead of being maintained. Shared
expiration headers and co-located non-perl entries kept intact;
`check-expirations` hook passes.

## Evidence (independently re-verified)

- Closure: 1,758,754,952 → 1,645,235,648 bytes (**−108.3 MiB** — the issue
  estimated ~55–60; the full perl-module stack + wl-clipboard + xdg-utils came
  out with it)
- **`nix path-info -r | grep -iE 'perl|wl-clipboard|xdg-utils'` → EMPTY**
  (baseline had 33 such paths)
- `nvim --version` → `NVIM v0.12.3`; `--headless +q` exits 0; the wrapper
  script contains zero wl-clipboard/xdg-utils references; under a clean PATH
  `:checkhealth` reports the benign "No clipboard tool found" (OSC52 territory),
  no crash
- No test or shipped-config changes needed: no image test asserts the wrapped
  variant; no nvim config sets a clipboard provider
- Full hook suite green (`prek run --all-files`, exit 0)

Part of epic #1103 (sub-issue 5/5 — completes the epic).

Closes #1108