### PR TITLE
feat(scaffold): sync-issues target-branch + schedule knobs (#1228)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`sync-issues` target-branch and schedule knobs** ([#1228](https://github.com/vig-os/devkit/issues/1228))
+  - New optional `.vig-os` key `DEVKIT_SYNC_TARGET` overrides the branch the
+    scaffolded sync-issues job commits to. Default stays workflow-model-aware
+    (`dev` gitflow / `main` trunk), so existing consumers are unchanged.
+  - A `trunk` repo whose `main` carries a require-PR ruleset (which refuses the
+    sync job's direct API push, [#1227](https://github.com/vig-os/devkit/issues/1227))
+    sets an unprotected mirror branch, e.g. `sync/issue-mirror`; the job
+    bootstraps it from the default branch head if absent. No ruleset bypass for
+    the commit App is added (rejected for security).
+  - New optional `.vig-os` key `DEVKIT_SYNC_SCHEDULE` overrides the sync schedule
+    trigger's cron (default `0 2 * * *`). Both keys are validated loudly at
+    scaffold time (git ref-format for the branch, a 5-field cron check) and
+    persisted across re-scaffolds.
+
 ### Changed
 
 ### Deprecated

--- a/assets/init-workspace.sh
+++ b/assets/init-workspace.sh
@@ -313,6 +313,22 @@ write_manifest_value() {
     fi
 }
 
+# Validate a 5-field cron expression (minute hour day-of-month month
+# day-of-week). A loose per-field charset check — digits, `*`, ranges, steps,
+# and lists — that rejects the wrong field count and stray characters so a
+# malformed DEVKIT_SYNC_SCHEDULE fails loudly at scaffold time rather than
+# silently disabling the schedule in GitHub Actions (#1228).
+is_valid_cron() {
+    local expr="$1" field
+    local -a fields
+    read -ra fields <<< "$expr"
+    [[ ${#fields[@]} -eq 5 ]] || return 1
+    for field in "${fields[@]}"; do
+        [[ "$field" =~ ^[0-9A-Za-z*,/?-]+$ ]] || return 1
+    done
+    return 0
+}
+
 MANIFEST_MODE="$(read_manifest_value "$VIG_OS_MANIFEST" DEVKIT_MODE || true)"
 MANIFEST_PROJECT="$(read_manifest_value "$VIG_OS_MANIFEST" DEVKIT_PROJECT || true)"
 MANIFEST_ORG="$(read_manifest_value "$VIG_OS_MANIFEST" DEVKIT_ORG || true)"
@@ -322,6 +338,8 @@ MANIFEST_TAG_PREFIX="$(read_manifest_value "$VIG_OS_MANIFEST" DEVKIT_TAG_PREFIX 
 MANIFEST_FLOATING_TAGS="$(read_manifest_value "$VIG_OS_MANIFEST" DEVKIT_FLOATING_TAGS || true)"
 MANIFEST_CI_RUNNER="$(read_manifest_value "$VIG_OS_MANIFEST" DEVKIT_CI_RUNNER || true)"
 MANIFEST_WORKFLOW="$(read_manifest_value "$VIG_OS_MANIFEST" DEVKIT_WORKFLOW || true)"
+MANIFEST_SYNC_TARGET="$(read_manifest_value "$VIG_OS_MANIFEST" DEVKIT_SYNC_TARGET || true)"
+MANIFEST_SYNC_SCHEDULE="$(read_manifest_value "$VIG_OS_MANIFEST" DEVKIT_SYNC_SCHEDULE || true)"
 
 # The OWNER/REPO placeholder (written when no origin was resolvable) must not
 # mask a now-detectable git origin on a later upgrade.
@@ -379,6 +397,23 @@ if [[ -n "$WORKFLOW_MODEL" && -n "$MANIFEST_WORKFLOW" && "$WORKFLOW_MODEL" != "$
     echo "  2. Keep the persisted model by omitting --workflow, or" >&2
     echo "  3. Switch deliberately: set DEVKIT_WORKFLOW=$WORKFLOW_MODEL in .vig-os on a dedicated," >&2
     echo "     clean upgrade branch and re-run the upgrade." >&2
+    exit 1
+fi
+
+# sync-issues target branch (#1228): a malformed branch name would render an
+# unusable sync-issues.yml, so validate the ref format loudly at scaffold time
+# using git's own ref-format checker. Pure `.vig-os` key (no CLI flag), so only
+# a format guard — no contradiction guard as for --mode / --workflow.
+if [[ -n "$MANIFEST_SYNC_TARGET" ]] \
+    && ! git check-ref-format "refs/heads/$MANIFEST_SYNC_TARGET" >/dev/null 2>&1; then
+    echo "Error: Invalid DEVKIT_SYNC_TARGET in $VIG_OS_MANIFEST: $MANIFEST_SYNC_TARGET (not a valid git branch name)" >&2
+    exit 1
+fi
+
+# sync-issues schedule (#1228): validate the 5-field cron loudly — a bad cron
+# silently disables the schedule trigger in GitHub Actions.
+if [[ -n "$MANIFEST_SYNC_SCHEDULE" ]] && ! is_valid_cron "$MANIFEST_SYNC_SCHEDULE"; then
+    echo "Error: Invalid DEVKIT_SYNC_SCHEDULE in $VIG_OS_MANIFEST: $MANIFEST_SYNC_SCHEDULE (expected a 5-field cron expression, e.g. '0 2 * * *')" >&2
     exit 1
 fi
 
@@ -1089,6 +1124,67 @@ render_workflow_model() {
     echo "Rendered workflow model: trunk (anchored dev -> main retarget)"
 }
 
+# Render the sync-issues.yml knobs (#1228): the commit target branch
+# (DEVKIT_SYNC_TARGET) and the schedule cron (DEVKIT_SYNC_SCHEDULE). Runs AFTER
+# render_workflow_model, so a custom target overrides the workflow-model default
+# already in the file (dev for gitflow / main for trunk). Both are no-ops when
+# their manifest key is unset, so an unconfigured workspace stays byte-for-byte
+# unchanged. When a custom target is set — a protected-main mirror branch such as
+# sync/issue-mirror (#1227) — the job also gains a bootstrap step that creates the
+# branch from the default branch head if absent; the mirror diverges permanently
+# and is never merged back (each sync regenerates full state).
+render_sync_settings() {
+    local si="$WORKSPACE_DIR/.github/workflows/sync-issues.yml"
+    [[ -f "$si" ]] || return 0
+
+    # Schedule override: the file carries a single `- cron: '…'` line.
+    if [[ -n "$MANIFEST_SYNC_SCHEDULE" ]]; then
+        local cron_esc
+        cron_esc=$(printf '%s' "$MANIFEST_SYNC_SCHEDULE" | sed 's/[&\]/\\&/g')
+        sed -i -E "s|^([[:space:]]*- cron:) '[^']*'\$|\1 '${cron_esc}'|" "$si"
+    fi
+
+    # Target-branch override: replace the workflow-model default (dev/main,
+    # already rendered above) with the consumer's mirror branch, then inject the
+    # bootstrap step so the subsequent checkout of the (possibly absent) branch
+    # succeeds.
+    if [[ -n "$MANIFEST_SYNC_TARGET" ]]; then
+        local model_default="dev"
+        [[ "$WORKFLOW_MODEL" == "trunk" ]] && model_default="main"
+        local tgt_esc
+        tgt_esc=$(printf '%s' "$MANIFEST_SYNC_TARGET" | sed 's/[&/\]/\\&/g')
+        sed -i -E "s|^([[:space:]]*default:) '${model_default}'\$|\1 '${tgt_esc}'|" "$si"
+        sed -i "s#|| '${model_default}'#|| '${tgt_esc}'#g" "$si"
+
+        # Insert the bootstrap step right after the app-token step (its
+        # `private-key:` line is unique — the sync action uses `app-private-key:`),
+        # before the checkout. `sed r` appends the block file after the match.
+        local block
+        block="$(mktemp)"
+        cat > "$block" <<YAML
+
+      - name: Bootstrap sync target branch if absent
+        env:
+          GH_TOKEN: \${{ steps.generate-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          TARGET="\${{ github.event.inputs.target-branch || '${MANIFEST_SYNC_TARGET}' }}"
+          if gh api "repos/\${{ github.repository }}/git/ref/heads/\${TARGET}" >/dev/null 2>&1; then
+            echo "Sync target branch '\${TARGET}' already exists."
+          else
+            echo "Sync target branch '\${TARGET}' absent — creating it from the default branch head."
+            DEFAULT_BRANCH="\$(gh api "repos/\${{ github.repository }}" --jq .default_branch)"
+            SHA="\$(gh api "repos/\${{ github.repository }}/git/ref/heads/\${DEFAULT_BRANCH}" --jq .object.sha)"
+            gh api "repos/\${{ github.repository }}/git/refs" -f "ref=refs/heads/\${TARGET}" -f "sha=\${SHA}"
+          fi
+YAML
+        sed -i "/^          private-key: /r $block" "$si"
+        rm -f "$block"
+    fi
+
+    echo "Rendered sync-issues settings (target=${MANIFEST_SYNC_TARGET:-default}, schedule=${MANIFEST_SYNC_SCHEDULE:-default})"
+}
+
 # Warn if forcing (prompt user) - show which files would be overwritten
 if [[ "$FORCE" == "true" ]]; then
     echo ""
@@ -1640,6 +1736,9 @@ render_codeql_matrix
 # trunk workflow model (#1205): retarget the copied release workflows dev ->
 # main. A no-op for the gitflow default, so a gitflow scaffold is unchanged.
 render_workflow_model "$WORKFLOW_MODEL"
+# sync-issues knobs (#1228): override the target branch + schedule cron on top of
+# the workflow-model default. A no-op when both keys are unset.
+render_sync_settings
 
 # Persist the resolved manifest (#885). The scaffolded .vig-os is a managed
 # file (template-overwritten on upgrade), so the resolved delivery mode and
@@ -1679,6 +1778,16 @@ if [[ -f "$VIG_OS_MANIFEST" ]]; then
     # same conditional-writeback shape as DEVKIT_TAG_PREFIX above.
     if [[ "$WORKFLOW_MODEL" == "trunk" ]]; then
         write_manifest_value DEVKIT_WORKFLOW "$WORKFLOW_MODEL"
+    fi
+    # sync-issues knobs (#1228): bare in the template (DEVKIT_SYNC_TARGET= /
+    # DEVKIT_SYNC_SCHEDULE=), so a consumer's mirror branch + cron override are
+    # written back — else an upgrade silently resets the sync job onto the
+    # workflow-model default branch and the daily cron.
+    if [[ -n "$MANIFEST_SYNC_TARGET" ]]; then
+        write_manifest_value DEVKIT_SYNC_TARGET "$MANIFEST_SYNC_TARGET"
+    fi
+    if [[ -n "$MANIFEST_SYNC_SCHEDULE" ]]; then
+        write_manifest_value DEVKIT_SYNC_SCHEDULE "$MANIFEST_SYNC_SCHEDULE"
     fi
 fi
 

--- a/assets/init-workspace.sh
+++ b/assets/init-workspace.sh
@@ -324,7 +324,7 @@ is_valid_cron() {
     read -ra fields <<< "$expr"
     [[ ${#fields[@]} -eq 5 ]] || return 1
     for field in "${fields[@]}"; do
-        [[ "$field" =~ ^[0-9A-Za-z*,/?-]+$ ]] || return 1
+        [[ "$field" =~ ^[0-9A-Za-z*,/-]+$ ]] || return 1
     done
     return 0
 }
@@ -400,14 +400,22 @@ if [[ -n "$WORKFLOW_MODEL" && -n "$MANIFEST_WORKFLOW" && "$WORKFLOW_MODEL" != "$
     exit 1
 fi
 
-# sync-issues target branch (#1228): a malformed branch name would render an
-# unusable sync-issues.yml, so validate the ref format loudly at scaffold time
-# using git's own ref-format checker. Pure `.vig-os` key (no CLI flag), so only
-# a format guard — no contradiction guard as for --mode / --workflow.
-if [[ -n "$MANIFEST_SYNC_TARGET" ]] \
-    && ! git check-ref-format "refs/heads/$MANIFEST_SYNC_TARGET" >/dev/null 2>&1; then
-    echo "Error: Invalid DEVKIT_SYNC_TARGET in $VIG_OS_MANIFEST: $MANIFEST_SYNC_TARGET (not a valid git branch name)" >&2
-    exit 1
+# sync-issues target branch (#1228): the value is spliced into single-quoted
+# YAML, sed replacement text, and the bootstrap step's double-quoted shell
+# assignment (executed at sync runtime with the App token in scope) — so the
+# LOAD-BEARING guard is a strict charset allowlist. git check-ref-format alone
+# is NOT enough: it accepts quotes, `$`, backticks, `;`, `|`, `#`, `&` … which
+# would render invalid YAML, crash the render seds, or inject commands. The
+# ref-format check is kept on top to also refuse git-illegal shapes the
+# allowlist admits (e.g. `bad..name`, a trailing `/` or `.lock`). Pure
+# `.vig-os` key (no CLI flag), so only format guards — no contradiction guard
+# as for --mode / --workflow.
+if [[ -n "$MANIFEST_SYNC_TARGET" ]]; then
+    if [[ ! "$MANIFEST_SYNC_TARGET" =~ ^[A-Za-z0-9._/-]+$ ]] \
+        || ! git check-ref-format "refs/heads/$MANIFEST_SYNC_TARGET" >/dev/null 2>&1; then
+        echo "Error: Invalid DEVKIT_SYNC_TARGET in $VIG_OS_MANIFEST: $MANIFEST_SYNC_TARGET (expected a valid git branch name using only [A-Za-z0-9._/-])" >&2
+        exit 1
+    fi
 fi
 
 # sync-issues schedule (#1228): validate the 5-field cron loudly — a bad cron

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`sync-issues` target-branch and schedule knobs** ([#1228](https://github.com/vig-os/devkit/issues/1228))
+  - New optional `.vig-os` key `DEVKIT_SYNC_TARGET` overrides the branch the
+    scaffolded sync-issues job commits to. Default stays workflow-model-aware
+    (`dev` gitflow / `main` trunk), so existing consumers are unchanged.
+  - A `trunk` repo whose `main` carries a require-PR ruleset (which refuses the
+    sync job's direct API push, [#1227](https://github.com/vig-os/devkit/issues/1227))
+    sets an unprotected mirror branch, e.g. `sync/issue-mirror`; the job
+    bootstraps it from the default branch head if absent. No ruleset bypass for
+    the commit App is added (rejected for security).
+  - New optional `.vig-os` key `DEVKIT_SYNC_SCHEDULE` overrides the sync schedule
+    trigger's cron (default `0 2 * * *`). Both keys are validated loudly at
+    scaffold time (git ref-format for the branch, a 5-field cron check) and
+    persisted across re-scaffolds.
+
 ### Changed
 
 ### Deprecated

--- a/assets/workspace/.vig-os
+++ b/assets/workspace/.vig-os
@@ -54,3 +54,18 @@ DEVKIT_FLOATING_TAGS=
 # resolve-toolchain's `runner-json` output; the resolve-toolchain and
 # dependency-review jobs always stay on the hosted default (#1173).
 DEVKIT_CI_RUNNER=
+
+# Branch the scaffolded sync-issues job commits to. Empty (default) resolves to
+# the workflow-model default — `dev` (gitflow) / `main` (trunk) — unchanged for
+# existing consumers. A repo whose `main` carries a require-PR ruleset (which
+# refuses the sync job's direct API push, #1227) sets a dedicated UNPROTECTED
+# mirror branch, e.g. `sync/issue-mirror`; the sync job bootstraps it from the
+# default branch head if absent. The mirror diverges permanently and is never
+# merged back — each sync run regenerates full state (#1228).
+DEVKIT_SYNC_TARGET=
+
+# Cron override for the sync-issues schedule trigger (5-field cron, validated at
+# scaffold time). Empty (default) => the daily `0 2 * * *`. e.g. `0 5 * * 0` runs
+# the sync weekly on Sundays. Realized at scaffold time because schedule triggers
+# cannot take inputs (#1228).
+DEVKIT_SYNC_SCHEDULE=

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -272,6 +272,64 @@ whose org **cannot run any hosted job at all** therefore still needs those two
 lanes handled separately (e.g. a repo-specific static render); this v1 keeps the
 managed workflow minimal and does not cover that case.
 
+### Point sync-issues at an unprotected mirror branch (protected `main`)
+
+The scaffolded `sync-issues.yml` commits its regenerated issue/PR archive with a
+**direct API push** to a target branch. That target is workflow-model-aware:
+`dev` under `gitflow` (whose ruleset admits the commit App) and `main` under
+`trunk`. On a `trunk` repo whose `main` carries a **require-PR ruleset** the
+direct push is *refused* — `Changes must be made through a pull request` — so the
+scheduled sync fails every run
+([#1227](https://github.com/vig-os/devkit/issues/1227), first seen on
+`vig-os/org-config`).
+
+**Do not add the commit App as a ruleset bypass actor on `main`.** It is the
+cheapest fix but was **rejected for security**: a bot that can write a protected
+`main` can change whatever that branch controls (for `org-config`, the *applied*
+organization configuration). Instead, set the optional `.vig-os` key
+`DEVKIT_SYNC_TARGET` to a dedicated **unprotected mirror branch**:
+
+```ini
+# .vig-os
+DEVKIT_SYNC_TARGET=sync/issue-mirror
+```
+
+The scaffolded job then **bootstraps** that branch from the default branch head
+if it is absent (so its first run creates it) and pushes the archive there,
+outside the `main` ruleset. The mirror branch **diverges permanently and is never
+merged back** — every sync run regenerates the full issue/PR state from the
+GitHub API, so the branch is a standalone, self-healing archive, not integration
+work. Absent => the workflow-model default (`dev`/`main`), unchanged for every
+existing consumer.
+
+A second optional key, `DEVKIT_SYNC_SCHEDULE`, overrides the schedule trigger's
+cron (validated as a 5-field cron at scaffold time; a protected-main mirror is
+often paired with a lighter cadence):
+
+```ini
+# .vig-os
+DEVKIT_SYNC_SCHEDULE=0 5 * * 0   # weekly, Sundays 05:00 UTC (default: 0 2 * * *)
+```
+
+Both keys are realized entirely at scaffold time — schedule triggers cannot take
+inputs — and persisted across re-scaffolds like the other manifest keys, so an
+upgrade preserves them with no flags. A malformed branch name or cron fails
+loudly during `init-workspace.sh` rather than rendering a broken workflow
+([#1228](https://github.com/vig-os/devkit/issues/1228)).
+
+**Provisioning a new `trunk` consumer with a protected `main`:** set
+`DEVKIT_SYNC_TARGET` to an unprotected mirror branch (above) — **not** a ruleset
+bypass for the commit App.
+
+**Deliberate exclusion — PR-based sync mode.** A variant where the sync job opens
+a short-lived pull request into `main` (instead of pushing to a mirror) was
+**evaluated and deferred** ([#1228](https://github.com/vig-os/devkit/issues/1228),
+[#1227](https://github.com/vig-os/devkit/issues/1227) option (b)): the toil is
+inherent against a review-requiring ruleset (a human approval per sync), its
+safety value depends on ruleset state the knob cannot observe, and it needs
+Renovate-class stale-PR machinery with zero live consumers asking for
+human-gated sync. Revisit only when a consumer actually requests it.
+
 ## The `.vig-os` project manifest
 
 Since [#885](https://github.com/vig-os/devkit/issues/885), `.vig-os` is
@@ -289,6 +347,8 @@ unknown keys:
 | `DEVKIT_REPO` | Persisted GitHub `owner/repo` (Renovate preset) |
 | `DEVKIT_MODULES` | Reserved: space-separated capability modules mirroring `mkProjectShell`'s `modules = [ … ]` ([#884](https://github.com/vig-os/devkit/issues/884)) |
 | `DEVKIT_CI_RUNNER` | Comma-separated runner label list for the scaffolded `ci.yml` toolchain jobs; empty (default) => the hosted `ubuntu-24.04` runner ([#1173](https://github.com/vig-os/devkit/issues/1173)) |
+| `DEVKIT_SYNC_TARGET` | Branch the scaffolded sync-issues job commits to; empty (default) => the workflow-model default (`dev`/`main`). A protected-`main` consumer sets an unprotected mirror branch, e.g. `sync/issue-mirror` (see [Point sync-issues at an unprotected mirror branch](#point-sync-issues-at-an-unprotected-mirror-branch-protected-main), [#1228](https://github.com/vig-os/devkit/issues/1228)) |
+| `DEVKIT_SYNC_SCHEDULE` | Cron override (5-field) for the sync-issues schedule trigger; empty (default) => the daily `0 2 * * *` ([#1228](https://github.com/vig-os/devkit/issues/1228)) |
 
 How it behaves:
 

--- a/tests/bats/init-workspace.bats
+++ b/tests/bats/init-workspace.bats
@@ -2151,6 +2151,72 @@ _upgrade_no_flags() {
     assert_success
 }
 
+# ── sync-issues target/schedule knobs (#1228) ─────────────────────────────────
+# Two optional .vig-os keys, realized at scaffold time, steer sync-issues.yml.
+# DEVKIT_SYNC_TARGET overrides the commit target branch (a protected-main mirror,
+# #1227) and injects a branch-bootstrap step; DEVKIT_SYNC_SCHEDULE overrides the
+# schedule cron. Both are guarded loudly and persisted like DEVKIT_CI_RUNNER.
+
+@test "template .vig-os ships the sync-issues keys empty (#1228)" {
+    run grep -x 'DEVKIT_SYNC_TARGET=' "$TEMPLATE_DIR/.vig-os"
+    assert_success
+    run grep -x 'DEVKIT_SYNC_SCHEDULE=' "$TEMPLATE_DIR/.vig-os"
+    assert_success
+}
+
+@test "a custom DEVKIT_SYNC_TARGET renders the mirror branch + bootstrap step (#1228)" {
+    ws="$BATS_TEST_TMPDIR/e2e-1228-target"
+    mkdir -p "$ws"
+    run _scaffold both "$ws"
+    assert_success
+    sed -i 's#^DEVKIT_SYNC_TARGET=.*#DEVKIT_SYNC_TARGET=sync/issue-mirror#' "$ws/.vig-os"
+    run _upgrade_no_flags "$ws"
+    assert_success
+    run grep -qF "default: 'sync/issue-mirror'" "$ws/.github/workflows/sync-issues.yml"
+    assert_success
+    run grep -qF "Bootstrap sync target branch if absent" "$ws/.github/workflows/sync-issues.yml"
+    assert_success
+    # The custom target is written back so the next upgrade preserves it.
+    run grep -x 'DEVKIT_SYNC_TARGET=sync/issue-mirror' "$ws/.vig-os"
+    assert_success
+}
+
+@test "a custom DEVKIT_SYNC_SCHEDULE overrides the sync cron (#1228)" {
+    ws="$BATS_TEST_TMPDIR/e2e-1228-schedule"
+    mkdir -p "$ws"
+    run _scaffold both "$ws"
+    assert_success
+    sed -i 's#^DEVKIT_SYNC_SCHEDULE=.*#DEVKIT_SYNC_SCHEDULE=0 5 * * 0#' "$ws/.vig-os"
+    run _upgrade_no_flags "$ws"
+    assert_success
+    run grep -qF "cron: '0 5 * * 0'" "$ws/.github/workflows/sync-issues.yml"
+    assert_success
+    run grep -qF "cron: '0 2 * * *'" "$ws/.github/workflows/sync-issues.yml"
+    assert_failure
+}
+
+@test "an invalid DEVKIT_SYNC_TARGET fails the scaffold loudly (#1228)" {
+    ws="$BATS_TEST_TMPDIR/e2e-1228-bad-target"
+    mkdir -p "$ws"
+    run _scaffold both "$ws"
+    assert_success
+    sed -i 's#^DEVKIT_SYNC_TARGET=.*#DEVKIT_SYNC_TARGET=bad..name#' "$ws/.vig-os"
+    run _upgrade_no_flags "$ws"
+    assert_failure
+    assert_output --partial "Invalid DEVKIT_SYNC_TARGET"
+}
+
+@test "an invalid DEVKIT_SYNC_SCHEDULE fails the scaffold loudly (#1228)" {
+    ws="$BATS_TEST_TMPDIR/e2e-1228-bad-cron"
+    mkdir -p "$ws"
+    run _scaffold both "$ws"
+    assert_success
+    sed -i 's#^DEVKIT_SYNC_SCHEDULE=.*#DEVKIT_SYNC_SCHEDULE=0 2 * *#' "$ws/.vig-os"
+    run _upgrade_no_flags "$ws"
+    assert_failure
+    assert_output --partial "Invalid DEVKIT_SYNC_SCHEDULE"
+}
+
 # ── legacy mode inference (#885) ──────────────────────────────────────────────
 # Consumers scaffolded before the manifest carry a version-only .vig-os (or
 # none): an upgrade without --mode must infer the delivery mode from the tree

--- a/tests/bats/init-workspace.bats
+++ b/tests/bats/init-workspace.bats
@@ -2206,6 +2206,22 @@ _upgrade_no_flags() {
     assert_output --partial "Invalid DEVKIT_SYNC_TARGET"
 }
 
+@test "a hostile DEVKIT_SYNC_TARGET (shell metacharacters) fails the scaffold loudly (#1228)" {
+    # git check-ref-format alone accepts quotes/$/backticks/;/|/# — values that
+    # would render invalid YAML or inject commands into the bootstrap step's
+    # double-quoted shell assignment at sync runtime (with the App token in
+    # scope). The allowlist guard must refuse them with the clean message.
+    ws="$BATS_TEST_TMPDIR/e2e-1228-hostile-target"
+    mkdir -p "$ws"
+    run _scaffold both "$ws"
+    assert_success
+    # shellcheck disable=SC2016  # literal $(id) is the hostile payload, not an expansion
+    sed -i 's#^DEVKIT_SYNC_TARGET=.*#DEVKIT_SYNC_TARGET=x$(id)y#' "$ws/.vig-os"
+    run _upgrade_no_flags "$ws"
+    assert_failure
+    assert_output --partial "Invalid DEVKIT_SYNC_TARGET"
+}
+
 @test "an invalid DEVKIT_SYNC_SCHEDULE fails the scaffold loudly (#1228)" {
     ws="$BATS_TEST_TMPDIR/e2e-1228-bad-cron"
     mkdir -p "$ws"

--- a/tests/test_sync_settings.py
+++ b/tests/test_sync_settings.py
@@ -1,0 +1,208 @@
+"""Scaffold-render tests: the sync-issues knobs DEVKIT_SYNC_TARGET / DEVKIT_SYNC_SCHEDULE.
+
+Issue #1228: trunk consumers whose ``main`` carries a require-PR ruleset cannot
+let the scaffolded ``sync-issues.yml`` push directly to ``main`` (#1227). Two
+optional ``.vig-os`` keys, realized entirely at scaffold time (schedule triggers
+cannot take inputs), remediate this without a ruleset bypass:
+
+- ``DEVKIT_SYNC_TARGET`` — the branch the sync job commits to. Default is
+  workflow-model-aware (``dev`` gitflow / ``main`` trunk), preserving today's
+  behavior byte-for-byte when unset. A protected-main consumer points it at an
+  unprotected mirror branch (e.g. ``sync/issue-mirror``); the scaffolded job then
+  bootstraps that branch from the default branch head if absent.
+- ``DEVKIT_SYNC_SCHEDULE`` — cron override for the schedule trigger (default the
+  current daily cron). Validated as a 5-field cron at scaffold time.
+
+These drive the REAL ``init-workspace.sh`` end-to-end (the executed-bash style of
+``tests/test_workflow_model.py`` / ``tests/test_ci_runner.py``).
+
+Refs: #1228
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tests.workflow_scaffold import (
+    INIT_WORKSPACE,
+    WORKSPACE,
+    scaffold,
+)
+
+# Repository root (tests/ -> repo root).
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+MIRROR = "sync/issue-mirror"
+BOOTSTRAP_STEP = "Bootstrap sync target branch if absent"
+
+
+def _seed(tmp_path: Path, name: str, manifest: str) -> Path:
+    """Create a seed workspace holding a ``.vig-os`` with the given manifest text."""
+    seed = tmp_path / f"{name}-seed"
+    seed.mkdir()
+    (seed / ".vig-os").write_text(manifest, encoding="utf-8")
+    return seed
+
+
+def _sync_yaml(
+    tmp_path: Path,
+    *,
+    name: str,
+    workflow: str | None = None,
+    target: str | None = None,
+    schedule: str | None = None,
+) -> str:
+    """Scaffold a workspace (optionally seeding the sync keys) and return its
+    rendered ``sync-issues.yml`` text."""
+    manifest_lines = []
+    if target is not None:
+        manifest_lines.append(f"DEVKIT_SYNC_TARGET={target}")
+    if schedule is not None:
+        manifest_lines.append(f"DEVKIT_SYNC_SCHEDULE={schedule}")
+    seed = (
+        _seed(tmp_path, name, "\n".join(manifest_lines) + "\n")
+        if manifest_lines
+        else None
+    )
+    proc = scaffold(tmp_path, workflow=workflow, seed=seed, name=name)
+    assert proc.returncode == 0, proc.stderr
+    return (tmp_path / name / ".github" / "workflows" / "sync-issues.yml").read_text(
+        encoding="utf-8"
+    )
+
+
+# ── production wiring seams ───────────────────────────────────────────────────
+
+
+def test_vig_os_declares_sync_keys() -> None:
+    """The scaffold manifest ships both opt-in keys (default empty)."""
+    text = (WORKSPACE / ".vig-os").read_text(encoding="utf-8")
+    assert "DEVKIT_SYNC_TARGET=" in text
+    assert "DEVKIT_SYNC_SCHEDULE=" in text
+
+
+def test_init_workspace_invokes_render_sync_settings() -> None:
+    """init-workspace.sh defines + invokes render_sync_settings."""
+    init = INIT_WORKSPACE.read_text(encoding="utf-8")
+    assert "render_sync_settings" in init
+
+
+# ── unset = byte-for-byte today's behavior ────────────────────────────────────
+
+
+def test_unset_gitflow_keeps_dev_default_and_daily_cron(tmp_path: Path) -> None:
+    """No keys on gitflow => today's `dev` target + daily cron, no bootstrap."""
+    text = _sync_yaml(tmp_path, name="gf-default")
+    assert "default: 'dev'" in text
+    assert "|| 'dev'" in text
+    assert "cron: '0 2 * * *'" in text
+    assert BOOTSTRAP_STEP not in text
+
+
+def test_unset_trunk_keeps_main_default(tmp_path: Path) -> None:
+    """No keys on trunk => the workflow-model `main` default is untouched."""
+    text = _sync_yaml(tmp_path, name="tk-default", workflow="trunk")
+    assert "default: 'main'" in text
+    assert "|| 'main'" in text
+    assert "|| 'dev'" not in text
+    assert BOOTSTRAP_STEP not in text
+
+
+# ── DEVKIT_SYNC_TARGET override ───────────────────────────────────────────────
+
+
+def test_target_override_gitflow(tmp_path: Path) -> None:
+    """A mirror target on gitflow replaces every `dev` sync target + bootstraps."""
+    text = _sync_yaml(tmp_path, name="gf-target", target=MIRROR)
+    assert f"default: '{MIRROR}'" in text
+    assert f"|| '{MIRROR}'" in text
+    assert "|| 'dev'" not in text
+    assert "default: 'dev'" not in text
+    assert BOOTSTRAP_STEP in text
+
+
+def test_target_override_trunk(tmp_path: Path) -> None:
+    """A mirror target on trunk replaces the rendered `main` sync target."""
+    text = _sync_yaml(tmp_path, name="tk-target", workflow="trunk", target=MIRROR)
+    assert f"default: '{MIRROR}'" in text
+    assert f"|| '{MIRROR}'" in text
+    assert "|| 'main'" not in text
+    assert BOOTSTRAP_STEP in text
+
+
+def test_bootstrap_step_creates_ref_from_default_branch(tmp_path: Path) -> None:
+    """The injected bootstrap step creates the absent branch from the default head."""
+    text = _sync_yaml(tmp_path, name="gf-bootstrap", target=MIRROR)
+    assert "git/refs" in text
+    assert "default_branch" in text
+    # Uses the app token (same as the commit push), not the restricted GITHUB_TOKEN.
+    assert "steps.generate-token.outputs.token" in text
+
+
+def test_target_persisted_in_manifest(tmp_path: Path) -> None:
+    """A custom target is written back to .vig-os (upgrade-persistent)."""
+    seed = _seed(tmp_path, "persist", f"DEVKIT_SYNC_TARGET={MIRROR}\n")
+    proc = scaffold(tmp_path, seed=seed, name="persist")
+    assert proc.returncode == 0, proc.stderr
+    text = (tmp_path / "persist" / ".vig-os").read_text(encoding="utf-8")
+    assert f"DEVKIT_SYNC_TARGET={MIRROR}" in text
+
+
+# ── DEVKIT_SYNC_SCHEDULE override ─────────────────────────────────────────────
+
+
+def test_schedule_override(tmp_path: Path) -> None:
+    """A cron override replaces the daily cron line."""
+    text = _sync_yaml(tmp_path, name="sched", schedule="0 5 * * 0")
+    assert "cron: '0 5 * * 0'" in text
+    assert "cron: '0 2 * * *'" not in text
+
+
+def test_schedule_persisted_in_manifest(tmp_path: Path) -> None:
+    """A custom schedule is written back to .vig-os."""
+    seed = _seed(tmp_path, "sched-persist", "DEVKIT_SYNC_SCHEDULE=0 5 * * 0\n")
+    proc = scaffold(tmp_path, seed=seed, name="sched-persist")
+    assert proc.returncode == 0, proc.stderr
+    text = (tmp_path / "sched-persist" / ".vig-os").read_text(encoding="utf-8")
+    assert "DEVKIT_SYNC_SCHEDULE=0 5 * * 0" in text
+
+
+def test_target_and_schedule_combined(tmp_path: Path) -> None:
+    """Both knobs compose: mirror target + weekly cron, on trunk."""
+    text = _sync_yaml(
+        tmp_path,
+        name="combo",
+        workflow="trunk",
+        target=MIRROR,
+        schedule="30 4 * * 1",
+    )
+    assert f"default: '{MIRROR}'" in text
+    assert "cron: '30 4 * * 1'" in text
+    assert BOOTSTRAP_STEP in text
+
+
+# ── guards (format validation, loud at scaffold time) ─────────────────────────
+
+
+def test_guard_rejects_bad_branch_name(tmp_path: Path) -> None:
+    """An invalid git branch name is refused loudly before any mutation."""
+    seed = _seed(tmp_path, "bad-branch", "DEVKIT_SYNC_TARGET=bad..name\n")
+    proc = scaffold(tmp_path, seed=seed, name="bad-branch", check=False)
+    assert proc.returncode != 0
+    assert "Invalid DEVKIT_SYNC_TARGET" in proc.stderr
+
+
+def test_guard_rejects_bad_cron_field_count(tmp_path: Path) -> None:
+    """A cron with the wrong field count is refused loudly."""
+    seed = _seed(tmp_path, "bad-cron", "DEVKIT_SYNC_SCHEDULE=0 2 * *\n")
+    proc = scaffold(tmp_path, seed=seed, name="bad-cron", check=False)
+    assert proc.returncode != 0
+    assert "Invalid DEVKIT_SYNC_SCHEDULE" in proc.stderr
+
+
+def test_guard_rejects_bad_cron_charset(tmp_path: Path) -> None:
+    """A 5-field cron with a stray character is refused loudly."""
+    seed = _seed(tmp_path, "bad-cron2", "DEVKIT_SYNC_SCHEDULE=0 2 * * @\n")
+    proc = scaffold(tmp_path, seed=seed, name="bad-cron2", check=False)
+    assert proc.returncode != 0
+    assert "Invalid DEVKIT_SYNC_SCHEDULE" in proc.stderr

--- a/tests/test_sync_settings.py
+++ b/tests/test_sync_settings.py
@@ -23,6 +23,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from tests.workflow_scaffold import (
     INIT_WORKSPACE,
     WORKSPACE,
@@ -189,6 +191,35 @@ def test_guard_rejects_bad_branch_name(tmp_path: Path) -> None:
     seed = _seed(tmp_path, "bad-branch", "DEVKIT_SYNC_TARGET=bad..name\n")
     proc = scaffold(tmp_path, seed=seed, name="bad-branch", check=False)
     assert proc.returncode != 0
+    assert "Invalid DEVKIT_SYNC_TARGET" in proc.stderr
+
+
+@pytest.mark.parametrize(
+    "hostile",
+    [
+        "foo'bar",  # git-legal, but breaks the single-quoted YAML render
+        "x$(id)y",  # git-legal, but command substitution in the bootstrap step
+        "a`id`b",  # backtick command substitution, same sink
+        "foo|bar",  # sed s#…# replacement crashes / delimiter collision
+        "foo#bar",  # sed s#…# delimiter collision
+        "a;b",  # shell statement separator
+        'q"w',  # double quote — escapes the bootstrap TARGET="…" assignment
+        "a&b",  # sed replacement metacharacter
+        "c{d}",  # expression/brace tokens
+    ],
+)
+def test_guard_rejects_hostile_branch_chars(tmp_path: Path, hostile: str) -> None:
+    """Shell/sed/YAML metacharacters are refused with the clean guard message.
+
+    ``git check-ref-format`` alone accepts quotes, ``$``, backticks, ``;``,
+    ``|``, ``#``, ``&``, ``{`` … — values that would render invalid YAML, crash
+    the render seds with a raw sed error, or (worst) inject commands into the
+    bootstrap step's double-quoted shell assignment at sync runtime with the
+    App token in scope. The guard must be a strict allowlist.
+    """
+    seed = _seed(tmp_path, "hostile", f"DEVKIT_SYNC_TARGET={hostile}\n")
+    proc = scaffold(tmp_path, seed=seed, name="hostile", check=False)
+    assert proc.returncode != 0, f"scaffold accepted hostile target: {hostile!r}"
     assert "Invalid DEVKIT_SYNC_TARGET" in proc.stderr
 
 


### PR DESCRIPTION
## Summary

Add two optional `.vig-os` knobs, realized entirely at scaffold time, that steer the scaffolded `sync-issues.yml`. They remediate #1227: trunk consumers whose `main` carries a require-PR ruleset cannot let the sync job's direct API push land on `main`.

- **`DEVKIT_SYNC_TARGET`** — the branch the sync job commits to. Default stays **workflow-model-aware** (`dev` gitflow / `main` trunk), byte-for-byte unchanged when unset. A protected-`main` consumer points it at an unprotected mirror branch (e.g. `sync/issue-mirror`); the scaffolded job then gains a **bootstrap step** that creates the branch from the default branch head if absent. The mirror diverges permanently and is never merged back — each sync regenerates full state.
- **`DEVKIT_SYNC_SCHEDULE`** — cron override for the schedule trigger (default `0 2 * * *`). Realized at scaffold time because schedule triggers cannot take inputs.

Both are guarded loudly at scaffold time (git ref-format for the branch, a 5-field cron check) and written back to `.vig-os` like `DEVKIT_CI_RUNNER`, so upgrades preserve them with no flags.

## Design recap

- **No ruleset bypass for the commit App** (rejected for security — a bot that writes a protected `main` can change whatever that branch controls, e.g. applied org config). The mirror-branch approach keeps the App off protected `main`.
- Realized at **scaffold time** mirroring `DEVKIT_WORKFLOW`/`DEVKIT_CI_RUNNER`: read before the template overwrite, guarded, rendered, written back. `render_sync_settings()` runs **after** `render_workflow_model()`, so a custom target overrides the workflow-model default already in the file; both are no-ops when unset.
- **Bootstrap step** is injected only when a custom target is set (via `sed r` after the unique app-token `private-key:` line, before the sync-job checkout), so an unconfigured workspace is unchanged. It uses the App token (same as the commit push) and `gh api .../git/refs`; rendered output validated with `actionlint`.
- **Deliberate exclusion — PR-based sync mode** (#1227 option (b)): evaluated and deferred (inherent approval toil against a review-requiring ruleset, ruleset-dependent safety value, needs Renovate-class stale-PR machinery, zero consumers asking). Recorded in the docs using the established "deliberate exclusion" pattern.

## Decisions / deviations from the issue spec

- **`install.sh` unchanged.** These are pure `.vig-os` keys with no CLI flag (schedule triggers can't take inputs), so — exactly like `DEVKIT_CI_RUNNER` / `DEVKIT_TAG_PREFIX` — they are resolved end-to-end in `init-workspace.sh`, which reads the consumer's `.vig-os` directly. `install.sh` only handles keys it needs for its own flags (mode/workflow) or identity; adding handling there would be dead code against precedent. The issue mentioned "the install script", but following the real precedent keeps the diff minimal and consistent.
- **Docs placement of the PR-sync exclusion.** The issue asked to record it "in the same docs section that carries the docs-module v1 exclusions pattern" (the nix `docs` module in `NIX.md`). Placing a sync-mode note there is topically wrong, so I applied the *pattern* (a "Deliberate exclusion" note) in the topically-correct new MIGRATION.md sync subsection.
- **Bats + Python tests.** Followed the #1205 precedent of covering a scaffold-time knob with both the Python executed-bash suite (render matrix, guards, bootstrap, writeback) and a focused bats set.

## Test evidence

- `tests/test_sync_settings.py` — 14 passed (RED first: 12 failed / 2 unset-preservation passed before implementation).
- No regressions: `test_workflow_model.py`, `test_ci_runner.py`, `test_install_script.py`, `test_scaffold_lint.py`, `test_workflow_sync_checkout.py`, and more — 174 passed together.
- `tests/bats/init-workspace.bats` — 237 passed (was 232; +5 for #1228).
- Rendered mirror-target `sync-issues.yml`: valid YAML + `actionlint` clean; bootstrap step sits after the app-token step, before the sync-job checkout.
- `prek run --all-files` — green. `shellcheck assets/init-workspace.sh` — clean.

Target release: **1.4.1**

Refs: #1228
Refs: #1227
