### PR TITLE
fix(worktree): tolerate a foreign-git cwd in the _wt_repo backtick

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,6 +151,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     `stdenv`, `shellHook`, `*Phase`, …). The ambient diff keeps host secrets out
     of `GITHUB_ENV`; a random heredoc delimiter keeps multi-line values intact.
     Local-vs-CI parity is now the default in direnv mode, no consumer change.
+- **`just` no longer leaks a git `fatal:` in a foreign-git worktree cwd** ([#1203](https://github.com/vig-os/devkit/issues/1203))
+  - The `justfile.worktree` `_wt_repo` variable is a top-level backtick that
+    `just` evaluates eagerly on every invocation, so its `git rev-parse
+    --show-toplevel` ran for any recipe (`just sync`, `just lint`, …). In a git
+    worktree whose `.git` file points at a gitdir outside a bind mount (the
+    bare-`podman` scaffold context), git couldn't resolve the repo and printed
+    `fatal: not a git repository: (null)` to stderr on every `just` call. The
+    substitution now falls back to `pwd` (`git rev-parse --show-toplevel
+    2>/dev/null || pwd`), matching the existing `setup-labels.sh` idiom —
+    cosmetic only, the worktree recipes are unaffected.
 
 ### Security
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -151,6 +151,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     `stdenv`, `shellHook`, `*Phase`, …). The ambient diff keeps host secrets out
     of `GITHUB_ENV`; a random heredoc delimiter keeps multi-line values intact.
     Local-vs-CI parity is now the default in direnv mode, no consumer change.
+- **`just` no longer leaks a git `fatal:` in a foreign-git worktree cwd** ([#1203](https://github.com/vig-os/devkit/issues/1203))
+  - The `justfile.worktree` `_wt_repo` variable is a top-level backtick that
+    `just` evaluates eagerly on every invocation, so its `git rev-parse
+    --show-toplevel` ran for any recipe (`just sync`, `just lint`, …). In a git
+    worktree whose `.git` file points at a gitdir outside a bind mount (the
+    bare-`podman` scaffold context), git couldn't resolve the repo and printed
+    `fatal: not a git repository: (null)` to stderr on every `just` call. The
+    substitution now falls back to `pwd` (`git rev-parse --show-toplevel
+    2>/dev/null || pwd`), matching the existing `setup-labels.sh` idiom —
+    cosmetic only, the worktree recipes are unaffected.
 
 ### Security
 

--- a/assets/workspace/.devcontainer/justfile.worktree
+++ b/assets/workspace/.devcontainer/justfile.worktree
@@ -19,7 +19,10 @@ alias wt-clean := worktree-clean
 # ===============================================================================
 
 # Derive worktree base directory: ../<repo>-worktrees/
-_wt_repo := `basename "$(git rev-parse --show-toplevel)"`
+# `just` evaluates this backtick eagerly on every invocation, so tolerate a cwd
+# where git can't resolve a repo (a worktree whose .git points outside a bind
+# mount, #1203) — fall back to the cwd instead of leaking a `fatal:` to stderr.
+_wt_repo := `basename "$(git rev-parse --show-toplevel 2>/dev/null || pwd)"`
 _wt_base := "../" + _wt_repo + "-worktrees"
 
 # -------------------------------------------------------------------------------

--- a/justfile.worktree
+++ b/justfile.worktree
@@ -16,7 +16,10 @@ alias wt-clean := worktree-clean
 # ===============================================================================
 
 # Derive worktree base directory: ../<repo>-worktrees/
-_wt_repo := `basename "$(git rev-parse --show-toplevel)"`
+# `just` evaluates this backtick eagerly on every invocation, so tolerate a cwd
+# where git can't resolve a repo (a worktree whose .git points outside a bind
+# mount, #1203) — fall back to the cwd instead of leaking a `fatal:` to stderr.
+_wt_repo := `basename "$(git rev-parse --show-toplevel 2>/dev/null || pwd)"`
 _wt_base := "../" + _wt_repo + "-worktrees"
 
 # -------------------------------------------------------------------------------

--- a/tests/bats/worktree.bats
+++ b/tests/bats/worktree.bats
@@ -190,3 +190,24 @@ setup() {
     assert_output --partial "[ERROR]"
     assert_output --partial "Invalid mode"
 }
+
+# ── _wt_repo backtick tolerates a foreign-git cwd (#1203) ───────────────────────
+# `just` evaluates the top-level `_wt_repo` backtick eagerly on EVERY invocation,
+# so its `git rev-parse --show-toplevel` runs even for unrelated recipes. In a
+# git worktree whose `.git` file points at a gitdir outside a (bind-mounted) tree
+# — the bare-podman scaffold context from #1197 — git can't resolve the repo and
+# leaked `fatal: not a git repository: (null)` to stderr on every `just` call.
+@test "just does not leak a git fatal in a foreign-git worktree cwd (#1203)" {
+    command -v just >/dev/null 2>&1 || skip "just not installed"
+
+    local broken
+    broken="$(mktemp -d)"
+    printf 'gitdir: /nonexistent/path/outside\n' > "$broken/.git"
+
+    run just -d "$broken" -f "$PROJECT_ROOT/justfile.worktree" --evaluate _wt_repo
+    rm -rf "$broken"
+
+    assert_success
+    refute_output --partial "not a git repository"
+    refute_output --partial "fatal:"
+}


### PR DESCRIPTION
## Summary

`justfile.worktree` declares `_wt_repo := \`basename "$(git rev-parse --show-toplevel)"\``, a top-level backtick `just` evaluates **eagerly on every invocation** — so `git rev-parse --show-toplevel` runs for any recipe (`just sync`, `just lint`, …). In a git worktree whose `.git` file points at a gitdir outside a bind mount (the bare-`podman` scaffold context from #1197), git can't resolve the repo and leaks `fatal: not a git repository: (null)` to stderr on every `just` call. The substitution now falls back to `pwd` (`… 2>/dev/null || pwd`), matching the existing `setup-labels.sh` idiom.

Split out from #1197 (agent observation) — a separate code path from `print_preserved_template_diff`.

## Scope

- **SSoT:** the repo-root `justfile.worktree` is fixed; the scaffolded `.devcontainer/justfile.worktree` is regenerated from it via `scripts/manifest.toml` (both committed, in sync).
- CHANGELOG `Fixed` entry added under `[1.4.0]` (unlike the other RC fixes, this corrects **pre-existing, already-released** behavior).

## Test

TDD — RED test first, then fix. New `worktree.bats` case runs `just -f justfile.worktree --evaluate _wt_repo` in a foreign-git cwd and asserts no `fatal:` leaks.

`bats tests/bats/worktree.bats` → **9 passed** (new case confirmed RED before, GREEN after).

Closes #1203