### PR TITLE
feat(workflow): add scaffold-drift CI gate (DEVKIT_DRIFT_CHECK)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Scaffold-drift CI gate (DEVKIT_DRIFT_CHECK)** ([#1295](https://github.com/vig-os/devkit/issues/1295))
+  - The scaffolded `ci.yml` gains a `scaffold-drift` job that re-runs the pinned
+    devkit version's scaffold over the checkout and fails a PR whose managed
+    files diverge from it — `DEVKIT_VERSION` bumped without re-scaffolding, or a
+    managed file hand-edited. A pin-only bump otherwise merges green. `*.project`
+    files and persisted `.vig-os` values are exempt by construction (the scaffold
+    never overwrites them), and `.gitignore`d files (e.g. `*.local`) are ignored.
+  - Mechanism: re-scaffold + `git diff` (the `install.sh --preview` report
+    classifies OVERWRITTEN by path existence, not content, so it cannot tell
+    drift from an up-to-date file). The job `docker run`s the in-image scaffold on
+    the host so a direnv/bare consumer (which resolves an empty container image)
+    is covered too; `resolve-toolchain` emits the all-modes image ref.
+  - Opt-out via the new `.vig-os` key `DEVKIT_DRIFT_CHECK` (`true` default,
+    `false` disables). It is a runtime gate — CI reads it through
+    `resolve-toolchain`'s `drift-check` output, so flipping it needs no
+    re-scaffold — and the value round-trips across `--force` upgrades. Runs on
+    PRs only (the ~1.5 GiB image pull); an invalid value fails the scaffold.
+
 - **Solo/private-repo adoption profile** ([#1285](https://github.com/vig-os/devkit/issues/1285))
   - New `docs/SOLO_ADOPTION.md`: the one document a single-user, private repo
     follows to adopt devkit without the team/traceability layer, expressed as a

--- a/assets/init-workspace.sh
+++ b/assets/init-workspace.sh
@@ -346,6 +346,8 @@ MANIFEST_FEATURES_DISABLED="$(read_manifest_value "$VIG_OS_MANIFEST" DEVKIT_FEAT
 
 MANIFEST_REFS_POLICY="$(read_manifest_value "$VIG_OS_MANIFEST" DEVKIT_REFS_POLICY || true)"
 
+MANIFEST_DRIFT_CHECK="$(read_manifest_value "$VIG_OS_MANIFEST" DEVKIT_DRIFT_CHECK || true)"
+
 # The OWNER/REPO placeholder (written when no origin was resolvable) must not
 # mask a now-detectable git origin on a later upgrade.
 [[ "$MANIFEST_REPO" == "OWNER/REPO" ]] && MANIFEST_REPO=""
@@ -483,6 +485,18 @@ case "$MANIFEST_REFS_POLICY" in
     ""|chore-optional|optional|required) ;;
     *)
         echo "Error: Invalid DEVKIT_REFS_POLICY in $VIG_OS_MANIFEST: $MANIFEST_REFS_POLICY (expected: chore-optional | optional | required)" >&2
+        exit 1
+        ;;
+esac
+
+# Scaffold-drift gate (#1295): pure runtime toggle for the ci.yml scaffold-drift
+# job (empty resolves to the enabled `true` default). No scaffold render — the CI
+# job reads it via resolve-toolchain's `drift-check` output — so only a value
+# guard here, refusing an unexpected literal loudly (mirrors DEVKIT_REFS_POLICY).
+case "$MANIFEST_DRIFT_CHECK" in
+    ""|true|false) ;;
+    *)
+        echo "Error: Invalid DEVKIT_DRIFT_CHECK in $VIG_OS_MANIFEST: $MANIFEST_DRIFT_CHECK (expected: true | false)" >&2
         exit 1
         ;;
 esac
@@ -2108,6 +2122,12 @@ if [[ -f "$VIG_OS_MANIFEST" ]]; then
     # resets the commit-msg/commit-range Refs enforcement to chore-optional.
     if [[ -n "$MANIFEST_REFS_POLICY" ]]; then
         write_manifest_value DEVKIT_REFS_POLICY "$MANIFEST_REFS_POLICY"
