### PR TITLE
feat(modules): add docs capability module with typst toolchain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`docs` capability module — typst document toolchain** ([#1178](https://github.com/vig-os/devkit/issues/1178))
+  - New opt-in `docs` capability module puts `typst` (the document compiler) and
+    `typstyle` (its formatter) on the dev-shell PATH, so document-oriented
+    consumers (exo-pet/vault, the future `qms` app, EXOMA presentations/grants)
+    declare `mkProjectShell { modules = [ "docs" ]; }` instead of pinning `typst`
+    via PyPI. It stays out of the base `devTools` and the published image, so
+    non-doc consumers and the slimmed image are unaffected (opt-in only,
+    backward compatible). No version option in v1 — nixpkgs carries a single
+    typst per pin and the module tracks that toolchain pin. Deliberate v1
+    exclusions (documented in `docs/NIX.md`): pandoc/LaTeX (ask-gated), headless
+    drawio/excalidraw export (electron-shaped, repo-owned), and Python
+    doc-processing libraries (`pymupdf4llm`, `openpyxl`) which belong in the
+    consumer's own `pyproject.toml` via uv.
 - **Route scaffolded CI jobs to self-hosted runners via `.vig-os`** ([#1173](https://github.com/vig-os/devkit/issues/1173))
   - New optional `.vig-os` key `DEVKIT_CI_RUNNER` (comma-separated runner label
     list, e.g. `self-hosted,linux,x64,meatgrinder`) lets a self-hosted consumer

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`docs` capability module — typst document toolchain** ([#1178](https://github.com/vig-os/devkit/issues/1178))
+  - New opt-in `docs` capability module puts `typst` (the document compiler) and
+    `typstyle` (its formatter) on the dev-shell PATH, so document-oriented
+    consumers (exo-pet/vault, the future `qms` app, EXOMA presentations/grants)
+    declare `mkProjectShell { modules = [ "docs" ]; }` instead of pinning `typst`
+    via PyPI. It stays out of the base `devTools` and the published image, so
+    non-doc consumers and the slimmed image are unaffected (opt-in only,
+    backward compatible). No version option in v1 — nixpkgs carries a single
+    typst per pin and the module tracks that toolchain pin. Deliberate v1
+    exclusions (documented in `docs/NIX.md`): pandoc/LaTeX (ask-gated), headless
+    drawio/excalidraw export (electron-shaped, repo-owned), and Python
+    doc-processing libraries (`pymupdf4llm`, `openpyxl`) which belong in the
+    consumer's own `pyproject.toml` via uv.
 - **Route scaffolded CI jobs to self-hosted runners via `.vig-os`** ([#1173](https://github.com/vig-os/devkit/issues/1173))
   - New optional `.vig-os` key `DEVKIT_CI_RUNNER` (comma-separated runner label
     list, e.g. `self-hosted,linux,x64,meatgrinder`) lets a self-hosted consumer

--- a/docs/NIX.md
+++ b/docs/NIX.md
@@ -106,6 +106,28 @@ devShells.default = vigos.lib.mkProjectShell {
   - `node` ([#1027](https://github.com/vig-os/devkit/issues/1027)) — the
     Node/TypeScript capability: `nodejs` (which bundles `npm`) in the shell,
     for consumers who previously hand-wired `extraPackages = [ pkgs.nodejs ]`.
+  - `docs` ([#1178](https://github.com/vig-os/devkit/issues/1178)) — the
+    document-edition capability: `typst` (the document compiler) and `typstyle`
+    (its formatter) in the shell, for document-oriented consumers
+    (exo-pet/vault, the future `qms` app, EXOMA presentations/grants) that
+    previously pinned `typst` via PyPI. Opt in with:
+
+    ```nix
+    devShells.default = vigos.lib.mkProjectShell {
+      inherit pkgs;
+      modules = [ "docs" ];
+    };
+    ```
+
+    **No version option in v1** — nixpkgs carries a single `typst`/`typstyle`
+    per pin, so the module tracks the toolchain nixpkgs pin rather than exposing
+    a selectable version (typst output is not stable across versions, so a
+    consumer regenerates its `generated/` artifacts once under the pinned
+    toolchain — pin-tracking beats a bespoke version overlay). **Deliberate v1
+    exclusions:** pandoc/LaTeX (ask-gated until a consumer needs them), headless
+    drawio/excalidraw export (electron-shaped, stays repo-owned), and Python
+    doc-processing libraries (`pymupdf4llm`, `openpyxl`) which belong in the
+    consumer's own `pyproject.toml` via uv, not in a nix module.
   - **Candidates (ask-gated, not shipped):** `geant4`, `rust`, `fortran`/`f2py`,
     `root`.
 - **Per-module options (the `node` version).** A `modules` entry is either a

--- a/nix/modules/default.nix
+++ b/nix/modules/default.nix
@@ -14,4 +14,5 @@
 {
   native = import ./native.nix;
   node = import ./node.nix;
+  docs = import ./docs.nix;
 }

--- a/nix/modules/docs.nix
+++ b/nix/modules/docs.nix
@@ -1,0 +1,25 @@
+# `docs` capability module (#1178): the document-edition dev-shell capability.
+# v1 contract (packages only, per docs/rfcs/ADR-capability-modules.md): puts
+# `typst` (the document compiler) and `typstyle` (its formatter) on the
+# dev-shell PATH so a document-oriented consumer opts in with
+# `modules = [ "docs" ]` instead of a PyPI typst pin or hand-wiring
+# `extraPackages`. First consumer: exo-pet/vault; qms and EXOMA
+# presentations/grants share the same profile.
+#
+# Takes no options (`_options`): unlike `node`, there is NO version knob in v1 —
+# nixpkgs carries a single `typst`/`typstyle` per pin, so the module simply
+# tracks the toolchain nixpkgs pin rather than exposing a selectable version.
+# typst output is not stable across versions, so a consumer's `generated/`
+# artifacts are regenerated once under the pinned toolchain; pin-tracking beats
+# maintaining a bespoke version overlay.
+#
+# Deliberate v1 exclusions (see docs/NIX.md): pandoc/LaTeX (ask-gated until a
+# consumer needs them), headless drawio/excalidraw export (electron-shaped, stays
+# repo-owned), and Python doc-processing libs (pymupdf4llm, openpyxl) which
+# belong in the consumer's own pyproject.toml via uv, not in a nix module.
+pkgs: _options: {
+  packages = with pkgs; [
+    typst
+    typstyle
+  ];
+}

--- a/tests/test_flake_modules.py
+++ b/tests/test_flake_modules.py
@@ -328,6 +328,37 @@ def test_node_module_rejects_unknown_option(current_system: str) -> None:
     )
 
 
+# ---------------------------------------------------------------------------
+# docs module (#1178) — the document-edition capability. v1 contract (packages
+# only): `typst` and `typstyle` on the dev-shell PATH so a document-oriented
+# consumer (exo-pet/vault, future qms, EXOMA presentations/grants) opts in with
+# `modules = [ "docs" ]` instead of a PyPI typst pin. No version option in v1 —
+# nixpkgs carries a single typst per pin and the module tracks that pin. See
+# docs/rfcs/ADR-capability-modules.md.
+# ---------------------------------------------------------------------------
+
+
+def test_docs_module_provides_typst_and_typstyle(current_system: str) -> None:
+    """The ``docs`` module puts ``typst`` and ``typstyle`` on PATH (#1178).
+
+    The plain-string ``modules = [ "docs" ]`` form (exercised through the
+    registry-generated ``module-docs`` check — which is also the proof the
+    registry resolves the name) contributes the nixpkgs-pinned ``typst`` and
+    ``typstyle``; both must resolve from the shell's own PATH, not the host's.
+    """
+    proc = _develop_module(
+        current_system,
+        "docs",
+        "command -v typst && command -v typstyle "
+        "&& typst --version && typstyle --version",
+    )
+    assert proc.returncode == 0, (
+        "docs-module devshell is missing typst/typstyle: "
+        f"rc={proc.returncode} stdout={proc.stdout.strip()!r} "
+        f"stderr={proc.stderr.strip()[:300]}"
+    )
+
+
 @pytest.mark.parametrize(
     "bad_version",
     ['"22"', "{ }"],


### PR DESCRIPTION
## Summary

Closes #1178.

Adds the `docs` capability module (`nix/modules/docs.nix`): document-oriented consumers opt in with `mkProjectShell { modules = [ "docs" ]; }` and get `typst` + `typstyle` on the dev-shell PATH. First consumer: exo-pet/vault (direnv-only deployment in the current wave); qms and EXOMA presentation/grant repos share the profile — the ADR's ask-gate is met.

- v1 contract per ADR-capability-modules: packages only, no version knob — nixpkgs ships a single typst per pin, so the module tracks the toolchain pin (typst output isn't version-stable; a consumer's `generated/` artifacts regenerate once at migration).
- Deliberate v1 exclusions documented in `docs/NIX.md` and the module header: pandoc/LaTeX (ask-gated), headless drawio/excalidraw export (electron-shaped, repo-owned), Python doc libs (pymupdf4llm/openpyxl → consumer `pyproject.toml` via uv).
- Registered in `nix/modules/default.nix`; geant4/rust/fortran/root stay deferred.

## Verification

- TDD: RED `779252c3` (missing `module-docs` check attr) → GREEN `29ed4844` → docs `455aa3f8`; merge of dev (post-#1177) `5bb9d9dc` clean, no conflicts.
- `pytest tests/test_flake_modules.py` → 9 passed (re-run by the reviewing session after the dev merge).
- Through the modules path (`nix develop .#checks…module-docs`): `typst 0.14.2`, `typstyle 0.14.4` — proven from the module's own purity-isolated shell, not devkit's own devshell (re-run by the reviewing session).
- Full `prek run --all-files` green (incl. the new pymarkdown system hook from #1177), working tree clean.