### PR TITLE
fix(release-core): sync deps before building the release artifact

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     append-only and deduplicated, so it never reorders the consumer's existing
     entries and a second upgrade re-adds nothing (idempotent); it prints the
     count and list of migrated lines.
+
+- **Install project deps before building the release artifact** ([#1130](https://github.com/vig-os/devkit/issues/1130))
+  - The `Build release artifact` step in `release-core.yml` ran `just bundle`
+    without a preceding `just sync`, so a JS-Action consumer's bundler (`ncc`, a
+    devDependency) was absent from PATH — the finalization step exited 127 and
+    the `final` release rolled back. Only surfaced on a real `final` release (the
+    step is gated on `release_kind == 'final'` and a detected `bundle` recipe).
+  - The step now runs `just sync` (language-neutral: `npm ci` / `uv sync`) before
+    `just bundle`, matching every other build job. No-op for consumers without a
+    bundle recipe.
+
 - **Wire `core.hooksPath` for direnv consumers** ([#1112](https://github.com/vig-os/devkit/issues/1112))
   - In direnv / `nix develop` mode the dev-shell never set `core.hooksPath`, so
     commit-time hooks (pre-commit / commit-msg via prek) were silently inactive

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -104,6 +104,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     append-only and deduplicated, so it never reorders the consumer's existing
     entries and a second upgrade re-adds nothing (idempotent); it prints the
     count and list of migrated lines.
+
+- **Install project deps before building the release artifact** ([#1130](https://github.com/vig-os/devkit/issues/1130))
+  - The `Build release artifact` step in `release-core.yml` ran `just bundle`
+    without a preceding `just sync`, so a JS-Action consumer's bundler (`ncc`, a
+    devDependency) was absent from PATH — the finalization step exited 127 and
+    the `final` release rolled back. Only surfaced on a real `final` release (the
+    step is gated on `release_kind == 'final'` and a detected `bundle` recipe).
+  - The step now runs `just sync` (language-neutral: `npm ci` / `uv sync`) before
+    `just bundle`, matching every other build job. No-op for consumers without a
+    bundle recipe.
+
 - **Wire `core.hooksPath` for direnv consumers** ([#1112](https://github.com/vig-os/devkit/issues/1112))
   - In direnv / `nix develop` mode the dev-shell never set `core.hooksPath`, so
     commit-time hooks (pre-commit / commit-msg via prek) were silently inactive

--- a/assets/workspace/.github/workflows/release-core.yml
+++ b/assets/workspace/.github/workflows/release-core.yml
@@ -467,6 +467,11 @@ jobs:
         if: ${{ inputs.release_kind == 'final' && steps.bundle.outputs.has_bundle == 'true' }}
         run: |
           set -euo pipefail
+          # Install project deps (npm ci / uv sync) so the bundler (e.g. ncc, a
+          # devDependency) is on PATH. The toolchain preamble provisions the
+          # dev-shell but not the repo's node_modules, so `just bundle` alone
+          # exits 127; every other build job syncs first (#1130).
+          just sync
           # Rebuild the committed artifact from the finalized sources so the tag
           # ships a fresh bundle, not a stale one. Output (dist/) is committed
           # alongside CHANGELOG.md below.


### PR DESCRIPTION
## What

Add `just sync` before `just bundle` in the `Build release artifact` step of the scaffolded `release-core.yml`.

## Why

For a JS-Action consumer, `just bundle` → `npm run bundle` → `ncc …`, and `ncc` (`@vercel/ncc`) is a devDependency present only after `npm ci`. The devkit toolchain preamble provisions the dev-shell but not the repo's `node_modules`, so the step exited **127** (`ncc: command not found`) and rolled back the `final` release. It only surfaces on a real `final` release (gated on `release_kind == 'final'` and a detected `bundle` recipe), so it slipped past normal CI.

This restores parity with the sync-then-build pattern every other build job already follows (`just sync` is language-neutral: `npm ci` for Node, `uv sync` for Python). No-op for consumers without a bundle recipe.

Observed downstream: vig-os/commit-action release 0.3.0 — [failed run](https://github.com/vig-os/commit-action/actions/runs/29423806600).

## Changes

- `assets/workspace/.github/workflows/release-core.yml` — `just sync` before `just bundle`.
- `CHANGELOG.md` (+ synced `.devcontainer/` mirror) — Fixed entry.

Refs: #1130
