### PR TITLE
fix(workspace): forward workflow to mkProjectShell only when accepted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     scaffolded `flake.nix` reads `DEVKIT_WORKFLOW` from `.vig-os` and forwards
     it, so a trunk direnv consumer's generated guard follows the model out of
     the box. gitflow is a no-op, leaving existing consumers unchanged.
+  - The template forwards `workflow` only when the resolved builder accepts it
+    ([#1249](https://github.com/vig-os/devkit/issues/1249)): the `vigos` input
+    deliberately floats on the default branch, so a fresh scaffold can resolve
+    a devkit `main` that predates the argument — unconditional forwarding then
+    failed eval on first shell entry (`called with unexpected argument
+    'workflow'`). The call site now gates `inherit workflow;` behind a
+    `builtins.functionArgs … ? workflow` check, so older builders fall back to
+    their gitflow default instead of breaking the scaffold.
 - **`install.sh --docker` restores scaffold ownership before the git phase** ([#1235](https://github.com/vig-os/devkit/issues/1235))
   - Under docker the scaffold container runs as root, so its bind-mounted output
     landed root-owned on the host and the host-side git phase (`setup_git_repo`,

--- a/assets/init-workspace.sh
+++ b/assets/init-workspace.sh
@@ -846,16 +846,16 @@ activate_flake_hooks_default() {
     local tmp="${flake}.hooks-default"
     awk '
         { print }
-        /^          extraPackages = extraPackages pkgs;$/ && !inserted {
+        /^            extraPackages = extraPackages pkgs;$/ && !inserted {
             print ""
-            print "          # Host-runner hooks (#1167): direnv CI runs on the bare host"
-            print "          # runner, so let the flake GENERATE .pre-commit-config.yaml from"
-            print "          # the shared base hook set, resolved entirely from the Nix store"
-            print "          # (incl. pymarkdown, now a flake system hook, #1170) rather than"
-            print "          # building the committed YAML remote pre-commit repo hook envs"
-            print "          # per runner. Customize like the opt-in block below; the generated"
-            print "          # config is a gitignored /nix/store symlink."
-            print "          hooks = { };"
+            print "            # Host-runner hooks (#1167): direnv CI runs on the bare host"
+            print "            # runner, so let the flake GENERATE .pre-commit-config.yaml from"
+            print "            # the shared base hook set, resolved entirely from the Nix store"
+            print "            # (incl. pymarkdown, now a flake system hook, #1170) rather than"
+            print "            # building the committed YAML remote pre-commit repo hook envs"
+            print "            # per runner. Customize like the opt-in block below; the generated"
+            print "            # config is a gitignored /nix/store symlink."
+            print "            hooks = { };"
             inserted = 1
         }
     ' "$flake" >"$tmp" && mv "$tmp" "$flake"

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -93,6 +93,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     scaffolded `flake.nix` reads `DEVKIT_WORKFLOW` from `.vig-os` and forwards
     it, so a trunk direnv consumer's generated guard follows the model out of
     the box. gitflow is a no-op, leaving existing consumers unchanged.
+  - The template forwards `workflow` only when the resolved builder accepts it
+    ([#1249](https://github.com/vig-os/devkit/issues/1249)): the `vigos` input
+    deliberately floats on the default branch, so a fresh scaffold can resolve
+    a devkit `main` that predates the argument — unconditional forwarding then
+    failed eval on first shell entry (`called with unexpected argument
+    'workflow'`). The call site now gates `inherit workflow;` behind a
+    `builtins.functionArgs … ? workflow` check, so older builders fall back to
+    their gitflow default instead of breaking the scaffold.
 - **`install.sh --docker` restores scaffold ownership before the git phase** ([#1235](https://github.com/vig-os/devkit/issues/1235))
   - Under docker the scaffold container runs as root, so its bind-mounted output
     landed root-owned on the host and the host-side git phase (`setup_git_repo`,

--- a/assets/workspace/flake.nix
+++ b/assets/workspace/flake.nix
@@ -72,37 +72,44 @@
       {
         # The dev shell = the shared vigOS toolchain + your extras.
         # `direnv allow` (via .envrc) or `nix develop` enters it.
-        devShells.default = vigos.lib.mkProjectShell {
-          inherit pkgs;
-          extraPackages = extraPackages pkgs;
-          # Branch guard follows the workspace workflow model (#1224).
-          inherit workflow;
+        devShells.default = vigos.lib.mkProjectShell (
+          {
+            inherit pkgs;
+            extraPackages = extraPackages pkgs;
 
-          # Opt-in: let the flake GENERATE .pre-commit-config.yaml from the
-          # shared base hook set instead of hand-managing the scaffolded
-          # YAML — toggle base hooks, add per-hook/global excludes, or add
-          # fully custom hooks; hook updates then flow with `nix flake
-          # update vigos`, and your customization lives HERE (preserved).
-          # Contract + migration steps:
-          # https://github.com/vig-os/devkit/blob/main/docs/MIGRATION.md ("Customizing
-          # pre-commit hooks from the project flake"). Uncomment to opt in, then
-          # delete .pre-commit-config.yaml (the generated config refuses to
-          # overwrite an existing file). The generated store symlink is ignored
-          # automatically on (re)scaffold (#1092); add durable root ignores you
-          # own to .gitignore.project.
-          #
-          #   hooks = {
-          #     typos.enable = false;                    # toggle a base hook
-          #     detect-private-keys.excludes = [ "worker/src/index\\.ts" ];
-          #     my-data-check = {                        # fully custom hook
-          #       enable = true;
-          #       entry = "./scripts/check-dat.sh";
-          #       files = "\\.dat$";
-          #       language = "system";
-          #     };
-          #   };
-          #   hooksExcludes = [ "^data/stopping/" "\\.dat$" ]; # global excludes
-        };
+            # Opt-in: let the flake GENERATE .pre-commit-config.yaml from the
+            # shared base hook set instead of hand-managing the scaffolded
+            # YAML — toggle base hooks, add per-hook/global excludes, or add
+            # fully custom hooks; hook updates then flow with `nix flake
+            # update vigos`, and your customization lives HERE (preserved).
+            # Contract + migration steps:
+            # https://github.com/vig-os/devkit/blob/main/docs/MIGRATION.md ("Customizing
+            # pre-commit hooks from the project flake"). Uncomment to opt in, then
+            # delete .pre-commit-config.yaml (the generated config refuses to
+            # overwrite an existing file). The generated store symlink is ignored
+            # automatically on (re)scaffold (#1092); add durable root ignores you
+            # own to .gitignore.project.
+            #
+            #   hooks = {
+            #     typos.enable = false;                    # toggle a base hook
+            #     detect-private-keys.excludes = [ "worker/src/index\\.ts" ];
+            #     my-data-check = {                        # fully custom hook
+            #       enable = true;
+            #       entry = "./scripts/check-dat.sh";
+            #       files = "\\.dat$";
+            #       language = "system";
+            #     };
+            #   };
+            #   hooksExcludes = [ "^data/stopping/" "\\.dat$" ]; # global excludes
+          }
+          # Forwarded only when the resolved devkit accepts it (#1249): the vigos
+          # input floats to main, which may predate the argument; older builders
+          # then fall back to their gitflow default instead of failing eval.
+          // nixpkgs.lib.optionalAttrs (builtins.functionArgs vigos.lib.mkProjectShell ? workflow) {
+            # Branch guard follows the workspace workflow model (#1224).
+            inherit workflow;
+          }
+        );
 
         # Opt-in local dev services (#795): a daemonless process-compose stack
         # (Postgres, SeaweedFS/S3, Redis, …) with service versions from the

--- a/tests/test_workflow_model.py
+++ b/tests/test_workflow_model.py
@@ -272,6 +272,28 @@ def test_trunk_flake_forwards_workflow_to_hooks(tmp_path: Path) -> None:
     assert "DEVKIT_WORKFLOW=trunk" in manifest
 
 
+def test_template_flake_guards_workflow_forwarding() -> None:
+    """#1249: forward ``workflow`` only when the resolved builder accepts it.
+
+    The template's ``vigos`` input deliberately floats on the default branch,
+    so a fresh scaffold may resolve a devkit whose ``mkProjectShell`` predates
+    the ``workflow`` argument — unconditional forwarding then fails eval on
+    first shell entry (``called with unexpected argument 'workflow'``). The
+    call site must gate ``inherit workflow;`` behind a
+    ``builtins.functionArgs … ? workflow`` check so older builders fall back
+    to their gitflow default instead of breaking the scaffold.
+    """
+    flake = (WORKSPACE / "flake.nix").read_text(encoding="utf-8")
+    assert "inherit workflow;" in flake, "flake.nix does not forward `workflow`"
+    assert "builtins.functionArgs vigos.lib.mkProjectShell ? workflow" in flake, (
+        "flake.nix forwards `workflow` unconditionally — the floating vigos "
+        "input may resolve a devkit that predates the argument (#1249)"
+    )
+    assert "optionalAttrs" in flake, (
+        "flake.nix must merge the guarded `workflow` via lib.optionalAttrs"
+    )
+
+
 def test_anchoring_preserves_dev_prefixed_and_device_tokens(tmp_path: Path) -> None:
     """Anchoring must not touch /dev/null, dev_sha, or development/devkit tokens.
 


### PR DESCRIPTION
## Summary

The scaffolded `flake.nix` forwards the new `workflow` argument (#1224) unconditionally, but its `vigos` input deliberately floats on the default branch — so until 1.4.1 promotes, a fresh scaffold resolves devkit `main` (1.4.0) and dies on first shell entry with `called with unexpected argument 'workflow'`. This is what broke devkit-smoke-test PR #288's Direnv Smoke jobs and the smoke rc1 dispatch, deadlocking the promote precondition.

The call site now gates `inherit workflow;` behind `builtins.functionArgs vigos.lib.mkProjectShell ? workflow` via `optionalAttrs`, so older builders degrade to their gitflow default instead of failing eval. All template comments preserved; upgrades were never affected (`flake.nix` is scaffold-once).

Closes #1249
Refs #1249

## Verification

- TDD: guard asserted red-first in `tests/test_workflow_model.py`
- `tests/test_workflow_model.py` 22/22, `test_scaffold_lint.py` + `test_flake_hooks.py` + `test_downstream_flake.py` green; full pre-commit suite green (51 hooks)
- **Live proof**: fixed template + `.vig-os` `DEVKIT_WORKFLOW=trunk` enters the shell against BOTH `github:vig-os/devkit` (main = 1.4.0, previously fatal) and `?ref=1.4.1-rc1`
- Smoke-test PR #288 Direnv Smoke going green on the rc2 respin is the final live gate