### PR TITLE
ci: drop nix-image dev push paths filter so nix-dev tracks dev

### DIFF
--- a/.github/workflows/nix-image.yml
+++ b/.github/workflows/nix-image.yml
@@ -30,23 +30,28 @@
 # with `docker buildx imagetools create`, mirroring the proven release.yml flow.
 #
 # Triggers:
-#   - Push to the migration epic branch OR the integration branch (`dev`) when
-#     the flake or this workflow changes. `dev` keeps the native arm64 build+test
-#     lane alive post-merge — PR CI (ci.yml) builds/tests amd64 only, so without
-#     this the arm64 image coverage would be stranded once the epic merges (#760).
+#   - Push to the migration epic branch OR the integration branch (`dev`). No
+#     `paths:` filter: the baked image content is broader than the flake files,
+#     so every push rebuilds to keep the `nix-dev` tag from drifting stale
+#     (#1236). `dev` keeps the native arm64 build+test lane alive post-merge — PR
+#     CI (ci.yml) builds/tests amd64 only, so without this the arm64 image
+#     coverage would be stranded once the epic merges (#760).
 #   - workflow_dispatch (so it can be triggered later from the default branch).
 
 name: Nix Image (discovery)
 
 on:  # yamllint disable-line rule:truthy
   push:
+    # No `paths:` filter (#1236): the image is NOT a function of the flake files
+    # alone — the flake bakes broad repo content at build time (the `assets/`
+    # scaffold tree, `docs/MIGRATION.md`, the `packages/vig-utils` console
+    # scripts via `devTools`, the `nix/home` environment, `scripts/`). A precise
+    # allowlist tracking every baked input is fragile and drifts, so any push
+    # that could affect the image rebuilds. Cachix/eval caching keeps a no-op
+    # rebuild of an unchanged closure cheap.
     branches:
       - 'feature/625-nix-claude-migration'
       - 'dev'
-    paths:
-      - 'flake.nix'
-      - 'flake.lock'
-      - '.github/workflows/nix-image.yml'
   workflow_dispatch:
 
 # Least-privilege default (Scorecard TokenPermissions): top-level is read-only;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`nix-dev` discovery image no longer drifts stale on baked-content pushes** ([#1236](https://github.com/vig-os/devkit/issues/1236))
+  - The `nix-image.yml` `dev` push trigger only watched `flake.nix`,
+    `flake.lock`, and the workflow file, but the image bakes broader repo content
+    at build time (the `assets/` scaffold tree, `docs/MIGRATION.md`, the
+    `packages/vig-utils` console scripts, the `nix/home` environment, `scripts/`).
+    A `dev` push touching only baked content left the mutable `nix-dev` tag stale
+    with no rebuild. Dropped the fragile `paths:` allowlist so every push to
+    `dev` (or the epic branch) rebuilds, tests, and repushes the tag; Cachix/eval
+    caching keeps no-op rebuilds cheap.
 - **Trunk render scrubs residual `dev` prose from scaffolded workflows** ([#1226](https://github.com/vig-os/devkit/issues/1226))
   - `render_workflow_model` now retargets the inert `dev` mentions in comments
     and input descriptions as well as the functional literals, so a `trunk`

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -31,6 +31,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`nix-dev` discovery image no longer drifts stale on baked-content pushes** ([#1236](https://github.com/vig-os/devkit/issues/1236))
+  - The `nix-image.yml` `dev` push trigger only watched `flake.nix`,
+    `flake.lock`, and the workflow file, but the image bakes broader repo content
+    at build time (the `assets/` scaffold tree, `docs/MIGRATION.md`, the
+    `packages/vig-utils` console scripts, the `nix/home` environment, `scripts/`).
+    A `dev` push touching only baked content left the mutable `nix-dev` tag stale
+    with no rebuild. Dropped the fragile `paths:` allowlist so every push to
+    `dev` (or the epic branch) rebuilds, tests, and repushes the tag; Cachix/eval
+    caching keeps no-op rebuilds cheap.
 - **Trunk render scrubs residual `dev` prose from scaffolded workflows** ([#1226](https://github.com/vig-os/devkit/issues/1226))
   - `render_workflow_model` now retargets the inert `dev` mentions in comments
     and input descriptions as well as the functional literals, so a `trunk`


### PR DESCRIPTION
## Summary

Fixes the stale-tag gap on the `nix-dev` discovery image. `nix-image.yml` keeps
the mutable `ghcr.io/vig-os/devcontainer:nix-dev` tag (plus `-amd64`/`-arm64` and
the multi-arch index) tracking `dev`, but its `dev` push trigger was
path-filtered to only `flake.nix`, `flake.lock`, and the workflow file:

```yaml
paths:
  - 'flake.nix'
  - 'flake.lock'
  - '.github/workflows/nix-image.yml'
```

The image content is **not** a function of the flake files alone — the flake
bakes broad repo content at build time. A `dev` push touching only that baked
content changed the image **without rebuilding or repushing `nix-dev`**, so the
discovery tag silently drifted behind `dev` with no signal.

## Baked-input analysis

The `devkitImage` output in `flake.nix` bakes, beyond the flake files:

- `assets/` — the whole workspace scaffold tree (`cp -r ${./assets}/.`)
- `docs/MIGRATION.md` — copied to `/root/assets/MIGRATION.md`
- `packages/vig-utils/` — the console scripts (`prepare-changelog`,
  `check-expirations`, …) that reach the image via `devTools`
- `nix/home/` — the vigos home environment
- `scripts/` — the runtime smoke script bind-mounted/executed against the image

A precise `paths:` allowlist tracking every one of these baked inputs is fragile
and drifts out of sync with the flake outputs it feeds — exactly the failure mode
the issue calls out.

## Fix

Per the issue's recommended solution, **drop the `paths:` filter** so every push
to `dev` (or the epic branch) rebuilds, tests (portable testinfra + runtime
smoke, both arches), and repushes the tag. Cachix/eval caching keeps a no-op
rebuild of an unchanged closure cheap, so the cost of an over-trigger is minimal.
The trigger header comment is updated to match.

No scheduled nightly / `nightly` alias is added — per the issue scope note, the
flake is fully pinned, so correctness of the event-driven trigger is the whole
fix.

## Testing

This is a workflow-trigger config change with **no runtime test surface**, so TDD
is skipped (noted here per convention). Validation:

- `pre-commit run --all-files` (via `just precommit`) fully green — `actionlint`,
  `yamllint`, and `sync-manifest` all pass. The `sync-manifest` hook propagated
  the `CHANGELOG.md` edit to `assets/workspace/.devcontainer/CHANGELOG.md` (staged).
- `zizmor` is covered in CI (not on the local PATH here).

## Observation (out of scope)

The `paths:`-adjacent `feature/625-nix-claude-migration` branch entry in the push
trigger looks stale (the migration epic branch). The issue does not ask to remove
it, so it is left untouched here — flagging it as a possible follow-up cleanup.

Closes #1236
