### PR TITLE
fix(workspace): treat pytest no-tests-collected exit as a green no-op

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`just test` no longer fails a Python repo with zero collected tests** ([#1281](https://github.com/vig-os/devkit/issues/1281))
+  - The scaffolded `justfile.project` `test`/`test-cov` recipes gate on
+    `pyproject.toml` presence, so a consumer with a `pyproject.toml` but no test
+    suite ran `uv run pytest` → exit 5 ("no tests collected") → red `just test`
+    and red CI out of the box. Both recipes now treat pytest's exit 5 as a green
+    no-op — "nothing to test" is not a failure, matching how non-Python
+    consumers silently skip — while every other nonzero exit still fails. This
+    is a template-only change; preserved consumer copies of `justfile.project`
+    keep their own recipes (the #877 repair only appends missing ones).
+
 - **Undotted `typos.toml` no longer collides with the template `.typos.toml`** ([#1280](https://github.com/vig-os/devkit/issues/1280))
   - The `typos` tool reads config from `.typos.toml`, `_typos.toml`, or the
     undotted `typos.toml`. The scaffold guarded the first two (a preserved

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -33,6 +33,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`just test` no longer fails a Python repo with zero collected tests** ([#1281](https://github.com/vig-os/devkit/issues/1281))
+  - The scaffolded `justfile.project` `test`/`test-cov` recipes gate on
+    `pyproject.toml` presence, so a consumer with a `pyproject.toml` but no test
+    suite ran `uv run pytest` → exit 5 ("no tests collected") → red `just test`
+    and red CI out of the box. Both recipes now treat pytest's exit 5 as a green
+    no-op — "nothing to test" is not a failure, matching how non-Python
+    consumers silently skip — while every other nonzero exit still fails. This
+    is a template-only change; preserved consumer copies of `justfile.project`
+    keep their own recipes (the #877 repair only appends missing ones).
+
 - **Undotted `typos.toml` no longer collides with the template `.typos.toml`** ([#1280](https://github.com/vig-os/devkit/issues/1280))
   - The `typos` tool reads config from `.typos.toml`, `_typos.toml`, or the
     undotted `typos.toml`. The scaffold guarded the first two (a preserved

--- a/assets/workspace/justfile.project
+++ b/assets/workspace/justfile.project
@@ -43,15 +43,15 @@ precommit:
 # TESTING
 # -------------------------------------------------------------------------------
 
-# Run tests with pytest
+# Run tests with pytest (exit 5 = "no tests collected" is a no-op, not a failure)
 [group('test')]
 test *args:
-    @if [ -f pyproject.toml ]; then uv run pytest {{ args }}; fi
+    @if [ -f pyproject.toml ]; then uv run pytest {{ args }} || { rc=$?; [ "$rc" -eq 5 ] || exit "$rc"; }; fi
 
-# Run tests with coverage
+# Run tests with coverage (exit 5 = "no tests collected" is a no-op, not a failure)
 [group('test')]
 test-cov *args:
-    @if [ -f pyproject.toml ]; then uv run pytest --cov --cov-report=term-missing {{ args }}; fi
+    @if [ -f pyproject.toml ]; then uv run pytest --cov --cov-report=term-missing {{ args }} || { rc=$?; [ "$rc" -eq 5 ] || exit "$rc"; }; fi
 
 # -------------------------------------------------------------------------------
 # DEPENDENCIES

--- a/tests/bats/init-workspace.bats
+++ b/tests/bats/init-workspace.bats
@@ -4233,3 +4233,56 @@ _scaffold_seeded() {
     run test -e "$ws/.github/workflows/release.yml"
     assert_failure
 }
+
+# ── test/test-cov tolerate pytest's no-tests-collected exit (#1281) ───────────
+# A Python consumer with a pyproject.toml but no test suite runs `uv run pytest`
+# → exit 5 ("no tests collected"). "Nothing to test" is not a failure: `just
+# test` / `just test-cov` must no-op green, matching how non-Python consumers
+# silently skip. Every OTHER nonzero pytest exit must still fail the recipe.
+# Exercised with the real `just` binary against a scaffolded workspace, so the
+# recipe runs under the root justfile's pipefail shell (#854).
+
+# Scaffold a Python workspace ($2) and drop a stub `uv` that exits $3 on any
+# invocation, simulating pytest's exit code. Leaves the stub in $2/stub-bin.
+_py_ws_uv_exit() {
+    local mode="$1" ws="$2" code="$3"
+    mkdir -p "$ws"
+    _scaffold "$mode" "$ws"
+    printf '# SENTINEL-1281 minimal project, no test suite\n' >"$ws/pyproject.toml"
+    local stub="$ws/stub-bin"
+    mkdir -p "$stub"
+    printf '#!/usr/bin/env bash\nexit %s\n' "$code" >"$stub/uv"
+    chmod +x "$stub/uv"
+}
+
+@test "just test succeeds on a Python repo with zero collected tests (#1281)" {
+    real_just="$(command -v just)"
+    ws="$BATS_TEST_TMPDIR/e2e-1281-test-nocollect"
+    _py_ws_uv_exit both "$ws" 5
+    run bash -c "cd '$ws' && PATH='$ws/stub-bin:$PATH' '$real_just' test"
+    assert_success
+}
+
+@test "just test still fails on a genuinely failing suite (#1281)" {
+    real_just="$(command -v just)"
+    ws="$BATS_TEST_TMPDIR/e2e-1281-test-fail"
+    _py_ws_uv_exit both "$ws" 1
+    run bash -c "cd '$ws' && PATH='$ws/stub-bin:$PATH' '$real_just' test"
+    assert_failure 1
+}
+
+@test "just test-cov succeeds on a Python repo with zero collected tests (#1281)" {
+    real_just="$(command -v just)"
+    ws="$BATS_TEST_TMPDIR/e2e-1281-cov-nocollect"
+    _py_ws_uv_exit both "$ws" 5
+    run bash -c "cd '$ws' && PATH='$ws/stub-bin:$PATH' '$real_just' test-cov"
+    assert_success
+}
+
+@test "just test-cov still fails on a genuinely failing suite (#1281)" {
+    real_just="$(command -v just)"
+    ws="$BATS_TEST_TMPDIR/e2e-1281-cov-fail"
+    _py_ws_uv_exit both "$ws" 1
+    run bash -c "cd '$ws' && PATH='$ws/stub-bin:$PATH' '$real_just' test-cov"
+    assert_failure 1
+}


### PR DESCRIPTION
## Summary

A consumer with a `pyproject.toml` but no test suite gets `uv run pytest` → exit 5 ("no tests collected") → a red `just test` and a red CI `test` job on a repo with no defect. "Nothing to test" now no-ops green, matching how non-Python consumers silently pass through the same recipes; every other nonzero pytest exit still fails.

## Changes

- `assets/workspace/justfile.project` (`test`, `test-cov`): `... || { rc=$?; [ "$rc" -eq 5 ] || exit "$rc"; }` — proven live under the root justfile's `bash -euo pipefail` shell (#854 SSoT; exit 0/5 pass, exit 1 propagates). Template-only change; preserved consumer copies are untouched (#877 repair semantics).
- `tests/bats/init-workspace.bats`: 4 new #1281 cases driving the real `just` binary against a scaffolded workspace with a stub `uv` (exit 5 vs exit 1, both recipes).
- `CHANGELOG.md` (+ generated devcontainer mirror): Fixed entry.

## Test evidence

- TDD: failing tests committed first (`4128bf4b`), fix in `008dd90c`.
- `bats tests/bats/init-workspace.bats --filter "1281|877"`: 10/10 ok (new cases + full #877 CI-contract regressions).
- `prek run --all-files`: green.

## Merge order

Part of the #1280–#1285 solo-adoption batch; recommended merge order #1281 → #1280 → #1283 → #1282 → #1284 → #1285.

Closes #1281