### PR TITLE
feat(init): preflight abort on non-main default branches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Preflight abort on non-main default branches** ([#1283](https://github.com/vig-os/devkit/issues/1283))
+  - Scaffolding assumes the default branch is `main` (the branch-name hook,
+    `ci.yml` and its workflow triggers all key off it). On a legacy `master`
+    repo the scaffold used to succeed silently, then block every subsequent
+    commit with a confusing hook error. `install.sh` now detects a non-`main`
+    default branch (via `origin/HEAD`, a best-effort `gh api` lookup, or the
+    local branch) and refuses **before** writing anything, printing the rename
+    recipe. A topic/`dev` branch of a repo that already has `main` proceeds
+    unchanged; `--preview` warns without aborting; `--skip-preflight` bypasses.
+
 - **Manifest-driven scaffold feature opt-outs (DEVKIT_FEATURES_DISABLED)** ([#1284](https://github.com/vig-os/devkit/issues/1284))
   - New `.vig-os` key: a comma-separated, whitespace-tolerant list of scaffold
     feature groups a repo opts out of. Disabled groups are never scaffolded,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`just test` no longer fails a Python repo with zero collected tests** ([#1281](https://github.com/vig-os/devkit/issues/1281))
+  - The scaffolded `justfile.project` `test`/`test-cov` recipes gate on
+    `pyproject.toml` presence, so a consumer with a `pyproject.toml` but no test
+    suite ran `uv run pytest` → exit 5 ("no tests collected") → red `just test`
+    and red CI out of the box. Both recipes now treat pytest's exit 5 as a green
+    no-op — "nothing to test" is not a failure, matching how non-Python
+    consumers silently skip — while every other nonzero exit still fails. This
+    is a template-only change; preserved consumer copies of `justfile.project`
+    keep their own recipes (the #877 repair only appends missing ones).
+
 - **Undotted `typos.toml` no longer collides with the template `.typos.toml`** ([#1280](https://github.com/vig-os/devkit/issues/1280))
   - The `typos` tool reads config from `.typos.toml`, `_typos.toml`, or the
     undotted `typos.toml`. The scaffold guarded the first two (a preserved

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Preflight abort on non-main default branches** ([#1283](https://github.com/vig-os/devkit/issues/1283))
+  - Scaffolding assumes the default branch is `main` (the branch-name hook,
+    `ci.yml` and its workflow triggers all key off it). On a legacy `master`
+    repo the scaffold used to succeed silently, then block every subsequent
+    commit with a confusing hook error. `install.sh` now detects a non-`main`
+    default branch (via `origin/HEAD`, a best-effort `gh api` lookup, or the
+    local branch) and refuses **before** writing anything, printing the rename
+    recipe. A topic/`dev` branch of a repo that already has `main` proceeds
+    unchanged; `--preview` warns without aborting; `--skip-preflight` bypasses.
+
 - **Manifest-driven scaffold feature opt-outs (DEVKIT_FEATURES_DISABLED)** ([#1284](https://github.com/vig-os/devkit/issues/1284))
   - New `.vig-os` key: a comma-separated, whitespace-tolerant list of scaffold
     feature groups a repo opts out of. Disabled groups are never scaffolded,

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -33,6 +33,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`just test` no longer fails a Python repo with zero collected tests** ([#1281](https://github.com/vig-os/devkit/issues/1281))
+  - The scaffolded `justfile.project` `test`/`test-cov` recipes gate on
+    `pyproject.toml` presence, so a consumer with a `pyproject.toml` but no test
+    suite ran `uv run pytest` → exit 5 ("no tests collected") → red `just test`
+    and red CI out of the box. Both recipes now treat pytest's exit 5 as a green
+    no-op — "nothing to test" is not a failure, matching how non-Python
+    consumers silently skip — while every other nonzero exit still fails. This
+    is a template-only change; preserved consumer copies of `justfile.project`
+    keep their own recipes (the #877 repair only appends missing ones).
+
 - **Undotted `typos.toml` no longer collides with the template `.typos.toml`** ([#1280](https://github.com/vig-os/devkit/issues/1280))
   - The `typos` tool reads config from `.typos.toml`, `_typos.toml`, or the
     undotted `typos.toml`. The scaffold guarded the first two (a preserved

--- a/assets/workspace/justfile.project
+++ b/assets/workspace/justfile.project
@@ -43,15 +43,15 @@ precommit:
 # TESTING
 # -------------------------------------------------------------------------------
 
-# Run tests with pytest
+# Run tests with pytest (exit 5 = "no tests collected" is a no-op, not a failure)
 [group('test')]
 test *args:
-    @if [ -f pyproject.toml ]; then uv run pytest {{ args }}; fi
+    @if [ -f pyproject.toml ]; then uv run pytest {{ args }} || { rc=$?; [ "$rc" -eq 5 ] || exit "$rc"; }; fi
 
-# Run tests with coverage
+# Run tests with coverage (exit 5 = "no tests collected" is a no-op, not a failure)
 [group('test')]
 test-cov *args:
-    @if [ -f pyproject.toml ]; then uv run pytest --cov --cov-report=term-missing {{ args }}; fi
+    @if [ -f pyproject.toml ]; then uv run pytest --cov --cov-report=term-missing {{ args }} || { rc=$?; [ "$rc" -eq 5 ] || exit "$rc"; }; fi
 
 # -------------------------------------------------------------------------------
 # DEPENDENCIES

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -214,6 +214,24 @@ upgrade.
   (`git branch dev main && git push -u origin dev`) for the gitflow release flow
   to work.
 
+### Legacy default branches (`master`)
+
+Both models assume the repository's **default branch is `main`**: the scaffolded
+branch-name hook, `ci.yml`'s trunk rewrite and its workflow triggers all key off
+it. On a legacy `master` repo the scaffold would otherwise succeed silently and
+then every commit would be rejected by the branch-name hook. `install.sh`
+therefore **refuses to scaffold until the default branch is `main`** — including
+on a first-time install — pointing you here. Rename it first:
+
+```bash
+git branch -m master main && git push -u origin main
+gh repo edit --default-branch main
+```
+
+Then re-run the installer. A topic or `dev` branch of a repo that already has a
+`main` proceeds normally; `--preview` reports the finding without aborting, and
+`--skip-preflight` bypasses the check.
+
 ### Enable the dependency graph on new public consumers
 
 The scaffolded `ci.yml` also ships a **Dependency Review** gate that blocks PRs

--- a/install.sh
+++ b/install.sh
@@ -407,6 +407,84 @@ run_preflight_guard() {
     esac
 }
 
+# Refuse to scaffold when the default branch is not `main` (#1283). The
+# scaffolded branch-name hook, ci.yml's TRUNK sed and its workflow triggers all
+# assume `main`; on a legacy `master` repo the scaffold would succeed silently
+# and then every commit would hit a confusing branch-name hook error. This fails
+# loudly BEFORE anything is written, with the rename recipe. Unlike
+# run_preflight_guard (#886, --force only) it ALSO runs on fresh installs —
+# first-time adoption on a legacy master repo is the core case. Resolution order:
+# origin/HEAD, then a best-effort `gh api` default_branch (GitHub origin only,
+# offline-safe), then the local current branch when there is no origin. A
+# non-main default is accepted when a `main` branch already exists (local or
+# origin) — the gitflow case of scaffolding from a topic/dev branch of a
+# conforming repo. Non-git dirs are left to run_preflight_guard's warn+confirm
+# path. Under --preview it only warns; the caller skips it for --smoke-test and
+# --skip-preflight.
+check_default_branch() {
+    local path="$1"
+    local skip_hint="Re-run with --skip-preflight to bypass this check."
+    local default_branch="" url repo
+
+    # Non-git (or git unavailable): owned by run_preflight_guard's non-git path.
+    if ! command -v git >/dev/null 2>&1 \
+        || ! git -C "$path" rev-parse --git-dir >/dev/null 2>&1; then
+        return 0
+    fi
+
+    if default_branch="$(git -C "$path" symbolic-ref --quiet refs/remotes/origin/HEAD 2>/dev/null)"; then
+        default_branch="${default_branch#refs/remotes/origin/}"
+    else
+        default_branch=""
+    fi
+
+    if [ -z "$default_branch" ]; then
+        url="$(git -C "$path" remote get-url origin 2>/dev/null || true)"
+        if [ -n "$url" ]; then
+            # Origin exists but origin/HEAD is unset: ask GitHub, best-effort.
+            # Must never hang or fail the preflight because gh failed/offline.
+            if command -v gh >/dev/null 2>&1 && repo="$(parse_github_remote "$url" 2>/dev/null)"; then
+                if command -v timeout >/dev/null 2>&1; then
+                    default_branch="$(timeout 5 gh api "repos/$repo" --jq .default_branch 2>/dev/null || true)"
+                else
+                    default_branch="$(gh api "repos/$repo" --jq .default_branch 2>/dev/null || true)"
+                fi
+            fi
+        else
+            # Local-only repo (no origin): fall back to the current branch.
+            default_branch="$(git -C "$path" symbolic-ref --quiet --short HEAD 2>/dev/null || true)"
+        fi
+    fi
+
+    # Unresolvable (e.g. detached HEAD with no origin, gh offline): defer to
+    # run_preflight_guard rather than guess.
+    [ -n "$default_branch" ] || return 0
+    [ "$default_branch" = main ] && return 0
+
+    # A non-main default is fine when `main` already exists (local or origin).
+    if git -C "$path" rev-parse --verify --quiet main >/dev/null 2>&1 \
+        || git -C "$path" rev-parse --verify --quiet refs/remotes/origin/main >/dev/null 2>&1; then
+        return 0
+    fi
+
+    if [ -n "$PREVIEW" ]; then
+        warn "preflight: default branch is '$default_branch', not 'main' — a real scaffold would refuse."
+        warn "  Rename it first: git branch -m $default_branch main && git push -u origin main"
+        warn "  then: gh repo edit --default-branch main (see docs/MIGRATION.md)."
+        return 0
+    fi
+
+    err "preflight: refusing to scaffold — the default branch is '$default_branch', not 'main'."
+    echo "  vigOS scaffolding assumes 'main': the branch-name hook, ci.yml and its"
+    echo "  workflow triggers key off it, so every commit here would be blocked."
+    echo "  Rename the default branch to 'main' first:"
+    echo "    git branch -m $default_branch main && git push -u origin main"
+    echo "    gh repo edit --default-branch main"
+    echo "  Then re-run. See docs/MIGRATION.md (Legacy default branches)."
+    echo "  $skip_hint"
+    exit 1
+}
+
 # Parse arguments
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -656,6 +734,14 @@ if [ -z "$GITHUB_REPOSITORY" ] && [ -d "$PROJECT_PATH/.git" ]; then
 fi
 if [ -z "$GITHUB_REPOSITORY" ]; then
     GITHUB_REPOSITORY="OWNER/REPO"
+fi
+
+# Default-branch preflight (#1283): a non-`main` default branch (legacy master)
+# would let the scaffold succeed silently, then block every commit via the
+# branch-name hook. Runs on fresh installs too (first-time adoption is the core
+# case); --smoke-test and --skip-preflight skip it, --preview only warns.
+if [ -z "$SMOKE_TEST" ] && [ "$SKIP_PREFLIGHT" = false ]; then
+    check_default_branch "$PROJECT_PATH"
 fi
 
 # Preflight-gate --force upgrades (#886). Exemptions:

--- a/tests/bats/init-workspace.bats
+++ b/tests/bats/init-workspace.bats
@@ -4233,3 +4233,56 @@ _scaffold_seeded() {
     run test -e "$ws/.github/workflows/release.yml"
     assert_failure
 }
+
+# ── test/test-cov tolerate pytest's no-tests-collected exit (#1281) ───────────
+# A Python consumer with a pyproject.toml but no test suite runs `uv run pytest`
+# → exit 5 ("no tests collected"). "Nothing to test" is not a failure: `just
+# test` / `just test-cov` must no-op green, matching how non-Python consumers
+# silently skip. Every OTHER nonzero pytest exit must still fail the recipe.
+# Exercised with the real `just` binary against a scaffolded workspace, so the
+# recipe runs under the root justfile's pipefail shell (#854).
+
+# Scaffold a Python workspace ($2) and drop a stub `uv` that exits $3 on any
+# invocation, simulating pytest's exit code. Leaves the stub in $2/stub-bin.
+_py_ws_uv_exit() {
+    local mode="$1" ws="$2" code="$3"
+    mkdir -p "$ws"
+    _scaffold "$mode" "$ws"
+    printf '# SENTINEL-1281 minimal project, no test suite\n' >"$ws/pyproject.toml"
+    local stub="$ws/stub-bin"
+    mkdir -p "$stub"
+    printf '#!/usr/bin/env bash\nexit %s\n' "$code" >"$stub/uv"
+    chmod +x "$stub/uv"
+}
+
+@test "just test succeeds on a Python repo with zero collected tests (#1281)" {
+    real_just="$(command -v just)"
+    ws="$BATS_TEST_TMPDIR/e2e-1281-test-nocollect"
+    _py_ws_uv_exit both "$ws" 5
+    run bash -c "cd '$ws' && PATH='$ws/stub-bin:$PATH' '$real_just' test"
+    assert_success
+}
+
+@test "just test still fails on a genuinely failing suite (#1281)" {
+    real_just="$(command -v just)"
+    ws="$BATS_TEST_TMPDIR/e2e-1281-test-fail"
+    _py_ws_uv_exit both "$ws" 1
+    run bash -c "cd '$ws' && PATH='$ws/stub-bin:$PATH' '$real_just' test"
+    assert_failure 1
+}
+
+@test "just test-cov succeeds on a Python repo with zero collected tests (#1281)" {
+    real_just="$(command -v just)"
+    ws="$BATS_TEST_TMPDIR/e2e-1281-cov-nocollect"
+    _py_ws_uv_exit both "$ws" 5
+    run bash -c "cd '$ws' && PATH='$ws/stub-bin:$PATH' '$real_just' test-cov"
+    assert_success
+}
+
+@test "just test-cov still fails on a genuinely failing suite (#1281)" {
+    real_just="$(command -v just)"
+    ws="$BATS_TEST_TMPDIR/e2e-1281-cov-fail"
+    _py_ws_uv_exit both "$ws" 1
+    run bash -c "cd '$ws' && PATH='$ws/stub-bin:$PATH' '$real_just' test-cov"
+    assert_failure 1
+}

--- a/tests/bats/install.bats
+++ b/tests/bats/install.bats
@@ -462,6 +462,11 @@ _make_repo() {
     mkdir -p "$dir"
     _git init -q -b "$branch" "$dir"
     _git -C "$dir" commit -q --allow-empty -m "chore: init"
+    # A realistic topic-branch checkout has a `main` alongside it. The
+    # default-branch preflight (#1283) refuses a non-main default only when no
+    # `main` exists anywhere, so give every non-main fixture a `main` branch —
+    # the gitflow accept-path — leaving the #886 guard's assertions unchanged.
+    [ "$branch" = main ] || _git -C "$dir" branch main
 }
 
 @test "preflight: --force refuses on main with the branch hint (#886)" {
@@ -648,6 +653,94 @@ _make_repo() {
     run bash "$INSTALL_SH" --dry-run "$dir" </dev/null
     assert_success
     assert_output --partial "Would execute:"
+}
+
+# ── default-branch preflight (#1283) ──────────────────────────────────────────
+# Scaffolding assumes the default branch is `main` (the branch-name hook, ci.yml
+# and its workflow triggers all key off it). On a legacy `master` repo the
+# scaffold would succeed silently, then block every commit. A preflight detects a
+# non-`main` default branch and aborts BEFORE anything is written, with the
+# rename recipe. Unlike the #886 guard it runs on fresh installs too;
+# --skip-preflight and --smoke-test skip it, --preview only warns, and a `main`
+# default (or a topic/dev branch of a repo that has `main`) proceeds unchanged.
+
+# A repo whose default branch is `master` via origin/HEAD, with no `main`
+# anywhere. Not built through _make_repo (which would add a `main`).
+_make_master_origin_repo() {
+    local work="$1" origin="$1.origin.git"
+    _git init -q -b master --bare "$origin"
+    mkdir -p "$work"
+    _git init -q -b master "$work"
+    _git -C "$work" commit -q --allow-empty -m "chore: init"
+    _git -C "$work" remote add origin "$origin"
+    _git -C "$work" push -q origin master
+    _git -C "$work" symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/master
+}
+
+# A local-only repo (no origin) checked out on `master`, no `main`.
+_make_local_master_repo() {
+    local dir="$1"
+    mkdir -p "$dir"
+    _git init -q -b master "$dir"
+    _git -C "$dir" commit -q --allow-empty -m "chore: init"
+}
+
+@test "preflight: master default via origin/HEAD aborts pre-copy with rename recipe (#1283)" {
+    repo="$BATS_TEST_TMPDIR/master-origin"
+    _make_master_origin_repo "$repo"
+    run bash "$INSTALL_SH" --dry-run "$repo" </dev/null
+    assert_failure
+    assert_output --partial "git branch -m master main && git push -u origin main"
+    assert_output --partial "gh repo edit --default-branch main"
+    assert_output --partial "MIGRATION.md"
+    # aborts before the copy step: never reaches the container command
+    refute_output --partial "Would execute:"
+}
+
+@test "preflight: main default proceeds unchanged (#1283)" {
+    repo="$BATS_TEST_TMPDIR/main-default-1283"
+    _make_repo "$repo" main
+    run bash "$INSTALL_SH" --dry-run "$repo" </dev/null
+    assert_success
+    assert_output --partial "Would execute:"
+}
+
+@test "preflight: --skip-preflight proceeds on a master repo (#1283)" {
+    repo="$BATS_TEST_TMPDIR/master-skip-1283"
+    _make_local_master_repo "$repo"
+    run bash "$INSTALL_SH" --dry-run --skip-preflight "$repo" </dev/null
+    assert_success
+    assert_output --partial "Would execute:"
+}
+
+@test "preflight: --preview warns on a master repo without aborting (#1283)" {
+    repo="$BATS_TEST_TMPDIR/master-preview-1283"
+    _make_local_master_repo "$repo"
+    run bash "$INSTALL_SH" --dry-run --preview "$repo" </dev/null
+    assert_success
+    assert_output --partial "not 'main'"
+    assert_output --partial "Would execute:"
+}
+
+@test "preflight: dev branch of a repo that has main proceeds (#1283)" {
+    repo="$BATS_TEST_TMPDIR/gitflow-dev-1283"
+    mkdir -p "$repo"
+    _git init -q -b main "$repo"
+    _git -C "$repo" commit -q --allow-empty -m "chore: init"
+    _git -C "$repo" checkout -q -b dev
+    run bash "$INSTALL_SH" --dry-run "$repo" </dev/null
+    assert_success
+    assert_output --partial "Would execute:"
+}
+
+@test "preflight: local-only master repo (no origin) aborts with the same guidance (#1283)" {
+    repo="$BATS_TEST_TMPDIR/master-local-1283"
+    _make_local_master_repo "$repo"
+    run bash "$INSTALL_SH" --dry-run "$repo" </dev/null
+    assert_failure
+    assert_output --partial "git branch -m master main && git push -u origin main"
+    assert_output --partial "gh repo edit --default-branch main"
+    refute_output --partial "Would execute:"
 }
 
 # ── --preview forwarding and docs (#886) ──────────────────────────────────────

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -488,7 +488,9 @@ class TestInstallScriptUnit:
 
         Uses a clean feature-branch git fixture: the upgrade preflight guard
         (#886) refuses --force on non-git directories, protected branches,
-        and dirty trees.
+        and dirty trees. A `main` branch exists alongside, as in any conforming
+        checkout — the default-branch preflight (#1283) refuses when no `main`
+        can be resolved at all.
         """
         git_env = [
             "git",
@@ -515,6 +517,11 @@ class TestInstallScriptUnit:
                 "-m",
                 "chore: init",
             ],
+            check=True,
+            timeout=10,
+        )
+        subprocess.run(
+            [*git_env, "-C", str(tmp_path), "branch", "main"],
             check=True,
             timeout=10,
         )


### PR DESCRIPTION
## Summary

On a legacy `master` repo the scaffold succeeded silently — then every commit was blocked by the scaffolded branch-name hook (which only permits `main`/`dev`/convention branches), with `ci.yml`'s trunk rewrite and workflow triggers equally keyed to `main`. The failure surfaced at the worst moment: the first commit after adoption.

`install.sh` now refuses to scaffold before anything is written when the default branch is not `main`, printing the two-command rename recipe (`git branch -m master main && git push -u origin main`; `gh repo edit --default-branch main`) and a `docs/MIGRATION.md` pointer. The check lives host-side in `install.sh` (next to the #886 `run_preflight_guard`) because the container-side `init-workspace.sh` has no git-branch visibility.

## Behavior

- Resolution order: `origin/HEAD` → best-effort `gh api` default_branch (GitHub origin only; offline-safe, `timeout 5`, errors swallowed) → current branch for local-only repos; unresolvable states defer to the existing guard.
- Runs on fresh installs AND `--force` (first-time adoption is the core case). `--preview` warns without aborting; `--smoke-test` and `--skip-preflight` skip it.
- A non-`main` default is accepted when a `main` ref already exists (local or origin) — the gitflow topic/`dev`-branch case. Conforming repos see no behavior change.
- New `docs/MIGRATION.md` subsection "Legacy default branches (`master`)" under Workflow models.

## Test evidence

- TDD: failing tests committed first (`65a87f32`), implementation in `86701a67`.
- 6 new #1283 cases (abort with recipe via origin/HEAD, main proceeds, `--skip-preflight`, `--preview` warn, gitflow dev+main proceeds, local-only master abort).
- Full `bats tests/bats/install.bats`: 115 ok / 0 failures (incl. all 22 #886 preflight regressions).
- `prek run --all-files`: green.

## Merge order

Part of the #1280–#1285 solo-adoption batch; recommended merge order #1281 → #1280 → #1283 → #1282 → #1284 → #1285.

Closes #1283