### PR TITLE
fix(workflows): drop vestigial job-level GITHUB_TOKEN write grants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -188,6 +188,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **Drop vestigial job-level `GITHUB_TOKEN` write grants from workflow templates** ([#1136](https://github.com/vig-os/devkit/issues/1136))
+  - An OpenSSF Scorecard TokenPermissions audit traced every job-level
+    `contents: write` / `actions: write` grant in the rendered release/sync
+    workflows to the token that performs the write: each git push, tag push,
+    `gh release`, `gh pr`, `gh api` mutation and `gh workflow run` rides a
+    COMMIT_APP / RELEASE_APP installation token, not the job's `GITHUB_TOKEN`.
+  - Those grants are now reduced to `read` across `prepare-release.yml` (prepare,
+    rollback), `promote-release.yml` (validate, promote, merge, cleanup,
+    floating-tags), `release.yml` (core + publish caller blocks, rollback),
+    `release-core.yml` (finalize), `release-publish.yml` (publish),
+    `sync-issues.yml` (sync) and `sync-main-to-dev.yml` (sync), shrinking the
+    blast radius of a compromised step to a read-only `GITHUB_TOKEN`.
+  - `promote-release.yml`'s *Verify draft GitHub Release exists* step now reads
+    drafts with the RELEASE_APP token (GitHub only returns drafts to a token with
+    push access), so the `validate` job can drop to `contents: read` without
+    hiding the draft. `sync-issues.yml`'s `sync` job keeps `actions: write` — its
+    cache-deletion step calls `gh api ... -X DELETE` on `github.token`.
 - **Retire the perl 5.42.0 CVE exception batch** ([#1108](https://github.com/vig-os/devkit/issues/1108))
   - With perl gone from the image closure (neovim no longer anchors it via
     wl-clipboard → xdg-utils), the perl 5.42.0 CVE exceptions in `.vulnixignore`

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -188,6 +188,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **Drop vestigial job-level `GITHUB_TOKEN` write grants from workflow templates** ([#1136](https://github.com/vig-os/devkit/issues/1136))
+  - An OpenSSF Scorecard TokenPermissions audit traced every job-level
+    `contents: write` / `actions: write` grant in the rendered release/sync
+    workflows to the token that performs the write: each git push, tag push,
+    `gh release`, `gh pr`, `gh api` mutation and `gh workflow run` rides a
+    COMMIT_APP / RELEASE_APP installation token, not the job's `GITHUB_TOKEN`.
+  - Those grants are now reduced to `read` across `prepare-release.yml` (prepare,
+    rollback), `promote-release.yml` (validate, promote, merge, cleanup,
+    floating-tags), `release.yml` (core + publish caller blocks, rollback),
+    `release-core.yml` (finalize), `release-publish.yml` (publish),
+    `sync-issues.yml` (sync) and `sync-main-to-dev.yml` (sync), shrinking the
+    blast radius of a compromised step to a read-only `GITHUB_TOKEN`.
+  - `promote-release.yml`'s *Verify draft GitHub Release exists* step now reads
+    drafts with the RELEASE_APP token (GitHub only returns drafts to a token with
+    push access), so the `validate` job can drop to `contents: read` without
+    hiding the draft. `sync-issues.yml`'s `sync` job keeps `actions: write` — its
+    cache-deletion step calls `gh api ... -X DELETE` on `github.token`.
 - **Retire the perl 5.42.0 CVE exception batch** ([#1108](https://github.com/vig-os/devkit/issues/1108))
   - With perl gone from the image closure (neovim no longer anchors it via
     wl-clipboard → xdg-utils), the perl 5.42.0 CVE exceptions in `.vulnixignore`

--- a/assets/workspace/.github/workflows/prepare-release.yml
+++ b/assets/workspace/.github/workflows/prepare-release.yml
@@ -155,7 +155,7 @@ jobs:
         shell: bash
     if: ${{ inputs.dry-run != true }}
     permissions:
-      contents: write
+      contents: read
       packages: read
     # Exposed to the extension, open-pr, and rollback jobs. The PR body (changelog)
     # and the rollback anchors (pre-freeze/post-freeze SHAs) were step outputs when
@@ -438,7 +438,7 @@ jobs:
         )
       }}
     permissions:
-      contents: write
+      contents: read
       packages: read
 
     steps:

--- a/assets/workspace/.github/workflows/promote-release.yml
+++ b/assets/workspace/.github/workflows/promote-release.yml
@@ -68,7 +68,7 @@ jobs:
     outputs:
       version: ${{ steps.vars.outputs.version }}
     permissions:
-      contents: write
+      contents: read
       pull-requests: read
       packages: read
     defaults:
@@ -112,7 +112,11 @@ jobs:
 
       - name: Verify draft GitHub Release exists
         env:
-          GH_TOKEN: ${{ github.token }}
+          # GitHub only returns draft releases to a token with push (contents:write)
+          # access. The job's GITHUB_TOKEN is read-only (#1136), so use the
+          # RELEASE_APP token this job already mints for its PR-check step; a
+          # read-only github.token would silently hide the draft and fail promote.
+          GH_TOKEN: ${{ steps.release_app_token.outputs.token }}
           VERSION: ${{ steps.vars.outputs.version }}
           TAG_PREFIX: ${{ needs.resolve-toolchain.outputs.tag-prefix }}
         run: |
@@ -294,7 +298,7 @@ jobs:
         password: ${{ secrets.GHCR_PULL_TOKEN || github.token }}
     timeout-minutes: 10
     permissions:
-      contents: write
+      contents: read
       packages: read
     defaults:
       run:
@@ -349,7 +353,7 @@ jobs:
         password: ${{ secrets.GHCR_PULL_TOKEN || github.token }}
     timeout-minutes: 10
     permissions:
-      contents: write
+      contents: read
       pull-requests: write
       packages: read
     defaults:
@@ -481,7 +485,7 @@ jobs:
     if: ${{ needs.merge.result == 'success' }}
     continue-on-error: true
     permissions:
-      contents: write
+      contents: read
       packages: read
     defaults:
       run:
@@ -601,7 +605,7 @@ jobs:
     timeout-minutes: 10
     if: ${{ needs.merge.result == 'success' && needs.resolve-toolchain.outputs.floating-tags != '' }}
     permissions:
-      contents: write
+      contents: read
       packages: read
     defaults:
       run:

--- a/assets/workspace/.github/workflows/release-core.yml
+++ b/assets/workspace/.github/workflows/release-core.yml
@@ -375,8 +375,8 @@ jobs:
     needs: validate
     runs-on: ubuntu-24.04
     permissions:
-      actions: write
-      contents: write
+      actions: read
+      contents: read
       packages: read
     container:
       image: ${{ inputs.toolchain_image }}

--- a/assets/workspace/.github/workflows/release-publish.yml
+++ b/assets/workspace/.github/workflows/release-publish.yml
@@ -109,7 +109,7 @@ jobs:
       run:
         shell: bash
     permissions:
-      contents: write
+      contents: read
       packages: read
     outputs:
       tag: ${{ steps.out.outputs.tag }}

--- a/assets/workspace/.github/workflows/release.yml
+++ b/assets/workspace/.github/workflows/release.yml
@@ -83,8 +83,8 @@ jobs:
     needs: [resolve-toolchain]
     uses: ./.github/workflows/release-core.yml
     permissions:
-      actions: write
-      contents: write
+      actions: read
+      contents: read
       pull-requests: read
       packages: read
     with:
@@ -119,7 +119,7 @@ jobs:
     if: ${{ inputs.dry-run != true }}
     uses: ./.github/workflows/release-publish.yml
     permissions:
-      contents: write
+      contents: read
       packages: read
     with:
       version: ${{ needs.core.outputs.version }}
@@ -162,7 +162,7 @@ jobs:
         )
       }}
     permissions:
-      contents: write
+      contents: read
       issues: write
       packages: read
     steps:

--- a/assets/workspace/.github/workflows/sync-issues.yml
+++ b/assets/workspace/.github/workflows/sync-issues.yml
@@ -82,10 +82,10 @@ jobs:
       group: sync-issues-${{ github.repository }}
       cancel-in-progress: true
     permissions:
-      contents: write
+      contents: read
       issues: read
       pull-requests: read
-      actions: write  # Required for cache deletion
+      actions: write  # Required for cache deletion (gh api DELETE on github.token)
       packages: read
 
     steps:

--- a/assets/workspace/.github/workflows/sync-main-to-dev.yml
+++ b/assets/workspace/.github/workflows/sync-main-to-dev.yml
@@ -137,7 +137,7 @@ jobs:
     env:
       SYNC_BRANCH: chore/sync-main-to-dev-${{ github.run_number }}-${{ github.run_attempt }}
     permissions:
-      contents: write
+      contents: read
       pull-requests: write
       issues: write
       packages: read

--- a/tests/bats/just.bats
+++ b/tests/bats/just.bats
@@ -267,8 +267,8 @@ EOF
     assert_success
 }
 
-@test "release caller and reusable workflows define explicit minimal permissions for gh operations" {
-    run bash -lc "awk '/^  core:/{flag=1} /^  extension:/{flag=0} flag {print}' assets/workspace/.github/workflows/release.yml | grep -Fq -- 'actions: write' && awk '/^  core:/{flag=1} /^  extension:/{flag=0} flag {print}' assets/workspace/.github/workflows/release.yml | grep -Fq -- 'pull-requests: read' && awk '/^  publish:/{flag=1} /^  rollback:/{flag=0} flag {print}' assets/workspace/.github/workflows/release.yml | grep -Fq -- 'contents: write' && awk '/^  validate:/{flag=1} /^  finalize:/{flag=0} flag {print}' assets/workspace/.github/workflows/release-core.yml | grep -Fq -- 'pull-requests: read' && awk '/^  finalize:/{flag=1} /^  test:/{flag=0} flag {print}' assets/workspace/.github/workflows/release-core.yml | grep -Fq -- 'actions: write'"
+@test "release caller and reusable workflows keep GITHUB_TOKEN read-only (writes ride App tokens) (#1136)" {
+    run bash -lc "awk '/^  core:/{flag=1} /^  extension:/{flag=0} flag {print}' assets/workspace/.github/workflows/release.yml | grep -Fq -- 'actions: read' && awk '/^  core:/{flag=1} /^  extension:/{flag=0} flag {print}' assets/workspace/.github/workflows/release.yml | grep -Fq -- 'contents: read' && awk '/^  core:/{flag=1} /^  extension:/{flag=0} flag {print}' assets/workspace/.github/workflows/release.yml | grep -Fq -- 'pull-requests: read' && awk '/^  publish:/{flag=1} /^  rollback:/{flag=0} flag {print}' assets/workspace/.github/workflows/release.yml | grep -Fq -- 'contents: read' && awk '/^  validate:/{flag=1} /^  finalize:/{flag=0} flag {print}' assets/workspace/.github/workflows/release-core.yml | grep -Fq -- 'pull-requests: read' && awk '/^  finalize:/{flag=1} /^  test:/{flag=0} flag {print}' assets/workspace/.github/workflows/release-core.yml | grep -Fq -- 'actions: read' && awk '/^  finalize:/{flag=1} /^  test:/{flag=0} flag {print}' assets/workspace/.github/workflows/release-core.yml | grep -Fq -- 'contents: read'"
     assert_success
 }
 


### PR DESCRIPTION
Closes #1136

## What

An OpenSSF Scorecard TokenPermissions audit (on `vig-os/commit-action`) traced every job-level `contents: write` / `actions: write` grant in the rendered release/sync workflow templates to the token that actually performs the write. Every git push, tag push, `gh release`, `gh pr`, `gh api` mutation and `gh workflow run` rides a **COMMIT_APP / RELEASE_APP installation token**, not the job's `GITHUB_TOKEN` — so those grants are vestigial. This reduces them to `read` at the source (`assets/workspace/.github/workflows/`), propagating to all consumers on upgrade.

## Reductions (write → read on `GITHUB_TOKEN`)

| Template | Job | Grant |
|---|---|---|
| prepare-release.yml | prepare, rollback | contents |
| promote-release.yml | validate, promote, merge, cleanup, floating-tags | contents |
| release.yml | core caller | actions + contents |
| release.yml | publish caller, rollback | contents |
| release-core.yml | finalize | actions + contents |
| release-publish.yml | publish | contents |
| sync-issues.yml | sync | contents |
| sync-main-to-dev.yml | sync | contents |

Caller/callee pairs (`release.yml` `core`/`publish` ↔ `release-core.yml`/`release-publish.yml`) are lowered on both sides in the same change.

## Two grants handled with care

1. **`promote-release.yml` `validate`** — its *Verify draft GitHub Release exists* step listed releases with `GH_TOKEN: github.token` and matched a **draft**; GitHub only returns drafts to a push-capable token, so a bare read-only token would hide the draft and fail every promotion. The step now uses the RELEASE_APP token the job already mints, so the job can safely drop to `contents: read`.
2. **`sync-issues.yml` `sync` `actions: write`** — **kept**. Its *Delete old cache* step calls `gh api .../actions/caches/{id} -X DELETE` on `github.token`.

Optional same-justification extras (`pull-requests`/`issues` write on App-token-driven jobs, not Scorecard-flagged) are deliberately left in place — out of scope here.

## Verification

- TDD: flipped `tests/bats/just.bats` to pin the release caller/callee `GITHUB_TOKEN` blocks read-only (RED → GREEN).
- `bats tests/bats/just.bats` — 46/46 pass.
- `pytest` on `test_promote_mergeability`, `test_floating_tags`, `test_release_tag_prefix`, `test_workflow_prepare_extension` — 30/30 pass.
- Full `just precommit` (incl. actionlint, yamllint, sync-manifest) green.
- Downstream precedent: `vig-os/commit-action#94`/`#95` moved the repo-local smoke workflows to `permissions: {}` + job-level write with E2E and published-tag smokes passing.

## Pre-merge validation

The `devcontainer-smoke-test` `repository_dispatch` flow already renders these templates into a real target and drives the full pipeline against them with real `RELEASE_APP`/`COMMIT_APP` tokens, so the App-token writes are genuinely exercised (a broken reduction fails the write and errors the wait step):

- **prepare-release** → **release** → `release-core` `finalize` → **sync-issues** (finalize triggers it *and waits*, so a broken `sync-issues` permission fails the release the dispatch is waiting on)
- **promote-release** → `merge` → push to `main` → **sync-main-to-dev**

**Caveat:** promote-release is gated `if release_kind == 'final'`. An RC-only dispatch covers prepare + release + release-core + release-publish + sync-issues, but **not** promote-release or (transitively) sync-main-to-dev. To give the promote-release changes — including the load-bearing `validate` *Verify draft GitHub Release exists* `GH_TOKEN` fix — live coverage, validate with a **final** dispatch, not just a candidate.

Refs: #1136
