### PR TITLE
fix(workflow): pin release finalize sync-issues dispatch to release branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Pin the release finalize sync-issues dispatch to the release branch** ([#1150](https://github.com/vig-os/devkit/issues/1150))
+  - The `finalize` job in `release-core.yml` dispatched `sync-issues.yml` with
+    no `--ref`, so GitHub resolved the workflow on the **default branch** — the
+    pre-devkit workflow until the first devkit release merges — and both
+    `gh run list` polls omitted `--branch`, so a concurrent scheduled run could
+    be mistaken for the dispatched one. On a consumer's first final release this
+    timed out at finalize and triggered the automatic rollback. The dispatch now
+    passes `--ref "release/$VERSION"`, both polls filter `--branch
+    "release/$VERSION"`, and the wait ceiling is raised from 120 s to 600 s
+    (the first release-branch sync has no cutoff cache and self-heals up to
+    14 days of history).
 - **Render CodeQL push `paths:` filter per detected language** ([#1142](https://github.com/vig-os/devkit/issues/1142))
   - The scaffolded `codeql.yml` hardcoded the push-to-main trigger's `paths:`
     filter to `**.py`, so on a Node consumer a push touching only TS/JS never

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -29,6 +29,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Pin the release finalize sync-issues dispatch to the release branch** ([#1150](https://github.com/vig-os/devkit/issues/1150))
+  - The `finalize` job in `release-core.yml` dispatched `sync-issues.yml` with
+    no `--ref`, so GitHub resolved the workflow on the **default branch** — the
+    pre-devkit workflow until the first devkit release merges — and both
+    `gh run list` polls omitted `--branch`, so a concurrent scheduled run could
+    be mistaken for the dispatched one. On a consumer's first final release this
+    timed out at finalize and triggered the automatic rollback. The dispatch now
+    passes `--ref "release/$VERSION"`, both polls filter `--branch
+    "release/$VERSION"`, and the wait ceiling is raised from 120 s to 600 s
+    (the first release-branch sync has no cutoff cache and self-heals up to
+    14 days of history).
 - **Render CodeQL push `paths:` filter per detected language** ([#1142](https://github.com/vig-os/devkit/issues/1142))
   - The scaffolded `codeql.yml` hardcoded the push-to-main trigger's `paths:`
     filter to `**.py`, so on a Node consumer a push touching only TS/JS never

--- a/assets/workspace/.github/workflows/release-core.yml
+++ b/assets/workspace/.github/workflows/release-core.yml
@@ -502,17 +502,30 @@ jobs:
           VERSION: ${{ needs.validate.outputs.version }}
         run: |
           set -euo pipefail
+          # Pin the dispatch to the release branch's ref. Without --ref, GitHub
+          # resolves the workflow definition on the DEFAULT branch — the
+          # pre-devkit sync-issues.yml until the first devkit release merges — so
+          # the sync must run the release branch's own workflow, not whatever
+          # trunk currently carries (#1150).
           retry --retries 2 --backoff 5 --max-backoff 20 -- \
-            gh workflow run sync-issues.yml -f "target-branch=release/$VERSION"
+            gh workflow run sync-issues.yml \
+              --ref "release/$VERSION" \
+              -f "target-branch=release/$VERSION"
 
       - name: Wait for sync-issues completion
         if: ${{ inputs.release_kind == 'final' }}
         id: wait_sync
         env:
           GH_TOKEN: ${{ steps.auth.outputs.token }}
+          VERSION: ${{ needs.validate.outputs.version }}
         run: |
           set -euo pipefail
-          TIMEOUT=120
+          # 120s was too tight even for the devkit workflow: the first
+          # release-branch run has no cutoff cache and self-heals up to 14 days
+          # of history, which can take minutes. Both polls filter --branch to the
+          # dispatched release-branch run so a concurrent scheduled run is never
+          # mistaken for it (#1150).
+          TIMEOUT=600
           ELAPSED=0
           INTERVAL=10
           RUN_STATUS="unknown"
@@ -522,6 +535,7 @@ jobs:
           while [ $ELAPSED -lt $TIMEOUT ]; do
             RUN_STATUS=$(gh run list \
               --workflow sync-issues.yml \
+              --branch "release/$VERSION" \
               --limit 1 \
               --json status,conclusion \
               --jq '.[0].status' 2>/dev/null || echo "unknown")
@@ -541,6 +555,7 @@ jobs:
 
           RUN_CONCLUSION=$(gh run list \
             --workflow sync-issues.yml \
+            --branch "release/$VERSION" \
             --limit 1 \
             --json conclusion \
             --jq '.[0].conclusion' 2>/dev/null || echo "unknown")

--- a/tests/test_release_core_sync_dispatch.py
+++ b/tests/test_release_core_sync_dispatch.py
@@ -1,0 +1,62 @@
+"""Workflow-shape tests: release-core sync-issues dispatch is release-branch-pinned.
+
+Issue #1150: a consumer's first final ``release.yml`` run timed out at finalize
+because the ``sync-issues`` dispatch and its polls were under-specified:
+
+1. ``gh workflow run sync-issues.yml`` passed no ``--ref``, so GitHub resolved
+   the workflow **on the default branch** — the pre-devkit workflow until the
+   first devkit release merges.
+2. ``TIMEOUT=120`` was too tight even for the devkit workflow's first
+   release-branch run (no cutoff cache → self-heal took > 3m).
+3. Both ``gh run list`` polls omitted ``--branch``, so a concurrent scheduled
+   run could be mistaken for the dispatched one.
+
+These assertions pin the fix in the shipped ``release-core.yml``: the dispatch
+is ``--ref``-pinned to the release branch, both polls are ``--branch``-filtered
+to it, and the wait timeout is generous. The choreography is bash and not
+unit-testable here.
+
+Refs: #1150
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+WORKFLOWS = REPO_ROOT / "assets" / "workspace" / ".github" / "workflows"
+
+
+def _finalize_steps() -> list[dict]:
+    workflow = yaml.safe_load(
+        (WORKFLOWS / "release-core.yml").read_text(encoding="utf-8")
+    )
+    return workflow["jobs"]["finalize"]["steps"]
+
+
+def _step(name_fragment: str) -> dict:
+    frag = name_fragment.lower()
+    return next(s for s in _finalize_steps() if frag in str(s.get("name", "")).lower())
+
+
+def test_dispatch_pins_the_release_branch_ref() -> None:
+    """The sync-issues dispatch runs the release branch's workflow, not the default."""
+    run = _step("Trigger sync-issues")["run"]
+    assert "gh workflow run sync-issues.yml" in run
+    assert '--ref "release/$VERSION"' in run
+
+
+def test_wait_timeout_is_generous() -> None:
+    """120s was too tight even for the devkit workflow; the ceiling is raised."""
+    run = _step("Wait for sync-issues")["run"]
+    assert "TIMEOUT=600" in run
+    assert "TIMEOUT=120" not in run
+
+
+def test_polls_filter_on_the_release_branch() -> None:
+    """Both the wait loop and the conclusion check filter to the dispatched run."""
+    run = _step("Wait for sync-issues")["run"]
+    # --branch appears on both the status poll and the conclusion poll.
+    assert run.count('--branch "release/$VERSION"') >= 2


### PR DESCRIPTION
## Summary

A consumer's first final `release.yml` run failed at finalize with
`Timed out waiting for sync-issues workflow completion` and rolled back. Three
stacked problems in `release-core.yml`'s `finalize` job:

1. **Dispatch ran the wrong workflow.** `gh workflow run sync-issues.yml` passed
   no `--ref`, so GitHub resolved the definition on the **default branch** — the
   pre-devkit workflow until the first devkit release merges.
2. **`TIMEOUT=120` too tight.** The devkit sync workflow's first release-branch
   run (no cutoff cache → self-heal) can take minutes.
3. **Polls raced.** Both `gh run list` calls omitted `--branch`, so a concurrent
   scheduled run could be mistaken for the dispatched one.

## Fix (adopts all three, validated live on the consumer workaround)

- `--ref "release/$VERSION"` on the dispatch (correct on every run).
- `--branch "release/$VERSION"` on both polls.
- `TIMEOUT` 120 → 600.

## Tests

`tests/test_release_core_sync_dispatch.py` pins the `--ref`, the two `--branch`
filters, and the raised timeout. Release-shape suite green.

Closes #1150