### PR TITLE
fix(workspace): render codeql push paths per detected language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Render CodeQL push `paths:` filter per detected language** ([#1142](https://github.com/vig-os/devkit/issues/1142))
+  - The scaffolded `codeql.yml` hardcoded the push-to-main trigger's `paths:`
+    filter to `**.py`, so on a Node consumer a push touching only TS/JS never
+    fired the post-merge CodeQL scan (only the unfiltered PR trigger caught it).
+    `init-workspace.sh` now renders the filter from the same language detection
+    as the matrix: python → `**.py`; node → `**.ts`/`**.js`/`**.mjs`/`**.cjs`;
+    rust adds no source globs; the `.github/workflows/**` catch-all is always
+    kept. Because `codeql.yml` is a managed file, consumer hand-fixes are no
+    longer reverted on every devkit upgrade.
 - **Never migrate scaffold-committed or template gitignore lines** ([#1145](https://github.com/vig-os/devkit/issues/1145))
   - The [#1111](https://github.com/vig-os/devkit/issues/1111) gitignore
     migration copied entries that shadow scaffold-COMMITTED files: the old

--- a/assets/init-workspace.sh
+++ b/assets/init-workspace.sh
@@ -798,25 +798,54 @@ migrate_root_gitignore() {
 # ships no first-class Rust analyzer). 'actions' is always analyzed, so the
 # matrix is never empty (a marker-less repo analyzes just actions). No-op when
 # the workflow is absent (e.g. it was never scaffolded or was pruned).
+#
+# The push-to-main trigger's `paths:` filter is rendered from the SAME detection
+# (#1142): a python source push must match '**.py', a node one '**.ts'/'**.js'/
+# '**.mjs'/'**.cjs'; rust has no CodeQL source leg so it adds no source globs.
+# The '.github/workflows/**' catch-all is always kept (the 'actions' leg always
+# runs). Left hardcoded to '**.py', a Node consumer's post-merge scan never fired
+# for TS/JS changes — and being a managed file, hand-fixes were reverted on every
+# upgrade.
 render_codeql_matrix() {
     local cq="$WORKSPACE_DIR/.github/workflows/codeql.yml"
     [[ -f "$cq" ]] || return 0
     local -a langs=()
+    local -a paths=()
     local lang
     for lang in ${DETECTED_LANGUAGES[@]+"${DETECTED_LANGUAGES[@]}"}; do
         case "$lang" in
-            python) langs+=("'python'") ;;
-            node) langs+=("'javascript-typescript'") ;;
+            python)
+                langs+=("'python'")
+                paths+=("'**.py'")
+                ;;
+            node)
+                langs+=("'javascript-typescript'")
+                paths+=("'**.ts'" "'**.js'" "'**.mjs'" "'**.cjs'")
+                ;;
             rust) : ;; # CodeQL rust support caveat (#1025): omit the leg
         esac
     done
     langs+=("'actions'")
+    paths+=("'.github/workflows/**'")
     local joined=""
     for lang in "${langs[@]}"; do
         joined="${joined:+$joined, }$lang"
     done
     sed -i -E "s|^([[:space:]]*language:).*|\1 [${joined}]|" "$cq"
     echo "Rendered CodeQL language matrix: [${joined}]"
+
+    # Replace the list items under the push `paths:` key (4-space `paths:`,
+    # 6-space `- ` items) with the rendered set. awk, not sed: the item count
+    # varies per language, so we rewrite the whole block in one pass.
+    local rendered_paths
+    rendered_paths="$(printf '      - %s\n' "${paths[@]}")"
+    awk -v items="$rendered_paths" '
+        /^    paths:$/ { print; print items; inpaths = 1; next }
+        inpaths && /^      - / { next }
+        inpaths { inpaths = 0 }
+        { print }
+    ' "$cq" >"$cq.tmp" && mv "$cq.tmp" "$cq"
+    echo "Rendered CodeQL push paths filter: [${paths[*]}]"
     # Preflight note (#1025): the advanced CodeQL config the scaffold ships
     # cannot coexist with GitHub's *default* code-scanning setup — its uploads
     # are rejected while default setup is enabled. We never flip that API

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -17,6 +17,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Render CodeQL push `paths:` filter per detected language** ([#1142](https://github.com/vig-os/devkit/issues/1142))
+  - The scaffolded `codeql.yml` hardcoded the push-to-main trigger's `paths:`
+    filter to `**.py`, so on a Node consumer a push touching only TS/JS never
+    fired the post-merge CodeQL scan (only the unfiltered PR trigger caught it).
+    `init-workspace.sh` now renders the filter from the same language detection
+    as the matrix: python → `**.py`; node → `**.ts`/`**.js`/`**.mjs`/`**.cjs`;
+    rust adds no source globs; the `.github/workflows/**` catch-all is always
+    kept. Because `codeql.yml` is a managed file, consumer hand-fixes are no
+    longer reverted on every devkit upgrade.
 - **Never migrate scaffold-committed or template gitignore lines** ([#1145](https://github.com/vig-os/devkit/issues/1145))
   - The [#1111](https://github.com/vig-os/devkit/issues/1111) gitignore
     migration copied entries that shadow scaffold-COMMITTED files: the old

--- a/tests/bats/init-workspace.bats
+++ b/tests/bats/init-workspace.bats
@@ -2856,6 +2856,70 @@ _RELEASE_RESOLVERS_991=(
     assert_output --partial "default code-scanning setup"
 }
 
+# ── language-aware codeql push paths filter (#1142) ───────────────────────────
+# The push-to-main trigger's `paths:` filter was hardcoded to '**.py' alongside
+# the '.github/workflows/**' catch-all, so on a Node consumer a push touching
+# only TS/JS never triggered the post-merge CodeQL scan (only the unfiltered PR
+# trigger caught it). init-workspace.sh now renders the push `paths:` from the
+# SAME language detection as the matrix (#1025): python → '**.py'; node →
+# '**.ts'/'**.js'/'**.mjs'/'**.cjs'; rust omits its source globs; the
+# '.github/workflows/**' catch-all is always kept. Because codeql.yml is a
+# managed file, this stops consumer hand-fixes being reverted on upgrade.
+
+@test "scaffold codeql push paths for a Node consumer are TS/JS globs + workflows (#1142)" {
+    ws="$BATS_TEST_TMPDIR/e2e-1142-node-paths"
+    mkdir -p "$ws"
+    printf '{ "name": "probe" }\n' >"$ws/package.json"
+    run _scaffold both "$ws"
+    assert_success
+    run cat "$ws/.github/workflows/codeql.yml"
+    assert_success
+    assert_output --partial "'**.ts'"
+    assert_output --partial "'**.js'"
+    assert_output --partial "'**.mjs'"
+    assert_output --partial "'**.cjs'"
+    assert_output --partial "'.github/workflows/**'"
+    refute_output --partial "'**.py'"
+}
+
+@test "scaffold codeql push paths for a Python consumer are '**.py' + workflows (#1142)" {
+    ws="$BATS_TEST_TMPDIR/e2e-1142-py-paths"
+    mkdir -p "$ws"
+    printf '[project]\nname = "probe"\n' >"$ws/pyproject.toml"
+    run _scaffold both "$ws"
+    assert_success
+    run cat "$ws/.github/workflows/codeql.yml"
+    assert_success
+    assert_output --partial "'**.py'"
+    assert_output --partial "'.github/workflows/**'"
+    refute_output --partial "'**.ts'"
+}
+
+@test "scaffold codeql push paths for a Rust consumer are workflows-only (#1142)" {
+    ws="$BATS_TEST_TMPDIR/e2e-1142-rust-paths"
+    mkdir -p "$ws"
+    printf '[package]\nname = "probe"\n' >"$ws/Cargo.toml"
+    run _scaffold both "$ws"
+    assert_success
+    run cat "$ws/.github/workflows/codeql.yml"
+    assert_success
+    assert_output --partial "'.github/workflows/**'"
+    refute_output --partial "'**.py'"
+    refute_output --partial "'**.ts'"
+}
+
+@test "scaffold codeql push paths for a marker-less consumer are workflows-only (#1142)" {
+    ws="$BATS_TEST_TMPDIR/e2e-1142-bare-paths"
+    mkdir -p "$ws"
+    run _scaffold both "$ws"
+    assert_success
+    run cat "$ws/.github/workflows/codeql.yml"
+    assert_success
+    assert_output --partial "'.github/workflows/**'"
+    refute_output --partial "'**.py'"
+    refute_output --partial "'**.ts'"
+}
+
 # ── first-scaffold npm justfile.project recipes for Node consumers (#1027) ─────
 # justfile.project is a PRESERVE_FILE: the stock template ships uv/pyproject
 # recipes, which no-op for a Node repo whose CI still calls `just sync|test`.


### PR DESCRIPTION
## Description

`render_codeql_matrix()` (`assets/init-workspace.sh`) rewrites the CodeQL
`language:` matrix per detected language (#1025) but left the push-to-main
trigger's `paths:` filter hardcoded to `**.py`. On a Node consumer, a push
touching only TS/JS therefore never fired the post-merge CodeQL scan — only the
unfiltered PR trigger caught it. And because `codeql.yml` is a managed file,
consumer hand-fixes (e.g. commit-action's `**.ts` patch, vig-os/commit-action#67)
were silently reverted on every devkit upgrade.

## Type of Change

- [x] `fix` -- Bug fix

## Changes Made

- Extend `render_codeql_matrix()` to build the push `paths:` list from the same
  language detection it already uses for the matrix:
  - python → `'**.py'`
  - node → `'**.ts'`, `'**.js'`, `'**.mjs'`, `'**.cjs'`
  - rust → no source globs (CodeQL ships no Rust analyzer)
  - the `'.github/workflows/**'` catch-all is always kept
  - marker-less repos get a workflows-only filter
- Rewrite the `paths:` block with `awk` (the item count varies per language, so
  a single `sed` line-replace can't do it); the language matrix render is
  unchanged.
- Regression bats tests for node / python / rust / marker-less consumers.

## Changelog Entry

### Fixed
- **Render CodeQL push `paths:` filter per detected language** ([#1142](https://github.com/vig-os/devkit/issues/1142))
  - full entry in `CHANGELOG.md` under `## Unreleased`.

## Testing

- [x] Tests pass locally (`just test`)
- [x] Manual testing performed (describe below)

### Manual Testing Details

- `bats tests/bats/init-workspace.bats` → 212/212 pass (4 new #1142 tests + the
  existing #1025 matrix tests).
- Scaffolded a throwaway Node consumer and confirmed the rendered `on.push.paths`
  block lists `**.ts`/`**.js`/`**.mjs`/`**.cjs` + `.github/workflows/**` with
  clean YAML indentation.
- `shellcheck -x assets/init-workspace.sh` clean; full `prek run --all-files` green.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

Found during the sync-issues-action deploy recon — affects every JS-action
consumer (commit-action today, sync-issues-action next). With this merged,
deploys no longer need to re-patch `codeql.yml` by hand after each scaffold sync.

Closes #1142

Refs: #1142
