### PR TITLE
fix(workspace): scope scaffold chmod +x to delivered scripts

### DIFF
--- a/assets/init-workspace.sh
+++ b/assets/init-workspace.sh
@@ -1451,9 +1451,16 @@ if [[ -f "$VIG_OS_MANIFEST" ]]; then
     fi
 fi
 
-# Restore executable permissions on shell scripts and hooks (must be after sed -i)
+# Restore executable permissions on shell scripts and hooks (must be after sed -i).
+# Scope the +x to the scaffold-delivered script set only: key the sweep on the
+# template's .sh files, not a blanket `find "$WORKSPACE_DIR"`. A consumer's own
+# sourced-only .sh libraries are not template paths, so a blanket sweep wrongly
+# flipped their mode (644 → 755) on every --force re-scaffold (#1195).
 echo "Setting executable permissions on shell scripts and hooks..."
-find "$WORKSPACE_DIR" -type f -name "*.sh" -exec chmod +x {} \;
+while IFS= read -r -d '' template_script; do
+    rel="${template_script#"$TEMPLATE_DIR"/}"
+    [[ -f "$WORKSPACE_DIR/$rel" ]] && chmod +x "$WORKSPACE_DIR/$rel"
+done < <(find -L "$TEMPLATE_DIR" -type f -name "*.sh" -print0)
 find "$WORKSPACE_DIR/.githooks" -type f -exec chmod +x {} \; 2>/dev/null || true
 
 # The root justfile is managed (rsync overwrites it on upgrade), so the

--- a/tests/bats/init-workspace.bats
+++ b/tests/bats/init-workspace.bats
@@ -3436,3 +3436,27 @@ _RELEASE_RESOLVERS_991=(
     assert_success
     assert_line '  ✓  .pre-commit-config.yaml'
 }
+
+# ── scaffold chmod scope for consumer .sh files (#1195) ───────────────────────
+# The post-copy "restore executable permissions" sweep must set +x only on the
+# scaffold-delivered script set (the template's .sh files), never on a
+# consumer's own sourced-only .sh libraries. A blanket `find … -name '*.sh'`
+# re-dirtied preserved consumer libs (mode 644 → 755) on every --force
+# re-scaffold — observed in the field on exo-fleet (#1195).
+
+@test "scaffold chmod +x skips a consumer's pre-existing sourced .sh lib (#1195)" {
+    ws="$BATS_TEST_TMPDIR/e2e-1195-chmod-scope"
+    mkdir -p "$ws/lib"
+    # Consumer-owned, sourced-only library: not a template path, intentionally
+    # non-executable (644). The scaffold must leave its mode untouched.
+    printf '#!/usr/bin/env bash\n# sourced, never executed\n' >"$ws/lib/consumer-lib.sh"
+    chmod 644 "$ws/lib/consumer-lib.sh"
+    run _scaffold both "$ws"
+    assert_success
+    # (a) the consumer's sourced lib keeps its non-executable mode
+    run test -x "$ws/lib/consumer-lib.sh"
+    assert_failure
+    # (b) a template-delivered script IS made executable
+    run test -x "$ws/.devcontainer/scripts/post-create.sh"
+    assert_success
+}


### PR DESCRIPTION
## Summary

`init-workspace.sh` set `+x` on **every** `.sh` in the consumer tree via a blanket `find "$WORKSPACE_DIR" -name '*.sh' -exec chmod +x`, which re-dirtied consumers' own sourced-only libraries on each `--force` re-scaffold (seen in exo-pet/exo-fleet#230). The sweep is now keyed to the **template-delivered** `.sh` set: it iterates the template's scripts and chmods only the matching workspace files, leaving consumer-owned libs at their original mode.

## Test

TDD — RED test added first (`test:` commit), then fix. New bats case asserts a pre-existing consumer sourced lib stays non-executable while a delivered script gets `+x`.

`bats tests/bats/init-workspace.bats` → **224 passed**.

Found during 1.4.0 RC validation. No CHANGELOG change (fix to an unreleased-1.4.0 feature, per the #1187/#1189/#1192 precedent).

Closes #1195