### PR TITLE
chore(governance): reduce CODEOWNERS to sole active maintainer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,11 +3,10 @@
 #
 # Each line defines a file pattern and the GitHub users/teams required to review
 # changes to matching files. Later rules take precedence over earlier ones.
-
-# agent workflows
-.claude/skills/                 @gerchowl
-justfile.worktree               @gerchowl
-
+#
+# Scope is deliberately minimal (single active maintainer, #1219): only the key
+# control surfaces carry a code-owner gate; everything else goes through the
+# normal required-approval flow.
 
 # CI/CD workflows — require maintainer review for any workflow change
 .github/workflows/              @c-vigo
@@ -16,13 +15,6 @@ justfile.worktree               @gerchowl
 # Build and release scripts
 scripts/clean.sh                @c-vigo
 scripts/sync_manifest.py        @c-vigo
-
-# Developer tooling scripts
-packages/vig-utils/src/vig_utils/gh_issues.py                   @gerchowl
-packages/vig-utils/src/vig_utils/setup_labels.py                @gerchowl
-packages/vig-utils/src/vig_utils/shell/setup-labels.sh          @gerchowl
-packages/vig-utils/src/vig_utils/resolve_branch.py              @gerchowl
-packages/vig-utils/src/vig_utils/shell/resolve-branch.sh        @gerchowl
 
 # Dev environment setup
 scripts/init.sh                 @c-vigo


### PR DESCRIPTION
Closes #1219.

Drops the @gerchowl CODEOWNERS entries (`.claude/skills/`, `justfile.worktree`, vig-utils developer tooling). c-vigo is the de-facto sole maintainer; with `require_code_owner_review` on main, those unreachable-owner paths hard-block release finalization whenever a release diff touches them — currently blocking 1.4.0 (#1186 stuck at REVIEW_REQUIRED over `justfile.worktree`, the #1203/#1204 fix). @c-vigo stays on the key control surfaces (workflows, actions, release scripts, renovate configs, CODEOWNERS itself, SECURITY.md).

Targets main directly (governance file; CODEOWNERS is evaluated from the PR base branch, so this must land on main to unblock #1186 — a dev-first route would wait a full release cycle). The sync-main-to-dev automation carries it back to dev. Merge requires admin bypass: the author cannot approve their own PR and there is no second code owner — explicitly authorized by the maintainer.

Refs: #1219