### PR TITLE
fix(workspace): support self-hosted runners with preinstalled Nix

### DIFF
--- a/assets/workspace/.github/actions/setup-devkit-toolchain/action.yml
+++ b/assets/workspace/.github/actions/setup-devkit-toolchain/action.yml
@@ -83,12 +83,29 @@ runs:
         echo "prek present: $(command -v prek)"
 
     # ── direnv — host, provision from the repo's own Nix flake dev-shell ──────
+    # Self-hosted runners (DEVKIT_CI_RUNNER, #1173) usually ship their own Nix;
+    # install-nix-action would abort on them and leave NIX_CONFIG malformed
+    # (#1192), so detect first and take the matching path below.
+    - name: Detect host Nix
+      if: inputs.mode == 'direnv'
+      id: detect-nix
+      shell: bash
+      run: |
+        set -euo pipefail
+        if command -v nix >/dev/null 2>&1; then
+          echo "has-nix=true" >> "$GITHUB_OUTPUT"
+          echo "Host Nix present: $(command -v nix) ($(nix --version))"
+        else
+          echo "has-nix=false" >> "$GITHUB_OUTPUT"
+        fi
+
     # Nix installer SHA-pinned to match the vig-os toolchain. The vig-os public
     # Cachix substituter (pull-only, no token) makes the dev-shell a fast
     # binary-cache pull; accept-flake-config lets the pinned vigos input
-    # contribute its own substituters.
+    # contribute its own substituters. Keep extra_nix_config in lockstep with
+    # the "Configure host Nix" step below (enforced by test).
     - name: Install Nix (upstream CppNix)
-      if: inputs.mode == 'direnv'
+      if: inputs.mode == 'direnv' && steps.detect-nix.outputs.has-nix != 'true'
       uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342  # v31.11.0
       with:
         extra_nix_config: |
@@ -96,6 +113,26 @@ runs:
           accept-flake-config = true
           extra-substituters = https://vig-os.cachix.org
           extra-trusted-public-keys = vig-os.cachix.org-1:yoOYRi3bvnM6ThxO0joLt7vtzhTfkq3r6jykeUMg7Bk=
+
+    # Preinstalled host Nix: export the same settings via a well-formed
+    # multi-line NIX_CONFIG instead of installing. On a multi-user host Nix
+    # the substituter entries may be ignored for non-trusted users — Cachix is
+    # an optimization, correctness does not depend on it. Keep the settings in
+    # lockstep with extra_nix_config above (enforced by test).
+    - name: Configure host Nix
+      if: inputs.mode == 'direnv' && steps.detect-nix.outputs.has-nix == 'true'
+      shell: bash
+      run: |
+        set -euo pipefail
+        {
+          echo 'NIX_CONFIG<<DEVKIT_NIX_CONFIG_EOF'
+          echo 'experimental-features = nix-command flakes'
+          echo 'accept-flake-config = true'
+          echo 'extra-substituters = https://vig-os.cachix.org'
+          echo 'extra-trusted-public-keys = vig-os.cachix.org-1:yoOYRi3bvnM6ThxO0joLt7vtzhTfkq3r6jykeUMg7Bk='
+          echo 'DEVKIT_NIX_CONFIG_EOF'
+        } >> "$GITHUB_ENV"
+        echo "Configured preinstalled host Nix via NIX_CONFIG."
 
     # Optional: push this repo's own closure to a consumer-owned Cachix cache.
     # Skipped unless the repo passes cachix-cache; pulls need no token, so the

--- a/tests/test_setup_toolchain_env.py
+++ b/tests/test_setup_toolchain_env.py
@@ -292,3 +292,97 @@ def test_shellhook_stdout_banner_never_reaches_github_env(tmp_path: Path) -> Non
     assert BANNER not in raw, "shellHook stdout leaked into GITHUB_ENV"
     # The first env record must survive intact, not be eaten by the banner.
     assert env.get("OTTERDOG_TOKEN") == "placeholder-set-by-shellhook"
