### PR TITLE
fix(workflow-model): scrub sync-main-to-dev prose in promote-release (trunk)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Trunk render scrubs `sync-main-to-dev` prose from `promote-release.yml`** ([#1233](https://github.com/vig-os/devkit/issues/1233))
+  - Follow-up to [#1226](https://github.com/vig-os/devkit/issues/1226) for a file
+    `render_workflow_model` did not touch: the `promote-release.yml` header step
+    list and the Summary echo each named `sync-main-to-dev`, a workflow that is
+    copy-excluded in `trunk`. The trunk render now drops both parentheticals, so
+    a `trunk` consumer no longer ships comments referencing a workflow absent
+    from its repo. Comments only — no functional change; gitflow is unaffected.
 - **Trunk render scrubs residual `dev` prose from scaffolded workflows** ([#1226](https://github.com/vig-os/devkit/issues/1226))
   - `render_workflow_model` now retargets the inert `dev` mentions in comments
     and input descriptions as well as the functional literals, so a `trunk`

--- a/assets/init-workspace.sh
+++ b/assets/init-workspace.sh
@@ -1090,6 +1090,16 @@ render_workflow_model() {
         sed -i 's|# sync merge and can never be silently dropped.*Keep a Changelog$|# releases land directly on main. Keep a Changelog|' "$pr"
     fi
 
+    # promote-release.yml — no behavioral `dev` literals, but two comments name
+    # sync-main-to-dev, which is copy-excluded in trunk (EXCLUDE_ARGS). Drop the
+    # parentheticals so a trunk repo carries no prose referencing a workflow it
+    # does not have (#1233; comments only, no behavior change).
+    local prom="$wf/promote-release.yml"
+    if [[ -f "$prom" ]]; then
+        sed -i 's| (triggers sync-main-to-dev)||' "$prom"
+        sed -i 's| (sync-main-to-dev may run next)||' "$prom"
+    fi
+
     # ci.yml — drop `- dev` from the PR branch filter; retarget the commit-gate
     # TRUNK anchor used to exclude already-merged history on release PRs. Also
     # scrub the inert prose: the trigger-header comment and the origin/dev

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -31,6 +31,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Trunk render scrubs `sync-main-to-dev` prose from `promote-release.yml`** ([#1233](https://github.com/vig-os/devkit/issues/1233))
+  - Follow-up to [#1226](https://github.com/vig-os/devkit/issues/1226) for a file
+    `render_workflow_model` did not touch: the `promote-release.yml` header step
+    list and the Summary echo each named `sync-main-to-dev`, a workflow that is
+    copy-excluded in `trunk`. The trunk render now drops both parentheticals, so
+    a `trunk` consumer no longer ships comments referencing a workflow absent
+    from its repo. Comments only — no functional change; gitflow is unaffected.
 - **Trunk render scrubs residual `dev` prose from scaffolded workflows** ([#1226](https://github.com/vig-os/devkit/issues/1226))
   - `render_workflow_model` now retargets the inert `dev` mentions in comments
     and input descriptions as well as the functional literals, so a `trunk`

--- a/tests/test_workflow_model.py
+++ b/tests/test_workflow_model.py
@@ -36,6 +36,7 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 # excluded here: render_codeql_matrix rewrites it in every mode).
 NO_PLACEHOLDER_RENDER_FILES = (
     ".github/workflows/prepare-release.yml",
+    ".github/workflows/promote-release.yml",
     ".github/workflows/ci.yml",
     ".github/workflows/sync-issues.yml",
     ".claude/skills/branch-naming/SKILL.md",
@@ -178,6 +179,18 @@ def test_trunk_prepare_release_has_no_dev_cruft(tmp_path: Path) -> None:
         and not any(a in line for a in allowed)
     ]
     assert not stray, "stray dev tokens:\n" + "\n".join(stray)
+
+
+def test_trunk_promote_release_has_no_sync_main_to_dev_prose(tmp_path: Path) -> None:
+    """promote-release.yml carries no `sync-main-to-dev` prose in trunk (#1233).
+
+    sync-main-to-dev.yml is copy-excluded in trunk, so the two parenthetical
+    comments naming it (the header step list + the Summary echo) must be
+    scrubbed — otherwise a trunk repo ships comments referencing a workflow it
+    does not have. Follow-up to #1226 for a file the render did not touch.
+    """
+    text = _wf(_tree(tmp_path, "trunk"), "promote-release.yml")
+    assert "sync-main-to-dev" not in text
 
 
 def test_trunk_ci_pr_filter_excludes_dev(tmp_path: Path) -> None:


### PR DESCRIPTION
## Problem

Follow-up to #1226 (PR #1229). The trunk workflow-model render scrubs residual `dev` prose from `prepare-release.yml`, `ci.yml`, `codeql.yml` and `sync-issues.yml`, but `render_workflow_model()` never touched `promote-release.yml`. Two comments there name `sync-main-to-dev`:

- `assets/workspace/.github/workflows/promote-release.yml:8` — `# 3. merge: merge release/X.Y.Z PR to main (triggers sync-main-to-dev)`
- `assets/workspace/.github/workflows/promote-release.yml:473` — `echo "... merged to main (sync-main-to-dev may run next)"`

`sync-main-to-dev.yml` is copy-excluded in trunk mode (EXCLUDE_ARGS), so trunk consumers ship comments referencing a workflow absent from their repo. Cosmetic only, same class as #1226 — a pre-existing gap, not a regression from PR #1229.

## Root cause

`render_workflow_model()` (`assets/init-workspace.sh`) enumerates the files it retargets; `promote-release.yml` was simply not among them.

## Fix

Add an anchored `promote-release.yml` block to the trunk render that drops both parentheticals (comments only, no behavior change). The template is untouched, so gitflow output stays byte-identical (the render early-returns for non-trunk).

```
sed -i 's| (triggers sync-main-to-dev)||' "$prom"
sed -i 's| (sync-main-to-dev may run next)||' "$prom"
```

## Test evidence

New test `test_trunk_promote_release_has_no_sync_main_to_dev_prose` asserts a trunk-scaffolded `promote-release.yml` carries no `sync-main-to-dev` mention; `promote-release.yml` is also registered in the gitflow byte-identical guard (`NO_PLACEHOLDER_RENDER_FILES`).

- **RED** (test commit): `assert 'sync-main-to-dev' not in text` failed on the two parentheticals.
- **GREEN** (fix commit): full `tests/test_workflow_model.py` suite — **21 passed**.
- **gitflow no-op**: `test_gitflow_render_files_are_byte_identical_to_template` (now covering `promote-release.yml`) and `test_gitflow_scaffold_matches_default_path` both green; the trunk-filtered bats suite (5 tests) green.
- `just precommit` (full suite, both hook environments) — all green, no auto-fixes.

Closes #1233
