### PR TITLE
feat(workflows): add dependency-review job to scaffold ci.yml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.3.0] - TBD
 
+### Added
+
+- **Scaffold CI dependency-review gate** ([#1140](https://github.com/vig-os/devkit/issues/1140))
+  - Consumer `ci.yml` now runs a standalone `dependency-review` job
+    (`actions/dependency-review-action` v5, `fail-on-severity: high`) that
+    blocks PRs introducing known-vulnerable dependencies off GitHub's
+    dependency graph — no toolchain or container required.
+  - Guarded to public-repo pull requests (the action only diffs base/head on
+    PRs, and the dependency-graph API is unavailable on Free-plan private
+    repos), so private repos get a skipped-neutral run and auto-activate when
+    flipped public (#1039 pattern); `CI Summary` requires it without going red
+    on push/dispatch/private-repo skips.
+
 ### Changed
 
 - **Renovate dependency update** ([#1134](https://github.com/vig-os/devkit/pull/1134))

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -21,6 +21,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.3.0] - TBD
 
+### Added
+
+- **Scaffold CI dependency-review gate** ([#1140](https://github.com/vig-os/devkit/issues/1140))
+  - Consumer `ci.yml` now runs a standalone `dependency-review` job
+    (`actions/dependency-review-action` v5, `fail-on-severity: high`) that
+    blocks PRs introducing known-vulnerable dependencies off GitHub's
+    dependency graph — no toolchain or container required.
+  - Guarded to public-repo pull requests (the action only diffs base/head on
+    PRs, and the dependency-graph API is unavailable on Free-plan private
+    repos), so private repos get a skipped-neutral run and auto-activate when
+    flipped public (#1039 pattern); `CI Summary` requires it without going red
+    on push/dispatch/private-repo skips.
+
 ### Changed
 
 - **Renovate dependency update** ([#1134](https://github.com/vig-os/devkit/pull/1134))

--- a/assets/workspace/.github/workflows/ci.yml
+++ b/assets/workspace/.github/workflows/ci.yml
@@ -24,7 +24,8 @@
 #   2. lint              — Pre-commit hooks
 #   3. test              — Run tests
 #   4. commit-checks     — Commit message + PR title validation (PRs only)
-#   5. summary           — Aggregate results for branch protection
+#   5. dependency-review — Vulnerable-dependency gate (public-repo PRs only)
+#   6. summary           — Aggregate results for branch protection
 #
 # Triggers:
 #   - Pull requests to dev, release/**, and main
@@ -223,11 +224,37 @@ jobs:
           PR_BODY: ${{ github.event.pull_request.body }}
         run: uv run check-pr-agent-fingerprints
 
+  # Blocks PRs that introduce known-vulnerable dependencies, off GitHub's
+  # dependency graph (lockfiles + action pins alike) — no toolchain, no
+  # container, no resolve-toolchain. Doubly guarded, mirroring the codeql.yml
+  # private-repo note: (1) dependency-review-action only works on pull_request,
+  # where it diffs the base and head dependency sets; (2) the dependency-graph
+  # API is unavailable on Free-plan private repos, so private repos get a
+  # skipped (neutral) run instead of a permanently red one, and a repo later
+  # flipped public starts gating automatically with no re-scaffold (#1039).
+  dependency-review:
+    name: Dependency Review
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    if: ${{ github.event_name == 'pull_request' && !github.event.repository.private }}
+    permissions:
+      contents: read
+      pull-requests: write   # post the dependency-review summary comment
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+
+      - name: Review dependencies for vulnerabilities
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294  # v5.0.0
+        with:
+          fail-on-severity: high
+
   summary:
     name: CI Summary
     runs-on: ubuntu-24.04
     timeout-minutes: 5
-    needs: [resolve-toolchain, lint, test, commit-checks]
+    needs: [resolve-toolchain, lint, test, commit-checks, dependency-review]
     if: always()
 
     steps:
@@ -240,6 +267,7 @@ jobs:
           echo "Lint: ${{ needs.lint.result }}"
           echo "Test: ${{ needs.test.result }}"
           echo "Commit messages: ${{ needs.commit-checks.result }}"
+          echo "Dependency review: ${{ needs.dependency-review.result }}"
           echo ""
 
           FAILED=false
@@ -261,6 +289,13 @@ jobs:
 
           if [ "${{ needs.commit-checks.result }}" = "failure" ]; then
             echo "ERROR: Commit message checks failed"
+            FAILED=true
+          fi
+
+          # Skipped on push/dispatch and on private repos (same skip-is-OK
+          # treatment as commit-checks); only a genuine failure trips the gate.
+          if [ "${{ needs.dependency-review.result }}" = "failure" ]; then
+            echo "ERROR: Dependency review failed"
             FAILED=true
           fi
 

--- a/tests/test_workflow_private_repo_guard.py
+++ b/tests/test_workflow_private_repo_guard.py
@@ -67,3 +67,92 @@ def test_scan_job_skips_on_private_repo(path: Path, job: str) -> None:
         f"is skipped on private repos (CodeQL/Scorecard cannot succeed there); "
         f"found {guard!r}"
     )
+
+
+# --- Scaffold ci.yml dependency-review job (#1140) ---------------------------
+#
+# The scaffold CI must gate PRs that introduce known-vulnerable dependencies,
+# mirroring the devkit's own `dependency-review` job (minus its exceptions
+# allow-list seam, which needs the dev-shell). The job is doubly guarded: the
+# action only works on pull_request (base/head diff), and the dependency-graph
+# API is unavailable on Free-plan private repos, so private repos get a
+# skipped-neutral run and a repo flipped public activates automatically
+# (#1039 pattern).
+
+SCAFFOLD_CI = REPO_ROOT / "assets/workspace/.github/workflows/ci.yml"
+
+# SHA pin for actions/dependency-review-action v5.0.0 (same pin as devkit-own).
+DEP_REVIEW_ACTION = (
+    "actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294"
+)
+
+
+def _dep_review_job() -> dict:
+    workflow = _load(SCAFFOLD_CI)
+    assert "dependency-review" in workflow["jobs"], (
+        f"{SCAFFOLD_CI} has no `dependency-review` job"
+    )
+    return workflow["jobs"]["dependency-review"]
+
+
+def test_scaffold_ci_has_dependency_review_job() -> None:
+    """The scaffold ci.yml ships a standalone `dependency-review` job."""
+    job = _dep_review_job()
+    assert "needs" not in job, "dependency-review must be standalone (no needs)"
+    assert "container" not in job, "dependency-review must not run in a container"
+
+
+def test_dependency_review_guarded_on_pr_and_public() -> None:
+    """The guard skips on non-PR triggers and on private repos (#1039 pattern)."""
+    guard = _dep_review_job().get("if", "")
+    assert "github.event_name == 'pull_request'" in guard, (
+        f"dependency-review `if` must gate on pull_request; found {guard!r}"
+    )
+    assert "!github.event.repository.private" in guard, (
+        f"dependency-review `if` must skip private repos; found {guard!r}"
+    )
+
+
+def test_dependency_review_action_pinned_v5_fail_on_high() -> None:
+    """The action is SHA-pinned to v5.0.0 and fails on high-severity findings."""
+    steps = _dep_review_job()["steps"]
+    review = [
+        s
+        for s in steps
+        if str(s.get("uses", "")).startswith("actions/dependency-review-action@")
+    ]
+    assert review, "dependency-review job must run dependency-review-action"
+    step = review[0]
+    assert step["uses"] == DEP_REVIEW_ACTION, (
+        f"dependency-review-action must be SHA-pinned to v5.0.0; found {step['uses']!r}"
+    )
+    assert step.get("with", {}).get("fail-on-severity") == "high", (
+        "dependency-review-action must set fail-on-severity: high"
+    )
+    # No exceptions/allow-list seam in the scaffold (unlike devkit-own).
+    assert "allow-ghsas" not in step.get("with", {}), (
+        "scaffold dependency-review must not carry an allow-ghsas seam"
+    )
+    # v5.0.0 version comment pins the human-readable ref next to the SHA.
+    assert "# v5.0.0" in SCAFFOLD_CI.read_text(encoding="utf-8"), (
+        "dependency-review-action pin must carry its `# v5.0.0` version comment"
+    )
+
+
+def test_summary_needs_dependency_review_with_skip_tolerance() -> None:
+    """CI Summary requires dependency-review but tolerates a skipped run."""
+    workflow = _load(SCAFFOLD_CI)
+    summary = workflow["jobs"]["summary"]
+    assert "dependency-review" in summary["needs"], (
+        "summary `needs` must include dependency-review"
+    )
+    run = summary["steps"][0]["run"]
+    # Skip-tolerant, exactly like the PR-only commit-checks job: FAILED is set
+    # only on a `failure` result, never on `skipped`/`cancelled`.
+    assert 'needs.dependency-review.result }}" = "failure"' in run, (
+        "summary must fail only when dependency-review result is failure"
+    )
+    for tolerated in ('"skipped"', '"cancelled"'):
+        assert f"needs.dependency-review.result }}}} = {tolerated}" not in run, (
+            f"dependency-review {tolerated} must not trip the summary"
+        )


### PR DESCRIPTION
## Summary

Adds the missing vulnerable-dependency gate to the scaffolded consumer CI
(`assets/workspace/.github/workflows/ci.yml`), targeting the in-flight 1.3.0
release so the next consumer deployments (commit-action redeploy,
sync-issues-action onboarding) ship with it.

- Standalone `dependency-review` job — no toolchain, no container, no
  `resolve-toolchain` dependency; SHA-pinned `actions/dependency-review-action`
  v5.0.0 with `fail-on-severity: high`.
- Doubly guarded (`pull_request` + `!github.event.repository.private`),
  mirroring the codeql.yml/scorecard.yml #1039 pattern: skipped-neutral on
  Free-plan private repos, auto-activates when a repo flips public.
- `CI Summary` requires it with the same skip-is-OK treatment as the PR-only
  `commit-checks` job — only a genuine failure trips the gate.
- Devkit's own `ci.yml` is untouched (it already runs Dependency Review with
  the allow-list mechanism); the scaffold version deliberately omits the
  exceptions seam.

TDD: shape tests in `tests/test_workflow_private_repo_guard.py` committed RED
first (`280712a2`), implementation GREEN (`76793824`); rendered-scaffold
actionlint bats 5/5, full `prek` suite green.

Changelog entry added under `## [1.3.0] - TBD` (### Added) + hook-synced
mirror.

Note for the release driver: rc1 predates this change — an rc2 cut is needed
before finalizing 1.3.0.

Closes #1140