### PR TITLE
fix(install): run docker ownership repair only when the tree is not user-owned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,15 +93,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     scaffolded `flake.nix` reads `DEVKIT_WORKFLOW` from `.vig-os` and forwards
     it, so a trunk direnv consumer's generated guard follows the model out of
     the box. gitflow is a no-op, leaving existing consumers unchanged.
-- **`install.sh --docker` restores scaffold ownership before the git phase** ([#1235](https://github.com/vig-os/devkit/issues/1235))
-  - Under docker the scaffold container runs as root, so its bind-mounted output
-    landed root-owned on the host and the host-side git phase (`setup_git_repo`,
-    warn-not-fail by design) could not write to it — the installer "succeeded"
-    but left a root-owned, git-less tree that every docker caller had to repair
-    by hand. `install.sh` now reuses the image in a throwaway container to
-    `chown` the tree back to the invoking user before the git phase, so the git
-    setup succeeds normally. Rootless podman already maps container-root to the
-    invoking user, so the repair runs on the docker runtime only.
+- **`install.sh --docker` restores scaffold ownership before the git phase, keyed on the observed post-scaffold state** ([#1235](https://github.com/vig-os/devkit/issues/1235), [#1248](https://github.com/vig-os/devkit/issues/1248))
+  - Under real docker the scaffold container runs as root, so its bind-mounted
+    output landed root-owned on the host and the host-side git phase
+    (`setup_git_repo`, warn-not-fail by design) could not write to it — the
+    installer "succeeded" but left a root-owned, git-less tree that every docker
+    caller had to repair by hand. `install.sh` now reuses the image in a
+    throwaway container to `chown` the tree back to the invoking user before the
+    git phase, so the git setup succeeds normally.
+  - The repair is conditioned on the observed post-scaffold ownership, not the
+    runtime CLI name: it runs only when the scaffolded tree contains files not
+    owned by the invoking user. Rootless podman — in any flavor, including a
+    `docker` compat shim — maps container-root to the invoking user, so its
+    output is already correctly owned and an unconditional in-container `chown`
+    would have flipped the tree to an unmapped subuid, breaking the git phase.
 
 ### Security
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -93,15 +93,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     scaffolded `flake.nix` reads `DEVKIT_WORKFLOW` from `.vig-os` and forwards
     it, so a trunk direnv consumer's generated guard follows the model out of
     the box. gitflow is a no-op, leaving existing consumers unchanged.
-- **`install.sh --docker` restores scaffold ownership before the git phase** ([#1235](https://github.com/vig-os/devkit/issues/1235))
-  - Under docker the scaffold container runs as root, so its bind-mounted output
-    landed root-owned on the host and the host-side git phase (`setup_git_repo`,
-    warn-not-fail by design) could not write to it — the installer "succeeded"
-    but left a root-owned, git-less tree that every docker caller had to repair
-    by hand. `install.sh` now reuses the image in a throwaway container to
-    `chown` the tree back to the invoking user before the git phase, so the git
-    setup succeeds normally. Rootless podman already maps container-root to the
-    invoking user, so the repair runs on the docker runtime only.
+- **`install.sh --docker` restores scaffold ownership before the git phase, keyed on the observed post-scaffold state** ([#1235](https://github.com/vig-os/devkit/issues/1235), [#1248](https://github.com/vig-os/devkit/issues/1248))
+  - Under real docker the scaffold container runs as root, so its bind-mounted
+    output landed root-owned on the host and the host-side git phase
+    (`setup_git_repo`, warn-not-fail by design) could not write to it — the
+    installer "succeeded" but left a root-owned, git-less tree that every docker
+    caller had to repair by hand. `install.sh` now reuses the image in a
+    throwaway container to `chown` the tree back to the invoking user before the
+    git phase, so the git setup succeeds normally.
+  - The repair is conditioned on the observed post-scaffold ownership, not the
+    runtime CLI name: it runs only when the scaffolded tree contains files not
+    owned by the invoking user. Rootless podman — in any flavor, including a
+    `docker` compat shim — maps container-root to the invoking user, so its
+    output is already correctly owned and an unconditional in-container `chown`
+    would have flipped the tree to an unmapped subuid, breaking the git phase.
 
 ### Security
 

--- a/install.sh
+++ b/install.sh
@@ -851,15 +851,21 @@ if [ -n "$PREVIEW" ]; then
     exit 0
 fi
 
-# ── Restore scaffold ownership (docker only) ──────────────────────────────────
-# Under docker the scaffold container runs as root, so its bind-mounted output
-# lands root-owned on the host and the host-side git phase below can't write to
-# it (#1235). The host user usually can't chown root-owned files back directly,
-# so reuse the same image in a throwaway container to chown the tree to the
-# invoking user. Rootless podman already maps container-root to that user, so
-# its output is correctly owned — only docker needs the repair. Warn-not-fail to
-# match the git phase's CI/fresh-machine-friendly posture.
-if [ "$RUNTIME" = "docker" ]; then
+# ── Restore scaffold ownership (observed state) ───────────────────────────────
+# Under real docker the scaffold container runs as root, so its bind-mounted
+# output lands root-owned on the host and the host-side git phase below can't
+# write to it (#1235). The host user usually can't chown root-owned files back
+# directly, so reuse the same image in a throwaway container to chown the tree
+# to the invoking user. Rootless podman — in ANY flavor, including a `docker`
+# CLI compat shim — maps container-root to the invoking user, so its output is
+# already correctly owned, and running the in-container chown there would flip
+# the tree to an unmapped subuid (#1248). The repair therefore keys on the
+# OBSERVED post-scaffold state, never on the CLI name (RUNTIME): it runs only
+# when the scaffolded tree contains files not owned by the invoking user. The
+# probe uses find(1) primaries portable across GNU and BSD (macOS bash 3.2 must
+# work — no GNU-only `stat -c`). Warn-not-fail to match the git phase's
+# CI/fresh-machine-friendly posture.
+if [ -n "$(find "$PROJECT_PATH" ! -user "$(id -un)" -print -quit)" ]; then
     HOST_UID="$(id -u)"
     HOST_GID="$(id -g)"
     info "Restoring ownership of scaffolded files to ${HOST_UID}:${HOST_GID}..."

--- a/tests/bats/install.bats
+++ b/tests/bats/install.bats
@@ -869,8 +869,13 @@ _run_install_stubbed() {
 # throwaway container BEFORE the git phase. Rootless podman maps container-root
 # to the invoking user, so it needs no repair. Exercised against a logging stub
 # runtime (records each invocation) so nothing is pulled or actually chowned.
+# The repair keys on the OBSERVED post-scaffold ownership, not the runtime name
+# (#1248): pass owned=foreign to simulate a tree with files not owned by the
+# invoking user (real docker's root-owned output) — an unprivileged test can't
+# create root-owned files, so a stub of install.sh's find(1) ownership probe
+# reporting a hit stands in for them (install.sh runs no other find).
 _run_install_logging_stub() {
-    local dir="$1" runtime="$2" log="$3"
+    local dir="$1" runtime="$2" log="$3" owned="${4:-user}"
     local stub="$BATS_TEST_TMPDIR/stub-$runtime"
     mkdir -p "$stub"
     cat >"$stub/$runtime" <<STUB
@@ -879,6 +884,13 @@ printf '%s\n' "\$*" >> "$log"
 exit 0
 STUB
     chmod +x "$stub/$runtime"
+    if [ "$owned" = "foreign" ]; then
+        cat >"$stub/find" <<'STUB'
+#!/usr/bin/env bash
+echo "/workspace/root-owned-file"
+STUB
+        chmod +x "$stub/find"
+    fi
     _make_repo "$dir"
     run env PATH="$stub:$PATH" bash "$INSTALL_SH" \
         "--$runtime" --skip-pull --mode direnv "$dir" </dev/null
@@ -886,7 +898,7 @@ STUB
 
 @test "docker path chowns scaffold output to the invoking user (#1235)" {
     log="$BATS_TEST_TMPDIR/docker-repair.log"
-    _run_install_logging_stub "$BATS_TEST_TMPDIR/repair-docker" docker "$log"
+    _run_install_logging_stub "$BATS_TEST_TMPDIR/repair-docker" docker "$log" foreign
     assert_success
     run grep -F "chown -R $(id -u):$(id -g) /workspace" "$log"
     assert_success

--- a/tests/bats/install.bats
+++ b/tests/bats/install.bats
@@ -900,6 +900,19 @@ STUB
     assert_failure
 }
 
+@test "docker path skips the ownership repair on an already-user-owned tree (#1248)" {
+    # Rootless podman behind a docker CLI compat shim maps container-root to
+    # the invoking user, so the scaffold output is already correctly owned;
+    # running the repair chown inside such a container would flip the tree to
+    # an unmapped subuid (#1248). The logging stub scaffold writes nothing, so
+    # the fixture tree stays user-owned — the repair container must not run.
+    log="$BATS_TEST_TMPDIR/docker-skip.log"
+    _run_install_logging_stub "$BATS_TEST_TMPDIR/repair-skip" docker "$log"
+    assert_success
+    run grep -F "chown -R" "$log"
+    assert_failure
+}
+
 @test "ownership repair is ordered before the git phase on the docker path (#1235)" {
     # The chown container run must appear ahead of the setup_git_repo invocation
     # in source, so the host-side git phase writes to a user-owned tree (#1235).


### PR DESCRIPTION
## Summary

The #1235 ownership repair keyed on the runtime CLI *name* (`RUNTIME = docker`). On hosts where `docker` is the rootless-podman compat shim, the scaffold output is already correctly owned, and the in-container `chown` to the host UID maps to an unmapped subuid — flipping a working tree to `UNKNOWN`-owned and breaking the git phase (a regression of the #1235 fix; 1.4.0 worked).

The repair now keys on the OBSERVED post-scaffold state: it runs only when the tree contains files not owned by the invoking user (`find ! -user` probe, portable across GNU/BSD — no GNU-only `stat -c`). RUNTIME is out of the condition entirely; real docker's root-owned output still triggers the repair, and any rootless-podman flavor skips it. Warn-not-fail posture and messages unchanged.

Closes #1248
Refs #1248

## Verification

- TDD: new bats test red-first (docker runtime + user-owned tree → no repair container); existing #1235 tests keep asserting the repair on root-owned output via a stubbed ownership probe
- `bats tests/bats/install.bats`: 103/103 ok; full pre-commit suite green (51 hooks)
- **Live proof on a rootless-podman shim host**: rc1 installer breaks (`UNKNOWN`-owned, no git repo); this branch's installer with identical flags yields a user-owned, git-initialized tree — matching the 1.4.0 baseline