### PR TITLE
chore: merge main into release/1.4.0 for CODEOWNERS cleanup

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,11 +3,10 @@
 #
 # Each line defines a file pattern and the GitHub users/teams required to review
 # changes to matching files. Later rules take precedence over earlier ones.
-
-# agent workflows
-.claude/skills/                 @gerchowl
-justfile.worktree               @gerchowl
-
+#
+# Scope is deliberately minimal (single active maintainer, #1219): only the key
+# control surfaces carry a code-owner gate; everything else goes through the
+# normal required-approval flow.
 
 # CI/CD workflows — require maintainer review for any workflow change
 .github/workflows/              @c-vigo
@@ -16,13 +15,6 @@ justfile.worktree               @gerchowl
 # Build and release scripts
 scripts/clean.sh                @c-vigo
 scripts/sync_manifest.py        @c-vigo
-
-# Developer tooling scripts
-packages/vig-utils/src/vig_utils/gh_issues.py                   @gerchowl
-packages/vig-utils/src/vig_utils/setup_labels.py                @gerchowl
-packages/vig-utils/src/vig_utils/shell/setup-labels.sh          @gerchowl
-packages/vig-utils/src/vig_utils/resolve_branch.py              @gerchowl
-packages/vig-utils/src/vig_utils/shell/resolve-branch.sh        @gerchowl
 
 # Dev environment setup
 scripts/init.sh                 @c-vigo


### PR DESCRIPTION
Brings main's #1220 (CODEOWNERS cleanup, Refs #1219) into release/1.4.0 so the release PR #1186 is no longer BEHIND main — the #1132 promote mergeability gate rejects BEHIND. Governance-only delta (one file, no image/scaffold impact); merge-base is the 1.3.1 branch point and main has moved only by #1220, so the merge is conflict-free.

Unblocks the 1.4.0 finalize re-dispatch.

Refs: #1219