### PR TITLE
fix(workspace): guard undotted typos.toml against dual configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Undotted `typos.toml` no longer collides with the template `.typos.toml`** ([#1280](https://github.com/vig-os/devkit/issues/1280))
+  - The `typos` tool reads config from `.typos.toml`, `_typos.toml`, or the
+    undotted `typos.toml`. The scaffold guarded the first two (a preserved
+    `.typos.toml` via the preserve list; a legacy `_typos.toml` via a copy-time
+    exclude) but not the undotted spelling, so a consumer carrying `typos.toml`
+    also received the template `.typos.toml` — two active configs, the curated
+    allowlist silently shadowed. An undotted `typos.toml` (with no `.typos.toml`)
+    is now treated exactly like the legacy `_typos.toml` case: the consumer file
+    stays the single active config, the template copy is not shipped, and the
+    skip is mirrored in `--preview` and named in the scaffold surface message.
+
 - **sync-issues cache cleanup no longer silently skips on early job failure** ([#1278](https://github.com/vig-os/devkit/issues/1278))
   - The `if: always()` "Delete old cache" step calls the `retry` shim, which
     only exists after toolchain setup. When the job died beforehand the shim

--- a/assets/init-workspace.sh
+++ b/assets/init-workspace.sh
@@ -109,7 +109,9 @@ PRESERVE_FILES=(
     # repo-specific extend-words/extend-exclude that a template overwrite
     # silently destroyed, so the typos hook then flagged legitimate domain
     # terms. Preserved like .pre-commit-config.yaml; the upgrade prints a diff
-    # against the template below. (Legacy `_typos.toml` handled at copy time.)
+    # against the template below. (The alternate spellings the `typos` tool also
+    # reads — legacy `_typos.toml` and undotted `typos.toml` — are handled at
+    # copy time, #913/#1280.)
     ".typos.toml"
     # The consumer owns its lint-rule exceptions (#1099): repos add repo-specific
     # yamllint `ignore:` globs / rule disables and pymarkdown rule tweaks that a
@@ -1041,11 +1043,19 @@ MODE_CONFIG_EXCLUDES=()
 if [[ "$MODE" == "direnv" || "$MODE" == "bare" ]]; then
     MODE_CONFIG_EXCLUDES+=(".devcontainer" "docs/container-ci-quirks.md")
 fi
-# Legacy typos config (#913): the `typos` tool reads .typos.toml AND _typos.toml.
-# A consumer still carrying _typos.toml (and no .typos.toml) keeps it as the
-# single config — do not also ship the template .typos.toml, or two active
-# configs collide. (A *preserved* .typos.toml is handled by the preserve list.)
-if [[ -f "$WORKSPACE_DIR/_typos.toml" && ! -f "$WORKSPACE_DIR/.typos.toml" ]]; then
+# Alternate typos config spellings (#913, #1280): the `typos` tool reads
+# .typos.toml, the legacy _typos.toml AND the undotted typos.toml. A consumer
+# carrying an alternate spelling (and no .typos.toml) keeps it as the single
+# config — do not also ship the template .typos.toml, or two active configs
+# collide (the curated allowlist gets silently shadowed). Record which
+# spelling(s) triggered the skip so the copy can name them; (a *preserved*
+# .typos.toml is handled by the preserve list).
+TYPOS_ALT_CONFIGS=()
+if [[ ! -f "$WORKSPACE_DIR/.typos.toml" ]]; then
+    [[ -f "$WORKSPACE_DIR/typos.toml" ]] && TYPOS_ALT_CONFIGS+=("typos.toml")
+    [[ -f "$WORKSPACE_DIR/_typos.toml" ]] && TYPOS_ALT_CONFIGS+=("_typos.toml")
+fi
+if [[ ${#TYPOS_ALT_CONFIGS[@]} -gt 0 ]]; then
     MODE_CONFIG_EXCLUDES+=(".typos.toml")
 fi
 # Flake-hooks consumer with an ABSENT generated config (#1255): the consumer's
@@ -1261,10 +1271,11 @@ if [[ "$FORCE" == "true" ]]; then
 
         # Mode/config copy excludes (#1196): skip the template paths the real
         # rsync copy skips for the resolved mode and the consumer's config
-        # (.devcontainer/ #738, docs/container-ci-quirks.md #989, the legacy
-        # .typos.toml #913), so --preview never lists them as ADDED. SSoT:
-        # MODE_CONFIG_EXCLUDES, also consumed by the rsync copy below; a
-        # directory entry (.devcontainer) matches its whole subtree.
+        # (.devcontainer/ #738, docs/container-ci-quirks.md #989, the template
+        # .typos.toml when the consumer carries an alternate spelling #913/#1280),
+        # so --preview never lists them as ADDED. SSoT: MODE_CONFIG_EXCLUDES, also
+        # consumed by the rsync copy below; a directory entry (.devcontainer)
+        # matches its whole subtree.
         skip_excluded=false
         for excl in "${MODE_CONFIG_EXCLUDES[@]}"; do
             if [[ "$rel_path" == "$excl" || "$rel_path" == "$excl"/* ]]; then
@@ -1509,16 +1520,17 @@ else
     # Mode/config copy excludes (#1196): the same SSoT the --preview ADDED report
     # consults (MODE_CONFIG_EXCLUDES) — so preview and copy never disagree —
     # covering the mode-pruned .devcontainer/ (#738) and container-ci-quirks.md
-    # (#989) plus the legacy .typos.toml (#913). Root-anchored (leading slash) to
+    # (#989) plus the template .typos.toml when the consumer carries an alternate
+    # spelling (#913/#1280). Root-anchored (leading slash) to
     # match is_preserved_file's exact transfer-root semantics (#953); a directory
     # entry (.devcontainer) excludes its whole subtree. Excluding these from the
     # copy (rather than copying-then-pruning) keeps a real .devcontainer/ intact.
     for excl in "${MODE_CONFIG_EXCLUDES[@]}"; do
         EXCLUDE_ARGS+=("--exclude=/$excl")
-        # Surface the otherwise-silent legacy-typos skip so the consumer knows
-        # their _typos.toml stands as the single config (#913).
+        # Surface the otherwise-silent alternate-typos skip so the consumer knows
+        # which spelling of their config stands as the single config (#913, #1280).
         if [[ "$excl" == ".typos.toml" ]]; then
-            echo "Consumer carries legacy _typos.toml; not shipping template .typos.toml (#913)."
+            echo "Consumer carries ${TYPOS_ALT_CONFIGS[*]}; not shipping template .typos.toml (#1280)."
         fi
         # Surface the flake-hooks skip so the upgrade report explains the
         # missing template YAML (#1255).

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -17,6 +17,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Undotted `typos.toml` no longer collides with the template `.typos.toml`** ([#1280](https://github.com/vig-os/devkit/issues/1280))
+  - The `typos` tool reads config from `.typos.toml`, `_typos.toml`, or the
+    undotted `typos.toml`. The scaffold guarded the first two (a preserved
+    `.typos.toml` via the preserve list; a legacy `_typos.toml` via a copy-time
+    exclude) but not the undotted spelling, so a consumer carrying `typos.toml`
+    also received the template `.typos.toml` — two active configs, the curated
+    allowlist silently shadowed. An undotted `typos.toml` (with no `.typos.toml`)
+    is now treated exactly like the legacy `_typos.toml` case: the consumer file
+    stays the single active config, the template copy is not shipped, and the
+    skip is mirrored in `--preview` and named in the scaffold surface message.
+
 - **sync-issues cache cleanup no longer silently skips on early job failure** ([#1278](https://github.com/vig-os/devkit/issues/1278))
   - The `if: always()` "Delete old cache" step calls the `retry` shim, which
     only exists after toolchain setup. When the job died beforehand the shim

--- a/tests/bats/init-workspace.bats
+++ b/tests/bats/init-workspace.bats
@@ -1717,6 +1717,72 @@ EOF
     refute_output --partial "+  .typos.toml"
 }
 
+# ── the undotted `typos.toml` spelling gets the same guard as _typos.toml (#1280) ─
+# The `typos` tool reads .typos.toml, _typos.toml AND undotted typos.toml. The
+# #913 guard only covered _typos.toml; a consumer carrying undotted typos.toml
+# (and no .typos.toml) still received the template .typos.toml alongside it,
+# leaving two active configs (the curated allowlist silently shadowed). Treat
+# undotted typos.toml exactly like the legacy _typos.toml case.
+
+@test "upgrade with an undotted typos.toml does not leave dual typos configs (#1280)" {
+    # consumer carries typos.toml and no .typos.toml. Shipping the template
+    # .typos.toml alongside it would give two active configs.
+    ws="$BATS_TEST_TMPDIR/e2e-1280-undotted"
+    mkdir -p "$ws"
+    printf '# SENTINEL-1280 undotted typos config\n[default.extend-words]\nmyterm = "myterm"\n' \
+        >"$ws/typos.toml"
+    run _upgrade both "$ws"
+    assert_success
+    # undotted config preserved verbatim
+    run grep -q 'SENTINEL-1280' "$ws/typos.toml"
+    assert_success
+    # template .typos.toml NOT shipped -> single active config
+    run test -e "$ws/.typos.toml"
+    assert_failure
+}
+
+@test "--preview does not list template .typos.toml as ADDED under an undotted typos.toml (#1280)" {
+    # Preview must mirror the copy's exclude set: the real copy skips the
+    # template .typos.toml when the consumer carries undotted typos.toml (and no
+    # .typos.toml), so --preview must not advertise it as ADDED.
+    ws="$BATS_TEST_TMPDIR/e2e-1280-preview-undotted"
+    mkdir -p "$ws"
+    printf '# SENTINEL-1280 undotted typos config\n' >"$ws/typos.toml"
+    run _preview "$ws" --mode both
+    assert_success
+    refute_output --partial "+  .typos.toml"
+}
+
+@test "upgrade surface message names the undotted typos.toml (#1280)" {
+    # The otherwise-silent skip is surfaced so the consumer knows their undotted
+    # typos.toml stands as the single config.
+    ws="$BATS_TEST_TMPDIR/e2e-1280-message"
+    mkdir -p "$ws"
+    printf '# SENTINEL-1280 undotted typos config\n' >"$ws/typos.toml"
+    run _upgrade both "$ws"
+    assert_success
+    assert_output --partial 'typos.toml'
+    assert_output --partial 'not shipping template .typos.toml'
+    assert_output --partial '#1280'
+}
+
+@test "upgrade with BOTH typos.toml and .typos.toml preserves .typos.toml, no misfire (#1280)" {
+    # When a curated .typos.toml IS present it takes precedence: it is preserved
+    # via the preserve list (#913) and the undotted-file exclusion must not
+    # misfire (the guard is gated on .typos.toml being absent).
+    ws="$BATS_TEST_TMPDIR/e2e-1280-combo"
+    mkdir -p "$ws"
+    printf '# SENTINEL-1280-DOTTED curated typos config\n' >"$ws/.typos.toml"
+    printf '# SENTINEL-1280-UNDOTTED stale typos config\n' >"$ws/typos.toml"
+    run _upgrade both "$ws"
+    assert_success
+    # curated .typos.toml preserved verbatim (preserve-list path)
+    run grep -q 'SENTINEL-1280-DOTTED' "$ws/.typos.toml"
+    assert_success
+    # the undotted-file exclusion did not misfire
+    refute_output --partial 'not shipping template .typos.toml'
+}
+
 # ── upgrade must preserve customized lint configs .yamllint / .pymarkdown (#1099) ─
 # Same class as #878/#913: these are fully-managed scaffold files, yet lint
 # CONFIGS a consumer legitimately customizes (repo-specific `ignore:` globs, rule


### PR DESCRIPTION
## Summary

The `typos` tool reads its config from `typos.toml`, `.typos.toml`, or `_typos.toml`. The scaffold guarded the preserved `.typos.toml` (#913) and the legacy `_typos.toml` (copy-time exclude), but an undotted `typos.toml` escaped the guard: the template `.typos.toml` was shipped alongside it, leaving two active configs and silently shadowing the consumer's curated allowlist.

The #913 copy-time branch now treats any alternate spelling (`typos.toml` and/or `_typos.toml`, with no `.typos.toml` present) as the consumer's single active config: the template copy is not shipped, the skip is mirrored in `--preview` via the shared `MODE_CONFIG_EXCLUDES` SSoT, and the scaffold surface message names the triggering file(s).

## Changes

- `assets/init-workspace.sh`: extend the legacy-typos exclude to undotted `typos.toml` (`TYPOS_ALT_CONFIGS` records the triggering spellings); generalize the surface message; update enumerating comments.
- `tests/bats/init-workspace.bats`: 4 new #1280 cases (dual-config guard, `--preview` ADDED truthfulness, surface message, both-files no-misfire combo).
- `CHANGELOG.md` (+ generated devcontainer mirror): Fixed entry.

## Test evidence

- TDD: failing tests committed first (`55c9f3b3`), fix in `11b2963c`.
- `bats tests/bats/init-workspace.bats --filter "913|1196|1280"`: 9/9 ok (new cases + all #913/#1196 regressions).
- `prek run --all-files`: green.

## Merge order

Part of the #1280–#1285 solo-adoption batch; recommended merge order #1281 → #1280 → #1283 → #1282 → #1284 → #1285 (shared `init-workspace.sh`/CHANGELOG surface).

Closes #1280