### PR TITLE
fix(workspace): capture host nix --version from stderr in detect step

### DIFF
--- a/assets/workspace/.github/actions/setup-devkit-toolchain/action.yml
+++ b/assets/workspace/.github/actions/setup-devkit-toolchain/action.yml
@@ -94,7 +94,9 @@ runs:
         set -euo pipefail
         if command -v nix >/dev/null 2>&1; then
           echo "has-nix=true" >> "$GITHUB_OUTPUT"
-          echo "Host Nix present: $(command -v nix) ($(nix --version))"
+          # Some multi-user host Nix wrappers print --version to stderr (#1198);
+          # fold it into the capture so the log keeps the version, not empty ().
+          echo "Host Nix present: $(command -v nix) ($(nix --version 2>&1))"
         else
           echo "has-nix=false" >> "$GITHUB_OUTPUT"
         fi

--- a/tests/test_setup_toolchain_env.py
+++ b/tests/test_setup_toolchain_env.py
@@ -386,3 +386,67 @@ def test_install_and_host_paths_carry_identical_settings() -> None:
         key, _, value = line.partition(" = ")
         got[key] = value
     assert got == _NIX_SETTINGS
+
+
+# ── Host Nix version capture in the detect step (#1198) ──────────────────────
+
+DETECT_STEP_NAME = "Detect host Nix"
+
+# A representative multi-user host Nix version banner. exo-fleet's wrapper writes
+# it to stderr, so a plain `$(nix --version)` capture came back empty.
+HOST_NIX_VERSION = "nix (Nix) 2.18.1"
+
+
+def _write_stderr_version_nix_stub(bin_dir: Path) -> None:
+    """A fake `nix` whose `--version` prints ONLY to stderr, mimicking the
+    exo-fleet multi-user host wrapper that produced the empty `()` log (#1198).
+    """
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    stub = bin_dir / "nix"
+    stub.write_text(
+        "\n".join(
+            [
+                "#!/usr/bin/env bash",
+                'if [ "${1:-}" = "--version" ]; then',
+                f"  echo {_bash_squote(HOST_NIX_VERSION)} >&2",
+                "  exit 0",
+                "fi",
+                "exit 0",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    stub.chmod(0o755)
+
+
+def test_detect_step_captures_version_from_stderr(tmp_path: Path) -> None:
+    """On a host Nix that writes `--version` to stderr, the detect step must
+    still log the real version, not an empty `()`.
+
+    Refs: #1198
+    """
+    step = _step_by_name(DETECT_STEP_NAME)
+
+    bin_dir = tmp_path / "stub-bin"
+    _write_stderr_version_nix_stub(bin_dir)
+
+    github_output = tmp_path / "github_output"
+    github_output.touch()
+
+    proc = subprocess.run(
+        ["bash", "-c", step["run"]],
+        env={
+            **os.environ,
+            "PATH": f"{bin_dir}:{os.environ['PATH']}",
+            "GITHUB_OUTPUT": str(github_output),
+        },
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert "Host Nix present:" in proc.stdout
+    assert HOST_NIX_VERSION in proc.stdout, (
+        f"version missing from log line:\n{proc.stdout}"
+    )
+    assert "()" not in proc.stdout, f"empty version parens in log:\n{proc.stdout}"


### PR DESCRIPTION
## Summary

The `Detect host Nix` step in `setup-devkit-toolchain` logged `Host Nix present: /…/nix ()` on exo-fleet's multi-user host because `$(nix --version)` wrote to stderr and the substitution captured nothing. Now captures `nix --version 2>&1` so the version is retained. Cosmetic follow-up to #1192; the step already branched correctly.

## Test

TDD — RED test first, then fix. New pytest runs the step's script against a stub `nix` that prints its version only to stderr and asserts the log line carries the version, not an empty `()`.

`uv run pytest tests/test_setup_toolchain_env.py -q` → **23 passed**.

Found during 1.4.0 RC validation. No CHANGELOG change (fix to an unreleased-1.4.0 feature, per the #1187/#1189/#1192 precedent).

Closes #1198