### PR TITLE
fix(workspace): scrub ambient NIX_CONFIG in host Nix version probe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,6 +146,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Detect host Nix probe scrubs the ambient `NIX_CONFIG`** ([#1216](https://github.com/vig-os/devkit/issues/1216))
+  - The direnv-mode "Detect host Nix" step captured `nix --version 2>&1` (#1198)
+    with the runner's ambient `NIX_CONFIG` still in effect. On a self-hosted
+    runner whose service environment carries a malformed `NIX_CONFIG` (observed
+    on exo-fleet's meatgrinder), nix rejects the config before printing the
+    version, so the detect log recorded a `syntax error in configuration` parse
+    error instead of the version string the diagnostic aims to capture. The probe
+    now runs `env -u NIX_CONFIG nix --version 2>&1`, keeping the `2>&1` fold for
+    other failure shapes, so the log shows the real version even when the
+    runner's environment is broken. Non-fatal before the fix (the "Configure host
+    Nix" step rewrites a clean `NIX_CONFIG`), diagnostic-only impact.
 - **uvx tools with native wheels load libstdc++ in direnv-mode CI** ([#1181](https://github.com/vig-os/devkit/issues/1181))
   - On a non-Python direnv-mode consumer the CI preamble keeps the Nix CPython
     on `PATH`, whose loader does not search `/usr/lib`, so a `uvx`-run tool's

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -146,6 +146,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Detect host Nix probe scrubs the ambient `NIX_CONFIG`** ([#1216](https://github.com/vig-os/devkit/issues/1216))
+  - The direnv-mode "Detect host Nix" step captured `nix --version 2>&1` (#1198)
+    with the runner's ambient `NIX_CONFIG` still in effect. On a self-hosted
+    runner whose service environment carries a malformed `NIX_CONFIG` (observed
+    on exo-fleet's meatgrinder), nix rejects the config before printing the
+    version, so the detect log recorded a `syntax error in configuration` parse
+    error instead of the version string the diagnostic aims to capture. The probe
+    now runs `env -u NIX_CONFIG nix --version 2>&1`, keeping the `2>&1` fold for
+    other failure shapes, so the log shows the real version even when the
+    runner's environment is broken. Non-fatal before the fix (the "Configure host
+    Nix" step rewrites a clean `NIX_CONFIG`), diagnostic-only impact.
 - **uvx tools with native wheels load libstdc++ in direnv-mode CI** ([#1181](https://github.com/vig-os/devkit/issues/1181))
   - On a non-Python direnv-mode consumer the CI preamble keeps the Nix CPython
     on `PATH`, whose loader does not search `/usr/lib`, so a `uvx`-run tool's

--- a/assets/workspace/.github/actions/setup-devkit-toolchain/action.yml
+++ b/assets/workspace/.github/actions/setup-devkit-toolchain/action.yml
@@ -96,7 +96,10 @@ runs:
           echo "has-nix=true" >> "$GITHUB_OUTPUT"
           # Some multi-user host Nix wrappers print --version to stderr (#1198);
           # fold it into the capture so the log keeps the version, not empty ().
-          echo "Host Nix present: $(command -v nix) ($(nix --version 2>&1))"
+          # Scrub the ambient NIX_CONFIG (#1216): a self-hosted runner's service
+          # env may carry a malformed one that makes nix error on the config
+          # before printing the version, defeating the diagnostic.
+          echo "Host Nix present: $(command -v nix) ($(env -u NIX_CONFIG nix --version 2>&1))"
         else
           echo "has-nix=false" >> "$GITHUB_OUTPUT"
         fi

--- a/tests/test_setup_toolchain_env.py
+++ b/tests/test_setup_toolchain_env.py
@@ -450,3 +450,81 @@ def test_detect_step_captures_version_from_stderr(tmp_path: Path) -> None:
         f"version missing from log line:\n{proc.stdout}"
     )
     assert "()" not in proc.stdout, f"empty version parens in log:\n{proc.stdout}"
+
+
+# ── Ambient NIX_CONFIG must not corrupt the version probe (#1216) ─────────────
+
+# A malformed ambient NIX_CONFIG as carried by a self-hosted runner's service
+# environment (exo-fleet's meatgrinder, exo-pet/exo-fleet#230): nix rejects it
+# before printing the version.
+MALFORMED_NIX_CONFIG = "experimental-features"
+NIX_CONFIG_PARSE_ERROR = (
+    "error: syntax error in configuration line "
+    "'experimental-features' in \"NIX_CONFIG\""
+)
+
+
+def _write_nix_config_sensitive_nix_stub(bin_dir: Path) -> None:
+    """A fake `nix` mimicking nix on exo-fleet's meatgrinder: a malformed ambient
+    `NIX_CONFIG` makes `--version` fail with a config parse error *before* the
+    version is printed, so a probe that inherits the ambient config captures the
+    error instead of the version. With `NIX_CONFIG` scrubbed it prints the
+    version normally (#1216).
+    """
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    stub = bin_dir / "nix"
+    stub.write_text(
+        "\n".join(
+            [
+                "#!/usr/bin/env bash",
+                'if [ "${1:-}" = "--version" ]; then',
+                '  if [ -n "${NIX_CONFIG:-}" ]; then',
+                f"    echo {_bash_squote(NIX_CONFIG_PARSE_ERROR)} >&2",
+                "    exit 1",
+                "  fi",
+                f"  echo {_bash_squote(HOST_NIX_VERSION)}",
+                "  exit 0",
+                "fi",
+                "exit 0",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    stub.chmod(0o755)
+
+
+def test_detect_step_probe_scrubs_ambient_nix_config(tmp_path: Path) -> None:
+    """A malformed ambient `NIX_CONFIG` (self-hosted runner service env) must not
+    corrupt the version probe: the detect log must show the real version, not the
+    config parse error the ambient value provokes.
+
+    Refs: #1216
+    """
+    step = _step_by_name(DETECT_STEP_NAME)
+
+    bin_dir = tmp_path / "stub-bin"
+    _write_nix_config_sensitive_nix_stub(bin_dir)
+
+    github_output = tmp_path / "github_output"
+    github_output.touch()
+
+    proc = subprocess.run(
+        ["bash", "-c", step["run"]],
+        env={
+            **os.environ,
+            "PATH": f"{bin_dir}:{os.environ['PATH']}",
+            "GITHUB_OUTPUT": str(github_output),
+            "NIX_CONFIG": MALFORMED_NIX_CONFIG,
+        },
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert "Host Nix present:" in proc.stdout
+    assert HOST_NIX_VERSION in proc.stdout, (
+        f"version missing from log line:\n{proc.stdout}"
+    )
+    assert "syntax error in configuration" not in proc.stdout, (
+        f"ambient NIX_CONFIG parse error leaked into probe:\n{proc.stdout}"
+    )


### PR DESCRIPTION
## Summary

Fixes #1216 (found during rc5 consumer-lane validation): the direnv-mode "Detect host Nix" step captured `nix --version 2>&1` (#1198) with the runner's ambient `NIX_CONFIG` in effect. On a self-hosted runner whose service env carries a malformed `NIX_CONFIG` (exo-fleet's meatgrinder, live evidence in exo-pet/exo-fleet#230 run 29738048251), nix errors on the config before printing the version, so the log records a parse error instead of the version the probe exists to capture.

The probe now runs `env -u NIX_CONFIG nix --version 2>&1` (`env -u` over `NIX_CONFIG=` to stay shellcheck-clean, SC1007), keeping the stderr fold for other failure shapes. Scope: the probe line only — has-nix detection, the gated install, and "Configure host Nix" are untouched. Single action copy (scaffold template; no devkit-own twin, not manifest-synced — verified).

## TDD

- RED `238cf1a6`: stub nix errors on malformed ambient NIX_CONFIG before `--version` — reproduces the exact meatgrinder log symptom.
- GREEN `fe97f457`: 24/24 in `tests/test_setup_toolchain_env.py`.
- Full pre-commit suite green (verified by orchestrator).

Requires an rc6 cut after merge; live proof = exo-fleet lane re-bump on meatgrinder.

Refs: #1216