### PR TITLE
feat(hooks): package pymarkdown and promote it to a system hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -114,12 +114,17 @@ repos:
         files: ^\.github/workflows/.*\.ya?ml$
         pass_filenames: false
 
-  # Markdown Linting (excludes auto-generated docs)
-  - repo: https://github.com/jackdewinter/pymarkdown
-    rev: f93643d339dfee2a1022e7b05e8b5a281bfac553  # v0.9.23
+  # Markdown linting (pymarkdown from the flake toolchain; excludes auto-generated
+  # docs). Packaged in nix/pymarkdown.nix and promoted to a language: system hook
+  # (#1170), so it resolves from PATH like shellcheck/typos instead of its
+  # upstream pre-commit repo (whose native pyjson5 fails on bare host runners).
+  - repo: local
     hooks:
       - id: pymarkdown
         name: pymarkdown
+        entry: pymarkdown
+        language: system
+        types: [markdown]
         args: ["-c", ".pymarkdown", "fix"]
         exclude: ^(README\.md|CONTRIBUTE\.md|TESTING\.md)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Package pymarkdown in the flake and promote it to a system hook** ([#1170](https://github.com/vig-os/devkit/issues/1170))
+  - `pymarkdownlnt` is now packaged as a Nix derivation (`nix/pymarkdown.nix`,
+    with its two PyPI-only pure-Python deps `application-properties` and
+    `columnar`; `pyjson5` comes from nixpkgs) and added to the toolchain SSoT
+    (`nix/devtools.nix`), so it ships in the dev-shell, the image, and the
+    `vigos.packages` home module.
+  - The `pymarkdown` hook is promoted from a runner-only remote-repo hook to a
+    `language: system` hook resolved from PATH — like `shellcheck`/`typos` — in
+    **all three** hook artifacts: the committed runner + scaffold YAML, the
+    sandbox `checks.pre-commit` gate, and the consumer generation surface. Same
+    `-c .pymarkdown fix` command and README/CONTRIBUTE/TESTING excludes as before.
+  - This retires the last runner-only residual of the single-SSoT hook system
+    (#883): **every** `direnv`/`bare` consumer regains (or gains) markdown lint
+    from the shared flake hook set, and the container/both lanes converge on the
+    same system hook.
 - **Document enabling the dependency graph on new public consumers** ([#1166](https://github.com/vig-os/devkit/issues/1166))
   - The scaffolded `ci.yml` Dependency Review gate reads GitHub's dependency
     graph, which the `vig-os` org leaves **disabled** on new repos

--- a/assets/init-workspace.sh
+++ b/assets/init-workspace.sh
@@ -702,11 +702,12 @@ render_gitignore() {
 # Turn a freshly-scaffolded direnv flake.nix into a flake-hooks generator (#1167)
 # by activating an empty `hooks = { }` argument to mkProjectShell. The direnv CI
 # lane runs on the bare host runner (resolve-toolchain emits an empty container
-# image), which lacks the image's FHS loader, so the hand-managed
-# .pre-commit-config.yaml's pymarkdown hook (native pyjson5) can't load there;
-# the shared flake hook set drops pymarkdown and runs host-side. Deterministic
-# single insert after the (unique) extraPackages line — a bats regression guard
-# pins that anchor. Only ever called on a FRESH scaffold (guarded by the caller).
+# image), so the shared flake hook set — resolved entirely from the Nix store,
+# including pymarkdown now that it is a flake system hook (#1170) — is more
+# robust there than the committed YAML, which builds its remote pre-commit repo
+# hook envs (pre-commit-hooks, yamllint) per runner. Deterministic single insert
+# after the (unique) extraPackages line — a bats regression guard pins that
+# anchor. Only ever called on a FRESH scaffold (guarded by the caller).
 activate_flake_hooks_default() {
     local flake="$WORKSPACE_DIR/flake.nix"
     [[ -f "$flake" ]] || return 0
@@ -717,9 +718,11 @@ activate_flake_hooks_default() {
             print ""
             print "          # Host-runner hooks (#1167): direnv CI runs on the bare host"
             print "          # runner, so let the flake GENERATE .pre-commit-config.yaml from"
-            print "          # the shared base hook set (drops pymarkdown, whose native pyjson5"
-            print "          # cannot load off the image). Customize like the opt-in block below;"
-            print "          # the generated config is a gitignored /nix/store symlink."
+            print "          # the shared base hook set, resolved entirely from the Nix store"
+            print "          # (incl. pymarkdown, now a flake system hook, #1170) rather than"
+            print "          # building the committed YAML remote pre-commit repo hook envs"
+            print "          # per runner. Customize like the opt-in block below; the generated"
+            print "          # config is a gitignored /nix/store symlink."
             print "          hooks = { };"
             inserted = 1
         }
@@ -1373,9 +1376,10 @@ fi
 
 # Host-runner hooks default (#1167): a FRESH direnv scaffold defaults to
 # flake-generated pre-commit hooks. The direnv CI lane runs on the bare host
-# runner (empty container image), which lacks the image's FHS loader that the
-# hand-managed YAML's pymarkdown hook (native pyjson5) needs — the shared flake
-# hook set drops it. Runs BEFORE render_gitignore so the generated config is
+# runner (empty container image), where the shared flake hook set — resolved
+# from the Nix store, including pymarkdown now that it is a flake system hook
+# (#1170) — is more robust than the committed YAML's per-runner remote
+# pre-commit repo hook env builds. Runs BEFORE render_gitignore so the generated config is
 # ignored from the first scaffold. Gated on a fresh scaffold: never rewrite a
 # consumer's own flake.nix nor delete a committed .pre-commit-config.yaml (both
 # PRESERVE_FILES). bare mode is out of scope — it prunes flake.nix (no generator)

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Package pymarkdown in the flake and promote it to a system hook** ([#1170](https://github.com/vig-os/devkit/issues/1170))
+  - `pymarkdownlnt` is now packaged as a Nix derivation (`nix/pymarkdown.nix`,
+    with its two PyPI-only pure-Python deps `application-properties` and
+    `columnar`; `pyjson5` comes from nixpkgs) and added to the toolchain SSoT
+    (`nix/devtools.nix`), so it ships in the dev-shell, the image, and the
+    `vigos.packages` home module.
+  - The `pymarkdown` hook is promoted from a runner-only remote-repo hook to a
+    `language: system` hook resolved from PATH — like `shellcheck`/`typos` — in
+    **all three** hook artifacts: the committed runner + scaffold YAML, the
+    sandbox `checks.pre-commit` gate, and the consumer generation surface. Same
+    `-c .pymarkdown fix` command and README/CONTRIBUTE/TESTING excludes as before.
+  - This retires the last runner-only residual of the single-SSoT hook system
+    (#883): **every** `direnv`/`bare` consumer regains (or gains) markdown lint
+    from the shared flake hook set, and the container/both lanes converge on the
+    same system hook.
 - **Document enabling the dependency graph on new public consumers** ([#1166](https://github.com/vig-os/devkit/issues/1166))
   - The scaffolded `ci.yml` Dependency Review gate reads GitHub's dependency
     graph, which the `vig-os` org leaves **disabled** on new repos

--- a/assets/workspace/.pre-commit-config.yaml
+++ b/assets/workspace/.pre-commit-config.yaml
@@ -85,12 +85,17 @@ repos:
         args: ["-x"]
         exclude: (^|/)\.envrc$
 
-  # Markdown Linting (excludes auto-generated docs)
-  - repo: https://github.com/jackdewinter/pymarkdown
-    rev: f93643d339dfee2a1022e7b05e8b5a281bfac553  # v0.9.23
+  # Markdown linting (pymarkdown from the flake toolchain; excludes auto-generated
+  # docs). Packaged in nix/pymarkdown.nix and promoted to a language: system hook
+  # (#1170), so it resolves from PATH like shellcheck/typos instead of its
+  # upstream pre-commit repo (whose native pyjson5 fails on bare host runners).
+  - repo: local
     hooks:
       - id: pymarkdown
         name: pymarkdown
+        entry: pymarkdown
+        language: system
+        types: [markdown]
         args: ["-c", ".pymarkdown", "fix"]
         exclude: ^(README\.md|CONTRIBUTE\.md|TESTING\.md)
 

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -390,11 +390,12 @@ scaffolded `.pre-commit-config.yaml`:
 > **`direnv` scaffolds opt in by default** ([#1167](https://github.com/vig-os/devkit/issues/1167)).
 > A fresh `direnv` scaffold ships `flake.nix` with `hooks = { }` already active
 > and no hand-managed `.pre-commit-config.yaml`, because the direnv CI lane runs
-> on the bare host runner where the YAML's `pymarkdown` hook cannot load (see the
-> residual note below). Everything in this section still applies — customize via
-> the `hooks`/`hooksExcludes` block; the generated config is a gitignored store
-> symlink. `container`/`both` scaffolds keep the hand-managed YAML with the block
-> commented out, and `bare` ships no flake at all.
+> on the bare host runner, where the flake-generated set — resolved entirely from
+> the Nix store — is more robust than building the committed YAML's remote
+> pre-commit repo hook envs per runner. Everything in this section still applies
+> — customize via the `hooks`/`hooksExcludes` block; the generated config is a
+> gitignored store symlink. `container`/`both` scaffolds keep the hand-managed
+> YAML with the block commented out, and `bare` ships no flake at all.
 
 ```nix
 devShells.default = vigos.lib.mkProjectShell {
@@ -440,13 +441,12 @@ The contract:
   `hooks`/`hooksExcludes` block as above, then delete the YAML and gitignore
   it. To opt back out, remove the `hooks` argument and commit a plain YAML
   again.
-- **Residual:** the `pymarkdown` hook is not in nixpkgs, so the generated
-  base set does not include it (the hand-managed YAML runs it from its upstream
-  pre-commit repo, which only loads inside the devkit image — its native
-  `pyjson5` fails with `ImportError: libstdc++.so.6` on the bare host runner the
-  `direnv`/`bare` CI lanes use, which is why `direnv` defaults to generation,
-  [#1167](https://github.com/vig-os/devkit/issues/1167)). Add it as a custom
-  hook if you need it under generation.
+- **`pymarkdown` is in the base set.** Since
+  [#1170](https://github.com/vig-os/devkit/issues/1170) `pymarkdownlnt` is
+  packaged in the flake and `pymarkdown` is a `language: system` base hook, so
+  the generated set includes it — `direnv`/`bare` consumers gain markdown lint
+  from the shared toolchain like `shellcheck`/`typos`. Toggle it off with
+  `pymarkdown.enable = false` if a repo has no markdown to lint.
 - The planned declarative `.vig-os` manifest
   ([#885](https://github.com/vig-os/devkit/issues/885)) will carry an
   explicit raw-YAML opt-out flag so the choice is recorded per-repo rather

--- a/docs/NIX.md
+++ b/docs/NIX.md
@@ -394,9 +394,8 @@ These are decided inline in `flake.nix`; summarized here.
 
   Hooks that cannot run in the sandbox stay **runner-only** in the committed
   render and carry no gate profile in `nix/hooks.nix`: the generators
-  `generate-docs`/`sync-manifest`, `pip-licenses` (reads `uv.lock`), `pymarkdown`
-  (not in nixpkgs — also the one residual missing from the consumer generation
-  profile), `no-commit-to-branch` and `destroyed-symlinks`
+  `generate-docs`/`sync-manifest`, `pip-licenses` (reads `uv.lock`),
+  `no-commit-to-branch` and `destroyed-symlinks`
   (git-state-dependent), `check-agent-identity` (inspects the commit
   author/committer), and the `commit-msg`/`prepare-commit-msg`-stage hooks (never
   run by `--all-files`). `checks.pre-commit` is thus a Nix-verified guarantee that
@@ -411,25 +410,29 @@ These are decided inline in `flake.nix`; summarized here.
 
 ### `libstdc++` for C-extension pre-commit hooks (#698)
 
-Some pre-commit hooks run from pre-commit's **own** manylinux-wheel Python env
-(not the project venv) and ship a C extension. The `pymarkdown` hook is the case
-in point: its dependency `pyjson5` is a C extension linked against
-`libstdc++.so.6`, which a NixOS host does not put on the loader path outside an
-FHS environment — so the hook aborted with
+Historically some pre-commit hooks ran from pre-commit's **own** manylinux-wheel
+Python env (not the project venv) and shipped a C extension. The `pymarkdown`
+hook was the case in point: its dependency `pyjson5` is a C extension linked
+against `libstdc++.so.6`, which a NixOS host does not put on the loader path
+outside an FHS environment — so the hook aborted with
 `ImportError: libstdc++.so.6: cannot open shared object file` and forced
-`--no-verify`. Unlike the standalone binaries in #697 (`ruff`/`typos`),
-`pymarkdown` is **not** in nixpkgs, so the "add to `devTools` + `language:
-system`" recipe does not apply.
+`--no-verify`. That residual is now retired: `pymarkdownlnt` is packaged in the
+flake (`nix/pymarkdown.nix`) and `pymarkdown` is a `language: system` hook
+resolved from `devTools` like `ruff`/`typos`/`shellcheck` — the exact #697 recipe
+that seemed not to apply while it was missing from nixpkgs (#1170). The gate and
+the consumer generation surface now carry it too, so the hook set has no
+runner-only lint residual left.
 
-`mkProjectShell` therefore **appends** `${pkgs.stdenv.cc.cc.lib}/lib` to
-`LD_LIBRARY_PATH` in the dev-shell, so the wheel resolves the Nix C++ runtime.
-That is the same `libstdc++` the Nix toolchain itself links, so the other
-dev-shell binaries keep working (no version clash), and the existing
-mkShell-injected `LD_LIBRARY_PATH` is appended to rather than clobbered. The fix
-generalises to any future C-extension Python hook. A `nix-ld` host config
-(`programs.nix-ld.enable` + `libraries = [ pkgs.stdenv.cc.cc ]`) would also work
-but is per-contributor system config the repo cannot enforce, so it is at most a
-fallback, not the fix.
+`mkProjectShell` still **appends** `${pkgs.stdenv.cc.cc.lib}/lib` to
+`LD_LIBRARY_PATH` in the dev-shell, so any *runtime-installed* manylinux wheel
+(e.g. a `uvx` tool, or a consumer's own C-extension hook) resolves the Nix C++
+runtime. That is the same `libstdc++` the Nix toolchain itself links, so the
+other dev-shell binaries keep working (no version clash), and the existing
+mkShell-injected `LD_LIBRARY_PATH` is appended to rather than clobbered. It
+remains a general safety net for any future C-extension Python hook. A `nix-ld`
+host config (`programs.nix-ld.enable` + `libraries = [ pkgs.stdenv.cc.cc ]`)
+would also work but is per-contributor system config the repo cannot enforce, so
+it is at most a fallback, not the fix.
 
 ## Cachix and the `direnv allow` onboarding flow
 

--- a/flake.nix
+++ b/flake.nix
@@ -429,16 +429,19 @@
           # on both NixOS and FHS hosts. The IMAGE path sets the same two vars
           # (baking pythonEnv). Refs #666, #683.
 
-          # The C++ runtime (libstdc++.so.6). The `pymarkdown` pre-commit hook
-          # runs from pre-commit's OWN manylinux-wheel Python env (not the project
-          # venv), whose dependency `pyjson5` is a C extension linked against
-          # `libstdc++.so.6`. On a NixOS host that library is not on the loader
-          # path outside an FHS environment, so the hook aborts with
+          # The C++ runtime (libstdc++.so.6). A pre-commit hook (or any tool) that
+          # runs from a manylinux-wheel Python env (not the project venv) may ship
+          # a C extension linked against `libstdc++.so.6` — historically the
+          # `pymarkdown` hook via its `pyjson5` dependency. On a NixOS host that
+          # library is not on the loader path outside an FHS environment, so such a
+          # wheel aborts with
           # `ImportError: libstdc++.so.6: cannot open shared object file`. Exposing
           # the Nix C++ runtime on LD_LIBRARY_PATH lets the wheel resolve it; it is
           # the same libstdc++ the Nix toolchain itself links (`stdenv.cc.cc.lib`).
-          # pymarkdown is not in nixpkgs, so the #697 "add to devTools +
-          # language:system" recipe does not apply here. Refs #698.
+          # `pymarkdown` itself is now packaged in the flake (nix/pymarkdown.nix,
+          # #1170) and runs as a language:system hook, so this is no longer needed
+          # for it, but it remains a general safety net for any runtime-installed
+          # C-extension wheel. Refs #698, #1170.
           ldLibraryPath = "${pkgs.stdenv.cc.cc.lib}/lib";
 
           # Inject it ONLY on NixOS, where it is both required (above) and ABI-safe

--- a/nix/devtools.nix
+++ b/nix/devtools.nix
@@ -52,6 +52,12 @@ with pkgs;
   nixfmt # nix file formatter, RFC style (treefmt `nix fmt`, pre-commit hook)
   ruff # python linter/formatter (pre-commit ruff/ruff-format hooks)
   typos # source typo checker (pre-commit typos hook)
+  # pymarkdownlnt packaged from PyPI (nix/pymarkdown.nix): the `pymarkdown`
+  # markdown-lint hook resolves this binary as a `language: system` hook from
+  # PATH — like ruff/typos/shellcheck — instead of pre-commit's own
+  # manylinux-wheel env (whose native pyjson5 cannot load on a bare host
+  # runner), retiring the one hook-SSoT residual. Refs #1170, #883.
+  (import ./pymarkdown.nix pkgs)
   deadnix # dead-Nix-code linter (flake `checks.deadnix`)
   statix # nix anti-pattern linter (flake `checks.statix`)
   actionlint # GitHub Actions workflow linter (pre-commit hook, #995)

--- a/nix/hooks.nix
+++ b/nix/hooks.nix
@@ -49,10 +49,6 @@ let
       repo = "https://github.com/adrienverge/yamllint";
       rev = "81e9f98ffd059efe8aa9c1b1a42e5cce61b640c6"; # v1.35.1
     };
-    pymarkdown = {
-      repo = "https://github.com/jackdewinter/pymarkdown";
-      rev = "f93643d339dfee2a1022e7b05e8b5a281bfac553"; # v0.9.23
-    };
   };
 
   # Shared per-hook filters used by more than one artifact of the same hook.
@@ -399,20 +395,50 @@ let
         pass_filenames = false;
       };
     };
-    # Markdown lint — runner-only everywhere: pymarkdown is not in nixpkgs,
-    # so neither the sandbox gate nor the consumer generation can resolve
-    # it (documented residual, docs/NIX.md).
+    # Markdown lint — a language:system hook resolved from the flake toolchain
+    # (pymarkdownlnt packaged in nix/pymarkdown.nix, #1170), retiring the last
+    # runner-only remote-repo residual of the hook SSoT (#883). All three
+    # artifacts run the SAME `-c .pymarkdown fix` command over the SAME
+    # `.pymarkdown` JSON config and README/CONTRIBUTE/TESTING excludes.
+    #
+    # `fix` (not `scan`) is deliberate and matches the runner/CI: pymarkdown fix
+    # rewrites auto-fixable violations and exits 0 while *tolerating* unfixable
+    # ones (e.g. MD013 line-length), so the hook fails only when it MODIFIES a
+    # file — the same modify-and-fail semantics the ruff/end-of-file-fixer gate
+    # hooks above rely on. The Nix gate operates on the sandboxed source copy, so
+    # a fix never mutates the real tree; `scan` would be stricter than the runner
+    # and would newly fail the gate on pre-existing unfixable markdown debt.
     pymarkdown = {
-      repo = "pymarkdown";
       scaffold = true;
       yaml = {
         name = "pymarkdown";
+        entry = "pymarkdown";
+        language = "system";
+        types = [ "markdown" ];
         args = [
           "-c"
           ".pymarkdown"
           "fix"
         ];
         exclude = "^(README\\.md|CONTRIBUTE\\.md|TESTING\\.md)";
+      };
+      check =
+        { pkgs, ... }:
+        {
+          enable = true;
+          name = "pymarkdown";
+          entry = "${import ./pymarkdown.nix pkgs}/bin/pymarkdown -c .pymarkdown fix";
+          language = "system";
+          types = [ "markdown" ];
+          excludes = [ "^(README\\.md|CONTRIBUTE\\.md|TESTING\\.md)" ];
+        };
+      consumer = pkgs: {
+        enable = true;
+        name = "pymarkdown";
+        entry = "${import ./pymarkdown.nix pkgs}/bin/pymarkdown -c .pymarkdown fix";
+        language = "system";
+        types = [ "markdown" ];
+        excludes = [ "^(README\\.md|CONTRIBUTE\\.md|TESTING\\.md)" ];
       };
     };
     # just formats justfiles. The runner rewrites in place; the Nix gate
@@ -677,7 +703,6 @@ let
         "pre-commit-hooks"
         "local"
         "yamllint"
-        "pymarkdown"
       ];
       hooksOf =
         repoKey:

--- a/nix/hooks.nix
+++ b/nix/hooks.nix
@@ -15,9 +15,9 @@
 #   - `consumer`  — its git-hooks.nix fragment for the consumer generation
 #                   surface (`mkProjectShell { hooks = …; }`): entering the
 #                   shell installs the rendered config via git-hooks.nix's
-#                   installation script (`null` = not generatable, e.g.
-#                   pymarkdown, which is not in nixpkgs — documented residual
-#                   in docs/NIX.md).
+#                   installation script (`null` = not generatable, e.g. the
+#                   `uv run` generator/venv hooks like generate-docs or
+#                   sync-manifest, or the commit-msg-stage hooks).
 #
 # `checkName`/`consumerName` map a committed hook id to the git-hooks.nix
 # attribute name where they differ (git-hooks.nix pluralises some

--- a/nix/pymarkdown.nix
+++ b/nix/pymarkdown.nix
@@ -1,0 +1,91 @@
+# pymarkdownlnt packaged for the flake toolchain (#1170).
+#
+# `pymarkdownlnt` (the `pymarkdown` markdown linter) is the single residual of
+# the one-hook-definition system (#883): it was not in nixpkgs, so the
+# `pymarkdown` pre-commit hook could only run runner-only from its upstream
+# pre-commit repo, whose native `pyjson5` C-extension fails to load on a bare
+# host runner (`ImportError: libstdc++.so.6`) — which is why every direnv
+# consumer silently lost markdown linting (#1167/#1168).
+#
+# Packaging it here promotes the hook to a `language: system` hook resolved from
+# PATH, like shellcheck/typos, so it reaches the sandbox gate and the consumer
+# generation surface too. Only two of its dependencies are missing from nixpkgs
+# (`application-properties`, `columnar`, both small pure-Python packages); its
+# JSON5 backend `pyjson5` IS in nixpkgs, so it is taken from there.
+#
+# A function of the (overlaid) `pkgs`; returns the wrapped `pymarkdown` CLI.
+# Consumed by nix/devtools.nix (dev-shell + image + `vigos.packages`) and by the
+# `pymarkdown` hook's gate/consumer fragments in nix/hooks.nix.
+pkgs:
+let
+  # Built against the project interpreter (3.14), matching the rest of the
+  # toolchain; pymarkdownlnt and both extra deps are pure Python.
+  py = pkgs.python314.pkgs;
+
+  # application-properties 0.9.x reads layered config (the `.pymarkdown` JSON the
+  # hook passes via `-c`). Its JSON5 support pulls `pyjson5` (nixpkgs).
+  application-properties = py.buildPythonPackage rec {
+    pname = "application-properties";
+    version = "0.9.3";
+    pyproject = true;
+    src = pkgs.fetchPypi {
+      pname = "application_properties";
+      inherit version;
+      hash = "sha256-fcfY8j0R5TlCfnuOOvpwNT4VnBb3A7rW3Qgsxs3+6qg=";
+    };
+    build-system = [ py.setuptools ];
+    dependencies = [
+      py.typing-extensions
+      py.tomli
+      py.pyyaml
+      py.pyjson5
+    ];
+    pythonImportsCheck = [ "application_properties" ];
+    # The upstream test suite needs pytest + fixtures not shipped in the sdist;
+    # pythonImportsCheck is the build-time smoke test here.
+    doCheck = false;
+  };
+
+  # columnar renders pymarkdown's tabular scan output.
+  columnar = py.buildPythonPackage rec {
+    pname = "columnar";
+    version = "1.4.1";
+    pyproject = true;
+    src = pkgs.fetchPypi {
+      pname = "Columnar";
+      inherit version;
+      hash = "sha256-w8tXJzMzsv+c+q/IbwkwdBkzDJf6qI3P4j3wXm+7nHI=";
+    };
+    build-system = [ py.setuptools ];
+    dependencies = [
+      py.toolz
+      py.wcwidth
+    ];
+    pythonImportsCheck = [ "columnar" ];
+    doCheck = false;
+  };
+in
+py.buildPythonPackage rec {
+  pname = "pymarkdownlnt";
+  version = "0.9.23";
+  pyproject = true;
+  src = pkgs.fetchPypi {
+    inherit pname version;
+    hash = "sha256-wabIYzLSU5D2FBYLObzZLdPSCxGe0HUKo/j5+L6U90w=";
+  };
+  build-system = [ py.setuptools ];
+  dependencies = [
+    application-properties
+    columnar
+    py.typing-extensions
+  ];
+  pythonImportsCheck = [ "pymarkdown" ];
+  # Upstream's own test suite is heavy and not shipped complete in the sdist; the
+  # hook exercises the CLI, and pythonImportsCheck covers importability.
+  doCheck = false;
+  meta = {
+    description = "A GitHub Flavored Markdown compliant linter (pymarkdownlnt)";
+    homepage = "https://github.com/jackdewinter/pymarkdown";
+    mainProgram = "pymarkdown";
+  };
+}

--- a/tests/bats/init-workspace.bats
+++ b/tests/bats/init-workspace.bats
@@ -344,13 +344,12 @@ _scaffold() {
 
 # ── direnv defaults to flake-generated pre-commit hooks (#1167) ────────────────
 # The direnv CI lane runs on the bare host runner (resolve-toolchain emits an
-# empty container image), which lacks the devkit image's FHS loader + C++
-# runtime that the hand-managed .pre-commit-config.yaml's pymarkdown hook (native
-# pyjson5) needs. A fresh direnv scaffold therefore defaults to the shared
-# flake-generated hook set (which drops pymarkdown), matching what every direnv
-# consumer converged on by hand. Container/both keep the hand-managed YAML (they
-# run inside the image where pymarkdown works); a consumer's own preserved
-# flake.nix/config is never rewritten.
+# empty container image). A fresh direnv scaffold therefore defaults to the
+# shared flake-generated hook set, which is resolved entirely from the Nix store
+# — including pymarkdown, now a flake system hook (#1170) — rather than building
+# the committed YAML's remote pre-commit repo hook envs per runner. Container/both
+# keep the hand-managed YAML; a consumer's own preserved flake.nix/config is
+# never rewritten.
 
 @test "direnv scaffold drops the hand-managed .pre-commit-config.yaml (#1167)" {
     ws="$BATS_TEST_TMPDIR/e2e-direnv-hooks-drop"

--- a/tests/test_flake_devshell.py
+++ b/tests/test_flake_devshell.py
@@ -341,6 +341,22 @@ def test_devshell_provides_precommit_binary_hooks(
     )
 
 
+def test_devshell_provides_pymarkdown(dev_shell_tools: list[str]) -> None:
+    """The flake must provide pymarkdown so its language: system hook runs (#1170).
+
+    ``pymarkdownlnt`` is packaged in the flake (nix/pymarkdown.nix) and added to
+    the ``devTools`` SSoT so the ``pymarkdown`` markdown-lint hook is a
+    ``language: system`` hook resolved from PATH — like ruff/typos/shellcheck —
+    instead of pre-commit's own manylinux-wheel env (whose native ``pyjson5``
+    cannot load on a bare host runner). Its ``meta.mainProgram`` is
+    ``pymarkdown``, so the SSoT tool name is that binary.
+    """
+    assert "pymarkdown" in dev_shell_tools, (
+        "devTools must provide 'pymarkdown' (via nix/pymarkdown.nix) so the "
+        "language: system markdown-lint hook resolves from the flake (#1170)"
+    )
+
+
 def test_devshell_hook_runner_is_prek(dev_shell_tools: list[str]) -> None:
     """The hook runner in the ``devTools`` SSoT must be ``prek``, not ``pre-commit`` (#778).
 

--- a/tests/test_flake_devshell.py
+++ b/tests/test_flake_devshell.py
@@ -48,6 +48,9 @@ VERSION_FLAG_OVERRIDES: dict[str, list[str]] = {
     # argument"); it is a subcommand CLI. `--help` exits 0 and proves the binary
     # is runnable in the dev-shell, which is what this parity check asserts.
     "statix": ["--help"],
+    # pymarkdown is a subcommand CLI: `--version` exits 2 ("unrecognized
+    # arguments"); the version is printed by the `version` subcommand. Refs #1170.
+    "pymarkdown": ["version"],
     # vig-utils is a subcommand CLI (its `main` requires a subcommand, so
     # `--version` exits 2); `--help` exits 0 and proves the binary runs. The
     # release console scripts it ships (prepare-changelog,

--- a/tests/test_flake_hooks.py
+++ b/tests/test_flake_hooks.py
@@ -186,6 +186,24 @@ class TestPortableRenderFidelity:
                 f"scaffold hook {hook_id} diverges from runner"
             )
 
+    def test_pymarkdown_is_a_system_hook(
+        self, rendered_portable: dict[str, Any]
+    ) -> None:
+        """pymarkdown resolves from the flake toolchain, not an upstream repo (#1170).
+
+        Packaging ``pymarkdownlnt`` in the flake (nix/pymarkdown.nix) retires the
+        one runner-only remote-repo residual: the committed runner + scaffold
+        render it as a ``language: system`` local hook on PATH, same ``fix`` args
+        and excludes as before, with no pinned ``rev``.
+        """
+        for profile in ("runner", "scaffold"):
+            hook = _normalize(rendered_portable[profile])["hooks"]["pymarkdown"]
+            assert hook["repo"] == "local", profile
+            assert hook.get("language") == "system", profile
+            assert hook.get("entry") == "pymarkdown", profile
+            assert hook.get("args") == ["-c", ".pymarkdown", "fix"], profile
+            assert "rev" not in hook, profile
+
 
 class TestCheckJsonExcludesJsoncBanners:
     """check-json skips the `//`-bannered JSONC scaffold files (#1053).
@@ -366,6 +384,9 @@ class TestConsumerHooksSurface:
             "shellcheck",
             "yamllint",
             "no-commit-to-branch",
+            # pymarkdown joins the consumer generation surface once packaged
+            # in the flake (#1170) — direnv/bare consumers regain markdown lint.
+            "pymarkdown",
         ):
             assert expected in hooks, (
                 f"base hook {expected} missing from generated config"


### PR DESCRIPTION
## Summary

Closes #1170.

Packages `pymarkdownlnt` 0.9.23 in the flake (`nix/pymarkdown.nix`: pymarkdownlnt + its two PyPI-only pure-Python deps `application-properties` 0.9.3 and `columnar` 1.4.1; the native `pyjson5` comes from nixpkgs) and promotes the `pymarkdown` hook from a runner-only remote-repo hook to a `language: system` hook across **all three** artifacts (committed runner YAML, sandbox `checks.pre-commit` gate, consumer flake-generated surface). This retires the documented "pymarkdown residual" — the reason direnv consumers lost markdown linting after #1167/#1168 — and unblocks the direnv-only deployment of exo-pet/vault (a markdown documentation vault).

- Built against `python314` (toolchain default); all three packages are pure Python and pass `pythonImportsCheck`.
- `remoteRepos.pymarkdown` pin and its `repoOrder` entry removed; both committed `.pre-commit-config.yaml`s re-rendered to the system-hook form.
- "Drops pymarkdown / not in nixpkgs" messaging retired in `assets/init-workspace.sh`, `docs/NIX.md`, `docs/MIGRATION.md`, and the #1167 bats assertions.
- **Deliberate deviation from the issue text:** the sandbox gate mirrors the hook in `fix` mode (on the sandboxed copy, fail-on-modify — same semantics as the ruff/end-of-file-fixer gates and identical to the runner), not `scan`: scan is strictly stricter and would fail the gate on pre-existing MD013 line-length debt, an out-of-scope behavior change. Documented in the hookDef comment.

## Verification

- TDD: RED `d76dbcc7` → GREEN `bf1c866a` → docs `98db437e`.
- `pymarkdown version` → 0.9.23 in the dev shell; `nix build .#checks.x86_64-linux.pre-commit` → gate builds and passes — re-run by the reviewing session.
- `pytest tests/test_flake_hooks.py tests/test_flake_devshell.py` → 40 passed, 1 skipped (re-run by the reviewing session); bats #1167 direnv-hooks tests 6/6.
- Full `prek run --all-files` in the dev shell: green (pymarkdown runs over all markdown), working tree clean (re-run by the reviewing session).
- Strict `buildEnv` collision probe (pymarkdown + pythonEnv) assembles cleanly; the full image build is left to CI.

## Notes

- The NixOS-only `LD_LIBRARY_PATH` libstdc++ shim is no longer strictly needed for pymarkdown but is left in place (general safety net, minimal diff).
- Expect CHANGELOG (+ mirror) and `nix/hooks.nix`/test-file merge conflicts with sibling PRs #1174/#1175/#1176 — union-merge as usual.