### PR TITLE
fix(workflow): route sync target input through env in bootstrap step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **Route the sync-issues bootstrap step's target input through env, not inline** ([#1279](https://github.com/vig-os/devkit/issues/1279))
+  - The scaffolded `sync-issues.yml` "Bootstrap sync target branch if absent"
+    step (rendered only when `DEVKIT_SYNC_TARGET` is set) interpolated the
+    `workflow_dispatch` `target-branch` input straight into its `run:` block,
+    which `zizmor` flags as a template-injection (High). The input is now
+    forwarded via a `TARGET_INPUT` env var and referenced as a shell parameter
+    expansion (`TARGET="${TARGET_INPUT:-<target>}"`), matching the template's
+    existing `TARGET_BRANCH` pattern; the allowlist-validated scaffold default
+    stays the safe literal fallback. First consumer hit: vig-os/org-config#80,
+    which carried a local forward-port of this fix until the template shipped it.
+
 ## [1.4.2](https://github.com/vig-os/devkit/releases/tag/1.4.2) - 2026-07-26
 
 ### Changed

--- a/assets/init-workspace.sh
+++ b/assets/init-workspace.sh
@@ -1221,9 +1221,14 @@ render_sync_settings() {
       - name: Bootstrap sync target branch if absent
         env:
           GH_TOKEN: \${{ steps.generate-token.outputs.token }}
+          # Env indirection instead of inline \${{ }} in the run block: the
+          # dispatch input would otherwise expand as code (zizmor
+          # template-injection, High). The scaffold-time default is the safe,
+          # allowlist-validated literal shell fallback.
+          TARGET_INPUT: \${{ github.event.inputs.target-branch }}
         run: |
           set -euo pipefail
-          TARGET="\${{ github.event.inputs.target-branch || '${MANIFEST_SYNC_TARGET}' }}"
+          TARGET="\${TARGET_INPUT:-${MANIFEST_SYNC_TARGET}}"
           if gh api "repos/\${{ github.repository }}/git/ref/heads/\${TARGET}" >/dev/null 2>&1; then
             echo "Sync target branch '\${TARGET}' already exists."
           else

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -19,6 +19,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **Route the sync-issues bootstrap step's target input through env, not inline** ([#1279](https://github.com/vig-os/devkit/issues/1279))
+  - The scaffolded `sync-issues.yml` "Bootstrap sync target branch if absent"
+    step (rendered only when `DEVKIT_SYNC_TARGET` is set) interpolated the
+    `workflow_dispatch` `target-branch` input straight into its `run:` block,
+    which `zizmor` flags as a template-injection (High). The input is now
+    forwarded via a `TARGET_INPUT` env var and referenced as a shell parameter
+    expansion (`TARGET="${TARGET_INPUT:-<target>}"`), matching the template's
+    existing `TARGET_BRANCH` pattern; the allowlist-validated scaffold default
+    stays the safe literal fallback. First consumer hit: vig-os/org-config#80,
+    which carried a local forward-port of this fix until the template shipped it.
+
 ## [1.4.2](https://github.com/vig-os/devkit/releases/tag/1.4.2) - 2026-07-26
 
 ### Changed

--- a/tests/bats/init-workspace.bats
+++ b/tests/bats/init-workspace.bats
@@ -2295,6 +2295,32 @@ _upgrade_no_flags() {
     assert_success
 }
 
+@test "the bootstrap step routes the target input through env, not inline (#1279)" {
+    # zizmor flags a template-injection (High) when the workflow_dispatch input
+    # is interpolated straight into the run: block. The bootstrap step must
+    # instead forward the input via an env var and reference it as a shell
+    # parameter expansion, matching the template's existing TARGET_BRANCH pattern.
+    ws="$BATS_TEST_TMPDIR/e2e-1279-env-indirection"
+    mkdir -p "$ws"
+    run _scaffold both "$ws"
+    assert_success
+    sed -i 's#^DEVKIT_SYNC_TARGET=.*#DEVKIT_SYNC_TARGET=sync/issue-mirror#' "$ws/.vig-os"
+    run _upgrade_no_flags "$ws"
+    assert_success
+    si="$ws/.github/workflows/sync-issues.yml"
+    # (a) the bootstrap step forwards the dispatch input via env
+    # shellcheck disable=SC2016  # literal GitHub expression, not a shell expansion
+    run grep -qF 'TARGET_INPUT: ${{ github.event.inputs.target-branch }}' "$si"
+    assert_success
+    # (b) the run body no longer interpolates the input directly into the shell
+    run grep -qF "TARGET=\"\${{ github.event.inputs" "$si"
+    assert_failure
+    # (c) the scaffold-time default still lands, via shell parameter expansion
+    # shellcheck disable=SC2016  # literal shell parameter expansion in rendered YAML
+    run grep -qF 'TARGET="${TARGET_INPUT:-sync/issue-mirror}"' "$si"
+    assert_success
+}
+
 @test "a custom DEVKIT_SYNC_SCHEDULE overrides the sync cron (#1228)" {
     ws="$BATS_TEST_TMPDIR/e2e-1228-schedule"
     mkdir -p "$ws"


### PR DESCRIPTION
## Summary

The `DEVKIT_SYNC_TARGET` mirror-bootstrap step (injected at scaffold time by `render_sync_settings()` in `assets/init-workspace.sh`) interpolated the `target-branch` workflow_dispatch input directly into its `run:` block — a zizmor **template-injection (High)** in the rendered consumer workflow. First hit in the wild: vig-os/org-config#80, which carries a local forward-port of this exact fix until the template ships it. The #1182 hardening sweep never saw it because the step only renders when the knob is set.

The heredoc now uses standard env indirection, matching the template's existing `TARGET_BRANCH:` pattern: the dispatch input is forwarded as `TARGET_INPUT` in the step's `env:`, and the run body reads `TARGET="${TARGET_INPUT:-<manifest-target>}"`. The scaffold-time default is safe as a literal — `DEVKIT_SYNC_TARGET` is allowlist-validated (`[A-Za-z0-9._/-]`) at scaffold time. Cron-triggered runs still fall back to the default (empty input → `:-` expansion).

## Changes

- `assets/init-workspace.sh` — env indirection in the bootstrap-step heredoc
- `tests/bats/init-workspace.bats` — new test: rendered bootstrap step forwards the input via env, has no inline `${{ github.event.inputs` in the run body, and still lands the default (TDD: committed RED first)
- `CHANGELOG.md` + `assets/workspace/.devcontainer/CHANGELOG.md` — `### Security` entry (mirror synced by the sync-manifest hook)

## Verification

- TDD: test committed failing (`26bdb254`), fix turns it green (`953a930a`)
- Full `bats tests/bats/init-workspace.bats`: 244/244 ok, including the hostile-`DEVKIT_SYNC_TARGET` guard test
- Rendered scaffold (with `DEVKIT_SYNC_TARGET=sync/issue-mirror`) structural check: 0 inline `${{ github.event.inputs` in the run body, 1 `TARGET_INPUT:` env forward; rendered form is functionally identical to org-config#80's forward-port
- shellcheck on `assets/init-workspace.sh`: clean; `prek run --all-files`: all hooks green

## Rollout note

org-config#80 can drop its local forward-port once this ships — and conversely, org-config's next devkit upgrade would re-introduce the zizmor finding if this doesn't ship first.

Closes #1279