### PR TITLE
fix(ci): exclude trunk-reachable history from release-PR commit gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Skip trunk-reachable history in release-PR commit validation** ([#1149](https://github.com/vig-os/devkit/issues/1149))
+  - On a freshly migrated consumer's first release PR (`release/X.Y.Z` →
+    `main`), the `Commit Messages` job validated `merge-base(base, head)..head`,
+    which spans the entire pre-migration history since the last release —
+    commits merged before the commit gate existed. A single non-compliant
+    historical commit permanently blocked the first release train (immutable
+    shared history, neither a merge nor bot-authored, so no exemption applied).
+    `validate-commit-range` gains a repeatable `--exclude-reachable REF` option,
+    and the scaffolded `ci.yml` now passes `--exclude-reachable origin/dev` on
+    non-dev PRs: commits already reachable from the trunk branch were gated (or
+    grandfathered) on their way into trunk and are no longer re-litigated. The
+    exclusion is a no-op on a dev PR (whose base *is* dev), so it only tightens
+    release/main PR ranges.
 - **Render CodeQL push `paths:` filter per detected language** ([#1142](https://github.com/vig-os/devkit/issues/1142))
   - The scaffolded `codeql.yml` hardcoded the push-to-main trigger's `paths:`
     filter to `**.py`, so on a Node consumer a push touching only TS/JS never

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -29,6 +29,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Skip trunk-reachable history in release-PR commit validation** ([#1149](https://github.com/vig-os/devkit/issues/1149))
+  - On a freshly migrated consumer's first release PR (`release/X.Y.Z` →
+    `main`), the `Commit Messages` job validated `merge-base(base, head)..head`,
+    which spans the entire pre-migration history since the last release —
+    commits merged before the commit gate existed. A single non-compliant
+    historical commit permanently blocked the first release train (immutable
+    shared history, neither a merge nor bot-authored, so no exemption applied).
+    `validate-commit-range` gains a repeatable `--exclude-reachable REF` option,
+    and the scaffolded `ci.yml` now passes `--exclude-reachable origin/dev` on
+    non-dev PRs: commits already reachable from the trunk branch were gated (or
+    grandfathered) on their way into trunk and are no longer re-litigated. The
+    exclusion is a no-op on a dev PR (whose base *is* dev), so it only tightens
+    release/main PR ranges.
 - **Render CodeQL push `paths:` filter per detected language** ([#1142](https://github.com/vig-os/devkit/issues/1142))
   - The scaffolded `codeql.yml` hardcoded the push-to-main trigger's `paths:`
     filter to `**.py`, so on a Node consumer a push touching only TS/JS never

--- a/assets/workspace/.github/workflows/ci.yml
+++ b/assets/workspace/.github/workflows/ci.yml
@@ -207,11 +207,23 @@ jobs:
           set -euo pipefail
           BASE_SHA="$(git merge-base "origin/${BASE_REF}" "${HEAD_SHA}")"
           echo "Validating ${BASE_SHA}..${HEAD_SHA} (base: ${BASE_REF})"
+          # A release PR (release/* -> main) spans pre-migration history that
+          # predates the commit gate. Those commits were gated (or
+          # grandfathered) on their way into the trunk branch, so exclude
+          # anything already reachable from origin/dev — a no-op on a dev PR
+          # (its base IS dev) that only tightens the release-PR range (#1149).
+          EXCLUDE=()
+          TRUNK="dev"
+          if [ "${BASE_REF}" != "${TRUNK}" ] && \
+             git fetch --no-tags --quiet origin "${TRUNK}" 2>/dev/null; then
+            EXCLUDE+=(--exclude-reachable "origin/${TRUNK}")
+          fi
           uv run validate-commit-range \
             --base "${BASE_SHA}" \
             --head "${HEAD_SHA}" \
             --title "${PR_TITLE}" \
-            --blocked-patterns .github/agent-blocklist.toml
+            --blocked-patterns .github/agent-blocklist.toml \
+            ${EXCLUDE[@]+"${EXCLUDE[@]}"}
 
       # The PR title and body are attacker-controlled text visible in the UI and
       # notifications even though the body never enters git history, so they reach

--- a/packages/vig-utils/src/vig_utils/validate_commit_range.py
+++ b/packages/vig-utils/src/vig_utils/validate_commit_range.py
@@ -95,10 +95,22 @@ def parse_git_log(raw: str) -> list[Commit]:
     return commits
 
 
-def read_commits(base: str, head: str, repo: Path | None = None) -> list[Commit]:
-    """Read ``base..head`` from git."""
+def read_commits(
+    base: str,
+    head: str,
+    repo: Path | None = None,
+    exclude: list[str] | None = None,
+) -> list[Commit]:
+    """Read ``base..head`` from git, minus anything reachable from ``exclude``.
+
+    Each ref in ``exclude`` is appended to the revision range as ``^<ref>``, so
+    commits reachable from it drop out. A release PR passes the trunk branch
+    here: its pre-migration history was already gated (or grandfathered) on the
+    way into trunk and must not be re-litigated (#1149).
+    """
+    negatives = [f"^{ref}" for ref in (exclude or [])]
     result = subprocess.run(  # nosec B603 B607 - fixed argv, shell=False
-        ["git", "log", f"--format={_GIT_LOG_FORMAT}", f"{base}..{head}"],
+        ["git", "log", f"--format={_GIT_LOG_FORMAT}", f"{base}..{head}", *negatives],
         capture_output=True,
         text=True,
         check=True,
@@ -180,6 +192,17 @@ def main(argv: list[str] | None = None) -> int:
         type=Path,
         help="Path to the agent blocklist TOML.",
     )
+    parser.add_argument(
+        "--exclude-reachable",
+        action="append",
+        default=[],
+        metavar="REF",
+        help=(
+            "Exclude commits reachable from REF (repeatable). A release PR "
+            "passes the trunk branch so pre-gate history already merged to "
+            "trunk is not re-validated."
+        ),
+    )
     args = parser.parse_args(argv)
 
     if not args.base and not args.title:
@@ -214,7 +237,7 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.base:
         try:
-            commits = read_commits(args.base, args.head)
+            commits = read_commits(args.base, args.head, exclude=args.exclude_reachable)
         except subprocess.CalledProcessError as exc:
             print(
                 f"git log {args.base}..{args.head} failed: {exc.stderr}",

--- a/packages/vig-utils/tests/test_validate_commit_range.py
+++ b/packages/vig-utils/tests/test_validate_commit_range.py
@@ -15,15 +15,23 @@ These tests run locally (pytest); they do not require the devcontainer CLI.
 
 from __future__ import annotations
 
+import os
+import subprocess
+from typing import TYPE_CHECKING
+
 import pytest
 from vig_utils.validate_commit_range import (
     Commit,
     is_bot_author,
     main,
     parse_git_log,
+    read_commits,
     validate_commits,
     validate_title,
 )
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 def _commit(
@@ -191,6 +199,66 @@ class TestParseGitLog:
     def test_empty_output_is_empty_list(self) -> None:
         assert parse_git_log("") == []
         assert parse_git_log("\n") == []
+
+
+class TestReadCommits:
+    """``--exclude-reachable`` drops history already gated on the trunk branch.
+
+    On a release PR (``release/X.Y.Z`` -> ``main``) the ``base..head`` span
+    reaches back through pre-migration commits that predate the commit gate but
+    were already merged into (or grandfathered onto) the trunk branch. Excluding
+    commits reachable from the trunk stops the first release train re-litigating
+    them, while staying a no-op on a dev PR whose base *is* the trunk (#1149).
+    """
+
+    @staticmethod
+    def _git(repo: Path, *args: str) -> str:
+        env = {
+            "GIT_AUTHOR_NAME": "Test",
+            "GIT_AUTHOR_EMAIL": "test@example.com",
+            "GIT_COMMITTER_NAME": "Test",
+            "GIT_COMMITTER_EMAIL": "test@example.com",
+            "GIT_CONFIG_GLOBAL": "/dev/null",
+            "GIT_CONFIG_SYSTEM": "/dev/null",
+            "PATH": os.environ.get("PATH", ""),
+        }
+        return subprocess.run(
+            ["git", *args],
+            cwd=repo,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+
+    def _commit(self, repo: Path, message: str) -> str:
+        self._git(repo, "commit", "--allow-empty", "-m", message)
+        return self._git(repo, "rev-parse", "HEAD")
+
+    @pytest.fixture
+    def repo(self, tmp_path: Path) -> Path:
+        """Build main(base) -> dev(grandfathered) -> release(head) topology."""
+        self._git(tmp_path, "init", "-q", "-b", "main")
+        self.base = self._commit(tmp_path, "chore: base commit")
+        # A non-compliant commit that was grandfathered onto the trunk branch.
+        self._git(tmp_path, "checkout", "-q", "-b", "dev")
+        self.grandfathered = self._commit(tmp_path, "broken commit with no type")
+        # The release branch cuts from dev, then adds one compliant commit.
+        self._git(tmp_path, "checkout", "-q", "-b", "release/1.0.0")
+        self.head = self._commit(tmp_path, "feat(x): new thing\n\nRefs: #2")
+        return tmp_path
+
+    def test_without_exclude_returns_trunk_history(self, repo: Path) -> None:
+        commits = read_commits(self.base, self.head, repo=repo)
+        subjects = {c.subject for c in commits}
+        assert "broken commit with no type" in subjects
+        assert "feat(x): new thing" in subjects
+
+    def test_exclude_reachable_drops_trunk_history(self, repo: Path) -> None:
+        commits = read_commits(self.base, self.head, repo=repo, exclude=["dev"])
+        subjects = {c.subject for c in commits}
+        assert "broken commit with no type" not in subjects
+        assert "feat(x): new thing" in subjects
 
 
 class TestMain:


### PR DESCRIPTION
## Summary

A freshly migrated consumer's **first** release PR (`release/X.Y.Z` → `main`)
re-lints its entire pre-migration history: the `Commit Messages` job validates
`merge-base(base, head)..head`, which reaches back to the last release — commits
merged before the commit gate existed. One non-compliant historical commit
(immutable, non-merge, human-authored → no exemption) permanently blocks the
train at the worst possible moment.

## Fix (issue preference #1 — self-healing, no per-repo SHA list)

- `validate-commit-range` gains a repeatable `--exclude-reachable REF` that
  appends `^REF` to the `git log` range.
- Scaffolded `ci.yml` `commit-checks` fetches the trunk and passes
  `--exclude-reachable origin/dev` on non-dev PRs. Commits already reachable
  from trunk were gated (or grandfathered) on their way in and are not
  re-litigated.
- **No-op on dev PRs** (base *is* dev); only tightens release/main ranges.

## Tests

- `TestReadCommits` builds a main→dev→release topology and asserts a
  trunk-grandfathered commit is dropped with `--exclude-reachable` and kept
  without it. Full `validate-commit-range` suite green (36 passed).

Closes #1149