### PR TITLE
fix(scaffold): default direnv to flake-generated pre-commit hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **direnv scaffolds default to flake-generated pre-commit hooks** ([#1167](https://github.com/vig-os/devkit/issues/1167))
+  - The direnv CI lane runs on the bare host runner (`resolve-toolchain` emits an
+    empty container image), which lacks the devkit image's FHS loader and C++
+    runtime that the hand-managed `.pre-commit-config.yaml`'s `pymarkdown` hook
+    (native `pyjson5`) needs — so it fails with `ImportError: libstdc++.so.6`
+    there, and every direnv consumer had to switch to flake-generated hooks by
+    hand. A fresh `direnv` scaffold now activates an empty `hooks = { }` in
+    `flake.nix` and drops the hand-managed YAML, so the shared flake hook set
+    generates `.pre-commit-config.yaml` (a gitignored `/nix/store` symlink,
+    dropping `pymarkdown`) and runs host-side. A consumer's own preserved
+    `flake.nix` or committed config is never rewritten; `container`/`both` keep
+    the hand-managed YAML (they run inside the image where `pymarkdown` works);
+    `bare` is unaffected (it ships no flake and owns its own toolchain).
+
 ### Deprecated
 
 ### Removed

--- a/assets/init-workspace.sh
+++ b/assets/init-workspace.sh
@@ -680,10 +680,14 @@ render_gitignore() {
     # a /nix/store symlink, which must be ignored — committing it pushes a
     # machine-local, broken symlink. Seed the ignore automatically, gated
     # STRICTLY on the store-symlink condition so a hand-managed consumer who
-    # commits a real .pre-commit-config.yaml file is never affected. Idempotent:
-    # skip when the assembled ignore (incl. .gitignore.project) already lists it.
+    # commits a real .pre-commit-config.yaml file is never affected. A fresh
+    # direnv scaffold defaults to flake-generated hooks (FLAKE_HOOKS_DEFAULT,
+    # #1167) before the store symlink exists, so seed the ignore for it too.
+    # Idempotent: skip when the assembled ignore (incl. .gitignore.project)
+    # already lists it.
     local pcc="$WORKSPACE_DIR/.pre-commit-config.yaml"
-    if [[ -L "$pcc" ]] && readlink "$pcc" | grep -q '/nix/store/'; then
+    if { [[ -L "$pcc" ]] && readlink "$pcc" | grep -q '/nix/store/'; } \
+        || [[ "${FLAKE_HOOKS_DEFAULT:-false}" == "true" ]]; then
         if ! grep -qxF '.pre-commit-config.yaml' "$gi"; then
             {
                 printf '\n# flake-hooks opt-in (#1092): the generated'
@@ -693,6 +697,33 @@ render_gitignore() {
             } >>"$gi"
         fi
     fi
+}
+
+# Turn a freshly-scaffolded direnv flake.nix into a flake-hooks generator (#1167)
+# by activating an empty `hooks = { }` argument to mkProjectShell. The direnv CI
+# lane runs on the bare host runner (resolve-toolchain emits an empty container
+# image), which lacks the image's FHS loader, so the hand-managed
+# .pre-commit-config.yaml's pymarkdown hook (native pyjson5) can't load there;
+# the shared flake hook set drops pymarkdown and runs host-side. Deterministic
+# single insert after the (unique) extraPackages line — a bats regression guard
+# pins that anchor. Only ever called on a FRESH scaffold (guarded by the caller).
+activate_flake_hooks_default() {
+    local flake="$WORKSPACE_DIR/flake.nix"
+    [[ -f "$flake" ]] || return 0
+    local tmp="${flake}.hooks-default"
+    awk '
+        { print }
+        /^          extraPackages = extraPackages pkgs;$/ && !inserted {
+            print ""
+            print "          # Host-runner hooks (#1167): direnv CI runs on the bare host"
+            print "          # runner, so let the flake GENERATE .pre-commit-config.yaml from"
+            print "          # the shared base hook set (drops pymarkdown, whose native pyjson5"
+            print "          # cannot load off the image). Customize like the opt-in block below;"
+            print "          # the generated config is a gitignored /nix/store symlink."
+            print "          hooks = { };"
+            inserted = 1
+        }
+    ' "$flake" >"$tmp" && mv "$tmp" "$flake"
 }
 
 # Migrate consumer-added root ignores into .gitignore.project (#1111). The #1092
@@ -1338,6 +1369,24 @@ else
             sed -i "s/{{SHORT_NAME}}/${SHORT_NAME_ESCAPED}/g; s/{{ORG_NAME}}/${ORG_NAME_ESCAPED}/g; s/{{GITHUB_REPOSITORY}}/${GITHUB_REPOSITORY_ESCAPED}/g" "$file"
         fi
     done
+fi
+
+# Host-runner hooks default (#1167): a FRESH direnv scaffold defaults to
+# flake-generated pre-commit hooks. The direnv CI lane runs on the bare host
+# runner (empty container image), which lacks the image's FHS loader that the
+# hand-managed YAML's pymarkdown hook (native pyjson5) needs — the shared flake
+# hook set drops it. Runs BEFORE render_gitignore so the generated config is
+# ignored from the first scaffold. Gated on a fresh scaffold: never rewrite a
+# consumer's own flake.nix nor delete a committed .pre-commit-config.yaml (both
+# PRESERVE_FILES). bare mode is out of scope — it prunes flake.nix (no generator)
+# and the consumer owns its own toolchain there.
+FLAKE_HOOKS_DEFAULT=false
+if [[ "$MODE" == "direnv" && "$FLAKE_PREEXISTED" == "false" \
+    && "$PRECOMMIT_CONFIG_PREEXISTED" == "false" ]]; then
+    activate_flake_hooks_default
+    rm -f "$WORKSPACE_DIR/.pre-commit-config.yaml"
+    FLAKE_HOOKS_DEFAULT=true
+    echo "direnv mode: defaulting to flake-generated pre-commit hooks (#1167)"
 fi
 
 # Render the language-aware managed statics (#1024/#1025) from the freshly

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -11,6 +11,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **direnv scaffolds default to flake-generated pre-commit hooks** ([#1167](https://github.com/vig-os/devkit/issues/1167))
+  - The direnv CI lane runs on the bare host runner (`resolve-toolchain` emits an
+    empty container image), which lacks the devkit image's FHS loader and C++
+    runtime that the hand-managed `.pre-commit-config.yaml`'s `pymarkdown` hook
+    (native `pyjson5`) needs — so it fails with `ImportError: libstdc++.so.6`
+    there, and every direnv consumer had to switch to flake-generated hooks by
+    hand. A fresh `direnv` scaffold now activates an empty `hooks = { }` in
+    `flake.nix` and drops the hand-managed YAML, so the shared flake hook set
+    generates `.pre-commit-config.yaml` (a gitignored `/nix/store` symlink,
+    dropping `pymarkdown`) and runs host-side. A consumer's own preserved
+    `flake.nix` or committed config is never rewritten; `container`/`both` keep
+    the hand-managed YAML (they run inside the image where `pymarkdown` works);
+    `bare` is unaffected (it ships no flake and owns its own toolchain).
+
 ### Deprecated
 
 ### Removed

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -362,6 +362,15 @@ hook set is defined once in the vigOS flake, and a consumer can compose it
 from the **preserved** project `flake.nix` instead of hand-editing the
 scaffolded `.pre-commit-config.yaml`:
 
+> **`direnv` scaffolds opt in by default** ([#1167](https://github.com/vig-os/devkit/issues/1167)).
+> A fresh `direnv` scaffold ships `flake.nix` with `hooks = { }` already active
+> and no hand-managed `.pre-commit-config.yaml`, because the direnv CI lane runs
+> on the bare host runner where the YAML's `pymarkdown` hook cannot load (see the
+> residual note below). Everything in this section still applies — customize via
+> the `hooks`/`hooksExcludes` block; the generated config is a gitignored store
+> symlink. `container`/`both` scaffolds keep the hand-managed YAML with the block
+> commented out, and `bare` ships no flake at all.
+
 ```nix
 devShells.default = vigos.lib.mkProjectShell {
   inherit pkgs;
@@ -407,8 +416,12 @@ The contract:
   it. To opt back out, remove the `hooks` argument and commit a plain YAML
   again.
 - **Residual:** the `pymarkdown` hook is not in nixpkgs, so the generated
-  base set does not include it (the scaffolded YAML runs it from its upstream
-  pre-commit repo). Add it as a custom hook if you need it under generation.
+  base set does not include it (the hand-managed YAML runs it from its upstream
+  pre-commit repo, which only loads inside the devkit image — its native
+  `pyjson5` fails with `ImportError: libstdc++.so.6` on the bare host runner the
+  `direnv`/`bare` CI lanes use, which is why `direnv` defaults to generation,
+  [#1167](https://github.com/vig-os/devkit/issues/1167)). Add it as a custom
+  hook if you need it under generation.
 - The planned declarative `.vig-os` manifest
   ([#885](https://github.com/vig-os/devkit/issues/885)) will carry an
   explicit raw-YAML opt-out flag so the choice is recorded per-repo rather

--- a/tests/bats/init-workspace.bats
+++ b/tests/bats/init-workspace.bats
@@ -342,6 +342,78 @@ _scaffold() {
     assert_success
 }
 
+# ── direnv defaults to flake-generated pre-commit hooks (#1167) ────────────────
+# The direnv CI lane runs on the bare host runner (resolve-toolchain emits an
+# empty container image), which lacks the devkit image's FHS loader + C++
+# runtime that the hand-managed .pre-commit-config.yaml's pymarkdown hook (native
+# pyjson5) needs. A fresh direnv scaffold therefore defaults to the shared
+# flake-generated hook set (which drops pymarkdown), matching what every direnv
+# consumer converged on by hand. Container/both keep the hand-managed YAML (they
+# run inside the image where pymarkdown works); a consumer's own preserved
+# flake.nix/config is never rewritten.
+
+@test "direnv scaffold drops the hand-managed .pre-commit-config.yaml (#1167)" {
+    ws="$BATS_TEST_TMPDIR/e2e-direnv-hooks-drop"
+    mkdir -p "$ws"
+    run _scaffold direnv "$ws"
+    assert_success
+    run test -e "$ws/.pre-commit-config.yaml"
+    assert_failure
+}
+
+@test "direnv scaffold activates flake-generated hooks in flake.nix (#1167)" {
+    ws="$BATS_TEST_TMPDIR/e2e-direnv-hooks-flake"
+    mkdir -p "$ws"
+    run _scaffold direnv "$ws"
+    assert_success
+    run grep -Eq '^[[:space:]]*hooks = \{ \};' "$ws/flake.nix"
+    assert_success
+}
+
+@test "direnv scaffold gitignores the generated .pre-commit-config.yaml (#1167)" {
+    ws="$BATS_TEST_TMPDIR/e2e-direnv-hooks-gitignore"
+    mkdir -p "$ws"
+    run _scaffold direnv "$ws"
+    assert_success
+    run grep -qxF '.pre-commit-config.yaml' "$ws/.gitignore"
+    assert_success
+}
+
+@test "devcontainer scaffold keeps the hand-managed .pre-commit-config.yaml (#1167)" {
+    ws="$BATS_TEST_TMPDIR/e2e-devc-hooks-keep"
+    mkdir -p "$ws"
+    run _scaffold devcontainer "$ws"
+    assert_success
+    run test -f "$ws/.pre-commit-config.yaml"
+    assert_success
+}
+
+@test "both scaffold keeps the YAML and leaves flake hooks opt-in (#1167)" {
+    ws="$BATS_TEST_TMPDIR/e2e-both-hooks-opt-in"
+    mkdir -p "$ws"
+    run _scaffold both "$ws"
+    assert_success
+    run test -f "$ws/.pre-commit-config.yaml"
+    assert_success
+    run grep -Eq '^[[:space:]]*hooks = \{ \};' "$ws/flake.nix"
+    assert_failure
+}
+
+@test "direnv --force preserves a consumer's own flake.nix and config (#1167)" {
+    ws="$BATS_TEST_TMPDIR/e2e-direnv-hooks-preserve"
+    mkdir -p "$ws"
+    printf '# SENTINEL-1167 consumer flake\n{ }\n' >"$ws/flake.nix"
+    printf '# SENTINEL-1167 consumer config\nrepos: []\n' >"$ws/.pre-commit-config.yaml"
+    run _scaffold direnv "$ws"
+    assert_success
+    # A preserved consumer flake is never rewritten with the default hooks line...
+    run grep -Eq '^[[:space:]]*hooks = \{ \};' "$ws/flake.nix"
+    assert_failure
+    # ...and their committed config survives.
+    run grep -q 'SENTINEL-1167 consumer config' "$ws/.pre-commit-config.yaml"
+    assert_success
+}
+
 # ── opt-in .devcontainer/ prune on container-less mode upgrade (#990) ──────────
 # The #738 default is non-destructive: a container→direnv/bare re-scaffold keeps
 # a populated pre-existing .devcontainer/. On a real container→direnv migration


### PR DESCRIPTION
## Summary

Closes #1167.

A fresh `direnv` scaffold now defaults to **flake-generated** pre-commit hooks instead of the hand-managed `.pre-commit-config.yaml`.

### Why

The `direnv` (and `bare`) CI lanes run on the **bare host runner** — `resolve-toolchain` emits an empty container `image`, so the job runs directly on the runner rather than inside the devkit image. The image ships the FHS dynamic loader + C++ runtime that the scaffolded YAML's `pymarkdown` hook needs (its native `pyjson5`); the host runner does not, so the hook fails with `ImportError: libstdc++.so.6`. Both existing direnv consumers (commit-action, sync-issues-action) had already switched to flake-generated hooks by hand. Observed during the 1.3.1 rollout on `vig-os/org-config`.

### What changed

- `assets/init-workspace.sh`: on a **fresh** `direnv` scaffold, activate an empty `hooks = { };` in `flake.nix` (deterministic single insert after the unique `extraPackages` line) and drop the seeded `.pre-commit-config.yaml`. The shared flake hook set then generates the config as a `/nix/store` symlink, which is gitignored from the first scaffold (`render_gitignore` gains a `FLAKE_HOOKS_DEFAULT` path so the ignore is seeded before the symlink exists).
- Guarded on a fresh scaffold: a consumer's own **preserved** `flake.nix` or committed `.pre-commit-config.yaml` is never rewritten.
- Out of scope by design: `container`/`both` keep the hand-managed YAML (they run inside the image where `pymarkdown` works); `bare` ships no `flake.nix` (it prunes it) and the consumer owns its own toolchain there.
- Docs: `docs/MIGRATION.md` pre-commit opt-in section + residual note; `CHANGELOG.md`.

### Testing

- TDD: 6 new bats cases in `tests/bats/init-workspace.bats` (drop YAML, activate hooks, gitignore seed; container/both keep YAML + opt-in; consumer files preserved).
- Full `init-workspace.bats` suite green (218 tests); `test_scaffold_lint.py` + `test_install_script.py` green.
- End-to-end: generated `flake.nix` passes `nix-instantiate --parse` and is `nixfmt --check` clean.
- Full `pre-commit run --all-files` green.

Refs: #1167