### PR TITLE
chore(security): extend gawk CVE exception expiry to 2026-08-18

### DIFF
--- a/.vulnixignore
+++ b/.vulnixignore
@@ -293,9 +293,13 @@ CVE-2026-60002
 # untrusted-input path in the single-user dev model). Flip to a nixpkgs
 # rev-advance once 5.4.1 lands in the pinned channel; short expiry to force
 # near-term re-check.
+# Re-verified 2026-07-21 (#1240): nixos-26.05 and release-26.05 still ship gawk
+# 5.4.0; the staging fix (5.4.1) has not yet propagated to the pinned channel,
+# so the rev-advance lever still has nowhere to land. Expiry extended to
+# 2026-08-18 (another short window) pending that propagation.
 # ============================================================================
 
-Expiration: 2026-07-28
+Expiration: 2026-08-18
 # gawk 5.4.0 — CVE-2026-40468 (9.1): integer overflow in builtin.c; memory
 #   exhaustion / heap-metadata overwrite with attacker-controlled bytes.
 #   Requires gawk to run a crafted awk program or input — developer-chosen

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **Extend gawk 5.4.0 CVE exception expiry to 2026-08-18** ([#1240](https://github.com/vig-os/devkit/issues/1240))
+  - The `.vulnixignore` exception for the gawk 5.4.0 CERT-PL batch
+    (`CVE-2026-40467`/`-40468`/`-40469`/`-40553`, from [#1071](https://github.com/vig-os/devkit/issues/1071))
+    is extended from 2026-07-28 to 2026-08-18. The upstream fix (gawk 5.4.1) is
+    still only on nixpkgs `staging` and has not reached the pinned `nixos-26.05`
+    channel, so the planned rev-advance remains unavailable.
+
 ## [1.4.0](https://github.com/vig-os/devkit/releases/tag/1.4.0) - 2026-07-20
 
 ### Added

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -54,6 +54,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **Extend gawk 5.4.0 CVE exception expiry to 2026-08-18** ([#1240](https://github.com/vig-os/devkit/issues/1240))
+  - The `.vulnixignore` exception for the gawk 5.4.0 CERT-PL batch
+    (`CVE-2026-40467`/`-40468`/`-40469`/`-40553`, from [#1071](https://github.com/vig-os/devkit/issues/1071))
+    is extended from 2026-07-28 to 2026-08-18. The upstream fix (gawk 5.4.1) is
+    still only on nixpkgs `staging` and has not reached the pinned `nixos-26.05`
+    channel, so the planned rev-advance remains unavailable.
+
 ## [1.4.0](https://github.com/vig-os/devkit/releases/tag/1.4.0) - 2026-07-20
 
 ### Added


### PR DESCRIPTION
## What

Extend the `.vulnixignore` exception for the gawk 5.4.0 CERT-PL CVE batch
(`CVE-2026-40467`/`-40468`/`-40469`/`-40553`, originally #1071 / #1072) from
`Expiration: 2026-07-28` to `2026-08-18`, and record the extension in the
`## Unreleased` → `### Security` changelog section.

## Why

The exception was short-dated to force a re-check once the fix lands in the
pinned nixpkgs channel and we can flip to a rev-advance. That has not happened
yet, so the exception would otherwise lapse and re-fail the vulnix gate.

## Upstream evidence (re-verified 2026-07-21 via raw.githubusercontent.com)

| nixpkgs branch | `pkgs/tools/text/gawk/default.nix` |
|----------------|-------------------------------------|
| `nixos-26.05` (pinned channel) | `version = "5.4.0"` — still vulnerable |
| `release-26.05` | `version = "5.4.0"` — still vulnerable |
| `staging` | `version = "5.4.1"` — fixed |

The fix (gawk 5.4.1, `NixOS/nixpkgs#540158`) merged to `staging` on 2026-07-12.
gawk is a stdenv mass-rebuild, so it must traverse `staging` -> `staging-next`
-> the release branch before reaching `nixos-26.05`; that propagation is still
in flight. Risk posture is unchanged from the #1071 triage (developer/CI-chosen
awk inputs only; readdir CVE requires the opt-in `-l readdir` path).

## Verification

- `prek run --all-files` fully green (including `check-expirations`, which now
  passes with the future 2026-08-18 date).
- `sync-manifest` auto-mirrored the changelog entry into
  `assets/workspace/.devcontainer/CHANGELOG.md` (regenerated, not hand-edited).

## Follow-up

Flip to the nixpkgs rev-advance and drop this exception once 5.4.1 reaches
`nixos-26.05`.

Closes #1240
