### PR TITLE
fix(release): commit only non-ignored dist on finalize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Commit only the non-ignored `dist/` on release finalize** ([#1159](https://github.com/vig-os/devkit/issues/1159))
+  - The finalize step passed the whole `dist` directory to `commit-action`
+    (`FILE_PATHS: CHANGELOG.md,dist`). `commit-action` walks a directory path on
+    disk and force-adds **every** file it finds — it never consults
+    `.gitignore` — so the gitignored tsc/ncc byproducts (`dist/src/**`,
+    `*.tsbuildinfo`) were re-committed on every final release, re-tracking them on
+    `main`, on `dev` (via `sync-main-to-dev`), and in the tag tree, and making the
+    sanctioned `git rm --cached` cleanup impossible to persist (it re-bit as a
+    release-PR `Dist Check` failure after an ncc/tsc-affecting dep bump). The
+    build step now computes the tracked-plus-untracked-but-not-ignored set with
+    `git ls-files -co --exclude-standard -- dist` (i.e. `git add`/`.gitignore`
+    semantics) and the finalize commit ships only those explicit files, so the
+    real bundle (`dist/index.js`, `dist/licenses.txt`) is committed without the
+    gitignored emit.
 - **Fail loud with remediation when a first-time floating-tag create is denied** ([#1157](https://github.com/vig-os/devkit/issues/1157))
   - `promote-release.yml` force-**updates** an existing `<prefix>X` /
     `<prefix>X.Y` via `PATCH`, but the first release of a **new** floating level

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -52,6 +52,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Commit only the non-ignored `dist/` on release finalize** ([#1159](https://github.com/vig-os/devkit/issues/1159))
+  - The finalize step passed the whole `dist` directory to `commit-action`
+    (`FILE_PATHS: CHANGELOG.md,dist`). `commit-action` walks a directory path on
+    disk and force-adds **every** file it finds — it never consults
+    `.gitignore` — so the gitignored tsc/ncc byproducts (`dist/src/**`,
+    `*.tsbuildinfo`) were re-committed on every final release, re-tracking them on
+    `main`, on `dev` (via `sync-main-to-dev`), and in the tag tree, and making the
+    sanctioned `git rm --cached` cleanup impossible to persist (it re-bit as a
+    release-PR `Dist Check` failure after an ncc/tsc-affecting dep bump). The
+    build step now computes the tracked-plus-untracked-but-not-ignored set with
+    `git ls-files -co --exclude-standard -- dist` (i.e. `git add`/`.gitignore`
+    semantics) and the finalize commit ships only those explicit files, so the
+    real bundle (`dist/index.js`, `dist/licenses.txt`) is committed without the
+    gitignored emit.
 - **Fail loud with remediation when a first-time floating-tag create is denied** ([#1157](https://github.com/vig-os/devkit/issues/1157))
   - `promote-release.yml` force-**updates** an existing `<prefix>X` /
     `<prefix>X.Y` via `PATCH`, but the first release of a **new** floating level

--- a/assets/workspace/.github/workflows/release-core.yml
+++ b/assets/workspace/.github/workflows/release-core.yml
@@ -464,6 +464,7 @@ jobs:
           fi
 
       - name: Build release artifact
+        id: artifact
         if: ${{ inputs.release_kind == 'final' && steps.bundle.outputs.has_bundle == 'true' }}
         run: |
           set -euo pipefail
@@ -476,6 +477,20 @@ jobs:
           # ships a fresh bundle, not a stale one. Output (dist/) is committed
           # alongside CHANGELOG.md below.
           just bundle
+          # Commit only the shipped bundle, not the whole dir. `just bundle`
+          # also emits gitignored tsc/ncc byproducts (dist/src/**, *.tsbuildinfo);
+          # commit-action walks a directory path on disk and force-adds EVERY
+          # file it finds — it never consults .gitignore — so passing bare `dist`
+          # re-tracks those byproducts on every final release (#1159).
+          # `git ls-files -co --exclude-standard` lists tracked + untracked files
+          # that are NOT gitignored (git-add semantics), so only the real bundle
+          # (dist/index.js, dist/licenses.txt) reaches the finalize commit.
+          DIST_PATHS=$(git ls-files -co --exclude-standard -- dist | paste -sd,)
+          if [[ -z "$DIST_PATHS" ]]; then
+            echo "::error::bundle recipe produced no non-ignored files under dist/" >&2
+            exit 1
+          fi
+          echo "dist_paths=$DIST_PATHS" >> "$GITHUB_OUTPUT"
 
       - name: Commit and push finalization changes via API
         if: ${{ inputs.release_kind == 'final' }}
@@ -491,9 +506,11 @@ jobs:
             Set release date to ${{ needs.validate.outputs.release_date }} in CHANGELOG.md
 
             Refs: #${{ needs.validate.outputs.pr_number }}
-          # dist/ joins the finalization commit only when a bundle was built, so
-          # the tagged commit carries the fresh artifact (#1029).
-          FILE_PATHS: ${{ steps.bundle.outputs.has_bundle == 'true' && 'CHANGELOG.md,dist' || 'CHANGELOG.md' }}
+          # The fresh bundle joins the finalization commit only when one was
+          # built (#1029), and only its non-ignored files — computed by the
+          # build step — not the whole dir, so gitignored tsc/ncc emit stays
+          # untracked (#1159).
+          FILE_PATHS: ${{ steps.bundle.outputs.has_bundle == 'true' && format('CHANGELOG.md,{0}', steps.artifact.outputs.dist_paths) || 'CHANGELOG.md' }}
 
       - name: Trigger sync-issues workflow
         if: ${{ inputs.release_kind == 'final' }}

--- a/tests/bats/init-workspace.bats
+++ b/tests/bats/init-workspace.bats
@@ -2656,16 +2656,23 @@ _RELEASE_RESOLVERS_991=(
 @test "release-core builds+commits an opt-in bundle when a bundle recipe exists (#1029)" {
     # A repo that ships a committed build artifact (e.g. a JS action's ncc
     # dist/) defines a `bundle` just recipe; the release finalize flow detects
-    # it via `just --summary`, runs `just bundle`, and commits dist/ as part of
-    # the finalization commit. Language-neutral: no bundle recipe -> no-op.
+    # it via `just --summary`, runs `just bundle`, and commits the bundle as
+    # part of the finalization commit. Language-neutral: no bundle recipe -> no-op.
     f="$TEMPLATE_DIR/.github/workflows/release-core.yml"
     run grep -q 'just --summary' "$f"
     assert_success
     run grep -q 'just bundle' "$f"
     assert_success
-    # dist/ joins CHANGELOG.md in the finalization commit's FILE_PATHS.
-    run grep -q 'CHANGELOG.md,dist' "$f"
+    # Only the non-ignored dist/ files join CHANGELOG.md in the finalization
+    # commit's FILE_PATHS -- the whole `dist` dir would force-add the gitignored
+    # tsc/ncc emit via commit-action (#1159). The build step computes the set
+    # with git-add/.gitignore semantics and exposes it as a step output.
+    run grep -q 'git ls-files -co --exclude-standard -- dist' "$f"
     assert_success
+    run grep -q 'steps.artifact.outputs.dist_paths' "$f"
+    assert_success
+    run grep -q 'CHANGELOG.md,dist' "$f"
+    assert_failure
 }
 
 @test "resolve-image action is removed from every rendered mode tree (#991)" {

--- a/tests/test_release_core_dist_gitignore.py
+++ b/tests/test_release_core_dist_gitignore.py
@@ -1,0 +1,62 @@
+"""Workflow-shape tests: release-core commits only the non-ignored dist/ files.
+
+Issue #1159: the finalize commit passed the whole ``dist`` directory to
+``commit-action`` (``FILE_PATHS: CHANGELOG.md,dist``). ``commit-action`` walks
+that directory on disk and force-adds **every** file it finds — it never
+consults ``.gitignore`` — so the gitignored tsc/ncc byproducts (``dist/src/**``,
+``*.tsbuildinfo``) get re-committed on every final release, defeating the
+"ship only the bundle" invariant and making the sanctioned ``git rm --cached``
+cleanup impossible to persist.
+
+The fix computes the tracked-plus-untracked-but-not-ignored set under ``dist``
+with ``git ls-files -co --exclude-standard`` (i.e. ``git add`` /``.gitignore``
+semantics) and passes only those explicit files, so the finalize commit ships
+``dist/index.js`` + ``dist/licenses.txt`` without the gitignored emit.
+
+Refs: #1159
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+WORKFLOWS = REPO_ROOT / "assets" / "workspace" / ".github" / "workflows"
+
+
+def _finalize_steps() -> list[dict]:
+    workflow = yaml.safe_load(
+        (WORKFLOWS / "release-core.yml").read_text(encoding="utf-8")
+    )
+    return workflow["jobs"]["finalize"]["steps"]
+
+
+def _step(name_fragment: str) -> dict:
+    frag = name_fragment.lower()
+    return next(s for s in _finalize_steps() if frag in str(s.get("name", "")).lower())
+
+
+def test_finalize_does_not_commit_the_whole_dist_dir() -> None:
+    """FILE_PATHS must not pass the bare ``dist`` directory (force-adds ignored)."""
+    file_paths = _step("Commit and push finalization")["env"]["FILE_PATHS"]
+    assert ",dist'" not in file_paths
+    assert "'CHANGELOG.md,dist'" not in file_paths
+
+
+def test_build_step_computes_non_ignored_dist_paths() -> None:
+    """The artifact build honors .gitignore when listing dist/ files to commit."""
+    run = _step("Build release artifact")["run"]
+    assert "git ls-files -co --exclude-standard -- dist" in run
+    # The list is exposed as a step output for the commit step to consume.
+    assert "dist_paths=" in run
+    assert '>> "$GITHUB_OUTPUT"' in run
+
+
+def test_file_paths_reference_the_computed_dist_paths() -> None:
+    """FILE_PATHS threads the computed, gitignore-respecting dist path list."""
+    file_paths = _step("Commit and push finalization")["env"]["FILE_PATHS"]
+    assert "dist_paths" in file_paths
+    # CHANGELOG.md is still committed in both the bundle and no-bundle branches.
+    assert "CHANGELOG.md" in file_paths


### PR DESCRIPTION
## Summary

`release-core.yml`'s finalize step passed the **whole `dist` directory** to
`commit-action` (`FILE_PATHS: CHANGELOG.md,dist`) for bundle projects.
`commit-action` walks a directory path on disk and force-adds **every** file it
finds — it never consults `.gitignore` (`findFilesRecursively` in
`commit-runner.ts` skips only `.git`) — so the gitignored tsc/ncc byproducts
(`dist/src/**`, `*.tsbuildinfo`) were re-committed on every final release. This
re-tracked them on `main`, on `dev` (via `sync-main-to-dev`), and in the tag
tree, defeating the "ship only the bundle" invariant and making the sanctioned
`git rm --cached` cleanup impossible to persist — it re-bit as a release-PR
`Dist Check` failure whenever an ncc/tsc-affecting dep bump drifted the emit on
the un-gated `dev` branch (what blocked `sync-issues-action` v0.4.0).

## Fix

Scoped to `release-core.yml` (issue's option 1 — respect existing tracking, no
hardcode). The `Build release artifact` step now computes the
tracked-plus-untracked-but-not-ignored set under `dist` with:

```
git ls-files -co --exclude-standard -- dist
```

i.e. `git add`/`.gitignore` semantics — and exposes it as a step output. The
finalize commit's `FILE_PATHS` threads that explicit list instead of the bare
`dist` dir, so only the real bundle (`dist/index.js`, `dist/licenses.txt`)
reaches the tag. `--exclude-standard` stops re-adding gitignored *untracked*
emit, so once a consumer runs the documented `git rm --cached` cleanup it now
**persists** across future finalize commits (already-tracked files still ship
until cleaned up — no regression). A guard fails the build loud if the bundle
recipe somehow produces no non-ignored files.

## Tests

- `tests/test_release_core_dist_gitignore.py` — new workflow-shape test
  (RED→GREEN, TDD): FILE_PATHS no longer passes bare `dist`, the build step
  computes non-ignored paths via `git ls-files -co --exclude-standard`, and
  FILE_PATHS threads the computed output.
- Full pre-commit suite green (incl. actionlint); 157 fast pytest cases pass.

## Related

Distinct from #1157 (native promote floating-tag create 422); both surfaced on
the same `sync-issues-action` v0.4.0 / `commit-action` v0.3.1 release trains. The
more general `commit-action`-level fix (honor `.gitignore` for directory paths)
remains available as a follow-up in that repo.

Closes #1159
