### PR TITLE
feat(vig-utils): merge repo-local label-taxonomy extension in setup-labels

### DIFF
--- a/.github/label-taxonomy.toml
+++ b/.github/label-taxonomy.toml
@@ -10,6 +10,13 @@
 #   The `setup-labels` command is provided by devcontainer bootstrap tooling.
 #   from this taxonomy. Use `--prune` to remove org-default labels that don't
 #   match the taxonomy. Use `--dry-run` to preview changes first.
+#
+# Repo-local extension:
+#   Declare repo-specific labels in `.github/label-taxonomy.local.toml` (same
+#   [[labels]] schema). That file is never devkit-managed — it survives
+#   upgrades, its labels are reconciled and spared by `--prune`, and on a name
+#   collision the local entry wins (mirrors the justfile.base -> justfile.local
+#   layering).
 
 # ── Type ──────────────────────────────────────────────────────────────────────
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`setup-labels`: repo-local taxonomy extension file** ([#1254](https://github.com/vig-os/devkit/issues/1254))
+  - Optional, non-devkit-managed `.github/label-taxonomy.local.toml` (same
+    `[[labels]]` schema) lets a consuming repo declare repo-specific labels
+    that survive devkit upgrades.
+  - `setup-labels` treats the union of both files as the effective taxonomy:
+    extension labels are created/updated in the normal reconciliation pass, and
+    `--prune` only deletes labels absent from both files.
+  - Local-wins collision policy: an extension entry with the same `name`
+    overrides the canonical color/description.
+
 - **Scheduled security scan now covers `dev` as well as `main`** ([#1237](https://github.com/vig-os/devkit/issues/1237))
   - `security-scan.yml` gains a `ref` matrix (`main`, `dev`) so the nightly
     vulnix gate scans the `dev` image closure alongside the default-branch one.

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -23,6 +23,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`setup-labels`: repo-local taxonomy extension file** ([#1254](https://github.com/vig-os/devkit/issues/1254))
+  - Optional, non-devkit-managed `.github/label-taxonomy.local.toml` (same
+    `[[labels]]` schema) lets a consuming repo declare repo-specific labels
+    that survive devkit upgrades.
+  - `setup-labels` treats the union of both files as the effective taxonomy:
+    extension labels are created/updated in the normal reconciliation pass, and
+    `--prune` only deletes labels absent from both files.
+  - Local-wins collision policy: an extension entry with the same `name`
+    overrides the canonical color/description.
+
 - **Scheduled security scan now covers `dev` as well as `main`** ([#1237](https://github.com/vig-os/devkit/issues/1237))
   - `security-scan.yml` gains a `ref` matrix (`main`, `dev`) so the nightly
     vulnix gate scans the `dev` image closure alongside the default-branch one.

--- a/assets/workspace/.github/label-taxonomy.toml
+++ b/assets/workspace/.github/label-taxonomy.toml
@@ -13,6 +13,13 @@
 #   The `setup-labels` command is provided by devcontainer bootstrap tooling.
 #   from this taxonomy. Use `--prune` to remove org-default labels that don't
 #   match the taxonomy. Use `--dry-run` to preview changes first.
+#
+# Repo-local extension:
+#   Declare repo-specific labels in `.github/label-taxonomy.local.toml` (same
+#   [[labels]] schema). That file is never devkit-managed — it survives
+#   upgrades, its labels are reconciled and spared by `--prune`, and on a name
+#   collision the local entry wins (mirrors the justfile.base -> justfile.local
+#   layering).
 
 # ── Type ──────────────────────────────────────────────────────────────────────
 

--- a/packages/vig-utils/README.md
+++ b/packages/vig-utils/README.md
@@ -197,6 +197,17 @@ setup-labels --repo vig-os/devkit
 setup-labels --repo vig-os/devkit --prune
 ```
 
+#### Repo-local taxonomy extension
+
+An optional `.github/label-taxonomy.local.toml` (same `[[labels]]` schema)
+declares repo-specific labels. It is never devkit-managed — the scaffold/upgrade
+step neither creates nor overwrites it — mirroring the justfile layering
+(managed base -> repo-owned local layer). When present, `setup-labels` merges it
+into the effective taxonomy: its labels are created/updated alongside the
+canonical ones, `--prune` only deletes labels absent from *both* files, and on a
+`name` collision the local entry wins (overrides the canonical
+color/description). `--dry-run` previews the merged result.
+
 ### `vig-utils` (utility helper)
 
 General utility entrypoint used by sync/build tooling.

--- a/packages/vig-utils/src/vig_utils/shell/setup-labels.sh
+++ b/packages/vig-utils/src/vig_utils/shell/setup-labels.sh
@@ -11,6 +11,10 @@ else
     REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 fi
 TAXONOMY_FILE="${REPO_ROOT}/.github/label-taxonomy.toml"
+# Optional repo-local extension: same [[labels]] schema, never devkit-managed
+# (mirrors the justfile layering: managed base -> repo-owned local layer).
+# Merged into the effective taxonomy; on a name collision the local entry wins.
+LOCAL_TAXONOMY_FILE="${REPO_ROOT}/.github/label-taxonomy.local.toml"
 
 REPO_ARGS=()
 PRUNE=false
@@ -54,8 +58,22 @@ current_name=""
 current_desc=""
 current_color=""
 
+# Append the pending label, or — local-wins collision policy — replace the
+# existing entry of the same name so a later file (the local extension)
+# overrides the canonical color/description without duplicating the entry.
 flush_label() {
+    local i
     if [[ -n "$current_name" ]]; then
+        for i in "${!NAMES[@]}"; do
+            if [[ "${NAMES[$i]}" == "$current_name" ]]; then
+                DESCRIPTIONS[i]="$current_desc"
+                COLORS[i]="$current_color"
+                current_name=""
+                current_desc=""
+                current_color=""
+                return
+            fi
+        done
         NAMES+=("$current_name")
         DESCRIPTIONS+=("$current_desc")
         COLORS+=("$current_color")
@@ -65,26 +83,36 @@ flush_label() {
     current_color=""
 }
 
-while IFS= read -r line || [[ -n "$line" ]]; do
-    [[ "$line" =~ ^[[:space:]]*# ]] && continue
-    [[ -z "${line// /}" ]] && continue
+parse_taxonomy() {
+    local file="$1" line
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        [[ "$line" =~ ^[[:space:]]*# ]] && continue
+        [[ -z "${line// /}" ]] && continue
 
-    if [[ "$line" =~ ^\[\[labels\]\] ]]; then
-        flush_label
-        continue
-    fi
+        if [[ "$line" =~ ^\[\[labels\]\] ]]; then
+            flush_label
+            continue
+        fi
 
-    if [[ "$line" =~ ^name[[:space:]]*=[[:space:]]*\"(.+)\" ]]; then
-        current_name="${BASH_REMATCH[1]}"
-    elif [[ "$line" =~ ^description[[:space:]]*=[[:space:]]*\"(.+)\" ]]; then
-        current_desc="${BASH_REMATCH[1]}"
-    elif [[ "$line" =~ ^color[[:space:]]*=[[:space:]]*\"(.+)\" ]]; then
-        current_color="${BASH_REMATCH[1]}"
-    fi
-done < "$TAXONOMY_FILE"
-flush_label
+        if [[ "$line" =~ ^name[[:space:]]*=[[:space:]]*\"(.+)\" ]]; then
+            current_name="${BASH_REMATCH[1]}"
+        elif [[ "$line" =~ ^description[[:space:]]*=[[:space:]]*\"(.+)\" ]]; then
+            current_desc="${BASH_REMATCH[1]}"
+        elif [[ "$line" =~ ^color[[:space:]]*=[[:space:]]*\"(.+)\" ]]; then
+            current_color="${BASH_REMATCH[1]}"
+        fi
+    done < "$file"
+    flush_label
+}
+
+parse_taxonomy "$TAXONOMY_FILE"
 
 echo "Taxonomy: ${#NAMES[@]} labels defined in $(basename "$TAXONOMY_FILE")"
+
+if [[ -f "$LOCAL_TAXONOMY_FILE" ]]; then
+    parse_taxonomy "$LOCAL_TAXONOMY_FILE"
+    echo "Extended: ${#NAMES[@]} labels after merging $(basename "$LOCAL_TAXONOMY_FILE") (local wins on collision)"
+fi
 
 mapfile -t EXISTING < <(gh label list "${REPO_ARGS[@]}" --limit 100 --json name --jq '.[].name')
 

--- a/packages/vig-utils/tests/test_shell_entrypoints.py
+++ b/packages/vig-utils/tests/test_shell_entrypoints.py
@@ -117,6 +117,153 @@ def test_setup_labels_command_available() -> None:
     assert shutil.which("setup-labels")
 
 
+# ── setup-labels: taxonomy parsing and local extension merge ─────────────────
+#
+# Harness: a stub `gh` on PATH records every invocation to $GH_STUB_LOG and
+# answers `gh label list` from $GH_STUB_EXISTING (space-separated names), so
+# the script's reconcile/prune loops run against a fake remote.
+
+_CANONICAL_TAXONOMY = """\
+[[labels]]
+name = "bug"
+description = "Something isn't working"
+color = "d73a4a"
+
+[[labels]]
+name = "feature"
+description = "New functionality"
+color = "a2eeef"
+"""
+
+_LOCAL_TAXONOMY = """\
+[[labels]]
+name = "drift"
+description = "Configuration drift detected"
+color = "5319e7"
+"""
+
+_LOCAL_TAXONOMY_COLLIDING = """\
+[[labels]]
+name = "drift"
+description = "Configuration drift detected"
+color = "5319e7"
+
+[[labels]]
+name = "bug"
+description = "Local bug override"
+color = "000000"
+"""
+
+_GH_STUB = """\
+#!/usr/bin/env bash
+printf '%s\\n' "$*" >> "$GH_STUB_LOG"
+if [[ "${1:-}" == "label" && "${2:-}" == "list" ]]; then
+    for name in ${GH_STUB_EXISTING:-}; do
+        printf '%s\\n' "$name"
+    done
+fi
+"""
+
+
+def _run_setup_labels(
+    tmp_path: Path,
+    *,
+    canonical: str = _CANONICAL_TAXONOMY,
+    local: str | None = None,
+    existing: str = "",
+    args: list[str] | None = None,
+) -> tuple[subprocess.CompletedProcess[str], list[str]]:
+    """Run setup-labels against a temp repo root with a stubbed gh CLI."""
+    stub_bin = tmp_path / "bin"
+    stub_bin.mkdir(exist_ok=True)
+    gh_stub = stub_bin / "gh"
+    gh_stub.write_text(_GH_STUB)
+    gh_stub.chmod(0o755)
+
+    repo_root = tmp_path / "repo"
+    (repo_root / ".github").mkdir(parents=True, exist_ok=True)
+    (repo_root / ".github" / "label-taxonomy.toml").write_text(canonical)
+    if local is not None:
+        (repo_root / ".github" / "label-taxonomy.local.toml").write_text(local)
+
+    gh_log = tmp_path / "gh.log"
+    gh_log.write_text("")
+
+    env = dict(os.environ)
+    env["PATH"] = f"{stub_bin}{os.pathsep}{env['PATH']}"
+    env["VIG_UTILS_REPO_ROOT"] = str(repo_root)
+    env["GH_STUB_LOG"] = str(gh_log)
+    env["GH_STUB_EXISTING"] = existing
+
+    result = _run(["setup-labels", *(args or [])], env=env)
+    return result, gh_log.read_text().splitlines()
+
+
+def test_setup_labels_reconciles_extension_labels(tmp_path: Path) -> None:
+    result, gh_log = _run_setup_labels(tmp_path, local=_LOCAL_TAXONOMY)
+
+    assert result.returncode == 0, result.stderr
+    assert "label-taxonomy.local.toml" in result.stdout
+    assert any(line.startswith("label create bug ") for line in gh_log)
+    assert any(line.startswith("label create drift ") for line in gh_log)
+
+
+def test_setup_labels_prune_spares_extension_labels(tmp_path: Path) -> None:
+    result, gh_log = _run_setup_labels(
+        tmp_path,
+        local=_LOCAL_TAXONOMY,
+        existing="bug feature drift stale",
+        args=["--prune"],
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert any(line.startswith("label delete stale ") for line in gh_log)
+    assert not any(line.startswith("label delete drift ") for line in gh_log)
+    assert not any(line.startswith("label delete bug ") for line in gh_log)
+
+
+def test_setup_labels_local_wins_on_name_collision(tmp_path: Path) -> None:
+    result, gh_log = _run_setup_labels(
+        tmp_path,
+        local=_LOCAL_TAXONOMY_COLLIDING,
+        existing="bug",
+    )
+
+    assert result.returncode == 0, result.stderr
+    bug_edits = [line for line in gh_log if line.startswith("label edit bug ")]
+    assert len(bug_edits) == 1
+    assert "Local bug override" in bug_edits[0]
+    assert "000000" in bug_edits[0]
+    assert not any(line.startswith("label create bug ") for line in gh_log)
+
+
+def test_setup_labels_without_extension_behaves_as_before(tmp_path: Path) -> None:
+    result, gh_log = _run_setup_labels(tmp_path, existing="bug")
+
+    assert result.returncode == 0, result.stderr
+    assert "Taxonomy: 2 labels defined in label-taxonomy.toml" in result.stdout
+    assert "local" not in result.stdout.lower()
+    assert any(line.startswith("label edit bug ") for line in gh_log)
+    assert any(line.startswith("label create feature ") for line in gh_log)
+    mutations = [line for line in gh_log if not line.startswith("label list")]
+    assert len(mutations) == 2
+
+
+def test_setup_labels_dry_run_previews_extension_labels(tmp_path: Path) -> None:
+    result, gh_log = _run_setup_labels(
+        tmp_path,
+        local=_LOCAL_TAXONOMY_COLLIDING,
+        existing="bug",
+        args=["--dry-run"],
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "[DRY-RUN]  create  drift" in result.stdout
+    assert result.stdout.count("[DRY-RUN]  update  bug") == 1
+    mutations = [line for line in gh_log if not line.startswith("label list")]
+    assert mutations == []
+
+
 def test_derive_branch_summary_outputs_summary_when_cmd_succeeds() -> None:
     env = dict(os.environ)
     env["BRANCH_SUMMARY_CMD"] = "echo fix-login-bug"


### PR DESCRIPTION
## Summary

`setup-labels` now discovers an optional, non-managed `.github/label-taxonomy.local.toml` (same `[[labels]]` schema) and merges it into the effective taxonomy before reconcile/prune: extension labels are created/updated normally, `--prune` only deletes labels absent from BOTH files, and on a name collision the local entry wins (justfile-layering convention). Absent file = byte-identical behavior. Headers of both taxonomy copies, the vig-utils README, and the changelog document the extension.

Targeted at `release/1.4.1` per maintainer decision (semver:minor feature folded into the patch train).

Closes #1254
Refs #1254

## Verification

- TDD red-first; `test_shell_entrypoints.py` 24/24 (extension reconcile, prune-spares-union, local-wins single edit, absent-file byte-identical baseline, dry-run preview)
- Full pre-commit suite green (51 hooks)
- **Live acceptance (dry-run) against vig-os/org-config**: canonical 25 + extension 4 → 29 effective; `drift`/`critical`/`change-request` update, `inventory` creates, none pruned. Counterfactual without the extension shows all of them as prune deletions — exactly the motivating bug.
- Local file confirmed unmanaged: exact-path manifest entry only, consumer rsync runs without `--delete`