### PR TITLE
feat(ci): route scaffolded ci.yml jobs to self-hosted runners via .vig-os

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Route scaffolded CI jobs to self-hosted runners via `.vig-os`** ([#1173](https://github.com/vig-os/devkit/issues/1173))
+  - New optional `.vig-os` key `DEVKIT_CI_RUNNER` (comma-separated runner label
+    list, e.g. `self-hosted,linux,x64,meatgrinder`) lets a self-hosted consumer
+    route the scaffold-managed `ci.yml` onto its own runners without hand-editing
+    a managed file (hand-edits are clobbered on upgrade). `resolve-toolchain`
+    reads the key and emits a `runner-json` output — a JSON array of labels,
+    defaulting to `["ubuntu-24.04"]` when the key is absent — which the toolchain
+    jobs (`lint`, `test`, `commit-checks`) and the `summary` gate consume via
+    `runs-on: ${{ fromJSON(needs.resolve-toolchain.outputs.runner-json) }}`. The
+    `resolve-toolchain` job itself stays on the hosted default (it produces the
+    output), and `dependency-review` stays hosted (public-repo-only,
+    toolchain-free). Absent key => unchanged behavior for every existing
+    consumer; the value is persisted across re-scaffolds like the other manifest
+    keys. Documented in `docs/MIGRATION.md`.
 - **Document enabling the dependency graph on new public consumers** ([#1166](https://github.com/vig-os/devkit/issues/1166))
   - The scaffolded `ci.yml` Dependency Review gate reads GitHub's dependency
     graph, which the `vig-os` org leaves **disabled** on new repos

--- a/assets/init-workspace.sh
+++ b/assets/init-workspace.sh
@@ -294,6 +294,7 @@ MANIFEST_REPO="$(read_manifest_value "$VIG_OS_MANIFEST" DEVKIT_REPO || true)"
 MANIFEST_MODULES="$(read_manifest_value "$VIG_OS_MANIFEST" DEVKIT_MODULES || true)"
 MANIFEST_TAG_PREFIX="$(read_manifest_value "$VIG_OS_MANIFEST" DEVKIT_TAG_PREFIX || true)"
 MANIFEST_FLOATING_TAGS="$(read_manifest_value "$VIG_OS_MANIFEST" DEVKIT_FLOATING_TAGS || true)"
+MANIFEST_CI_RUNNER="$(read_manifest_value "$VIG_OS_MANIFEST" DEVKIT_CI_RUNNER || true)"
 
 # The OWNER/REPO placeholder (written when no origin was resolvable) must not
 # mask a now-detectable git origin on a later upgrade.
@@ -1404,8 +1405,9 @@ render_codeql_matrix
 # needs no mode/identity flags at all. A consumer's DEVKIT_MODULES
 # declaration (#884, read before the template overwrite) is restored too, as
 # are the DEVKIT_TAG_PREFIX / DEVKIT_FLOATING_TAGS release tag-scheme keys
-# (#1116, read before the overwrite) — the template ships them empty, so
-# without a write-back an upgrade would silently reset a consumer's tag scheme.
+# (#1116, read before the overwrite) and the DEVKIT_CI_RUNNER runner override
+# (#1173) — the template ships them empty, so without a write-back an upgrade
+# would silently reset a consumer's tag scheme or self-hosted runner selection.
 if [[ -f "$VIG_OS_MANIFEST" ]]; then
     echo "Persisting resolved manifest values in .vig-os..."
     write_manifest_value DEVKIT_MODE "$MODE"
@@ -1422,6 +1424,12 @@ if [[ -f "$VIG_OS_MANIFEST" ]]; then
     fi
     if [[ -n "$MANIFEST_FLOATING_TAGS" ]]; then
         write_manifest_value DEVKIT_FLOATING_TAGS "$MANIFEST_FLOATING_TAGS"
+    fi
+    # CI runner override (#1173): bare in the template (DEVKIT_CI_RUNNER=), so a
+    # self-hosted consumer's label list is read before the overwrite and written
+    # back — else an upgrade silently resets ci.yml onto the hosted default.
+    if [[ -n "$MANIFEST_CI_RUNNER" ]]; then
+        write_manifest_value DEVKIT_CI_RUNNER "$MANIFEST_CI_RUNNER"
     fi
 fi
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Route scaffolded CI jobs to self-hosted runners via `.vig-os`** ([#1173](https://github.com/vig-os/devkit/issues/1173))
+  - New optional `.vig-os` key `DEVKIT_CI_RUNNER` (comma-separated runner label
+    list, e.g. `self-hosted,linux,x64,meatgrinder`) lets a self-hosted consumer
+    route the scaffold-managed `ci.yml` onto its own runners without hand-editing
+    a managed file (hand-edits are clobbered on upgrade). `resolve-toolchain`
+    reads the key and emits a `runner-json` output — a JSON array of labels,
+    defaulting to `["ubuntu-24.04"]` when the key is absent — which the toolchain
+    jobs (`lint`, `test`, `commit-checks`) and the `summary` gate consume via
+    `runs-on: ${{ fromJSON(needs.resolve-toolchain.outputs.runner-json) }}`. The
+    `resolve-toolchain` job itself stays on the hosted default (it produces the
+    output), and `dependency-review` stays hosted (public-repo-only,
+    toolchain-free). Absent key => unchanged behavior for every existing
+    consumer; the value is persisted across re-scaffolds like the other manifest
+    keys. Documented in `docs/MIGRATION.md`.
 - **Document enabling the dependency graph on new public consumers** ([#1166](https://github.com/vig-os/devkit/issues/1166))
   - The scaffolded `ci.yml` Dependency Review gate reads GitHub's dependency
     graph, which the `vig-os` org leaves **disabled** on new repos

--- a/assets/workspace/.github/actions/resolve-toolchain/action.yml
+++ b/assets/workspace/.github/actions/resolve-toolchain/action.yml
@@ -59,6 +59,12 @@ outputs:
   floating-tags:
     description: Floating tag levels from DEVKIT_FLOATING_TAGS (subset of major,minor; empty => off)
     value: ${{ steps.resolve.outputs.floating-tags }}
+  runner-json:
+    description: >-
+      JSON array of runner labels from DEVKIT_CI_RUNNER (comma-separated), for
+      `runs-on: ${{ fromJSON(...) }}`. Defaults to ["ubuntu-24.04"] when the key
+      is absent.
+    value: ${{ steps.resolve.outputs.runner-json }}
 
 runs:
   using: composite
@@ -76,6 +82,7 @@ runs:
         LEGACY_VERSION=""
         TAG_PREFIX=""
         FLOATING_TAGS=""
+        CI_RUNNER=""
 
         if [[ -f .vig-os ]]; then
           # Tolerant KEY=VALUE parsing shared with resolve-image (#781): capture
@@ -87,7 +94,7 @@ runs:
             [[ "$line" =~ ^[[:space:]]*# ]] && continue
 
             case "$line" in
-              DEVKIT_MODE=*|DEVKIT_VERSION=*|DEVCONTAINER_VERSION=*|DEVKIT_TAG_PREFIX=*|DEVKIT_FLOATING_TAGS=*)
+              DEVKIT_MODE=*|DEVKIT_VERSION=*|DEVCONTAINER_VERSION=*|DEVKIT_TAG_PREFIX=*|DEVKIT_FLOATING_TAGS=*|DEVKIT_CI_RUNNER=*)
                 key="${line%%=*}"
                 value="${line#*=}"
                 value="${value#"${value%%[![:space:]]*}"}"
@@ -105,6 +112,7 @@ runs:
                   DEVCONTAINER_VERSION) LEGACY_VERSION="$value" ;;
                   DEVKIT_TAG_PREFIX) TAG_PREFIX="$value" ;;
                   DEVKIT_FLOATING_TAGS) FLOATING_TAGS="$value" ;;
+                  DEVKIT_CI_RUNNER) CI_RUNNER="$value" ;;
                 esac
                 ;;
             esac
@@ -136,6 +144,28 @@ runs:
         # empty by default (= off). Only promote-release consumes it, force-moving
         # <prefix>X / <prefix>X.Y at the final release commit.
         echo "floating-tags=$FLOATING_TAGS" >> "$GITHUB_OUTPUT"
+
+        # CI runner labels (#1173): DEVKIT_CI_RUNNER is a comma-separated label
+        # list routed into `runs-on: ${{ fromJSON(...) }}` by the downstream CI
+        # jobs. Absent => the hosted default, so existing consumers are unchanged.
+        # Emitted for every mode, ALWAYS a valid JSON array (single label =>
+        # ["ubuntu-24.04"]); whitespace around each label is trimmed and empty
+        # entries dropped so a trailing/spaced comma never yields a blank label.
+        CI_RUNNER="${CI_RUNNER:-ubuntu-24.04}"
+        RUNNER_JSON="["
+        runner_first=1
+        IFS=',' read -ra runner_labels <<< "$CI_RUNNER"
+        for label in "${runner_labels[@]}"; do
+          label="${label#"${label%%[![:space:]]*}"}"
+          label="${label%"${label##*[![:space:]]}"}"
+          [[ -z "$label" ]] && continue
+          if [[ "$runner_first" -eq 1 ]]; then runner_first=0; else RUNNER_JSON+=","; fi
+          RUNNER_JSON+="\"$label\""
+        done
+        # An all-blank value (e.g. DEVKIT_CI_RUNNER=" ,") falls back to the default.
+        [[ "$runner_first" -eq 1 ]] && RUNNER_JSON+="\"ubuntu-24.04\""
+        RUNNER_JSON+="]"
+        echo "runner-json=$RUNNER_JSON" >> "$GITHUB_OUTPUT"
 
         # Resolve the version tag: explicit override wins, else DEVKIT_VERSION,
         # else the legacy DEVCONTAINER_VERSION.

--- a/assets/workspace/.github/workflows/ci.yml
+++ b/assets/workspace/.github/workflows/ci.yml
@@ -19,6 +19,16 @@
 # This collapses the former per-mode ci.yml overlays (container / direnv / bare)
 # into a single managed file (#991).
 #
+# Runner selection (#1173): `resolve-toolchain` also emits `runner-json`, a JSON
+# array of runner labels from the optional `.vig-os` key `DEVKIT_CI_RUNNER`
+# (comma-separated; absent => the hosted default). The toolchain jobs (lint,
+# test, commit-checks) and the summary gate declare
+# `runs-on: ${{ fromJSON(needs.resolve-toolchain.outputs.runner-json) }}`, so a
+# self-hosted consumer routes them onto its own runners without hand-editing this
+# managed file. `resolve-toolchain` itself stays on the hosted default (it
+# produces the output — chicken-and-egg); `dependency-review` stays hosted too
+# (public-repo-only, toolchain-free, and reads GitHub's dependency-graph API).
+#
 # Jobs:
 #   1. resolve-toolchain — Resolve delivery mode + image from .vig-os
 #   2. lint              — Pre-commit hooks
@@ -69,6 +79,7 @@ jobs:
       mode: ${{ steps.resolve.outputs.mode }}
       image: ${{ steps.resolve.outputs.image }}
       image-tag: ${{ steps.resolve.outputs.image-tag }}
+      runner-json: ${{ steps.resolve.outputs.runner-json }}
 
     steps:
       - name: Checkout repository
@@ -90,7 +101,7 @@ jobs:
   lint:
     name: Lint & Format
     needs: [resolve-toolchain]
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(needs.resolve-toolchain.outputs.runner-json) }}
     # Empty image (direnv/bare) => runs on the host; non-empty => in-container.
     # The credentials block is inert on the host (proven by the #992 spike).
     container:
@@ -128,7 +139,7 @@ jobs:
   test:
     name: Tests
     needs: [resolve-toolchain]
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(needs.resolve-toolchain.outputs.runner-json) }}
     container:
       image: ${{ needs.resolve-toolchain.outputs.image }}
       credentials:
@@ -166,7 +177,7 @@ jobs:
   commit-checks:
     name: Commit Messages
     needs: [resolve-toolchain]
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(needs.resolve-toolchain.outputs.runner-json) }}
     container:
       image: ${{ needs.resolve-toolchain.outputs.image }}
       credentials:
