### PR TITLE
chore(security): renew lapsed curl + openssh vulnix exceptions (#1257)

### DIFF
--- a/.vulnixignore
+++ b/.vulnixignore
@@ -225,9 +225,14 @@ CVE-2026-57231
 # and advance the pin once it does. curl is reachable (https/git-over-https,
 # the docker->podman shim, flake fetches), so exposure is NOT theoretical —
 # this is a time-boxed risk acceptance, not a dismissal.
+# Re-verified 2026-07-23 (#1257): curl 8.21.0 (2026-06-24) fixes the whole
+# batch and has reached nixpkgs-unstable, but the pinned channel (nixos-26.05)
+# still ships curl 8.20.0 — the rev-advance lever still has nowhere to land.
+# Expiry extended to 2026-08-15 (another short window) pending the backport
+# propagating to nixos-26.05; flip to a pin bump the moment 8.21.0 lands there.
 # ============================================================================
 
-Expiration: 2026-07-22
+Expiration: 2026-08-15
 # curl 8.20.0 — CVE-2026-10536 (9.8) HTTP/2 stream-dependency-tree UAF;
 #   CVE-2026-11856 (9.8) cross-origin Digest auth-state leak; CVE-2026-8925
 #   (9.8) SASL double-free; CVE-2026-9079 (9.8) stale proxy-password leak.
@@ -274,7 +279,11 @@ CVE-2026-9080
 #   staging-nixos-26.05, 2026-07-10) and has not reached nixos-26.05. Flip to a
 #   nixpkgs rev-advance once 10.4p1 lands in the pinned channel; short expiry to
 #   force near-term re-check.
-Expiration: 2026-07-24
+# Re-verified 2026-07-23 (#1257): nixos-26.05 still ships openssh 10.3p1; the
+#   10.4p1 fix has not propagated from the 26.05 staging pipeline to the pinned
+#   channel, so the rev-advance lever still has nowhere to land. Expiry extended
+#   to 2026-08-15 (another short window) pending that propagation.
+Expiration: 2026-08-15
 CVE-2026-60002
 
 # ============================================================================

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,6 +135,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     still only on nixpkgs `staging` and has not reached the pinned `nixos-26.05`
     channel, so the planned rev-advance remains unavailable.
 
+- **Renew lapsed curl + openssh `.vulnixignore` exceptions** ([#1257](https://github.com/vig-os/devkit/issues/1257))
+  - The curl 8.20.0 advisory batch (18 CVEs, from [#941](https://github.com/vig-os/devkit/issues/941))
+    and the openssh `CVE-2026-60002` client use-after-free (from [#963](https://github.com/vig-os/devkit/issues/963))
+    exceptions are extended to 2026-08-15 after the curl block lapsed on
+    2026-07-22 and reddened the nightly scan. The fixes (curl 8.21.0, openssh
+    10.4p1) exist upstream but have not reached the pinned `nixos-26.05` channel
+    (still curl 8.20.0 / openssh 10.3p1), so the planned rev-advance remains
+    unavailable.
+
 ## [1.4.0](https://github.com/vig-os/devkit/releases/tag/1.4.0) - 2026-07-20
 
 ### Added

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -135,6 +135,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     still only on nixpkgs `staging` and has not reached the pinned `nixos-26.05`
     channel, so the planned rev-advance remains unavailable.
 
+- **Renew lapsed curl + openssh `.vulnixignore` exceptions** ([#1257](https://github.com/vig-os/devkit/issues/1257))
+  - The curl 8.20.0 advisory batch (18 CVEs, from [#941](https://github.com/vig-os/devkit/issues/941))
+    and the openssh `CVE-2026-60002` client use-after-free (from [#963](https://github.com/vig-os/devkit/issues/963))
+    exceptions are extended to 2026-08-15 after the curl block lapsed on
+    2026-07-22 and reddened the nightly scan. The fixes (curl 8.21.0, openssh
+    10.4p1) exist upstream but have not reached the pinned `nixos-26.05` channel
+    (still curl 8.20.0 / openssh 10.3p1), so the planned rev-advance remains
+    unavailable.
+
 ## [1.4.0](https://github.com/vig-os/devkit/releases/tag/1.4.0) - 2026-07-20
 
 ### Added


### PR DESCRIPTION
## Summary

The nightly Scheduled Security Scan went red on 2026-07-23 ([run 29988472212](https://github.com/vig-os/devkit/actions/runs/29988472212)) at the `check-expirations` gate: the **curl 8.20.0** advisory batch in `.vulnixignore` (18 CVEs, `Expiration: 2026-07-22`) lapsed. This renews it, and pre-emptively renews the **openssh** `CVE-2026-60002` block (`Expiration: 2026-07-24`, which lapses tomorrow), to a fresh short window of **2026-08-15**.

Not a new/regressed vulnerability — two time-boxed risk acceptances that ran out.

## Why renew rather than rev-advance

- **curl:** 8.21.0 (2026-06-24) fixes the whole batch and is in `nixpkgs-unstable`, but the pin (`nixos-26.05`) still ships **8.20.0** — verified.
- **openssh:** 10.4p1 (2026-07-06) fixes it, but `nixos-26.05` still ships **10.3p1** — verified.

Both fixes are stuck in the 26.05 staging pipeline and haven't reached the pinned channel, so the rev-advance lever has nowhere to land. Each block gets a dated re-verification note; flip to a pin bump the moment the fixed version lands in `nixos-26.05`.

## Placement

Based on `release/1.4.1` so the renewal ships with the promote-ready train and reaches `main` at promote (which un-reds the nightly). Mirrors the #1240 gawk-extension precedent (`chore(security)` + `### Security` changelog entry, sync-manifest auto-mirror).

## Verification

- `uv run check-expirations .vulnixignore` → *Validated 57 exception(s)*.
- Full `just precommit` suite green locally.

## Out of scope

The tracking-issue automation didn't fire (its guard keys on `vulnix-gate.outcome`, but the run died at the earlier `check-expirations` step). Widening that guard is a separate follow-up.

Closes #1257