### PR TITLE
feat(scaffold): nix consumer support — detection, gitignore fragment, statix/deadnix hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Nix as a first-class consumer language** ([#1171](https://github.com/vig-os/devkit/issues/1171))
+  - Language detection: a repo is nix-oriented when it carries `*.nix` files
+    **beyond** the scaffold-managed `./flake.nix` (excluding `.git/`,
+    `.direnv/`, `.worktrees/`) — `flake.nix` alone would false-positive on
+    every direnv consumer at re-scaffold time, so the beyond-flake.nix rule is
+    deterministic and re-scaffold-safe.
+  - New `nix` gitignore fragment (`result`, `result-*` build symlinks),
+    appended to the managed root `.gitignore` on detection and feeding the
+    never-migrate managed set like every other fragment.
+  - `statix` and `deadnix` join the **flake-generated consumer hook surface**
+    (`mkProjectShell` hooks) as `language: system` hooks. They are NOT injected
+    into the committed hand-managed `.pre-commit-config.yaml`, so existing
+    container-mode consumers see zero change until they opt into flake hooks.
+    `deadnix` runs with `--no-lambda-arg --no-lambda-pattern-names` so the
+    scaffolded consumer `flake.nix` (idiomatic `{ self, … }` pattern,
+    `extraPackages = pkgs: [ ]` seed) passes out of the box; devkit's own
+    stricter internal `nix flake check` gates are unchanged.
+  - CodeQL is untouched: nix is not a CodeQL language, so the rendered matrix
+    and push paths omit it (same treatment as rust).
 - **Document enabling the dependency graph on new public consumers** ([#1166](https://github.com/vig-os/devkit/issues/1166))
   - The scaffolded `ci.yml` Dependency Review gate reads GitHub's dependency
     graph, which the `vig-os` org leaves **disabled** on new repos

--- a/assets/gitignore.d/nix.gitignore
+++ b/assets/gitignore.d/nix.gitignore
@@ -1,0 +1,7 @@
+# ── Nix ───────────────────────────────────────────────────────────────────────
+# Appended to the language-neutral base by init-workspace.sh when *.nix files
+# beyond the scaffold-managed ./flake.nix mark the repo as Nix (#1171).
+
+# nix build output symlinks
+result
+result-*

--- a/assets/init-workspace.sh
+++ b/assets/init-workspace.sh
@@ -618,6 +618,19 @@ DETECTED_LANGUAGES=()
 [[ -f "$WORKSPACE_DIR/pyproject.toml" ]] && DETECTED_LANGUAGES+=("python")
 [[ -f "$WORKSPACE_DIR/package.json" ]] && DETECTED_LANGUAGES+=("node")
 [[ -f "$WORKSPACE_DIR/Cargo.toml" ]] && DETECTED_LANGUAGES+=("rust")
+# nix (#1171): a repo is nix-oriented when it carries *.nix files BEYOND the
+# scaffold-managed ./flake.nix (excluding .git/, .direnv/, .worktrees/).
+# flake.nix alone cannot be the marker: every direnv scaffold ships one, so
+# naive detection would false-positive on every direnv consumer at re-scaffold
+# time. The beyond-flake.nix rule is deterministic and re-scaffold-safe.
+if find "$WORKSPACE_DIR" \
+    -path "$WORKSPACE_DIR/.git" -prune -o \
+    -path "$WORKSPACE_DIR/.direnv" -prune -o \
+    -path "$WORKSPACE_DIR/.worktrees" -prune -o \
+    -name '*.nix' ! -path "$WORKSPACE_DIR/flake.nix" -print -quit \
+    | grep -q .; then
+    DETECTED_LANGUAGES+=("nix")
+fi
 
 # Seed npm-mapped justfile.project recipes on the FIRST scaffold of a Node
 # consumer (#1027). justfile.project is a PRESERVE_FILE: the stock template
@@ -854,6 +867,7 @@ render_codeql_matrix() {
                 paths+=("'**.ts'" "'**.js'" "'**.mjs'" "'**.cjs'")
                 ;;
             rust) : ;; # CodeQL rust support caveat (#1025): omit the leg
+            nix) : ;; # nix is not a CodeQL language (#1171): omit the leg
         esac
     done
     langs+=("'actions'")

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -9,6 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Nix as a first-class consumer language** ([#1171](https://github.com/vig-os/devkit/issues/1171))
+  - Language detection: a repo is nix-oriented when it carries `*.nix` files
+    **beyond** the scaffold-managed `./flake.nix` (excluding `.git/`,
+    `.direnv/`, `.worktrees/`) — `flake.nix` alone would false-positive on
+    every direnv consumer at re-scaffold time, so the beyond-flake.nix rule is
+    deterministic and re-scaffold-safe.
+  - New `nix` gitignore fragment (`result`, `result-*` build symlinks),
+    appended to the managed root `.gitignore` on detection and feeding the
+    never-migrate managed set like every other fragment.
+  - `statix` and `deadnix` join the **flake-generated consumer hook surface**
+    (`mkProjectShell` hooks) as `language: system` hooks. They are NOT injected
+    into the committed hand-managed `.pre-commit-config.yaml`, so existing
+    container-mode consumers see zero change until they opt into flake hooks.
+    `deadnix` runs with `--no-lambda-arg --no-lambda-pattern-names` so the
+    scaffolded consumer `flake.nix` (idiomatic `{ self, … }` pattern,
+    `extraPackages = pkgs: [ ]` seed) passes out of the box; devkit's own
+    stricter internal `nix flake check` gates are unchanged.
+  - CodeQL is untouched: nix is not a CodeQL language, so the rendered matrix
+    and push paths omit it (same treatment as rust).
 - **Document enabling the dependency graph on new public consumers** ([#1166](https://github.com/vig-os/devkit/issues/1166))
   - The scaffolded `ci.yml` Dependency Review gate reads GitHub's dependency
     graph, which the `vig-os` org leaves **disabled** on new repos

--- a/nix/devtools.nix
+++ b/nix/devtools.nix
@@ -52,8 +52,8 @@ with pkgs;
   nixfmt # nix file formatter, RFC style (treefmt `nix fmt`, pre-commit hook)
   ruff # python linter/formatter (pre-commit ruff/ruff-format hooks)
   typos # source typo checker (pre-commit typos hook)
-  deadnix # dead-Nix-code linter (flake `checks.deadnix`)
-  statix # nix anti-pattern linter (flake `checks.statix`)
+  deadnix # dead-Nix-code linter (flake `checks.deadnix`, consumer hook #1171)
+  statix # nix anti-pattern linter (flake `checks.statix`, consumer hook #1171)
   actionlint # GitHub Actions workflow linter (pre-commit hook, #995)
 
   # Container runtime

--- a/nix/hooks.nix
+++ b/nix/hooks.nix
@@ -464,6 +464,41 @@ let
         files = "\\.nix$";
       };
     };
+    # Nix linters, flake-generated consumer surface ONLY (#1171). No `yaml`
+    # and `scaffold = false`, so neither committed hand-managed YAML (runner
+    # or scaffold) changes — existing container-mode consumers see zero
+    # change until they opt into flake hooks. Devkit's own coverage stays
+    # with the authored-flake-scoped `checks.{statix,deadnix}` gates in
+    # flake.nix (#777), which deliberately keep the STRICT deadnix defaults.
+    statix = {
+      scaffold = false;
+      # statix accepts exactly ONE target, so run it repo-wide from the root
+      # (it respects .gitignore) rather than on the changed filenames.
+      consumer = pkgs: {
+        enable = true;
+        name = "statix";
+        entry = "${pkgs.statix}/bin/statix check .";
+        language = "system";
+        files = "\\.nix$";
+        pass_filenames = false;
+      };
+    };
+    # deadnix relaxes the lambda checks (--no-lambda-arg
+    # --no-lambda-pattern-names): the scaffolded consumer flake.nix ships the
+    # idiomatic `{ self, … }` output pattern and the `extraPackages = pkgs:
+    # [ ]` seed, whose intentionally-unused args strict deadnix flags — a
+    # fresh scaffold must pass out of the box
+    # (tests/test_flake_hooks.py::TestNixLintersConsumerSurface).
+    deadnix = {
+      scaffold = false;
+      consumer = pkgs: {
+        enable = true;
+        name = "deadnix";
+        entry = "${pkgs.deadnix}/bin/deadnix --fail --no-lambda-arg --no-lambda-pattern-names";
+        language = "system";
+        files = "\\.nix$";
+      };
+    };
     typos = {
       scaffold = true;
       yaml = {

--- a/tests/bats/init-workspace.bats
+++ b/tests/bats/init-workspace.bats
@@ -2999,6 +2999,56 @@ _RELEASE_RESOLVERS_991=(
     refute_output --partial "'**.ts'"
 }
 
+# ── nix consumer detection + gitignore fragment (#1171) ───────────────────────
+# A repo is nix-oriented when it carries *.nix files BEYOND the scaffold-managed
+# ./flake.nix (which every direnv scaffold ships — so flake.nix alone cannot be
+# the marker without false-positiving on every direnv consumer at re-scaffold
+# time). The beyond-flake.nix rule is deterministic and re-scaffold-safe. A
+# detected nix repo appends the nix.gitignore fragment (result/result-* build
+# symlinks). nix is NOT a CodeQL language, so the matrix is unchanged (same
+# treatment as rust: the language leg is omitted).
+
+@test "scaffold .gitignore for a nix consumer ignores result symlinks (#1171)" {
+    ws="$BATS_TEST_TMPDIR/e2e-1171-nix-gi"
+    mkdir -p "$ws/nix"
+    # A *.nix file beyond the managed root flake.nix marks the repo as nix.
+    printf '{ }\n' >"$ws/nix/module.nix"
+    run _scaffold both "$ws"
+    assert_success
+    run cat "$ws/.gitignore"
+    assert_success
+    assert_line 'result'
+    assert_line 'result-*'
+}
+
+@test "scaffold .gitignore for a flake.nix-only consumer is not nix (#1171)" {
+    # Re-scaffold trap: every direnv consumer ships ./flake.nix. flake.nix alone
+    # must NOT trigger nix detection, or re-scaffold would false-positive on all
+    # of them. Pre-place ONLY the root flake.nix (no other *.nix).
+    ws="$BATS_TEST_TMPDIR/e2e-1171-flake-only"
+    mkdir -p "$ws"
+    printf '{ outputs = _: { }; }\n' >"$ws/flake.nix"
+    run _scaffold both "$ws"
+    assert_success
+    run cat "$ws/.gitignore"
+    assert_success
+    refute_line 'result'
+    refute_line 'result-*'
+}
+
+@test "scaffold codeql matrix for a nix consumer omits the language leg, keeps actions (#1171)" {
+    ws="$BATS_TEST_TMPDIR/e2e-1171-nix-cq"
+    mkdir -p "$ws/nix"
+    printf '{ }\n' >"$ws/nix/module.nix"
+    run _scaffold both "$ws"
+    assert_success
+    run grep -E '^[[:space:]]*language:' "$ws/.github/workflows/codeql.yml"
+    assert_success
+    assert_output --partial "'actions'"
+    refute_output --partial "'nix'"
+    refute_output --partial "'python'"
+}
+
 # ── first-scaffold npm justfile.project recipes for Node consumers (#1027) ─────
 # justfile.project is a PRESERVE_FILE: the stock template ships uv/pyproject
 # recipes, which no-op for a Node repo whose CI still calls `just sync|test`.

--- a/tests/test_flake_hooks.py
+++ b/tests/test_flake_hooks.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import json
 import os
+import shlex
 import shutil
 import subprocess
 from pathlib import Path
@@ -380,6 +381,84 @@ class TestConsumerHooksSurface:
         assert "^data/stopping/" in exclude
         # The base excludes stay active alongside the consumer additions.
         assert ".github_data" in exclude
+
+
+class TestNixLintersConsumerSurface:
+    """statix + deadnix live on the flake-generated consumer surface (#1171).
+
+    Nix-oriented consumers (exo-fleet, vigo-nixos) need the statix/deadnix
+    lint pair; today they exist only as devkit-internal ``nix flake check``
+    gates. ``nix/hooks.nix`` defines them as consumer-only ``language: system``
+    hooks: they render into ``mkProjectShell``'s generated config but are NOT
+    injected into either committed hand-managed YAML (``scaffold = false`` —
+    existing container-mode consumers must see zero change).
+    """
+
+    def test_statix_is_on_the_consumer_surface(
+        self, consumer_config: dict[str, Any]
+    ) -> None:
+        hooks = _normalize(consumer_config)["hooks"]
+        assert "statix" in hooks, "statix missing from generated consumer config"
+        assert "/bin/statix" in hooks["statix"]["entry"]
+        # statix accepts exactly ONE target, so filenames must not be appended.
+        assert hooks["statix"].get("pass_filenames") is False
+
+    def test_deadnix_is_on_the_consumer_surface(
+        self, consumer_config: dict[str, Any]
+    ) -> None:
+        hooks = _normalize(consumer_config)["hooks"]
+        assert "deadnix" in hooks, "deadnix missing from generated consumer config"
+        entry = hooks["deadnix"]["entry"]
+        assert "/bin/deadnix" in entry
+        assert "--fail" in entry, "deadnix must fail the hook on findings"
+
+    def test_nix_linters_stay_out_of_the_committed_yaml(
+        self, rendered_portable: dict[str, Any]
+    ) -> None:
+        """Neither committed YAML gains the pair (scaffold = false, #1171).
+
+        The hand-managed runner/scaffold configs are what existing
+        container-mode consumers re-scaffold from; injecting statix/deadnix
+        there would surprise every one of them on the next upgrade.
+        """
+        for profile in ("runner", "scaffold"):
+            hooks = _normalize(rendered_portable[profile])["hooks"]
+            assert "statix" not in hooks, f"statix leaked into the {profile} YAML"
+            assert "deadnix" not in hooks, f"deadnix leaked into the {profile} YAML"
+
+    def test_template_flake_passes_both_linters_as_configured(
+        self, consumer_config: dict[str, Any], tmp_path: Path
+    ) -> None:
+        """The scaffolded consumer flake.nix passes both hooks out of the box.
+
+        deadnix flags intentionally-unused lambda args — the template's
+        ``{ self, … }`` output pattern and the ``extraPackages = pkgs: [ ]``
+        seed — so the hook entries must carry the flags that keep a FRESH
+        scaffold green. Run the exact rendered entries against a copy of the
+        template (statix's single-target ``check .`` from the copy's root,
+        mirroring a fresh consumer repo).
+        """
+        template = REPO_ROOT / "assets" / "workspace" / "flake.nix"
+        (tmp_path / "flake.nix").write_text(template.read_text())
+        hooks = _normalize(consumer_config)["hooks"]
+
+        deadnix_cmd = shlex.split(hooks["deadnix"]["entry"]) + ["flake.nix"]
+        result = subprocess.run(
+            deadnix_cmd, capture_output=True, text=True, cwd=tmp_path
+        )
+        assert result.returncode == 0, (
+            "deadnix (as configured) rejects the scaffolded flake.nix:\n"
+            f"{result.stdout}{result.stderr}"
+        )
+
+        statix_cmd = shlex.split(hooks["statix"]["entry"])
+        result = subprocess.run(
+            statix_cmd, capture_output=True, text=True, cwd=tmp_path
+        )
+        assert result.returncode == 0, (
+            "statix (as configured) rejects the scaffolded flake.nix:\n"
+            f"{result.stdout}{result.stderr}"
+        )
 
 
 class TestZeroHooksParity:


### PR DESCRIPTION
## Summary

Closes #1171.

Makes Nix a first-class consumer language in the scaffold (ask-gate cleared by three nix-oriented consumers: exo-pet/exo-fleet, Personal/vigo-nixos, devkit itself):

- **Detection** (`assets/init-workspace.sh`): a repo is nix-oriented when it carries `*.nix` files **beyond the scaffold-managed `./flake.nix`** (pruning `.git/`, `.direnv/`, `.worktrees/`). `flake.nix` alone can't be the marker — every direnv scaffold ships one, so naive detection would false-positive on every direnv consumer at re-scaffold. Deterministic and re-scaffold-safe.
- **Gitignore fragment** (`assets/gitignore.d/nix.gitignore`): `result`, `result-*`. The #1145 managed set already derives from ALL gitignore.d fragments, so no migration-logic change was needed (existing #1145 tests stay green).
- **statix + deadnix on the consumer hook surface** (`nix/hooks.nix`): `language: system` hookDefs with `scaffold = false` and no `yaml` — both committed hand-managed YAMLs are byte-unchanged (guarded by the drift gates + an explicit test); the hooks render only into the flake-generated consumer config. statix runs `check .` repo-wide (single-target CLI, respects .gitignore); deadnix runs `--fail --no-lambda-arg --no-lambda-pattern-names` so the scaffolded template flake.nix (idiomatic `{ self, … }` pattern, `extraPackages = pkgs: [ ]` seed) passes out of the box — proven by a test that runs the *exact rendered hook entries* against a template copy. Devkit's own strict internal gates (`checks.{statix,deadnix}`) are untouched.
- **CodeQL**: explicit `nix) : ;;` no-op arm (nix is not a CodeQL language, same as rust), with a bats test proving the matrix stays `['actions']`-only for a pure-nix consumer.

## Verification

- TDD: RED `77fb07ac` (1 bats + 4 pytest failing pre-implementation; two deliberate green guards) → `e49d99c8` (detection + fragment) → `492ac467` (hooks).
- `bats tests/bats/init-workspace.bats` → 221/221; `pytest tests/test_flake_hooks.py` → 27 passed — both re-run by the reviewing session.
- Template proof: `statix check assets/workspace/flake.nix` and `deadnix --fail --no-lambda-arg --no-lambda-pattern-names assets/workspace/flake.nix` both clean.
- Full `prek run --all-files` in the dev shell: green, working tree clean (re-run by the reviewing session).

## Notes

- Since #1167, fresh direnv scaffolds default to flake hooks, so nix consumers get statix/deadnix immediately; a consumer with pre-existing nix code may see first-run findings — that is the feature working. Consumers can tighten/loosen via `hooks.deadnix.entry` overrides.
- Expect CHANGELOG (+ mirror) merge conflicts with sibling PRs #1174/#1175 — union-merge as usual.