### PR TITLE
fix(workflow): guard sync-issues cleanup step against missing retry shim

### DIFF
--- a/.github/workflows/sync-issues.yml
+++ b/.github/workflows/sync-issues.yml
@@ -87,6 +87,14 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          # This step runs `if: always()`, so it can fire after the job died
+          # before toolchain setup — before the `retry` shim exists. Without a
+          # fallback, `retry` in the CACHE_ID assignment below would emit
+          # "command not found" and `head` would still exit 0, silently masking
+          # the failure. Define a one-shot fallback (no retries) so a healthy
+          # run still uses the real shim and an early-failure run degrades
+          # gracefully. This cleanup is best-effort (continue-on-error).
+          command -v retry >/dev/null 2>&1 || retry() { while [ "$#" -gt 0 ] && [ "$1" != "--" ]; do shift; done; shift; "$@"; }
           echo "Attempting to delete old cache to prevent save collisions..."
           # Wait a moment to ensure any previous cache saves have completed
           sleep 2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **sync-issues cache cleanup no longer silently skips on early job failure** ([#1278](https://github.com/vig-os/devkit/issues/1278))
+  - The `if: always()` "Delete old cache" step calls the `retry` shim, which
+    only exists after toolchain setup. When the job died beforehand the shim
+    was absent and the `retry ... | head -1` assignment masked the
+    `command not found`, so the step took the "No cache found" branch. A
+    one-shot fallback shim now runs a single unretried attempt when `retry` is
+    missing; healthy runs still use the real wrapper.
+
 ### Security
 
 ## [1.4.2](https://github.com/vig-os/devkit/releases/tag/1.4.2) - 2026-07-26

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -17,6 +17,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **sync-issues cache cleanup no longer silently skips on early job failure** ([#1278](https://github.com/vig-os/devkit/issues/1278))
+  - The `if: always()` "Delete old cache" step calls the `retry` shim, which
+    only exists after toolchain setup. When the job died beforehand the shim
+    was absent and the `retry ... | head -1` assignment masked the
+    `command not found`, so the step took the "No cache found" branch. A
+    one-shot fallback shim now runs a single unretried attempt when `retry` is
+    missing; healthy runs still use the real wrapper.
+
 ### Security
 
 ## [1.4.2](https://github.com/vig-os/devkit/releases/tag/1.4.2) - 2026-07-26

--- a/assets/workspace/.github/workflows/sync-issues.yml
+++ b/assets/workspace/.github/workflows/sync-issues.yml
@@ -124,6 +124,14 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          # This step runs `if: always()`, so it can fire after the job died
+          # before toolchain setup — before the `retry` shim exists. Without a
+          # fallback, `retry` in the CACHE_ID assignment below would emit
+          # "command not found" and `head` would still exit 0, silently masking
+          # the failure. Define a one-shot fallback (no retries) so a healthy
+          # run still uses the real shim and an early-failure run degrades
+          # gracefully. This cleanup is best-effort (continue-on-error).
+          command -v retry >/dev/null 2>&1 || retry() { while [ "$#" -gt 0 ] && [ "$1" != "--" ]; do shift; done; shift; "$@"; }
           echo "Attempting to delete old cache to prevent save collisions..."
           # Wait a moment to ensure any previous cache saves have completed
           sleep 2

--- a/tests/bats/init-workspace.bats
+++ b/tests/bats/init-workspace.bats
@@ -2347,6 +2347,21 @@ _upgrade_no_flags() {
     assert_output --partial "Invalid DEVKIT_SYNC_SCHEDULE"
 }
 
+# ── cache-cleanup retry fallback shim (#1278) ─────────────────────────────────
+# The "Delete old cache" cleanup step runs `if: always()` and calls the `retry`
+# wrapper, which only exists after toolchain setup. A job that dies before setup
+# leaves the shim absent, so the step must define a one-shot fallback so the
+# `retry ... | head -1` assignment cannot silently mask a `command not found`.
+
+@test "sync-issues cleanup step guards against a missing retry shim (#1278)" {
+    ws="$BATS_TEST_TMPDIR/e2e-1278-retry-fallback"
+    mkdir -p "$ws"
+    run _scaffold both "$ws"
+    assert_success
+    run grep -qF 'command -v retry >/dev/null 2>&1 || retry()' "$ws/.github/workflows/sync-issues.yml"
+    assert_success
+}
+
 # ── legacy mode inference (#885) ──────────────────────────────────────────────
 # Consumers scaffolded before the manifest carry a version-only .vig-os (or
 # none): an upgrade without --mode must infer the delivery mode from the tree


### PR DESCRIPTION
## Summary

The `if: always()` "Delete old cache" cleanup step in `sync-issues.yml` calls the `retry` wrapper, which only exists after toolchain setup (BASH_ENV shim from `setup-devkit-toolchain` in the template / `setup-env` in devkit's own copy). When the job fails before setup — e.g. the exo-pet/vault "Generate a token" failures of 2026-07-26 — the step degraded to `retry: command not found`, and the `CACHE_ID=$(retry … | head -1)` pipeline masked the error via `head`'s exit 0, silently skipping the anti-collision deletion.

A one-shot fallback shim (`command -v retry >/dev/null 2>&1 || retry() { …; }`) is now prepended to the step's `run:` block in **both** copies (scaffold template + devkit's own workflow — scope approved in review). Healthy runs are unchanged (the real shim wins); early-failure runs degrade to a single unretried attempt instead of a masked error. `if: always()` and `continue-on-error: true` stay as designed.

## Changes

- `assets/workspace/.github/workflows/sync-issues.yml` — fallback shim in the cleanup step (scaffold template)
- `.github/workflows/sync-issues.yml` — same fix in devkit's own (independently maintained) copy
- `tests/bats/init-workspace.bats` — new test: rendered scaffold's cleanup step carries the fallback guard (TDD: committed RED first)
- `CHANGELOG.md` + `assets/workspace/.devcontainer/CHANGELOG.md` — `### Fixed` entry (mirror kept in sync by the sync-manifest hook)

## Verification

- TDD: test committed failing (`34541bb9`), fix turns it green (`1eb61c65`)
- Full `bats tests/bats/init-workspace.bats`: 244/244 ok
- zizmor 1.25.2 (CI gate config) on `assets/workspace/.github/workflows/`: no findings
- actionlint on both changed workflow files: clean
- `prek run --all-files`: all hooks green

Closes #1278