### PR TITLE
ci: cancel superseded nix-image builds per ref

### DIFF
--- a/.github/workflows/nix-image.yml
+++ b/.github/workflows/nix-image.yml
@@ -54,6 +54,16 @@ on:  # yamllint disable-line rule:truthy
       - 'dev'
   workflow_dispatch:
 
+# Cancel a superseded in-flight build when a newer push lands on the same ref
+# (#1250): with no `paths:` filter, a release train's changelog-freeze push to
+# `dev` starts a build whose baked-CHANGELOG checksum mismatch is guaranteed
+# red until the manifest-sync push one minute later — let the sync build cancel
+# it instead of painting a red run every train. Per-ref grouping keeps distinct
+# refs (epic branch, dispatch on other refs) independent.
+concurrency:
+  group: nix-image-${{ github.ref }}
+  cancel-in-progress: true
+
 # Least-privilege default (Scorecard TokenPermissions): top-level is read-only;
 # each job escalates `packages: write` for itself where it pushes to GHCR.
 permissions:

--- a/tests/test_workflow_cachix.py
+++ b/tests/test_workflow_cachix.py
@@ -92,6 +92,32 @@ def test_release_build_and_test_opts_into_closure_push() -> None:
         )
 
 
+def test_nix_image_cancels_superseded_runs_per_ref() -> None:
+    """A newer push to the same ref cancels the in-flight discovery build.
+
+    Since #1236 dropped the ``paths:`` filter, every ``dev`` push rebuilds —
+    including a release train's changelog-freeze commit, whose baked-CHANGELOG
+    checksum mismatch guarantees a red run until the manifest-sync commit lands
+    one minute later. Per-ref grouping with ``cancel-in-progress`` lets the sync
+    push supersede the doomed freeze build instead of letting it complete red,
+    while keeping distinct refs (epic branch, dispatch on other refs)
+    independent.
+
+    Refs: #1250
+    """
+    wf = _load(NIX_IMAGE_WF)
+    concurrency = wf.get("concurrency")
+    assert isinstance(concurrency, dict), (
+        "nix-image.yml must declare a workflow-level concurrency block"
+    )
+    assert "${{ github.ref }}" in concurrency.get("group", ""), (
+        "the concurrency group must be per-ref so distinct refs stay independent"
+    )
+    assert concurrency.get("cancel-in-progress") is True, (
+        "a newer push to the same ref must cancel the superseded build"
+    )
+
+
 def test_release_vulnix_gate_pushes_scan_target_closure() -> None:
     """The release CVE gate pushes the scan-target closure so scans are cache-backed."""
     wf = _load(RELEASE_WF)


### PR DESCRIPTION
## Summary

Adds a workflow-level per-ref `concurrency` block with `cancel-in-progress: true` to `nix-image.yml`, so a release train's manifest-sync push cancels the guaranteed-red build started by the changelog-freeze push one commit earlier (visible since #1236 dropped the `paths:` filter).

Per-ref grouping keeps the epic branch and dispatches on other refs independent; cancelled runs only produce disposable `nix-dev*` discovery tags and idempotent Cachix paths, both fully regenerated by the superseding run. Structure asserted test-first in `tests/test_workflow_cachix.py` (RED confirmed before the fix).

Closes #1250
Refs #1250

## Verification

- `actionlint` clean; zizmor finding-set diff shows zero new findings (removes one pedantic `concurrency-limits` finding)
- Full pre-commit suite green; `tests/test_workflow_cachix.py` 5/5