### PR TITLE
fix(release): actionable failure on first-time floating-tag create denial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Fail loud with remediation when a first-time floating-tag create is denied** ([#1157](https://github.com/vig-os/devkit/issues/1157))
+  - `promote-release.yml` force-**updates** an existing `<prefix>X` /
+    `<prefix>X.Y` via `PATCH`, but the first release of a **new** floating level
+    must **create** the ref (`POST /git/refs`). When the Tag ruleset restricts
+    tag creation and the Release App is not a bypass actor for its `creation`
+    rule, the create is denied as the opaque `Reference does not exist`
+    (HTTP 422); `retry` then hammered the permanent denial and the job exited 1
+    with no actionable signal — even though publish + merge had already
+    succeeded, leaving the advertised `@<prefix>X.Y` pin silently missing. The
+    move step now guards the create and emits a `::error::` annotation naming the
+    tag, target commit, ruleset root cause, and the one-off remediation
+    (`docs/MIGRATION.md#first-release-floating-tags`, extended to cover a new
+    level introduced in steady state) instead of a bare `gh` error.
 - **Skip trunk-reachable history in release-PR commit validation** ([#1149](https://github.com/vig-os/devkit/issues/1149))
   - On a freshly migrated consumer's first release PR (`release/X.Y.Z` →
     `main`), the `Commit Messages` job validated `merge-base(base, head)..head`,

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -52,6 +52,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Fail loud with remediation when a first-time floating-tag create is denied** ([#1157](https://github.com/vig-os/devkit/issues/1157))
+  - `promote-release.yml` force-**updates** an existing `<prefix>X` /
+    `<prefix>X.Y` via `PATCH`, but the first release of a **new** floating level
+    must **create** the ref (`POST /git/refs`). When the Tag ruleset restricts
+    tag creation and the Release App is not a bypass actor for its `creation`
+    rule, the create is denied as the opaque `Reference does not exist`
+    (HTTP 422); `retry` then hammered the permanent denial and the job exited 1
+    with no actionable signal — even though publish + merge had already
+    succeeded, leaving the advertised `@<prefix>X.Y` pin silently missing. The
+    move step now guards the create and emits a `::error::` annotation naming the
+    tag, target commit, ruleset root cause, and the one-off remediation
+    (`docs/MIGRATION.md#first-release-floating-tags`, extended to cover a new
+    level introduced in steady state) instead of a bare `gh` error.
 - **Skip trunk-reachable history in release-PR commit validation** ([#1149](https://github.com/vig-os/devkit/issues/1149))
   - On a freshly migrated consumer's first release PR (`release/X.Y.Z` →
     `main`), the `Commit Messages` job validated `merge-base(base, head)..head`,

--- a/assets/workspace/.github/workflows/promote-release.yml
+++ b/assets/workspace/.github/workflows/promote-release.yml
@@ -677,9 +677,20 @@ jobs:
                 -f sha="$TARGET_SHA" -F force=true >/dev/null
               echo "Moved floating tag ${name} -> ${TARGET_SHA}"
             else
-              retry --retries 3 --backoff 5 --max-backoff 30 -- \
-                gh api "repos/${GITHUB_REPOSITORY}/git/refs" \
-                -f ref="refs/tags/${name}" -f sha="$TARGET_SHA" >/dev/null
+              # First time this floating level is published: promote must
+              # CREATE the ref (POST /git/refs), not move it. The Tag ruleset
+              # denies creation to everyone but the Release App, so if the app
+              # is not an effective bypass actor for the ruleset's `creation`
+              # rule the call is refused — surfaced as the opaque "Reference
+              # does not exist" / HTTP 422 (#1157). Publish + merge already
+              # succeeded, so fail loud with actionable remediation rather than
+              # leaving the advertised `@${name}` pin silently missing.
+              if ! retry --retries 3 --backoff 5 --max-backoff 30 -- \
+                  gh api "repos/${GITHUB_REPOSITORY}/git/refs" \
+                  -f ref="refs/tags/${name}" -f sha="$TARGET_SHA" >/dev/null; then
+                echo "::error title=Floating tag ${name} not created::Could not create floating tag '${name}' at ${TARGET_SHA} (first release of this floating level). The repo Tag ruleset restricts tag creation; if the Release App is not a bypass actor for the ruleset's 'creation' rule the POST /git/refs is denied as 'Reference does not exist' (HTTP 422). The GitHub Release is published and the release PR merged — only this floating tag is missing, which silently breaks the advertised 'uses: ...@${name}' pin. Remediate once by hand (temporarily bypass the ruleset, create refs/tags/${name} -> ${TARGET_SHA}, then revert), or grant the Release App a 'creation' bypass so future levels move automatically. See https://github.com/vig-os/devkit/blob/main/docs/MIGRATION.md#first-release-floating-tags."
+                return 1
+              fi
               echo "Created floating tag ${name} -> ${TARGET_SHA}"
             fi
           }

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -650,6 +650,19 @@ release and `<prefix>X.Y` is missing — silently breaking the advertised
 `uses: owner/repo@<prefix>X` pin. The one-off bootstrap is to bypass the ruleset,
 move the tags, then revert:
 
+> **The same one-off recurs when a _new_ floating level first appears in steady
+> state** ([#1157](https://github.com/vig-os/devkit/issues/1157)). Once the
+> workflow is live it force-**updates** existing levels with the app token, but
+> the first release of a new level must **create** the ref (`POST /git/refs`),
+> and if the Tag ruleset does not bypass the Release App for its `creation` rule
+> that create is denied — surfaced as the opaque `Reference does not exist`
+> (HTTP 422). Example: a repo already carrying `<prefix>0` cuts its first
+> `<prefix>0.Y` release. `promote-release.yml` now fails loud with a `::error::`
+> naming the tag, target commit, and this remediation instead of a bare `gh`
+> error. Apply the same bypass-create-revert below (using the **create** call in
+> step 2), or grant the Release App a `creation` bypass so future levels move
+> automatically.
+
 1. **Temporarily grant repository admins a bypass.** In **Settings → Rules →
    Rulesets → (the Tag ruleset) → Bypass list**, add **Repository admin**
    (`RepositoryRole`, actor id `5`), then save. Equivalently via the API, append

--- a/tests/test_floating_tags.py
+++ b/tests/test_floating_tags.py
@@ -69,3 +69,27 @@ def test_floating_tags_job_threads_prefix_and_version() -> None:
     assert "TAG_PREFIX" in env
     assert "FLOATING_TAGS" in env
     assert "VERSION" in env
+
+
+def _move_step_script() -> str:
+    """The bash body of the ``Move floating major/minor tags`` step."""
+    workflow = _load(WORKFLOWS / "promote-release.yml")
+    steps = workflow["jobs"]["floating-tags"]["steps"]
+    move = next(s for s in steps if "floating" in str(s.get("name", "")).lower())
+    return move["run"]
+
+
+def test_create_failure_emits_actionable_error() -> None:
+    """A first-time floating-level create that the ruleset denies must fail loud.
+
+    #1157: the create path (``POST /git/refs`` for a brand-new ``<prefix>X.Y``)
+    is denied ``422`` when the Tag ruleset does not bypass the Release App for
+    the ``creation`` rule. The bare ``gh`` error is undiagnosable, so the step
+    must surface a ``::error::`` annotation and point at the documented one-off
+    remediation instead of a cryptic ``Reference does not exist``.
+    """
+    script = _move_step_script()
+    assert "::error" in script  # a GitHub error annotation, not a bare echo
+    # Names the ruleset root cause and the documented remediation.
+    assert "ruleset" in script.lower()
+    assert "first-release-floating-tags" in script


### PR DESCRIPTION
## Summary

Fixes #1157. The floating-tag move step in `promote-release.yml` force-**updates**
an existing `<prefix>X` / `<prefix>X.Y` via `PATCH`, but the **first** release of a
**new** floating level must **create** the ref (`POST /git/refs`). When the repo Tag
ruleset restricts tag creation and the Release App is not a bypass actor for the
ruleset's `creation` rule, the create is denied as the opaque `Reference does not
exist` (HTTP 422). `retry` then hammered the permanent denial and the job exited 1
with **no actionable signal** — even though publish + merge had already succeeded,
leaving the advertised `@<prefix>X.Y` pin silently missing (observed live on
vig-os/commit-action `v0.3.1`, run 29519580039: `v0` moved via PATCH, `v0.3` create
failed).

## What changed

- **`assets/workspace/.github/workflows/promote-release.yml`** — the create path in
  `move_tag()` is now guarded. On failure it emits a `::error::` annotation naming
  the tag, target commit, the **ruleset root cause**, and the one-off remediation,
  instead of a bare `gh` error. The job still fails loud (a missing floating tag is a
  real problem that needs human action — it breaks the advertised pin — not something
  to swallow with a warning).
- **`docs/MIGRATION.md`** — the *First-release floating tags* section is extended to
  cover the steady-state trigger this issue reproduces: a live consumer cutting the
  first release of a **new** floating level, where promote must *create* (not move)
  the ref. Documents the create-call variant of the bypass-and-revert one-off.
- **`tests/test_floating_tags.py`** — a workflow-shape test pins that the move step
  surfaces a `::error::` annotation naming the ruleset cause and the doc anchor.
- **`CHANGELOG.md`** (+ mirror) — `Fixed` entry.

## Scope note

The genuine *cure* (the managed Tag ruleset should bypass the Release App for its
`creation` rule, or not restrict creation) lives in per-consumer onboarding /
`org-config`, not this workflow — devkit ships no machine-managed ruleset here. This
PR delivers the in-repo, in-scope half: a **diagnosable** failure plus the documented
remediation (issue suggestion #2). Worth a follow-up issue to harden the onboarding
ruleset so this never recurs.

## Testing

- `just precommit` — full hook suite green (all files).
- `uv run pytest tests/test_floating_tags.py tests/test_scaffold_lint.py` — 40 passed.
- `bash -n` + `shellcheck` on the extracted move-step script — clean.
- Full suite: 1044 passed; the 2 remaining failures (`test_image.py::test_manifest_files`,
  `test_integration.py::test_github_cli_authentication`) reproduce on clean `origin/dev`
  and are environmental (built-image manifest state / gh-auth in devcontainer), not from
  this change.

Refs: #1157
