### PR TITLE
fix: let extraPackages python env win python3 on PATH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`mkProjectShell`: `extraPackages` Python env no longer silently shadowed** ([#1230](https://github.com/vig-os/devkit/issues/1230))
+  - A `pythonXX.withPackages` env passed through `extraPackages` — the
+    documented way to add Python libraries to a project shell — was shadowed on
+    `PATH` by `vig-utils`'s propagated pinned 3.14 interpreter, so the consumer
+    got the bare interpreter with none of their libraries and only hit a
+    `ModuleNotFoundError` later. The builder now prepends any such env in the
+    shellHook (the same PATH-order mechanism the `python` override uses), so the
+    consumer's interpreter and its `site-packages` own `python3`/`python`.
 - **Trunk render scrubs residual `dev` prose from scaffolded workflows** ([#1226](https://github.com/vig-os/devkit/issues/1226))
   - `render_workflow_model` now retargets the inert `dev` mentions in comments
     and input descriptions as well as the functional literals, so a `trunk`

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -31,6 +31,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`mkProjectShell`: `extraPackages` Python env no longer silently shadowed** ([#1230](https://github.com/vig-os/devkit/issues/1230))
+  - A `pythonXX.withPackages` env passed through `extraPackages` — the
+    documented way to add Python libraries to a project shell — was shadowed on
+    `PATH` by `vig-utils`'s propagated pinned 3.14 interpreter, so the consumer
+    got the bare interpreter with none of their libraries and only hit a
+    `ModuleNotFoundError` later. The builder now prepends any such env in the
+    shellHook (the same PATH-order mechanism the `python` override uses), so the
+    consumer's interpreter and its `site-packages` own `python3`/`python`.
 - **Trunk render scrubs residual `dev` prose from scaffolded workflows** ([#1226](https://github.com/vig-os/devkit/issues/1226))
   - `render_workflow_model` now retargets the inert `dev` mentions in comments
     and input descriptions as well as the functional literals, so a `trunk`

--- a/flake.nix
+++ b/flake.nix
@@ -534,6 +534,25 @@
           pythonOverrideHook = pkgs.lib.optionalString (python != pkgs.python314) ''
             export PATH="${python}/bin:$PATH"
           '';
+
+          # A `pythonXX.withPackages` env passed via `extraPackages` — the
+          # documented, natural way to add Python libraries to the shell — must
+          # own `python3`/`python` on PATH so the consumer actually gets their
+          # libraries. A plain `packages` entry does not: `vig-utils` (a devTools
+          # entry, pinned to 3.14) propagates its interpreter onto PATH and
+          # shadows the consumer's env, so they silently get the bare pinned
+          # interpreter with none of their libraries — surfacing only later as
+          # `ModuleNotFoundError`. Like `pythonOverrideHook`, win by PATH order:
+          # prepend each such env in the shellHook, where it beats the propagated
+          # interpreter. Envs carry a `python` passthru; the bare interpreter and
+          # plain library packages do not, so that attribute identifies them.
+          # Placed before `pythonOverrideHook` in the shellHook so an explicit
+          # `python` override (the primary interpreter knob, #1038) still wins.
+          # Refs #1230.
+          extraPythonEnvs = pkgs.lib.filter (p: p ? python) extraPackages;
+          extraPythonHook = pkgs.lib.concatMapStrings (env: ''
+            export PATH="${env}/bin:$PATH"
+          '') extraPythonEnvs;
         in
         assert pkgs.lib.assertMsg (builtins.elem workflow [
           "gitflow"
@@ -570,6 +589,7 @@
               + "\n"
               + nvimIsolationHook
               + "\n"
+              + extraPythonHook
               + pythonOverrideHook
               + githooksPathHook
               + moduleShellHook

--- a/tests/test_flake_devshell.py
+++ b/tests/test_flake_devshell.py
@@ -617,3 +617,65 @@ def test_devshell_python_override_switches_interpreter(current_system: str) -> N
         f"python3 on the shell PATH must report 3.13 under the override; got {version_line!r} "
         f"(full stdout: {proc.stdout!r})"
     )
+
+
+def test_devshell_extrapackages_python_env_wins_on_path(current_system: str) -> None:
+    """A ``withPackages`` env in ``extraPackages`` must win ``python3`` on PATH (#1230).
+
+    ``extraPackages`` is documented as where a consumer's project tools go, so
+    the natural way to add Python libraries is to pass a
+    ``pythonXX.withPackages`` env through it. Before the fix the builder's own
+    bare ``python`` (pinned 3.14) preceded ``extraPackages`` in the shell's
+    ``packages``, so ``bin/python3`` from that bare interpreter won the PATH race
+    and the consumer silently got the pinned interpreter with none of their
+    libraries — surfacing only later as ``ModuleNotFoundError``.
+
+    Exercised with a 3.13 env carrying ``setuptools`` (both reliably cached):
+    the env's interpreter (3.13, distinct from the pinned 3.14) and its bundled
+    library must be the ones the shell's own ``python3`` resolves. Asserting the
+    version is the RED discriminator — under the bug ``python3`` reports 3.14.
+    """
+    expr = _mkprojectshell_expr(
+        current_system,
+        "extraPackages = [ (pkgs.python313.withPackages (ps: [ ps.setuptools ])) ];",
+    )
+    script = (
+        "python3 --version; "
+        'python3 -c "import setuptools, sys; print(setuptools.__file__)"'
+    )
+    proc = subprocess.run(
+        [
+            "nix",
+            "develop",
+            "--impure",
+            "--ignore-environment",
+            "--keep",
+            "HOME",
+            "--expr",
+            expr,
+            "-c",
+            "bash",
+            "-c",
+            script,
+        ],
+        capture_output=True,
+        text=True,
+        env=_nix_env(),
+        timeout=1800,
+    )
+    assert proc.returncode == 0, (
+        "failed to build/enter or import from the extraPackages python env "
+        f"dev-shell: {proc.stderr[-500:]}"
+    )
+    lines = proc.stdout.splitlines()
+    version_line = next((ln for ln in lines if ln.startswith("Python ")), "")
+    assert "3.13" in version_line, (
+        "python3 on the shell PATH must resolve to the extraPackages env "
+        f"interpreter (3.13), not the pinned 3.14; got {version_line!r} "
+        f"(full stdout: {proc.stdout!r})"
+    )
+    setuptools_file = lines[-1] if lines else ""
+    assert "python3.13" in setuptools_file, (
+        "setuptools must be imported from the extraPackages env's 3.13 "
+        f"site-packages; got {setuptools_file!r} (full stdout: {proc.stdout!r})"
+    )


### PR DESCRIPTION
## Summary

`mkProjectShell` consumers who add Python libraries the documented way — a
`pythonXX.withPackages` env passed through `extraPackages` — silently got the
builder's bare pinned 3.14 interpreter on `PATH` with **none** of their
libraries, surfacing only later as `ModuleNotFoundError`. This blocked the
cad2gdml onboarding (FreeCAD via `extraPackages`).

Closes #1230

## Root cause

The bug is a `python3` PATH race, but not the one the issue's minimal repro
suggested. Reordering `extraPackages` ahead of the bare `python` in `packages`
(the issue's suggested fix 1) does **not** work, and neither does dropping the
bare `python` — I verified both live. The interpreter that actually shadows the
consumer's env is `vig-utils`: it is a `buildPythonPackage` in `devTools`,
pinned to 3.14, and its Python setup hook **propagates that 3.14 interpreter
onto `PATH`** ahead of anything in `packages`. This is the exact same shadowing
`pythonOverrideHook` (flake.nix) already fights for the `python = …` override
case — and it beats it the only reliable way in this builder: a shellHook
`PATH` prepend.

Evidence (before fix, `extraPackages = [ python313.withPackages … ]`):

```
python3 is /nix/store/…-python3-3.14.4/bin/python3        ← from vig-utils, wins
python3 is /nix/store/…-python3-3.13.13-env/bin/python3   ← consumer env, loses
```

## Fix

Prepend any `extraPackages`-provided Python env in the shellHook (identified by
its `python` passthru, which a `withPackages` env carries and the bare
interpreter / plain library packages do not), using the same PATH-order
mechanism as `pythonOverrideHook`. Placed **before** `pythonOverrideHook` in the
chain so an explicit `python` override (the primary interpreter knob, #1038)
still wins if a consumer sets both.

- `packages` list unchanged, so the zero-`extraPackages` default dev-shell stays
  byte-identical (the `#1038` parity test still passes).
- The `python` override path and `#729` bare-`python3` presence are unaffected.

## Test evidence

New `tests/test_flake_devshell.py::test_devshell_extrapackages_python_env_wins_on_path`
builds a real `mkProjectShell` with a `python313.withPackages([setuptools])` env
in `extraPackages`, enters it under `nix develop --ignore-environment`, and
asserts `python3` resolves to the env (3.13) and imports its `setuptools`.

- **RED** (before fix): `ModuleNotFoundError: No module named 'setuptools'` /
  `python3` reports 3.14 — the exact issue reproduction.
- **GREEN** (after fix): `1 passed`.

Regression set (all pass): `python_default_is_byte_identical`,
`python_override_switches_interpreter`, `exposes_python3_and_precommit`, plus the
new test — `4 passed`.

`prek run --all-files`: fully green.
