### PR TITLE
feat(workspace): manifest-driven scaffold feature opt-outs (DEVKIT_FEATURES_DISABLED)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Manifest-driven scaffold feature opt-outs (DEVKIT_FEATURES_DISABLED)** ([#1284](https://github.com/vig-os/devkit/issues/1284))
+  - New `.vig-os` key: a comma-separated, whitespace-tolerant list of scaffold
+    feature groups a repo opts out of. Disabled groups are never scaffolded,
+    pruned if a prior scaffold left them, reported by `--preview`, and stable
+    across `--force` upgrades; clearing the key re-ships them. Absent/empty
+    scaffolds identically to before; an unknown name aborts loudly.
+  - Seven groups: `release` (the release/prepare/promote workflows + downstream
+    docs), `renovate` (renovate config + changelog workflows), `sync-issues`
+    (the sync workflow + label taxonomy), `scanning` (CodeQL + Scorecard),
+    `gh-templates` (issue templates + PR template), `skills` (every
+    `.claude/skills/` dir except `worktree_*`), and `worktree` (the
+    `worktree_*` skills + `justfile.worktree`).
+  - Consumer-owned extension seams (`release-extension.yml`,
+    `prepare-release-extension.yml`) and `renovate.json` are never pruned when
+    their feature is disabled — they are left in place with a notice.
+
 ### Changed
 
 ### Deprecated

--- a/assets/init-workspace.sh
+++ b/assets/init-workspace.sh
@@ -340,6 +340,7 @@ MANIFEST_CI_RUNNER="$(read_manifest_value "$VIG_OS_MANIFEST" DEVKIT_CI_RUNNER ||
 MANIFEST_WORKFLOW="$(read_manifest_value "$VIG_OS_MANIFEST" DEVKIT_WORKFLOW || true)"
 MANIFEST_SYNC_TARGET="$(read_manifest_value "$VIG_OS_MANIFEST" DEVKIT_SYNC_TARGET || true)"
 MANIFEST_SYNC_SCHEDULE="$(read_manifest_value "$VIG_OS_MANIFEST" DEVKIT_SYNC_SCHEDULE || true)"
+MANIFEST_FEATURES_DISABLED="$(read_manifest_value "$VIG_OS_MANIFEST" DEVKIT_FEATURES_DISABLED || true)"
 
 # The OWNER/REPO placeholder (written when no origin was resolvable) must not
 # mask a now-detectable git origin on a later upgrade.
@@ -424,6 +425,43 @@ if [[ -n "$MANIFEST_SYNC_SCHEDULE" ]] && ! is_valid_cron "$MANIFEST_SYNC_SCHEDUL
     echo "Error: Invalid DEVKIT_SYNC_SCHEDULE in $VIG_OS_MANIFEST: $MANIFEST_SYNC_SCHEDULE (expected a 5-field cron expression, e.g. '0 2 * * *')" >&2
     exit 1
 fi
+
+# Scaffold feature opt-outs (#1284): DEVKIT_FEATURES_DISABLED is a
+# comma-separated (whitespace-tolerant, like DEVKIT_FLOATING_TAGS/CI_RUNNER)
+# subset of the seven scaffold feature groups. Parse + validate it loudly here —
+# an unknown name must abort, never silently disable nothing — into
+# DISABLED_FEATURES[], with a feature_disabled helper the copy/prune/notice
+# mechanisms below all consult. Pure `.vig-os` key (no CLI flag), so only a
+# format guard: no contradiction guard as for --mode / --workflow.
+VALID_FEATURES=(release renovate sync-issues scanning gh-templates skills worktree)
+DISABLED_FEATURES=()
+if [[ -n "$MANIFEST_FEATURES_DISABLED" ]]; then
+    IFS=',' read -ra _raw_features <<< "$MANIFEST_FEATURES_DISABLED"
+    for _feat in "${_raw_features[@]}"; do
+        # Trim surrounding whitespace (leading + trailing).
+        _feat="${_feat#"${_feat%%[![:space:]]*}"}"
+        _feat="${_feat%"${_feat##*[![:space:]]}"}"
+        [[ -z "$_feat" ]] && continue
+        _valid_feat=false
+        for _v in "${VALID_FEATURES[@]}"; do
+            [[ "$_feat" == "$_v" ]] && { _valid_feat=true; break; }
+        done
+        if [[ "$_valid_feat" != "true" ]]; then
+            echo "Error: Invalid DEVKIT_FEATURES_DISABLED in $VIG_OS_MANIFEST: $_feat (expected a comma-separated subset of: release, renovate, sync-issues, scanning, gh-templates, skills, worktree)" >&2
+            exit 1
+        fi
+        DISABLED_FEATURES+=("$_feat")
+    done
+fi
+
+# True when scaffold feature group $1 is in DISABLED_FEATURES (#1284).
+feature_disabled() {
+    local name="$1" f
+    for f in "${DISABLED_FEATURES[@]}"; do
+        [[ "$f" == "$name" ]] && return 0
+    done
+    return 1
+}
 
 # Get SHORT_NAME - from env var, manifest, or prompt (#885)
 if [[ -z "${SHORT_NAME:-}" && -n "$MANIFEST_PROJECT" ]]; then
@@ -1856,6 +1894,13 @@ if [[ -f "$VIG_OS_MANIFEST" ]]; then
     fi
     if [[ -n "$MANIFEST_SYNC_SCHEDULE" ]]; then
         write_manifest_value DEVKIT_SYNC_SCHEDULE "$MANIFEST_SYNC_SCHEDULE"
+    fi
+    # Feature opt-outs (#1284): bare in the template (DEVKIT_FEATURES_DISABLED=),
+    # so a consumer's disabled-feature list is read before the overwrite and
+    # written back — else an upgrade silently re-ships the pruned features. The
+    # raw value round-trips (like DEVKIT_TAG_PREFIX); clearing it re-enables.
+    if [[ -n "$MANIFEST_FEATURES_DISABLED" ]]; then
+        write_manifest_value DEVKIT_FEATURES_DISABLED "$MANIFEST_FEATURES_DISABLED"
     fi
 fi
 

--- a/assets/init-workspace.sh
+++ b/assets/init-workspace.sh
@@ -1106,6 +1106,79 @@ if [[ "$FLAKE_PREEXISTED" == "true" && "$PRECOMMIT_CONFIG_PREEXISTED" == "false"
     MODE_CONFIG_EXCLUDES+=(".pre-commit-config.yaml")
 fi
 
+# Feature opt-outs (#1284): expand a disabled feature group into its
+# transfer-root rel-paths — the SSoT feature->path map. The skills/worktree
+# groups are enumerated from the template tree at runtime (the filesystem is the
+# SSoT; skills = every .claude/skills/* dir EXCEPT worktree_*, worktree = the
+# worktree_* dirs plus the optional justfile.worktree import), so the ~24 skill
+# names are never hardcoded. A directory entry (an ISSUE_TEMPLATE or skill dir)
+# covers its whole subtree for the copy-exclude + preview classifier below.
+feature_paths() {
+    local feature="$1" d name
+    case "$feature" in
+        release)
+            printf '%s\n' \
+                ".github/workflows/release.yml" \
+                ".github/workflows/release-core.yml" \
+                ".github/workflows/release-extension.yml" \
+                ".github/workflows/release-publish.yml" \
+                ".github/workflows/prepare-release.yml" \
+                ".github/workflows/prepare-release-extension.yml" \
+                ".github/workflows/promote-release.yml" \
+                ".github/workflows/sync-main-to-dev.yml" \
+                "docs/DOWNSTREAM_RELEASE.md"
+            ;;
+        renovate)
+            printf '%s\n' \
+                "renovate.json" \
+                ".github/renovate-default.json" \
+                ".github/workflows/renovate-changelog-build.yml" \
+                ".github/workflows/renovate-changelog-commit.yml"
+            ;;
+        sync-issues)
+            printf '%s\n' \
+                ".github/workflows/sync-issues.yml" \
+                ".github/label-taxonomy.toml"
+            ;;
+        scanning)
+            printf '%s\n' \
+                ".github/workflows/codeql.yml" \
+                ".github/workflows/scorecard.yml"
+            ;;
+        gh-templates)
+            printf '%s\n' \
+                ".github/ISSUE_TEMPLATE" \
+                ".github/pull_request_template.md"
+            ;;
+        skills)
+            for d in "$TEMPLATE_DIR"/.claude/skills/*/; do
+                [[ -d "$d" ]] || continue
+                name="$(basename "$d")"
+                [[ "$name" == worktree_* ]] && continue
+                printf '%s\n' ".claude/skills/$name"
+            done
+            ;;
+        worktree)
+            for d in "$TEMPLATE_DIR"/.claude/skills/worktree_*/; do
+                [[ -d "$d" ]] || continue
+                printf '%s\n' ".claude/skills/$(basename "$d")"
+            done
+            printf '%s\n' ".devcontainer/justfile.worktree"
+            ;;
+    esac
+}
+
+# Feature opt-outs (#1284): append each disabled feature's paths to
+# MODE_CONFIG_EXCLUDES, which both the --preview ADDED classifier and the rsync
+# copy consult — so a disabled feature is never shipped and never advertised.
+# The post-copy prune + DELETIONS report (with the preserved-class carve-out)
+# handle a pre-existing copy left by an earlier scaffold.
+for _feat in "${DISABLED_FEATURES[@]}"; do
+    while IFS= read -r _p; do
+        [[ -n "$_p" ]] && MODE_CONFIG_EXCLUDES+=("$_p")
+    done < <(feature_paths "$_feat")
+done
+
 # Rewrite the scaffolded workspace from the gitflow default shape (long-lived
 # `dev` + `main` + sync-main-to-dev.yml) to the trunk shape (`main` only) when
 # the resolved DEVKIT_WORKFLOW is `trunk` (#1205). A pure no-op for gitflow (the
