### PR TITLE
fix(workspace): drop literal expression syntax from resolve-toolchain docs

### DIFF
--- a/assets/workspace/.github/actions/resolve-toolchain/action.yml
+++ b/assets/workspace/.github/actions/resolve-toolchain/action.yml
@@ -62,8 +62,8 @@ outputs:
   runner-json:
     description: >-
       JSON array of runner labels from DEVKIT_CI_RUNNER (comma-separated), for
-      `runs-on: ${{ fromJSON(...) }}`. Defaults to ["ubuntu-24.04"] when the key
-      is absent.
+      use with fromJSON() in `runs-on`. Defaults to ["ubuntu-24.04"] when the
+      key is absent.
     value: ${{ steps.resolve.outputs.runner-json }}
 
 runs:
@@ -146,7 +146,7 @@ runs:
         echo "floating-tags=$FLOATING_TAGS" >> "$GITHUB_OUTPUT"
 
         # CI runner labels (#1173): DEVKIT_CI_RUNNER is a comma-separated label
-        # list routed into `runs-on: ${{ fromJSON(...) }}` by the downstream CI
+        # list routed into `runs-on` via fromJSON() by the downstream CI
         # jobs. Absent => the hosted default, so existing consumers are unchanged.
         # Emitted for every mode, ALWAYS a valid JSON array (single label =>
         # ["ubuntu-24.04"]); whitespace around each label is trimmed and empty


### PR DESCRIPTION
## Summary

1.4.0-rc1 smoke test failed at manifest load of the managed `resolve-toolchain` composite action ([run](https://github.com/vig-os/devkit-smoke-test/actions/runs/29584889283)): documentation text added by #1173 contained a literal `${{ fromJSON(...) }}` in two runner-evaluated scalars (the `runner-json` output description and a bash comment in the `run:` block). There is no escape for `${{` in Actions YAML, so the placeholder dots were parsed as a real expression and the manifest failed to load, killing every consumer CI run at "Resolve toolchain".

This rephrases both doc strings without the expression wrapper. Repo-wide grep confirms no other literal-expression doc text remains in managed assets.

No changelog entry: the bug was introduced by the unreleased #1173 feature, so there is no user-visible delta versus 1.3.1.

Per the RC-validation runbook the fix targets `release/1.4.0`; dev picks it up via sync-main-to-dev after the release merges.

Refs: #1187