### PR TITLE
feat(workflow): raise release-extension seam token ceiling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Release extension seam gains a documented token ceiling** ([#1144](https://github.com/vig-os/devkit/issues/1144))
+  - The `extension` caller job in the scaffolded `release.yml` now grants the
+    `release-extension.yml` seam a ceiling of `contents: read`, `packages: write`,
+    `id-token: write`, `attestations: write`. A called reusable workflow can only
+    *downgrade* the caller's `GITHUB_TOKEN`, never elevate it, so with no caller
+    grant the seam was capped read-only and write-scoped extensions
+    (`actions/attest-build-provenance`, GHCR publish) were silently denied. This
+    is a ceiling, not a grant: the shipped default no-op stays read-only and a
+    consumer opts a job in by declaring the scopes it needs, up to the ceiling.
+    Scopes beyond it (e.g. `contents: write`) still belong in a consumer-owned
+    tag-push workflow. Documented in `docs/DOWNSTREAM_RELEASE.md`.
+
 ### Deprecated
 
 ### Removed

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -11,6 +11,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Release extension seam gains a documented token ceiling** ([#1144](https://github.com/vig-os/devkit/issues/1144))
+  - The `extension` caller job in the scaffolded `release.yml` now grants the
+    `release-extension.yml` seam a ceiling of `contents: read`, `packages: write`,
+    `id-token: write`, `attestations: write`. A called reusable workflow can only
+    *downgrade* the caller's `GITHUB_TOKEN`, never elevate it, so with no caller
+    grant the seam was capped read-only and write-scoped extensions
+    (`actions/attest-build-provenance`, GHCR publish) were silently denied. This
+    is a ceiling, not a grant: the shipped default no-op stays read-only and a
+    consumer opts a job in by declaring the scopes it needs, up to the ceiling.
+    Scopes beyond it (e.g. `contents: write`) still belong in a consumer-owned
+    tag-push workflow. Documented in `docs/DOWNSTREAM_RELEASE.md`.
+
 ### Deprecated
 
 ### Removed

--- a/assets/workspace/.github/workflows/release-extension.yml
+++ b/assets/workspace/.github/workflows/release-extension.yml
@@ -1,6 +1,15 @@
 # Seeded by vigOS devkit — yours to edit; upgrades never overwrite this file.
 # Bugs / missing tools: https://github.com/vig-os/devkit/issues
 
+#
+# Token ceiling (#1144): release.yml's `extension` caller job grants this seam a
+# ceiling of contents:read, packages:write, id-token:write, attestations:write —
+# the maximum a job here can reach (a called workflow can only downgrade the
+# caller's GITHUB_TOKEN, never elevate it). This default no-op stays read-only;
+# to publish/sign/attest, declare the scopes you need on YOUR job (up to that
+# ceiling), e.g. `permissions: { id-token: write, attestations: write }`. See
+# "Extension Hook" in docs/DOWNSTREAM_RELEASE.md.
+
 name: Release Extension
 
 on:  # yamllint disable-line rule:truthy

--- a/assets/workspace/.github/workflows/release.yml
+++ b/assets/workspace/.github/workflows/release.yml
@@ -105,6 +105,19 @@ jobs:
     needs: core
     if: ${{ inputs.dry-run != true }}
     uses: ./.github/workflows/release-extension.yml
+    # Token ceiling for the consumer seam (#1144). A called reusable workflow can
+    # only DOWNGRADE the caller's GITHUB_TOKEN, never elevate it, so this caller
+    # job sets the maximum the seam can reach. It is a ceiling, not a grant: the
+    # project-owned release-extension.yml declares its own (lower) permissions per
+    # job — the shipped default no-op stays read-only. A consumer opts a job in by
+    # raising its permissions up to these scopes: packages (container/package
+    # publishing), id-token (keyless cosign signing + provenance via OIDC),
+    # attestations (build provenance attestations).
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
     with:
       version: ${{ needs.core.outputs.version }}
       finalize_sha: ${{ needs.core.outputs.finalize_sha }}

--- a/assets/workspace/docs/DOWNSTREAM_RELEASE.md
+++ b/assets/workspace/docs/DOWNSTREAM_RELEASE.md
@@ -132,6 +132,21 @@ Extension contract inputs include both `release_kind` and `publish_version`, so 
 
 `release.yml` requires extension success before publish, so extension failures block release publication.
 
+### Permission ceiling
+
+A called reusable workflow can only **downgrade** the caller's `GITHUB_TOKEN` — it can never elevate it (issue [#1144](https://github.com/vig-os/devkit/issues/1144)). So the *maximum* token scope this seam can reach is set by the `extension` caller job in the managed `release.yml`, which grants:
+
+| Scope | Level | For |
+| --- | --- | --- |
+| `contents` | `read` | check out the finalized commit |
+| `packages` | `write` | container / package publishing (e.g. GHCR) |
+| `id-token` | `write` | keyless cosign signing + provenance via OIDC |
+| `attestations` | `write` | build provenance attestations (`actions/attest-build-provenance`) |
+
+This is a **ceiling, not a grant**. The shipped default no-op declares `permissions: contents: read` and stays read-only. To publish, sign, or attest, declare the scopes your step needs **on your own job** (up to the ceiling) — e.g. a job that runs `actions/attest-build-provenance` sets `permissions: { id-token: write, attestations: write }`. Deny-by-default is preserved: no job gets a write token it did not ask for.
+
+If an extension needs a scope **beyond** this ceiling (for example `contents: write` to push to a branch, which the read-only seam intentionally forbids), it belongs in a consumer-owned tag-push or post-release workflow that owns its own token grant — e.g. a workflow on `push: tags: 'v*.*.*'` with its own `permissions:` block — not in this seam.
+
 ## Prepare-Release Extension Hook
 
 Project-specific **release-branch preparation** belongs in `.github/workflows/prepare-release-extension.yml` — the *mutating* counterpart to the read-only `release-extension.yml`. Default template behavior is no-op.

--- a/docs/DOWNSTREAM_RELEASE.md
+++ b/docs/DOWNSTREAM_RELEASE.md
@@ -129,6 +129,21 @@ Extension contract inputs include both `release_kind` and `publish_version`, so 
 
 `release.yml` requires extension success before publish, so extension failures block release publication.
 
+### Permission ceiling
+
+A called reusable workflow can only **downgrade** the caller's `GITHUB_TOKEN` — it can never elevate it (issue [#1144](https://github.com/vig-os/devkit/issues/1144)). So the *maximum* token scope this seam can reach is set by the `extension` caller job in the managed `release.yml`, which grants:
+
+| Scope | Level | For |
+| --- | --- | --- |
+| `contents` | `read` | check out the finalized commit |
+| `packages` | `write` | container / package publishing (e.g. GHCR) |
+| `id-token` | `write` | keyless cosign signing + provenance via OIDC |
+| `attestations` | `write` | build provenance attestations (`actions/attest-build-provenance`) |
+
+This is a **ceiling, not a grant**. The shipped default no-op declares `permissions: contents: read` and stays read-only. To publish, sign, or attest, declare the scopes your step needs **on your own job** (up to the ceiling) — e.g. a job that runs `actions/attest-build-provenance` sets `permissions: { id-token: write, attestations: write }`. Deny-by-default is preserved: no job gets a write token it did not ask for.
+
+If an extension needs a scope **beyond** this ceiling (for example `contents: write` to push to a branch, which the read-only seam intentionally forbids), it belongs in a consumer-owned tag-push or post-release workflow that owns its own token grant — e.g. a workflow on `push: tags: 'v*.*.*'` with its own `permissions:` block — not in this seam.
+
 ## Prepare-Release Extension Hook
 
 Project-specific **release-branch preparation** belongs in `.github/workflows/prepare-release-extension.yml` — the *mutating* counterpart to the read-only `release-extension.yml`. Default template behavior is no-op.

--- a/tests/test_workflow_release_extension.py
+++ b/tests/test_workflow_release_extension.py
@@ -1,0 +1,99 @@
+"""Workflow-shape tests: the release extension seam's GITHUB_TOKEN ceiling.
+
+Issue #1144: ``release.yml`` calls the ``release-extension.yml`` consumer seam,
+but the ``extension`` caller job declared no ``permissions:`` block, so the
+called reusable workflow ran under the caller's workflow-level default
+(``contents: read, packages: read``). GitHub never lets a called reusable
+workflow *elevate* the caller's ``GITHUB_TOKEN`` — the callee's own
+``permissions:`` can only downgrade. So any write-scoped extension step was
+silently denied: ``actions/attest-build-provenance`` (needs ``id-token: write`` +
+``attestations: write``) and even the GHCR-publish example the docs already ship
+(needs ``packages: write``).
+
+Fix (option A): the managed ``extension`` job in ``release.yml`` grants a
+documented broader *ceiling* — ``contents: read``, ``packages: write``,
+``id-token: write``, ``attestations: write``. This is the maximum the seam can
+reach, not a default grant: the consumer-owned ``release-extension.yml`` still
+declares its own (lower) permissions per job, so the shipped default no-op stays
+read-only (deny-by-default preserved). A consumer opts a job in by raising its
+permissions up to this ceiling.
+
+Refs: #1144
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+# Repository root (tests/ -> repo root) and the consumer scaffold tree.
+REPO_ROOT = Path(__file__).resolve().parent.parent
+WORKSPACE = REPO_ROOT / "assets" / "workspace"
+
+SCAFFOLD_RELEASE = WORKSPACE / ".github" / "workflows" / "release.yml"
+SCAFFOLD_EXTENSION = WORKSPACE / ".github" / "workflows" / "release-extension.yml"
+
+# The seam's documented permission ceiling (issue #1144). Every scope the
+# documented extension tasks need — container/package publishing, keyless
+# signing, build provenance attestation — plus read to check out the commit.
+CEILING = {
+    "contents": "read",
+    "packages": "write",
+    "id-token": "write",
+    "attestations": "write",
+}
+
+
+def _load(path: Path) -> dict:
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def _jobs(doc: dict) -> dict:
+    return doc.get("jobs") or {}
+
+
+def _extension_job(doc: dict) -> tuple[str, dict] | tuple[None, None]:
+    """The (name, job) that calls the release-extension reusable workflow."""
+    for name, job in _jobs(doc).items():
+        if isinstance(job, dict) and str(job.get("uses", "")).endswith(
+            "release-extension.yml"
+        ):
+            return name, job
+    return None, None
+
+
+def test_scaffold_ships_release_extension() -> None:
+    """The scaffold ships the read-only extension seam."""
+    assert SCAFFOLD_EXTENSION.is_file(), (
+        "assets/workspace/.github/workflows/release-extension.yml must exist"
+    )
+
+
+def test_release_extension_caller_grants_documented_ceiling() -> None:
+    """The ``extension`` caller job raises the seam's token ceiling (#1144)."""
+    name, job = _extension_job(_load(SCAFFOLD_RELEASE))
+    assert name is not None, "release.yml must call release-extension.yml as a job"
+    perms = job.get("permissions")
+    assert isinstance(perms, dict), (
+        "the extension caller job must declare a permissions block so the seam "
+        "can reach write scopes (a called workflow cannot elevate the caller)"
+    )
+    for scope, level in CEILING.items():
+        assert perms.get(scope) == level, (
+            f"extension job ceiling must grant {scope}: {level} (got "
+            f"{perms.get(scope)!r})"
+        )
+
+
+def test_release_extension_default_stays_readonly() -> None:
+    """The shipped default no-op keeps deny-by-default (ceiling ≠ grant)."""
+    doc = _load(SCAFFOLD_EXTENSION)
+    perms = doc.get("permissions") or {}
+    assert perms.get("contents") == "read", (
+        "the default no-op extension must stay read-only at the workflow level"
+    )
+    assert "packages" not in perms and "attestations" not in perms, (
+        "the default no-op must not request write scopes — a consumer opts in "
+        "per job up to the release.yml ceiling"
+    )


### PR DESCRIPTION
## Description

The scaffolded `release.yml` calls the consumer-owned `release-extension.yml`
seam, but its `extension` caller job declared **no** `permissions:` block, so
the called reusable workflow ran under the caller's workflow-level default
(`contents: read, packages: read`). A called reusable workflow can only
*downgrade* the caller's `GITHUB_TOKEN` — never elevate it — so any write-scoped
extension step was silently denied:

- `actions/attest-build-provenance` (needs `id-token: write` + `attestations: write`) — the flow that surfaced this during the sync-issues-action adoption (vig-os/sync-issues-action#106).
- Even the **GHCR-publish example the docs already ship** (needs `packages: write`) — blocked by the same read-only ceiling.

## Type of Change

- [x] `feat` -- New feature

## Changes Made

Option A from the issue — raise the ceiling and document it:

- **`assets/workspace/.github/workflows/release.yml`** — the `extension` caller
  job now declares a documented token **ceiling**: `contents: read`,
  `packages: write`, `id-token: write`, `attestations: write`.
- **`assets/workspace/.github/workflows/release-extension.yml`** (seeded/consumer-owned) —
  header note explaining the ceiling and the per-job opt-in; the default no-op
  stays `contents: read`.
- **`docs/DOWNSTREAM_RELEASE.md`** — new "Permission ceiling" subsection (scope
  table + deny-by-default explanation + when to use a consumer-owned tag-push
  workflow instead).

**Ceiling, not grant.** It's the *maximum* the seam can reach; the shipped
default no-op is read-only and deny-by-default is preserved — a consumer opts a
job in by declaring the scopes it needs (up to the ceiling), e.g. a
`actions/attest-build-provenance` job sets
`permissions: { id-token: write, attestations: write }`. Scopes beyond the
ceiling (e.g. `contents: write` to push a branch) still belong in a
consumer-owned tag-push workflow — documented.

Scope note: this is scaffold-only. Devkit's own `release.yml` is a bespoke
upstream pipeline and does not use the `release-extension.yml` seam, so there's
no dogfooding copy to change.

## Changelog Entry

### Changed
- **Release extension seam gains a documented token ceiling** ([#1144](https://github.com/vig-os/devkit/issues/1144))
  - full entry in `CHANGELOG.md` under `## Unreleased`.

## Testing

- [x] Tests pass locally (`just test`)
- [x] Manual testing performed (describe below)

### Manual Testing Details

- New `tests/test_workflow_release_extension.py` (TDD, RED→GREEN): asserts the
  caller ceiling grants the four scopes **and** the default no-op stays
  read-only (ceiling ≠ grant).
- `uv run pytest -k "workflow or scaffold or release or downstream or extension"`
  → **109 passed**; `actionlint` clean on the edited workflow (only the expected
  cross-tree reusable-path notes); full `prek run --all-files` **green**.
- Manifest sync propagated the doc into `assets/workspace/docs/` (mirror test green).

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

Companion to #1147 (#1142); both surfaced during the sync-issues-action deploy
recon. The workaround shipping there today (`attest-release.yml` on
`push: tags: v*.*.*`) remains valid — this makes the in-seam path work too, so
future consumers can keep provenance attestation inside `release-extension.yml`.

Closes #1144

Refs: #1144
