### PR TITLE
fix(init-workspace): migrate hand-added root gitignore lines into .gitignore.project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Migrate hand-added root `.gitignore` lines into `.gitignore.project` on upgrade** ([#1111](https://github.com/vig-os/devkit/issues/1111))
+  - The [#1092](https://github.com/vig-os/devkit/issues/1092) fix made
+    `.gitignore.project` the durable home for repo-root ignores, but the upgrade
+    that introduces it seeds it empty — so any ignores a consumer had hand-added
+    directly to the managed (regenerated) root `.gitignore` (`.DS_Store`,
+    editor/OS cruft, project paths) were silently dropped when `render_gitignore`
+    rebuilt root `.gitignore` from the template.
+  - `init-workspace.sh` now snapshots the pre-overwrite root `.gitignore` and
+    migrates its consumer-added entries (non-blank, non-comment lines that are
+    not provided by the template base, an active language fragment, or the #1092
+    seed, and not already present) into `.gitignore.project`, from where they
+    flow back into the regenerated root `.gitignore`. The migration is
+    append-only and deduplicated, so it never reorders the consumer's existing
+    entries and a second upgrade re-adds nothing (idempotent); it prints the
+    count and list of migrated lines.
 - **Preserve a flake-hooks `.pre-commit-config.yaml` store symlink on upgrade** ([#1117](https://github.com/vig-os/devkit/issues/1117))
   - In direnv mode a flake with `hooks = { }` generates `.pre-commit-config.yaml`
     as a symlink into the host `/nix/store`, which is not mounted inside the image

--- a/assets/init-workspace.sh
+++ b/assets/init-workspace.sh
@@ -596,6 +596,15 @@ PYMARKDOWN_CONFIG_PREEXISTED=false
 PYMARKDOWN_DOC_PREEXISTED=false
 [[ -f "$WORKSPACE_DIR/.pymarkdown.config.md" ]] && PYMARKDOWN_DOC_PREEXISTED=true
 
+# Snapshot the consumer's OLD root .gitignore before the rsync overwrite (#1111).
+# Root .gitignore is managed (NOT a PRESERVE_FILE), so rsync replaces it below;
+# capture it now so migrate_root_gitignore can recover any root ignores the
+# consumer had hand-added directly to it (they predate the #1092 durable home,
+# .gitignore.project, and would otherwise be silently dropped on the upgrade that
+# introduces it). Empty on a fresh scaffold (no old file) — the migration no-ops.
+OLD_GITIGNORE_SNAPSHOT=""
+[[ -f "$WORKSPACE_DIR/.gitignore" ]] && OLD_GITIGNORE_SNAPSHOT="$(cat "$WORKSPACE_DIR/.gitignore")"
+
 # ── consumer language detection (#1024/#1025) ─────────────────────────────────
 # Managed scaffold statics (.gitignore, .github/workflows/codeql.yml) are
 # Python-shaped by default, which is wrong for Node/Rust consumers and does not
@@ -684,6 +693,77 @@ render_gitignore() {
             } >>"$gi"
         fi
     fi
+}
+
+# Migrate consumer-added root ignores into .gitignore.project (#1111). The #1092
+# fix made .gitignore.project the durable, preserved home for repo-ROOT ignores,
+# but the upgrade that INTRODUCES it seeds it empty — so any ignores a consumer
+# had hand-added directly to the managed root .gitignore (.DS_Store, editor/OS
+# cruft, project paths) are silently dropped when render_gitignore regenerates
+# root .gitignore from the template. Recover them: any non-blank, non-comment
+# line in the pre-overwrite root .gitignore (OLD_GITIGNORE_SNAPSHOT) that is NOT
+# a managed entry (template base + active language fragments + the #1092 seed)
+# and NOT already in .gitignore.project is appended to .gitignore.project, whence
+# render_gitignore (called AFTER this) folds it back into the regenerated root
+# .gitignore — no separate write to the root file. Append-only and deduplicated
+# against the existing .gitignore.project, so a second upgrade re-adds nothing
+# (idempotent: the migrated lines now live in .gitignore.project) and the
+# consumer's existing entries are never reordered or rewritten. Only entries
+# (non-blank, non-comment lines) migrate; a consumer's free-text comments are not
+# semantically ignorable, so they are left behind with the old managed file.
+migrate_root_gitignore() {
+    local proj="$WORKSPACE_DIR/.gitignore.project"
+    [[ -f "$proj" ]] || return 0
+    [[ -n "$OLD_GITIGNORE_SNAPSHOT" ]] || return 0
+
+    local line lang frag
+    # Managed entries the regenerated root .gitignore already provides — never
+    # migrate one of these (idempotent even for a line the template later drops).
+    local -A managed=()
+    while IFS= read -r line; do
+        [[ "$line" =~ ^[[:space:]]*$ || "$line" =~ ^[[:space:]]*# ]] && continue
+        managed["$line"]=1
+    done < "$TEMPLATE_DIR/.gitignore"
+    for lang in ${DETECTED_LANGUAGES[@]+"${DETECTED_LANGUAGES[@]}"}; do
+        frag="$SCRIPT_DIR/gitignore.d/$lang.gitignore"
+        [[ -f "$frag" ]] || continue
+        while IFS= read -r line; do
+            [[ "$line" =~ ^[[:space:]]*$ || "$line" =~ ^[[:space:]]*# ]] && continue
+            managed["$line"]=1
+        done < "$frag"
+    done
+    # The #1092 flake-hooks seed is a managed entry too.
+    managed[".pre-commit-config.yaml"]=1
+
+    # Entries already committed in .gitignore.project must not be re-added — this
+    # is what makes a second upgrade a no-op.
+    local -A existing=()
+    while IFS= read -r line; do
+        [[ "$line" =~ ^[[:space:]]*$ || "$line" =~ ^[[:space:]]*# ]] && continue
+        existing["$line"]=1
+    done < "$proj"
+
+    # Consumer-added lines: present in the old root .gitignore, owned by neither
+    # the managed sources nor .gitignore.project. Deduplicated, order preserved.
+    local -a migrate=()
+    local -A seen=()
+    while IFS= read -r line; do
+        [[ "$line" =~ ^[[:space:]]*$ || "$line" =~ ^[[:space:]]*# ]] && continue
+        [[ -n "${managed[$line]:-}" ]] && continue
+        [[ -n "${existing[$line]:-}" ]] && continue
+        [[ -n "${seen[$line]:-}" ]] && continue
+        seen["$line"]=1
+        migrate+=("$line")
+    done <<< "$OLD_GITIGNORE_SNAPSHOT"
+
+    [[ ${#migrate[@]} -eq 0 ]] && return 0
+
+    {
+        printf '\n# Migrated from the managed root .gitignore on upgrade (#1111).\n'
+        printf '%s\n' "${migrate[@]}"
+    } >> "$proj"
+    echo "Migrated ${#migrate[@]} consumer line(s) into .gitignore.project (#1111):"
+    printf '  %s\n' "${migrate[@]}"
 }
 
 # Rewrite the managed CodeQL language matrix to the detected language(s) (#1025):
@@ -1209,6 +1289,7 @@ fi
 # every (re)scaffold, so the correct .gitignore / codeql matrix is
 # upgrade-persistent. These files carry no placeholders, so ordering after the
 # substitution above is incidental.
+migrate_root_gitignore
 render_gitignore
 render_codeql_matrix
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -69,6 +69,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Migrate hand-added root `.gitignore` lines into `.gitignore.project` on upgrade** ([#1111](https://github.com/vig-os/devkit/issues/1111))
+  - The [#1092](https://github.com/vig-os/devkit/issues/1092) fix made
+    `.gitignore.project` the durable home for repo-root ignores, but the upgrade
+    that introduces it seeds it empty — so any ignores a consumer had hand-added
+    directly to the managed (regenerated) root `.gitignore` (`.DS_Store`,
+    editor/OS cruft, project paths) were silently dropped when `render_gitignore`
+    rebuilt root `.gitignore` from the template.
+  - `init-workspace.sh` now snapshots the pre-overwrite root `.gitignore` and
+    migrates its consumer-added entries (non-blank, non-comment lines that are
+    not provided by the template base, an active language fragment, or the #1092
+    seed, and not already present) into `.gitignore.project`, from where they
+    flow back into the regenerated root `.gitignore`. The migration is
+    append-only and deduplicated, so it never reorders the consumer's existing
+    entries and a second upgrade re-adds nothing (idempotent); it prints the
+    count and list of migrated lines.
 - **Preserve a flake-hooks `.pre-commit-config.yaml` store symlink on upgrade** ([#1117](https://github.com/vig-os/devkit/issues/1117))
   - In direnv mode a flake with `hooks = { }` generates `.pre-commit-config.yaml`
     as a symlink into the host `/nix/store`, which is not mounted inside the image

--- a/tests/bats/init-workspace.bats
+++ b/tests/bats/init-workspace.bats
@@ -3002,6 +3002,73 @@ _RELEASE_RESOLVERS_991=(
     refute_line '.pre-commit-config.yaml'
 }
 
+# ── migrate hand-added root ignores into .gitignore.project (#1111) ────────────
+# The #1092 fix made .gitignore.project the durable home for repo-root ignores,
+# but the upgrade that INTRODUCES it seeds it empty — so any ignores a consumer
+# had hand-added directly to the managed (regenerated) root .gitignore were
+# silently dropped. init-workspace snapshots the pre-overwrite root .gitignore
+# and migrates its consumer-added, non-managed lines into .gitignore.project,
+# whence render_gitignore folds them back into the regenerated root .gitignore.
+
+@test "upgrade migrates consumer-added root .gitignore lines into .gitignore.project (#1111)" {
+    ws="$BATS_TEST_TMPDIR/e2e-1111-migrate"
+    mkdir -p "$ws"
+    run _scaffold both "$ws"
+    assert_success
+    # Consumer hand-adds root ignores to the managed root .gitignore, as they had
+    # to before .gitignore.project existed (#1092).
+    printf '.DS_Store\nmy-secret-dir/\n' >>"$ws/.gitignore"
+    run _upgrade both "$ws"
+    assert_success
+    # The upgrade note (fix variant (b)) lists what was rescued.
+    assert_output --partial 'Migrated 2 consumer line'
+    # Hand-added lines are recovered into the durable, preserved home ...
+    run grep -qxF '.DS_Store' "$ws/.gitignore.project"
+    assert_success
+    run grep -qxF 'my-secret-dir/' "$ws/.gitignore.project"
+    assert_success
+    # ... and stay effective in the regenerated root .gitignore.
+    run grep -qxF '.DS_Store' "$ws/.gitignore"
+    assert_success
+    run grep -qxF 'my-secret-dir/' "$ws/.gitignore"
+    assert_success
+}
+
+@test "a second upgrade does not re-migrate already-migrated root ignores (#1111)" {
+    ws="$BATS_TEST_TMPDIR/e2e-1111-idempotent"
+    mkdir -p "$ws"
+    run _scaffold both "$ws"
+    assert_success
+    printf '.DS_Store\nmy-secret-dir/\n' >>"$ws/.gitignore"
+    run _upgrade both "$ws"
+    assert_success
+    run _upgrade both "$ws"
+    assert_success
+    # The second upgrade migrates nothing new (idempotent) ...
+    refute_output --partial 'Migrated'
+    # ... and the migrated line appears exactly once in .gitignore.project.
+    run grep -cxF '.DS_Store' "$ws/.gitignore.project"
+    assert_output '1'
+}
+
+@test "managed template/fragment ignore lines are never migrated into .gitignore.project (#1111)" {
+    ws="$BATS_TEST_TMPDIR/e2e-1111-managed"
+    mkdir -p "$ws"
+    run _scaffold both "$ws"
+    assert_success
+    # Add one genuinely consumer-owned line to the managed root .gitignore.
+    printf 'consumer-only-dir/\n' >>"$ws/.gitignore"
+    run _upgrade both "$ws"
+    assert_success
+    # The consumer's own line migrates ...
+    run grep -qxF 'consumer-only-dir/' "$ws/.gitignore.project"
+    assert_success
+    # ... but a managed template-base line (justfile.local) is NOT copied in:
+    # it is already provided by the regenerated root .gitignore.
+    run grep -qxF 'justfile.local' "$ws/.gitignore.project"
+    assert_failure
+}
+
 # ── dangling /nix/store symlink is preserved and seeds the ignore (#1117) ──────
 # In direnv mode the flake generates .pre-commit-config.yaml as a symlink into
 # the HOST /nix/store, which is NOT mounted inside the devcontainer image where


### PR DESCRIPTION
## Description

The #1092 fix made `.gitignore.project` the durable, preserved home for repo-root ignores, but the upgrade that introduces it seeds it empty: any root ignores a consumer had previously hand-added directly to the managed root `.gitignore` (`.DS_Store`, editor/OS cruft, project paths) were silently dropped when the upgrade regenerated the file from the template. Of the issue's two suggested fixes, this implements the preferred one — **auto-migrate** the consumer's lines into `.gitignore.project` — with the upgrade-note listing as its natural side output.

Closes #1111

## Type of Change

- [ ] `feat` -- New feature
- [x] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [ ] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [ ] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- `assets/init-workspace.sh`:
  - Snapshot the consumer's old root `.gitignore` before the rsync overwrite (placed with the other pre-overwrite state captures).
  - New single-responsibility `migrate_root_gitignore()`, called just before `render_gitignore()`: appends to `.gitignore.project` every old-root line that is non-blank, non-comment, not a managed entry (template base + active language fragments + the #1092 seed), and not already in `.gitignore.project`. Append-only (never reorders/rewrites the consumer's existing entries), deduplicated, and idempotent — after the first migration the lines live in `.gitignore.project`, so later upgrades re-add nothing. Prints `Migrated N consumer line(s) into .gitignore.project (#1111):` with the list.
  - The migrated lines flow into the regenerated root `.gitignore` via `render_gitignore()`'s existing `.gitignore.project` append — no separate write.
- `tests/bats/init-workspace.bats`: three regression tests — migrate (lines land in `.gitignore.project` and remain effective in the rendered root `.gitignore`, note printed), idempotence (second upgrade adds nothing), managed-lines-not-migrated.

## Changelog Entry

### Fixed
- **Migrate hand-added root `.gitignore` lines into `.gitignore.project` on upgrade** ([#1111](https://github.com/vig-os/devkit/issues/1111))
  - The upgrade that introduced the #1092 `.gitignore.project` seam seeded it empty, silently dropping any root ignores a consumer had hand-added to the managed root `.gitignore` (regenerated from the template every upgrade).
  - Consumer-added entries (non-blank, non-comment, not template/fragment/seed-managed, not already present) are now migrated append-only into `.gitignore.project` before the render — deduplicated, idempotent across upgrades, with an upgrade note listing what moved.

## Testing

- [x] Tests pass locally (`just test`)
- [x] Manual testing performed (describe below)

### Manual Testing Details

- TDD: all three regression tests committed failing (RED — no migration: note absent, `.DS_Store` missing from `.gitignore.project`), turned GREEN by the fix.
- Full `tests/bats/init-workspace.bats`: 204 tests, 0 failures (implementation run + independent review run).
- `prek run --all-files`: green (including shellcheck on the new function).

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

Wave 2 of the commit-action-deployment bug batch, branched after #1124 (same `render_gitignore()` region) merged. Deliberate design choice worth noting: a template example line a consumer *uncommented* (e.g. activating `.idea/`) migrates into `.gitignore.project` — correct data preservation, since their active ignore survives the upgrade.

Refs: #1111
