### PR TITLE
ci: add scheduled GHCR cleanup of stale devcontainer versions

### DIFF
--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -1,0 +1,65 @@
+# GHCR cleanup — prune stale devcontainer package versions
+#
+# Weekly sweep of the org package `vig-os/devcontainer`. Deletes untagged image
+# versions: orphaned `nix-dev*` discovery generations (every dev/epic push
+# re-points those tags, stranding the previous index + arch manifests) and
+# dangling attestation referrers left behind when promote-release prunes RC
+# images. The action is multi-arch and referrer aware: platform children of
+# tagged indexes and attestation/cosign referrers whose subject is a kept
+# (tagged) image are preserved.
+#
+# Triggers: weekly cron; manual dispatch (dry-run defaults to true so a manual
+# run is a safe preview — scheduled runs delete for real). Scheduled runs
+# execute from the default branch.
+#
+# Uses the default GITHUB_TOKEN with job-scoped `packages: write` — the repo
+# has admin on the org package (same mechanism as the promote-release GHCR
+# prune step). Devkit-only: not scaffolded to consumers.
+#
+# Refs #1238.
+
+name: GHCR Cleanup
+
+on:  # yamllint disable-line rule:truthy
+  schedule:
+    - cron: '0 4 * * 1'  # weekly, Mon 04:00 UTC
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: 'Preview deletions without removing anything'
+        type: boolean
+        default: true
+
+# Restrict default permissions; the job declares its own.
+permissions: {}
+
+# Serialize with promote-release's RC prune window is not needed (disjoint
+# targets), but never let two cleanup passes interleave their delete sets.
+concurrency:
+  group: ghcr-cleanup
+  cancel-in-progress: false
+
+jobs:
+  cleanup:
+    name: Prune stale package versions
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      packages: write
+    steps:
+      - name: Delete stale untagged devcontainer versions
+        uses: dataaxiom/ghcr-cleanup-action@d52806a0dc70b430571a37da1fde39733ffd640f  # v1.2.2
+        with:
+          token: ${{ github.token }}
+          owner: vig-os
+          package: devcontainer
+          delete-untagged: true
+          # delete-untagged skips dangling attestation referrers (their subject
+          # digest is gone but they are still referrer-shaped); this option
+          # reaps them plus orphaned sha256-* referrer tags.
+          delete-orphaned-images: true
+          # Age guard: in-flight artifacts (current release train, fresh
+          # discovery builds) survive until they are stale for real.
+          older-than: 7 days
+          validate: true
+          dry-run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run }}


### PR DESCRIPTION
Closes #1238

## What

Adds a devkit-only scheduled workflow `.github/workflows/ghcr-cleanup.yml` (weekly Mon 04:00 UTC + `workflow_dispatch` with `dry-run` defaulting to **true** for safe manual previews) that prunes stale versions of the `vig-os/devcontainer` org package using `dataaxiom/ghcr-cleanup-action` v1.2.2 (SHA-pinned; Renovate's `github-actions` manager will keep it fresh):

- `delete-untagged: true` — orphaned `nix-dev*` discovery generations (~3 per dev/epic push).
- `delete-orphaned-images: true` — dangling attestation referrers + orphaned `sha256-*` referrer tags left behind by the promote-release RC prune.
- `older-than: 7 days` age guard, `validate: true` manifest integrity check.
- Default `GITHUB_TOKEN` with job-scoped `packages: write` — same mechanism as the existing promote-release GHCR prune step.

Not scaffolded to consumers (root workflows only; not in `assets/workspace/` or the sync manifest), so outside the zizmor-managed audit scope; covered by actionlint/yamllint/shellcheck pre-commit hooks. No CHANGELOG entry per repo rules (`ci`-internal).

## Validation evidence (pre-merge, acceptance criteria of #1238)

Ran the pinned action locally (`node dist/index.js` at `d52806a0`, Node 24) against the **live package**, three configurations, all `dry-run=true` (587 versions loaded each run):

| Run | Options | Would delete | Kept |
|---|---|---|---|
| 1 | `delete-untagged` + `older-than: 7 days` | 298 | 289 |
| 2 | `delete-untagged` only | 382 | 205 |
| 3 | run 2 + `delete-orphaned-images` | 423 | 164 |

- **Keep-safety PASS**: zero live tagged versions in any delete set. Explicitly verified kept: `1.4.0`/`latest`, `1.3.1`, `1.3.0`, current `nix-dev*` trio, all `sha256-*` cosign/referrer tags of live releases, and the untagged attestation children of 1.4.0/1.3.1/1.3.0 (cross-checked against live referrer indexes fetched from GHCR).
- **Delete-effectiveness PASS**: old orphaned `nix-dev` generations (index + arch children) and dangling attestation manifests (subject digest gone) land in the delete set; the dangling ones specifically require `delete-orphaned-images` (run 3), hence that option.
- `validate` mode: 107 warnings (existing dangling-referrer debt this workflow removes), 0 errors, no ghost/partial images.

## Notes

- First scheduled run executes from the default branch after merge/promotion; a manual `workflow_dispatch` (dry-run preview) can be exercised any time after merge as a final live check.
- TDD skipped: config-only workflow, no testable script surface (selection logic lives in the pinned action).
