### PR TITLE
ci(security): add dev-ref vulnix scan lane

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -8,16 +8,23 @@
 #
 # Triggers:
 #   - Nightly schedule: 05:00 UTC
-#   - Manual dispatch (e.g. a pre-release run on dev — scheduled runs execute
-#     from the default branch, so this workflow never runs on dev otherwise)
+#   - Manual dispatch (e.g. an ad-hoc pre-release run)
+#
+# Refs scanned (matrix, #1237):
+#   - main — the default-branch closure consumers actually run (primary target)
+#   - dev  — reached purely via a `ref: dev` checkout, so a nixpkgs bump or an
+#            expiring `.vulnixignore` exception surfaces as a tracking issue days
+#            before a release branch is cut, not mid-release-train
 #
 # Jobs:
-#   1. scan-nix-image - build the image closure, run vulnix (+ Trivy SBOM)
+#   1. scan-nix-image - build the image closure, run vulnix (+ Trivy SBOM), once
+#      per matrix ref (main, dev)
 #
 # On failure:
-#   - A deduplicated `security-scan` tracking issue is opened (#965). Scheduled
-#     runs execute from the default branch with no other signal, so a red gate
-#     must surface as an issue, not just a red run.
+#   - A deduplicated `security-scan` tracking issue is opened per ref (#965,
+#     #1237), with a ref-distinct title so the two lanes never collide on dedup.
+#     Scheduled runs execute from the default branch with no other signal, so a
+#     red gate must surface as an issue, not just a red run.
 #
 # Artifacts:
 #   - vulnix findings (JSON + table) and a CycloneDX SBOM (uploaded)
@@ -26,7 +33,7 @@ name: Scheduled Security Scan
 
 on:  # yamllint disable-line rule:truthy
   schedule:
-    # Nightly (staggered after nightly CI at 04:00 UTC)
+    # Nightly at 05:00 UTC — one matrix leg per ref (main, dev) runs on this tick
     - cron: '0 5 * * *'
   workflow_dispatch:
 
@@ -46,7 +53,17 @@ jobs:
   # scan, which opens a deduplicated tracking issue (#965). SARIF upload to the
   # Security tab can still be added alongside the actual publish-cutover.
   scan-nix-image:
-    name: Scan Nix image (vulnix + SBOM)
+    name: Scan Nix image (vulnix + SBOM) [${{ matrix.ref }}]
+    # Scan both the default-branch (main) closure — what consumers run — and the
+    # dev closure (#1237). Each leg reaches its ref's closure, `.vulnixignore`
+    # register and machinery purely through the checkout `ref` below; the run
+    # itself always executes from the default branch on a scheduled trigger.
+    # fail-fast: false so a red main lane never cancels the dev scan (or vice
+    # versa) — the two lanes are independent signals.
+    strategy:
+      fail-fast: false
+      matrix:
+        ref: [main, dev]
     runs-on: ubuntu-24.04
     # Worst case is a cold NVD cache week plus retries against a throttled
     # nvd.nist.gov (~25 min per attempt); warm-cache runs finish in minutes.
@@ -58,6 +75,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          # Scan this matrix leg's ref. The local composite actions, flake and
+          # `.vulnixignore` register all resolve from the checked-out tree, so
+          # the dev leg exercises dev's machinery unchanged (#1237).
+          ref: ${{ matrix.ref }}
 
       - name: Set up environment (Nix + flake toolchain for the gate utilities)
         uses: ./.github/actions/setup-env
@@ -170,7 +192,8 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
-          name: nix-image-cve-scan
+          # Ref-scoped so the two matrix legs never collide on artifact name.
+          name: nix-image-cve-scan-${{ matrix.ref }}
           path: |
             vulnix-findings.json
             vulnix-report.txt
@@ -179,11 +202,14 @@ jobs:
 
       - name: Write Nix image scan summary
         if: always()
