### PR TITLE
docs(scaffold): document enabling the dependency graph for new consumers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Document enabling the dependency graph on new public consumers** ([#1166](https://github.com/vig-os/devkit/issues/1166))
+  - The scaffolded `ci.yml` Dependency Review gate reads GitHub's dependency
+    graph, which the `vig-os` org leaves **disabled** on new repos
+    (`dependency_graph_enabled_for_new_repositories: false`) — so a fresh public
+    consumer's first run `403`s until it is enabled. `docs/MIGRATION.md` gains an
+    "Enable the dependency graph on new public consumers" step (idempotent
+    `gh api -X PUT repos/<owner>/<repo>/vulnerability-alerts`, one-time per repo,
+    mode-agnostic), and the scaffolded `ci.yml` `dependency-review` job carries a
+    pointer comment at the failure site. Private consumers are unaffected (the
+    gate is neutral there).
+
 ### Changed
 
 ### Deprecated

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Document enabling the dependency graph on new public consumers** ([#1166](https://github.com/vig-os/devkit/issues/1166))
+  - The scaffolded `ci.yml` Dependency Review gate reads GitHub's dependency
+    graph, which the `vig-os` org leaves **disabled** on new repos
+    (`dependency_graph_enabled_for_new_repositories: false`) — so a fresh public
+    consumer's first run `403`s until it is enabled. `docs/MIGRATION.md` gains an
+    "Enable the dependency graph on new public consumers" step (idempotent
+    `gh api -X PUT repos/<owner>/<repo>/vulnerability-alerts`, one-time per repo,
+    mode-agnostic), and the scaffolded `ci.yml` `dependency-review` job carries a
+    pointer comment at the failure site. Private consumers are unaffected (the
+    gate is neutral there).
+
 ### Changed
 
 ### Deprecated

--- a/assets/workspace/.github/workflows/ci.yml
+++ b/assets/workspace/.github/workflows/ci.yml
@@ -244,6 +244,11 @@ jobs:
   # API is unavailable on Free-plan private repos, so private repos get a
   # skipped (neutral) run instead of a permanently red one, and a repo later
   # flipped public starts gating automatically with no re-scaffold (#1039).
+  #
+  # First run on a NEW public repo returns 403 if the org disables the dependency
+  # graph for new repos (dependency_graph_enabled_for_new_repositories: false).
+  # Enable it once (repo admin), the same toggle as Settings > Security >
+  # Dependency graph: gh api -X PUT repos/OWNER/REPO/vulnerability-alerts (#1166).
   dependency-review:
     name: Dependency Review
     runs-on: ubuntu-24.04

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -125,6 +125,31 @@ Free-plan private repos; OpenSSF Scorecard is public-only), so private consumers
 get a skipped (neutral) run instead of a permanently red one. A repo later
 flipped public starts scanning automatically, with no re-scaffold.
 
+### Enable the dependency graph on new public consumers
+
+The scaffolded `ci.yml` also ships a **Dependency Review** gate that blocks PRs
+introducing known-vulnerable dependencies
+([#1140](https://github.com/vig-os/devkit/issues/1140)). Like the scans above it
+is guarded to public repos, because the dependency-graph API it reads is
+unavailable on Free-plan private repos.
+
+On a **public** repo the dependency graph is normally on by default — but the
+`vig-os` org creates new repos with it **disabled**
+(`dependency_graph_enabled_for_new_repositories: false`), so a fresh public
+consumer's first Dependency Review run returns `403` until the graph is turned
+on. Enable it once when provisioning a new public consumer (needs repo admin) —
+the same idempotent endpoint the repo's *Settings → Security → Dependency graph*
+toggle calls:
+
+```bash
+gh api -X PUT "repos/<owner>/<repo>/vulnerability-alerts"
+```
+
+This is a one-time, per-repo step run by no scaffold script, so it applies in
+every delivery mode. A private consumer can skip it — the gate is neutral there
+and starts working automatically if the repo is later flipped public
+([#1166](https://github.com/vig-os/devkit/issues/1166)).
+
 ## The `.vig-os` project manifest
 
 Since [#885](https://github.com/vig-os/devkit/issues/885), `.vig-os` is


### PR DESCRIPTION
## Summary

Closes #1166.

Documents the one-time provisioning step that a new **public** consumer needs so the scaffolded `ci.yml` **Dependency Review** gate passes out of the box.

### Why

The scaffold's Dependency Review job (added in #1140) reads GitHub's dependency graph. On a public repo the graph is normally on by default, but the `vig-os` org creates new repos with `dependency_graph_enabled_for_new_repositories: false`, so a fresh public consumer's first run **403s** until the graph is enabled. Observed during the 1.3.1 rollout on `vig-os/org-config` and fixed there manually with `gh api -X PUT .../vulnerability-alerts`.

Per the review decision this is **documentation only** — no scaffold script enables the graph (the observed repo is `direnv`, which runs no container provisioning script anyway), so the fix lands where every mode sees it: the onboarding doc plus a pointer at the failure site.

### What changed

- `docs/MIGRATION.md`: new "Enable the dependency graph on new public consumers" step next to the existing CodeQL/Scorecard private-repo guard notes — the idempotent `gh api -X PUT repos/<owner>/<repo>/vulnerability-alerts` command (the same toggle as *Settings → Security → Dependency graph*), one-time and mode-agnostic.
- `assets/workspace/.github/workflows/ci.yml`: a pointer comment on the `dependency-review` job so a maintainer hitting the 403 finds the fix at the failure site.
- `CHANGELOG.md`.

No code/runtime surface → no TDD; `test_scaffold_lint.py` (34) green and full `pre-commit run --all-files` green.

Refs: #1166