### PR TITLE
feat(workspace): scaffold-time Refs policy knob (DEVKIT_REFS_POLICY)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Preflight abort on non-main default branches** ([#1283](https://github.com/vig-os/devkit/issues/1283))
+  - Scaffolding assumes the default branch is `main` (the branch-name hook,
+    `ci.yml` and its workflow triggers all key off it). On a legacy `master`
+    repo the scaffold used to succeed silently, then block every subsequent
+    commit with a confusing hook error. `install.sh` now detects a non-`main`
+    default branch (via `origin/HEAD`, a best-effort `gh api` lookup, or the
+    local branch) and refuses **before** writing anything, printing the rename
+    recipe. A topic/`dev` branch of a repo that already has `main` proceeds
+    unchanged; `--preview` warns without aborting; `--skip-preflight` bypasses.
+
 - **Manifest-driven scaffold feature opt-outs (DEVKIT_FEATURES_DISABLED)** ([#1284](https://github.com/vig-os/devkit/issues/1284))
   - New `.vig-os` key: a comma-separated, whitespace-tolerant list of scaffold
     feature groups a repo opts out of. Disabled groups are never scaffolded,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`just test` no longer fails a Python repo with zero collected tests** ([#1281](https://github.com/vig-os/devkit/issues/1281))
+  - The scaffolded `justfile.project` `test`/`test-cov` recipes gate on
+    `pyproject.toml` presence, so a consumer with a `pyproject.toml` but no test
+    suite ran `uv run pytest` → exit 5 ("no tests collected") → red `just test`
+    and red CI out of the box. Both recipes now treat pytest's exit 5 as a green
+    no-op — "nothing to test" is not a failure, matching how non-Python
+    consumers silently skip — while every other nonzero exit still fails. This
+    is a template-only change; preserved consumer copies of `justfile.project`
+    keep their own recipes (the #877 repair only appends missing ones).
+
 - **Undotted `typos.toml` no longer collides with the template `.typos.toml`** ([#1280](https://github.com/vig-os/devkit/issues/1280))
   - The `typos` tool reads config from `.typos.toml`, `_typos.toml`, or the
     undotted `typos.toml`. The scaffold guarded the first two (a preserved

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Scaffold-time Refs policy knob (DEVKIT_REFS_POLICY)** ([#1282](https://github.com/vig-os/devkit/issues/1282))
+  - A new `.vig-os` manifest key drives the `Refs:`-line enforcement of both the
+    `validate-commit-msg` pre-commit hook and CI's `validate-commit-range` from a
+    single value: `chore-optional` (default — only `chore` may omit `Refs:`,
+    today's behavior), `optional` (any approved type may omit it), and `required`
+    (every type, `chore` included, must carry a `Refs:` line). Absent key => a
+    byte-identical scaffold; the value round-trips across `--force` upgrades.
+
 - **Preflight abort on non-main default branches** ([#1283](https://github.com/vig-os/devkit/issues/1283))
   - Scaffolding assumes the default branch is `main` (the branch-name hook,
     `ci.yml` and its workflow triggers all key off it). On a legacy `master`

--- a/assets/init-workspace.sh
+++ b/assets/init-workspace.sh
@@ -344,6 +344,8 @@ MANIFEST_SYNC_TARGET="$(read_manifest_value "$VIG_OS_MANIFEST" DEVKIT_SYNC_TARGE
 MANIFEST_SYNC_SCHEDULE="$(read_manifest_value "$VIG_OS_MANIFEST" DEVKIT_SYNC_SCHEDULE || true)"
 MANIFEST_FEATURES_DISABLED="$(read_manifest_value "$VIG_OS_MANIFEST" DEVKIT_FEATURES_DISABLED || true)"
 
+MANIFEST_REFS_POLICY="$(read_manifest_value "$VIG_OS_MANIFEST" DEVKIT_REFS_POLICY || true)"
+
 # The OWNER/REPO placeholder (written when no origin was resolvable) must not
 # mask a now-detectable git origin on a later upgrade.
 [[ "$MANIFEST_REPO" == "OWNER/REPO" ]] && MANIFEST_REPO=""
@@ -472,6 +474,18 @@ feature_disabled() {
 if feature_disabled sync-issues && [[ -n "$MANIFEST_SYNC_TARGET" || -n "$MANIFEST_SYNC_SCHEDULE" ]]; then
     echo "Notice: sync-issues feature disabled (DEVKIT_FEATURES_DISABLED); DEVKIT_SYNC_TARGET/DEVKIT_SYNC_SCHEDULE will have no effect (#1284)." >&2
 fi
+
+# Refs policy (#1282): scaffold-time knob steering the Refs enforcement of the
+# validate-commit-msg hook and CI's validate-commit-range. Pure `.vig-os` key
+# (no CLI flag), so only a value guard — empty resolves to the chore-optional
+# default. Refuse an unknown value loudly (mirrors the DEVKIT_WORKFLOW guard).
+case "$MANIFEST_REFS_POLICY" in
+    ""|chore-optional|optional|required) ;;
+    *)
+        echo "Error: Invalid DEVKIT_REFS_POLICY in $VIG_OS_MANIFEST: $MANIFEST_REFS_POLICY (expected: chore-optional | optional | required)" >&2
+        exit 1
+        ;;
+esac
 
 # Get SHORT_NAME - from env var, manifest, or prompt (#885)
 if [[ -z "${SHORT_NAME:-}" && -n "$MANIFEST_PROJECT" ]]; then
@@ -1374,6 +1388,35 @@ YAML
     echo "Rendered sync-issues settings (target=${MANIFEST_SYNC_TARGET:-default}, schedule=${MANIFEST_SYNC_SCHEDULE:-default})"
 }
 
+# Render the Refs policy knob (#1282): DEVKIT_REFS_POLICY steers the
+# validate-commit-msg hook's `--refs-optional-types` arg in the scaffolded
+# .pre-commit-config.yaml. The IDENTICAL policy->types mapping drives CI's
+# validate-commit-range from the same key in
+# .github/actions/resolve-toolchain/action.yml (two renderers, one key) — keep
+# them in lockstep. Empty/absent or `chore-optional` is a pure no-op, so a
+# default scaffold's .pre-commit-config.yaml stays byte-identical. The anchored
+# sed targets only the quoted arg value, distinct from render_workflow_model's
+# `(?!dev$)` sed on the same file, so the two compose.
+render_refs_policy() {
+    [[ -z "$MANIFEST_REFS_POLICY" || "$MANIFEST_REFS_POLICY" == "chore-optional" ]] && return 0
+
+    local pc="$WORKSPACE_DIR/.pre-commit-config.yaml"
+    [[ -f "$pc" ]] || return 0
+
+    # `optional` mirrors the hook entry's `--types` list verbatim; `required`
+    # uses a `none` sentinel type (no real commit is type `none`, and the CLI
+    # treats an empty --refs-optional-types as falsy => the {chore} default), so
+    # every real type requires Refs.
+    local types
+    case "$MANIFEST_REFS_POLICY" in
+        optional) types="feat,fix,docs,chore,refactor,perf,test,ci,build,revert,style" ;;
+        required) types="none" ;;
+    esac
+
+    sed -i -E "s|^([[:space:]]*\"--refs-optional-types\", \")[^\"]*(\",)\$|\1${types}\2|" "$pc"
+    echo "Rendered Refs policy: ${MANIFEST_REFS_POLICY} (refs-optional-types=${types})"
+}
+
 # Warn if forcing (prompt user) - show which files would be overwritten
 if [[ "$FORCE" == "true" ]]; then
     echo ""
@@ -1997,6 +2040,12 @@ if feature_disabled sync-issues; then
 else
     render_sync_settings
 fi
+# Refs policy (#1282): render the validate-commit-msg hook's --refs-optional-types
+# from DEVKIT_REFS_POLICY (paired with the CI mapping in resolve-toolchain). A
+# no-op for the chore-optional default, so a default scaffold is unchanged. Runs
+# after render_workflow_model (both sed .pre-commit-config.yaml on distinct
+# anchors) so the trunk render and the refs policy compose.
+render_refs_policy
 
 # Persist the resolved manifest (#885). The scaffolded .vig-os is a managed
 # file (template-overwritten on upgrade), so the resolved delivery mode and
@@ -2053,6 +2102,12 @@ if [[ -f "$VIG_OS_MANIFEST" ]]; then
     # raw value round-trips (like DEVKIT_TAG_PREFIX); clearing it re-enables.
     if [[ -n "$MANIFEST_FEATURES_DISABLED" ]]; then
         write_manifest_value DEVKIT_FEATURES_DISABLED "$MANIFEST_FEATURES_DISABLED"
+    fi
+    # Refs policy (#1282): bare in the template (DEVKIT_REFS_POLICY=), so a
+    # consumer's non-default policy is written back — else an upgrade silently
+    # resets the commit-msg/commit-range Refs enforcement to chore-optional.
+    if [[ -n "$MANIFEST_REFS_POLICY" ]]; then
+        write_manifest_value DEVKIT_REFS_POLICY "$MANIFEST_REFS_POLICY"
     fi
 fi
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Preflight abort on non-main default branches** ([#1283](https://github.com/vig-os/devkit/issues/1283))
+  - Scaffolding assumes the default branch is `main` (the branch-name hook,
+    `ci.yml` and its workflow triggers all key off it). On a legacy `master`
+    repo the scaffold used to succeed silently, then block every subsequent
+    commit with a confusing hook error. `install.sh` now detects a non-`main`
+    default branch (via `origin/HEAD`, a best-effort `gh api` lookup, or the
+    local branch) and refuses **before** writing anything, printing the rename
+    recipe. A topic/`dev` branch of a repo that already has `main` proceeds
+    unchanged; `--preview` warns without aborting; `--skip-preflight` bypasses.
+
 - **Manifest-driven scaffold feature opt-outs (DEVKIT_FEATURES_DISABLED)** ([#1284](https://github.com/vig-os/devkit/issues/1284))
   - New `.vig-os` key: a comma-separated, whitespace-tolerant list of scaffold
     feature groups a repo opts out of. Disabled groups are never scaffolded,

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -33,6 +33,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`just test` no longer fails a Python repo with zero collected tests** ([#1281](https://github.com/vig-os/devkit/issues/1281))
+  - The scaffolded `justfile.project` `test`/`test-cov` recipes gate on
+    `pyproject.toml` presence, so a consumer with a `pyproject.toml` but no test
+    suite ran `uv run pytest` → exit 5 ("no tests collected") → red `just test`
+    and red CI out of the box. Both recipes now treat pytest's exit 5 as a green
+    no-op — "nothing to test" is not a failure, matching how non-Python
+    consumers silently skip — while every other nonzero exit still fails. This
+    is a template-only change; preserved consumer copies of `justfile.project`
+    keep their own recipes (the #877 repair only appends missing ones).
+
 - **Undotted `typos.toml` no longer collides with the template `.typos.toml`** ([#1280](https://github.com/vig-os/devkit/issues/1280))
   - The `typos` tool reads config from `.typos.toml`, `_typos.toml`, or the
     undotted `typos.toml`. The scaffold guarded the first two (a preserved

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Scaffold-time Refs policy knob (DEVKIT_REFS_POLICY)** ([#1282](https://github.com/vig-os/devkit/issues/1282))
+  - A new `.vig-os` manifest key drives the `Refs:`-line enforcement of both the
+    `validate-commit-msg` pre-commit hook and CI's `validate-commit-range` from a
+    single value: `chore-optional` (default — only `chore` may omit `Refs:`,
+    today's behavior), `optional` (any approved type may omit it), and `required`
+    (every type, `chore` included, must carry a `Refs:` line). Absent key => a
+    byte-identical scaffold; the value round-trips across `--force` upgrades.
+
 - **Preflight abort on non-main default branches** ([#1283](https://github.com/vig-os/devkit/issues/1283))
   - Scaffolding assumes the default branch is `main` (the branch-name hook,
     `ci.yml` and its workflow triggers all key off it). On a legacy `master`

--- a/assets/workspace/.github/actions/resolve-toolchain/action.yml
+++ b/assets/workspace/.github/actions/resolve-toolchain/action.yml
@@ -65,6 +65,12 @@ outputs:
       use with fromJSON() in `runs-on`. Defaults to ["ubuntu-24.04"] when the
       key is absent.
     value: ${{ steps.resolve.outputs.runner-json }}
+  refs-optional-types:
+    description: >-
+      Comma-separated commit types whose Refs line is optional, mapped from
+      DEVKIT_REFS_POLICY for validate-commit-range. `chore` (default/absent),
+      the full types list (`optional`), or the `none` sentinel (`required`).
+    value: ${{ steps.resolve.outputs.refs-optional-types }}
 
 runs:
   using: composite
@@ -83,6 +89,7 @@ runs:
         TAG_PREFIX=""
         FLOATING_TAGS=""
         CI_RUNNER=""
+        REFS_POLICY=""
 
         if [[ -f .vig-os ]]; then
           # Tolerant KEY=VALUE parsing shared with resolve-image (#781): capture
@@ -94,7 +101,7 @@ runs:
             [[ "$line" =~ ^[[:space:]]*# ]] && continue
 
             case "$line" in
-              DEVKIT_MODE=*|DEVKIT_VERSION=*|DEVCONTAINER_VERSION=*|DEVKIT_TAG_PREFIX=*|DEVKIT_FLOATING_TAGS=*|DEVKIT_CI_RUNNER=*)
+              DEVKIT_MODE=*|DEVKIT_VERSION=*|DEVCONTAINER_VERSION=*|DEVKIT_TAG_PREFIX=*|DEVKIT_FLOATING_TAGS=*|DEVKIT_CI_RUNNER=*|DEVKIT_REFS_POLICY=*)
                 key="${line%%=*}"
                 value="${line#*=}"
                 value="${value#"${value%%[![:space:]]*}"}"
@@ -113,6 +120,7 @@ runs:
                   DEVKIT_TAG_PREFIX) TAG_PREFIX="$value" ;;
                   DEVKIT_FLOATING_TAGS) FLOATING_TAGS="$value" ;;
                   DEVKIT_CI_RUNNER) CI_RUNNER="$value" ;;
+                  DEVKIT_REFS_POLICY) REFS_POLICY="$value" ;;
                 esac
                 ;;
             esac
@@ -166,6 +174,22 @@ runs:
         [[ "$runner_first" -eq 1 ]] && RUNNER_JSON+="\"ubuntu-24.04\""
         RUNNER_JSON+="]"
         echo "runner-json=$RUNNER_JSON" >> "$GITHUB_OUTPUT"
+
+        # Refs policy (#1282): map DEVKIT_REFS_POLICY to the --refs-optional-types
+        # list validate-commit-range consumes in the commit-checks job. This is
+        # the single mapping point for the CI surface; it MIRRORS render_refs_policy
+        # in assets/init-workspace.sh (two renderers, one key — keep in lockstep).
+        # The loud enum guard lives at the write path (init-workspace.sh); here an
+        # unexpected/absent value defaults safely to `chore` (today's behavior) so
+        # CI never breaks on a surprise literal. `required` uses a `none` sentinel
+        # type (no real commit is type `none`) because an empty list is parsed as
+        # falsy by the tool and reverts to the {chore} default.
+        case "$REFS_POLICY" in
+          optional) REFS_OPTIONAL_TYPES="feat,fix,docs,chore,refactor,perf,test,ci,build,revert,style" ;;
+          required) REFS_OPTIONAL_TYPES="none" ;;
+          *)        REFS_OPTIONAL_TYPES="chore" ;;
+        esac
+        echo "refs-optional-types=$REFS_OPTIONAL_TYPES" >> "$GITHUB_OUTPUT"
 
         # Resolve the version tag: explicit override wins, else DEVKIT_VERSION,
         # else the legacy DEVCONTAINER_VERSION.

--- a/assets/workspace/.github/workflows/ci.yml
+++ b/assets/workspace/.github/workflows/ci.yml
@@ -219,6 +219,11 @@ jobs:
           PR_TITLE: ${{ github.event.pull_request.title }}
           BASE_REF: ${{ github.event.pull_request.base.ref }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          # Refs policy (#1282): the resolved --refs-optional-types list reaches
+          # the validator via env, never inline ${{ }} in the run block (the
+          # zizmor template-injection gate / #1279 env-routing pattern). Mapped
+          # once from DEVKIT_REFS_POLICY by resolve-toolchain.
+          REFS_OPTIONAL_TYPES: ${{ needs.resolve-toolchain.outputs.refs-optional-types }}
         run: |
           set -euo pipefail
           BASE_SHA="$(git merge-base "origin/${BASE_REF}" "${HEAD_SHA}")"
@@ -238,6 +243,7 @@ jobs:
             --base "${BASE_SHA}" \
             --head "${HEAD_SHA}" \
             --title "${PR_TITLE}" \
+            --refs-optional-types "${REFS_OPTIONAL_TYPES}" \
             --blocked-patterns .github/agent-blocklist.toml \
             ${EXCLUDE[@]+"${EXCLUDE[@]}"}
 

--- a/assets/workspace/.github/workflows/ci.yml
+++ b/assets/workspace/.github/workflows/ci.yml
@@ -80,6 +80,9 @@ jobs:
       image: ${{ steps.resolve.outputs.image }}
       image-tag: ${{ steps.resolve.outputs.image-tag }}
       runner-json: ${{ steps.resolve.outputs.runner-json }}
+      # Refs policy (#1282): re-export the composite action's mapped
+      # --refs-optional-types list so commit-checks can consume it via needs.
+      refs-optional-types: ${{ steps.resolve.outputs.refs-optional-types }}
 
     steps:
       - name: Checkout repository

--- a/assets/workspace/.vig-os
+++ b/assets/workspace/.vig-os
@@ -80,3 +80,13 @@ DEVKIT_SYNC_SCHEDULE=
 # left in place if present (never pruned). Governs scaffold SHAPE only, not the
 # flake — an unknown name aborts the scaffold loudly (#1284).
 DEVKIT_FEATURES_DISABLED=
+
+# Refs-line enforcement policy for the commit-message gate, driving BOTH the
+# validate-commit-msg pre-commit hook and CI's validate-commit-range from this
+# one key. Empty (default) resolves to `chore-optional` — every type but `chore`
+# requires a `Refs:` line — unchanged for devkit or existing consumers.
+# `optional` never requires Refs (any approved type may omit it); `required`
+# demands Refs on every type, `chore` included. Realized at scaffold time (an
+# anchored render of the hook arg + resolve-toolchain's `refs-optional-types`
+# output); written back only for a non-default value (#1282).
+DEVKIT_REFS_POLICY=

--- a/assets/workspace/justfile.project
+++ b/assets/workspace/justfile.project
@@ -43,15 +43,15 @@ precommit:
 # TESTING
 # -------------------------------------------------------------------------------
 
-# Run tests with pytest
+# Run tests with pytest (exit 5 = "no tests collected" is a no-op, not a failure)
 [group('test')]
 test *args:
-    @if [ -f pyproject.toml ]; then uv run pytest {{ args }}; fi
+    @if [ -f pyproject.toml ]; then uv run pytest {{ args }} || { rc=$?; [ "$rc" -eq 5 ] || exit "$rc"; }; fi
 
-# Run tests with coverage
+# Run tests with coverage (exit 5 = "no tests collected" is a no-op, not a failure)
 [group('test')]
 test-cov *args:
-    @if [ -f pyproject.toml ]; then uv run pytest --cov --cov-report=term-missing {{ args }}; fi
+    @if [ -f pyproject.toml ]; then uv run pytest --cov --cov-report=term-missing {{ args }} || { rc=$?; [ "$rc" -eq 5 ] || exit "$rc"; }; fi
 
 # -------------------------------------------------------------------------------
 # DEPENDENCIES

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -214,6 +214,24 @@ upgrade.
   (`git branch dev main && git push -u origin dev`) for the gitflow release flow
   to work.
 
+### Legacy default branches (`master`)
+
+Both models assume the repository's **default branch is `main`**: the scaffolded
+branch-name hook, `ci.yml`'s trunk rewrite and its workflow triggers all key off
+it. On a legacy `master` repo the scaffold would otherwise succeed silently and
+then every commit would be rejected by the branch-name hook. `install.sh`
+therefore **refuses to scaffold until the default branch is `main`** — including
+on a first-time install — pointing you here. Rename it first:
+
+```bash
+git branch -m master main && git push -u origin main
+gh repo edit --default-branch main
+```
+
+Then re-run the installer. A topic or `dev` branch of a repo that already has a
+`main` proceeds normally; `--preview` reports the finding without aborting, and
+`--skip-preflight` bypasses the check.
+
 ### Enable the dependency graph on new public consumers
 
 The scaffolded `ci.yml` also ships a **Dependency Review** gate that blocks PRs

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -368,6 +368,7 @@ unknown keys:
 | `DEVKIT_SYNC_TARGET` | Branch the scaffolded sync-issues job commits to; empty (default) => the workflow-model default (`dev`/`main`). A protected-`main` consumer sets an unprotected mirror branch, e.g. `sync/issue-mirror` (see [Point sync-issues at an unprotected mirror branch](#point-sync-issues-at-an-unprotected-mirror-branch-protected-main), [#1228](https://github.com/vig-os/devkit/issues/1228)) |
 | `DEVKIT_SYNC_SCHEDULE` | Cron override (5-field) for the sync-issues schedule trigger; empty (default) => the daily `0 2 * * *` ([#1228](https://github.com/vig-os/devkit/issues/1228)) |
 | `DEVKIT_FEATURES_DISABLED` | Comma-separated scaffold feature groups this repo opts OUT of; empty (default) => every group is scaffolded. A disabled group is never shipped and a prior scaffold's copy is pruned on upgrade (see [Scaffold feature opt-outs](#scaffold-feature-opt-outs), [#1284](https://github.com/vig-os/devkit/issues/1284)) |
+| `DEVKIT_REFS_POLICY` | Refs-line enforcement policy driving both the `validate-commit-msg` hook and CI's `validate-commit-range`: `chore-optional` (default/empty — only `chore` may omit `Refs:`) \| `optional` (never required) \| `required` (every type needs `Refs:`) ([#1282](https://github.com/vig-os/devkit/issues/1282)) |
 
 ### Scaffold feature opt-outs
 
@@ -428,6 +429,15 @@ How it behaves:
   with `--preview` first, then either keep the persisted mode or set
   `DEVKIT_MODE` in `.vig-os` yourself on a dedicated, clean upgrade branch (the
   preflight-guard flow below) and re-run the upgrade.
+- **Manifest keys govern scaffold shape and policy rendering; `flake.nix`
+  governs the toolchain and hooks.** A `.vig-os` key steers *what the scaffold
+  renders* (branching model, tag scheme, CI runner, Refs policy — realized at
+  scaffold time into workflows and configs); the dev-shell toolchain and the
+  flake-generated pre-commit hooks are `flake.nix`'s domain. A knob that drives
+  two enforcement points (e.g. `DEVKIT_REFS_POLICY` renders both the
+  `validate-commit-msg` hook arg and CI's `validate-commit-range` from one key,
+  [#1282](https://github.com/vig-os/devkit/issues/1282)) keeps its mapping in
+  lockstep across both renderers.
 - **Future flags live here.** The manifest is the home for upcoming per-project
   devkit switches (e.g. the raw-YAML hook opt-out planned in
   [#883](https://github.com/vig-os/devkit/issues/883)). `.vig-os` is a

--- a/install.sh
+++ b/install.sh
@@ -407,6 +407,84 @@ run_preflight_guard() {
     esac
 }
 
+# Refuse to scaffold when the default branch is not `main` (#1283). The
+# scaffolded branch-name hook, ci.yml's TRUNK sed and its workflow triggers all
+# assume `main`; on a legacy `master` repo the scaffold would succeed silently
+# and then every commit would hit a confusing branch-name hook error. This fails
+# loudly BEFORE anything is written, with the rename recipe. Unlike
+# run_preflight_guard (#886, --force only) it ALSO runs on fresh installs —
+# first-time adoption on a legacy master repo is the core case. Resolution order:
+# origin/HEAD, then a best-effort `gh api` default_branch (GitHub origin only,
+# offline-safe), then the local current branch when there is no origin. A
+# non-main default is accepted when a `main` branch already exists (local or
+# origin) — the gitflow case of scaffolding from a topic/dev branch of a
+# conforming repo. Non-git dirs are left to run_preflight_guard's warn+confirm
+# path. Under --preview it only warns; the caller skips it for --smoke-test and
+# --skip-preflight.
+check_default_branch() {
+    local path="$1"
+    local skip_hint="Re-run with --skip-preflight to bypass this check."
+    local default_branch="" url repo
+
+    # Non-git (or git unavailable): owned by run_preflight_guard's non-git path.
+    if ! command -v git >/dev/null 2>&1 \
+        || ! git -C "$path" rev-parse --git-dir >/dev/null 2>&1; then
+        return 0
+    fi
+
+    if default_branch="$(git -C "$path" symbolic-ref --quiet refs/remotes/origin/HEAD 2>/dev/null)"; then
+        default_branch="${default_branch#refs/remotes/origin/}"
+    else
+        default_branch=""
+    fi
+
+    if [ -z "$default_branch" ]; then
+        url="$(git -C "$path" remote get-url origin 2>/dev/null || true)"
+        if [ -n "$url" ]; then
+            # Origin exists but origin/HEAD is unset: ask GitHub, best-effort.
+            # Must never hang or fail the preflight because gh failed/offline.
+            if command -v gh >/dev/null 2>&1 && repo="$(parse_github_remote "$url" 2>/dev/null)"; then
+                if command -v timeout >/dev/null 2>&1; then
+                    default_branch="$(timeout 5 gh api "repos/$repo" --jq .default_branch 2>/dev/null || true)"
+                else
+                    default_branch="$(gh api "repos/$repo" --jq .default_branch 2>/dev/null || true)"
+                fi
+            fi
+        else
+            # Local-only repo (no origin): fall back to the current branch.
+            default_branch="$(git -C "$path" symbolic-ref --quiet --short HEAD 2>/dev/null || true)"
+        fi
+    fi
+
+    # Unresolvable (e.g. detached HEAD with no origin, gh offline): defer to
+    # run_preflight_guard rather than guess.
+    [ -n "$default_branch" ] || return 0
+    [ "$default_branch" = main ] && return 0
+
+    # A non-main default is fine when `main` already exists (local or origin).
+    if git -C "$path" rev-parse --verify --quiet main >/dev/null 2>&1 \
+        || git -C "$path" rev-parse --verify --quiet refs/remotes/origin/main >/dev/null 2>&1; then
+        return 0
+    fi
+
+    if [ -n "$PREVIEW" ]; then
+        warn "preflight: default branch is '$default_branch', not 'main' — a real scaffold would refuse."
+        warn "  Rename it first: git branch -m $default_branch main && git push -u origin main"
+        warn "  then: gh repo edit --default-branch main (see docs/MIGRATION.md)."
+        return 0
+    fi
+
+    err "preflight: refusing to scaffold — the default branch is '$default_branch', not 'main'."
+    echo "  vigOS scaffolding assumes 'main': the branch-name hook, ci.yml and its"
+    echo "  workflow triggers key off it, so every commit here would be blocked."
+    echo "  Rename the default branch to 'main' first:"
+    echo "    git branch -m $default_branch main && git push -u origin main"
+    echo "    gh repo edit --default-branch main"
+    echo "  Then re-run. See docs/MIGRATION.md (Legacy default branches)."
+    echo "  $skip_hint"
+    exit 1
+}
+
 # Parse arguments
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -656,6 +734,14 @@ if [ -z "$GITHUB_REPOSITORY" ] && [ -d "$PROJECT_PATH/.git" ]; then
 fi
 if [ -z "$GITHUB_REPOSITORY" ]; then
     GITHUB_REPOSITORY="OWNER/REPO"
+fi
+
+# Default-branch preflight (#1283): a non-`main` default branch (legacy master)
+# would let the scaffold succeed silently, then block every commit via the
+# branch-name hook. Runs on fresh installs too (first-time adoption is the core
+# case); --smoke-test and --skip-preflight skip it, --preview only warns.
+if [ -z "$SMOKE_TEST" ] && [ "$SKIP_PREFLIGHT" = false ]; then
+    check_default_branch "$PROJECT_PATH"
 fi
 
 # Preflight-gate --force upgrades (#886). Exemptions:

--- a/tests/bats/init-workspace.bats
+++ b/tests/bats/init-workspace.bats
@@ -4233,3 +4233,56 @@ _scaffold_seeded() {
     run test -e "$ws/.github/workflows/release.yml"
     assert_failure
 }
+
+# ── test/test-cov tolerate pytest's no-tests-collected exit (#1281) ───────────
+# A Python consumer with a pyproject.toml but no test suite runs `uv run pytest`
+# → exit 5 ("no tests collected"). "Nothing to test" is not a failure: `just
+# test` / `just test-cov` must no-op green, matching how non-Python consumers
+# silently skip. Every OTHER nonzero pytest exit must still fail the recipe.
+# Exercised with the real `just` binary against a scaffolded workspace, so the
+# recipe runs under the root justfile's pipefail shell (#854).
+
+# Scaffold a Python workspace ($2) and drop a stub `uv` that exits $3 on any
+# invocation, simulating pytest's exit code. Leaves the stub in $2/stub-bin.
+_py_ws_uv_exit() {
+    local mode="$1" ws="$2" code="$3"
+    mkdir -p "$ws"
+    _scaffold "$mode" "$ws"
+    printf '# SENTINEL-1281 minimal project, no test suite\n' >"$ws/pyproject.toml"
+    local stub="$ws/stub-bin"
+    mkdir -p "$stub"
+    printf '#!/usr/bin/env bash\nexit %s\n' "$code" >"$stub/uv"
+    chmod +x "$stub/uv"
+}
+
+@test "just test succeeds on a Python repo with zero collected tests (#1281)" {
+    real_just="$(command -v just)"
+    ws="$BATS_TEST_TMPDIR/e2e-1281-test-nocollect"
+    _py_ws_uv_exit both "$ws" 5
+    run bash -c "cd '$ws' && PATH='$ws/stub-bin:$PATH' '$real_just' test"
+    assert_success
+}
+
+@test "just test still fails on a genuinely failing suite (#1281)" {
+    real_just="$(command -v just)"
+    ws="$BATS_TEST_TMPDIR/e2e-1281-test-fail"
+    _py_ws_uv_exit both "$ws" 1
+    run bash -c "cd '$ws' && PATH='$ws/stub-bin:$PATH' '$real_just' test"
+    assert_failure 1
+}
+
+@test "just test-cov succeeds on a Python repo with zero collected tests (#1281)" {
+    real_just="$(command -v just)"
+    ws="$BATS_TEST_TMPDIR/e2e-1281-cov-nocollect"
+    _py_ws_uv_exit both "$ws" 5
+    run bash -c "cd '$ws' && PATH='$ws/stub-bin:$PATH' '$real_just' test-cov"
+    assert_success
+}
+
+@test "just test-cov still fails on a genuinely failing suite (#1281)" {
+    real_just="$(command -v just)"
+    ws="$BATS_TEST_TMPDIR/e2e-1281-cov-fail"
+    _py_ws_uv_exit both "$ws" 1
+    run bash -c "cd '$ws' && PATH='$ws/stub-bin:$PATH' '$real_just' test-cov"
+    assert_failure 1
+}

--- a/tests/bats/init-workspace.bats
+++ b/tests/bats/init-workspace.bats
@@ -2439,6 +2439,91 @@ _upgrade_no_flags() {
     assert_output --partial "Invalid DEVKIT_SYNC_SCHEDULE"
 }
 
+# ── Refs policy knob (#1282) ──────────────────────────────────────────────────
+# DEVKIT_REFS_POLICY steers the validate-commit-msg hook's --refs-optional-types
+# arg at scaffold time (the CI validate-commit-range surface is driven from the
+# same key via resolve-toolchain, covered in tests/test_ci_runner.py). Values:
+# chore-optional (default, byte-identical) | optional (full types list) |
+# required (a `none` sentinel type => every real type requires Refs). Persisted
+# like DEVKIT_CI_RUNNER; invalid values fail the scaffold loudly.
+
+@test "template .vig-os ships the Refs policy key empty (#1282)" {
+    run grep -x 'DEVKIT_REFS_POLICY=' "$TEMPLATE_DIR/.vig-os"
+    assert_success
+}
+
+@test "default scaffold keeps the chore-optional refs-optional-types arg (#1282)" {
+    # No DEVKIT_REFS_POLICY key => the template default is untouched, so the
+    # validate-commit-msg hook keeps its byte-identical `chore` arg.
+    ws="$BATS_TEST_TMPDIR/e2e-1282-default"
+    mkdir -p "$ws"
+    run _scaffold both "$ws"
+    assert_success
+    run grep -qF '"--refs-optional-types", "chore",' "$ws/.pre-commit-config.yaml"
+    assert_success
+}
+
+@test "DEVKIT_REFS_POLICY=optional renders the full types list + writes back (#1282)" {
+    ws="$BATS_TEST_TMPDIR/e2e-1282-optional"
+    mkdir -p "$ws"
+    run _scaffold both "$ws"
+    assert_success
+    sed -i 's/^DEVKIT_REFS_POLICY=.*/DEVKIT_REFS_POLICY=optional/' "$ws/.vig-os"
+    run _upgrade_no_flags "$ws"
+    assert_success
+    run grep -qF '"--refs-optional-types", "feat,fix,docs,chore,refactor,perf,test,ci,build,revert,style",' "$ws/.pre-commit-config.yaml"
+    assert_success
+    run grep -x 'DEVKIT_REFS_POLICY=optional' "$ws/.vig-os"
+    assert_success
+}
+
+@test "DEVKIT_REFS_POLICY=required renders the none sentinel + writes back (#1282)" {
+    # required means every real type requires Refs. The CLI treats an empty
+    # --refs-optional-types as falsy and reverts to the {chore} default, so the
+    # renderer emits a `none` sentinel type (no real commit is type `none`).
+    ws="$BATS_TEST_TMPDIR/e2e-1282-required"
+    mkdir -p "$ws"
+    run _scaffold both "$ws"
+    assert_success
+    sed -i 's/^DEVKIT_REFS_POLICY=.*/DEVKIT_REFS_POLICY=required/' "$ws/.vig-os"
+    run _upgrade_no_flags "$ws"
+    assert_success
+    run grep -qF '"--refs-optional-types", "none",' "$ws/.pre-commit-config.yaml"
+    assert_success
+    run grep -x 'DEVKIT_REFS_POLICY=required' "$ws/.vig-os"
+    assert_success
+}
+
+@test "an invalid DEVKIT_REFS_POLICY fails the scaffold loudly (#1282)" {
+    ws="$BATS_TEST_TMPDIR/e2e-1282-bad-policy"
+    mkdir -p "$ws"
+    run _scaffold both "$ws"
+    assert_success
+    sed -i 's/^DEVKIT_REFS_POLICY=.*/DEVKIT_REFS_POLICY=garbage/' "$ws/.vig-os"
+    run _upgrade_no_flags "$ws"
+    assert_failure
+    assert_output --partial "Invalid DEVKIT_REFS_POLICY"
+}
+
+@test "DEVKIT_REFS_POLICY composes with the trunk workflow render (#1282)" {
+    # render_workflow_model (trunk) and render_refs_policy both sed
+    # .pre-commit-config.yaml on distinct anchors — they must compose.
+    ws="$BATS_TEST_TMPDIR/e2e-1282-compose-trunk"
+    mkdir -p "$ws"
+    run _scaffold both "$ws"
+    assert_success
+    sed -i 's/^DEVKIT_WORKFLOW=.*/DEVKIT_WORKFLOW=trunk/' "$ws/.vig-os"
+    sed -i 's/^DEVKIT_REFS_POLICY=.*/DEVKIT_REFS_POLICY=optional/' "$ws/.vig-os"
+    run _upgrade_no_flags "$ws"
+    assert_success
+    # (a) the refs policy rendered the full types list
+    run grep -qF '"--refs-optional-types", "feat,fix,docs,chore,refactor,perf,test,ci,build,revert,style",' "$ws/.pre-commit-config.yaml"
+    assert_success
+    # (b) the trunk render still dropped the dev protect-clause on the same file
+    run grep -qF '(?!dev$)' "$ws/.pre-commit-config.yaml"
+    assert_failure
+}
+
 # ── cache-cleanup retry fallback shim (#1278) ─────────────────────────────────
 # The "Delete old cache" cleanup step runs `if: always()` and calls the `retry`
 # wrapper, which only exists after toolchain setup. A job that dies before setup

--- a/tests/bats/install.bats
+++ b/tests/bats/install.bats
@@ -462,6 +462,11 @@ _make_repo() {
     mkdir -p "$dir"
     _git init -q -b "$branch" "$dir"
     _git -C "$dir" commit -q --allow-empty -m "chore: init"
+    # A realistic topic-branch checkout has a `main` alongside it. The
+    # default-branch preflight (#1283) refuses a non-main default only when no
+    # `main` exists anywhere, so give every non-main fixture a `main` branch —
+    # the gitflow accept-path — leaving the #886 guard's assertions unchanged.
+    [ "$branch" = main ] || _git -C "$dir" branch main
 }
 
 @test "preflight: --force refuses on main with the branch hint (#886)" {
@@ -648,6 +653,94 @@ _make_repo() {
     run bash "$INSTALL_SH" --dry-run "$dir" </dev/null
     assert_success
     assert_output --partial "Would execute:"
+}
+
+# ── default-branch preflight (#1283) ──────────────────────────────────────────
+# Scaffolding assumes the default branch is `main` (the branch-name hook, ci.yml
+# and its workflow triggers all key off it). On a legacy `master` repo the
+# scaffold would succeed silently, then block every commit. A preflight detects a
+# non-`main` default branch and aborts BEFORE anything is written, with the
+# rename recipe. Unlike the #886 guard it runs on fresh installs too;
+# --skip-preflight and --smoke-test skip it, --preview only warns, and a `main`
+# default (or a topic/dev branch of a repo that has `main`) proceeds unchanged.
+
+# A repo whose default branch is `master` via origin/HEAD, with no `main`
+# anywhere. Not built through _make_repo (which would add a `main`).
+_make_master_origin_repo() {
+    local work="$1" origin="$1.origin.git"
+    _git init -q -b master --bare "$origin"
+    mkdir -p "$work"
+    _git init -q -b master "$work"
+    _git -C "$work" commit -q --allow-empty -m "chore: init"
+    _git -C "$work" remote add origin "$origin"
+    _git -C "$work" push -q origin master
+    _git -C "$work" symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/master
+}
+
+# A local-only repo (no origin) checked out on `master`, no `main`.
+_make_local_master_repo() {
+    local dir="$1"
+    mkdir -p "$dir"
+    _git init -q -b master "$dir"
+    _git -C "$dir" commit -q --allow-empty -m "chore: init"
+}
+
+@test "preflight: master default via origin/HEAD aborts pre-copy with rename recipe (#1283)" {
+    repo="$BATS_TEST_TMPDIR/master-origin"
+    _make_master_origin_repo "$repo"
+    run bash "$INSTALL_SH" --dry-run "$repo" </dev/null
+    assert_failure
+    assert_output --partial "git branch -m master main && git push -u origin main"
+    assert_output --partial "gh repo edit --default-branch main"
+    assert_output --partial "MIGRATION.md"
+    # aborts before the copy step: never reaches the container command
+    refute_output --partial "Would execute:"
+}
+
+@test "preflight: main default proceeds unchanged (#1283)" {
+    repo="$BATS_TEST_TMPDIR/main-default-1283"
+    _make_repo "$repo" main
+    run bash "$INSTALL_SH" --dry-run "$repo" </dev/null
+    assert_success
+    assert_output --partial "Would execute:"
+}
+
+@test "preflight: --skip-preflight proceeds on a master repo (#1283)" {
+    repo="$BATS_TEST_TMPDIR/master-skip-1283"
+    _make_local_master_repo "$repo"
+    run bash "$INSTALL_SH" --dry-run --skip-preflight "$repo" </dev/null
+    assert_success
+    assert_output --partial "Would execute:"
+}
+
+@test "preflight: --preview warns on a master repo without aborting (#1283)" {
+    repo="$BATS_TEST_TMPDIR/master-preview-1283"
+    _make_local_master_repo "$repo"
+    run bash "$INSTALL_SH" --dry-run --preview "$repo" </dev/null
+    assert_success
+    assert_output --partial "not 'main'"
+    assert_output --partial "Would execute:"
+}
+
+@test "preflight: dev branch of a repo that has main proceeds (#1283)" {
+    repo="$BATS_TEST_TMPDIR/gitflow-dev-1283"
+    mkdir -p "$repo"
+    _git init -q -b main "$repo"
+    _git -C "$repo" commit -q --allow-empty -m "chore: init"
+    _git -C "$repo" checkout -q -b dev
+    run bash "$INSTALL_SH" --dry-run "$repo" </dev/null
+    assert_success
+    assert_output --partial "Would execute:"
+}
+
+@test "preflight: local-only master repo (no origin) aborts with the same guidance (#1283)" {
+    repo="$BATS_TEST_TMPDIR/master-local-1283"
+    _make_local_master_repo "$repo"
+    run bash "$INSTALL_SH" --dry-run "$repo" </dev/null
+    assert_failure
+    assert_output --partial "git branch -m master main && git push -u origin main"
+    assert_output --partial "gh repo edit --default-branch main"
+    refute_output --partial "Would execute:"
 }
 
 # ── --preview forwarding and docs (#886) ──────────────────────────────────────

--- a/tests/test_ci_runner.py
+++ b/tests/test_ci_runner.py
@@ -229,6 +229,21 @@ def _commit_checks_step(workflow: dict) -> dict:
     raise AssertionError(f"commit-checks step {COMMIT_CHECKS_STEP!r} not found")
 
 
+def test_resolve_toolchain_job_reexports_refs_optional_types() -> None:
+    """ci.yml's resolve-toolchain job maps the action output to a job output.
+
+    `needs.resolve-toolchain.outputs.*` reads JOB outputs, not the composite
+    action's — without this mapping the commit-checks env resolves empty and
+    the policy silently reverts to the chore default (actionlint catches it).
+    """
+    workflow = _load(WORKFLOWS / "ci.yml")
+    outputs = workflow["jobs"]["resolve-toolchain"]["outputs"]
+    assert (
+        outputs.get("refs-optional-types")
+        == "${{ steps.resolve.outputs.refs-optional-types }}"
+    )
+
+
 def test_commit_checks_step_routes_refs_policy_through_env() -> None:
     """The commit-checks step consumes the resolved list via env, not inline."""
     workflow = _load(WORKFLOWS / "ci.yml")

--- a/tests/test_ci_runner.py
+++ b/tests/test_ci_runner.py
@@ -158,3 +158,87 @@ def test_runner_json_emitted_in_every_mode(tmp_path: Path, mode: str) -> None:
     )
     outputs = _run_resolve(tmp_path, manifest)
     assert json.loads(outputs["runner-json"]) == ["self-hosted"]
+
+
+# ── Refs policy knob (#1282) ──────────────────────────────────────────────────
+# DEVKIT_REFS_POLICY drives CI's validate-commit-range Refs enforcement from the
+# same key that steers the validate-commit-msg hook at scaffold time. The
+# policy->types mapping lives once in resolve-toolchain (single mapping point for
+# the CI surface) and mirrors render_refs_policy in init-workspace.sh. The
+# `commit-checks` step consumes the resolved list via env, never inline (the
+# env-routing pattern the zizmor gate / #1279 require).
+
+# The full approved-types list `optional` expands to (mirrors the hook `--types`).
+FULL_REFS_TYPES = "feat,fix,docs,chore,refactor,perf,test,ci,build,revert,style"
+
+# The step that validates commit messages / PR title in the commit-checks job.
+COMMIT_CHECKS_STEP = "Validate commit messages and PR title"
+
+
+def test_resolve_toolchain_emits_refs_optional_types_output() -> None:
+    """resolve-toolchain declares a refs-optional-types output for CI to consume."""
+    action = _load(RESOLVE_ACTION)
+    assert "refs-optional-types" in action["outputs"]
+
+
+def test_refs_optional_types_defaults_to_chore_when_key_absent(tmp_path: Path) -> None:
+    """No DEVKIT_REFS_POLICY => the chore-optional default (only chore optional)."""
+    outputs = _run_resolve(tmp_path, "DEVKIT_MODE=direnv\n")
+    assert outputs["refs-optional-types"] == "chore"
+
+
+def test_refs_optional_types_chore_optional_maps_to_chore(tmp_path: Path) -> None:
+    """chore-optional is today's behavior => the bare `chore` list."""
+    outputs = _run_resolve(
+        tmp_path, "DEVKIT_MODE=direnv\nDEVKIT_REFS_POLICY=chore-optional\n"
+    )
+    assert outputs["refs-optional-types"] == "chore"
+
+
+def test_refs_optional_types_optional_maps_to_full_list(tmp_path: Path) -> None:
+    """optional never requires Refs => every approved type is optional."""
+    outputs = _run_resolve(
+        tmp_path, "DEVKIT_MODE=direnv\nDEVKIT_REFS_POLICY=optional\n"
+    )
+    assert outputs["refs-optional-types"] == FULL_REFS_TYPES
+
+
+def test_refs_optional_types_required_maps_to_none_sentinel(tmp_path: Path) -> None:
+    """required => the `none` sentinel so every real type requires Refs."""
+    outputs = _run_resolve(
+        tmp_path, "DEVKIT_MODE=direnv\nDEVKIT_REFS_POLICY=required\n"
+    )
+    assert outputs["refs-optional-types"] == "none"
+
+
+def test_refs_optional_types_invalid_falls_back_to_chore(tmp_path: Path) -> None:
+    """An unexpected value falls back to the safe chore-optional default.
+
+    The loud guard lives at the write path (init-workspace.sh); by the time CI
+    reads .vig-os the value was validated at scaffold, so a defensive fallback
+    keeps CI from breaking on an unexpected literal.
+    """
+    outputs = _run_resolve(tmp_path, "DEVKIT_MODE=direnv\nDEVKIT_REFS_POLICY=garbage\n")
+    assert outputs["refs-optional-types"] == "chore"
+
+
+def _commit_checks_step(workflow: dict) -> dict:
+    for step in workflow["jobs"]["commit-checks"]["steps"]:
+        if step.get("name") == COMMIT_CHECKS_STEP:
+            return step
+    raise AssertionError(f"commit-checks step {COMMIT_CHECKS_STEP!r} not found")
+
+
+def test_commit_checks_step_routes_refs_policy_through_env() -> None:
+    """The commit-checks step consumes the resolved list via env, not inline."""
+    workflow = _load(WORKFLOWS / "ci.yml")
+    step = _commit_checks_step(workflow)
+    env_values = step["env"].values()
+    assert "${{ needs.resolve-toolchain.outputs.refs-optional-types }}" in env_values
+
+
+def test_commit_checks_step_passes_refs_optional_types_flag() -> None:
+    """The run block forwards the env value to validate-commit-range."""
+    workflow = _load(WORKFLOWS / "ci.yml")
+    step = _commit_checks_step(workflow)
+    assert "--refs-optional-types" in step["run"]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -488,7 +488,9 @@ class TestInstallScriptUnit:
 
         Uses a clean feature-branch git fixture: the upgrade preflight guard
         (#886) refuses --force on non-git directories, protected branches,
-        and dirty trees.
+        and dirty trees. A `main` branch exists alongside, as in any conforming
+        checkout — the default-branch preflight (#1283) refuses when no `main`
+        can be resolved at all.
         """
         git_env = [
             "git",
@@ -515,6 +517,11 @@ class TestInstallScriptUnit:
                 "-m",
                 "chore: init",
             ],
+            check=True,
+            timeout=10,
+        )
+        subprocess.run(
+            [*git_env, "-C", str(tmp_path), "branch", "main"],
             check=True,
             timeout=10,
         )


### PR DESCRIPTION
## Summary

New `.vig-os` manifest key `DEVKIT_REFS_POLICY` steering the `Refs: #N` enforcement policy from ONE key into BOTH enforcement points — the `validate-commit-msg` hook args in the scaffolded `.pre-commit-config.yaml` and CI's `validate-commit-range` (which until now silently ran the tool default, the #1074 desync class):

- `chore-optional` (default / empty key) — today's behavior, byte-identical scaffold
- `optional` — Refs never required (type/format validation kept)
- `required` — every type needs `Refs:`, `chore` included

Solo/private consumers get Refs-optional without editing the preserved `.pre-commit-config.yaml` (no permanent upgrade-diff nag, no hook/CI desync).

## Design notes

- **`required` maps to a `none` sentinel, not `""`**: both CLIs guard with `if args.refs_optional_types:` — an empty string is falsy and silently reverts to the `{chore}` default (the existing empty-set unit test bypasses the CLI). `none` is not a real commit type, so every real type requires Refs; no vig-utils change needed.
- Scaffold surface: `render_refs_policy` in `init-workspace.sh` (anchored sed, no-op for the default, composes with the trunk render on the same file); manifest READ/validate/write-back per the #1116 round-trip idiom. In direnv/flake-hooks mode (no scaffolded pre-commit YAML) the render no-ops — hooks are flake domain; CI still enforces.
- CI surface: `resolve-toolchain` parses the key and emits a `refs-optional-types` output (tolerant: unexpected/absent → `chore`); `ci.yml` commit-checks routes it via `env:` (zizmor/#1279 pattern) into `--refs-optional-types`. The two policy→types mappings are cross-referenced in comments at both renderers.
- `docs/MIGRATION.md`: manifest-table row + the manifest-vs-flake doctrine bullet.

## Test evidence

- TDD, two cycles (scaffold `588414c2`→`72cdd46e`, CI `d6527693`→`2ea2036d`), failing-first confirmed each.
- `bats --filter 1282`: 6/6 ok (default byte-identical, optional/required round-trip, invalid-value abort, trunk compose).
- `pytest tests/test_ci_runner.py tests/test_workflow_model.py`: 41 passed (incl. the byte-identical `.pre-commit-config.yaml` render pin).
- `prek run --all-files`: green.

## Merge order

Part of the #1280–#1285 solo-adoption batch (semver:minor); recommended merge order #1281 → #1280 → #1283 → #1282 → #1284 → #1285.

Closes #1282