### PR TITLE
fix(install): chown docker scaffold output before the git phase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     scaffolded `flake.nix` reads `DEVKIT_WORKFLOW` from `.vig-os` and forwards
     it, so a trunk direnv consumer's generated guard follows the model out of
     the box. gitflow is a no-op, leaving existing consumers unchanged.
+- **`install.sh --docker` restores scaffold ownership before the git phase** ([#1235](https://github.com/vig-os/devkit/issues/1235))
+  - Under docker the scaffold container runs as root, so its bind-mounted output
+    landed root-owned on the host and the host-side git phase (`setup_git_repo`,
+    warn-not-fail by design) could not write to it — the installer "succeeded"
+    but left a root-owned, git-less tree that every docker caller had to repair
+    by hand. `install.sh` now reuses the image in a throwaway container to
+    `chown` the tree back to the invoking user before the git phase, so the git
+    setup succeeds normally. Rootless podman already maps container-root to the
+    invoking user, so the repair runs on the docker runtime only.
 
 ### Security
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -51,6 +51,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     scaffolded `flake.nix` reads `DEVKIT_WORKFLOW` from `.vig-os` and forwards
     it, so a trunk direnv consumer's generated guard follows the model out of
     the box. gitflow is a no-op, leaving existing consumers unchanged.
+- **`install.sh --docker` restores scaffold ownership before the git phase** ([#1235](https://github.com/vig-os/devkit/issues/1235))
+  - Under docker the scaffold container runs as root, so its bind-mounted output
+    landed root-owned on the host and the host-side git phase (`setup_git_repo`,
+    warn-not-fail by design) could not write to it — the installer "succeeded"
+    but left a root-owned, git-less tree that every docker caller had to repair
+    by hand. `install.sh` now reuses the image in a throwaway container to
+    `chown` the tree back to the invoking user before the git phase, so the git
+    setup succeeds normally. Rootless podman already maps container-root to the
+    invoking user, so the repair runs on the docker runtime only.
 
 ### Security
 

--- a/install.sh
+++ b/install.sh
@@ -851,6 +851,28 @@ if [ -n "$PREVIEW" ]; then
     exit 0
 fi
 
+# ── Restore scaffold ownership (docker only) ──────────────────────────────────
+# Under docker the scaffold container runs as root, so its bind-mounted output
+# lands root-owned on the host and the host-side git phase below can't write to
+# it (#1235). The host user usually can't chown root-owned files back directly,
+# so reuse the same image in a throwaway container to chown the tree to the
+# invoking user. Rootless podman already maps container-root to that user, so
+# its output is correctly owned — only docker needs the repair. Warn-not-fail to
+# match the git phase's CI/fresh-machine-friendly posture.
+if [ "$RUNTIME" = "docker" ]; then
+    HOST_UID="$(id -u)"
+    HOST_GID="$(id -g)"
+    info "Restoring ownership of scaffolded files to ${HOST_UID}:${HOST_GID}..."
+    if ! "$RUNTIME" run --rm \
+        -v "$PROJECT_PATH:/workspace" \
+        "$IMAGE" \
+        chown -R "${HOST_UID}:${HOST_GID}" /workspace; then
+        warn "Could not restore ownership of $PROJECT_PATH (non-fatal)"
+        echo "  Scaffolded files may remain root-owned. Fix manually with:"
+        echo "    sudo chown -R ${HOST_UID}:${HOST_GID} $PROJECT_PATH"
+    fi
+fi
+
 # ── Post-initialization: host-side setup ──────────────────────────────────────
 
 echo ""

--- a/tests/bats/install.bats
+++ b/tests/bats/install.bats
@@ -860,3 +860,52 @@ _run_install_stubbed() {
     assert_output --partial "Open in VS Code"
     assert_output --partial "direnv allow"
 }
+
+# ── docker ownership repair before the git phase (#1235) ──────────────────────
+# Under docker the scaffold container runs as root, so the bind-mounted output
+# lands root-owned and the host-side git phase (setup_git_repo) can't write to
+# it — warn-not-fail by design, so the installer "succeeds" leaving a root-owned,
+# git-less tree. install.sh must chown the tree back to the invoking user via a
+# throwaway container BEFORE the git phase. Rootless podman maps container-root
+# to the invoking user, so it needs no repair. Exercised against a logging stub
+# runtime (records each invocation) so nothing is pulled or actually chowned.
+_run_install_logging_stub() {
+    local dir="$1" runtime="$2" log="$3"
+    local stub="$BATS_TEST_TMPDIR/stub-$runtime"
+    mkdir -p "$stub"
+    cat >"$stub/$runtime" <<STUB
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$log"
+exit 0
+STUB
+    chmod +x "$stub/$runtime"
+    _make_repo "$dir"
+    run env PATH="$stub:$PATH" bash "$INSTALL_SH" \
+        "--$runtime" --skip-pull --mode direnv "$dir" </dev/null
+}
+
+@test "docker path chowns scaffold output to the invoking user (#1235)" {
+    log="$BATS_TEST_TMPDIR/docker-repair.log"
+    _run_install_logging_stub "$BATS_TEST_TMPDIR/repair-docker" docker "$log"
+    assert_success
+    run grep -F "chown -R $(id -u):$(id -g) /workspace" "$log"
+    assert_success
+}
+
+@test "podman path runs no ownership-repair container (#1235)" {
+    log="$BATS_TEST_TMPDIR/podman-repair.log"
+    _run_install_logging_stub "$BATS_TEST_TMPDIR/repair-podman" podman "$log"
+    assert_success
+    run grep -F "chown -R" "$log"
+    assert_failure
+}
+
+@test "ownership repair is ordered before the git phase on the docker path (#1235)" {
+    # The chown container run must appear ahead of the setup_git_repo invocation
+    # in source, so the host-side git phase writes to a user-owned tree (#1235).
+    chown_line="$(grep -n 'chown -R' "$INSTALL_SH" | head -1 | cut -d: -f1)"
+    git_line="$(grep -n 'if ! setup_git_repo' "$INSTALL_SH" | head -1 | cut -d: -f1)"
+    [ -n "$chown_line" ]
+    [ -n "$git_line" ]
+    [ "$chown_line" -lt "$git_line" ]
+}


### PR DESCRIPTION
## Root cause

Closes #1235.

Under `install.sh --docker`, the scaffold container runs as root, so its
bind-mounted output (`-v "$PROJECT_PATH:/workspace"`) lands **root-owned** on the
host. The host-side git phase (`setup_git_repo`) then runs against that
still-root-owned tree and fails with `.git: Permission denied`. That failure is
warn-not-fail *by design* (CI/fresh-machine friendliness), so the installer
"succeeds" but leaves a root-owned, git-less tree. Before this change there was
no `chown` anywhere in `install.sh` (`grep -c chown install.sh` == 0), so every
docker caller had to repair ownership and `git init` by hand — the direnv smoke
lane (devkit-smoke-test#286, #1194) carries exactly that workaround.

## Fix

After the scaffold container run and before the host-side setup (git phase +
`run_user_conf`), on the **docker runtime only**, reuse the same image in a
throwaway container to chown the tree back to the invoking user:

```
docker run --rm -v "$PROJECT_PATH:/workspace" "$IMAGE" \
    chown -R "$(id -u):$(id -g)" /workspace
```

The host user usually can't chown root-owned files directly, hence the
second container run. Rootless **podman** already maps container-root to the
invoking user, so its output is correctly owned — the repair is gated on
`[ "$RUNTIME" = "docker" ]` and skipped for podman. The step is warn-not-fail to
match the git phase's posture, and it sits after the `--preview`/`--dry-run`
early exits so those paths are unaffected. The warn-not-fail git phase itself is
left untouched as the issue requires.

The smoke-lane workaround is intentionally **not** touched here (per the issue,
that simplification is a follow-up once this releases).

## Test evidence (TDD)

New section in `tests/bats/install.bats` (`#1235`), exercised against a logging
stub runtime:

- `docker path chowns scaffold output to the invoking user` — asserts a
  `chown -R <uid>:<gid> /workspace` container run is issued on `--docker`.
- `podman path runs no ownership-repair container` — asserts `--podman` never
  chowns.
- `ownership repair is ordered before the git phase` — structural: the chown
  block precedes the `setup_git_repo` call in source.

RED (test commit `d652f95b`): docker + ordering tests fail (no chown present).
GREEN (fix commit `49ead96e`): all 3 pass; full `install.bats` suite 102/102 ok.

`just precommit` (full `pre-commit run --all-files`): all hooks green.

Refs: #1235