### PR TITLE
feat(hooks): add gitleaks as an opt-in default-disabled hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Opt-in `gitleaks` secret-scanning hook** ([#1172](https://github.com/vig-os/devkit/issues/1172))
+  - `gitleaks` joins the shared toolchain (`nix/devtools.nix` → dev-shell,
+    image, and `vigos.packages`) and is defined as a `language: system`
+    pre-commit hook resolved from the pinned nixpkgs binary — no upstream
+    pre-commit repo clone, works offline. It is **default-disabled** and lives
+    only on the `mkProjectShell` consumer generation surface: absent from
+    devkit's own committed `.pre-commit-config.yaml`, the scaffold copy, and the
+    sandbox `checks.pre-commit` gate, so no devkit lane runs it. A secret-bearing
+    consumer opts in with `mkProjectShell { hooks = { gitleaks.enable = true; }; }`;
+    the hook runs `gitleaks git --pre-commit --staged --redact --verbose` and a
+    repo-root `.gitleaks.toml` is honored automatically. Off by default because
+    false-positive tuning is repo-specific (`docs/NIX.md`). Backward compatible:
+    zero behavior change for consumers that do not enable it.
 - **Document enabling the dependency graph on new public consumers** ([#1166](https://github.com/vig-os/devkit/issues/1166))
   - The scaffolded `ci.yml` Dependency Review gate reads GitHub's dependency
     graph, which the `vig-os` org leaves **disabled** on new repos

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Opt-in `gitleaks` secret-scanning hook** ([#1172](https://github.com/vig-os/devkit/issues/1172))
+  - `gitleaks` joins the shared toolchain (`nix/devtools.nix` → dev-shell,
+    image, and `vigos.packages`) and is defined as a `language: system`
+    pre-commit hook resolved from the pinned nixpkgs binary — no upstream
+    pre-commit repo clone, works offline. It is **default-disabled** and lives
+    only on the `mkProjectShell` consumer generation surface: absent from
+    devkit's own committed `.pre-commit-config.yaml`, the scaffold copy, and the
+    sandbox `checks.pre-commit` gate, so no devkit lane runs it. A secret-bearing
+    consumer opts in with `mkProjectShell { hooks = { gitleaks.enable = true; }; }`;
+    the hook runs `gitleaks git --pre-commit --staged --redact --verbose` and a
+    repo-root `.gitleaks.toml` is honored automatically. Off by default because
+    false-positive tuning is repo-specific (`docs/NIX.md`). Backward compatible:
+    zero behavior change for consumers that do not enable it.
 - **Document enabling the dependency graph on new public consumers** ([#1166](https://github.com/vig-os/devkit/issues/1166))
   - The scaffolded `ci.yml` Dependency Review gate reads GitHub's dependency
     graph, which the `vig-os` org leaves **disabled** on new repos

--- a/docs/NIX.md
+++ b/docs/NIX.md
@@ -392,6 +392,31 @@ These are decided inline in `flake.nix`; summarized here.
      overwritten (#878) and the planned `.vig-os` manifest opt-out flag
      (#885).
 
+### Opt-in `gitleaks` secret scanning (#1172)
+
+`gitleaks` ships in the toolchain (`nix/devtools.nix` → dev-shell, image, and
+`vigos.packages`) and is defined as a `language: system` hook, but it is
+**default-disabled** and lives only on the consumer generation surface — it is
+absent from devkit's own committed `.pre-commit-config.yaml`, the scaffold copy,
+and the sandbox `checks.pre-commit` gate, so no devkit lane runs it. A
+secret-bearing consumer opts in from its project flake:
+
+```nix
+devShells.default = vigos.lib.mkProjectShell {
+  inherit pkgs;
+  hooks = { gitleaks.enable = true; };
+};
+```
+
+The hook runs `gitleaks git --pre-commit --staged --redact --verbose` (the
+v8.19+ invocation) resolved from the pinned nixpkgs binary — no upstream
+pre-commit repo clone, and it works offline. A repo-root `.gitleaks.toml` is
+picked up by gitleaks automatically; no extra plumbing is needed to tune
+allowlists. It is off by default deliberately: false-positive tuning is
+repo-specific, and a red first `just precommit` on every existing consumer would
+be a poor upgrade experience — so devkit ships no `.gitleaks.toml` and never
+enables it for itself.
+
   Hooks that cannot run in the sandbox stay **runner-only** in the committed
   render and carry no gate profile in `nix/hooks.nix`: the generators
   `generate-docs`/`sync-manifest`, `pip-licenses` (reads `uv.lock`), `pymarkdown`

--- a/nix/devtools.nix
+++ b/nix/devtools.nix
@@ -55,6 +55,7 @@ with pkgs;
   deadnix # dead-Nix-code linter (flake `checks.deadnix`)
   statix # nix anti-pattern linter (flake `checks.statix`)
   actionlint # GitHub Actions workflow linter (pre-commit hook, #995)
+  gitleaks # secret scanner (opt-in `language: system` pre-commit hook, #1172)
 
   # Container runtime
   podman

--- a/nix/hooks.nix
+++ b/nix/hooks.nix
@@ -382,6 +382,25 @@ let
         excludes = [ shellcheckExclude ];
       };
     };
+    # Secret scanner (#1172). Opt-in and default-DISABLED: it carries no
+    # `yaml` (absent from the committed runner and scaffold configs) and no
+    # `check` (absent from the sandbox gate), so devkit's own lanes never run
+    # it — gitleaks needs a repo-specific `.gitleaks.toml` to tune false
+    # positives and devkit ships none. It lives only on the consumer
+    # generation surface with `enable = false`, so a secret-bearing consumer
+    # opts in with `mkProjectShell { hooks = { gitleaks.enable = true; }; }`.
+    # A repo-root `.gitleaks.toml` is picked up by gitleaks automatically — no
+    # extra plumbing. v8.19+ invocation form (`gitleaks git --pre-commit`; the
+    # nixpkgs pin is 8.30.x). Refs #1172.
+    gitleaks = {
+      consumer = pkgs: {
+        enable = false;
+        name = "gitleaks";
+        entry = "${pkgs.gitleaks}/bin/gitleaks git --pre-commit --staged --redact --verbose";
+        language = "system";
+        pass_filenames = false;
+      };
+    };
     # GitHub Actions workflow linter (#995). Runner-only and devkit-only: it
     # lints THIS repo's own .github/workflows/ via actionlint's auto-discovery
     # (pass_filenames = false). Not scaffolded to consumers and not in the

--- a/tests/test_flake_hooks.py
+++ b/tests/test_flake_hooks.py
@@ -320,6 +320,72 @@ def consumer_config() -> dict[str, Any]:
 
 
 @pytest.fixture(scope="module")
+def gitleaks_enabled_config() -> dict[str, Any]:
+    """Generated config for a consumer that opts into the gitleaks hook (#1172)."""
+    expr = f"""
+    let
+      flake = builtins.getFlake "path:{REPO_ROOT}";
+      system = builtins.currentSystem;
+      pkgs = import flake.inputs.nixpkgs {{ inherit system; }};
+      shell = flake.lib.mkProjectShell {{
+        inherit pkgs;
+        hooks = {{
+          gitleaks.enable = true;
+        }};
+      }};
+    in
+    shell.hooksConfigFile
+    """
+    result = _run_nix(
+        ["build", "--impure", "--no-link", "--print-out-paths", "--expr", expr],
+        timeout=1800,
+    )
+    assert result.returncode == 0, (
+        "building the gitleaks-enabled hook config failed:\n" + result.stderr
+    )
+    return yaml.safe_load(Path(result.stdout.strip()).read_text())
+
+
+class TestGitleaksOptInHook:
+    """gitleaks is an opt-in, default-disabled consumer hook (#1172).
+
+    It carries no runner/scaffold render and no sandbox-gate profile (devkit's
+    own lanes never run it — there is no repo-root ``.gitleaks.toml`` tuning),
+    and it stays off the consumer surface until a consumer sets
+    ``gitleaks.enable = true``.
+    """
+
+    def test_gitleaks_absent_from_runner_render(
+        self, rendered_portable: dict[str, Any]
+    ) -> None:
+        """devkit's own committed .pre-commit-config.yaml never runs gitleaks."""
+        assert "gitleaks" not in _normalize(rendered_portable["runner"])["hooks"]
+
+    def test_gitleaks_absent_from_scaffold_render(
+        self, rendered_portable: dict[str, Any]
+    ) -> None:
+        """The scaffolded consumer config does not ship gitleaks."""
+        assert "gitleaks" not in _normalize(rendered_portable["scaffold"])["hooks"]
+
+    def test_gitleaks_disabled_by_default_on_consumer_surface(
+        self, consumer_config: dict[str, Any]
+    ) -> None:
+        """A consumer that does not opt in gets no gitleaks hook."""
+        assert "gitleaks" not in _normalize(consumer_config)["hooks"]
+
+    def test_gitleaks_rendered_when_enabled(
+        self, gitleaks_enabled_config: dict[str, Any]
+    ) -> None:
+        """Opting in renders gitleaks with the v8.19+ pre-commit invocation."""
+        hooks = _normalize(gitleaks_enabled_config)["hooks"]
+        assert "gitleaks" in hooks, "gitleaks.enable = true did not render the hook"
+        entry = hooks["gitleaks"]["entry"]
+        assert "gitleaks git --pre-commit --staged --redact --verbose" in entry
+        assert hooks["gitleaks"]["language"] == "system"
+        assert hooks["gitleaks"]["pass_filenames"] is False
+
+
+@pytest.fixture(scope="module")
 def default_shellhook() -> str:
     """The shellHook of the flake's own default dev-shell (``hooks = null``)."""
     result = _run_nix(["eval", "--raw", ".#devShells.x86_64-linux.default.shellHook"])


### PR DESCRIPTION
## Summary

Closes #1172.

Adds `gitleaks` (nixpkgs pin: 8.30.1) to the toolchain SSoT (`nix/devtools.nix` — dev-shell + image + `vigos.packages`) and defines it as an **opt-in, default-disabled** hook on the consumer flake hook surface only:

- Consumers enable it with `mkProjectShell { hooks = { gitleaks.enable = true; }; }`; the base hookDef ships `enable = false` (base values are `mkOverride 999`, so a plain consumer `enable = true` wins).
- `language: system`, store-path entry `gitleaks git --pre-commit --staged --redact --verbose` (v8.19+ form) — offline, no upstream repo clone/build. This retires the `SKIP=gitleaks` pattern secret-bearing consumers (exo-fleet) use today.
- Deliberately absent from devkit's own lanes: no `yaml` (not in the committed runner/scaffold configs — enforced by the existing drift gate + explicit absence tests) and no `check` (not in the sandbox gate), since devkit ships no `.gitleaks.toml` and false-positive tuning is repo-specific.
- A repo-root `.gitleaks.toml` is auto-discovered by gitleaks; documented in `docs/NIX.md` ("Opt-in gitleaks secret scanning").

## Verification

- TDD: RED `16d79cbc` (enabled-case eval failed on missing hookDef; absence cases pass) → GREEN `3bc43f52` → docs `4513f7b3`.
- `pytest tests/test_flake_hooks.py` → 27 passed (4 new: enabled render contains the hook with the right invocation; default render, committed YAMLs, and sandbox gate all exclude it) — re-run by the reviewing session.
- `gitleaks version` → 8.30.1; `gitleaks git --help` confirms the flags.
- Full `prek run --all-files` in the dev shell: green, working tree clean (re-run by the reviewing session).

## Notes

- No live end-to-end exercise in a secret-bearing consumer yet — that lands with the exo-fleet deployment (its tuned `.gitleaks.toml` is the real test).