### PR TITLE
fix(promote-release): gate promote on release-PR mergeability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Gate promote on release-PR mergeability before the irreversible publish** ([#1132](https://github.com/vig-os/devkit/issues/1132))
+  - `promote-release.yml`'s `validate` job verified the release PR was
+    non-draft, approved, and CI-green but never checked whether it was actually
+    *mergeable*. Because the sequence is `validate → promote (undraft, one-way
+    under immutable releases) → merge`, a PR that was `BEHIND` `main` (or
+    `BLOCKED`/`DIRTY`) passed validation, the GitHub Release was published, and
+    only then did the merge fail — leaving a half-promoted release whose PR
+    never reached `main` and which cannot be re-run to recover.
+  - The `validate` PR check now fetches `mergeable`/`mergeStateStatus` and
+    fails fast unless the PR is mergeable, re-querying while GitHub is still
+    computing the state (`UNKNOWN`). Keeps the invariant: never start the
+    irreversible publish unless the merge can succeed.
+
 - **Migrate hand-added root `.gitignore` lines into `.gitignore.project` on upgrade** ([#1111](https://github.com/vig-os/devkit/issues/1111))
   - The [#1092](https://github.com/vig-os/devkit/issues/1092) fix made
     `.gitignore.project` the durable home for repo-root ignores, but the upgrade

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -89,6 +89,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Gate promote on release-PR mergeability before the irreversible publish** ([#1132](https://github.com/vig-os/devkit/issues/1132))
+  - `promote-release.yml`'s `validate` job verified the release PR was
+    non-draft, approved, and CI-green but never checked whether it was actually
+    *mergeable*. Because the sequence is `validate → promote (undraft, one-way
+    under immutable releases) → merge`, a PR that was `BEHIND` `main` (or
+    `BLOCKED`/`DIRTY`) passed validation, the GitHub Release was published, and
+    only then did the merge fail — leaving a half-promoted release whose PR
+    never reached `main` and which cannot be re-run to recover.
+  - The `validate` PR check now fetches `mergeable`/`mergeStateStatus` and
+    fails fast unless the PR is mergeable, re-querying while GitHub is still
+    computing the state (`UNKNOWN`). Keeps the invariant: never start the
+    irreversible publish unless the merge can succeed.
+
 - **Migrate hand-added root `.gitignore` lines into `.gitignore.project` on upgrade** ([#1111](https://github.com/vig-os/devkit/issues/1111))
   - The [#1092](https://github.com/vig-os/devkit/issues/1092) fix made
     `.gitignore.project` the durable home for repo-root ignores, but the upgrade

--- a/assets/workspace/.github/workflows/promote-release.yml
+++ b/assets/workspace/.github/workflows/promote-release.yml
@@ -236,6 +236,45 @@ jobs:
             exit 1
           fi
 
+          # Mergeability gate (#1132). promote → merge is preceded by an
+          # IRREVERSIBLE publish (undraft), so a PR that is approved + CI-green
+          # but not actually mergeable (BEHIND main, BLOCKED, or DIRTY) would
+          # undraft the Release and only then fail to merge — a half-promoted
+          # release. Fail fast here instead. GitHub computes mergeability
+          # asynchronously, so re-query while either field is UNKNOWN.
+          MERGEABLE="UNKNOWN"
+          MERGE_STATE="UNKNOWN"
+          for attempt in 1 2 3 4 5; do
+            MERGE_JSON=$(retry --retries 3 --backoff 5 --max-backoff 30 -- \
+              gh pr view "$PR_NUMBER" --json mergeable,mergeStateStatus)
+            MERGEABLE=$(echo "$MERGE_JSON" | jq -r '.mergeable')
+            MERGE_STATE=$(echo "$MERGE_JSON" | jq -r '.mergeStateStatus')
+            if [ "$MERGEABLE" != "UNKNOWN" ] && [ "$MERGE_STATE" != "UNKNOWN" ]; then
+              break
+            fi
+            echo "Mergeability still computing (mergeable=$MERGEABLE, mergeStateStatus=$MERGE_STATE), retry $attempt/5..."
+            sleep $((attempt * 5))
+          done
+
+          if [ "$MERGEABLE" != "MERGEABLE" ]; then
+            echo "ERROR: PR #$PR_NUMBER is not mergeable (mergeable=$MERGEABLE, mergeStateStatus=$MERGE_STATE)"
+            echo "Refusing to promote: the publish step is irreversible and this merge would fail after it."
+            exit 1
+          fi
+          case "$MERGE_STATE" in
+            CLEAN | HAS_HOOKS | UNSTABLE)
+              echo "PR #$PR_NUMBER is mergeable (mergeStateStatus=$MERGE_STATE)"
+              ;;
+            BEHIND)
+              echo "ERROR: PR #$PR_NUMBER is BEHIND main — update release/$VERSION to base before promoting"
+              exit 1
+              ;;
+            *)
+              echo "ERROR: PR #$PR_NUMBER is not in a mergeable state (mergeStateStatus=$MERGE_STATE)"
+              exit 1
+              ;;
+          esac
+
           echo "✓ PR #$PR_NUMBER verified for promote"
 
       - name: Summary

--- a/tests/test_promote_mergeability.py
+++ b/tests/test_promote_mergeability.py
@@ -1,0 +1,55 @@
+"""Workflow-shape test: promote validate gates on PR mergeability.
+
+Issue #1132: ``promote-release.yml``'s ``validate`` job verified the release PR
+existed, was non-draft, approved, and CI-green — but never checked whether the
+PR was actually *mergeable*. Because the sequence is ``validate → promote
+(undraft, irreversible) → merge``, a PR that was BEHIND ``main`` passed
+validation, the Release was undrafted, and only then did the merge fail —
+leaving a half-promoted release.
+
+This pins the fail-fast gate: the validate job's release-PR verification must
+query mergeability and reject a non-mergeable PR (notably BEHIND) *before* the
+promote job undrafts the Release. The bash choreography (async re-query on
+UNKNOWN) is not unit-testable here.
+
+Refs: #1132
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+WORKFLOWS = REPO_ROOT / "assets" / "workspace" / ".github" / "workflows"
+
+
+def _load(path: Path) -> dict:
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def _validate_pr_step_run() -> str:
+    workflow = _load(WORKFLOWS / "promote-release.yml")
+    steps = workflow["jobs"]["validate"]["steps"]
+    step = next(s for s in steps if s.get("name") == "Find and verify release PR")
+    return step["run"]
+
+
+def test_validate_queries_pr_mergeability() -> None:
+    """The validate PR check fetches the PR's merge state."""
+    run = _validate_pr_step_run()
+    assert "mergeStateStatus" in run
+    assert "mergeable" in run
+
+
+def test_validate_rejects_behind_pr() -> None:
+    """A BEHIND (not-up-to-date) PR is rejected before the irreversible promote."""
+    run = _validate_pr_step_run()
+    assert "BEHIND" in run
+
+
+def test_validate_requeries_unknown_mergeability() -> None:
+    """GitHub computes mergeability async, so UNKNOWN is re-queried, not trusted."""
+    run = _validate_pr_step_run()
+    assert "UNKNOWN" in run


### PR DESCRIPTION
## Summary

`promote-release.yml`'s `validate` job verified the release PR was non-draft,
approved, and CI-green — but never checked whether it was actually **mergeable**.
Because the sequence is `validate → promote (undraft, irreversible under immutable
releases) → merge`, a PR that was `BEHIND` `main` (or `BLOCKED`/`DIRTY`) passed
validation, the GitHub Release was published, and only then did the merge fail —
leaving a **half-promoted release** whose PR never reached `main` and which cannot
be re-run to recover.

Observed on vig-os/commit-action 0.3.0 promote (release branch 5 CI-only commits
behind `main`; `main` enforces "require branches up to date").

## Change

In `validate → Find and verify release PR`, after the existing draft/approval/CI
checks, fetch `mergeable` + `mergeStateStatus` via `gh pr view` and **fail fast**
unless the PR is mergeable:

- accept `CLEAN` / `HAS_HOOKS` / `UNSTABLE` (CI already asserted green separately)
- reject `BEHIND` (with a "update the release branch" hint), `BLOCKED`, `DIRTY`
- re-query while either field is `UNKNOWN` (GitHub computes mergeability async)

This keeps the invariant: never start the irreversible publish unless the merge
can succeed. Scope is the downstream scaffold template
(`assets/workspace/.github/workflows/promote-release.yml`); the primary fail-fast
`validate` gate the issue asked for.

The secondary considerations in the issue (TOCTOU between `validate` and `merge`;
`gh pr merge --auto` / branch-update in the `merge` step) are intentionally left
out of this minimal fix.

## Tests

- `tests/test_promote_mergeability.py` (new) pins that `validate`'s PR check
  queries `mergeable`/`mergeStateStatus`, rejects `BEHIND`, and re-queries
  `UNKNOWN`. Added RED-first, then implemented.
- `actionlint` (shellcheck on the embedded run script) and the full pre-commit
  suite are green.

Closes #1132