+
+
+# ── Self-hosted runners with preinstalled Nix (#1192) ────────────────────────
+
+INSTALL_STEP_NAME = "Install Nix (upstream CppNix)"
+DETECT_STEP_ID = "detect-nix"
+HOST_NIX_STEP_NAME = "Configure host Nix"
+
+# The Nix settings the toolchain needs, identically on both paths (fresh
+# install via install-nix-action's extra_nix_config, preinstalled host Nix via
+# NIX_CONFIG).
+_NIX_SETTINGS = {
+    "experimental-features": "nix-command flakes",
+    "accept-flake-config": "true",
+    "extra-substituters": "https://vig-os.cachix.org",
+    "extra-trusted-public-keys": (
+        "vig-os.cachix.org-1:yoOYRi3bvnM6ThxO0joLt7vtzhTfkq3r6jykeUMg7Bk="
+    ),
+}
+
+
+def _action_steps() -> list[dict]:
+    action = yaml.safe_load(ACTION.read_text(encoding="utf-8"))
+    return action["runs"]["steps"]
+
+
+def _step_by_name(name: str) -> dict:
+    for step in _action_steps():
+        if step.get("name") == name:
+            return step
+    raise AssertionError(f"step {name!r} not found in {ACTION}")
+
+
+def test_install_nix_is_gated_on_missing_host_nix() -> None:
+    """install-nix-action aborts on a Nix-preinstalled self-hosted runner and
+    leaves NIX_CONFIG malformed; it must be skipped when host Nix exists, with
+    a detect step preceding it.
+
+    Refs: #1192
+    """
+    steps = _action_steps()
+    detect_idx = next(
+        (i for i, s in enumerate(steps) if s.get("id") == DETECT_STEP_ID), None
+    )
+    assert detect_idx is not None, f"no step with id {DETECT_STEP_ID!r}"
+    install_idx = next(
+        i for i, s in enumerate(steps) if s.get("name") == INSTALL_STEP_NAME
+    )
+    assert detect_idx < install_idx, "detect step must precede the install step"
+    install_if = _step_by_name(INSTALL_STEP_NAME).get("if", "")
+    assert f"steps.{DETECT_STEP_ID}.outputs.has-nix != 'true'" in install_if
+
+
+def test_host_nix_config_step_writes_wellformed_nix_config(tmp_path: Path) -> None:
+    """On the preinstalled-Nix path, the action must export the same Nix
+    settings via a well-formed multi-line NIX_CONFIG (the malformed one from
+    the aborted installer broke `nix develop` on exo-fleet's runner).
+
+    Refs: #1192
+    """
+    step = _step_by_name(HOST_NIX_STEP_NAME)
+    assert f"steps.{DETECT_STEP_ID}.outputs.has-nix == 'true'" in step.get("if", "")
+
+    github_env = tmp_path / "github_env"
+    github_env.touch()
+    proc = subprocess.run(
+        ["bash", "-c", step["run"]],
+        env={**os.environ, "GITHUB_ENV": str(github_env)},
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, proc.stderr
+    parsed = _parse_github_env(github_env.read_text(encoding="utf-8"))
+    nix_config = parsed.get("NIX_CONFIG")
+    assert nix_config, "NIX_CONFIG not written to GITHUB_ENV"
+    got = {}
+    for line in nix_config.splitlines():
+        assert " = " in line, f"malformed NIX_CONFIG line: {line!r}"
+        key, _, value = line.partition(" = ")
+        got[key] = value
+    assert got == _NIX_SETTINGS
+
+
+def test_install_and_host_paths_carry_identical_settings() -> None:
+    """The fresh-install extra_nix_config and the test's expected host-path
+    settings must stay in lockstep — drift would give the two runner classes
+    different Nix behavior."""
+    install = _step_by_name(INSTALL_STEP_NAME)
+    extra = install["with"]["extra_nix_config"]
+    got = {}
+    for line in extra.strip().splitlines():
+        key, _, value = line.partition(" = ")
+        got[key] = value
+    assert got == _NIX_SETTINGS


### PR DESCRIPTION
## Summary

Third rc finding (after #1187, #1189), from the first live exercise of the #1173 `DEVKIT_CI_RUNNER` knob on exo-pet/exo-fleet (PR exo-pet/exo-fleet#230): the direnv branch of `setup-devkit-toolchain` hard-codes `cachix/install-nix-action`, which **aborts on a self-hosted runner that already ships Nix** and leaves `NIX_CONFIG` malformed — the next `nix develop` dies with `syntax error in configuration line 'experimental-features' in "NIX_CONFIG"`. The runner routing itself worked exactly as designed.

## Fix (TDD)

- `0429b290` **test (RED)**: structural gate (detect step precedes install; install gated on `has-nix != 'true'`), executed-bash test of the new host-Nix config step (well-formed newline-separated NIX_CONFIG in GITHUB_ENV), and a lockstep test pinning both paths to identical Nix settings.
- **fix (GREEN)**: new `Detect host Nix` step; `install-nix-action` now runs only when no host Nix exists (hosted runners unchanged); preinstalled runners get the same settings via a multi-line `NIX_CONFIG` heredoc. 22/22 action tests + related suites green, full hook suite green.

Hosted-runner consumers are untouched by this path (detect → has-nix=false → identical install flow), so the four rc3-green validation lanes stay valid.

Refs: #1192