### PR TITLE
fix(workspace): scope libstdc++ for uvx native wheels in direnv CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **uvx tools with native wheels load libstdc++ in direnv-mode CI** ([#1181](https://github.com/vig-os/devkit/issues/1181))
+  - On a non-Python direnv-mode consumer the CI preamble keeps the Nix CPython
+    on `PATH`, whose loader does not search `/usr/lib`, so a `uvx`-run tool's
+    manylinux native wheel (e.g. otterdog's `rjsonnet`) aborted with
+    `libstdc++.so.6: cannot open shared object file` — the same failure class as
+    the dropped `pymarkdown`/`pyjson5` hook. The root `justfile` now ships a base
+    `with-native-libs` recipe that wraps one command with a command-scoped
+    `LD_LIBRARY_PATH` sourced from `$VIGOS_STDCPP_LIB` or derived from the
+    on-`PATH` `cc` wrapper, so a `justfile.project` recipe can run such a tool
+    (`just with-native-libs uvx …`) without the wheel failing to import. It
+    degrades to a no-op when neither source resolves the library.
+
 ### Security
 
 ## [1.3.1](https://github.com/vig-os/devkit/releases/tag/1.3.1) - 2026-07-17

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -116,6 +116,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **uvx tools with native wheels load libstdc++ in direnv-mode CI** ([#1181](https://github.com/vig-os/devkit/issues/1181))
+  - On a non-Python direnv-mode consumer the CI preamble keeps the Nix CPython
+    on `PATH`, whose loader does not search `/usr/lib`, so a `uvx`-run tool's
+    manylinux native wheel (e.g. otterdog's `rjsonnet`) aborted with
+    `libstdc++.so.6: cannot open shared object file` — the same failure class as
+    the dropped `pymarkdown`/`pyjson5` hook. The root `justfile` now ships a base
+    `with-native-libs` recipe that wraps one command with a command-scoped
+    `LD_LIBRARY_PATH` sourced from `$VIGOS_STDCPP_LIB` or derived from the
+    on-`PATH` `cc` wrapper, so a `justfile.project` recipe can run such a tool
+    (`just with-native-libs uvx …`) without the wheel failing to import. It
+    degrades to a no-op when neither source resolves the library.
+
 ### Security
 
 ## [1.3.1](https://github.com/vig-os/devkit/releases/tag/1.3.1) - 2026-07-17

--- a/assets/workspace/justfile
+++ b/assets/workspace/justfile
@@ -24,8 +24,11 @@ help:
 # a command-scoped LD_LIBRARY_PATH sourced from $VIGOS_STDCPP_LIB (dev-shell
 # export) or derived from the on-PATH `cc` wrapper (cc echoes the bare name
 # back — not an absolute path — when it cannot resolve the lib, so the leading-/
-# check degrades to a no-op). Scoping it to this one command keeps the Nix
-# libstdc++ out of every other tool's process. Lives here (not justfile.devc,
+# check leaves the prefix empty). Scoping it to this one command keeps the Nix
+# libstdc++ out of every other tool's process. When nothing resolves, the
+# environment is left UNTOUCHED — never compose with an empty prefix, since an
+# empty LD_LIBRARY_PATH entry (leading colon, or a bare "") means "current
+# working directory" to the dynamic loader. Lives here (not justfile.devc,
 # devcontainer-only) so it is reachable in direnv/bare mode — the case that
 # needs it. Usage from a justfile.project recipe:
 # just with-native-libs uvx --from otterdog@1.2.3 otterdog validate --local
@@ -36,7 +39,11 @@ with-native-libs +command:
       p="$(cc -print-file-name=libstdc++.so.6)"; \
       case "$p" in /*) stdcpp_lib="$(dirname "$p")" ;; esac; \
     fi; \
-    LD_LIBRARY_PATH="$stdcpp_lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" {{ command }}
+    if [ -n "$stdcpp_lib" ]; then \
+      LD_LIBRARY_PATH="$stdcpp_lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" {{ command }}; \
+    else \
+      {{ command }}; \
+    fi
 
 # Import devcontainer-managed base recipes (replaced on upgrade).
 # Optional: a `direnv`-mode workspace (`init-workspace --mode direnv`) has no

--- a/assets/workspace/justfile
+++ b/assets/workspace/justfile
@@ -16,6 +16,28 @@ set shell := ["bash", "-euo", "pipefail", "-c"]
 help:
     @just --list
 
+# Run a command with libstdc++ resolvable for uvx-run native wheels (#1181).
+# On a non-Python direnv-mode consumer the CI preamble keeps the Nix CPython on
+# PATH, whose loader does not search /usr/lib, so a uvx tool's manylinux native
+# wheel (e.g. otterdog's rjsonnet) fails to import with
+# "libstdc++.so.6: cannot open shared object file". This wraps ONE command with
+# a command-scoped LD_LIBRARY_PATH sourced from $VIGOS_STDCPP_LIB (dev-shell
+# export) or derived from the on-PATH `cc` wrapper (cc echoes the bare name
+# back — not an absolute path — when it cannot resolve the lib, so the leading-/
+# check degrades to a no-op). Scoping it to this one command keeps the Nix
+# libstdc++ out of every other tool's process. Lives here (not justfile.devc,
+# devcontainer-only) so it is reachable in direnv/bare mode — the case that
+# needs it. Usage from a justfile.project recipe:
+# just with-native-libs uvx --from otterdog@1.2.3 otterdog validate --local
+[group('helpers')]
+with-native-libs +command:
+    @stdcpp_lib="${VIGOS_STDCPP_LIB:-}"; \
+    if [ -z "$stdcpp_lib" ] && command -v cc >/dev/null 2>&1; then \
+      p="$(cc -print-file-name=libstdc++.so.6)"; \
+      case "$p" in /*) stdcpp_lib="$(dirname "$p")" ;; esac; \
+    fi; \
+    LD_LIBRARY_PATH="$stdcpp_lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" {{ command }}
+
 # Import devcontainer-managed base recipes (replaced on upgrade).
 # Optional: a `direnv`-mode workspace (`init-workspace --mode direnv`) has no
 # .devcontainer/, so these must not be hard imports or `just` fails to load.

--- a/docs/NIX.md
+++ b/docs/NIX.md
@@ -504,8 +504,10 @@ validate:
 
 Scoping the variable to the one command keeps the Nix `libstdc++` out of every
 other tool's process; when neither `$VIGOS_STDCPP_LIB` nor `cc` resolves the
-library the prefix degrades to the caller's own `LD_LIBRARY_PATH` (or empty) — a
-no-op. Only reach for it on a repo that runs `uvx`/`uv tool` tools with compiled
+library the command runs with the environment untouched — the recipe never
+composes an empty prefix, because an empty `LD_LIBRARY_PATH` entry (a leading
+colon or a bare `""`) means "current working directory" to the dynamic loader.
+Only reach for it on a repo that runs `uvx`/`uv tool` tools with compiled
 extensions under the Nix CPython; pure-Python tools need nothing.
 
 ## Cachix and the `direnv allow` onboarding flow

--- a/docs/NIX.md
+++ b/docs/NIX.md
@@ -481,6 +481,33 @@ host config (`programs.nix-ld.enable` + `libraries = [ pkgs.stdenv.cc.cc ]`)
 would also work but is per-contributor system config the repo cannot enforce, so
 it is at most a fallback, not the fix.
 
+That `LD_LIBRARY_PATH` safety net only exists **inside** the dev-shell. In
+`direnv`-mode CI the preamble forwards the dev-shell `PATH` but not its exported
+environment, so a `uvx`-run tool on a non-Python repo (where the manylinux
+exclusion of [#1028](https://github.com/vig-os/devkit/issues/1028) does not
+apply and the Nix CPython stays on `PATH`) loads its native wheel with no
+`libstdc++` on the loader path and aborts with
+`libstdc++.so.6: cannot open shared object file`
+([#1181](https://github.com/vig-os/devkit/issues/1181), otterdog's `rjsonnet` in
+org-config#40). For that case the root `justfile` ships a base
+`with-native-libs` recipe (all delivery modes — it is **not** in the
+devcontainer-only `justfile.devc`) that wraps a single command with a
+command-scoped `LD_LIBRARY_PATH`, sourced from `$VIGOS_STDCPP_LIB` (a dev-shell
+`shellHook` export, when present) or otherwise derived from the on-`PATH` `cc`
+wrapper via `cc -print-file-name=libstdc++.so.6`. A `justfile.project` recipe
+that runs a `uvx` tool with a native extension prefixes it:
+
+```just
+validate:
+    just with-native-libs uvx --from otterdog@1.2.3 otterdog validate --local
+```
+
+Scoping the variable to the one command keeps the Nix `libstdc++` out of every
+other tool's process; when neither `$VIGOS_STDCPP_LIB` nor `cc` resolves the
+library the prefix degrades to the caller's own `LD_LIBRARY_PATH` (or empty) — a
+no-op. Only reach for it on a repo that runs `uvx`/`uv tool` tools with compiled
+extensions under the Nix CPython; pure-Python tools need nothing.
+
 ## Cachix and the `direnv allow` onboarding flow
 
 The dev-shell closure is published to the public **`vig-os`** Cachix binary

--- a/tests/bats/just.bats
+++ b/tests/bats/just.bats
@@ -352,7 +352,7 @@ STUB
     run env -u LD_LIBRARY_PATH PATH="$NL_DIR/notfound:$PATH" \
         just -f "$NL_DIR/justfile" -d "$NL_DIR" with-native-libs env
     assert_success
-    refute_output --partial "LD_LIBRARY_PATH"
+    refute_line --regexp '^LD_LIBRARY_PATH='
 }
 
 @test "with-native-libs prepends to an existing LD_LIBRARY_PATH (#1181)" {

--- a/tests/bats/just.bats
+++ b/tests/bats/just.bats
@@ -293,3 +293,70 @@ EOF
     run bash -lc "awk '/^      - name: Collect finalization files/{flag=1} /^      - name: Commit finalization changes via API/{flag=0} flag {print}' .github/workflows/release.yml | grep -Fq \"tr '\\n' ','\""
     assert_success
 }
+
+# ── uvx native-wheel libstdc++ helper (#1181) ─────────────────────────────────
+# On a non-Python direnv-mode consumer the CI preamble keeps the Nix CPython on
+# PATH, whose loader does not search /usr/lib, so a uvx tool's manylinux native
+# wheel (e.g. otterdog's rjsonnet) fails to import with
+# "libstdc++.so.6: cannot open shared object file" (org-config#40). The base
+# `with-native-libs` recipe wraps ONE command with a command-scoped
+# LD_LIBRARY_PATH sourced from $VIGOS_STDCPP_LIB (dev-shell export) or derived
+# from the on-PATH `cc` wrapper, degrading to a no-op when neither is available.
+# It lives in the root justfile (all delivery modes), not justfile.devc which is
+# devcontainer-only — direnv-mode CI is exactly the case that needs it.
+
+# Materialize the scaffolded root justfile plus two `cc` stubs in a temp dir:
+# `found/cc` echoes an absolute path (gcc's behavior when it resolves the lib),
+# `notfound/cc` echoes the bare name back (gcc's behavior when it cannot).
+_with_native_libs_fixture() {
+    NL_DIR="$BATS_TEST_TMPDIR/nl"
+    mkdir -p "$NL_DIR/found" "$NL_DIR/notfound"
+    cp "$PROJECT_ROOT/assets/workspace/justfile" "$NL_DIR/justfile"
+    cat > "$NL_DIR/found/cc" <<'STUB'
+#!/usr/bin/env bash
+[ "$1" = "-print-file-name=libstdc++.so.6" ] && echo /opt/fake/lib/libstdc++.so.6
+STUB
+    cat > "$NL_DIR/notfound/cc" <<'STUB'
+#!/usr/bin/env bash
+[ "$1" = "-print-file-name=libstdc++.so.6" ] && echo libstdc++.so.6
+STUB
+    chmod +x "$NL_DIR/found/cc" "$NL_DIR/notfound/cc"
+}
+
+@test "root justfile ships the with-native-libs helper recipe (#1181)" {
+    run grep -qE '^with-native-libs \+command:' assets/workspace/justfile
+    assert_success
+}
+
+@test "with-native-libs derives LD_LIBRARY_PATH from the on-PATH cc wrapper (#1181)" {
+    _with_native_libs_fixture
+    run env -u LD_LIBRARY_PATH PATH="$NL_DIR/found:$PATH" \
+        just -f "$NL_DIR/justfile" -d "$NL_DIR" with-native-libs env
+    assert_success
+    assert_line "LD_LIBRARY_PATH=/opt/fake/lib"
+}
+
+@test "with-native-libs prefers VIGOS_STDCPP_LIB over deriving from cc (#1181)" {
+    _with_native_libs_fixture
+    run env -u LD_LIBRARY_PATH VIGOS_STDCPP_LIB=/from/var PATH="$NL_DIR/found:$PATH" \
+        just -f "$NL_DIR/justfile" -d "$NL_DIR" with-native-libs env
+    assert_success
+    assert_line "LD_LIBRARY_PATH=/from/var"
+}
+
+@test "with-native-libs no-ops cleanly when libstdc++ is not found (#1181)" {
+    _with_native_libs_fixture
+    run env -u LD_LIBRARY_PATH PATH="$NL_DIR/notfound:$PATH" \
+        just -f "$NL_DIR/justfile" -d "$NL_DIR" with-native-libs env
+    assert_success
+    assert_line "LD_LIBRARY_PATH="
+    refute_output --partial "/opt/fake/lib"
+}
+
+@test "with-native-libs prepends to an existing LD_LIBRARY_PATH (#1181)" {
+    _with_native_libs_fixture
+    run env LD_LIBRARY_PATH=/pre/existing PATH="$NL_DIR/found:$PATH" \
+        just -f "$NL_DIR/justfile" -d "$NL_DIR" with-native-libs env
+    assert_success
+    assert_line "LD_LIBRARY_PATH=/opt/fake/lib:/pre/existing"
+}

--- a/tests/bats/just.bats
+++ b/tests/bats/just.bats
@@ -345,12 +345,14 @@ STUB
 }
 
 @test "with-native-libs no-ops cleanly when libstdc++ is not found (#1181)" {
+    # A true no-op: LD_LIBRARY_PATH stays UNSET, not set-to-empty — an empty
+    # value is itself one empty entry, which the dynamic loader treats as the
+    # current working directory.
     _with_native_libs_fixture
     run env -u LD_LIBRARY_PATH PATH="$NL_DIR/notfound:$PATH" \
         just -f "$NL_DIR/justfile" -d "$NL_DIR" with-native-libs env
     assert_success
-    assert_line "LD_LIBRARY_PATH="
-    refute_output --partial "/opt/fake/lib"
+    refute_output --partial "LD_LIBRARY_PATH"
 }
 
 @test "with-native-libs prepends to an existing LD_LIBRARY_PATH (#1181)" {
@@ -359,4 +361,18 @@ STUB
         just -f "$NL_DIR/justfile" -d "$NL_DIR" with-native-libs env
     assert_success
     assert_line "LD_LIBRARY_PATH=/opt/fake/lib:/pre/existing"
+}
+
+@test "with-native-libs leaves an existing LD_LIBRARY_PATH untouched when nothing resolves (#1181)" {
+    # With an empty prefix a naive composition yields ":/pre/existing" — the
+    # leading empty entry means "current working directory" to the dynamic
+    # loader, silently adding cwd to the library search path (a planted
+    # libstdc++.so.6 in an untrusted directory would be loaded). The caller's
+    # value must pass through byte-identical, no leading colon.
+    _with_native_libs_fixture
+    run env LD_LIBRARY_PATH=/pre/existing PATH="$NL_DIR/notfound:$PATH" \
+        just -f "$NL_DIR/justfile" -d "$NL_DIR" with-native-libs env
+    assert_success
+    assert_line "LD_LIBRARY_PATH=/pre/existing"
+    refute_output --partial "LD_LIBRARY_PATH=:"
 }


### PR DESCRIPTION
## What & why

On a non-Python **direnv-mode** consumer, the CI preamble keeps the Nix CPython on `PATH` (the manylinux exclusion of #1028 only applies when `pyproject.toml` exists). A `uvx`-run tool whose manylinux native wheel links `libstdc++.so.6` then aborts with `libstdc++.so.6: cannot open shared object file`, because the Nix loader does not search `/usr/lib` — the same failure class as the dropped `pymarkdown`/`pyjson5` hook.

Fixes #1181.

## Approach

Ship the proven org-config pattern as a **base justfile helper** rather than a global preamble export or a change to `setup-devkit-toolchain` (owned by #1180). The root `assets/workspace/justfile` gains a `with-native-libs +command` recipe:

- Lives in the **root** justfile so it is reachable in **every** delivery mode (direnv/bare have no `.devcontainer/justfile.devc`) — direnv-mode CI is exactly the case that needs it.
- Derives a **command-scoped** `LD_LIBRARY_PATH` from `$VIGOS_STDCPP_LIB` (dev-shell export) or, failing that, from the on-`PATH` `cc` wrapper via `cc -print-file-name=libstdc++.so.6` (the wrapper is on the preamble-forwarded PATH; `cc` echoes the bare name back — not an absolute path — when it cannot resolve the lib, so the leading-`/` check degrades to a no-op).
- Scoped to the one wrapped command, so the Nix `libstdc++` never leaks into other tools' processes; degrades to the caller's own `LD_LIBRARY_PATH` (or empty) when neither source resolves.

A consumer recipe wraps its tool:

```just
validate:
    just with-native-libs uvx --from otterdog@1.2.3 otterdog validate --local
```

## Provenance & evidence

- Mirrors the consumer-side fix proven in **org-config@f01175a** (vig-os/org-config#40), reproduced under a CI-faithful `env -i PATH=<store bins>` simulation.
- TDD: failing bats test committed first, then the recipe. New coverage in `tests/bats/just.bats` exercises all branches:
  - derives `LD_LIBRARY_PATH` from the on-PATH `cc` wrapper,
  - prefers `$VIGOS_STDCPP_LIB` over deriving from `cc`,
  - no-ops cleanly when the lib is not found,
  - prepends to an existing `LD_LIBRARY_PATH`.
- `bats tests/bats/just.bats`: **51/51 pass** (5 new). `prek run --all-files`: **fully green**.

## Scope

Minimal diff — root justfile helper, its bats coverage, changelog (+ synced `.devcontainer/` mirror), and NIX.md docs. Does **not** touch `setup-devkit-toolchain` (#1180) and does **not** resurrect the pymarkdown hook (nix-packaged separately in #1177).

## Review fix: no empty LD_LIBRARY_PATH entries

Review found an edge case: when nothing resolved the libstdc++ dir (no `$VIGOS_STDCPP_LIB`, `cc` absent or lib not found) the recipe still composed the prefix, yielding `:/pre/existing` when the caller had an `LD_LIBRARY_PATH` (a leading empty entry = **cwd** on the dynamic loader's search path — a tool run from an untrusted directory could load a planted `libstdc++.so.6`), or setting the variable to `""` when it did not. Fixed (TDD, RED then GREEN): the recipe now branches on a non-empty prefix and otherwise runs the command with the environment **untouched** — never a leading colon, never set-to-empty. New bats coverage asserts the caller's value passes through byte-identical and that the variable stays unset in the pure no-op case. After the fix: `bats tests/bats/just.bats` **52/52 pass**, `prek run --all-files` fully green.

Refs: #1181, vig-os/org-config#40
