### PR TITLE
fix(workflow-model): scrub residual dev prose in trunk render

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Trunk render scrubs residual `dev` prose from scaffolded workflows** ([#1226](https://github.com/vig-os/devkit/issues/1226))
+  - `render_workflow_model` now retargets the inert `dev` mentions in comments
+    and input descriptions as well as the functional literals, so a `trunk`
+    consumer no longer ships slightly-lying comments: the `ci.yml` and
+    `codeql.yml` trigger-header comments, the `origin/dev` commit-gate rationale
+    in `ci.yml`, and the `sync-issues.yml` `target-branch` example description
+    all read `main` instead of `dev`. Comments/descriptions only — no functional
+    change; gitflow is unaffected.
+
 ### Security
 
 ## [1.4.0](https://github.com/vig-os/devkit/releases/tag/1.4.0) - 2026-07-20

--- a/assets/init-workspace.sh
+++ b/assets/init-workspace.sh
@@ -1048,22 +1048,35 @@ render_workflow_model() {
     fi
 
     # ci.yml — drop `- dev` from the PR branch filter; retarget the commit-gate
-    # TRUNK anchor used to exclude already-merged history on release PRs.
+    # TRUNK anchor used to exclude already-merged history on release PRs. Also
+    # scrub the inert prose: the trigger-header comment and the origin/dev
+    # commit-gate rationale so a trunk repo carries no lying `dev` comments
+    # (#1226; no behavior change — comments only).
     local ci="$wf/ci.yml"
     if [[ -f "$ci" ]]; then
         sed -i '/^      - dev$/d' "$ci"
         sed -i 's|TRUNK="dev"|TRUNK="main"|' "$ci"
+        sed -i 's|Pull requests to dev, release/\*\*, and main|Pull requests to release/** and main|' "$ci"
+        sed -i 's|origin/dev — a no-op on a dev PR|origin/main — a no-op on a main PR|' "$ci"
+        sed -i 's|(its base IS dev)|(its base IS main)|' "$ci"
     fi
 
-    # codeql.yml — drop `- dev` from the PR branch filter (push is main-only).
-    [[ -f "$wf/codeql.yml" ]] && sed -i '/^      - dev$/d' "$wf/codeql.yml"
+    # codeql.yml — drop `- dev` from the PR branch filter (push is main-only)
+    # and scrub the trigger-header comment prose dev -> main (#1226).
+    local cq="$wf/codeql.yml"
+    if [[ -f "$cq" ]]; then
+        sed -i '/^      - dev$/d' "$cq"
+        sed -i 's|Pull requests to dev, release/\*\*, and main|Pull requests to release/** and main|' "$cq"
+    fi
 
-    # sync-issues.yml — default target branch + `|| 'dev'` fallbacks dev -> main
-    # (the illustrative `e.g., dev, …` description text is left alone).
+    # sync-issues.yml — default target branch + `|| 'dev'` fallbacks dev -> main,
+    # plus the illustrative `e.g., dev, …` description text so no stray `dev`
+    # prose survives (#1226).
     local si="$wf/sync-issues.yml"
     if [[ -f "$si" ]]; then
         sed -i -E "s|^([[:space:]]*default:) 'dev'\$|\1 'main'|" "$si"
         sed -i "s#|| 'dev'#|| 'main'#g" "$si"
+        sed -i 's|e.g., dev, release/x.y.z|e.g., main, release/x.y.z|' "$si"
     fi
 
     # branch-naming SKILL.md — base-branch default dev -> main. (Single-quoted

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -17,6 +17,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Trunk render scrubs residual `dev` prose from scaffolded workflows** ([#1226](https://github.com/vig-os/devkit/issues/1226))
+  - `render_workflow_model` now retargets the inert `dev` mentions in comments
+    and input descriptions as well as the functional literals, so a `trunk`
+    consumer no longer ships slightly-lying comments: the `ci.yml` and
+    `codeql.yml` trigger-header comments, the `origin/dev` commit-gate rationale
+    in `ci.yml`, and the `sync-issues.yml` `target-branch` example description
+    all read `main` instead of `dev`. Comments/descriptions only — no functional
+    change; gitflow is unaffected.
+
 ### Security
 
 ## [1.4.0](https://github.com/vig-os/devkit/releases/tag/1.4.0) - 2026-07-20

--- a/tests/test_workflow_model.py
+++ b/tests/test_workflow_model.py
@@ -186,6 +186,13 @@ def test_trunk_ci_pr_filter_excludes_dev(tmp_path: Path) -> None:
     assert "\n      - dev\n" not in text
     assert 'TRUNK="main"' in text
     assert 'TRUNK="dev"' not in text
+    # #1226: the trigger-header + origin/dev rationale prose retarget to main too
+    # so a trunk repo carries no lying `dev` comments.
+    assert "Pull requests to dev" not in text
+    assert "Pull requests to release/** and main" in text
+    assert "origin/dev" not in text
+    assert "a no-op on a main PR" in text
+    assert "its base IS main" in text
 
 
 def test_trunk_codeql_pr_filter_excludes_dev(tmp_path: Path) -> None:
@@ -193,6 +200,9 @@ def test_trunk_codeql_pr_filter_excludes_dev(tmp_path: Path) -> None:
     text = _wf(_tree(tmp_path, "trunk"), "codeql.yml")
     assert "\n      - dev\n" not in text
     assert "\n      - main\n" in text
+    # #1226: the trigger-header comment retargets to main too.
+    assert "Pull requests to dev" not in text
+    assert "Pull requests to release/** and main" in text
 
 
 def test_trunk_sync_issues_default_main(tmp_path: Path) -> None:
@@ -201,8 +211,10 @@ def test_trunk_sync_issues_default_main(tmp_path: Path) -> None:
     assert "default: 'main'" in text
     assert "|| 'dev'" not in text
     assert "|| 'main'" in text
-    # The illustrative `e.g., dev, release/x.y.z` description text is left alone.
-    assert "e.g., dev" in text
+    # #1226: the illustrative `e.g., dev, …` description retargets dev -> main too
+    # (previously left alone), so no stray `dev` prose survives.
+    assert "e.g., dev" not in text
+    assert "e.g., main, release/x.y.z" in text
 
 
 def test_trunk_skill_base_branch_main(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Both live trunk switches (vig-os/org-config#64, exo-pet/exo-fleet#230) flagged
cosmetic residue: `render_workflow_model()` retargeted only functional literals,
so a `trunk` consumer still shipped comments naming `dev`. This extends the
anchored render to rewrite the four inert prose spots too — **comments and input
descriptions only, no functional change**. gitflow is unaffected (the render is a
no-op there) and the templates are untouched, so gitflow output stays
byte-identical.

Follows the `prepare-release.yml` precedent (#1208), which already rewrites inert
`dev` step-names/comments to `main` for trunk in the same function.

## Before / after (trunk-rendered)

| File | Before | After |
|------|--------|-------|
| `ci.yml` header | `#   - Pull requests to dev, release/**, and main` | `#   - Pull requests to release/** and main` |
| `ci.yml` commit-gate rationale | `# … reachable from origin/dev — a no-op on a dev PR` / `# (its base IS dev) …` | `# … reachable from origin/main — a no-op on a main PR` / `# (its base IS main) …` |
| `codeql.yml` header | `#   - Pull requests to dev, release/**, and main` | `#   - Pull requests to release/** and main` |
| `sync-issues.yml` `target-branch` description | `… (e.g., dev, release/x.y.z).` | `… (e.g., main, release/x.y.z).` |

A trunk scaffold now contains no stray `dev` workflow-branch prose in these
files (legit `devkit` / `dev-shell` tokens are untouched).

## Test evidence

- Extended `tests/test_workflow_model.py` (targeted string assertions, no
  over-assert) in `test_trunk_ci_pr_filter_excludes_dev`,
  `test_trunk_codeql_pr_filter_excludes_dev`, and
  `test_trunk_sync_issues_default_main`. TDD: assertions committed failing first
  (`test:`), then the render fix made them pass (`fix:`).
- `uv run pytest tests/test_workflow_model.py` → **19 passed**.
- `prek run --all-files` → **all hooks green**.
- The two pre-existing `TestVersionCheckInitWorkspace` failures are unrelated
  (reproduce on the base release commit `d16541f5`; environment-specific).

## Concurrency note

Issue #1228 concurrently adds functional sync-target knobs to the
`sync-issues.yml` template and render function. This PR touches the
`sync-issues.yml` block of `render_workflow_model` (one added comment-only sed
line) and may need a trivial rebase after the #1228 PR lands (or vice versa).
Changes here are strictly comments/descriptions.

Refs: #1226
