### PR TITLE
fix: keep the dev-shell toolchain in lockstep with consumer adoption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Consumer adoption no longer strands the dev-shell toolchain a release behind** ([#1263](https://github.com/vig-os/devkit/issues/1263))
+  - A `--force` upgrade of a direnv/`both` consumer with a floating `vigos`
+    flake input now runs `nix flake update vigos` host-side after the scaffold,
+    so `flake.lock` (which governs the dev shell: `vig-utils`, hook sets,
+    `mkProjectShell`) advances together with the `.vig-os` `DEVKIT_VERSION`
+    pin. Non-fatal when `nix` is missing or offline — the manual step is
+    printed instead. Pinned (`?ref=`) inputs keep the existing #1093 warning.
+  - `mkProjectShell` gains a shell-entry version-skew guard: the shellHook
+    compares the flake's own release (the devkit `.vig-os` at the locked input
+    rev) against the workspace `.vig-os` pin and warns with the
+    `nix flake update vigos` remedy on every entry until the lock is advanced.
+    Silent for matching versions, prerelease (`-rc*`) pins, and bare
+    `mkProjectShell` consumers without a manifest.
+  - `docs/MIGRATION.md` documents the lock-advance step in the upgrade
+    checklist and corrects the claim that a floating input needs no manual
+    bump — it skews via `flake.lock` instead.
+
 ### Security
 
 ## [1.4.1](https://github.com/vig-os/devkit/releases/tag/1.4.1) - 2026-07-23

--- a/assets/init-workspace.sh
+++ b/assets/init-workspace.sh
@@ -1693,8 +1693,11 @@ if [[ -n "${VIG_OS_VERSION:-}" && -f "$WORKSPACE_DIR/.vig-os" ]]; then
     # delivered through the flake input). Bumping only the scaffold while a pinned
     # `vigos` ref lags behind silently breaks every commit. We cannot fix it for
     # the consumer — flake.nix is a PRESERVE_FILE they own — but we can warn.
-    # A FLOATING input (no ?ref=) is intentionally unpinned, so it never warns;
-    # only a pin that differs from the target does.
+    # A FLOATING input (no ?ref=) never warns HERE — not because it cannot skew
+    # (it does, via the rev flake.lock last locked, #1263), but because that
+    # case is handled elsewhere: install.sh advances the lock host-side on
+    # --force upgrades, and mkProjectShell's shell-entry guard warns until the
+    # lock catches up. Only a pin that differs from the target warns here.
     if [[ "$FORCE" == "true" && ( "$MODE" == "direnv" || "$MODE" == "both" ) \
         && -f "$WORKSPACE_DIR/flake.nix" ]]; then
         # `|| true`: a floating input yields no grep match (exit 1), which would

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -17,6 +17,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Consumer adoption no longer strands the dev-shell toolchain a release behind** ([#1263](https://github.com/vig-os/devkit/issues/1263))
+  - A `--force` upgrade of a direnv/`both` consumer with a floating `vigos`
+    flake input now runs `nix flake update vigos` host-side after the scaffold,
+    so `flake.lock` (which governs the dev shell: `vig-utils`, hook sets,
+    `mkProjectShell`) advances together with the `.vig-os` `DEVKIT_VERSION`
+    pin. Non-fatal when `nix` is missing or offline — the manual step is
+    printed instead. Pinned (`?ref=`) inputs keep the existing #1093 warning.
+  - `mkProjectShell` gains a shell-entry version-skew guard: the shellHook
+    compares the flake's own release (the devkit `.vig-os` at the locked input
+    rev) against the workspace `.vig-os` pin and warns with the
+    `nix flake update vigos` remedy on every entry until the lock is advanced.
+    Silent for matching versions, prerelease (`-rc*`) pins, and bare
+    `mkProjectShell` consumers without a manifest.
+  - `docs/MIGRATION.md` documents the lock-advance step in the upgrade
+    checklist and corrects the claim that a floating input needs no manual
+    bump — it skews via `flake.lock` instead.
+
 ### Security
 
 ## [1.4.1](https://github.com/vig-os/devkit/releases/tag/1.4.1) - 2026-07-23

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -638,9 +638,22 @@ The contract:
 
 ## Updating
 
-- **Downstream dev environment:** `nix flake update vigos` (or re-run
-  `install.sh --force` to refresh the scaffold; your `flake.nix`/`.envrc`/
+A devkit release reaches a consumer through **two coupled channels** that must
+move together ([#1263](https://github.com/vig-os/devkit/issues/1263)):
+
+- **Scaffold + image** — `install.sh --force` rewrites the managed files and
+  advances `DEVKIT_VERSION` in `.vig-os` (your `flake.nix`/`.envrc`/
   `pyproject.toml` and a populated `.devcontainer/` are preserved).
+- **Dev-shell toolchain** (`vig-utils`, hook sets, `mkProjectShell`) — governed
+  by the `vigos` input in `flake.lock`, advanced by `nix flake update vigos`.
+
+The upgrade takes care of both: after the scaffold, `install.sh --force` runs
+`nix flake update vigos` itself when the workspace is a direnv/`both` consumer
+with a floating input and host `nix` is available; otherwise it prints the
+manual step. Review and commit the `flake.lock` change together with the
+scaffold diff. Should the two ever drift anyway (e.g. a raw `podman run`
+upgrade), the dev shell warns on every entry until the lock is advanced.
+
 - **Toolchain versions / CVEs:** advance the pinned `nixpkgs` revision
   (Renovate's `nix` manager opens the PR); `flake.lock` is the controlling
   version document.
@@ -984,6 +997,12 @@ nix flake update vigos
 ```
 
 A `--force` upgrade whose scaffold version differs from a pinned `vigos` ref now
-prints a warning to that effect. A **floating** input
-(`vigos.url = "github:vig-os/devkit"`, no `?ref=`) tracks the branch and needs no
-manual bump — it is exempt.
+prints a warning to that effect.
+
+A **floating** input (`vigos.url = "github:vig-os/devkit"`, no `?ref=`) needs no
+manual `ref` bump, but it is **not** exempt from skew: the dev shell runs
+whatever `flake.lock` last locked, so the lock must still advance with every
+upgrade ([#1263](https://github.com/vig-os/devkit/issues/1263)). `install.sh
+--force` runs `nix flake update vigos` for you when it can (direnv/`both` mode,
+host `nix` available), and the dev shell warns at entry whenever its own release
+differs from the `.vig-os` `DEVKIT_VERSION` pin — see [Updating](#updating).

--- a/flake.nix
+++ b/flake.nix
@@ -521,6 +521,49 @@
             unset _gitTop
           '';
 
+          # Shell-entry version-skew guard (#1263). The workspace `.vig-os`
+          # DEVKIT_VERSION (advanced by the scaffold upgrade) and the `vigos`
+          # flake input (frozen by the consumer's flake.lock) deliver coupled
+          # halves of each release, but a FLOATING input only advances when
+          # someone runs `nix flake update vigos` — the #1093 scaffold warning
+          # covers pinned (?ref=) inputs only, so a floating consumer's shell
+          # silently ran last release's toolchain (vig-utils, hook sets) under
+          # this release's scaffold. The flake knows its own release purely:
+          # the devkit repo-root `.vig-os` (read here at the locked input rev)
+          # is already the version SSoT for `nix build`. Bake it into the
+          # shellHook and compare against the workspace `.vig-os` on every
+          # shell entry — the one place both halves of the skew are visible.
+          # Silent when: no workspace `.vig-os` (bare mkProjectShell consumer),
+          # versions match, or the workspace pin is a prerelease (`-rc*`) —
+          # release-train lanes bump consumers to rc tags whose content lives
+          # on the release branch, which a floating update (default branch)
+          # cannot reach, so the warning would be unactionable there.
+          # Warn-only: never fails the shell.
+          devkitVersion =
+            let
+              manifestLines = pkgs.lib.splitString "\n" (builtins.readFile ./.vig-os);
+              pinMatches = builtins.filter (m: m != null) (
+                map (builtins.match "DEVKIT_VERSION=(.*)") manifestLines
+              );
+            in
+            if pinMatches == [ ] then "" else builtins.head (builtins.head pinMatches);
+          versionSkewHook = pkgs.lib.optionalString (devkitVersion != "") ''
+            _vigosWs=$(${pkgs.gitMinimal}/bin/git rev-parse --show-toplevel 2>/dev/null || pwd)
+            if [ -f "$_vigosWs/.vig-os" ]; then
+              _vigosPin=$(sed -n 's/^DEVKIT_VERSION=//p' "$_vigosWs/.vig-os" | head -n1 | tr -d '[:space:]')
+              case "$_vigosPin" in
+                "" | *-rc* | "${devkitVersion}") : ;;
+                *)
+                  echo 1>&2 "WARNING: vigos: dev-shell toolchain is devkit ${devkitVersion}, but .vig-os pins DEVKIT_VERSION=$_vigosPin."
+                  echo 1>&2 "         The scaffold and the vigos flake input deliver coupled halves of each release;"
+                  echo 1>&2 "         run 'nix flake update vigos' (then reload the shell) to advance the toolchain."
+                  echo 1>&2 "         Refs: https://github.com/vig-os/devkit/issues/1263"
+                  ;;
+              esac
+            fi
+            unset _vigosWs _vigosPin
+          '';
+
           # When the interpreter is overridden (#1038), prepend it to PATH so the
           # bare `python`/`python3` follow the override too — not just uv's
           # `UV_PYTHON` pin. `vig-utils` (a devTools entry) is built against the
@@ -585,7 +628,8 @@
               ++ extraPackages
               ++ modulePackages;
             shellHook =
-              ldLibraryPathHook
+              versionSkewHook
+              + ldLibraryPathHook
               + "\n"
               + nvimIsolationHook
               + "\n"

--- a/install.sh
+++ b/install.sh
@@ -978,6 +978,43 @@ if ! setup_git_repo "$PROJECT_PATH"; then
     echo "    cd $PROJECT_PATH && git init -b main && git add -A && git commit -m 'chore: initial project scaffold'"
 fi
 
+# 3. Floating vigos flake-lock advance (#1263)
+# An upgrade advances .vig-os DEVKIT_VERSION (scaffold + image), but a FLOATING
+# `vigos` input's dev shell is governed by flake.lock, which stays wherever the
+# last `nix flake update vigos` left it — so the direnv toolchain (vig-utils,
+# hook sets) silently keeps running the previous release. Advance the lock
+# here, on the host, after the ownership repair and git phase: a direnv
+# consumer has nix by definition, and the scaffold container must not write the
+# lock (network dependence + root-owned output hazards, #1235/#1248). Pinned
+# (?ref=) inputs are the consumer's explicit choice and get the #1093
+# init-workspace.sh warning instead; a missing flake.lock (fresh scaffold)
+# locks current content on first shell entry anyway. Upgrades only (--force):
+# the skew needs a pre-existing lock to lag behind. Non-fatal on failure
+# (e.g. offline): print the manual step. The anchored grep matches the REAL
+# floating input line only — the doc-comment example and any ?ref= pin do not
+# match (same anchoring rationale as #1110).
+if [ -n "$FORCE" ] && { [ "$MODE" = "direnv" ] || [ "$MODE" = "both" ]; } \
+    && [ -f "$PROJECT_PATH/flake.nix" ] && [ -f "$PROJECT_PATH/flake.lock" ] \
+    && grep -qE '^[[:space:]]*vigos\.url[[:space:]]*=[[:space:]]*"github:vig-os/devkit"' \
+        "$PROJECT_PATH/flake.nix"; then
+    if command -v nix >/dev/null 2>&1; then
+        info "Advancing the floating vigos flake input (nix flake update vigos)..."
+        if nix --extra-experimental-features "nix-command flakes" \
+            flake update vigos --flake "$PROJECT_PATH"; then
+            info "flake.lock advanced; review and commit it with the upgrade."
+        else
+            warn "nix flake update vigos failed (non-fatal)"
+            echo "  The dev-shell toolchain still points at the previously locked release."
+            echo "  Advance it manually:"
+            echo "    cd $PROJECT_PATH && nix flake update vigos"
+        fi
+    else
+        warn "nix not found on PATH; the dev-shell toolchain keeps the previously locked release"
+        echo "  Advance it from a machine with nix:"
+        echo "    cd $PROJECT_PATH && nix flake update vigos"
+    fi
+fi
+
 # ── Done ──────────────────────────────────────────────────────────────────────
 
 echo ""

--- a/tests/bats/install.bats
+++ b/tests/bats/install.bats
@@ -934,3 +934,116 @@ STUB
     [ -n "$git_line" ]
     [ "$chown_line" -lt "$git_line" ]
 }
+
+# ── floating vigos flake-lock advance on upgrade (#1263) ──────────────────────
+# A --force upgrade advances .vig-os DEVKIT_VERSION (the scaffold + image), but
+# a FLOATING `vigos` input's dev shell is governed by flake.lock, which stays
+# wherever the last `nix flake update vigos` left it — so direnv consumers
+# silently keep running the previous release's toolchain (vig-utils, hook
+# sets). install.sh must advance the lock HOST-SIDE after the scaffold (the
+# container must not write it: network dependence + ownership hazards,
+# #1235/#1248) when the workspace is a direnv/both consumer with a floating
+# input and an existing flake.lock. Pinned (?ref=) inputs stay the consumer's
+# explicit choice (covered by the #1093 scaffold warning); a missing lock
+# (fresh scaffold) locks current content on first shell entry anyway.
+# Exercised against a stub `docker` (scaffold no-op) + logging stub `nix`.
+
+# Build an upgradeable consumer fixture at $1: clean feature-branch repo with a
+# .vig-os manifest (mode $4, default direnv), a flake.nix whose vigos input is
+# $2 (a full `vigos.url = ...` line), and — unless $3=nolock — a flake.lock.
+_make_flake_workspace() {
+    local dir="$1" url_line="$2" with_lock="${3:-lock}" mode="${4:-direnv}"
+    _make_repo "$dir"
+    printf 'DEVKIT_VERSION=1.4.1\nDEVKIT_MODE=%s\n' "$mode" >"$dir/.vig-os"
+    cat >"$dir/flake.nix" <<FLAKE
+{
+  inputs = {
+    #   vigos.url = "github:vig-os/devkit?ref=<tag>";
+    $url_line
+    nixpkgs.follows = "vigos/nixpkgs";
+  };
+}
+FLAKE
+    if [ "$with_lock" = "lock" ]; then
+        echo '{}' >"$dir/flake.lock"
+    fi
+    _git -C "$dir" add -A
+    _git -C "$dir" commit -q -m "chore: fixture"
+}
+
+# Run install.sh against stub docker + a logging stub nix (exit code $3).
+# Extra install.sh args (e.g. --force) follow.
+_run_install_nix_stub() {
+    local dir="$1" nixlog="$2" nix_exit="${3:-0}"
+    shift 3
+    local stub="$BATS_TEST_TMPDIR/stub-flake-bin"
+    mkdir -p "$stub"
+    printf '#!/usr/bin/env bash\nexit 0\n' >"$stub/docker"
+    chmod +x "$stub/docker"
+    cat >"$stub/nix" <<STUB
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "$nixlog"
+exit $nix_exit
+STUB
+    chmod +x "$stub/nix"
+    run env PATH="$stub:$PATH" bash "$INSTALL_SH" --docker --skip-pull "$@" "$dir" </dev/null
+}
+
+@test "upgrade advances a floating vigos flake lock (#1263)" {
+    dir="$BATS_TEST_TMPDIR/flake-floating"
+    log="$BATS_TEST_TMPDIR/flake-floating-nix.log"
+    _make_flake_workspace "$dir" 'vigos.url = "github:vig-os/devkit";'
+    _run_install_nix_stub "$dir" "$log" 0 --force
+    assert_success
+    run grep -F "flake update vigos --flake $dir" "$log"
+    assert_success
+}
+
+@test "upgrade leaves a pinned vigos input alone (#1263)" {
+    dir="$BATS_TEST_TMPDIR/flake-pinned"
+    log="$BATS_TEST_TMPDIR/flake-pinned-nix.log"
+    _make_flake_workspace "$dir" 'vigos.url = "github:vig-os/devkit?ref=1.4.1";'
+    _run_install_nix_stub "$dir" "$log" 0 --force
+    assert_success
+    run grep -F "flake update" "$log"
+    assert_failure
+}
+
+@test "upgrade without a flake.lock skips the advance (#1263)" {
+    dir="$BATS_TEST_TMPDIR/flake-nolock"
+    log="$BATS_TEST_TMPDIR/flake-nolock-nix.log"
+    _make_flake_workspace "$dir" 'vigos.url = "github:vig-os/devkit";' nolock
+    _run_install_nix_stub "$dir" "$log" 0 --force
+    assert_success
+    run grep -F "flake update" "$log"
+    assert_failure
+}
+
+@test "fresh install (no --force) runs no lock advance (#1263)" {
+    dir="$BATS_TEST_TMPDIR/flake-fresh"
+    log="$BATS_TEST_TMPDIR/flake-fresh-nix.log"
+    _make_flake_workspace "$dir" 'vigos.url = "github:vig-os/devkit";'
+    _run_install_nix_stub "$dir" "$log" 0
+    assert_success
+    run grep -F "flake update" "$log"
+    assert_failure
+}
+
+@test "devcontainer-mode upgrade runs no lock advance (#1263)" {
+    dir="$BATS_TEST_TMPDIR/flake-container-mode"
+    log="$BATS_TEST_TMPDIR/flake-container-mode-nix.log"
+    _make_flake_workspace "$dir" 'vigos.url = "github:vig-os/devkit";' lock devcontainer
+    _run_install_nix_stub "$dir" "$log" 0 --force
+    assert_success
+    run grep -F "flake update" "$log"
+    assert_failure
+}
+
+@test "failed lock advance is non-fatal and prints the manual step (#1263)" {
+    dir="$BATS_TEST_TMPDIR/flake-fail"
+    log="$BATS_TEST_TMPDIR/flake-fail-nix.log"
+    _make_flake_workspace "$dir" 'vigos.url = "github:vig-os/devkit";'
+    _run_install_nix_stub "$dir" "$log" 1 --force
+    assert_success
+    assert_output --partial "nix flake update vigos"
+}

--- a/tests/test_flake_version_guard.py
+++ b/tests/test_flake_version_guard.py
@@ -1,0 +1,102 @@
+"""Shell-entry version-skew guard tests for ``mkProjectShell`` (#1263).
+
+A direnv consumer's ``.vig-os`` ``DEVKIT_VERSION`` (advanced by the scaffold
+upgrade) and its ``vigos`` flake input (frozen by ``flake.lock``) deliver
+coupled halves of the same release. A floating input silently lags: the lock
+stays wherever the last ``nix flake update vigos`` saw it, so the dev shell
+runs last release's toolchain against this release's scaffold (#1263 — the
+1.4.0 ``setup-labels`` planning label deletion under a 1.4.1 scaffold).
+
+``mkProjectShell`` therefore bakes its own release version (read at eval time
+from the devkit repo's ``.vig-os``, i.e. the locked input rev) into the
+shellHook and compares it against the workspace ``.vig-os`` on every shell
+entry, warning on a mismatch. These tests enter the devkit's own dev shell
+(``devShells.default`` is a plain ``mkProjectShell`` instantiation) from a
+synthetic workspace directory and assert the warning fires — and stays silent —
+in the right cases.
+
+The suite is skipped when ``nix`` is not on PATH, like the other flake suites.
+
+Refs: #1263
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+from .test_flake_devshell import REPO_ROOT, _nix_env
+
+# The stable marker the guard prints; keep in sync with flake.nix.
+WARNING_MARKER = "dev-shell toolchain is devkit"
+REMEDY_MARKER = "nix flake update vigos"
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("nix") is None,
+    reason="nix is not installed; dev-shell guard tests require Nix",
+)
+
+
+def _devkit_version() -> str:
+    """The devkit's own release version, from the repo-root ``.vig-os``."""
+    manifest = (REPO_ROOT / ".vig-os").read_text()
+    match = re.search(r"^DEVKIT_VERSION=(.+)$", manifest, flags=re.MULTILINE)
+    assert match, "repo-root .vig-os must carry DEVKIT_VERSION"
+    return match.group(1).strip()
+
+
+def _enter_shell(workspace: Path) -> str:
+    """Enter the devkit dev shell from ``workspace`` and return its stderr."""
+    result = subprocess.run(
+        ["nix", "develop", str(REPO_ROOT), "-c", "bash", "-c", ":"],
+        capture_output=True,
+        text=True,
+        env=_nix_env(),
+        cwd=workspace,
+        timeout=900,
+    )
+    assert result.returncode == 0, (
+        f"nix develop failed from {workspace}:\n{result.stderr}"
+    )
+    return result.stderr
+
+
+def test_warns_when_workspace_pin_differs(tmp_path: Path) -> None:
+    """A workspace pinned to a different final release gets the skew warning."""
+    (tmp_path / ".vig-os").write_text("DEVKIT_VERSION=0.0.1\nDEVKIT_MODE=direnv\n")
+    stderr = _enter_shell(tmp_path)
+    assert WARNING_MARKER in stderr
+    assert _devkit_version() in stderr
+    assert "DEVKIT_VERSION=0.0.1" in stderr
+    assert REMEDY_MARKER in stderr
+
+
+def test_silent_when_workspace_pin_matches(tmp_path: Path) -> None:
+    """A workspace pinned to the shell's own release stays silent."""
+    (tmp_path / ".vig-os").write_text(
+        f"DEVKIT_VERSION={_devkit_version()}\nDEVKIT_MODE=direnv\n"
+    )
+    stderr = _enter_shell(tmp_path)
+    assert WARNING_MARKER not in stderr
+
+
+def test_silent_on_prerelease_pin(tmp_path: Path) -> None:
+    """An ``-rc`` pin never warns: release-train lanes deliberately bump to rc
+    tags the floating input cannot follow (rc content lives on the release
+    branch, not the default branch a ``nix flake update vigos`` fetches)."""
+    (tmp_path / ".vig-os").write_text("DEVKIT_VERSION=99.0.0-rc1\n")
+    stderr = _enter_shell(tmp_path)
+    assert WARNING_MARKER not in stderr
+
+
+def test_silent_without_manifest(tmp_path: Path) -> None:
+    """A bare ``mkProjectShell`` consumer (no ``.vig-os``) is left alone."""
+    stderr = _enter_shell(tmp_path)
+    assert WARNING_MARKER not in stderr


### PR DESCRIPTION
Closes #1263

## Problem

Consumer adoption advances the `.vig-os` `DEVKIT_VERSION` pin (image + scaffold) but never touches the consumer's `flake.lock`, which governs the direnv dev shell. A floating `vigos` input stays wherever the last `nix flake update vigos` saw it, so every direnv consumer's shell silently runs the previous release's toolchain — live symptom: org-config's 1.4.0 `setup-labels` ignored the #1254 taxonomy extension and planned to delete the repo's own labels one release after the protecting feature shipped. The existing #1093 scaffold warning deliberately covers pinned (`?ref=`) inputs only.

## Fix (three coordinated layers, per the spike on #1263)

1. **`mkProjectShell` shell-entry version-skew guard** (`flake.nix`) — the shellHook bakes the flake's own release version (the devkit repo-root `.vig-os` at the locked input rev, read purely at eval) and compares it against the workspace `.vig-os` pin on every shell entry, warning with the `nix flake update vigos` remedy until the lock advances. Silent for matching versions, prerelease (`-rc*`) pins (release-train lanes bump to rc tags a floating update cannot reach — rc content lives on the release branch), and bare consumers without a manifest. Warn-only, never fails the shell. This is the authoritative detector: it is the one place both halves of the skew are visible without network access.
2. **Host-side lock advance on upgrade** (`install.sh`) — a `--force` upgrade of a direnv/`both` consumer with a floating input and an existing `flake.lock` now runs `nix flake update vigos` after the scaffold, host-side (a direnv consumer has nix by definition; the scaffold container must not write the lock — network dependence + ownership hazards, #1235/#1248). Non-fatal when nix is missing or the update fails: the manual step is printed. Pinned inputs and fresh scaffolds (no lock yet) are untouched.
3. **Docs** — `docs/MIGRATION.md` now describes the two coupled delivery channels in the Updating checklist and corrects the lockstep section's claim that a floating input "needs no manual bump — it is exempt" (it skews via `flake.lock`). The #1093 comment in `init-workspace.sh` gets the same correction. Changelog entry under Unreleased.

## Verification

- `tests/test_flake_version_guard.py` (new, nix-gated like the other flake suites): warns on a mismatched final pin (both versions + remedy in stderr), silent on matching pin / `-rc*` pin / no manifest — 4/4 green, plus `test_flake_devshell.py` + `test_flake_hooks.py` parity suites green (53 passed, 1 skipped).
- `tests/bats/install.bats` (+6, TDD): floating+lock+`--force` invokes `nix flake update vigos --flake <dir>`; pinned input, missing lock, fresh install, and devcontainer mode all skip; a failing update stays non-fatal and prints the manual step — full file 109/109 green against stub `docker`/`nix`.
- `prek run --all-files` green on the final tree.

Note for the release train: the shell-side guard is itself flake-delivered, so existing consumers first see it after their next lock advance — which the upgrade path in this PR now performs for them.