+    fi
+    # Scaffold-drift gate (#1295): bare in the template (DEVKIT_DRIFT_CHECK=), so a
+    # consumer's explicit false (opt-out) is written back — else an upgrade
+    # silently re-enables the drift gate the consumer disabled.
+    if [[ -n "$MANIFEST_DRIFT_CHECK" ]]; then
+        write_manifest_value DEVKIT_DRIFT_CHECK "$MANIFEST_DRIFT_CHECK"
     fi
 fi
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -9,6 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Scaffold-drift CI gate (DEVKIT_DRIFT_CHECK)** ([#1295](https://github.com/vig-os/devkit/issues/1295))
+  - The scaffolded `ci.yml` gains a `scaffold-drift` job that re-runs the pinned
+    devkit version's scaffold over the checkout and fails a PR whose managed
+    files diverge from it — `DEVKIT_VERSION` bumped without re-scaffolding, or a
+    managed file hand-edited. A pin-only bump otherwise merges green. `*.project`
+    files and persisted `.vig-os` values are exempt by construction (the scaffold
+    never overwrites them), and `.gitignore`d files (e.g. `*.local`) are ignored.
+  - Mechanism: re-scaffold + `git diff` (the `install.sh --preview` report
+    classifies OVERWRITTEN by path existence, not content, so it cannot tell
+    drift from an up-to-date file). The job `docker run`s the in-image scaffold on
+    the host so a direnv/bare consumer (which resolves an empty container image)
+    is covered too; `resolve-toolchain` emits the all-modes image ref.
+  - Opt-out via the new `.vig-os` key `DEVKIT_DRIFT_CHECK` (`true` default,
+    `false` disables). It is a runtime gate — CI reads it through
+    `resolve-toolchain`'s `drift-check` output, so flipping it needs no
+    re-scaffold — and the value round-trips across `--force` upgrades. Runs on
+    PRs only (the ~1.5 GiB image pull); an invalid value fails the scaffold.
+
 - **Solo/private-repo adoption profile** ([#1285](https://github.com/vig-os/devkit/issues/1285))
   - New `docs/SOLO_ADOPTION.md`: the one document a single-user, private repo
     follows to adopt devkit without the team/traceability layer, expressed as a

--- a/assets/workspace/.github/actions/resolve-toolchain/action.yml
+++ b/assets/workspace/.github/actions/resolve-toolchain/action.yml
@@ -50,6 +50,12 @@ outputs:
   image:
     description: Container image (ghcr.io/... for container modes, empty string for host modes)
     value: ${{ steps.resolve.outputs.image }}
+  drift-image:
+    description: >-
+      Devcontainer image ref for EVERY mode (empty only when no tag resolved),
+      for the scaffold-drift job that `docker run`s the scaffold on the host.
+      Keeps the ghcr.io/vig-os/devcontainer literal out of ci.yml (#1295).
+    value: ${{ steps.resolve.outputs.drift-image }}
   image-tag:
     description: Resolved image/version tag
     value: ${{ steps.resolve.outputs.tag }}
@@ -71,6 +77,12 @@ outputs:
       DEVKIT_REFS_POLICY for validate-commit-range. `chore` (default/absent),
       the full types list (`optional`), or the `none` sentinel (`required`).
     value: ${{ steps.resolve.outputs.refs-optional-types }}
+  drift-check:
+    description: >-
+      Scaffold-drift gate toggle from DEVKIT_DRIFT_CHECK: `true` (default/absent)
+      keeps ci.yml's scaffold-drift job enabled, `false` self-skips it. Emitted
+      for every mode so the job's `if:` can gate on it with no re-scaffold.
+    value: ${{ steps.resolve.outputs.drift-check }}
 
 runs:
   using: composite
@@ -90,6 +102,7 @@ runs:
         FLOATING_TAGS=""
         CI_RUNNER=""
         REFS_POLICY=""
+        DRIFT_CHECK=""
 
         if [[ -f .vig-os ]]; then
           # Tolerant KEY=VALUE parsing shared with resolve-image (#781): capture
@@ -101,7 +114,7 @@ runs:
             [[ "$line" =~ ^[[:space:]]*# ]] && continue
 
             case "$line" in
-              DEVKIT_MODE=*|DEVKIT_VERSION=*|DEVCONTAINER_VERSION=*|DEVKIT_TAG_PREFIX=*|DEVKIT_FLOATING_TAGS=*|DEVKIT_CI_RUNNER=*|DEVKIT_REFS_POLICY=*)
+              DEVKIT_MODE=*|DEVKIT_VERSION=*|DEVCONTAINER_VERSION=*|DEVKIT_TAG_PREFIX=*|DEVKIT_FLOATING_TAGS=*|DEVKIT_CI_RUNNER=*|DEVKIT_REFS_POLICY=*|DEVKIT_DRIFT_CHECK=*)
                 key="${line%%=*}"
                 value="${line#*=}"
                 value="${value#"${value%%[![:space:]]*}"}"
@@ -121,6 +134,7 @@ runs:
                   DEVKIT_FLOATING_TAGS) FLOATING_TAGS="$value" ;;
                   DEVKIT_CI_RUNNER) CI_RUNNER="$value" ;;
                   DEVKIT_REFS_POLICY) REFS_POLICY="$value" ;;
+                  DEVKIT_DRIFT_CHECK) DRIFT_CHECK="$value" ;;
                 esac
                 ;;
             esac
@@ -191,6 +205,17 @@ runs:
         esac
         echo "refs-optional-types=$REFS_OPTIONAL_TYPES" >> "$GITHUB_OUTPUT"
 
+        # Scaffold-drift gate (#1295): DEVKIT_DRIFT_CHECK toggles ci.yml's
+        # scaffold-drift job. Absent/empty => `true` (enabled), so existing
+        # consumers gain the gate on adoption; only an explicit `false` disables
+        # it. Emitted for every mode; the loud value guard lives at the write path
+        # (init-workspace.sh), so any non-`false` literal here defaults to enabled
+        # (fail-safe: the drift check runs). The job self-skips on `false` via its
+        # `if:`, so flipping the knob needs no re-scaffold.
+        DRIFT_CHECK="${DRIFT_CHECK:-true}"
+        [[ "$DRIFT_CHECK" == "false" ]] || DRIFT_CHECK="true"
+        echo "drift-check=$DRIFT_CHECK" >> "$GITHUB_OUTPUT"
+
         # Resolve the version tag: explicit override wins, else DEVKIT_VERSION,
         # else the legacy DEVCONTAINER_VERSION.
         TAG="$INPUT_IMAGE_TAG"
@@ -217,6 +242,18 @@ runs:
             ;;
         esac
         echo "image=$IMAGE" >> "$GITHUB_OUTPUT"
+
+        # Scaffold-drift image (#1295): the devcontainer image ref for EVERY mode
+        # (empty only when no tag resolved). Unlike `image` above — which is an
+        # explicit empty string for host modes so downstream `container:` runs on
+        # the host — the scaffold-drift job `docker run`s the image itself (the
+        # scaffold assets live only in the image, and a direnv/bare consumer's
+        # jobs otherwise never pull it). Emitting the ref here keeps the
+        # `ghcr.io/vig-os/devcontainer` literal out of the scaffolded ci.yml (the
+        # #991 single-source-of-truth invariant).
+        DRIFT_IMAGE=""
+        [[ -n "$TAG" ]] && DRIFT_IMAGE="ghcr.io/vig-os/devcontainer:${TAG}"
+        echo "drift-image=$DRIFT_IMAGE" >> "$GITHUB_OUTPUT"
         echo "Resolved mode=$MODE tag=${TAG:-<none>} image=${IMAGE:-<host>}"
 
     - name: Validate image accessibility

--- a/assets/workspace/.github/workflows/ci.yml
+++ b/assets/workspace/.github/workflows/ci.yml
@@ -34,8 +34,9 @@
 #   2. lint              — Pre-commit hooks
 #   3. test              — Run tests
 #   4. commit-checks     — Commit message + PR title validation (PRs only)
-#   5. dependency-review — Vulnerable-dependency gate (public-repo PRs only)
-#   6. summary           — Aggregate results for branch protection
+#   5. scaffold-drift    — Managed-file drift gate (PRs only; DEVKIT_DRIFT_CHECK)
+#   6. dependency-review — Vulnerable-dependency gate (public-repo PRs only)
+#   7. summary           — Aggregate results for branch protection
 #
 # Triggers:
 #   - Pull requests to dev, release/**, and main
@@ -83,6 +84,12 @@ jobs:
       # Refs policy (#1282): re-export the composite action's mapped
       # --refs-optional-types list so commit-checks can consume it via needs.
       refs-optional-types: ${{ steps.resolve.outputs.refs-optional-types }}
+      # Scaffold-drift gate (#1295): re-export the DEVKIT_DRIFT_CHECK toggle so
+      # the scaffold-drift job's `if:` can self-skip when a consumer opts out,
+      # plus the all-modes image ref it `docker run`s (keeps the ghcr literal in
+      # resolve-toolchain, the #991 SSoT, out of this file).
+      drift-check: ${{ steps.resolve.outputs.drift-check }}
+      drift-image: ${{ steps.resolve.outputs.drift-image }}
 
     steps:
       - name: Checkout repository
@@ -261,6 +268,90 @@ jobs:
           PR_BODY: ${{ github.event.pull_request.body }}
         run: uv run check-pr-agent-fingerprints
 
+  # Scaffold-drift gate (#1295): re-run the pinned devkit version's scaffold over
+  # the checkout and fail if any managed file diverges — DEVKIT_VERSION bumped
+  # without re-scaffolding, or a managed file hand-edited. A pin-only bump PR
+  # otherwise merges green: nothing else re-runs the scaffold or diffs against it.
+  #
+  # Mechanism: re-scaffold + `git diff`, NOT `install.sh --preview`. The preview
+  # report classifies OVERWRITTEN by path existence, not content, so it fires for
+  # every managed file that exists and cannot distinguish drift from an
+  # up-to-date file. Re-running init-workspace.sh --force rewrites the managed
+  # files to exactly what the pin produces while preserving *.project files and
+  # persisted .vig-os values by construction; `git diff` (which honors .gitignore,
+  # so *.local files are exempt too) then surfaces any real divergence.
+  #
+  # This runs the in-image scaffold via `docker run` on the host runner rather
+  # than a job-level `container:`, because a direnv/bare consumer resolves an
+  # EMPTY image (its jobs run on the host) yet the scaffold assets live only
+  # inside the devcontainer image. Passing VIG_OS_VERSION=<current pin> keeps the
+  # .vig-os DEVKIT_VERSION line stable (the image's baked full version would
+  # otherwise rewrite a floating pin and read as spurious drift).
+  #
+  # Cost control: PRs only (the ~1.5 GiB image pull). A single workflow cannot
+  # apply a per-job `paths` filter, so the job rides the same pull_request-only
+  # gate as commit-checks/dependency-review; the DEVKIT_DRIFT_CHECK knob
+  # self-skips it at runtime (no re-scaffold needed to flip).
+  scaffold-drift:
+    name: Scaffold Drift
+    needs: [resolve-toolchain]
+    runs-on: ${{ fromJSON(needs.resolve-toolchain.outputs.runner-json) }}
+    timeout-minutes: 15
+    if: >-
+      github.event_name == 'pull_request' &&
+      needs.resolve-toolchain.outputs.drift-check != 'false'
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+
+      # All ${{ }} values reach the shell via env (never inline in run:), per the
+      # zizmor template-injection gate. The inner `docker run` script is a
+      # single-quoted literal — it reads only the -e env it is handed.
+      - name: Check for scaffold drift
+        env:
+          IMAGE: ${{ needs.resolve-toolchain.outputs.drift-image }}
+          IMAGE_TAG: ${{ needs.resolve-toolchain.outputs.image-tag }}
+          REGISTRY_TOKEN: ${{ secrets.GHCR_PULL_TOKEN || github.token }}
+          REGISTRY_USERNAME: ${{ github.actor }}
+          CONSUMER_REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          if [[ -z "$IMAGE" ]]; then
+            echo "::error::Could not resolve DEVKIT_VERSION from .vig-os — cannot run the scaffold-drift check."
+            exit 1
+          fi
+
+          echo "Authenticating to ghcr.io as '${REGISTRY_USERNAME}'"
+          echo "$REGISTRY_TOKEN" | docker login ghcr.io -u "$REGISTRY_USERNAME" --password-stdin
+          echo "Pulling $IMAGE"
+          docker pull --quiet "$IMAGE"
+
+          # Re-scaffold in place inside the pinned image, then diff. The scaffold
+          # writes root-owned files into the mounted checkout, so run git in the
+          # same container (as root) with the mount marked a safe directory.
+          docker run --rm \
+            -e VIG_OS_VERSION="$IMAGE_TAG" \
+            -e GITHUB_REPOSITORY="$CONSUMER_REPOSITORY" \
+            -v "${GITHUB_WORKSPACE}:/workspace" \
+            "$IMAGE" \
+            bash -c '
+              set -euo pipefail
+              git config --global --add safe.directory /workspace
+              /root/assets/init-workspace.sh --force --no-prompts
+              cd /workspace
+              git add -A
+              if git diff --cached --quiet; then
+                echo "No scaffold drift detected — managed files match devkit ${VIG_OS_VERSION}."
+                exit 0
+              fi
+              echo "::error::Scaffold drift detected: the working tree diverges from what devkit ${VIG_OS_VERSION} would scaffold. Re-run the devkit upgrade (install.sh --force) and commit the result, or set DEVKIT_DRIFT_CHECK=false in .vig-os to opt out."
+              git --no-pager diff --cached
+              exit 1
+            '
+
   # Blocks PRs that introduce known-vulnerable dependencies, off GitHub's
   # dependency graph (lockfiles + action pins alike) — no toolchain, no
   # container, no resolve-toolchain. Doubly guarded, mirroring the codeql.yml
@@ -298,7 +389,7 @@ jobs:
     name: CI Summary
     runs-on: ${{ fromJSON(needs.resolve-toolchain.outputs.runner-json) }}
     timeout-minutes: 5
-    needs: [resolve-toolchain, lint, test, commit-checks, dependency-review]
+    needs: [resolve-toolchain, lint, test, commit-checks, scaffold-drift, dependency-review]
     if: always()
 
     steps:
@@ -311,6 +402,7 @@ jobs:
           echo "Lint: ${{ needs.lint.result }}"
           echo "Test: ${{ needs.test.result }}"
           echo "Commit messages: ${{ needs.commit-checks.result }}"
+          echo "Scaffold drift: ${{ needs.scaffold-drift.result }}"
           echo "Dependency review: ${{ needs.dependency-review.result }}"
           echo ""
 
@@ -333,6 +425,13 @@ jobs:
 
           if [ "${{ needs.commit-checks.result }}" = "failure" ]; then
             echo "ERROR: Commit message checks failed"
+            FAILED=true
+          fi
+
+          # Skipped on push/dispatch and when DEVKIT_DRIFT_CHECK=false; only a
+          # genuine failure (managed-file drift) trips the gate.
+          if [ "${{ needs.scaffold-drift.result }}" = "failure" ]; then
+            echo "ERROR: Scaffold drift detected"
             FAILED=true
           fi
 

--- a/assets/workspace/.vig-os
+++ b/assets/workspace/.vig-os
@@ -90,3 +90,13 @@ DEVKIT_FEATURES_DISABLED=
 # anchored render of the hook arg + resolve-toolchain's `refs-optional-types`
 # output); written back only for a non-default value (#1282).
 DEVKIT_REFS_POLICY=
+
+# Scaffold-drift CI gate: true (default) | false. Empty (= unset) resolves to
+# `true` — ci.yml's `scaffold-drift` job re-runs the pinned devkit version's
+# scaffold over the checkout and fails a PR whose managed files diverge from it
+# (DEVKIT_VERSION bumped without re-scaffold, or a managed file hand-edited).
+# `*.project` files and persisted values in this manifest are exempt by
+# construction (the scaffold never overwrites them). Pure runtime gate — CI reads
+# it via resolve-toolchain's `drift-check` output, so flipping it takes effect
+# with no re-scaffold; the value round-trips across `--force` upgrades (#1295).
+DEVKIT_DRIFT_CHECK=

--- a/tests/bats/init-workspace.bats
+++ b/tests/bats/init-workspace.bats
@@ -2524,6 +2524,40 @@ _upgrade_no_flags() {
     assert_failure
 }
 
+# ── scaffold-drift opt-out knob (#1295) ───────────────────────────────────────
+# DEVKIT_DRIFT_CHECK is a pure runtime gate for the ci.yml scaffold-drift job
+# (empty/absent => enabled). It steers no scaffold render — the CI job reads it
+# via resolve-toolchain (covered in tests/test_scaffold_drift.py). init-workspace
+# only guards its value and persists it across upgrades, like DEVKIT_REFS_POLICY.
+
+@test "template .vig-os ships the drift-check key empty (#1295)" {
+    run grep -x 'DEVKIT_DRIFT_CHECK=' "$TEMPLATE_DIR/.vig-os"
+    assert_success
+}
+
+@test "upgrade writes back a persisted DEVKIT_DRIFT_CHECK value (#1295)" {
+    ws="$BATS_TEST_TMPDIR/e2e-1295-writeback"
+    mkdir -p "$ws"
+    run _scaffold both "$ws"
+    assert_success
+    sed -i 's/^DEVKIT_DRIFT_CHECK=.*/DEVKIT_DRIFT_CHECK=false/' "$ws/.vig-os"
+    run _upgrade_no_flags "$ws"
+    assert_success
+    run grep -x 'DEVKIT_DRIFT_CHECK=false' "$ws/.vig-os"
+    assert_success
+}
+
+@test "an invalid DEVKIT_DRIFT_CHECK fails the scaffold loudly (#1295)" {
+    ws="$BATS_TEST_TMPDIR/e2e-1295-bad-value"
+    mkdir -p "$ws"
+    run _scaffold both "$ws"
+    assert_success
+    sed -i 's/^DEVKIT_DRIFT_CHECK=.*/DEVKIT_DRIFT_CHECK=garbage/' "$ws/.vig-os"
+    run _upgrade_no_flags "$ws"
+    assert_failure
+    assert_output --partial "Invalid DEVKIT_DRIFT_CHECK"
+}
+
 # ── cache-cleanup retry fallback shim (#1278) ─────────────────────────────────
 # The "Delete old cache" cleanup step runs `if: always()` and calls the `retry`
 # wrapper, which only exists after toolchain setup. A job that dies before setup

--- a/tests/test_scaffold_drift.py
+++ b/tests/test_scaffold_drift.py
@@ -1,0 +1,176 @@
+"""Workflow-shape + behavior tests: scaffold-drift CI gate (DEVKIT_DRIFT_CHECK).
+
+Issue #1295: the scaffolded ``ci.yml`` gains a ``scaffold-drift`` job that
+re-runs the pinned devkit version's scaffold over the checkout and fails when
+any managed file diverges — i.e. ``DEVKIT_VERSION`` was bumped without
+re-scaffolding, or a managed file was hand-edited. ``resolve-toolchain`` reads
+the opt-out knob ``DEVKIT_DRIFT_CHECK`` from ``.vig-os`` and emits a
+``drift-check`` output (default ``true`` when the key is absent); the job
+self-skips at runtime when it resolves ``false``.
+
+The mechanism is re-scaffold + ``git diff`` (not ``install.sh --preview``): the
+preview report classifies OVERWRITTEN by path existence, not content, so it
+cannot distinguish genuine drift from an up-to-date managed file. Re-running
+``init-workspace.sh --force`` rewrites the managed files to exactly what the pin
+would produce while preserving the preserved set + persisted ``.vig-os`` values
+by construction; ``git diff`` then surfaces any divergence.
+
+Refs: #1295
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import yaml
+
+# Repository root (tests/ -> repo root).
+REPO_ROOT = Path(__file__).resolve().parent.parent
+WORKSPACE = REPO_ROOT / "assets" / "workspace"
+WORKFLOWS = WORKSPACE / ".github" / "workflows"
+RESOLVE_ACTION = WORKFLOWS.parent / "actions" / "resolve-toolchain" / "action.yml"
+
+# The scaffold-drift job key in ci.yml.
+DRIFT_JOB = "scaffold-drift"
+
+
+def _load(path: Path) -> dict:
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def _run_resolve(
+    tmp_path: Path, manifest: str | None, *, check: bool = True
+) -> dict[str, str]:
+    """Execute the resolve-toolchain step's real bash against a .vig-os manifest.
+
+    Returns the parsed GITHUB_OUTPUT key=value map. ``drift-check`` is emitted
+    early (before tag resolution), alongside runner-json.
+    """
+    action = _load(RESOLVE_ACTION)
+    script = action["runs"]["steps"][0]["run"]
+
+    if manifest is not None:
+        (tmp_path / ".vig-os").write_text(manifest, encoding="utf-8")
+
+    github_output = tmp_path / "github_output"
+    github_output.touch()
+
+    env = {
+        **os.environ,
+        "INPUT_IMAGE_TAG": "",
+        "GITHUB_OUTPUT": str(github_output),
+    }
+    subprocess.run(
+        ["bash", "-c", script],
+        cwd=tmp_path,
+        env=env,
+        check=check,
+        capture_output=True,
+        text=True,
+    )
+
+    outputs: dict[str, str] = {}
+    for line in github_output.read_text(encoding="utf-8").splitlines():
+        if "=" in line:
+            key, _, value = line.partition("=")
+            outputs[key] = value
+    return outputs
+
+
+# ── Manifest knob ─────────────────────────────────────────────────────────────
+
+
+def test_vig_os_declares_drift_check_key() -> None:
+    """The scaffold manifest ships the opt-out key (default empty => enabled)."""
+    text = (WORKSPACE / ".vig-os").read_text(encoding="utf-8")
+    assert "DEVKIT_DRIFT_CHECK=" in text
+
+
+# ── resolve-toolchain output ──────────────────────────────────────────────────
+
+
+def test_resolve_toolchain_emits_drift_check_output() -> None:
+    """resolve-toolchain declares a drift-check output for ci.yml to gate on."""
+    action = _load(RESOLVE_ACTION)
+    assert "drift-check" in action["outputs"]
+
+
+def test_drift_check_defaults_true_when_key_absent(tmp_path: Path) -> None:
+    """No DEVKIT_DRIFT_CHECK => the enabled default (`true`)."""
+    outputs = _run_resolve(tmp_path, "DEVKIT_MODE=direnv\n")
+    assert outputs["drift-check"] == "true"
+
+
+def test_drift_check_false_maps_to_false(tmp_path: Path) -> None:
+    """An explicit `false` disables the gate."""
+    outputs = _run_resolve(tmp_path, "DEVKIT_MODE=direnv\nDEVKIT_DRIFT_CHECK=false\n")
+    assert outputs["drift-check"] == "false"
+
+
+def test_drift_check_true_maps_to_true(tmp_path: Path) -> None:
+    """An explicit `true` keeps the gate enabled."""
+    outputs = _run_resolve(tmp_path, "DEVKIT_MODE=direnv\nDEVKIT_DRIFT_CHECK=true\n")
+    assert outputs["drift-check"] == "true"
+
+
+def test_drift_check_emitted_in_every_mode(tmp_path: Path) -> None:
+    """drift-check is emitted regardless of delivery mode."""
+    outputs = _run_resolve(
+        tmp_path, "DEVKIT_MODE=both\nDEVKIT_VERSION=1.2.3\nDEVKIT_DRIFT_CHECK=false\n"
+    )
+    assert outputs["drift-check"] == "false"
+
+
+# ── ci.yml wiring ─────────────────────────────────────────────────────────────
+
+
+def test_resolve_toolchain_job_reexports_drift_check() -> None:
+    """The resolve-toolchain job re-exports drift-check so needs can consume it."""
+    workflow = _load(WORKFLOWS / "ci.yml")
+    outputs = workflow["jobs"]["resolve-toolchain"]["outputs"]
+    assert "drift-check" in outputs
+
+
+def test_ci_declares_scaffold_drift_job() -> None:
+    """ci.yml carries the scaffold-drift job, wired to resolve-toolchain."""
+    workflow = _load(WORKFLOWS / "ci.yml")
+    assert DRIFT_JOB in workflow["jobs"]
+    assert workflow["jobs"][DRIFT_JOB]["needs"] == ["resolve-toolchain"]
+
+
+def test_scaffold_drift_gated_on_pr_and_knob() -> None:
+    """The job runs on PRs only (cost) and self-skips when the knob is false."""
+    workflow = _load(WORKFLOWS / "ci.yml")
+    gate = workflow["jobs"][DRIFT_JOB]["if"]
+    assert "github.event_name == 'pull_request'" in gate
+    assert "drift-check" in gate
+    assert "'false'" in gate
+
+
+def test_scaffold_drift_runs_rescaffold_and_diff() -> None:
+    """The job re-runs init-workspace.sh and diffs the managed tree for drift."""
+    workflow = _load(WORKFLOWS / "ci.yml")
+    run_blocks = "\n".join(
+        step.get("run", "") for step in workflow["jobs"][DRIFT_JOB]["steps"]
+    )
+    assert "init-workspace.sh" in run_blocks
+    assert "--force" in run_blocks
+    assert "git" in run_blocks and "diff" in run_blocks
+
+
+def test_scaffold_drift_honors_runner_override() -> None:
+    """The job routes runs-on through the resolved runner (self-hosted aware)."""
+    workflow = _load(WORKFLOWS / "ci.yml")
+    assert workflow["jobs"][DRIFT_JOB]["runs-on"] == (
+        "${{ fromJSON(needs.resolve-toolchain.outputs.runner-json) }}"
+    )
+
+
+def test_summary_gates_on_scaffold_drift() -> None:
+    """The summary aggregate depends on scaffold-drift and checks its result."""
+    workflow = _load(WORKFLOWS / "ci.yml")
+    assert DRIFT_JOB in workflow["jobs"]["summary"]["needs"]
+    run = workflow["jobs"]["summary"]["steps"][0]["run"]
+    assert "needs.scaffold-drift.result" in run

--- a/tests/test_scaffold_drift.py
+++ b/tests/test_scaffold_drift.py
@@ -97,6 +97,23 @@ def test_resolve_toolchain_emits_drift_check_output() -> None:
     assert "drift-check" in action["outputs"]
 
 
+def test_resolve_toolchain_emits_drift_image_output() -> None:
+    """resolve-toolchain declares an all-modes image ref for the drift job."""
+    action = _load(RESOLVE_ACTION)
+    assert "drift-image" in action["outputs"]
+
+
+def test_drift_image_is_all_modes_ghcr_ref(tmp_path: Path) -> None:
+    """A host-mode (direnv) pin still yields a non-empty devcontainer image ref.
+
+    The `image` output is an explicit empty string for host modes, so the drift
+    job — which docker-runs the image on the host — needs a separate ref.
+    """
+    outputs = _run_resolve(tmp_path, "DEVKIT_MODE=direnv\nDEVKIT_VERSION=1.2.3\n")
+    assert outputs["image"] == ""
+    assert outputs["drift-image"] == "ghcr.io/vig-os/devcontainer:1.2.3"
+
+
 def test_drift_check_defaults_true_when_key_absent(tmp_path: Path) -> None:
     """No DEVKIT_DRIFT_CHECK => the enabled default (`true`)."""
     outputs = _run_resolve(tmp_path, "DEVKIT_MODE=direnv\n")
@@ -158,6 +175,17 @@ def test_scaffold_drift_runs_rescaffold_and_diff() -> None:
     assert "init-workspace.sh" in run_blocks
     assert "--force" in run_blocks
     assert "git" in run_blocks and "diff" in run_blocks
+
+
+def test_scaffold_drift_uses_resolved_image_ref() -> None:
+    """The job docker-runs the resolved image ref, not a hardcoded ghcr literal.
+
+    The #991 SSoT invariant keeps ghcr.io/vig-os/devcontainer out of ci.yml.
+    """
+    workflow = _load(WORKFLOWS / "ci.yml")
+    job_text = yaml.safe_dump(workflow["jobs"][DRIFT_JOB])
+    assert "drift-image" in job_text
+    assert "ghcr.io/vig-os/devcontainer" not in job_text
 
 
 def test_scaffold_drift_honors_runner_override() -> None:


### PR DESCRIPTION
Closes #1295

## Summary

Adds a `scaffold-drift` job to the scaffolded consumer `ci.yml` that re-runs the pinned devkit version's scaffold over the checkout and fails a PR whose managed files diverge from it — `DEVKIT_VERSION` bumped without re-scaffolding, or a managed file hand-edited. Today a pin-only bump merges green; this closes the #1093 skew gap with an enforced gate. Prerequisite for #1296.

## Mechanism

Re-scaffold + `git diff`, **not** `install.sh --preview`: the preview report classifies OVERWRITTEN by path existence, not content, so it cannot distinguish drift from an up-to-date file. The job `docker run`s `init-workspace.sh --force --no-prompts` from the pinned image over the checkout (direnv/bare consumers resolve an empty `container:` image, and the scaffold assets live only inside the image), then `git add -A && git diff --cached` surfaces divergence. `*.project` files and persisted `.vig-os` values are exempt by construction; `.gitignore`d files (`*.local`) via git. `VIG_OS_VERSION=<pin>` keeps the `DEVKIT_VERSION` line stable against the image's baked version. `install.sh` needed no changes.

## Knob

New `.vig-os` key `DEVKIT_DRIFT_CHECK` (`true` default / `false`), a pure runtime gate read via `resolve-toolchain`'s new `drift-check` output — flipping it needs no re-scaffold; the value round-trips across `--force` upgrades, and an invalid literal fails the scaffold loudly (mirrors `DEVKIT_REFS_POLICY`). The ghcr image literal stays in `resolve-toolchain` (new all-modes `drift-image` output) per the #991 SSoT invariant.

## Cost control

Runs on PRs only (~1.5 GiB image pull), riding the same gate as `commit-checks`/`dependency-review` — a per-job `paths` filter isn't possible inside one workflow. Summary treats skip-as-OK, failure trips the gate.

## Test evidence

- `tests/test_scaffold_drift.py` (new, 15 tests) + `test_ci_runner.py` + `test_scaffold_lint.py`: 70 passed
- `tests/bats/init-workspace.bats` (3 new tests): 278/278 pass
- `prek run --all-files`: green (both hook layers)
- `actionlint` on the template: clean

## Reviewer notes

- On a `DEVKIT_CI_RUNNER` self-hosted runner the job inherits `runs-on` and needs a `docker` CLI on that host; hosted `ubuntu-24.04` is unaffected. Worth checking on meatgrinder before a consumer with a self-hosted runner adopts.
- True path-narrowing (only pull the image when `.vig-os`/`flake.lock`/managed files change) would need a dedicated `scaffold-drift.yml` with `on.pull_request.paths`; kept as an in-`ci.yml` job per the issue's wording.

Refs: #1295
