### PR TITLE
fix(workspace): make preserved-template diff robust to foreign-git worktrees

### DIFF
--- a/assets/init-workspace.sh
+++ b/assets/init-workspace.sh
@@ -520,18 +520,27 @@ is_preserved_file() {
 # whose --quiet form gates the block and which exits 1 (the expected "they
 # diverged" signal, not an error) when the files differ. Returns 0 when a diff
 # was printed (files differ), 1 when identical or either file is missing.
+#
+# `git diff --no-index` needs no repository, yet git first DISCOVERS a repo from
+# the cwd. When the workspace is a git worktree (bare `podman run -v` mount), its
+# `.git` is a FILE pointing at a gitdir outside the mount; discovery fails and
+# the diff aborts with `fatal: not a git repository: (null)` before comparing
+# (#1197). `GIT_DIR=/dev/null` pins the git dir explicitly, so git skips
+# discovery entirely and the pure file comparison runs regardless of any
+# broken/foreign `.git` in the cwd.
 print_preserved_template_diff() {
     local rel="$1"
     local preserved="$WORKSPACE_DIR/$rel"
     local template="$TEMPLATE_DIR/$rel"
     [[ -f "$preserved" && -f "$template" ]] || return 1
-    if git diff --no-index --quiet -- "$template" "$preserved" > /dev/null 2>&1; then
+    if GIT_DIR=/dev/null git diff --no-index --quiet -- "$template" "$preserved" \
+        > /dev/null 2>&1; then
         return 1  # identical: nothing to surface
     fi
     echo "Preserved $rel differs from the template (yours was kept)."
     echo "Template changes NOT applied (fold in what you need, see MIGRATION.md):"
     echo "─────────────────────────────────────────────────────────────"
-    git diff --no-index -- "$template" "$preserved" || true
+    GIT_DIR=/dev/null git diff --no-index -- "$template" "$preserved" || true
     echo "─────────────────────────────────────────────────────────────"
     return 0
 }

--- a/tests/bats/init-workspace.bats
+++ b/tests/bats/init-workspace.bats
@@ -1493,6 +1493,47 @@ EOF
     assert_output --partial 'default_language_version'
 }
 
+# ── preserved diff must survive a foreign/broken .git in the cwd (#1197) ──────
+# When init-workspace.sh runs via a bare `podman run -v <worktree>:/workspace`
+# and the mounted workspace is a git WORKTREE, its `.git` is a FILE pointing at
+# `gitdir: <path outside the mount>`. In-container git discovers that `.git`
+# from the cwd, fails to resolve the gitdir, and `git diff --no-index` aborts
+# with `fatal: not a git repository: (null)` BEFORE diffing — swallowed by
+# `|| true`, so the operator lost the preserved-file divergence and the log
+# gained a `fatal:` line per file. The no-index diff needs no repo, so it must
+# ignore repo discovery entirely.
+
+@test "preserved diff survives a foreign-git worktree cwd (#1197)" {
+    ws="$BATS_TEST_TMPDIR/e2e-1197-worktree"
+    mkdir -p "$ws"
+    # Simulate a worktree whose real gitdir is unreachable (outside the mount).
+    printf 'gitdir: /nonexistent/path/outside\n' >"$ws/.git"
+    _custom_precommit_config "$ws"
+    # Run with cwd INSIDE the workspace so git discovers the broken `.git`.
+    # Stub uv AND just (like _scaffold): the trailing sync step is a fast no-op,
+    # and stubbing just keeps just's own `git rev-parse` (an out-of-scope code
+    # path) from muddying the assertion — the only git call left is the
+    # preserved-template diff under test.
+    local stub="$BATS_TEST_TMPDIR/stub-1197"
+    mkdir -p "$stub"
+    printf '#!/usr/bin/env bash\nexit 0\n' >"$stub/uv"
+    printf '#!/usr/bin/env bash\nexit 0\n' >"$stub/just"
+    chmod +x "$stub/uv" "$stub/just"
+    run env -C "$ws" PATH="$stub:$PATH" \
+        TEMPLATE_DIR="$PROJECT_ROOT/assets/workspace" \
+        WORKSPACE_DIR="$ws" \
+        SHORT_NAME=testproj \
+        GITHUB_REPOSITORY=test/repo \
+        bash "$INIT_WORKSPACE_SH" --force --no-prompts --mode both
+    assert_success
+    # The broken-repo abort must never surface...
+    refute_output --partial 'fatal:'
+    refute_output --partial 'not a git repository'
+    # ...and the divergence diff is still produced.
+    assert_output --partial 'Preserved .pre-commit-config.yaml differs from the template'
+    assert_output --partial 'default_language_version'
+}
+
 # ── upgrade must preserve a customized .typos.toml, no dual configs (#913) ────
 # The typos hook reads a project's spell-check exceptions; a consumer curates
 # repo-specific extend-words/extend-exclude that a template overwrite silently


### PR DESCRIPTION
## Summary

`print_preserved_template_diff` used `git diff --no-index`, which aborted with `fatal: not a git repository: (null)` (once per preserved file, diff suppressed) when `init-workspace.sh` ran via bare `podman` inside a git **worktree** whose `.git` file points at a gitdir outside the bind mount (how the rollout agents run — exo-pet/vault#31). Both invocations now run with `GIT_DIR=/dev/null`, which makes git skip repository discovery entirely, so a broken/foreign `.git` in the cwd can't abort the pure file comparison. `GIT_CEILING_DIRECTORIES` was verified not to help (the `.git` is in the cwd itself).

## Test

TDD — RED test first, then fix. New bats case scaffolds a workspace whose `.git` is a file pointing at a nonexistent gitdir, runs the function, and asserts no `fatal:` appears while the divergence diff is still produced.

`bats tests/bats/init-workspace.bats` → **224 passed**.

Found during 1.4.0 RC validation. No CHANGELOG change (fix to an unreleased-1.4.0 feature, per the #1187/#1189/#1192 precedent).

Closes #1197