@@ -269,7 +280,7 @@ jobs:
 
   summary:
     name: CI Summary
-    runs-on: ubuntu-24.04
+    runs-on: ${{ fromJSON(needs.resolve-toolchain.outputs.runner-json) }}
     timeout-minutes: 5
     needs: [resolve-toolchain, lint, test, commit-checks, dependency-review]
     if: always()

--- a/assets/workspace/.vig-os
+++ b/assets/workspace/.vig-os
@@ -36,3 +36,11 @@ DEVKIT_TAG_PREFIX=
 # `major,minor` moves <prefix>X and <prefix>X.Y so consumers can pin
 # `uses: owner/repo@v0`. Composes with DEVKIT_TAG_PREFIX; final releases only (#1045).
 DEVKIT_FLOATING_TAGS=
+
+# CI runner labels for the scaffolded ci.yml toolchain jobs (lint, test,
+# commit-checks) and the summary gate — comma-separated, e.g.
+# `self-hosted,linux,x64,meatgrinder`. Empty (default) => the hosted `ubuntu-24.04`
+# runner (no change for existing consumers). Routed into `runs-on` via
+# resolve-toolchain's `runner-json` output; the resolve-toolchain and
+# dependency-review jobs always stay on the hosted default (#1173).
+DEVKIT_CI_RUNNER=

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -150,6 +150,39 @@ every delivery mode. A private consumer can skip it — the gate is neutral ther
 and starts working automatically if the repo is later flipped public
 ([#1166](https://github.com/vig-os/devkit/issues/1166)).
 
+### Run CI on self-hosted runners
+
+`ci.yml` defaults to GitHub-hosted `ubuntu-24.04` runners. A consumer whose org
+runs its CI on self-hosted runners (e.g. GitHub billing blocks hosted runners
+for heavy jobs) sets the optional `.vig-os` key `DEVKIT_CI_RUNNER` to a
+**comma-separated runner label list** instead of hand-editing the
+scaffold-managed workflow (hand-edits to `runs-on` are clobbered on the next
+upgrade):
+
+```ini
+# .vig-os
+DEVKIT_CI_RUNNER=self-hosted,linux,x64,meatgrinder
+```
+
+`resolve-toolchain` reads the key and emits a `runner-json` output — a JSON array
+of the labels (`["self-hosted","linux","x64","meatgrinder"]`), or
+`["ubuntu-24.04"]` when the key is absent — and the toolchain jobs (`lint`,
+`test`, `commit-checks`) plus the `summary` gate declare
+`runs-on: ${{ fromJSON(needs.resolve-toolchain.outputs.runner-json) }}`. A single
+label still emits a valid one-element array. The key is persisted across
+re-scaffolds like the other manifest keys, so an upgrade preserves it with no
+flags. Absent => unchanged behavior for every existing consumer
+([#1173](https://github.com/vig-os/devkit/issues/1173)).
+
+**Limitation — two jobs always stay hosted.** `resolve-toolchain` runs on the
+hosted default because it *produces* `runner-json` (a job cannot depend on its
+own output — chicken-and-egg); it is a seconds-long sparse checkout.
+`dependency-review` also stays hosted: it is public-repo-only (skipped on private
+repos), needs no toolchain, and reads GitHub's dependency-graph API. A consumer
+whose org **cannot run any hosted job at all** therefore still needs those two
+lanes handled separately (e.g. a repo-specific static render); this v1 keeps the
+managed workflow minimal and does not cover that case.
+
 ## The `.vig-os` project manifest
 
 Since [#885](https://github.com/vig-os/devkit/issues/885), `.vig-os` is
@@ -165,6 +198,7 @@ unknown keys:
 | `DEVKIT_ORG` | Persisted organization name (`ORG_NAME`) |
 | `DEVKIT_REPO` | Persisted GitHub `owner/repo` (Renovate preset) |
 | `DEVKIT_MODULES` | Reserved: space-separated capability modules mirroring `mkProjectShell`'s `modules = [ … ]` ([#884](https://github.com/vig-os/devkit/issues/884)) |
+| `DEVKIT_CI_RUNNER` | Comma-separated runner label list for the scaffolded `ci.yml` toolchain jobs; empty (default) => the hosted `ubuntu-24.04` runner ([#1173](https://github.com/vig-os/devkit/issues/1173)) |
 
 How it behaves:
 

--- a/tests/bats/init-workspace.bats
+++ b/tests/bats/init-workspace.bats
@@ -2077,6 +2077,26 @@ _upgrade_no_flags() {
     assert_success
 }
 
+@test "template .vig-os ships the CI runner key empty (#1173)" {
+    run grep -x 'DEVKIT_CI_RUNNER=' "$TEMPLATE_DIR/.vig-os"
+    assert_success
+}
+
+@test "upgrade preserves a persisted DEVKIT_CI_RUNNER value (#1173)" {
+    # .vig-os is a managed file, so a self-hosted consumer's DEVKIT_CI_RUNNER
+    # must be read before the template overwrite and written back — else an
+    # upgrade silently resets ci.yml's jobs onto the hosted default runner.
+    ws="$BATS_TEST_TMPDIR/e2e-1173-cirunner"
+    mkdir -p "$ws"
+    run _scaffold both "$ws"
+    assert_success
+    sed -i 's/^DEVKIT_CI_RUNNER=.*/DEVKIT_CI_RUNNER=self-hosted,linux,x64,meatgrinder/' "$ws/.vig-os"
+    run _upgrade_no_flags "$ws"
+    assert_success
+    run grep -x 'DEVKIT_CI_RUNNER=self-hosted,linux,x64,meatgrinder' "$ws/.vig-os"
+    assert_success
+}
+
 # ── legacy mode inference (#885) ──────────────────────────────────────────────
 # Consumers scaffolded before the manifest carry a version-only .vig-os (or
 # none): an upgrade without --mode must infer the delivery mode from the tree

--- a/tests/test_ci_runner.py
+++ b/tests/test_ci_runner.py
@@ -1,0 +1,152 @@
+"""Workflow-shape + behavior tests: DEVKIT_CI_RUNNER runner override.
+
+Issue #1173: a self-hosted consumer declares ``DEVKIT_CI_RUNNER`` in ``.vig-os``
+(comma-separated runner label list); ``resolve-toolchain`` reads it and emits a
+``runner-json`` output (a JSON array of labels, defaulting to the hosted runner
+when the key is absent), and the scaffolded ``ci.yml`` toolchain jobs consume it
+via ``runs-on: ${{ fromJSON(needs.resolve-toolchain.outputs.runner-json) }}``.
+
+The shape assertions pin the wiring; the executed-bash assertions pin the JSON
+emission (default, single-label, multi-label) directly against the action's real
+``run:`` script.
+
+Refs: #1173
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+# Repository root (tests/ -> repo root).
+REPO_ROOT = Path(__file__).resolve().parent.parent
+WORKSPACE = REPO_ROOT / "assets" / "workspace"
+WORKFLOWS = WORKSPACE / ".github" / "workflows"
+RESOLVE_ACTION = WORKFLOWS.parent / "actions" / "resolve-toolchain" / "action.yml"
+
+# The hosted default kept when DEVKIT_CI_RUNNER is absent.
+HOSTED_DEFAULT = "ubuntu-24.04"
+
+# The expression the runner-configurable jobs must use for runs-on.
+RUNNER_JSON_EXPR = "${{ fromJSON(needs.resolve-toolchain.outputs.runner-json) }}"
+
+# Toolchain jobs that must honor the consumer's runner override.
+RUNNER_JSON_JOBS = ("lint", "test", "commit-checks", "summary")
+
+
+def _load(path: Path) -> dict:
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def test_vig_os_declares_ci_runner_key() -> None:
+    """The scaffold manifest ships the opt-in key (default empty)."""
+    text = (WORKSPACE / ".vig-os").read_text(encoding="utf-8")
+    assert "DEVKIT_CI_RUNNER=" in text
+
+
+def test_resolve_toolchain_emits_runner_json_output() -> None:
+    """resolve-toolchain declares a runner-json output for callers to consume."""
+    action = _load(RESOLVE_ACTION)
+    assert "runner-json" in action["outputs"]
+
+
+def test_ci_toolchain_jobs_use_runner_json() -> None:
+    """lint/test/commit-checks/summary route runs-on through the resolved runner."""
+    workflow = _load(WORKFLOWS / "ci.yml")
+    for job in RUNNER_JSON_JOBS:
+        assert workflow["jobs"][job]["runs-on"] == RUNNER_JSON_EXPR
+
+
+def test_resolve_toolchain_job_stays_hosted() -> None:
+    """The producer job cannot depend on its own output — it stays hosted."""
+    workflow = _load(WORKFLOWS / "ci.yml")
+    assert workflow["jobs"]["resolve-toolchain"]["runs-on"] == HOSTED_DEFAULT
+
+
+def test_dependency_review_stays_hosted() -> None:
+    """dependency-review is public-repo-only + toolchain-free, so it stays hosted."""
+    workflow = _load(WORKFLOWS / "ci.yml")
+    assert workflow["jobs"]["dependency-review"]["runs-on"] == HOSTED_DEFAULT
+
+
+def _run_resolve(tmp_path: Path, manifest: str | None) -> dict[str, str]:
+    """Execute the resolve-toolchain step's real bash against a .vig-os manifest.
+
+    Returns the parsed GITHUB_OUTPUT key=value map.
+    """
+    action = _load(RESOLVE_ACTION)
+    script = action["runs"]["steps"][0]["run"]
+
+    if manifest is not None:
+        (tmp_path / ".vig-os").write_text(manifest, encoding="utf-8")
+
+    github_output = tmp_path / "github_output"
+    github_output.touch()
+
+    env = {
+        **os.environ,
+        "INPUT_IMAGE_TAG": "",
+        "GITHUB_OUTPUT": str(github_output),
+    }
+    subprocess.run(
+        ["bash", "-c", script],
+        cwd=tmp_path,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    outputs: dict[str, str] = {}
+    for line in github_output.read_text(encoding="utf-8").splitlines():
+        if "=" in line:
+            key, _, value = line.partition("=")
+            outputs[key] = value
+    return outputs
+
+
+def test_runner_json_defaults_to_hosted_when_key_absent(tmp_path: Path) -> None:
+    """No DEVKIT_CI_RUNNER => a valid JSON array holding the hosted default."""
+    outputs = _run_resolve(tmp_path, "DEVKIT_MODE=direnv\n")
+    assert json.loads(outputs["runner-json"]) == [HOSTED_DEFAULT]
+
+
+def test_runner_json_defaults_when_no_manifest(tmp_path: Path) -> None:
+    """No .vig-os at all still yields the hosted default array."""
+    outputs = _run_resolve(tmp_path, None)
+    assert json.loads(outputs["runner-json"]) == [HOSTED_DEFAULT]
+
+
+def test_runner_json_single_label(tmp_path: Path) -> None:
+    """A single custom label is emitted as a one-element JSON array."""
+    outputs = _run_resolve(tmp_path, "DEVKIT_MODE=direnv\nDEVKIT_CI_RUNNER=my-runner\n")
+    assert json.loads(outputs["runner-json"]) == ["my-runner"]
+
+
+def test_runner_json_multi_label(tmp_path: Path) -> None:
+    """A comma-separated label list becomes a JSON array, whitespace trimmed."""
+    outputs = _run_resolve(
+        tmp_path,
+        "DEVKIT_MODE=direnv\nDEVKIT_CI_RUNNER=self-hosted, linux, x64, meatgrinder\n",
+    )
+    assert json.loads(outputs["runner-json"]) == [
+        "self-hosted",
+        "linux",
+        "x64",
+        "meatgrinder",
+    ]
+
+
+@pytest.mark.parametrize("mode", ["direnv", "both"])
+def test_runner_json_emitted_in_every_mode(tmp_path: Path, mode: str) -> None:
+    """runner-json is emitted regardless of delivery mode."""
+    manifest = (
+        f"DEVKIT_MODE={mode}\nDEVKIT_VERSION=1.2.3\nDEVKIT_CI_RUNNER=self-hosted\n"
+    )
+    outputs = _run_resolve(tmp_path, manifest)
+    assert json.loads(outputs["runner-json"]) == ["self-hosted"]

--- a/tests/test_ci_runner.py
+++ b/tests/test_ci_runner.py
@@ -74,10 +74,14 @@ def test_dependency_review_stays_hosted() -> None:
     assert workflow["jobs"]["dependency-review"]["runs-on"] == HOSTED_DEFAULT
 
 
-def _run_resolve(tmp_path: Path, manifest: str | None) -> dict[str, str]:
+def _run_resolve(
+    tmp_path: Path, manifest: str | None, *, check: bool = True
+) -> dict[str, str]:
     """Execute the resolve-toolchain step's real bash against a .vig-os manifest.
 
-    Returns the parsed GITHUB_OUTPUT key=value map.
+    Returns the parsed GITHUB_OUTPUT key=value map. ``runner-json`` is emitted
+    early (before mode/tag resolution), so callers exercising an error path
+    (e.g. no manifest => default `both` mode with no tag) pass ``check=False``.
     """
     action = _load(RESOLVE_ACTION)
     script = action["runs"]["steps"][0]["run"]
@@ -97,7 +101,7 @@ def _run_resolve(tmp_path: Path, manifest: str | None) -> dict[str, str]:
         ["bash", "-c", script],
         cwd=tmp_path,
         env=env,
-        check=True,
+        check=check,
         capture_output=True,
         text=True,
     )
@@ -117,8 +121,12 @@ def test_runner_json_defaults_to_hosted_when_key_absent(tmp_path: Path) -> None:
 
 
 def test_runner_json_defaults_when_no_manifest(tmp_path: Path) -> None:
-    """No .vig-os at all still yields the hosted default array."""
-    outputs = _run_resolve(tmp_path, None)
+    """No .vig-os at all still yields the hosted default array.
+
+    The default `both` mode then errors on the missing tag (an unrelated
+    production error path), but runner-json is emitted before that exit.
+    """
+    outputs = _run_resolve(tmp_path, None, check=False)
     assert json.loads(outputs["runner-json"]) == [HOSTED_DEFAULT]
 
 


### PR DESCRIPTION
## Summary

Closes #1173.

Adds an optional `.vig-os` key `DEVKIT_CI_RUNNER` (comma-separated runner labels, e.g. `self-hosted,linux,x64,meatgrinder`). The scaffold `resolve-toolchain` action emits a new `runner-json` output (always a valid JSON array; absent/blank key => `["ubuntu-24.04"]`, so existing consumers are byte-for-byte unchanged), and the scaffolded `ci.yml` routes `lint`, `test`, `commit-checks`, and the `summary` gate through `runs-on: ${{ fromJSON(needs.resolve-toolchain.outputs.runner-json) }}`.

- `resolve-toolchain` stays hosted (chicken-and-egg: it produces the output) and `dependency-review` stays hosted (public-repo-only, toolchain-free, reads GitHub's dependency-graph API) — documented as a v1 limitation in `docs/MIGRATION.md`.
- `init-workspace.sh` persists `DEVKIT_CI_RUNNER` across re-scaffolds like the #1116 tag-scheme keys, so upgrades don't silently reset a consumer onto hosted runners.
- No installer flag (v1 minimal per the issue): consumers set the key by editing `.vig-os`.

Motivating consumer: exo-pet/exo-fleet (self-hosted CI per its ADR-0022; `ci.yml` is scaffold-managed so hand-edits are clobbered on upgrade).

## Verification

- TDD: RED commit `2ce19443` (11 pytest cases exercising the action's real `run:` bash against temp manifests: default/single/multi-label/whitespace/per-mode + ci.yml wiring assertions; 2 bats cases for template key + upgrade persistence) → GREEN `d967139b` → docs `37991149`.
- `uv run pytest tests/test_ci_runner.py -q` → 11 passed; `bats tests/bats/init-workspace.bats --filter 1173` → 2 passed (re-run by the reviewing session, not just the implementing agent).
- `actionlint` clean on the touched workflow; full `prek run --all-files` green in the dev shell; working tree clean.