### PR TITLE
ci: audit, fix, and baseline zizmor findings in managed workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,6 +232,16 @@ jobs:
       - name: Check downstream flake stub
         run: nix flake check ./assets/workspace --override-input vigos "path:$PWD" --accept-flake-config
 
+      # Audit the devkit-managed workflow set (assets/workspace/.github/workflows/)
+      # against the shipped zizmor baseline (zizmor.yml). Gates regressions: a new
+      # zizmor finding — or a managed workflow that regains a fixed finding — fails
+      # here and must be fixed in the workflow or triaged in zizmor.yml, so
+      # consumers never inherit an unbaselined finding from devkit's output. The
+      # baseline scopes exemptions to managed basenames only, so consumer-authored
+      # workflows are never suppressed. Refs #1182.
+      - name: Audit managed workflows (zizmor)
+        run: uvx zizmor@1.25.2 --offline --config zizmor.yml assets/workspace/.github/workflows/
+
   # Commit-message validation (#1019). `validate-commit-msg` is a commit-msg
   # stage hook, so `prek run --all-files` (the project-checks lane) never runs
   # it — and the only other enforcement path, the local core.hooksPath shim,

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -70,6 +70,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a  # v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **Audit and baseline the managed GitHub Actions workflows (zizmor)** ([#1182](https://github.com/vig-os/devkit/issues/1182))
+  - `zizmor` over the 14 devkit-managed workflows previously surfaced 73 findings
+    (40 high / 32 medium) that every consumer had to baseline against code it does
+    not own. Devkit now audits its own output: 8 findings fixed upstream and the
+    intentional remainder shipped as a devkit-owned baseline so consumer baselines
+    shrink to zero.
+  - **Fixed (8):** `persist-credentials: false` on the read-only checkouts that
+    never push or fetch (CI lint/test/resolve-toolchain/dependency-review,
+    `codeql.yml`, and the `renovate-changelog-build`/`sync-issues` toolchain
+    checkouts) — 7 `artipacked` findings; and the `sync-main-to-dev` cleanup step's
+    release-app token moved into `env:` — 1 `template-injection` finding. All
+    behavior-preserving.
+  - **Baseline shipped:** a maintained `zizmor.yml` (scaffolded/managed, registered
+    in `scripts/manifest.toml`) suppresses the 65 residual findings that cannot be
+    fixed without changing release/CI behavior (`unpinned-images` for the
+    runtime-resolved toolchain image, broadly-scoped `github-app` release tokens,
+    `secrets: inherit` release fan-out, the renovate-changelog `dangerous-triggers`,
+    and credential-persisting push checkouts). Every exemption is scoped to a
+    managed-workflow basename, so a consumer-authored workflow never inherits one.
+  - **Gate added:** devkit CI (`ci.yml` `project-checks`) lints the managed set
+    against the shipped baseline, so a regression or a new audit fails devkit CI
+    instead of reaching consumers. Policy documented in `docs/WORKFLOW_SECURITY.md`.
+
 ## [1.3.1](https://github.com/vig-os/devkit/releases/tag/1.3.1) - 2026-07-17
 
 ### Added

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -118,6 +118,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **Audit and baseline the managed GitHub Actions workflows (zizmor)** ([#1182](https://github.com/vig-os/devkit/issues/1182))
+  - `zizmor` over the 14 devkit-managed workflows previously surfaced 73 findings
+    (40 high / 32 medium) that every consumer had to baseline against code it does
+    not own. Devkit now audits its own output: 8 findings fixed upstream and the
+    intentional remainder shipped as a devkit-owned baseline so consumer baselines
+    shrink to zero.
+  - **Fixed (8):** `persist-credentials: false` on the read-only checkouts that
+    never push or fetch (CI lint/test/resolve-toolchain/dependency-review,
+    `codeql.yml`, and the `renovate-changelog-build`/`sync-issues` toolchain
+    checkouts) — 7 `artipacked` findings; and the `sync-main-to-dev` cleanup step's
+    release-app token moved into `env:` — 1 `template-injection` finding. All
+    behavior-preserving.
+  - **Baseline shipped:** a maintained `zizmor.yml` (scaffolded/managed, registered
+    in `scripts/manifest.toml`) suppresses the 65 residual findings that cannot be
+    fixed without changing release/CI behavior (`unpinned-images` for the
+    runtime-resolved toolchain image, broadly-scoped `github-app` release tokens,
+    `secrets: inherit` release fan-out, the renovate-changelog `dangerous-triggers`,
+    and credential-persisting push checkouts). Every exemption is scoped to a
+    managed-workflow basename, so a consumer-authored workflow never inherits one.
+  - **Gate added:** devkit CI (`ci.yml` `project-checks`) lints the managed set
+    against the shipped baseline, so a regression or a new audit fails devkit CI
+    instead of reaching consumers. Policy documented in `docs/WORKFLOW_SECURITY.md`.
+
 ## [1.3.1](https://github.com/vig-os/devkit/releases/tag/1.3.1) - 2026-07-17
 
 ### Added

--- a/assets/workspace/.github/workflows/ci.yml
+++ b/assets/workspace/.github/workflows/ci.yml
@@ -85,6 +85,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
+          persist-credentials: false
           sparse-checkout: |
             .vig-os
             .github/actions/resolve-toolchain
@@ -118,6 +119,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       # Mode-aware preamble: exports the in-image env + prek skew guard in
       # container mode, provisions the Nix dev-shell (direnv) or the uv host
@@ -154,6 +157,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Set up devkit toolchain
         uses: ./.github/actions/setup-devkit-toolchain
@@ -272,6 +277,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Review dependencies for vulnerabilities
         uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294  # v5.0.0

--- a/assets/workspace/.github/workflows/codeql.yml
+++ b/assets/workspace/.github/workflows/codeql.yml
@@ -73,6 +73,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a  # v4

--- a/assets/workspace/.github/workflows/renovate-changelog-build.yml
+++ b/assets/workspace/.github/workflows/renovate-changelog-build.yml
@@ -35,6 +35,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
+          persist-credentials: false
           ref: ${{ github.event.pull_request.base.ref }}
           sparse-checkout: |
             .vig-os

--- a/assets/workspace/.github/workflows/sync-issues.yml
+++ b/assets/workspace/.github/workflows/sync-issues.yml
@@ -56,6 +56,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
+          persist-credentials: false
           sparse-checkout: |
             .vig-os
             .github/actions/resolve-toolchain

--- a/assets/workspace/.github/workflows/sync-main-to-dev.yml
+++ b/assets/workspace/.github/workflows/sync-main-to-dev.yml
@@ -204,13 +204,14 @@ jobs:
         if: steps.recheck.outputs.up_to_date != 'true'
         env:
           GH_TOKEN: ${{ steps.commit-app-token.outputs.token }}
+          RELEASE_GH_TOKEN: ${{ steps.release-app-token.outputs.token }}
         run: |
           set -euo pipefail
           REFS=$(retry --retries 3 --backoff 5 --max-backoff 30 -- \
             gh api --paginate "repos/${{ github.repository }}/git/matching-refs/heads/chore/sync-main-to-dev-" \
             --jq '.[].ref' | sed 's|refs/heads/||') || true
           for branch in ${REFS}; do
-            HAS_PR=$(GH_TOKEN="${{ steps.release-app-token.outputs.token }}" retry --retries 3 --backoff 5 --max-backoff 30 -- \
+            HAS_PR=$(GH_TOKEN="${RELEASE_GH_TOKEN}" retry --retries 3 --backoff 5 --max-backoff 30 -- \
               gh pr list --base dev --head "${branch}" \
               --state open --json number --jq 'length')
             if [ "${HAS_PR}" = "0" ]; then

--- a/assets/workspace/zizmor.yml
+++ b/assets/workspace/zizmor.yml
@@ -1,0 +1,87 @@
+# Managed by vigOS devkit — regenerated on upgrade; local edits are lost.
+# Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues
+
+# zizmor configuration — GitHub Actions security auditing baseline.
+#
+# Devkit OWNS this baseline. It suppresses the residual zizmor findings in the
+# devkit-managed workflows that cannot be fixed without changing release/CI
+# behavior for every consumer. Devkit's own CI gates the managed workflow set
+# against this file (see .github/workflows/ci.yml → "Audit managed workflows"),
+# so a regression — a new finding, or a managed workflow that regains a fixed
+# finding — fails devkit CI and must be fixed or triaged here, not silently
+# baselined downstream.
+#
+# This file is SCAFFOLDED into every consumer repo (manifest entry: zizmor.yml)
+# so their baseline for devkit's output shrinks to zero: a consumer adopting
+# `zizmor` inherits exactly these exemptions and maintains none of their own for
+# managed files.
+#
+# SCOPE RULE (load-bearing): every entry is a SPECIFIC managed workflow
+# BASENAME, never a `*.yml` glob. A repo-authored (consumer-authored) workflow
+# has a different filename and therefore NEVER inherits a managed file's
+# exemption — its findings are always reported. When a devkit upgrade adds,
+# renames, or removes a managed workflow, or a new zizmor audit surfaces, update
+# this file as part of that upgrade (or fix the workflow upstream in
+# vig-os/devkit). Full policy:
+# https://github.com/vig-os/devkit/blob/main/docs/WORKFLOW_SECURITY.md
+#
+# Fixed upstream (NOT baselined — listed here as a record of what devkit fixed):
+#   - artipacked        → persist-credentials: false on read-only checkouts
+#                         (ci.yml lint/test/resolve/dependency-review, codeql.yml,
+#                         renovate-changelog-build.yml, sync-issues.yml resolve).
+#   - template-injection → release-app token moved into step env in
+#                         sync-main-to-dev.yml.
+#
+# Residual (baselined below), why each is intentional:
+#   - artipacked        → checkouts that push or fetch from a private remote and
+#                         therefore rely on the persisted git credential
+#                         (ci.yml commit-checks, all release/sync branch work).
+#   - dangerous-triggers → renovate-changelog-commit.yml runs on `workflow_run`
+#                         by design (it commits the built changelog).
+#   - github-app        → create-github-app-token intentionally mints a
+#                         broadly-scoped installation token for release
+#                         orchestration; per-permission scoping would break the
+#                         multi-repo release/sync flows.
+#   - secrets-inherit   → release.yml / prepare-release.yml fan out to reusable
+#                         workflows with `secrets: inherit` by design.
+#   - unpinned-images   → `image:` is the devkit toolchain image resolved at
+#                         runtime (needs.*.outputs.image / inputs.toolchain_image);
+#                         it cannot be SHA-pinned in source.
+rules:
+  artipacked:
+    ignore:
+      - ci.yml
+      - prepare-release.yml
+      - promote-release.yml
+      - release-core.yml
+      - release-publish.yml
+      - release.yml
+      - sync-main-to-dev.yml
+  dangerous-triggers:
+    ignore:
+      - renovate-changelog-commit.yml
+  github-app:
+    ignore:
+      - prepare-release.yml
+      - promote-release.yml
+      - release-core.yml
+      - release-publish.yml
+      - release.yml
+      - renovate-changelog-commit.yml
+      - sync-issues.yml
+      - sync-main-to-dev.yml
+  secrets-inherit:
+    ignore:
+      - prepare-release.yml
+      - release.yml
+  unpinned-images:
+    ignore:
+      - ci.yml
+      - prepare-release.yml
+      - promote-release.yml
+      - release-core.yml
+      - release-publish.yml
+      - release.yml
+      - renovate-changelog-build.yml
+      - sync-issues.yml
+      - sync-main-to-dev.yml

--- a/docs/WORKFLOW_SECURITY.md
+++ b/docs/WORKFLOW_SECURITY.md
@@ -1,0 +1,69 @@
+# Managed Workflow Security (zizmor)
+
+This document describes how devkit audits the GitHub Actions workflows it
+generates for consumers, and the policy behind the shipped
+[`zizmor`](https://docs.zizmor.sh) baseline (`zizmor.yml`).
+
+## Problem
+
+Every consumer scaffolded by devkit receives ~14 managed workflows
+(`assets/workspace/.github/workflows/`) whose header banners say they are
+regenerated on upgrade. A consumer that adopts workflow security linting cannot
+fix findings in that generated code — it does not own it — so without a
+devkit-supplied baseline each consumer has to maintain its own exemption list
+for devkit's output, re-triaging it on every upgrade (#1182).
+
+## Policy
+
+1. **Fix upstream what is fixable, without changing behavior.** These workflows
+   run releases and CI for every consumer, so fixes are surgical and
+   behavior-preserving:
+   - **`persist-credentials: false`** on checkouts that only read the tree (CI
+     lint/test, toolchain resolution, CodeQL, dependency review) — they never
+     push or fetch from the remote, so dropping the persisted git credential is
+     inert. Checkouts that push or fetch from a (possibly private) remote keep
+     the credential.
+   - **Untrusted `${{ … }}` interpolations move into `env:`** so a step body
+     cannot be templated into by expansion context.
+   - **`uses:` are SHA-pinned** with a trailing `# vX.Y.Z` comment; Renovate's
+     `github-actions` manager keeps the digests fresh.
+2. **Baseline the intentional remainder — devkit owns it.** `zizmor.yml` (repo
+   root) is the single source of truth. It suppresses only the residual findings
+   that cannot be fixed without changing release/CI behavior:
+   | Audit | Why it is intentional |
+   |-------|-----------------------|
+   | `artipacked` | The checkout pushes or fetches from a private remote and needs the persisted credential (release/sync branch work, the CI commit-checks base-diff). |
+   | `dangerous-triggers` | `renovate-changelog-commit.yml` runs on `workflow_run` by design to commit the built changelog. |
+   | `github-app` | `create-github-app-token` mints a broadly-scoped installation token for multi-repo release orchestration; per-permission scoping would break those flows. |
+   | `secrets-inherit` | `release.yml` / `prepare-release.yml` fan out to reusable workflows with `secrets: inherit` by design. |
+   | `unpinned-images` | `image:` is the devkit toolchain image resolved at runtime; it cannot be SHA-pinned in source. |
+3. **Consumers inherit the baseline; their own baseline shrinks to zero.**
+   `zizmor.yml` is a scaffolded/managed asset (registered in
+   `scripts/manifest.toml`), so a consumer adopting `zizmor` gets exactly
+   devkit's exemptions and maintains none of its own for managed files.
+4. **A repo-authored workflow never inherits an exemption.** Every baseline
+   entry is a specific managed-workflow **basename** (e.g. `release.yml`), never
+   a `*.yml` glob. A consumer's own workflow has a different filename, so its
+   findings are always reported. This scope rule is enforced by
+   `tests/test_workflow_zizmor_baseline.py`.
+
+## Regression gate
+
+Devkit's own CI (`.github/workflows/ci.yml`, `project-checks` job) runs
+
+```
+uvx zizmor@<pinned> --offline --config zizmor.yml assets/workspace/.github/workflows/
+```
+
+so the managed set must report **zero** unbaselined findings. A new zizmor
+audit, a new/renamed managed workflow, or a managed workflow that regains a
+fixed finding fails devkit CI — it must be fixed in the workflow or triaged into
+`zizmor.yml` as part of that change, never left for consumers to absorb.
+
+## Maintenance
+
+When a devkit upgrade adds, renames, or removes a managed workflow, or a new
+zizmor audit surfaces, update `zizmor.yml` (or fix the workflow) in the same PR.
+The zizmor version in the CI gate is pinned deliberately: a floating version
+would let a newly-released audit break CI unpredictably, so version bumps are an
+explicit, reviewed change that re-baselines any new findings at the same time.

--- a/scripts/manifest.toml
+++ b/scripts/manifest.toml
@@ -43,6 +43,14 @@ src = ".yamllint"
 [[entries]]
 src = ".typos.toml"
 
+# zizmor GitHub Actions security baseline (#1182). Devkit owns the residual
+# findings in its managed workflows; the root file is the SSoT (devkit's own CI
+# gate reads it) and it scaffolds verbatim into every consumer so their baseline
+# for devkit's output is zero. Scope is per-managed-basename; a repo-authored
+# workflow never inherits an exemption.
+[[entries]]
+src = "zizmor.yml"
+
 [[entries]]
 src = ".pymarkdown"
 

--- a/tests/test_workflow_zizmor_baseline.py
+++ b/tests/test_workflow_zizmor_baseline.py
@@ -1,0 +1,86 @@
+"""zizmor baseline + gate invariants for the devkit-managed workflow set.
+
+Issue #1182: zizmor over the devkit-managed workflows surfaced 73 findings that
+every consumer had to baseline against code they do not own. Devkit now fixes
+what is fixable and ships a maintained, devkit-owned baseline (``zizmor.yml``)
+so consumer baselines shrink to zero, gated by devkit's own CI.
+
+These tests pin the deliverable without invoking the ``zizmor`` binary (which is
+not part of the toolchain): the baseline ships to consumers, is registered in
+the sync manifest, scopes every exemption to a *managed workflow basename*
+(never a glob — so a repo-authored workflow can never inherit an exemption), and
+the CI gate that lints the managed set against it stays wired.
+
+Refs: #1182
+"""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+ROOT_BASELINE = REPO_ROOT / "zizmor.yml"
+SCAFFOLD_BASELINE = REPO_ROOT / "assets" / "workspace" / "zizmor.yml"
+MANAGED_WORKFLOWS = REPO_ROOT / "assets" / "workspace" / ".github" / "workflows"
+MANIFEST = REPO_ROOT / "scripts" / "manifest.toml"
+DEVKIT_CI = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+
+
+def _rules(path: Path) -> dict:
+    return yaml.safe_load(path.read_text(encoding="utf-8"))["rules"]
+
+
+def test_baseline_ships_at_root_and_in_scaffold() -> None:
+    """The baseline exists both as the devkit SSoT and in the consumer scaffold."""
+    assert ROOT_BASELINE.is_file(), "devkit-owned zizmor.yml (SSoT) is missing"
+    assert SCAFFOLD_BASELINE.is_file(), "scaffold zizmor.yml is missing"
+    # The scaffold copy carries the same audit rules as the root SSoT (the sync
+    # hook only prepends the managed-file banner).
+    assert _rules(ROOT_BASELINE) == _rules(SCAFFOLD_BASELINE)
+
+
+def test_baseline_registered_in_sync_manifest() -> None:
+    """The scaffolded baseline is registered so consumers inherit it on upgrade."""
+    manifest = tomllib.loads(MANIFEST.read_text(encoding="utf-8"))
+    sources = {entry["src"] for entry in manifest["entries"]}
+    assert "zizmor.yml" in sources
+
+
+@pytest.mark.parametrize("baseline", [ROOT_BASELINE, SCAFFOLD_BASELINE])
+def test_every_exemption_targets_a_managed_workflow_basename(baseline: Path) -> None:
+    """Scope rule: exemptions are bare managed basenames, never globs.
+
+    A glob (or a path) could suppress a consumer-authored workflow. Requiring a
+    bare filename that resolves to a shipped managed workflow guarantees a
+    repo-authored file (different name) is always audited.
+    """
+    for audit, cfg in _rules(baseline).items():
+        for entry in cfg["ignore"]:
+            assert "*" not in entry and "/" not in entry, (
+                f"{audit}: '{entry}' must be a bare managed basename, not a glob/path"
+            )
+            assert (MANAGED_WORKFLOWS / entry).is_file(), (
+                f"{audit}: '{entry}' does not name a shipped managed workflow"
+            )
+
+
+def test_ci_gate_lints_managed_set_against_baseline() -> None:
+    """devkit CI runs zizmor over the managed set with the shipped baseline."""
+    ci = yaml.safe_load(DEVKIT_CI.read_text(encoding="utf-8"))
+    runs = [
+        step.get("run", "")
+        for step in ci["jobs"]["project-checks"]["steps"]
+        if "run" in step
+    ]
+    gate = [
+        r
+        for r in runs
+        if "zizmor" in r
+        and "--config zizmor.yml" in r
+        and "assets/workspace/.github/workflows" in r
+    ]
+    assert gate, "project-checks must gate the managed workflow set on zizmor"

--- a/zizmor.yml
+++ b/zizmor.yml
@@ -1,0 +1,84 @@
+# zizmor configuration — GitHub Actions security auditing baseline.
+#
+# Devkit OWNS this baseline. It suppresses the residual zizmor findings in the
+# devkit-managed workflows that cannot be fixed without changing release/CI
+# behavior for every consumer. Devkit's own CI gates the managed workflow set
+# against this file (see .github/workflows/ci.yml → "Audit managed workflows"),
+# so a regression — a new finding, or a managed workflow that regains a fixed
+# finding — fails devkit CI and must be fixed or triaged here, not silently
+# baselined downstream.
+#
+# This file is SCAFFOLDED into every consumer repo (manifest entry: zizmor.yml)
+# so their baseline for devkit's output shrinks to zero: a consumer adopting
+# `zizmor` inherits exactly these exemptions and maintains none of their own for
+# managed files.
+#
+# SCOPE RULE (load-bearing): every entry is a SPECIFIC managed workflow
+# BASENAME, never a `*.yml` glob. A repo-authored (consumer-authored) workflow
+# has a different filename and therefore NEVER inherits a managed file's
+# exemption — its findings are always reported. When a devkit upgrade adds,
+# renames, or removes a managed workflow, or a new zizmor audit surfaces, update
+# this file as part of that upgrade (or fix the workflow upstream in
+# vig-os/devkit). Full policy:
+# https://github.com/vig-os/devkit/blob/main/docs/WORKFLOW_SECURITY.md
+#
+# Fixed upstream (NOT baselined — listed here as a record of what devkit fixed):
+#   - artipacked        → persist-credentials: false on read-only checkouts
+#                         (ci.yml lint/test/resolve/dependency-review, codeql.yml,
+#                         renovate-changelog-build.yml, sync-issues.yml resolve).
+#   - template-injection → release-app token moved into step env in
+#                         sync-main-to-dev.yml.
+#
+# Residual (baselined below), why each is intentional:
+#   - artipacked        → checkouts that push or fetch from a private remote and
+#                         therefore rely on the persisted git credential
+#                         (ci.yml commit-checks, all release/sync branch work).
+#   - dangerous-triggers → renovate-changelog-commit.yml runs on `workflow_run`
+#                         by design (it commits the built changelog).
+#   - github-app        → create-github-app-token intentionally mints a
+#                         broadly-scoped installation token for release
+#                         orchestration; per-permission scoping would break the
+#                         multi-repo release/sync flows.
+#   - secrets-inherit   → release.yml / prepare-release.yml fan out to reusable
+#                         workflows with `secrets: inherit` by design.
+#   - unpinned-images   → `image:` is the devkit toolchain image resolved at
+#                         runtime (needs.*.outputs.image / inputs.toolchain_image);
+#                         it cannot be SHA-pinned in source.
+rules:
+  artipacked:
+    ignore:
+      - ci.yml
+      - prepare-release.yml
+      - promote-release.yml
+      - release-core.yml
+      - release-publish.yml
+      - release.yml
+      - sync-main-to-dev.yml
+  dangerous-triggers:
+    ignore:
+      - renovate-changelog-commit.yml
+  github-app:
+    ignore:
+      - prepare-release.yml
+      - promote-release.yml
+      - release-core.yml
+      - release-publish.yml
+      - release.yml
+      - renovate-changelog-commit.yml
+      - sync-issues.yml
+      - sync-main-to-dev.yml
+  secrets-inherit:
+    ignore:
+      - prepare-release.yml
+      - release.yml
+  unpinned-images:
+    ignore:
+      - ci.yml
+      - prepare-release.yml
+      - promote-release.yml
+      - release-core.yml
+      - release-publish.yml
+      - release.yml
+      - renovate-changelog-build.yml
+      - sync-issues.yml
+      - sync-main-to-dev.yml


### PR DESCRIPTION
## Summary

`zizmor` (v1.25.2) over the 14 devkit-managed workflows in `assets/workspace/.github/workflows/` reported **73 findings (40 high / 32 medium / 1 informational)**. Consumers adopting workflow security linting had to baseline devkit-generated code they cannot fix (see vig-os/org-config `zizmor.yml`, org-config#37). This PR:

1. **Fixes the 8 fixable findings** upstream, behavior-preserving.
2. **Ships a devkit-owned `zizmor.yml` baseline** (root SSoT, scaffolded via `scripts/manifest.toml`) for the 65 intentional residual findings — consumer baselines for devkit output shrink to zero.
3. **Gates regressions in devkit CI**: `project-checks` now runs `uvx zizmor@1.25.2 --offline --config zizmor.yml assets/workspace/.github/workflows/`.
4. **Documents the policy** in `docs/WORKFLOW_SECURITY.md`.

## Audit table

| Audit | Severity | Count | Disposition | Why |
|-------|----------|-------|-------------|-----|
| `artipacked` | Medium | 7 | **Fixed** | `persist-credentials: false` on checkouts that only read the tree: ci.yml resolve-toolchain / lint / test / dependency-review, codeql.yml (root SSoT + scaffold mirror), renovate-changelog-build + sync-issues resolve-toolchain sparse checkouts. |
| `template-injection` | Informational | 1 | **Fixed** | sync-main-to-dev stale-branch cleanup: release-app token moved from inline `${{ }}` interpolation into the step `env:` block. |
| `artipacked` | Medium | 21 | **Baselined** | Remaining checkouts push or fetch from a (possibly private) remote and need the persisted git credential (release/sync branch work; ci.yml commit-checks fetches the trunk for the base diff). |
| `unpinned-images` | High | 20 | **Baselined** | `image:` is the devkit toolchain image resolved at runtime (`needs.*.outputs.image` / `inputs.toolchain_image`); it cannot be SHA-pinned in source. |
| `github-app` | High | 19 | **Baselined** | `create-github-app-token` intentionally mints a broadly-scoped installation token for multi-repo release/sync orchestration; per-permission scoping breaks those flows. |
| `secrets-inherit` | Medium | 4 | **Baselined** | `release.yml` / `prepare-release.yml` fan out to reusable workflows with `secrets: inherit` by design. |
| `dangerous-triggers` | High | 1 | **Baselined** | `renovate-changelog-commit.yml` runs on `workflow_run` by design (commits the built changelog). |

**Totals: 8 fixed, 65 baselined, 0 left for consumers.**

Baseline scope rule (enforced by `tests/test_workflow_zizmor_baseline.py`): every exemption is a specific managed-workflow **basename** — never a glob or path — so a consumer-authored workflow can never inherit an exemption.

## Action pinning / Renovate

All `uses:` references in the managed set were already full-SHA-pinned with `# vX.Y.Z` trailing comments (enforced by the `check-action-pins` hook), and the repo `renovate.json` has `"enabledManagers": [..., "github-actions", ...]` with no path restriction, so digests stay Renovate-fresh — no change needed.

## Evidence (zizmor 1.25.2)

```
$ zizmor --offline --config zizmor.yml assets/workspace/.github/workflows/
No findings to report. Good job! (65 ignored, 119 suppressed)
$ echo $?
0
```

- `just precommit` (`prek run --all-files`): green, sync-manifest converged (scaffold `zizmor.yml` + codeql mirror regenerated by the hook).
- `tests/test_workflow_zizmor_baseline.py`: 5 passed; `test_scaffold_lint.py` + `test_workflow_sync_checkout.py`: 41 passed total.

## Notes

- TDD: the regression tests pin finished config/workflow artifacts rather than drive code, so the RED-first sequence does not apply; they were committed as their own slice.
- Out of scope (not touched): `setup-devkit-toolchain` internals (#1180), `justfile.base` (#1181).

Refs: #1182
Refs: vig-os/org-config#15
