### PR TITLE
fix(workspace): never deploy template pre-commit YAML over flake-generated hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Upgrade no longer deploys the template `.pre-commit-config.yaml` over flake-generated hooks** ([#1255](https://github.com/vig-os/devkit/issues/1255))
+  - On a flake-hooks consumer ([#1167](https://github.com/vig-os/devkit/issues/1167))
+    the generated config is a gitignored `/nix/store` symlink that only
+    materializes on shell entry, so a fresh checkout/worktree has no file for
+    the preserve list to protect — an `install.sh --force` upgrade then
+    deployed the scaffold template YAML, which silently shadowed the generated
+    config (git-hooks.nix refuses to overwrite an existing file) and dropped
+    the consumer's `hooks`/`hooksExcludes` customizations. Pre-existing since
+    1.4.0; gitignored, so CI and PRs were unaffected.
+  - The upgrade now detects the opt-in from the preserved `flake.nix` itself
+    (an active `hooks`/`hooksExcludes` argument — exactly `mkProjectShell`'s
+    generation trigger), skips the template YAML in both the copy and the
+    `--preview` report, and still seeds the `.pre-commit-config.yaml` gitignore
+    entry so the regenerated root `.gitignore` stays correct.
 - **`mkProjectShell`: `extraPackages` Python env no longer silently shadowed** ([#1230](https://github.com/vig-os/devkit/issues/1230))
   - A `pythonXX.withPackages` env passed through `extraPackages` — the
     documented way to add Python libraries to a project shell — was shadowed on

--- a/assets/init-workspace.sh
+++ b/assets/init-workspace.sh
@@ -814,12 +814,17 @@ render_gitignore() {
     # STRICTLY on the store-symlink condition so a hand-managed consumer who
     # commits a real .pre-commit-config.yaml file is never affected. A fresh
     # direnv scaffold defaults to flake-generated hooks (FLAKE_HOOKS_DEFAULT,
-    # #1167) before the store symlink exists, so seed the ignore for it too.
+    # #1167) before the store symlink exists, so seed the ignore for it too —
+    # as does an UPGRADED flake-hooks consumer whose generated config is absent
+    # from a fresh checkout/worktree (FLAKE_HOOKS_CONSUMER, #1255): without the
+    # seed the regenerated root .gitignore would drop the entry and the next
+    # shell entry would leave the store symlink dirtying git status.
     # Idempotent: skip when the assembled ignore (incl. .gitignore.project)
     # already lists it.
     local pcc="$WORKSPACE_DIR/.pre-commit-config.yaml"
     if { [[ -L "$pcc" ]] && readlink "$pcc" | grep -q '/nix/store/'; } \
-        || [[ "${FLAKE_HOOKS_DEFAULT:-false}" == "true" ]]; then
+        || [[ "${FLAKE_HOOKS_DEFAULT:-false}" == "true" ]] \
+        || [[ "${FLAKE_HOOKS_CONSUMER:-false}" == "true" ]]; then
         if ! grep -qxF '.pre-commit-config.yaml' "$gi"; then
             {
                 printf '\n# flake-hooks opt-in (#1092): the generated'
@@ -1042,6 +1047,25 @@ fi
 # configs collide. (A *preserved* .typos.toml is handled by the preserve list.)
 if [[ -f "$WORKSPACE_DIR/_typos.toml" && ! -f "$WORKSPACE_DIR/.typos.toml" ]]; then
     MODE_CONFIG_EXCLUDES+=(".typos.toml")
+fi
+# Flake-hooks consumer with an ABSENT generated config (#1255): the consumer's
+# .pre-commit-config.yaml is flake-GENERATED (#883/#1167) — a gitignored
+# /nix/store symlink that only materializes on shell entry — so in a fresh
+# checkout/worktree the file is absent and the preserve list cannot protect it.
+# Deploying the template YAML then SHADOWS the generated config (git-hooks.nix
+# refuses to overwrite an existing file): the shell silently runs the generic
+# template without the consumer's hooks/hooksExcludes customizations. The
+# opt-in is detectable without the file: an ACTIVE (uncommented)
+# hooks/hooksExcludes argument in the preserved flake.nix — exactly
+# mkProjectShell's generation trigger (hooks != null || hooksExcludes != [ ]);
+# the template's commented opt-in block never matches. Gated on the config
+# being absent: when it IS present the existing paths already handle it (store
+# symlink -> preserved #1117; regular file -> mid-migration, consumer-owned).
+FLAKE_HOOKS_CONSUMER=false
+if [[ "$FLAKE_PREEXISTED" == "true" && "$PRECOMMIT_CONFIG_PREEXISTED" == "false" ]] \
+    && grep -Eq '^[[:space:]]*hooks(Excludes)?[[:space:]]*=' "$WORKSPACE_DIR/flake.nix"; then
+    FLAKE_HOOKS_CONSUMER=true
+    MODE_CONFIG_EXCLUDES+=(".pre-commit-config.yaml")
 fi
 
 # Rewrite the scaffolded workspace from the gitflow default shape (long-lived
@@ -1490,6 +1514,11 @@ else
         # their _typos.toml stands as the single config (#913).
         if [[ "$excl" == ".typos.toml" ]]; then
             echo "Consumer carries legacy _typos.toml; not shipping template .typos.toml (#913)."
+        fi
+        # Surface the flake-hooks skip so the upgrade report explains the
+        # missing template YAML (#1255).
+        if [[ "$excl" == ".pre-commit-config.yaml" ]]; then
+            echo "Flake-generated pre-commit hooks consumer; not shipping template .pre-commit-config.yaml (#1255)."
         fi
     done
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -59,6 +59,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Upgrade no longer deploys the template `.pre-commit-config.yaml` over flake-generated hooks** ([#1255](https://github.com/vig-os/devkit/issues/1255))
+  - On a flake-hooks consumer ([#1167](https://github.com/vig-os/devkit/issues/1167))
+    the generated config is a gitignored `/nix/store` symlink that only
+    materializes on shell entry, so a fresh checkout/worktree has no file for
+    the preserve list to protect — an `install.sh --force` upgrade then
+    deployed the scaffold template YAML, which silently shadowed the generated
+    config (git-hooks.nix refuses to overwrite an existing file) and dropped
+    the consumer's `hooks`/`hooksExcludes` customizations. Pre-existing since
+    1.4.0; gitignored, so CI and PRs were unaffected.
+  - The upgrade now detects the opt-in from the preserved `flake.nix` itself
+    (an active `hooks`/`hooksExcludes` argument — exactly `mkProjectShell`'s
+    generation trigger), skips the template YAML in both the copy and the
+    `--preview` report, and still seeds the `.pre-commit-config.yaml` gitignore
+    entry so the regenerated root `.gitignore` stays correct.
 - **`mkProjectShell`: `extraPackages` Python env no longer silently shadowed** ([#1230](https://github.com/vig-os/devkit/issues/1230))
   - A `pythonXX.withPackages` env passed through `extraPackages` — the
     documented way to add Python libraries to a project shell — was shadowed on

--- a/tests/bats/init-workspace.bats
+++ b/tests/bats/init-workspace.bats
@@ -413,6 +413,120 @@ _scaffold() {
     assert_success
 }
 
+# ── upgrade never deploys the template YAML over flake-generated hooks (#1255) ─
+# On a flake-hooks consumer the generated .pre-commit-config.yaml is a
+# gitignored /nix/store symlink, so in a fresh checkout/worktree the file is
+# ABSENT — the preserve list cannot protect it, and the upgrade deployed the
+# scaffold template YAML. git-hooks.nix generation refuses to overwrite an
+# existing file, so the template silently SHADOWED the consumer's flake hook
+# customizations. The opt-in is detectable without the file: an ACTIVE
+# (uncommented) hooks/hooksExcludes argument in the preserved flake.nix —
+# exactly mkProjectShell's generation trigger.
+
+# A consumer flake.nix with an active flake-hooks opt-in, as #1167 activates it.
+_flake_hooks_consumer_flake() {
+    cat >"$1/flake.nix" <<'EOF'
+# SENTINEL-1255 consumer flake
+{
+  outputs = { self, vigos }: {
+    devShells.default = vigos.lib.mkProjectShell {
+      extraPackages = [ ];
+      hooks = { };
+    };
+  };
+}
+EOF
+}
+
+@test "upgrade does not deploy the template YAML over an absent flake-generated config (#1255)" {
+    ws="$BATS_TEST_TMPDIR/e2e-1255-no-deploy"
+    mkdir -p "$ws"
+    _flake_hooks_consumer_flake "$ws"
+    run _scaffold direnv "$ws"
+    assert_success
+    # The generated config stays absent (the flake materializes it on shell
+    # entry); the consumer's flake is preserved untouched.
+    run test -e "$ws/.pre-commit-config.yaml"
+    assert_failure
+    run grep -q 'SENTINEL-1255' "$ws/flake.nix"
+    assert_success
+}
+
+@test "upgrade keeps the .pre-commit-config.yaml ignore for a flake-hooks consumer with absent config (#1255)" {
+    ws="$BATS_TEST_TMPDIR/e2e-1255-gitignore"
+    mkdir -p "$ws"
+    _flake_hooks_consumer_flake "$ws"
+    run _scaffold direnv "$ws"
+    assert_success
+    # The #1092 seed must fire even though neither the store symlink exists nor
+    # the #1167 fresh-scaffold default applies (the flake pre-existed).
+    run grep -qxF '.pre-commit-config.yaml' "$ws/.gitignore"
+    assert_success
+}
+
+@test "a hooksExcludes-only opt-in is detected as a flake-hooks consumer (#1255)" {
+    ws="$BATS_TEST_TMPDIR/e2e-1255-excludes-only"
+    mkdir -p "$ws"
+    cat >"$ws/flake.nix" <<'EOF'
+# SENTINEL-1255 consumer flake (hooksExcludes only)
+{
+  outputs = { self, vigos }: {
+    devShells.default = vigos.lib.mkProjectShell {
+      hooksExcludes = [ "^dist/" ];
+    };
+  };
+}
+EOF
+    run _scaffold direnv "$ws"
+    assert_success
+    run test -e "$ws/.pre-commit-config.yaml"
+    assert_failure
+}
+
+@test "a flake with only the COMMENTED template opt-in still receives the template YAML (#1255)" {
+    ws="$BATS_TEST_TMPDIR/e2e-1255-commented"
+    mkdir -p "$ws"
+    # The scaffold template ships the opt-in commented out; that must never
+    # count as a flake-hooks consumer, or every direnv upgrade of a
+    # hand-managed-YAML repo would stop shipping the template config.
+    cat >"$ws/flake.nix" <<'EOF'
+# SENTINEL-1255 consumer flake (opt-in NOT active)
+{
+  outputs = { self, vigos }: {
+    devShells.default = vigos.lib.mkProjectShell {
+      extraPackages = [ ];
+      #   hooks = {
+      #     typos.enable = false;
+      #   };
+      #   hooksExcludes = [ "^data/" ];
+    };
+  };
+}
+EOF
+    run _scaffold direnv "$ws"
+    assert_success
+    run test -f "$ws/.pre-commit-config.yaml"
+    assert_success
+}
+
+@test "--preview does not advertise .pre-commit-config.yaml as ADDED for a flake-hooks consumer (#1255)" {
+    ws="$BATS_TEST_TMPDIR/e2e-1255-preview"
+    mkdir -p "$ws"
+    _flake_hooks_consumer_flake "$ws"
+    local stub="$BATS_TEST_TMPDIR/stub-bin"
+    mkdir -p "$stub"
+    printf '#!/usr/bin/env bash\nexit 0\n' >"$stub/just"
+    chmod +x "$stub/just"
+    run env PATH="$stub:$PATH" \
+        TEMPLATE_DIR="$PROJECT_ROOT/assets/workspace" \
+        WORKSPACE_DIR="$ws" \
+        SHORT_NAME=testproj \
+        GITHUB_REPOSITORY=test/repo \
+        bash "$INIT_WORKSPACE_SH" --preview --no-prompts --mode direnv
+    assert_success
+    refute_line '  +  .pre-commit-config.yaml'
+}
+
 # ── opt-in .devcontainer/ prune on container-less mode upgrade (#990) ──────────
 # The #738 default is non-destructive: a container→direnv/bare re-scaffold keeps
 # a populated pre-existing .devcontainer/. On a real container→direnv migration


### PR DESCRIPTION
## Summary

An `install.sh --force` upgrade on a flake-hooks consumer deployed the scaffold
template `.pre-commit-config.yaml` whenever the file was absent from the tree.
On such a consumer the config is flake-GENERATED (#1167/#883): a gitignored
`/nix/store` symlink that only materializes on shell entry, so a fresh
checkout/worktree legitimately has no file for the preserve list to protect.
The deployed template then SHADOWED the generated config — git-hooks.nix
refuses to overwrite an existing file — silently dropping the consumer's
`hooks`/`hooksExcludes` customizations (observed on commit-action: typos ran
against the committed `dist/` bundle).

## Fix

The opt-in is detectable without the file: an ACTIVE (uncommented)
`hooks`/`hooksExcludes` argument in the preserved `flake.nix` — exactly
`mkProjectShell`'s generation trigger (`hooks != null || hooksExcludes != [ ]`);
the template's commented opt-in block never matches.

- When detected and the config is absent, `.pre-commit-config.yaml` joins
  `MODE_CONFIG_EXCLUDES` (the #1196 SSoT), so the rsync copy and the
  `--preview` report skip it consistently; the report says why.
- The #1092 gitignore seed also fires for this case, so the regenerated root
  `.gitignore` keeps the `.pre-commit-config.yaml` entry (previously it was
  dropped whenever neither the store symlink nor the #1167 fresh-scaffold
  default applied).
- Present-config paths are untouched: a store symlink stays PRESERVED (#1117),
  and a committed regular YAML (hand-managed or mid-migration) keeps today's
  behavior, including no ignore seed.

Targeted at `release/1.4.1`: pre-existing since 1.4.0, but it bites every
fresh-worktree upgrade of the direnv lanes, so it rides the patch train.

## Verification

- New bats coverage (5 tests): upgrade with absent generated config deploys no
  template YAML and keeps the gitignore entry; `hooksExcludes`-only opt-in is
  detected; a flake with only the COMMENTED template opt-in still receives the
  template YAML; `--preview` no longer advertises the file as ADDED.
- Full `tests/bats/init-workspace.bats` suite: 243/243 green.
- `just precommit`: all hooks green except the pre-existing, unrelated
  `check-expirations` failure (curl 8.20.0 batch expired 2026-07-22 — filed
  separately; it will also fail this PR's CI until resolved).

Closes #1255