### PR TITLE
fix(ci): forward flake shellHook env in direnv preamble

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **direnv CI: forward the flake `shellHook` environment** ([#1180](https://github.com/vig-os/devkit/issues/1180))
+  - The direnv-mode `setup-devkit-toolchain` preamble exported the dev-shell
+    store bin dirs to `GITHUB_PATH` but dropped every environment variable a
+    project's flake `shellHook` exports, so env defaults present in every local
+    `nix develop`/direnv session silently vanished on CI — surfacing as unrelated
+    tool errors (vig-os/org-config#40: a shellHook-seeded `OTTERDOG_TOKEN`
+    placeholder worked locally, failed on CI). The preamble now diffs the ambient
+    environment against the dev-shell environment (the `shellHook` has run inside
+    `nix develop`) and forwards the vars the dev-shell adds or changes to
+    `GITHUB_ENV`, minus a denylist of shell session state (`PATH`, `HOME`,
+    `SHLVL`, `TMPDIR`, …) and Nix/stdenv build machinery (`NIX_*`, `buildInputs`,
+    `stdenv`, `shellHook`, `*Phase`, …). The ambient diff keeps host secrets out
+    of `GITHUB_ENV`; a random heredoc delimiter keeps multi-line values intact.
+    Local-vs-CI parity is now the default in direnv mode, no consumer change.
+
 ### Security
 
 ## [1.3.1](https://github.com/vig-os/devkit/releases/tag/1.3.1) - 2026-07-17

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -116,6 +116,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **direnv CI: forward the flake `shellHook` environment** ([#1180](https://github.com/vig-os/devkit/issues/1180))
+  - The direnv-mode `setup-devkit-toolchain` preamble exported the dev-shell
+    store bin dirs to `GITHUB_PATH` but dropped every environment variable a
+    project's flake `shellHook` exports, so env defaults present in every local
+    `nix develop`/direnv session silently vanished on CI — surfacing as unrelated
+    tool errors (vig-os/org-config#40: a shellHook-seeded `OTTERDOG_TOKEN`
+    placeholder worked locally, failed on CI). The preamble now diffs the ambient
+    environment against the dev-shell environment (the `shellHook` has run inside
+    `nix develop`) and forwards the vars the dev-shell adds or changes to
+    `GITHUB_ENV`, minus a denylist of shell session state (`PATH`, `HOME`,
+    `SHLVL`, `TMPDIR`, …) and Nix/stdenv build machinery (`NIX_*`, `buildInputs`,
+    `stdenv`, `shellHook`, `*Phase`, …). The ambient diff keeps host secrets out
+    of `GITHUB_ENV`; a random heredoc delimiter keeps multi-line values intact.
+    Local-vs-CI parity is now the default in direnv mode, no consumer change.
+
 ### Security
 
 ## [1.3.1](https://github.com/vig-os/devkit/releases/tag/1.3.1) - 2026-07-17

--- a/assets/workspace/.github/actions/setup-devkit-toolchain/action.yml
+++ b/assets/workspace/.github/actions/setup-devkit-toolchain/action.yml
@@ -149,6 +149,72 @@ runs:
             echo "UV_PYTHON_DOWNLOADS_JSON_URL=$UV_DL_JSON_URL" >> "$GITHUB_ENV"
           fi
         fi
+
+        # ── Forward the dev-shell's shellHook environment (#1180) ────────────
+        # GITHUB_PATH carries PATH only, so every env var a project exports from
+        # its flake `shellHook` (tool config, sensible defaults) — present in
+        # every local `nix develop`/direnv session — silently vanished on CI
+        # (vig-os/org-config#40: a shellHook-seeded OTTERDOG_TOKEN placeholder
+        # worked locally, failed on CI). Diff the ambient environment against the
+        # dev-shell environment (the shellHook has run inside `nix develop`) and
+        # forward the vars the dev-shell adds or changes, minus a denylist of
+        # shell session state and Nix/stdenv build machinery that must never leak
+        # into the CI environment. The diff is what keeps ambient host secrets
+        # (already in the runner env, unchanged inside the shell) out of
+        # GITHUB_ENV. Null-delimited dumps + a random GITHUB_ENV heredoc
+        # delimiter keep multi-line and special-character values intact.
+        env -0 > "$RUNNER_TEMP/devkit-host-env"
+        nix develop --profile "$RUNNER_TEMP/devkit-dev-profile" \
+          --command env -0 > "$RUNNER_TEMP/devkit-devshell-env"
+
+        # Denylist: shell session state (must never override the CI shell) and
+        # Nix/stdenv build machinery (PATH is already handled via GITHUB_PATH).
+        devkit_env_denied() {
+          case "$1" in
+            PATH|HOME|USER|LOGNAME|SHELL|TERM|PWD|OLDPWD|SHLVL|IFS|_) return 0 ;;
+            TMPDIR|TMP|TEMP|TEMPDIR) return 0 ;;
+            NIX_*) return 0 ;;
+            out|outputs|src|stdenv|system|builder|name|pname|version|shell|shellHook) return 0 ;;
+            buildInputs|nativeBuildInputs|propagatedBuildInputs|propagatedNativeBuildInputs) return 0 ;;
+            deps*|*Phase|phases|dont*) return 0 ;;
+            configureFlags|cmakeFlags|mesonFlags|makeFlags|patches|strictDeps|enableParallelBuilding) return 0 ;;
+            SOURCE_DATE_EPOCH|HOST_PATH|__structuredAttrs|outputHash*|preferLocalBuild|allowSubstitutes|cmakeDir) return 0 ;;
+            *) return 1 ;;
+          esac
+        }
+
+        # Ambient environment, keyed by name, to detect unchanged vars.
+        declare -A DEVKIT_HOST_ENV=()
+        while IFS= read -r -d '' devkit_kv; do
+          DEVKIT_HOST_ENV["${devkit_kv%%=*}"]="${devkit_kv#*=}"
+        done < "$RUNNER_TEMP/devkit-host-env"
+
+        devkit_env_forwarded=0
+        while IFS= read -r -d '' devkit_kv; do
+          devkit_name="${devkit_kv%%=*}"
+          devkit_value="${devkit_kv#*=}"
+          # Skip vars unchanged from the ambient environment (already present in
+          # the CI env; forwarding them would needlessly re-emit host secrets).
+          if [[ -n "${DEVKIT_HOST_ENV[$devkit_name]+x}" \
+                && "${DEVKIT_HOST_ENV[$devkit_name]}" == "$devkit_value" ]]; then
+            continue
+          fi
+          if devkit_env_denied "$devkit_name"; then
+            continue
+          fi
+          # Random heredoc delimiter: multi-line and special-character values
+          # survive intact and cannot break GITHUB_ENV parsing (GitHub's own
+          # multiline idiom).
+          devkit_delim="DEVKIT_ENV_EOF_${RANDOM}${RANDOM}${RANDOM}${RANDOM}"
+          {
+            printf '%s<<%s\n' "$devkit_name" "$devkit_delim"
+            printf '%s\n' "$devkit_value"
+            printf '%s\n' "$devkit_delim"
+          } >> "$GITHUB_ENV"
+          devkit_env_forwarded=$((devkit_env_forwarded + 1))
+        done < "$RUNNER_TEMP/devkit-devshell-env"
+        echo "Forwarded $devkit_env_forwarded dev-shell shellHook env var(s) to GITHUB_ENV."
+
         echo "Repo flake dev-shell provisioned; tools added to PATH."
 
     - name: Verify toolchain (prek present in dev-shell)

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -125,6 +125,43 @@ Free-plan private repos; OpenSSF Scorecard is public-only), so private consumers
 get a skipped (neutral) run instead of a permanently red one. A repo later
 flipped public starts scanning automatically, with no re-scaffold.
 