+        env:
+          SCAN_REF: ${{ matrix.ref }}
         run: |
           set -euo pipefail
           {
             echo "## Nix image CVE scan (vulnix + SBOM)"
             echo ""
+            echo "- **Scanned ref:** \`${SCAN_REF}\`"
             echo "- **Scan target:** flake \`devkitImageEnv\` (image package closure)"
             echo "- **Primary scanner:** vulnix (nixpkgs-native)"
             echo "- **Date (UTC):** $(date -u +%Y-%m-%dT%H:%M:%SZ)"
@@ -204,6 +230,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           SECURITY_URL: ${{ github.server_url }}/${{ github.repository }}/security
+          SCAN_REF: ${{ matrix.ref }}
         run: |
           set -euo pipefail
           # Refresh the (Nix-era) label; --force updates an existing label's
@@ -214,8 +241,10 @@ jobs:
           # Dedup by the auto-issue's distinctive title, NOT the label alone, so
           # we never collide with human-filed security-scan issues (per-CVE
           # triage, this very regression, etc.). One open tracking issue at a
-          # time; it is closed when a later scheduled run passes the gate.
-          TITLE='Nightly security scan: unexcepted HIGH/CRITICAL vulnix findings'
+          # time; it is closed when a later scheduled run passes the gate. The
+          # ref is in the title so the main and dev lanes dedup independently
+          # and never collide on each other's issue (#1237).
+          TITLE="Nightly security scan (${SCAN_REF}): unexcepted HIGH/CRITICAL vulnix findings"
           EXISTING=$(gh issue list --state open --label security-scan \
             --search "\"$TITLE\" in:title" --json number -q '.[0].number // empty')
           if [ -n "$EXISTING" ]; then
@@ -223,12 +252,13 @@ jobs:
             exit 0
           fi
           BODY="$(cat <<EOF
-          The nightly vulnix gate found **unexcepted HIGH/CRITICAL** CVEs in the Nix image closure (after \`.vulnixignore\`).
+          The nightly vulnix gate found **unexcepted HIGH/CRITICAL** CVEs in the \`${SCAN_REF}\` Nix image closure (after \`.vulnixignore\`).
 
+          - **Scanned ref:** \`${SCAN_REF}\`
           - **Scan target:** flake \`devkitImageEnv\` (image package closure)
           - **Scan date (UTC):** $(date -u +%Y-%m-%dT%H:%M:%SZ)
           - **Workflow run:** ${RUN_URL}
-          - **Findings artifact:** \`nix-image-cve-scan\` on the run above (\`vulnix-findings.json\`, \`vulnix-report.txt\`)
+          - **Findings artifact:** \`nix-image-cve-scan-${SCAN_REF}\` on the run above (\`vulnix-findings.json\`, \`vulnix-report.txt\`)
           - **Security tab:** ${SECURITY_URL}
 
           **To remediate:** advance the pinned nixpkgs rev if a fix has landed, or add a time-boxed \`.vulnixignore\` exception with a rationale (see \`docs/CONTAINER_SECURITY.md\`). Close this issue once a later scheduled run passes the gate.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Scheduled security scan now covers `dev` as well as `main`** ([#1237](https://github.com/vig-os/devkit/issues/1237))
+  - `security-scan.yml` gains a `ref` matrix (`main`, `dev`) so the nightly
+    vulnix gate scans the `dev` image closure alongside the default-branch one.
+    A weekly `nixpkgs` bump or an expiring `.vulnixignore` exception on `dev` now
+    surfaces as an ordinary tracking issue days early, instead of first tripping
+    the gate mid-release-train. Each leg reuses the existing machinery unchanged
+    (`check-expirations`, `devkitImageEnv` closure build, vulnix via the
+    nvd-mirror, `vulnix-gate`, deduplicated tracking issue) through its checkout
+    `ref`, files a ref-distinct tracking issue so the lanes never collide on
+    dedup, and runs with `fail-fast: false` so one lane never cancels the other.
 - **`sync-issues` target-branch and schedule knobs** ([#1228](https://github.com/vig-os/devkit/issues/1228))
   - New optional `.vig-os` key `DEVKIT_SYNC_TARGET` overrides the branch the
     scaffolded sync-issues job commits to. Default stays workflow-model-aware

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Scheduled security scan now covers `dev` as well as `main`** ([#1237](https://github.com/vig-os/devkit/issues/1237))
+  - `security-scan.yml` gains a `ref` matrix (`main`, `dev`) so the nightly
+    vulnix gate scans the `dev` image closure alongside the default-branch one.
+    A weekly `nixpkgs` bump or an expiring `.vulnixignore` exception on `dev` now
+    surfaces as an ordinary tracking issue days early, instead of first tripping
+    the gate mid-release-train. Each leg reuses the existing machinery unchanged
+    (`check-expirations`, `devkitImageEnv` closure build, vulnix via the
+    nvd-mirror, `vulnix-gate`, deduplicated tracking issue) through its checkout
+    `ref`, files a ref-distinct tracking issue so the lanes never collide on
+    dedup, and runs with `fail-fast: false` so one lane never cancels the other.
 - **`sync-issues` target-branch and schedule knobs** ([#1228](https://github.com/vig-os/devkit/issues/1228))
   - New optional `.vig-os` key `DEVKIT_SYNC_TARGET` overrides the branch the
     scaffolded sync-issues job commits to. Default stays workflow-model-aware


### PR DESCRIPTION
## Summary

Closes #1237.

`security-scan.yml`'s nightly vulnix gate checked out no `ref`, so scheduled runs only ever scanned the **default branch (main)** closure. `dev`'s closure was only scanned at RC time (or by manual dispatch), so a `nixpkgs-unstable` bump introducing an unexcepted HIGH/CRITICAL — or a time-boxed `.vulnixignore` exception expiring (e.g. the gawk exception expiring 2026-07-28) — first surfaced *mid-release-train*, the most expensive moment.

This adds a `dev`-ref scan lane that reuses the existing machinery unchanged and files an ordinary tracking issue days earlier.

## Design: `ref` matrix (not a second job)

Per the issue ("a second scheduled job **or** matrix leg") and the repo DRY/minimal-diff rules, I chose a **matrix** over a duplicated job — least duplication, single source of truth for the scan steps:

- `scan-nix-image` gains `strategy.matrix.ref: [main, dev]` with `fail-fast: false` so a red main lane never cancels the dev scan (independent signals).
- The checkout step passes `ref: ${{ matrix.ref }}`. Local composite actions (`setup-env`), the flake (`devkitImageEnv`), and the `.vulnixignore` register all resolve from the checked-out tree, so the dev leg exercises **dev's** machinery/register unchanged — exactly as the issue specifies. The run itself still executes from the default branch (scheduled trigger).
- Behavior is kept **identical per ref**: each leg runs `check-expirations`, the closure build, vulnix (via the nvd-mirror), `vulnix-gate`, and the deduplicated tracking-issue step.
- **Dedup collision avoided:** the tracking-issue title is now ref-distinct (`Nightly security scan (main|dev): …`) and the findings artifact is ref-scoped (`nix-image-cve-scan-<ref>`) so the two matrix legs never collide on issue dedup or artifact name. The ref is passed to the shell via an `env:` var (not interpolated into `run:`), keeping zizmor's template-injection audit clean.

## Drive-by (per the issue)

Fixed the stale schedule comment (`staggered after nightly CI at 04:00 UTC` — no workflow runs at 04:00 anymore) and refreshed the trigger/jobs/on-failure header prose to describe the two-ref matrix.

## Testing

Workflow-only change with no runtime test surface, so **TDD is skipped for that reason**. Verification:

- `pre-commit run --all-files` (`just precommit`) fully green (actionlint, yamllint, sync-manifest, agent-identity, etc.).
- `zizmor 1.25.2 --config zizmor.yml` run against the changed file **and** the base version: both report the identical `4 findings (2 suppressed)` — this change introduces **zero new zizmor findings** (the two shown, `artipacked` on checkout and `template-injection` on the pre-existing summary step, are unchanged pre-existing findings; not baselined by me). CI's zizmor gate only audits `assets/workspace/.github/workflows/`, which this file is not part of.

## Caveat (same as `ghcr-cleanup.yml`)

The `schedule:` trigger only fires from the default branch, so the new dev lane **goes live at the next promote** (when this reaches main). Until then it is exercisable via `workflow_dispatch`.
