### PR TITLE
fix: make flake-generated branch guard workflow-model aware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Flake-generated pre-commit branch guard follows the workflow model** ([#1224](https://github.com/vig-os/devkit/issues/1224))
+  - `render_workflow_model` drops the `(?!dev$)` clause from the scaffolded
+    `.pre-commit-config.yaml` for `DEVKIT_WORKFLOW=trunk`, but a direnv consumer
+    on flake-generated hooks (#1167) gets its branch guard from `mkProjectShell`,
+    which was not workflow-aware — after switching to trunk it kept
+    `^(?!main$)(?!dev$)…`, guarding a `dev` branch a trunk repo does not have.
+  - `mkProjectShell` now takes a `workflow` argument (gitflow default | trunk)
+    threaded into the `nix/hooks.nix` consumer render, which drops the
+    `(?!dev$)` clause for trunk — mirroring the scaffold render exactly. The
+    scaffolded `flake.nix` reads `DEVKIT_WORKFLOW` from `.vig-os` and forwards
+    it, so a trunk direnv consumer's generated guard follows the model out of
+    the box. gitflow is a no-op, leaving existing consumers unchanged.
+
 ### Security
 
 ## [1.4.0](https://github.com/vig-os/devkit/releases/tag/1.4.0) - 2026-07-20

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -17,6 +17,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Flake-generated pre-commit branch guard follows the workflow model** ([#1224](https://github.com/vig-os/devkit/issues/1224))
+  - `render_workflow_model` drops the `(?!dev$)` clause from the scaffolded
+    `.pre-commit-config.yaml` for `DEVKIT_WORKFLOW=trunk`, but a direnv consumer
+    on flake-generated hooks (#1167) gets its branch guard from `mkProjectShell`,
+    which was not workflow-aware — after switching to trunk it kept
+    `^(?!main$)(?!dev$)…`, guarding a `dev` branch a trunk repo does not have.
+  - `mkProjectShell` now takes a `workflow` argument (gitflow default | trunk)
+    threaded into the `nix/hooks.nix` consumer render, which drops the
+    `(?!dev$)` clause for trunk — mirroring the scaffold render exactly. The
+    scaffolded `flake.nix` reads `DEVKIT_WORKFLOW` from `.vig-os` and forwards
+    it, so a trunk direnv consumer's generated guard follows the model out of
+    the box. gitflow is a no-op, leaving existing consumers unchanged.
+
 ### Security
 
 ## [1.4.0](https://github.com/vig-os/devkit/releases/tag/1.4.0) - 2026-07-20

--- a/assets/workspace/flake.nix
+++ b/assets/workspace/flake.nix
@@ -49,6 +49,25 @@
         extraPackages = pkgs: [
           # add project tools here
         ];
+
+        # Workflow model (#1224): read DEVKIT_WORKFLOW from .vig-os and forward
+        # it to mkProjectShell so the flake-generated pre-commit branch guard
+        # follows the model — a `trunk` workspace drops the dev-branch clause,
+        # mirroring the scaffolded .pre-commit-config.yaml. `gitflow` (the
+        # default) and an absent/blank value are inert. Managed line; leave it.
+        workflow =
+          let
+            vigOsPath = self + "/.vig-os";
+            declared = builtins.filter (l: nixpkgs.lib.hasPrefix "DEVKIT_WORKFLOW=" l) (
+              nixpkgs.lib.splitString "\n" (builtins.readFile vigOsPath)
+            );
+            value =
+              if declared == [ ] then
+                ""
+              else
+                nixpkgs.lib.removePrefix "DEVKIT_WORKFLOW=" (builtins.head declared);
+          in
+          if builtins.pathExists vigOsPath && value == "trunk" then "trunk" else "gitflow";
       in
       {
         # The dev shell = the shared vigOS toolchain + your extras.
@@ -56,6 +75,8 @@
         devShells.default = vigos.lib.mkProjectShell {
           inherit pkgs;
           extraPackages = extraPackages pkgs;
+          # Branch guard follows the workspace workflow model (#1224).
+          inherit workflow;
 
           # Opt-in: let the flake GENERATE .pre-commit-config.yaml from the
           # shared base hook set instead of hand-managing the scaffolded

--- a/flake.nix
+++ b/flake.nix
@@ -244,6 +244,13 @@
           extraPackages ? [ ],
           hooks ? null,
           hooksExcludes ? [ ],
+          # Workflow model (#1224): gitflow (default) | trunk. Tunes the
+          # flake-generated branch guard so a trunk consumer's
+          # no-commit-to-branch pattern drops the `(?!dev$)` clause, mirroring
+          # what render_workflow_model does to the scaffolded config. The
+          # scaffold template reads this from the workspace `.vig-os`
+          # DEVKIT_WORKFLOW and forwards it here. Inert for gitflow.
+          workflow ? "gitflow",
           shellHook ? ''echo "devcontainer dev environment loaded (nix)"'',
           # Overridable CPython (#1038). Defaults to the pinned 3.14 so the
           # zero-argument shell is byte-identical to the pre-#1038 builder
@@ -342,7 +349,7 @@
           # tests/test_flake_devshell.py, tests/test_flake_hooks.py).
           # ------------------------------------------------------------------
           hooksEnabled = hooks != null || hooksExcludes != [ ];
-          consumerHooksBase = hooksModule.consumer pkgs;
+          consumerHooksBase = hooksModule.consumer pkgs workflow;
           # Base values at priority 999: they beat git-hooks.nix's own
           # built-in hook defaults (mkDefault, 1000 — equal priorities would
           # conflict, e.g. the built-in nixfmt entry vs the base one) and
@@ -528,6 +535,10 @@
             export PATH="${python}/bin:$PATH"
           '';
         in
+        assert pkgs.lib.assertMsg (builtins.elem workflow [
+          "gitflow"
+          "trunk"
+        ]) "mkProjectShell: workflow must be \"gitflow\" or \"trunk\", got \"${workflow}\"";
         pkgs.mkShell (
           # Module env first: the builder's attrset below wins any collision,
           # so a capability module can never break the Python bootstrap pins

--- a/nix/hooks.nix
+++ b/nix/hooks.nix
@@ -27,7 +27,22 @@ let
   # Topic-branch naming convention enforced by no-commit-to-branch:
   # chore/<summary>, <type>/<issue>-<summary>, worktree/<issue>; main and dev
   # are allowed (pushing there is blocked server-side, not here).
-  branchNamePattern = "^(?!main$)(?!dev$)(?!^(chore)/[a-z0-9]+(-[a-z0-9]+)*$)(?!^(feature|bugfix|hotfix|release|docs|test|refactor)/[0-9]+-[a-z0-9]+(-[a-z0-9]+)*$)(?!^worktree/[0-9]+$).+$";
+  #
+  # Workflow-model aware (#1224): the `(?!dev$)` clause protects the long-lived
+  # gitflow `dev` branch, which a trunk workspace does not have — so the trunk
+  # pattern drops it, mirroring EXACTLY the `s|(?!dev$)||` deletion
+  # `render_workflow_model` (assets/init-workspace.sh) applies to the scaffolded
+  # `.pre-commit-config.yaml`. The committed runner/scaffold YAML stays gitflow
+  # (its trunk render is the scaffold path's job); only the flake-generated
+  # consumer surface follows `workflow`.
+  branchNamePatternFor =
+    workflow:
+    let
+      devClause = lib.optionalString (workflow != "trunk") "(?!dev$)";
+    in
+    "^(?!main$)${devClause}(?!^(chore)/[a-z0-9]+(-[a-z0-9]+)*$)(?!^(feature|bugfix|hotfix|release|docs|test|refactor)/[0-9]+-[a-z0-9]+(-[a-z0-9]+)*$)(?!^worktree/[0-9]+$).+$";
+  # The gitflow default, used by the committed runner/scaffold YAML renders.
+  branchNamePattern = branchNamePatternFor "gitflow";
 
   # Top-level exclude — one regex string in the committed YAML, a list for
   # git-hooks.nix (which joins with `|`). Same paths, two spellings.
@@ -804,9 +819,26 @@ in
   };
 
   # Base hook set for the consumer generation surface
-  # (`mkProjectShell { hooks = …; }`). ctx: pkgs.
-  consumer = pkgs: {
-    excludes = baseExcludes;
-    hooks = collectFor "consumer" "consumerName" pkgs;
-  };
+  # (`mkProjectShell { hooks = …; }`). ctx: pkgs; `workflow` (gitflow default |
+  # trunk) tunes the branch guard so a flake-hooks consumer's no-commit-to-branch
+  # pattern follows DEVKIT_WORKFLOW, mirroring the scaffold render (#1224). For
+  # gitflow the override is a no-op, so the generated config stays byte-identical
+  # to the pre-#1224 render (zero-hooks parity + consumer-surface tests).
+  consumer =
+    pkgs: workflow:
+    let
+      base = collectFor "consumer" "consumerName" pkgs;
+    in
+    {
+      excludes = baseExcludes;
+      hooks =
+        base
+        // lib.optionalAttrs (workflow == "trunk") {
+          no-commit-to-branch = base.no-commit-to-branch // {
+            settings = base.no-commit-to-branch.settings // {
+              pattern = [ (branchNamePatternFor "trunk") ];
+            };
+          };
+        };
+    };
 }

--- a/tests/test_flake_hooks.py
+++ b/tests/test_flake_hooks.py
@@ -105,6 +105,16 @@ def _normalize(config: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _branch_guard(config: dict[str, Any]) -> str:
+    """The no-commit-to-branch entry (carries the ``--pattern`` regex).
+
+    git-hooks.nix renders the ``settings.pattern`` into the hook's ``entry``
+    (``… --pattern <regex>``), so the branch-guard regex is read straight off
+    the generated config's no-commit-to-branch entry.
+    """
+    return _normalize(config)["hooks"]["no-commit-to-branch"]["entry"]
+
+
 def _diff_hooks(rendered: dict[str, Any], committed: dict[str, Any]) -> str:
     """Human-readable normalized diff (empty string == no drift)."""
     lines: list[str] = []
@@ -402,6 +412,93 @@ class TestGitleaksOptInHook:
         assert "gitleaks git --pre-commit --staged --redact --verbose" in entry
         assert hooks["gitleaks"]["language"] == "system"
         assert hooks["gitleaks"]["pass_filenames"] is False
+
+
+@pytest.fixture(scope="module")
+def trunk_consumer_config() -> dict[str, Any]:
+    """Generated config for a trunk-workflow consumer (#1224).
+
+    A ``DEVKIT_WORKFLOW=trunk`` workspace has no long-lived ``dev`` branch, so
+    the flake-generated branch guard must drop the ``(?!dev$)`` clause — exactly
+    what ``render_workflow_model`` does to the scaffolded YAML. Mirrors the
+    ``consumer_config`` fixture but threads ``workflow = "trunk"``.
+    """
+    expr = f"""
+    let
+      flake = builtins.getFlake "path:{REPO_ROOT}";
+      system = builtins.currentSystem;
+      pkgs = import flake.inputs.nixpkgs {{ inherit system; }};
+      shell = flake.lib.mkProjectShell {{
+        inherit pkgs;
+        workflow = "trunk";
+        hooks = {{ }};
+      }};
+    in
+    shell.hooksConfigFile
+    """
+    result = _run_nix(
+        ["build", "--impure", "--no-link", "--print-out-paths", "--expr", expr],
+        timeout=1800,
+    )
+    assert result.returncode == 0, (
+        "building the trunk-workflow hook config failed:\n" + result.stderr
+    )
+    return yaml.safe_load(Path(result.stdout.strip()).read_text())
+
+
+class TestWorkflowModelBranchGuard:
+    """The flake-generated branch guard follows DEVKIT_WORKFLOW (#1224).
+
+    The scaffolded ``.pre-commit-config.yaml`` is workflow-model-aware
+    (``render_workflow_model`` drops the ``(?!dev$)`` clause for trunk), but a
+    direnv consumer on flake-generated hooks (#1167) gets its guard from
+    ``mkProjectShell``. Passing ``workflow`` makes that generated guard mirror
+    the scaffold render, so the two artifacts can no longer disagree.
+    """
+
+    def test_gitflow_consumer_guards_dev(self, consumer_config: dict[str, Any]) -> None:
+        """The default (gitflow) consumer keeps the dev-branch protect-clause."""
+        entry = _branch_guard(consumer_config)
+        assert "(?!main$)" in entry
+        assert "(?!dev$)" in entry
+
+    def test_trunk_consumer_drops_dev_clause(
+        self, trunk_consumer_config: dict[str, Any]
+    ) -> None:
+        """A trunk consumer drops the ``(?!dev$)`` clause; main stays protected."""
+        entry = _branch_guard(trunk_consumer_config)
+        assert "(?!main$)" in entry
+        assert "(?!dev$)" not in entry
+
+    def test_trunk_guard_mirrors_scaffold_trunk_render(
+        self, consumer_config: dict[str, Any], trunk_consumer_config: dict[str, Any]
+    ) -> None:
+        """Trunk guard == gitflow guard minus the ``(?!dev$)`` clause.
+
+        The exact parity ``render_workflow_model`` produces on the scaffolded
+        path (a lone ``s|(?!dev$)||`` deletion), proven here on the flake path.
+        """
+        gitflow = _branch_guard(consumer_config)
+        trunk = _branch_guard(trunk_consumer_config)
+        assert trunk == gitflow.replace("(?!dev$)", "")
+
+    def test_invalid_workflow_is_rejected(self) -> None:
+        """An unknown ``workflow`` value is refused loudly at eval time."""
+        expr = f"""
+        let
+          flake = builtins.getFlake "path:{REPO_ROOT}";
+          system = builtins.currentSystem;
+          pkgs = import flake.inputs.nixpkgs {{ inherit system; }};
+        in
+        (flake.lib.mkProjectShell {{
+          inherit pkgs;
+          workflow = "bogus";
+          hooks = {{ }};
+        }}).drvPath
+        """
+        result = _run_nix(["eval", "--impure", "--raw", "--expr", expr])
+        assert result.returncode != 0
+        assert "workflow" in result.stderr
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_workflow_model.py
+++ b/tests/test_workflow_model.py
@@ -226,6 +226,27 @@ def test_trunk_precommit_drops_dev_clause(tmp_path: Path) -> None:
     assert "(?!main$)" in text
 
 
+def test_trunk_flake_forwards_workflow_to_hooks(tmp_path: Path) -> None:
+    """The flake-hooks path follows the workflow model too (#1224).
+
+    The scaffolded ``.pre-commit-config.yaml`` is workflow-model-aware, but a
+    direnv consumer on flake-generated hooks (#1167) gets its branch guard from
+    ``mkProjectShell`` (the ``nix/hooks.nix`` consumer render), not that file.
+    So the scaffolded ``flake.nix`` reads ``DEVKIT_WORKFLOW`` from ``.vig-os``
+    and forwards it as ``mkProjectShell``'s ``workflow`` argument, which drops
+    the ``(?!dev$)`` clause for trunk — mirroring the scaffold render. Here we
+    assert the forwarding wiring is present and the manifest it reads declares
+    trunk; the flake-eval half (the generated guard actually loses the clause)
+    is covered by ``tests/test_flake_hooks.py::TestWorkflowModelBranchGuard``.
+    """
+    rendered = _tree(tmp_path, "trunk")
+    flake = (rendered / "flake.nix").read_text(encoding="utf-8")
+    assert "DEVKIT_WORKFLOW=" in flake, "flake.nix does not read the workflow model"
+    assert "inherit workflow;" in flake, "flake.nix does not forward `workflow`"
+    manifest = (rendered / ".vig-os").read_text(encoding="utf-8")
+    assert "DEVKIT_WORKFLOW=trunk" in manifest
+
+
 def test_anchoring_preserves_dev_prefixed_and_device_tokens(tmp_path: Path) -> None:
     """Anchoring must not touch /dev/null, dev_sha, or development/devkit tokens.
 


### PR DESCRIPTION
## Summary

The scaffolded `.pre-commit-config.yaml` is workflow-model aware — `render_workflow_model` (assets/init-workspace.sh) drops the `(?!dev$)` protect-clause for `DEVKIT_WORKFLOW=trunk`. But a direnv consumer on flake-generated hooks (#1167, the default) gets its branch guard from `mkProjectShell`'s `nix/hooks.nix` consumer render, which was **not** workflow aware: after switching to trunk it kept `^(?!main$)(?!dev$)…`, guarding a `dev` branch a trunk repo does not have.

Impact is inert (the residual clause guards a non-existent branch; `main` protection and the type prefixes still work), but the pattern must follow the workflow model for correctness. Found during the first live trunk switches (exo-pet/vault#31).

Closes #1224.

## Fix

Two seams, mirroring the scaffold render exactly:

1. **`nix/hooks.nix`** — the branch-guard regex is now produced by a single `branchNamePatternFor <workflow>` helper; the `(?!dev$)` clause is emitted only for non-trunk. The top-level `consumer` render takes a `workflow` and drops the clause for `trunk` via a targeted `no-commit-to-branch` override (`lib.optionalAttrs`), so **gitflow is a no-op** and the generated config stays byte-identical for existing consumers. The committed runner/scaffold YAML keeps the gitflow pattern (its trunk render remains the scaffold path's job).
2. **`flake.nix`** — `mkProjectShell` gains a `workflow ? "gitflow"` argument (validated: `gitflow | trunk`), threaded into the consumer render.
3. **`assets/workspace/flake.nix`** (scaffold template) — reads `DEVKIT_WORKFLOW` from `.vig-os` (via `self`, lazy + `pathExists`-guarded) and forwards it as `workflow`, so a fresh trunk direnv consumer's generated guard follows the model out of the box. gitflow / absent / blank all resolve to `gitflow`.

### Decisions (autonomous)

- **Argument, not impure read.** `mkProjectShell` cannot purely read the consumer's `.vig-os` (a devkit-flake path literal resolves to devkit's own tree). So the seam accepts a `workflow` argument and the consumer flake — which has `self` — does the read. This is the issue's second suggested option.
- **Reach for existing consumers.** A consumer's `flake.nix` is preserved (never overwritten), so an already-scaffolded trunk repo needs its `flake.nix` re-scaffolded or a one-line `workflow = "trunk";` to benefit; fresh trunk direnv scaffolds get it automatically. The bug is inert, so this is acceptable.
- **Test placement.** The flake-eval half lives in `tests/test_flake_hooks.py` (reusing that suite's `nix build` fixtures); the scaffold-path half (the template forwards the value) lives in `tests/test_workflow_model.py`, per the issue's ask to extend that matrix.

## Test evidence

- New `tests/test_flake_hooks.py::TestWorkflowModelBranchGuard` (4 tests): gitflow consumer keeps `(?!dev$)`; trunk consumer drops it while keeping `(?!main$)`; trunk guard == gitflow guard minus the exact `(?!dev$)` deletion; invalid `workflow` rejected at eval.
- New `tests/test_workflow_model.py::test_trunk_flake_forwards_workflow_to_hooks`: a trunk scaffold's `flake.nix` reads `DEVKIT_WORKFLOW` and forwards `workflow`, and its `.vig-os` declares `trunk`.
- `tests/test_flake_hooks.py` + `tests/test_workflow_model.py`: **56 passed**.
- `tests/test_flake_devshell.py test_downstream_flake.py test_flake_checks.py test_flake_modules.py`: **41 passed, 1 skipped** (drift gate + zero-hooks parity intact).
- `bats tests/bats/init-workspace.bats`: **232 passed** (flake-hooks activation + template stub unaffected).
- `prek run --all-files`: **all green**.

Refs: #1224