@@ -1435,6 +1508,12 @@ if [[ "$FORCE" == "true" ]]; then
                 echo "  +  $added"
             done
             echo "─────────────────────────────────────────────────────────────"
+        fi
+        # Feature opt-outs (#1284): surface the disabled set so the preview is
+        # self-explaining — the skipped paths are absent from ADDED above.
+        if [[ ${#DISABLED_FEATURES[@]} -gt 0 ]]; then
+            echo ""
+            echo "Disabled features (DEVKIT_FEATURES_DISABLED): ${DISABLED_FEATURES[*]}"
         fi
         # trunk workflow model (#1205): the copied release workflows are
         # rendered dev -> main after the copy, so call it out in the preview.

--- a/assets/init-workspace.sh
+++ b/assets/init-workspace.sh
@@ -1455,6 +1455,30 @@ if [[ "$FORCE" == "true" ]]; then
         DELETIONS+=(".github/workflows/sync-main-to-dev.yml")
     fi
 
+    # Feature opt-outs (#1284): a disabled feature's pre-existing paths are
+    # pruned on upgrade — list them under DELETIONS (mirrors the trunk
+    # sync-main-to-dev entry above). EXCEPT the preserved class
+    # (release-extension.yml, prepare-release-extension.yml, renovate.json),
+    # which carry consumer implementation and are never pruned: report a
+    # left-in-place notice instead (preview only — the post-copy prune echoes it
+    # on a real --force run). sync-main-to-dev.yml is skipped when trunk already
+    # listed it, so a trunk + release-disabled upgrade reports it exactly once.
+    for _feat in "${DISABLED_FEATURES[@]}"; do
+        while IFS= read -r _p; do
+            [[ -n "$_p" && -e "$WORKSPACE_DIR/$_p" ]] || continue
+            if [[ "$WORKFLOW_MODEL" == "trunk" \
+                && "$_p" == ".github/workflows/sync-main-to-dev.yml" ]]; then
+                continue
+            fi
+            if is_preserved_file "$_p"; then
+                [[ "$PREVIEW" == "true" ]] && \
+                    echo "  Note: $_p left in place (preserved); delete manually if unwanted (#1284)."
+                continue
+            fi
+            DELETIONS+=("$_p")
+        done < <(feature_paths "$_feat")
+    done
+
     # Show preserved files
     if [[ ${#PRESERVED[@]} -gt 0 ]]; then
         echo ""
@@ -1766,6 +1790,29 @@ if [[ "$WORKFLOW_MODEL" == "trunk" \
     echo "Pruning sync-main-to-dev.yml for the trunk workflow model (#1205)..."
     rm -f "$WORKSPACE_DIR/.github/workflows/sync-main-to-dev.yml"
 fi
+
+# Feature opt-outs (#1284): prune a disabled feature's pre-existing paths left
+# by an earlier scaffold (the rsync copy already excludes them via
+# MODE_CONFIG_EXCLUDES; this removes the upgrade leftover). Preserved-class files
+# (release-extension.yml, prepare-release-extension.yml, renovate.json) carry
+# consumer implementation and are never pruned — print a left-in-place notice
+# instead. Composes with the trunk sync-main-to-dev prune above: that one path
+# is skipped under trunk so it is pruned + echoed exactly once.
+for _feat in "${DISABLED_FEATURES[@]}"; do
+    while IFS= read -r _p; do
+        [[ -n "$_p" && -e "$WORKSPACE_DIR/$_p" ]] || continue
+        if [[ "$WORKFLOW_MODEL" == "trunk" \
+            && "$_p" == ".github/workflows/sync-main-to-dev.yml" ]]; then
+            continue
+        fi
+        if is_preserved_file "$_p"; then
+            echo "Feature '$_feat' disabled: $_p left in place (preserved); delete manually if unwanted (#1284)."
+            continue
+        fi
+        echo "Pruning $_p for disabled feature '$_feat' (#1284)..."
+        rm -rf "${WORKSPACE_DIR:?}/$_p"
+    done < <(feature_paths "$_feat")
+done
 
 # 0.4.0 retired .devcontainer/justfile.base (recipes relocated to
 # justfile.project), so drop the stale copy an upgraded 0.3.x repo carries —

--- a/assets/init-workspace.sh
+++ b/assets/init-workspace.sh
@@ -463,6 +463,14 @@ feature_disabled() {
     return 1
 }
 
+# Contradiction notice (#1284): a disabled sync-issues feature removes
+# sync-issues.yml, so DEVKIT_SYNC_TARGET / DEVKIT_SYNC_SCHEDULE have nothing to
+# steer. Warn (never abort — the keys are inert, not invalid) so the combination
+# is not silently confusing.
+if feature_disabled sync-issues && [[ -n "$MANIFEST_SYNC_TARGET" || -n "$MANIFEST_SYNC_SCHEDULE" ]]; then
+    echo "Notice: sync-issues feature disabled (DEVKIT_FEATURES_DISABLED); DEVKIT_SYNC_TARGET/DEVKIT_SYNC_SCHEDULE will have no effect (#1284)." >&2
+fi
+
 # Get SHORT_NAME - from env var, manifest, or prompt (#885)
 if [[ -z "${SHORT_NAME:-}" && -n "$MANIFEST_PROJECT" ]]; then
     SHORT_NAME="$MANIFEST_PROJECT"
@@ -1969,8 +1977,14 @@ render_codeql_matrix
 # main. A no-op for the gitflow default, so a gitflow scaffold is unchanged.
 render_workflow_model "$WORKFLOW_MODEL"
 # sync-issues knobs (#1228): override the target branch + schedule cron on top of
-# the workflow-model default. A no-op when both keys are unset.
-render_sync_settings
+# the workflow-model default. A no-op when both keys are unset. Skipped entirely
+# when the sync-issues feature is disabled (#1284) — the file it seds no longer
+# exists, so the render would be a silent no-op anyway; skip it explicitly.
+if feature_disabled sync-issues; then
+    echo "Skipping sync-issues render (feature disabled via DEVKIT_FEATURES_DISABLED, #1284)."
+else
+    render_sync_settings
+fi
 
 # Persist the resolved manifest (#885). The scaffolded .vig-os is a managed
 # file (template-overwritten on upgrade), so the resolved delivery mode and

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Manifest-driven scaffold feature opt-outs (DEVKIT_FEATURES_DISABLED)** ([#1284](https://github.com/vig-os/devkit/issues/1284))
+  - New `.vig-os` key: a comma-separated, whitespace-tolerant list of scaffold
+    feature groups a repo opts out of. Disabled groups are never scaffolded,
+    pruned if a prior scaffold left them, reported by `--preview`, and stable
+    across `--force` upgrades; clearing the key re-ships them. Absent/empty
+    scaffolds identically to before; an unknown name aborts loudly.
+  - Seven groups: `release` (the release/prepare/promote workflows + downstream
+    docs), `renovate` (renovate config + changelog workflows), `sync-issues`
+    (the sync workflow + label taxonomy), `scanning` (CodeQL + Scorecard),
+    `gh-templates` (issue templates + PR template), `skills` (every
+    `.claude/skills/` dir except `worktree_*`), and `worktree` (the
+    `worktree_*` skills + `justfile.worktree`).
+  - Consumer-owned extension seams (`release-extension.yml`,
+    `prepare-release-extension.yml`) and `renovate.json` are never pruned when
+    their feature is disabled — they are left in place with a notice.
+
 ### Changed
 
 ### Deprecated

--- a/assets/workspace/.vig-os
+++ b/assets/workspace/.vig-os
@@ -69,3 +69,14 @@ DEVKIT_SYNC_TARGET=
 # the sync weekly on Sundays. Realized at scaffold time because schedule triggers
 # cannot take inputs (#1228).
 DEVKIT_SYNC_SCHEDULE=
+
+# Scaffold feature groups this repo opts OUT of — a comma-separated,
+# whitespace-tolerant subset of: release, renovate, sync-issues, scanning,
+# gh-templates, skills, worktree. Empty (default) => every group is scaffolded
+# (no change for existing consumers). A disabled group is never shipped, and a
+# copy left by a prior scaffold is pruned on upgrade; clearing the key re-ships
+# it on the next `--force`. Consumer-owned extension seams
+# (release-extension.yml, prepare-release-extension.yml) and renovate.json are
+# left in place if present (never pruned). Governs scaffold SHAPE only, not the
+# flake — an unknown name aborts the scaffold loudly (#1284).
+DEVKIT_FEATURES_DISABLED=

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -349,6 +349,46 @@ unknown keys:
 | `DEVKIT_CI_RUNNER` | Comma-separated runner label list for the scaffolded `ci.yml` toolchain jobs; empty (default) => the hosted `ubuntu-24.04` runner ([#1173](https://github.com/vig-os/devkit/issues/1173)) |
 | `DEVKIT_SYNC_TARGET` | Branch the scaffolded sync-issues job commits to; empty (default) => the workflow-model default (`dev`/`main`). A protected-`main` consumer sets an unprotected mirror branch, e.g. `sync/issue-mirror` (see [Point sync-issues at an unprotected mirror branch](#point-sync-issues-at-an-unprotected-mirror-branch-protected-main), [#1228](https://github.com/vig-os/devkit/issues/1228)) |
 | `DEVKIT_SYNC_SCHEDULE` | Cron override (5-field) for the sync-issues schedule trigger; empty (default) => the daily `0 2 * * *` ([#1228](https://github.com/vig-os/devkit/issues/1228)) |
+| `DEVKIT_FEATURES_DISABLED` | Comma-separated scaffold feature groups this repo opts OUT of; empty (default) => every group is scaffolded. A disabled group is never shipped and a prior scaffold's copy is pruned on upgrade (see [Scaffold feature opt-outs](#scaffold-feature-opt-outs), [#1284](https://github.com/vig-os/devkit/issues/1284)) |
+
+### Scaffold feature opt-outs
+
+`DEVKIT_FEATURES_DISABLED` is a comma-separated (whitespace-tolerant) subset of
+the scaffold feature groups a repo declines. A disabled group is never
+scaffolded, pruned if an earlier scaffold left it, reported truthfully by
+`init-workspace.sh --preview`, and stable across `--force` upgrades (the value
+round-trips in `.vig-os` like `DEVKIT_TAG_PREFIX`). Clearing the key re-ships the
+group on the next `--force`; an empty/absent key scaffolds byte-identically to
+before. An unknown group name aborts the scaffold loudly. The key governs
+scaffold **shape** only — it does not touch the flake or the dev-shell modules
+(`DEVKIT_MODULES`).
+
+The seven groups:
+
+- `release` — the release/prepare/promote workflows (`release*.yml`,
+  `prepare-release*.yml`, `promote-release.yml`, `sync-main-to-dev.yml`) and
+  `docs/DOWNSTREAM_RELEASE.md`.
+- `renovate` — `renovate.json`, `.github/renovate-default.json`, and the
+  renovate-changelog workflows.
+- `sync-issues` — `sync-issues.yml` and `.github/label-taxonomy.toml`. With this
+  group disabled, `DEVKIT_SYNC_TARGET`/`DEVKIT_SYNC_SCHEDULE` become inert (a
+  notice is printed).
+- `scanning` — `codeql.yml` and `scorecard.yml` (not `zizmor.yml`, a lint
+  config).
+- `gh-templates` — `.github/ISSUE_TEMPLATE/` and `pull_request_template.md`.
+- `skills` — every `.claude/skills/` directory except `worktree_*`.
+- `worktree` — the `.claude/skills/worktree_*` directories and
+  `.devcontainer/justfile.worktree`.
+
+`ci.yml` is intentionally out of scope (v1): it stays a single atomic,
+mode-aware workflow.
+
+**Preserved-class caveat.** The consumer-owned extension seams
+`release-extension.yml` and `prepare-release-extension.yml`, and `renovate.json`
+(all in the upgrade preserve list) are **never pruned** when their feature is
+disabled — an existing one is left in place with a notice, and `--preview`
+reports it as left-in-place rather than under DELETIONS. Delete it by hand if you
+truly want it gone.
 
 How it behaves:
 

--- a/tests/bats/init-workspace.bats
+++ b/tests/bats/init-workspace.bats
@@ -3859,3 +3859,79 @@ _RELEASE_RESOLVERS_991=(
     assert_success
     refute_output --partial "contradicts the persisted DEVKIT_WORKFLOW"
 }
+
+# ── manifest-driven scaffold feature opt-outs (#1284) ─────────────────────────
+# DEVKIT_FEATURES_DISABLED is a comma-separated, whitespace-tolerant list of
+# scaffold feature groups (release, renovate, sync-issues, scanning,
+# gh-templates, skills, worktree). A disabled group is never scaffolded, pruned
+# if a prior scaffold left it, truthfully reported by --preview, and stable
+# across --force upgrades. Absent/empty => byte-identical scaffold to today;
+# unknown name => loud abort. Round-trips like DEVKIT_TAG_PREFIX (#1116).
+
+# Seed a manifest key=value into an already-scaffolded workspace .vig-os.
+_seed_features_disabled() {
+    local ws="$1" value="$2"
+    sed -i "s#^DEVKIT_FEATURES_DISABLED=.*#DEVKIT_FEATURES_DISABLED=${value}#" "$ws/.vig-os"
+}
+
+@test "template .vig-os ships the feature opt-out key empty (#1284)" {
+    run grep -x 'DEVKIT_FEATURES_DISABLED=' "$TEMPLATE_DIR/.vig-os"
+    assert_success
+}
+
+@test "an unknown feature name fails the scaffold loudly (#1284)" {
+    ws="$BATS_TEST_TMPDIR/e2e-1284-unknown"
+    mkdir -p "$ws"
+    run _scaffold both "$ws"
+    assert_success
+    _seed_features_disabled "$ws" "renovate,bogus"
+    run _upgrade_no_flags "$ws"
+    assert_failure
+    assert_output --partial "Invalid DEVKIT_FEATURES_DISABLED"
+}
+
+@test "a whitespace-padded feature list is accepted (#1284)" {
+    ws="$BATS_TEST_TMPDIR/e2e-1284-whitespace"
+    mkdir -p "$ws"
+    run _scaffold both "$ws"
+    assert_success
+    _seed_features_disabled "$ws" " renovate ,  scanning "
+    run _upgrade_no_flags "$ws"
+    assert_success
+    refute_output --partial "Invalid DEVKIT_FEATURES_DISABLED"
+}
+
+@test "upgrade writes back a persisted DEVKIT_FEATURES_DISABLED value (#1284)" {
+    ws="$BATS_TEST_TMPDIR/e2e-1284-writeback"
+    mkdir -p "$ws"
+    run _scaffold both "$ws"
+    assert_success
+    _seed_features_disabled "$ws" "renovate,scanning"
+    run _upgrade_no_flags "$ws"
+    assert_success
+    run grep -x 'DEVKIT_FEATURES_DISABLED=renovate,scanning' "$ws/.vig-os"
+    assert_success
+}
+
+@test "an absent DEVKIT_FEATURES_DISABLED scaffolds every feature group (#1284)" {
+    ws="$BATS_TEST_TMPDIR/e2e-1284-absent"
+    mkdir -p "$ws"
+    run _scaffold both "$ws"
+    assert_success
+    refute_output --partial "disabled feature"
+    # A representative file from each of the seven groups is present.
+    run test -f "$ws/.github/workflows/release.yml"
+    assert_success
+    run test -f "$ws/renovate.json"
+    assert_success
+    run test -f "$ws/.github/workflows/sync-issues.yml"
+    assert_success
+    run test -f "$ws/.github/workflows/codeql.yml"
+    assert_success
+    run test -d "$ws/.github/ISSUE_TEMPLATE"
+    assert_success
+    run test -d "$ws/.claude/skills/tdd"
+    assert_success
+    run test -d "$ws/.claude/skills/worktree_execute"
+    assert_success
+}

--- a/tests/bats/init-workspace.bats
+++ b/tests/bats/init-workspace.bats
@@ -3874,6 +3874,15 @@ _seed_features_disabled() {
     sed -i "s#^DEVKIT_FEATURES_DISABLED=.*#DEVKIT_FEATURES_DISABLED=${value}#" "$ws/.vig-os"
 }
 
+# Fresh scaffold with DEVKIT_FEATURES_DISABLED pre-seeded in .vig-os BEFORE the
+# first copy: the key is read before the rsync overwrite, so the disabled paths
+# are never scaffolded (copy-exclude only — no prune involved).
+_scaffold_seeded() {
+    local mode="$1" ws="$2" value="$3"
+    printf 'DEVKIT_FEATURES_DISABLED=%s\n' "$value" >"$ws/.vig-os"
+    _scaffold "$mode" "$ws"
+}
+
 @test "template .vig-os ships the feature opt-out key empty (#1284)" {
     run grep -x 'DEVKIT_FEATURES_DISABLED=' "$TEMPLATE_DIR/.vig-os"
     assert_success
@@ -3934,4 +3943,100 @@ _seed_features_disabled() {
     assert_success
     run test -d "$ws/.claude/skills/worktree_execute"
     assert_success
+}
+
+@test "disabling a feature keeps its files out of the scaffold (#1284)" {
+    ws="$BATS_TEST_TMPDIR/e2e-1284-absent-files"
+    mkdir -p "$ws"
+    run _scaffold_seeded both "$ws" "release,renovate,sync-issues,scanning,gh-templates"
+    assert_success
+    # release
+    run test -e "$ws/.github/workflows/release.yml"
+    assert_failure
+    run test -e "$ws/.github/workflows/prepare-release.yml"
+    assert_failure
+    run test -e "$ws/docs/DOWNSTREAM_RELEASE.md"
+    assert_failure
+    # renovate
+    run test -e "$ws/.github/renovate-default.json"
+    assert_failure
+    run test -e "$ws/.github/workflows/renovate-changelog-build.yml"
+    assert_failure
+    # sync-issues
+    run test -e "$ws/.github/workflows/sync-issues.yml"
+    assert_failure
+    run test -e "$ws/.github/label-taxonomy.toml"
+    assert_failure
+    # scanning
+    run test -e "$ws/.github/workflows/codeql.yml"
+    assert_failure
+    run test -e "$ws/.github/workflows/scorecard.yml"
+    assert_failure
+    # gh-templates
+    run test -e "$ws/.github/ISSUE_TEMPLATE"
+    assert_failure
+    run test -e "$ws/.github/pull_request_template.md"
+    assert_failure
+    # untouched: ci.yml stays atomic (v1 scope), and a non-disabled workflow
+    run test -f "$ws/.github/workflows/ci.yml"
+    assert_success
+}
+
+@test "disabling worktree keeps the other skill dirs (dir-granularity, #1284)" {
+    ws="$BATS_TEST_TMPDIR/e2e-1284-worktree-only"
+    mkdir -p "$ws"
+    run _scaffold_seeded both "$ws" "worktree"
+    assert_success
+    run test -e "$ws/.claude/skills/worktree_execute"
+    assert_failure
+    run test -e "$ws/.devcontainer/justfile.worktree"
+    assert_failure
+    # non-worktree skills survive
+    run test -d "$ws/.claude/skills/tdd"
+    assert_success
+    run test -d "$ws/.claude/skills/code_review"
+    assert_success
+}
+
+@test "disabling skills keeps the worktree_* dirs (dir-granularity, #1284)" {
+    ws="$BATS_TEST_TMPDIR/e2e-1284-skills-only"
+    mkdir -p "$ws"
+    run _scaffold_seeded both "$ws" "skills"
+    assert_success
+    run test -e "$ws/.claude/skills/tdd"
+    assert_failure
+    run test -e "$ws/.claude/skills/branch-naming"
+    assert_failure
+    # worktree_* skills survive, as does justfile.worktree
+    run test -d "$ws/.claude/skills/worktree_execute"
+    assert_success
+    run test -f "$ws/.devcontainer/justfile.worktree"
+    assert_success
+}
+
+@test "disabling both skills and worktree empties .claude/skills/ (#1284)" {
+    ws="$BATS_TEST_TMPDIR/e2e-1284-skills-worktree"
+    mkdir -p "$ws"
+    run _scaffold_seeded both "$ws" "skills,worktree"
+    assert_success
+    # no skill directories remain (the parent dir may be absent or empty)
+    run bash -c 'shopt -s nullglob; d=("'"$ws"'"/.claude/skills/*/); echo "${#d[@]}"'
+    assert_output "0"
+}
+
+@test "--preview never lists a disabled feature's files as ADDED and names the disabled set (#1284)" {
+    ws="$BATS_TEST_TMPDIR/e2e-1284-preview-added"
+    mkdir -p "$ws"
+    run _scaffold both "$ws"
+    assert_success
+    _seed_features_disabled "$ws" "scanning"
+    # Remove the group's files so they WOULD be re-added by an ordinary upgrade.
+    rm -f "$ws/.github/workflows/codeql.yml" "$ws/.github/workflows/scorecard.yml"
+    run _preview "$ws" --mode both
+    assert_success
+    assert_output --partial "Disabled features"
+    assert_output --partial "scanning"
+    # the disabled files are not advertised as additions
+    refute_output --partial "+  .github/workflows/codeql.yml"
+    refute_output --partial "+  .github/workflows/scorecard.yml"
 }

--- a/tests/bats/init-workspace.bats
+++ b/tests/bats/init-workspace.bats
@@ -4040,3 +4040,88 @@ _scaffold_seeded() {
     refute_output --partial "+  .github/workflows/codeql.yml"
     refute_output --partial "+  .github/workflows/scorecard.yml"
 }
+
+@test "adding the key on an upgrade prunes a previously scaffolded feature (#1284)" {
+    ws="$BATS_TEST_TMPDIR/e2e-1284-upgrade-prune"
+    mkdir -p "$ws"
+    run _scaffold both "$ws"
+    assert_success
+    run test -f "$ws/.github/workflows/release.yml"
+    assert_success
+    _seed_features_disabled "$ws" "release,skills"
+    run _upgrade_no_flags "$ws"
+    assert_success
+    assert_output --partial "Pruning"
+    run test -e "$ws/.github/workflows/release.yml"
+    assert_failure
+    run test -e "$ws/.github/workflows/promote-release.yml"
+    assert_failure
+    run test -e "$ws/.claude/skills/tdd"
+    assert_failure
+    # written back so the prune is stable on the next upgrade
+    run grep -x 'DEVKIT_FEATURES_DISABLED=release,skills' "$ws/.vig-os"
+    assert_success
+}
+
+@test "--preview lists a pre-existing disabled feature's files under DELETIONS (#1284)" {
+    ws="$BATS_TEST_TMPDIR/e2e-1284-preview-delete"
+    mkdir -p "$ws"
+    run _scaffold both "$ws"
+    assert_success
+    _seed_features_disabled "$ws" "scanning"
+    run _preview "$ws" --mode both
+    assert_success
+    assert_output --partial "DELETED"
+    assert_output --partial ".github/workflows/codeql.yml"
+    # side-effect-free: the preview left the file in place
+    run test -f "$ws/.github/workflows/codeql.yml"
+    assert_success
+}
+
+@test "a preserved-class extension seam survives a disabled feature with a notice (#1284)" {
+    ws="$BATS_TEST_TMPDIR/e2e-1284-preserved"
+    mkdir -p "$ws"
+    run _scaffold both "$ws"
+    assert_success
+    # Consumer customization sentinel in the extension seam + renovate.json.
+    printf '# SENTINEL-EXT\n' >>"$ws/.github/workflows/release-extension.yml"
+    printf '{ "SENTINEL": true }\n' >"$ws/renovate.json"
+    _seed_features_disabled "$ws" "release,renovate"
+    # preview: the seam is reported as left-in-place, never under DELETIONS
+    run _preview "$ws" --mode both
+    assert_success
+    assert_output --partial "left in place (preserved)"
+    refute_output --partial "✗  .github/workflows/release-extension.yml"
+    refute_output --partial "✗  renovate.json"
+    # a real upgrade keeps the seam + its sentinel, and does not prune it
+    run _upgrade_no_flags "$ws"
+    assert_success
+    assert_output --partial "left in place (preserved)"
+    run grep -qF "SENTINEL-EXT" "$ws/.github/workflows/release-extension.yml"
+    assert_success
+    run grep -qF '"SENTINEL": true' "$ws/renovate.json"
+    assert_success
+    # but the non-preserved release workflows are gone
+    run test -e "$ws/.github/workflows/release.yml"
+    assert_failure
+}
+
+@test "clearing the key re-ships a previously disabled feature (#1284)" {
+    ws="$BATS_TEST_TMPDIR/e2e-1284-reenable"
+    mkdir -p "$ws"
+    run _scaffold both "$ws"
+    assert_success
+    _seed_features_disabled "$ws" "scanning"
+    run _upgrade_no_flags "$ws"
+    assert_success
+    run test -e "$ws/.github/workflows/codeql.yml"
+    assert_failure
+    # clear the opt-out and upgrade again — the feature returns
+    _seed_features_disabled "$ws" ""
+    run _upgrade_no_flags "$ws"
+    assert_success
+    run test -f "$ws/.github/workflows/codeql.yml"
+    assert_success
+    run test -f "$ws/.github/workflows/scorecard.yml"
+    assert_success
+}

--- a/tests/bats/init-workspace.bats
+++ b/tests/bats/init-workspace.bats
@@ -4125,3 +4125,45 @@ _scaffold_seeded() {
     run test -f "$ws/.github/workflows/scorecard.yml"
     assert_success
 }
+
+@test "disabling sync-issues with a sync target set warns but does not abort (#1284)" {
+    ws="$BATS_TEST_TMPDIR/e2e-1284-contradiction"
+    mkdir -p "$ws"
+    run _scaffold both "$ws"
+    assert_success
+    sed -i 's#^DEVKIT_SYNC_TARGET=.*#DEVKIT_SYNC_TARGET=sync/issue-mirror#' "$ws/.vig-os"
+    _seed_features_disabled "$ws" "sync-issues"
+    run _upgrade_no_flags "$ws"
+    assert_success
+    assert_output --partial "will have no effect"
+    # the sync workflow really is gone, and no sed error tripped the scaffold
+    run test -e "$ws/.github/workflows/sync-issues.yml"
+    assert_failure
+    refute_output --partial "No such file or directory"
+    refute_output --partial "Rendered sync-issues settings"
+}
+
+@test "trunk workflow plus a disabled release feature compose without double-reporting (#1284)" {
+    ws="$BATS_TEST_TMPDIR/e2e-1284-compose"
+    mkdir -p "$ws"
+    run _scaffold both "$ws"
+    assert_success
+    run test -f "$ws/.github/workflows/sync-main-to-dev.yml"
+    assert_success
+    _seed_features_disabled "$ws" "release"
+    # preview a gitflow->trunk switch with release disabled: sync-main-to-dev.yml
+    # is a member of BOTH the trunk deletion and the release group, yet it must
+    # be listed exactly once and the preview must not error.
+    run _preview "$ws" --mode both --workflow trunk
+    assert_success
+    count="$(printf '%s\n' "$output" | grep -c 'sync-main-to-dev.yml')"
+    assert_equal "$count" "1"
+    # and a real upgrade composes the prunes without error
+    sed -i 's/^DEVKIT_WORKFLOW=$/DEVKIT_WORKFLOW=trunk/' "$ws/.vig-os"
+    run _upgrade_no_flags "$ws"
+    assert_success
+    run test -e "$ws/.github/workflows/sync-main-to-dev.yml"
+    assert_failure
+    run test -e "$ws/.github/workflows/release.yml"
+    assert_failure
+}


### PR DESCRIPTION
## Summary

New `.vig-os` key `DEVKIT_FEATURES_DISABLED` — a comma-separated (whitespace-tolerant) subset of seven scaffold feature groups that are never scaffolded, pruned if a previous scaffold left them behind, truthfully reported by `--preview`, and stable across `--force` upgrades. Clearing the key re-ships the features on the next `--force`. Absent/empty key ⇒ byte-identical scaffold.

Groups (feature → path map, SSoT in `feature_paths()`):
- `release` — the 8 release-train workflows + `docs/DOWNSTREAM_RELEASE.md`
- `renovate` — `renovate.json`, `renovate-default.json`, both renovate-changelog workflows
- `sync-issues` — `sync-issues.yml` + `label-taxonomy.toml`
- `scanning` — `codeql.yml`, `scorecard.yml`
- `gh-templates` — `ISSUE_TEMPLATE/`, `pull_request_template.md`
- `skills` / `worktree` — `.claude/skills/` split, enumerated dynamically from the template tree (no hardcoded names)

## Design notes

- **Mechanism reuse:** disabled paths feed `MODE_CONFIG_EXCLUDES`, so the `--preview` ADDED classifier and the rsync copy stay in agreement for free; DELETIONS report + post-copy prune mirror the #1205 trunk `sync-main-to-dev.yml` quartet, and compose with it (trunk + `release` disabled → exactly one prune/report).
- **Preserved-class carve-out:** `release-extension.yml`, `prepare-release-extension.yml`, `renovate.json` carry consumer implementation (PRESERVE_FILES) — excluded from the copy but never pruned; a left-in-place notice is printed instead of a DELETIONS entry.
- **Contradiction notice:** `sync-issues` disabled with `DEVKIT_SYNC_TARGET`/`DEVKIT_SYNC_SCHEDULE` set warns (never aborts); `render_sync_settings` is skipped explicitly.
- Unknown feature name aborts loudly; round-trip via the #1116 write-back idiom; comma-separated deviates deliberately from the issue's space-separated example for consistency with `DEVKIT_FLOATING_TAGS`/`DEVKIT_CI_RUNNER`.
- Deliberately named NOT `DEVKIT_MODULES` (#884 reservation); v1 scope = standalone files only, `ci.yml` stays atomic.
- `docs/MIGRATION.md`: manifest-table row + "Scaffold feature opt-outs" subsection.

## Test evidence

- Strict TDD, five RED→GREEN cycles (commits `52e2fd74`…`8f8a36f3`), failing-first confirmed each cycle.
- 16 new bats cases: per-group disable, preview truthfulness, upgrade prune + DELETIONS, re-enable, byte-identical default, unknown-name abort, skills/worktree granularity, preserved-class survival, trunk compose, contradiction notice.
- Verified: `--filter "1284|1205|913|1196"` 27/27 ok; `pytest tests/test_workflow_model.py` 22 passed; full `bats tests/bats/init-workspace.bats` 261 tests zero failures; `prek run --all-files` green.

## Merge order

Part of the #1280–#1285 solo-adoption batch (semver:minor); recommended merge order #1281 → #1280 → #1283 → #1282 → #1284 → #1285.

Closes #1284