### PR TITLE
fix(workspace): never migrate scaffold-committed or template gitignore lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Never migrate scaffold-committed or template gitignore lines** ([#1145](https://github.com/vig-os/devkit/issues/1145))
+  - The [#1111](https://github.com/vig-os/devkit/issues/1111) gitignore
+    migration copied entries that shadow scaffold-COMMITTED files: the old
+    Python-template `.gitignore` shipped `.envrc`, and migrating that entry
+    into `.gitignore.project` silently kept the scaffolded `.envrc`
+    ([#640](https://github.com/vig-os/devkit/issues/640)) untracked, breaking
+    direnv onboarding on every clone (observed live on the sync-issues-action
+    1.3.0 deploy, vig-os/sync-issues-action#106). Scaffold-committed file
+    names (`.envrc`, `.gitignore.project`, `flake.nix`, `flake.lock`,
+    `justfile`, `justfile.project`, `.vig-os`) now never migrate.
+  - It also treated stale devkit language-template lines as consumer-authored:
+    the managed set was built from the DETECTED languages' fragments only, so
+    a repo that switched language templates (e.g. old Python-flavored managed
+    `.gitignore`, now a Node repo) got ~90 lines of `__pycache__/`-style junk
+    dumped into its consumer-owned file. The managed set is now built from ALL
+    `gitignore.d/` fragments — any line found in any devkit fragment is
+    template material, never migrated.
+
 ### Security
 
 ## [1.3.0](https://github.com/vig-os/devkit/releases/tag/1.3.0) - 2026-07-15

--- a/assets/init-workspace.sh
+++ b/assets/init-workspace.sh
@@ -702,8 +702,9 @@ render_gitignore() {
 # cruft, project paths) are silently dropped when render_gitignore regenerates
 # root .gitignore from the template. Recover them: any non-blank, non-comment
 # line in the pre-overwrite root .gitignore (OLD_GITIGNORE_SNAPSHOT) that is NOT
-# a managed entry (template base + active language fragments + the #1092 seed)
-# and NOT already in .gitignore.project is appended to .gitignore.project, whence
+# a managed entry (template base + ALL language fragments + the #1092 seed), NOT
+# a scaffold-committed file, and NOT already in .gitignore.project is appended
+# to .gitignore.project, whence
 # render_gitignore (called AFTER this) folds it back into the regenerated root
 # .gitignore — no separate write to the root file. Append-only and deduplicated
 # against the existing .gitignore.project, so a second upgrade re-adds nothing
@@ -711,12 +712,26 @@ render_gitignore() {
 # consumer's existing entries are never reordered or rewritten. Only entries
 # (non-blank, non-comment lines) migrate; a consumer's free-text comments are not
 # semantically ignorable, so they are left behind with the old managed file.
+#
+# Two never-migrate rules (#1145, field report vig-os/sync-issues-action#106):
+#  1. Scaffold-COMMITTED files (.envrc & co.) never migrate: an old template's
+#     ignore entry for one (the pre-#640 Python template shipped `.envrc`)
+#     would shadow the file the scaffold itself commits — e.g. keep the
+#     committed .envrc untracked and silently break direnv onboarding on every
+#     clone. These are literal file names, not glob patterns, so a plain
+#     literal match on the line is enough — no variant handling.
+#  2. The managed set is built from ALL gitignore.d fragments, not just the
+#     detected languages': the OLD root .gitignore was a devkit-managed
+#     template for whatever language set applied back then, so any line found
+#     in ANY devkit fragment is template material, not consumer-authored — a
+#     repo that switched language templates must not inherit the stale
+#     fragment's lines as "consumer" entries.
 migrate_root_gitignore() {
     local proj="$WORKSPACE_DIR/.gitignore.project"
     [[ -f "$proj" ]] || return 0
     [[ -n "$OLD_GITIGNORE_SNAPSHOT" ]] || return 0
 
-    local line lang frag
+    local line frag
     # Managed entries the regenerated root .gitignore already provides — never
     # migrate one of these (idempotent even for a line the template later drops).
     local -A managed=()
@@ -724,8 +739,10 @@ migrate_root_gitignore() {
         [[ "$line" =~ ^[[:space:]]*$ || "$line" =~ ^[[:space:]]*# ]] && continue
         managed["$line"]=1
     done < "$TEMPLATE_DIR/.gitignore"
-    for lang in ${DETECTED_LANGUAGES[@]+"${DETECTED_LANGUAGES[@]}"}; do
-        frag="$SCRIPT_DIR/gitignore.d/$lang.gitignore"
+    # ALL fragments, not just the detected languages' (#1145 rule 2): the old
+    # root .gitignore may be a stale template of a language this repo no longer
+    # markers for — its fragment lines are template material, never consumer's.
+    for frag in "$SCRIPT_DIR"/gitignore.d/*.gitignore; do
         [[ -f "$frag" ]] || continue
         while IFS= read -r line; do
             [[ "$line" =~ ^[[:space:]]*$ || "$line" =~ ^[[:space:]]*# ]] && continue
@@ -734,6 +751,16 @@ migrate_root_gitignore() {
     done
     # The #1092 flake-hooks seed is a managed entry too.
     managed[".pre-commit-config.yaml"]=1
+    # Never-migrate denylist (#1145 rule 1): files the scaffold itself COMMITS.
+    # Migrating an old template's ignore entry for one of these would shadow the
+    # committed file (e.g. `.envrc` from the pre-#640 Python template keeps the
+    # scaffolded .envrc untracked and breaks direnv onboarding). Literal file
+    # names, so a plain literal line match suffices.
+    local entry
+    for entry in .envrc .gitignore.project flake.nix flake.lock \
+        justfile justfile.project .vig-os; do
+        managed["$entry"]=1
+    done
 
     # Entries already committed in .gitignore.project must not be re-added — this
     # is what makes a second upgrade a no-op.

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -17,6 +17,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Never migrate scaffold-committed or template gitignore lines** ([#1145](https://github.com/vig-os/devkit/issues/1145))
+  - The [#1111](https://github.com/vig-os/devkit/issues/1111) gitignore
+    migration copied entries that shadow scaffold-COMMITTED files: the old
+    Python-template `.gitignore` shipped `.envrc`, and migrating that entry
+    into `.gitignore.project` silently kept the scaffolded `.envrc`
+    ([#640](https://github.com/vig-os/devkit/issues/640)) untracked, breaking
+    direnv onboarding on every clone (observed live on the sync-issues-action
+    1.3.0 deploy, vig-os/sync-issues-action#106). Scaffold-committed file
+    names (`.envrc`, `.gitignore.project`, `flake.nix`, `flake.lock`,
+    `justfile`, `justfile.project`, `.vig-os`) now never migrate.
+  - It also treated stale devkit language-template lines as consumer-authored:
+    the managed set was built from the DETECTED languages' fragments only, so
+    a repo that switched language templates (e.g. old Python-flavored managed
+    `.gitignore`, now a Node repo) got ~90 lines of `__pycache__/`-style junk
+    dumped into its consumer-owned file. The managed set is now built from ALL
+    `gitignore.d/` fragments — any line found in any devkit fragment is
+    template material, never migrated.
+
 ### Security
 
 ## [1.3.0](https://github.com/vig-os/devkit/releases/tag/1.3.0) - 2026-07-15

--- a/tests/bats/init-workspace.bats
+++ b/tests/bats/init-workspace.bats
@@ -3126,6 +3126,56 @@ _RELEASE_RESOLVERS_991=(
     assert_failure
 }
 
+# ── never migrate scaffold-committed or template gitignore lines (#1145) ──────
+# Field report: the sync-issues-action 1.3.0 deploy (vig-os/sync-issues-action
+# #106 / PR #108) showed migrate_root_gitignore copying (1) `.envrc` — a
+# scaffold-COMMITTED file (#640) — into .gitignore.project, silently keeping the
+# scaffolded .envrc untracked on every clone, and (2) ~90 lines of stale Python
+# template junk into a Node repo's consumer-owned file, because the managed set
+# only included the DETECTED languages' fragments.
+
+@test "scaffold-committed .envrc is never migrated into .gitignore.project (#1145)" {
+    ws="$BATS_TEST_TMPDIR/e2e-1145-envrc"
+    mkdir -p "$ws"
+    run _scaffold both "$ws"
+    assert_success
+    # The old Python-template root .gitignore shipped an `.envrc` entry; in
+    # direnv mode .envrc is a scaffold-committed file, so migrating the entry
+    # would shadow it and break nix-direnv onboarding on every clone.
+    printf '.envrc\nconsumer-only-dir/\n' >>"$ws/.gitignore"
+    run _upgrade both "$ws"
+    assert_success
+    # The scaffold-committed file's entry is NOT migrated ...
+    run grep -qxF '.envrc' "$ws/.gitignore.project"
+    assert_failure
+    # ... while the genuine consumer line IS.
+    run grep -qxF 'consumer-only-dir/' "$ws/.gitignore.project"
+    assert_success
+    # And the scaffolded .envrc is not git-ignored after the upgrade.
+    git init -q "$ws"
+    run git -C "$ws" check-ignore .envrc
+    assert_failure
+}
+
+@test "stale lines from a NON-detected language fragment are never migrated (#1145)" {
+    ws="$BATS_TEST_TMPDIR/e2e-1145-crosslang"
+    mkdir -p "$ws"
+    # Node-only marker: python is NOT among the detected languages.
+    printf '{ "name": "probe" }\n' >"$ws/package.json"
+    run _scaffold both "$ws"
+    assert_success
+    # The repo once used the Python-flavored managed template; its old root
+    # .gitignore still carries Python fragment lines. Those are devkit template
+    # material, not consumer-authored — they must not be migrated.
+    printf '__pycache__/\nconsumer-only-dir/\n' >>"$ws/.gitignore"
+    run _upgrade both "$ws"
+    assert_success
+    run grep -qxF '__pycache__/' "$ws/.gitignore.project"
+    assert_failure
+    run grep -qxF 'consumer-only-dir/' "$ws/.gitignore.project"
+    assert_success
+}
+
 # ── dangling /nix/store symlink is preserved and seeds the ignore (#1117) ──────
 # In direnv mode the flake generates .pre-commit-config.yaml as a symlink into
 # the HOST /nix/store, which is NOT mounted inside the devcontainer image where


### PR DESCRIPTION
## Summary

The #1111 gitignore migration (`migrate_root_gitignore()` in `assets/init-workspace.sh`) copied consumer lines from the old root `.gitignore` into `.gitignore.project` with two defects, both observed live on the sync-issues-action 1.3.0 deploy (field report: vig-os/sync-issues-action#106, PR vig-os/sync-issues-action#108):

1. **It migrated entries that shadow scaffold-COMMITTED files.** The old Python-template `.gitignore` shipped `.envrc`; in direnv mode `.envrc` is scaffold-committed for nix-direnv onboarding (#640). Because `.gitignore.project` is appended to the regenerated root `.gitignore` (#1092), the migrated entry silently kept the scaffolded `.envrc` untracked and broke direnv onboarding on every clone.
2. **It migrated stale devkit language-template junk as if consumer-authored.** The `managed` set was built from the template base plus the DETECTED languages' fragments only, so a repo that switched language templates (old Python-flavored managed `.gitignore`, now a Node repo) got ~90 lines of `__pycache__/`/`.tox/`-style template material dumped into its consumer-owned file.

## Fix (two never-migrate rules)

- **Rule 1 — scaffold-committed denylist:** entries whose pattern equals a file the scaffold itself commits never migrate: `.envrc`, `.gitignore.project`, `flake.nix`, `flake.lock`, `justfile`, `justfile.project`, `.vig-os`. These are literal file names, not glob patterns, so a plain literal line match suffices (commented in the code).
- **Rule 2 — filter against ALL fragments:** the `managed` set now iterates every `gitignore.d/*.gitignore` fragment instead of only the detected languages'. The OLD root `.gitignore` was a devkit-managed template for whatever language set applied back then, so any line found in ANY devkit fragment is template material, never consumer-authored.

Order, dedup, idempotency, and append-only behavior are unchanged; the function's header comment documents both rules.

## Test evidence (strict TDD)

- RED: two new bats tests (`tests/bats/init-workspace.bats`, #1145 section) failed on the pre-fix code exactly at the leak assertions (`.envrc` and `__pycache__/` found in `.gitignore.project`), committed first.
- GREEN: both #1145 tests pass post-fix; `.envrc` also verified untracked via `git check-ignore`.
- No regression: the full `tests/bats/init-workspace.bats` file passes — 208/208 tests, including all #1111 / #1092 / #1117 gitignore tests.
- `prek run --all-files`: all hooks green.

## Notes

Closes #1145

Note: `Closes #N` does not auto-close on dev-targeted merges in this repo (main-only) — close #1145 manually on merge.

Refs: #1145