+### direnv mode: `shellHook` environment forwarding
+
+In `direnv` mode the `setup-devkit-toolchain` preamble forwards your flake
+dev-shell's `shellHook` environment to CI **by default**
+([#1180](https://github.com/vig-os/devkit/issues/1180)). Any env var a project
+exports from its `shellHook` (tool configuration, sensible defaults) is present
+in every local `nix develop`/direnv session; before #1180 the preamble exported
+only the dev-shell's `PATH` (via `GITHUB_PATH`), so those vars silently vanished
+on CI — a local-vs-CI divergence that surfaced as unrelated tool errors
+(a `shellHook`-seeded `OTTERDOG_TOKEN` placeholder worked locally and failed on
+CI). The preamble now diffs the ambient runner environment against the dev-shell
+environment (the `shellHook` has run inside `nix develop`) and writes the vars
+the dev-shell **adds or changes** to `GITHUB_ENV`. The ambient diff is what keeps
+host secrets — already in the runner env, unchanged inside the shell — out of
+`GITHUB_ENV`; multi-line values are written with a random `GITHUB_ENV` heredoc
+delimiter so they survive intact.
+
+A denylist keeps shell-session state and Nix/stdenv build machinery from leaking
+into the CI environment. Never forwarded:
+
+- **Session/runtime shell state** — `PATH` (already handled via `GITHUB_PATH`),
+  `HOME`, `USER`, `LOGNAME`, `SHELL`, `TERM`, `PWD`, `OLDPWD`, `SHLVL`, `IFS`,
+  `TMPDIR`/`TMP`/`TEMP`/`TEMPDIR`.
+- **Nix/stdenv build internals** — everything `NIX_*`; the stdenv scalars/lists
+  `out`, `outputs`, `src`, `stdenv`, `system`, `builder`, `name`, `pname`,
+  `version`, `shell`, `shellHook`, `buildInputs`, `nativeBuildInputs`,
+  `propagatedBuildInputs`, `propagatedNativeBuildInputs`, `SOURCE_DATE_EPOCH`,
+  `HOST_PATH`; and the build-machinery patterns `deps*`, `*Phase`, `phases`,
+  `dont*`, `configureFlags`/`cmakeFlags`/`mesonFlags`/`makeFlags`, `patches`,
+  `strictDeps`, `outputHash*`.
+
+This is why the diff-plus-denylist approach is used instead of forwarding
+`nix print-dev-env` wholesale: that dumps the full build machinery, none of which
+belongs in a CI environment. Recipes should still avoid depending on env a
+`shellHook` sets **only for interactive convenience** — CI parity is best-effort
+for build machinery, but genuine `shellHook` exports are now forwarded.
+
 ### Enable the dependency graph on new public consumers
 
 The scaffolded `ci.yml` also ships a **Dependency Review** gate that blocks PRs

--- a/tests/test_setup_toolchain_env.py
+++ b/tests/test_setup_toolchain_env.py
@@ -1,0 +1,245 @@
+"""Behavior tests: direnv-mode shellHook env forwarding in setup-devkit-toolchain.
+
+Issue #1180: the direnv-mode CI preamble exports the dev-shell store bin dirs to
+``GITHUB_PATH`` but dropped every environment variable a project's flake
+``shellHook`` exports, so env defaults that exist in every local
+``nix develop``/direnv session silently vanished on CI (proven in
+vig-os/org-config#40, where a shellHook-seeded ``OTTERDOG_TOKEN`` placeholder
+worked locally and failed on CI).
+
+The fix diffs the ambient environment against the dev-shell environment (the
+shellHook has run inside ``nix develop``) and forwards the vars the dev-shell
+adds or changes to ``GITHUB_ENV``, minus a denylist of shell session state and
+Nix/stdenv build machinery that must never leak into the CI environment.
+
+These tests execute the "Build repo flake dev-shell and export PATH" step's real
+``run:`` script against a stubbed ``nix`` that emits a simulated dev-shell
+environment, then assert on the ``GITHUB_ENV`` the script wrote — the same
+executed-bash pattern as ``test_ci_runner.py``.
+
+Refs: #1180
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+# Repository root (tests/ -> repo root).
+REPO_ROOT = Path(__file__).resolve().parent.parent
+ACTION = (
+    REPO_ROOT
+    / "assets"
+    / "workspace"
+    / ".github"
+    / "actions"
+    / "setup-devkit-toolchain"
+    / "action.yml"
+)
+
+# The direnv step under test.
+DEVSHELL_STEP_NAME = "Build repo flake dev-shell and export PATH"
+
+# The simulated dev-shell environment the stub `nix` emits (null-delimited). It
+# mixes shellHook exports (must forward), Nix/stdenv build machinery (must be
+# denied), shell session state (must be denied), and an ambient var unchanged
+# from the host env (must be filtered out, never re-forwarded — this is how host
+# secrets stay out of GITHUB_ENV).
+_DEVSHELL_ENV = [
+    ("OTTERDOG_TOKEN", "placeholder-set-by-shellhook"),
+    ("PROJECT_GREETING", "hello world"),
+    ("MULTILINE_VAR", "line-one\nline-two\nline-three"),
+    # Nix/stdenv build machinery — every one must be denied.
+    ("buildInputs", "/nix/store/xxxxxxxx-foo"),
+    ("nativeBuildInputs", "/nix/store/yyyyyyyy-bar"),
+    ("stdenv", "/nix/store/zzzzzzzz-stdenv-linux"),
+    ("shellHook", "export OTTERDOG_TOKEN=placeholder-set-by-shellhook"),
+    ("out", "/nix/store/oooooooo-out"),
+    ("system", "x86_64-linux"),
+    ("NIX_CFLAGS_COMPILE", "-isystem /nix/store/aaa/include"),
+    ("NIX_BUILD_CORES", "4"),
+    ("dontUnpack", "1"),
+    ("configurePhase", ":"),
+    ("depsBuildBuild", ""),
+    # Shell session state — must be denied.
+    ("PATH", "/nix/store/aaaaaaaa-foo/bin:/usr/bin"),
+    ("HOME", "/home/dev-shell"),
+    ("SHLVL", "2"),
+    ("TMPDIR", "/tmp/nix-shell"),
+    # Ambient var, unchanged from the host env — must not be re-forwarded.
+    ("AMBIENT_SHARED", "same-on-both-sides"),
+]
+
+
+def _devshell_step_script() -> str:
+    action = yaml.safe_load(ACTION.read_text(encoding="utf-8"))
+    for step in action["runs"]["steps"]:
+        if step.get("name") == DEVSHELL_STEP_NAME:
+            return step["run"]
+    raise AssertionError(f"step {DEVSHELL_STEP_NAME!r} not found in {ACTION}")
+
+
+def _write_nix_stub(bin_dir: Path) -> None:
+    """A fake `nix` covering every invocation the devshell step makes.
+
+    - `nix develop … --command true`                  -> exit 0 (profile build)
+    - `nix develop … --command bash -c 'printf … PATH'`-> a fake store PATH
+    - `nix develop … --command bash -c '… UV_… '`      -> the uv-download URL
+    - `nix develop … --command env …`                  -> the simulated env dump
+    """
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    lines = [
+        "#!/usr/bin/env bash",
+        "set -euo pipefail",
+        "# Collect the command after `--command`.",
+        "cmd=()",
+        "found=0",
+        'for a in "$@"; do',
+        '  if [ "$found" = 1 ]; then cmd+=("$a"); fi',
+        '  if [ "$a" = "--command" ]; then found=1; fi',
+        "done",
+        'joined="${cmd[*]:-}"',
+        'if [ "${cmd[0]:-}" = "true" ]; then exit 0; fi',
+        'if [ "${cmd[0]:-}" = "env" ]; then',
+    ]
+    for name, value in _DEVSHELL_ENV:
+        lines.append(f"  printf '%s\\0' {_bash_squote(name + '=' + value)}")
+    lines += [
+        "  exit 0",
+        "fi",
+        'case "$joined" in',
+        '  *"printf \\"%s\\" \\"\\$PATH\\""*)',
+        "    printf '%s' '/nix/store/aaaaaaaa-foo/bin:/nix/store/bbbbbbbb-bar/bin:/usr/bin'; exit 0 ;;",
+        "  *UV_PYTHON_DOWNLOADS_JSON_URL*)",
+        "    printf 'UV_PYTHON_DOWNLOADS_JSON_URL=https://example.invalid/downloads.json\\n'; exit 0 ;;",
+        "esac",
+        "exit 0",
+    ]
+    stub = bin_dir / "nix"
+    stub.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    stub.chmod(0o755)
+
+
+def _bash_squote(s: str) -> str:
+    """Single-quote a string for safe embedding in the generated bash stub."""
+    return "'" + s.replace("'", "'\\''") + "'"
+
+
+def _run_devshell_step(tmp_path: Path) -> dict[str, str]:
+    """Execute the devshell step and return the parsed GITHUB_ENV map.
+
+    Multi-line heredoc values are collapsed with `\\n` joins so a caller can
+    assert on them; the presence of a heredoc is asserted separately on the raw
+    text where it matters.
+    """
+    script = _devshell_step_script()
+
+    bin_dir = tmp_path / "stub-bin"
+    _write_nix_stub(bin_dir)
+
+    github_env = tmp_path / "github_env"
+    github_path = tmp_path / "github_path"
+    runner_temp = tmp_path / "runner_temp"
+    github_env.touch()
+    github_path.touch()
+    runner_temp.mkdir()
+
+    env = {
+        **os.environ,
+        "PATH": f"{bin_dir}:{os.environ['PATH']}",
+        "GITHUB_ENV": str(github_env),
+        "GITHUB_PATH": str(github_path),
+        "RUNNER_TEMP": str(runner_temp),
+        # Ambient var that the dev-shell leaves unchanged: must be filtered out.
+        "AMBIENT_SHARED": "same-on-both-sides",
+    }
+
+    proc = subprocess.run(
+        ["bash", "-c", script],
+        cwd=tmp_path,  # no pyproject.toml -> non-Python consumer path
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, (
+        f"devshell step failed:\nSTDOUT:\n{proc.stdout}\nSTDERR:\n{proc.stderr}"
+    )
+    return _parse_github_env(github_env.read_text(encoding="utf-8"))
+
+
+def _parse_github_env(text: str) -> dict[str, str]:
+    """Parse GITHUB_ENV supporting both `KEY=value` and heredoc blocks."""
+    out: dict[str, str] = {}
+    lines = text.splitlines()
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        if "<<" in line and "=" not in line.split("<<", 1)[0]:
+            name, _, delim = line.partition("<<")
+            i += 1
+            body: list[str] = []
+            while i < len(lines) and lines[i] != delim:
+                body.append(lines[i])
+                i += 1
+            out[name] = "\n".join(body)
+            i += 1  # skip the closing delimiter
+            continue
+        if "=" in line:
+            key, _, value = line.partition("=")
+            out[key] = value
+        i += 1
+    return out
+
+
+# ── Behavior ─────────────────────────────────────────────────────────────────
+
+
+def test_shellhook_scalar_exports_are_forwarded(tmp_path: Path) -> None:
+    """Plain shellHook exports reach GITHUB_ENV (the org-config#40 regression)."""
+    env = _run_devshell_step(tmp_path)
+    assert env.get("OTTERDOG_TOKEN") == "placeholder-set-by-shellhook"
+    assert env.get("PROJECT_GREETING") == "hello world"
+
+
+def test_multiline_value_survives_via_heredoc(tmp_path: Path) -> None:
+    """A multi-line export is forwarded intact using the GITHUB_ENV heredoc."""
+    env = _run_devshell_step(tmp_path)
+    assert env.get("MULTILINE_VAR") == "line-one\nline-two\nline-three"
+
+
+@pytest.mark.parametrize(
+    "denied",
+    [
+        # Nix/stdenv build machinery.
+        "buildInputs",
+        "nativeBuildInputs",
+        "stdenv",
+        "shellHook",
+        "out",
+        "system",
+        "NIX_CFLAGS_COMPILE",
+        "NIX_BUILD_CORES",
+        "dontUnpack",
+        "configurePhase",
+        "depsBuildBuild",
+        # Shell session state.
+        "PATH",
+        "HOME",
+        "SHLVL",
+        "TMPDIR",
+    ],
+)
+def test_denylisted_vars_are_not_forwarded(tmp_path: Path, denied: str) -> None:
+    """Build machinery and shell session state never leak into GITHUB_ENV."""
+    env = _run_devshell_step(tmp_path)
+    assert denied not in env, f"{denied} must not be forwarded to GITHUB_ENV"
+
+
+def test_unchanged_ambient_var_is_not_reforwarded(tmp_path: Path) -> None:
+    """A var identical to the host env is filtered — host secrets never re-leak."""
+    env = _run_devshell_step(tmp_path)
+    assert "AMBIENT_SHARED" not in env


### PR DESCRIPTION
## What

Fixes #1180. In direnv mode the `setup-devkit-toolchain` preamble exported the
dev-shell store bin dirs to `GITHUB_PATH` but dropped everything a project's
flake `shellHook` exports, so env defaults present in every local
`nix develop`/direnv session silently vanished on CI — a local-vs-CI divergence
that surfaced as unrelated tool errors (vig-os/org-config#40: a shellHook-seeded
`OTTERDOG_TOKEN` placeholder worked locally, failed on CI).

The preamble now forwards the flake `shellHook` environment to CI **by default,
sanitized** (the approved design).

## Approach — env-diff + denylist

- **Capture:** snapshot the ambient runner env (`env -0`) and the dev-shell env
  (`nix develop --command env -0`, so the `shellHook` has already run), both
  null-delimited so newlines/special chars survive.
- **Diff:** forward only the vars the dev-shell **adds or changes**. The ambient
  diff is the security boundary — host secrets already in the runner env are
  unchanged inside the shell, so they are never re-emitted into `GITHUB_ENV`.
- **Denylist:** never forward shell session state (`PATH` — already handled via
  `GITHUB_PATH` — `HOME`, `USER`, `LOGNAME`, `SHELL`, `TERM`, `PWD`, `OLDPWD`,
  `SHLVL`, `IFS`, `TMPDIR`/`TMP`/`TEMP`/`TEMPDIR`) or Nix/stdenv build machinery
  (`NIX_*`, `out`, `outputs`, `src`, `stdenv`, `system`, `builder`, `name`,
  `pname`, `version`, `shell`, `shellHook`, `buildInputs`, `nativeBuildInputs`,
  `propagated*BuildInputs`, `deps*`, `*Phase`, `phases`, `dont*`,
  `configureFlags`/`cmakeFlags`/`mesonFlags`/`makeFlags`, `patches`, `strictDeps`,
  `SOURCE_DATE_EPOCH`, `HOST_PATH`, `outputHash*`, …).
- **Write:** each forwarded var uses a random `GITHUB_ENV` heredoc delimiter, so
  multi-line and special-character values cannot break `GITHUB_ENV` parsing.

### Why env-diff, not `nix print-dev-env`

`nix print-dev-env` dumps the full stdenv build machinery (phases, buildInputs,
stdenv, out, …), none of which belongs in a CI environment — separating a
project's genuine `shellHook` exports from that noise still needs a diff and a
denylist. The env-diff (outside vs inside the dev shell) isolates exactly the
dev-shell's contribution, and the denylist removes the build machinery that the
shell layers on top. Cleaner and more robust than parsing print-dev-env.

Contained to the direnv step (`if: inputs.mode == 'direnv'`); container and bare
modes are untouched.

## Tests / evidence

New `tests/test_setup_toolchain_env.py` executes the step's **real** `run:`
script against a stubbed `nix` that emits a simulated dev-shell env (same
executed-bash pattern as `test_ci_runner.py`):

- scalar shellHook exports (`OTTERDOG_TOKEN`, `PROJECT_GREETING`) reach
  `GITHUB_ENV`;
- a multi-line value survives intact via the heredoc;
- 15 denylisted names (build machinery + session state) are never forwarded;
- a var unchanged from the ambient env is not re-forwarded (host-secret
  boundary).

`18 passed`; full `prek run --all-files` green; manual shellcheck of the step's
run script clean (only pre-existing SC2016 info notes on the existing
single-quoted `nix develop` captures).

## Scope

Minimal diff: the direnv step, a new test, changelog (+ synced `.devcontainer`
mirror), and a MIGRATION.md subsection. The LD_LIBRARY_PATH/native-wheel issue
(#1181) is deliberately untouched; `justfile.base` untouched.

Refs: #1180, vig-os/org-config#40
