### PR TITLE
feat(workflow): scaffold self-polling devkit-upgrade workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Self-polling devkit-upgrade workflow** ([#1296](https://github.com/vig-os/devkit/issues/1296))
+  - New managed `devkit-upgrade.yml` scaffolded into every consumer: a weekly
+    schedule (Monday, aligned with the Renovate window) polls devkit's public
+    `releases/latest` and, when this repo's `DEVKIT_VERSION` is behind, runs the
+    full-fidelity `install.sh --force` upgrade — the `.vig-os` pin, the
+    `flake.lock` `vigos` node and the whole scaffold move together, committed
+    inside the project shell so consumer hooks run — then opens the adoption PR.
+    `workflow_dispatch` takes an explicit `version` (final or rc) for the
+    release-train / lane-re-bump path.
+  - The version check is prerelease-aware: a consumer on an rc of a newer train
+    is never downgraded (no-op when current **or ahead**). Within a train the
+    adoption issue, branch and PR are reused across rc→rc→final, force-updated to
+    the latest bump.
+  - Two `.vig-os` knobs: `DEVKIT_AUTO_UPGRADE=false` disables the schedule only
+    (manual dispatch still works); `DEVKIT_UPGRADE_EXCLUDE` lists paths reset
+    before the adoption commit. The whole file opts out via the new
+    `devkit-upgrade` feature group (`DEVKIT_FEATURES_DISABLED`).
+  - Requires a dedicated `DEVKIT_UPGRADE_TOKEN` secret (the default
+    `GITHUB_TOKEN` cannot open a PR that triggers CI); the workflow fails fast
+    with a clear message when it is absent, and the commit identity is
+    configurable and kept off the agent blocklist.
+
 - **Solo/private-repo adoption profile** ([#1285](https://github.com/vig-os/devkit/issues/1285))
   - New `docs/SOLO_ADOPTION.md`: the one document a single-user, private repo
     follows to adopt devkit without the team/traceability layer, expressed as a

--- a/assets/init-workspace.sh
+++ b/assets/init-workspace.sh
@@ -346,6 +346,12 @@ MANIFEST_FEATURES_DISABLED="$(read_manifest_value "$VIG_OS_MANIFEST" DEVKIT_FEAT
 
 MANIFEST_REFS_POLICY="$(read_manifest_value "$VIG_OS_MANIFEST" DEVKIT_REFS_POLICY || true)"
 
+# devkit-upgrade knobs (#1296): runtime-only keys consumed by the scaffolded
+# devkit-upgrade.yml at run time (not rendered here) — read them solely to write
+# them back below, so an upgrade preserves a consumer's opt-out / exclusions.
+MANIFEST_AUTO_UPGRADE="$(read_manifest_value "$VIG_OS_MANIFEST" DEVKIT_AUTO_UPGRADE || true)"
+MANIFEST_UPGRADE_EXCLUDE="$(read_manifest_value "$VIG_OS_MANIFEST" DEVKIT_UPGRADE_EXCLUDE || true)"
+
 # The OWNER/REPO placeholder (written when no origin was resolvable) must not
 # mask a now-detectable git origin on a later upgrade.
 [[ "$MANIFEST_REPO" == "OWNER/REPO" ]] && MANIFEST_REPO=""
@@ -432,12 +438,12 @@ fi
 
 # Scaffold feature opt-outs (#1284): DEVKIT_FEATURES_DISABLED is a
 # comma-separated (whitespace-tolerant, like DEVKIT_FLOATING_TAGS/CI_RUNNER)
-# subset of the seven scaffold feature groups. Parse + validate it loudly here —
+# subset of the eight scaffold feature groups. Parse + validate it loudly here —
 # an unknown name must abort, never silently disable nothing — into
 # DISABLED_FEATURES[], with a feature_disabled helper the copy/prune/notice
 # mechanisms below all consult. Pure `.vig-os` key (no CLI flag), so only a
 # format guard: no contradiction guard as for --mode / --workflow.
-VALID_FEATURES=(release renovate sync-issues scanning gh-templates skills worktree)
+VALID_FEATURES=(release renovate sync-issues scanning gh-templates skills worktree devkit-upgrade)
 DISABLED_FEATURES=()
 if [[ -n "$MANIFEST_FEATURES_DISABLED" ]]; then
     IFS=',' read -ra _raw_features <<< "$MANIFEST_FEATURES_DISABLED"
@@ -451,7 +457,7 @@ if [[ -n "$MANIFEST_FEATURES_DISABLED" ]]; then
             [[ "$_feat" == "$_v" ]] && { _valid_feat=true; break; }
         done
         if [[ "$_valid_feat" != "true" ]]; then
-            echo "Error: Invalid DEVKIT_FEATURES_DISABLED in $VIG_OS_MANIFEST: $_feat (expected a comma-separated subset of: release, renovate, sync-issues, scanning, gh-templates, skills, worktree)" >&2
+            echo "Error: Invalid DEVKIT_FEATURES_DISABLED in $VIG_OS_MANIFEST: $_feat (expected a comma-separated subset of: release, renovate, sync-issues, scanning, gh-templates, skills, worktree, devkit-upgrade)" >&2
             exit 1
         fi
         DISABLED_FEATURES+=("$_feat")
@@ -1197,6 +1203,10 @@ feature_paths() {
             done
             printf '%s\n' ".devcontainer/justfile.worktree"
             ;;
+        devkit-upgrade)
+            printf '%s\n' \
+                ".github/workflows/devkit-upgrade.yml"
+            ;;
     esac
 }
 
@@ -1297,6 +1307,16 @@ render_workflow_model() {
         sed -i -E "s|^([[:space:]]*default:) 'dev'\$|\1 'main'|" "$si"
         sed -i "s#|| 'dev'#|| 'main'#g" "$si"
         sed -i 's|e.g., dev, release/x.y.z|e.g., main, release/x.y.z|' "$si"
+    fi
+
+    # devkit-upgrade.yml — retarget the self-upgrade base branch dev -> main:
+    # the checkout `ref:` and the PR `BASE:` env value (the only behavioral `dev`
+    # literals; both full-line anchored, #1296). Absent when the devkit-upgrade
+    # feature is disabled — the -f guard skips it then.
+    local du="$wf/devkit-upgrade.yml"
+    if [[ -f "$du" ]]; then
+        sed -i -E 's|^([[:space:]]*ref:) dev$|\1 main|' "$du"
+        sed -i -E 's|^([[:space:]]*BASE:) dev$|\1 main|' "$du"
     fi
 
     # branch-naming SKILL.md — base-branch default dev -> main. (Single-quoted
@@ -2108,6 +2128,16 @@ if [[ -f "$VIG_OS_MANIFEST" ]]; then
     # resets the commit-msg/commit-range Refs enforcement to chore-optional.
     if [[ -n "$MANIFEST_REFS_POLICY" ]]; then
         write_manifest_value DEVKIT_REFS_POLICY "$MANIFEST_REFS_POLICY"
+    fi
+    # devkit-upgrade knobs (#1296): bare in the template (DEVKIT_AUTO_UPGRADE= /
+    # DEVKIT_UPGRADE_EXCLUDE=), so a consumer's opt-out / exclusion list is read
+    # before the overwrite and written back — else an upgrade silently re-enables
+    # auto-upgrade and drops the exclusions. Round-trips like DEVKIT_FEATURES_DISABLED.
+    if [[ -n "$MANIFEST_AUTO_UPGRADE" ]]; then
+        write_manifest_value DEVKIT_AUTO_UPGRADE "$MANIFEST_AUTO_UPGRADE"
+    fi
+    if [[ -n "$MANIFEST_UPGRADE_EXCLUDE" ]]; then
+        write_manifest_value DEVKIT_UPGRADE_EXCLUDE "$MANIFEST_UPGRADE_EXCLUDE"
     fi
 fi
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -9,6 +9,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Self-polling devkit-upgrade workflow** ([#1296](https://github.com/vig-os/devkit/issues/1296))
+  - New managed `devkit-upgrade.yml` scaffolded into every consumer: a weekly
+    schedule (Monday, aligned with the Renovate window) polls devkit's public
+    `releases/latest` and, when this repo's `DEVKIT_VERSION` is behind, runs the
+    full-fidelity `install.sh --force` upgrade — the `.vig-os` pin, the
+    `flake.lock` `vigos` node and the whole scaffold move together, committed
+    inside the project shell so consumer hooks run — then opens the adoption PR.
+    `workflow_dispatch` takes an explicit `version` (final or rc) for the
+    release-train / lane-re-bump path.
+  - The version check is prerelease-aware: a consumer on an rc of a newer train
+    is never downgraded (no-op when current **or ahead**). Within a train the
+    adoption issue, branch and PR are reused across rc→rc→final, force-updated to
+    the latest bump.
+  - Two `.vig-os` knobs: `DEVKIT_AUTO_UPGRADE=false` disables the schedule only
+    (manual dispatch still works); `DEVKIT_UPGRADE_EXCLUDE` lists paths reset
+    before the adoption commit. The whole file opts out via the new
+    `devkit-upgrade` feature group (`DEVKIT_FEATURES_DISABLED`).
+  - Requires a dedicated `DEVKIT_UPGRADE_TOKEN` secret (the default
+    `GITHUB_TOKEN` cannot open a PR that triggers CI); the workflow fails fast
+    with a clear message when it is absent, and the commit identity is
+    configurable and kept off the agent blocklist.
+
 - **Solo/private-repo adoption profile** ([#1285](https://github.com/vig-os/devkit/issues/1285))
   - New `docs/SOLO_ADOPTION.md`: the one document a single-user, private repo
     follows to adopt devkit without the team/traceability layer, expressed as a

--- a/assets/workspace/.github/workflows/devkit-upgrade.yml
+++ b/assets/workspace/.github/workflows/devkit-upgrade.yml
@@ -1,0 +1,283 @@
+# Managed by vigOS devkit — regenerated on upgrade; local edits are lost.
+# Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues
+
+# Self-polling devkit upgrade (#1296). Weekly (and on explicit dispatch) this
+# checks for a newer devkit release and, when found, runs the full-fidelity
+# `install.sh --force` upgrade — the .vig-os pin, the flake.lock `vigos` node and
+# the full scaffold regeneration move together, with the commit made inside the
+# project shell so consumer hooks run — then opens the adoption PR. Renovate-style
+# pull: no devkit-side action at release time, no consumer registry.
+#
+# Requires the DEVKIT_UPGRADE_TOKEN secret — a dedicated identity (fine-grained
+# PAT or GitHub App token with contents:write + pull-requests:write +
+# issues:write). The default GITHUB_TOKEN cannot open the PR: PRs it creates do
+# not trigger CI. The workflow fails fast when the secret is absent. Provisioning
+# + rotation: https://github.com/vig-os/devkit/issues/1296
+
+name: Devkit Upgrade
+
+on:  # yamllint disable-line rule:truthy
+  # Weekly, Monday early AM — aligned with the Renovate window (before 9am Mon).
+  # Scheduled runs execute from the default branch; the job checks out and
+  # targets the right base itself.
+  schedule:
+    - cron: '0 6 * * 1'
+  # Explicit version (final or rc) — the release-train / lane-re-bump path.
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Devkit version to adopt (final or rc, e.g. 1.5.0 or 1.5.0-rc1)'
+        required: true
+        type: string
+
+permissions: {}  # restrict default; the job declares its own
+
+concurrency:
+  group: devkit-upgrade-${{ github.repository }}
+  cancel-in-progress: false
+
+jobs:
+  upgrade:
+    name: Adopt newer devkit
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      # The branch, issue and PR are all created with DEVKIT_UPGRADE_TOKEN (a
+      # dedicated identity, so the PR triggers CI); the default token stays
+      # read-only for the public releases/latest query.
+      contents: read
+    steps:
+      - name: Require the dedicated upgrade token
+        env:
+          DEVKIT_UPGRADE_TOKEN: ${{ secrets.DEVKIT_UPGRADE_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${DEVKIT_UPGRADE_TOKEN}" ]; then
+            echo "::error::DEVKIT_UPGRADE_TOKEN secret is not configured. This workflow needs a dedicated identity (fine-grained PAT or GitHub App token with contents:write + pull-requests:write + issues:write): the default GITHUB_TOKEN cannot open a PR that triggers CI. See https://github.com/vig-os/devkit/issues/1296."
+            exit 1
+          fi
+
+      - name: Checkout base branch
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          # Base branch per workflow model: gitflow -> dev, trunk -> main
+          # (retargeted to `main` at scaffold time for a trunk repo).
+          ref: dev
+          # Persist the dedicated token so the later push authenticates as the
+          # upgrade identity (whose PR triggers CI).
+          token: ${{ secrets.DEVKIT_UPGRADE_TOKEN }}
+          fetch-depth: 0
+
+      - name: Resolve target version
+        id: resolve
+        env:
+          # Route untrusted values through env (never inline ${{ }} in run:) —
+          # a dispatch input expanded as code is a template-injection sink.
+          EVENT_NAME: ${{ github.event_name }}
+          DISPATCH_VERSION: ${{ github.event.inputs.version }}
+          # Read-only public query — the default token is sufficient.
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          # Prerelease-aware semver compare: returns 0 (true) when $1 >= $2,
+          # treating a prerelease (X.Y.Z-rc1) as LOWER than its release (X.Y.Z).
+          # Load-bearing for the "current or ahead" no-op: a consumer on an rc of
+          # a newer train must never be downgraded to the older final.
+          version_ge() {
+            local a="$1" b="$2"
+            local acore="${a%%-*}" bcore="${b%%-*}"
+            local apre="" bpre=""
+            [ "$a" != "$acore" ] && apre="${a#*-}"
+            [ "$b" != "$bcore" ] && bpre="${b#*-}"
+            local i ai bi
+            local -a av bv
+            IFS='.' read -ra av <<< "$acore"
+            IFS='.' read -ra bv <<< "$bcore"
+            for i in 0 1 2; do
+              ai="${av[$i]:-0}"; bi="${bv[$i]:-0}"
+              if [ "$ai" -gt "$bi" ]; then return 0; fi
+              if [ "$ai" -lt "$bi" ]; then return 1; fi
+            done
+            # Equal cores: release > prerelease; prerelease compared lexically.
+            if [ -z "$apre" ] && [ -z "$bpre" ]; then return 0; fi
+            if [ -z "$apre" ]; then return 0; fi
+            if [ -z "$bpre" ]; then return 1; fi
+            [ "$apre" = "$bpre" ] && return 0
+            [ "$(printf '%s\n%s\n' "$apre" "$bpre" | LC_ALL=C sort | head -n1)" = "$bpre" ]
+          }
+
+          CURRENT="$(sed -n 's/^DEVKIT_VERSION=//p' .vig-os | head -n1)"
+          if [ -z "$CURRENT" ]; then
+            echo "::error::.vig-os has no DEVKIT_VERSION pin."
+            exit 1
+          fi
+
+          if [ "$EVENT_NAME" = "schedule" ]; then
+            # Opt-out knob: gates the schedule path only. Empty (default) or any
+            # value other than the literal `false` keeps auto-upgrade enabled.
+            AUTO="$(sed -n 's/^DEVKIT_AUTO_UPGRADE=//p' .vig-os | head -n1)"
+            if [ "$AUTO" = "false" ]; then
+              echo "DEVKIT_AUTO_UPGRADE=false — scheduled upgrade disabled; no-op."
+              echo "proceed=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            # releases/latest excludes prereleases and drafts by construction, so
+            # cron never proposes an rc.
+            TARGET="$(gh api repos/vig-os/devkit/releases/latest --jq .tag_name | sed 's/^v//')"
+          else
+            TARGET="${DISPATCH_VERSION#v}"
+          fi
+
+          # Validate the resolved version (defence-in-depth: TARGET flows into
+          # later shell / gh / git commands). A strict semver shape also rejects
+          # any hostile dispatch input before it can reach those sinks.
+          if ! printf '%s' "$TARGET" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'; then
+            echo "::error::Refusing to act on malformed target version: '${TARGET}'."
+            exit 1
+          fi
+
+          if [ "$EVENT_NAME" = "schedule" ] && version_ge "$CURRENT" "$TARGET"; then
+            echo "Current pin ${CURRENT} is at or ahead of latest ${TARGET}; no-op."
+            echo "proceed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # The adoption issue + branch key on the TRAIN (prerelease stripped) so
+          # rc1 -> rc2 -> final within a train reuse the same issue/branch/PR; the
+          # commit + PR title carry the exact installed version.
+          TRAIN="${TARGET%%-*}"
+          echo "proceed=true" >> "$GITHUB_OUTPUT"
+          echo "target=${TARGET}" >> "$GITHUB_OUTPUT"
+          echo "train=${TRAIN}" >> "$GITHUB_OUTPUT"
+          echo "branch-suffix=$(echo "${TRAIN}" | tr '.' '-')" >> "$GITHUB_OUTPUT"
+
+      - name: Find or create the adoption issue
+        id: issue
+        if: steps.resolve.outputs.proceed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.DEVKIT_UPGRADE_TOKEN }}
+          TRAIN: ${{ steps.resolve.outputs.train }}
+        run: |
+          set -euo pipefail
+          TITLE="chore: adopt devkit ${TRAIN}"
+          NUMBER="$(gh issue list --state open --search "${TITLE} in:title" \
+            --json number,title \
+            --jq "map(select(.title == \"${TITLE}\")) | .[0].number // empty")"
+          if [ -z "$NUMBER" ]; then
+            URL="$(gh issue create --title "${TITLE}" \
+              --body "Automated adoption of devkit ${TRAIN}. Opened by the devkit-upgrade workflow (#1296).")"
+            NUMBER="${URL##*/}"
+            echo "Created adoption issue #${NUMBER}."
+          else
+            echo "Reusing open adoption issue #${NUMBER}."
+          fi
+          echo "number=${NUMBER}" >> "$GITHUB_OUTPUT"
+
+      - name: Create the upgrade branch
+        id: branch
+        if: steps.resolve.outputs.proceed == 'true'
+        env:
+          ISSUE: ${{ steps.issue.outputs.number }}
+          SUFFIX: ${{ steps.resolve.outputs.branch-suffix }}
+        run: |
+          set -euo pipefail
+          # Dots -> dashes: the consumer branch guard rejects dots and any
+          # prefix outside its allowlist (chore/ is allowed).
+          BRANCH="chore/${ISSUE}-devkit-${SUFFIX}"
+          git switch -c "$BRANCH" 2>/dev/null || git switch "$BRANCH"
+          echo "name=${BRANCH}" >> "$GITHUB_OUTPUT"
+
+      - name: Install Nix
+        if: steps.resolve.outputs.proceed == 'true'
+        uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342  # v31.11.0
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+
+      - name: Run the devkit upgrade (install.sh --force)
+        if: steps.resolve.outputs.proceed == 'true'
+        env:
+          TARGET: ${{ steps.resolve.outputs.target }}
+        run: |
+          set -euo pipefail
+          # docker is present on ubuntu-latest (install.sh auto-detects it); nix
+          # (installed above) advances the floating `vigos` flake.lock node. The
+          # workflow owns the branch, so bypass install.sh's own preflight guard.
+          curl -sSfL https://raw.githubusercontent.com/vig-os/devkit/main/install.sh \
+            | bash -s -- --force --version "$TARGET" --skip-preflight .
+
+      - name: Reset excluded paths
+        if: steps.resolve.outputs.proceed == 'true'
+        run: |
+          set -euo pipefail
+          # DEVKIT_UPGRADE_EXCLUDE: comma-separated paths (whitespace-tolerant)
+          # reset to the base branch before the commit — e.g. generated-doc churn
+          # that must not ride along in the adoption diff.
+          EXCLUDE="$(sed -n 's/^DEVKIT_UPGRADE_EXCLUDE=//p' .vig-os | head -n1)"
+          IFS=',' read -ra PATHS <<< "$EXCLUDE"
+          for path in ${PATHS[@]+"${PATHS[@]}"}; do
+            path="$(echo "$path" | xargs)"
+            [ -z "$path" ] && continue
+            echo "Resetting excluded path: ${path}"
+            git checkout -- "$path" 2>/dev/null || true
+          done
+
+      - name: Commit the upgrade in the project shell
+        id: commit
+        if: steps.resolve.outputs.proceed == 'true'
+        env:
+          TARGET: ${{ steps.resolve.outputs.target }}
+          ISSUE: ${{ steps.issue.outputs.number }}
+          # Commit identity (configurable via repo variables). Must not match
+          # .github/agent-blocklist.toml — the default avoids github-actions[bot]
+          # and any AI-agent fingerprint.
+          GIT_AUTHOR_NAME: ${{ vars.DEVKIT_UPGRADE_AUTHOR_NAME || 'vigos-devkit-bot' }}
+          GIT_AUTHOR_EMAIL: ${{ vars.DEVKIT_UPGRADE_AUTHOR_EMAIL || 'devkit-bot@users.noreply.github.com' }}
+          GIT_COMMITTER_NAME: ${{ vars.DEVKIT_UPGRADE_AUTHOR_NAME || 'vigos-devkit-bot' }}
+          GIT_COMMITTER_EMAIL: ${{ vars.DEVKIT_UPGRADE_AUTHOR_EMAIL || 'devkit-bot@users.noreply.github.com' }}
+        run: |
+          set -euo pipefail
+          git add -A
+          if git diff --cached --quiet; then
+            echo "No changes after upgrade; nothing to commit."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Commit INSIDE the project shell so consumer hooks run (dist rebuild in
+          # commit-action, trailer strip, validate-commit-msg). chore is
+          # Refs-exempt but include it for traceability.
+          printf 'chore: adopt devkit %s\n\nRefs: #%s\n' "$TARGET" "$ISSUE" > "${RUNNER_TEMP}/commit-msg"
+          nix develop -c git commit -F "${RUNNER_TEMP}/commit-msg"
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Push the upgrade branch
+        if: steps.resolve.outputs.proceed == 'true' && steps.commit.outputs.changed == 'true'
+        env:
+          BRANCH: ${{ steps.branch.outputs.name }}
+        run: |
+          set -euo pipefail
+          # Force-update: within a train an earlier rc may already have pushed
+          # this branch; the PR is refreshed to the latest bump.
+          git push --force origin "HEAD:${BRANCH}"
+
+      - name: Open or update the adoption PR
+        if: steps.resolve.outputs.proceed == 'true' && steps.commit.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.DEVKIT_UPGRADE_TOKEN }}
+          TARGET: ${{ steps.resolve.outputs.target }}
+          ISSUE: ${{ steps.issue.outputs.number }}
+          BRANCH: ${{ steps.branch.outputs.name }}
+          # PR base per workflow model (retargeted dev -> main at scaffold time).
+          BASE: dev
+        run: |
+          set -euo pipefail
+          TITLE="chore: adopt devkit ${TARGET}"
+          BODY="$(printf 'Automated devkit upgrade to %s via install.sh --force.\n\nReview the scaffold + flake.lock diff and merge. Closes #%s\n' "$TARGET" "$ISSUE")"
+          if gh pr view "$BRANCH" --json number >/dev/null 2>&1; then
+            gh pr edit "$BRANCH" --title "$TITLE" --body "$BODY"
+            echo "Updated the existing adoption PR."
+          else
+            gh pr create --base "$BASE" --head "$BRANCH" --title "$TITLE" --body "$BODY"
+            echo "Opened the adoption PR."
+          fi

--- a/assets/workspace/.github/workflows/devkit-upgrade.yml
+++ b/assets/workspace/.github/workflows/devkit-upgrade.yml
@@ -147,10 +147,12 @@ jobs:
           # rc1 -> rc2 -> final within a train reuse the same issue/branch/PR; the
           # commit + PR title carry the exact installed version.
           TRAIN="${TARGET%%-*}"
-          echo "proceed=true" >> "$GITHUB_OUTPUT"
-          echo "target=${TARGET}" >> "$GITHUB_OUTPUT"
-          echo "train=${TRAIN}" >> "$GITHUB_OUTPUT"
-          echo "branch-suffix=$(echo "${TRAIN}" | tr '.' '-')" >> "$GITHUB_OUTPUT"
+          {
+            echo "proceed=true"
+            echo "target=${TARGET}"
+            echo "train=${TRAIN}"
+            echo "branch-suffix=$(echo "${TRAIN}" | tr '.' '-')"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Find or create the adoption issue
         id: issue

--- a/assets/workspace/.vig-os
+++ b/assets/workspace/.vig-os
@@ -72,7 +72,7 @@ DEVKIT_SYNC_SCHEDULE=
 
 # Scaffold feature groups this repo opts OUT of — a comma-separated,
 # whitespace-tolerant subset of: release, renovate, sync-issues, scanning,
-# gh-templates, skills, worktree. Empty (default) => every group is scaffolded
+# gh-templates, skills, worktree, devkit-upgrade. Empty (default) => every group is scaffolded
 # (no change for existing consumers). A disabled group is never shipped, and a
 # copy left by a prior scaffold is pruned on upgrade; clearing the key re-ships
 # it on the next `--force`. Consumer-owned extension seams
@@ -90,3 +90,20 @@ DEVKIT_FEATURES_DISABLED=
 # anchored render of the hook arg + resolve-toolchain's `refs-optional-types`
 # output); written back only for a non-default value (#1282).
 DEVKIT_REFS_POLICY=
+
+# Auto-upgrade opt-out for the scaffolded devkit-upgrade.yml workflow. Empty
+# (default) or any value other than `false` keeps the WEEKLY schedule path
+# enabled — it polls devkit's latest release and, when this repo's DEVKIT_VERSION
+# is behind, opens the adoption PR. `false` disables ONLY the schedule; manual
+# `workflow_dispatch` (the release-train / rc re-bump path) always runs. A
+# runtime gate read from this file — no re-scaffold to flip. Written back only
+# for a non-default (`false`) value, so a default .vig-os is unchanged (#1296).
+DEVKIT_AUTO_UPGRADE=
+
+# Paths the devkit-upgrade workflow resets (git checkout --) after the scaffold
+# regeneration but before the adoption commit, so they never ride along in the
+# upgrade diff — e.g. a consumer's generated-doc churn. Comma-separated,
+# whitespace-tolerant (like DEVKIT_FEATURES_DISABLED). Empty (default) => no
+# exclusions. A runtime gate read from this file; written back only for a
+# non-empty value (#1296).
+DEVKIT_UPGRADE_EXCLUDE=

--- a/assets/workspace/zizmor.yml
+++ b/assets/workspace/zizmor.yml
@@ -35,7 +35,8 @@
 # Residual (baselined below), why each is intentional:
 #   - artipacked        → checkouts that push or fetch from a private remote and
 #                         therefore rely on the persisted git credential
-#                         (ci.yml commit-checks, all release/sync branch work).
+#                         (ci.yml commit-checks, all release/sync branch work,
+#                         devkit-upgrade's self-upgrade branch push).
 #   - dangerous-triggers → renovate-changelog-commit.yml runs on `workflow_run`
 #                         by design (it commits the built changelog).
 #   - github-app        → create-github-app-token intentionally mints a
@@ -51,6 +52,7 @@ rules:
   artipacked:
     ignore:
       - ci.yml
+      - devkit-upgrade.yml
       - prepare-release.yml
       - promote-release.yml
       - release-core.yml

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -369,6 +369,8 @@ unknown keys:
 | `DEVKIT_SYNC_SCHEDULE` | Cron override (5-field) for the sync-issues schedule trigger; empty (default) => the daily `0 2 * * *` ([#1228](https://github.com/vig-os/devkit/issues/1228)) |
 | `DEVKIT_FEATURES_DISABLED` | Comma-separated scaffold feature groups this repo opts OUT of; empty (default) => every group is scaffolded. A disabled group is never shipped and a prior scaffold's copy is pruned on upgrade (see [Scaffold feature opt-outs](#scaffold-feature-opt-outs), [#1284](https://github.com/vig-os/devkit/issues/1284)) |
 | `DEVKIT_REFS_POLICY` | Refs-line enforcement policy driving both the `validate-commit-msg` hook and CI's `validate-commit-range`: `chore-optional` (default/empty — only `chore` may omit `Refs:`) \| `optional` (never required) \| `required` (every type needs `Refs:`) ([#1282](https://github.com/vig-os/devkit/issues/1282)) |
+| `DEVKIT_AUTO_UPGRADE` | Opt-out for the scaffolded `devkit-upgrade.yml` weekly schedule; empty (default) or any value but `false` keeps the auto-adoption poll on. `false` disables only the schedule — manual `workflow_dispatch` always runs ([#1296](https://github.com/vig-os/devkit/issues/1296)) |
+| `DEVKIT_UPGRADE_EXCLUDE` | Comma-separated (whitespace-tolerant) paths the `devkit-upgrade` workflow resets before the adoption commit, so generated-doc churn never rides along in the upgrade diff; empty (default) => no exclusions ([#1296](https://github.com/vig-os/devkit/issues/1296)) |
 
 ### Scaffold feature opt-outs
 
@@ -382,7 +384,7 @@ before. An unknown group name aborts the scaffold loudly. The key governs
 scaffold **shape** only — it does not touch the flake or the dev-shell modules
 (`DEVKIT_MODULES`).
 
-The seven groups:
+The eight groups:
 
 - `release` — the release/prepare/promote workflows (`release*.yml`,
   `prepare-release*.yml`, `promote-release.yml`, `sync-main-to-dev.yml`) and
@@ -398,6 +400,10 @@ The seven groups:
 - `skills` — every `.claude/skills/` directory except `worktree_*`.
 - `worktree` — the `.claude/skills/worktree_*` directories and
   `.devcontainer/justfile.worktree`.
+- `devkit-upgrade` — the `devkit-upgrade.yml` self-polling upgrade workflow
+  ([#1296](https://github.com/vig-os/devkit/issues/1296)). Disabling it (rather
+  than the runtime `DEVKIT_AUTO_UPGRADE=false` knob) stops the file from shipping
+  at all.
 
 `ci.yml` is intentionally out of scope (v1): it stays a single atomic,
 mode-aware workflow.

--- a/tests/bats/init-workspace.bats
+++ b/tests/bats/init-workspace.bats
@@ -4079,7 +4079,9 @@ _scaffold_seeded() {
     run _scaffold both "$ws"
     assert_success
     refute_output --partial "disabled feature"
-    # A representative file from each of the seven groups is present.
+    # A representative file from each of the eight groups is present.
+    run test -f "$ws/.github/workflows/devkit-upgrade.yml"
+    assert_success
     run test -f "$ws/.github/workflows/release.yml"
     assert_success
     run test -f "$ws/renovate.json"
@@ -4099,8 +4101,11 @@ _scaffold_seeded() {
 @test "disabling a feature keeps its files out of the scaffold (#1284)" {
     ws="$BATS_TEST_TMPDIR/e2e-1284-absent-files"
     mkdir -p "$ws"
-    run _scaffold_seeded both "$ws" "release,renovate,sync-issues,scanning,gh-templates"
+    run _scaffold_seeded both "$ws" "release,renovate,sync-issues,scanning,gh-templates,devkit-upgrade"
     assert_success
+    # devkit-upgrade
+    run test -e "$ws/.github/workflows/devkit-upgrade.yml"
+    assert_failure
     # release
     run test -e "$ws/.github/workflows/release.yml"
     assert_failure

--- a/tests/test_workflow_devkit_upgrade.py
+++ b/tests/test_workflow_devkit_upgrade.py
@@ -1,0 +1,212 @@
+"""Scaffold + wiring tests for the self-polling devkit-upgrade workflow (#1296).
+
+A managed ``devkit-upgrade.yml`` ships into every consumer and, weekly (or on
+explicit dispatch), runs the full-fidelity ``install.sh --force`` upgrade and
+opens the adoption PR — Renovate-style pull, with no devkit-side action at
+release time. These tests pin the deliverable without executing the workflow:
+
+- the ``.vig-os`` manifest declares the two runtime knobs (``DEVKIT_AUTO_UPGRADE``
+  gates the schedule path; ``DEVKIT_UPGRADE_EXCLUDE`` lists paths reset before the
+  commit), both shipping empty;
+- the template carries the managed banner, both triggers, the public
+  ``releases/latest`` version check with prerelease-aware compare, the dedicated
+  ``DEVKIT_UPGRADE_TOKEN`` (fail-fast when absent; never the default
+  ``GITHUB_TOKEN`` for the PR), the ``install.sh`` bootstrap and the
+  ``nix develop`` commit;
+- no ``run:`` block interpolates a dispatch input or event field directly
+  (zizmor template-injection: every such value is routed through ``env:``);
+- the base branch is workflow-model aware (``dev`` gitflow / ``main`` trunk),
+  realized by the scaffold-time ``render_workflow_model`` retarget;
+- the ``devkit-upgrade`` feature group (#1284) opts the whole file out.
+
+Refs: #1296
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from tests.workflow_scaffold import (
+    INIT_WORKSPACE,
+    WORKSPACE,
+    scaffold,
+    scaffold_tree,
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+TEMPLATE = WORKSPACE / ".github" / "workflows" / "devkit-upgrade.yml"
+REL = ".github/workflows/devkit-upgrade.yml"
+
+
+def _rendered(tmp_path: Path, workflow: str | None = None) -> str:
+    tree = scaffold_tree(tmp_path, workflow=workflow)
+    return (tree / REL).read_text(encoding="utf-8")
+
+
+def _steps(text: str) -> list[dict]:
+    doc = yaml.safe_load(text)
+    steps: list[dict] = []
+    for job in (doc.get("jobs") or {}).values():
+        for step in job.get("steps", []) or []:
+            if isinstance(step, dict):
+                steps.append(step)
+    return steps
+
+
+# ── production wiring seams ───────────────────────────────────────────────────
+
+
+def test_vig_os_declares_upgrade_keys() -> None:
+    """The scaffold manifest ships both runtime knobs, empty by default."""
+    text = (WORKSPACE / ".vig-os").read_text(encoding="utf-8")
+    assert "DEVKIT_AUTO_UPGRADE=" in text
+    assert "DEVKIT_UPGRADE_EXCLUDE=" in text
+    # Empty (default enabled / no exclusions), like every other opt-in key.
+    assert "DEVKIT_AUTO_UPGRADE=\n" in text or text.rstrip().endswith(
+        "DEVKIT_AUTO_UPGRADE="
+    )
+
+
+def test_init_workspace_registers_feature_group() -> None:
+    """init-workspace.sh lists devkit-upgrade among the valid feature groups."""
+    init = INIT_WORKSPACE.read_text(encoding="utf-8")
+    assert "devkit-upgrade" in init
+    # The VALID_FEATURES allowlist must carry it (an unknown group aborts).
+    valid_line = next(
+        line for line in init.splitlines() if line.strip().startswith("VALID_FEATURES=")
+    )
+    assert "devkit-upgrade" in valid_line
+
+
+def test_init_workspace_writes_back_upgrade_keys() -> None:
+    """The manifest-only keys are written back so an upgrade preserves them."""
+    init = INIT_WORKSPACE.read_text(encoding="utf-8")
+    assert "write_manifest_value DEVKIT_AUTO_UPGRADE" in init
+    assert "write_manifest_value DEVKIT_UPGRADE_EXCLUDE" in init
+
+
+# ── template shape ────────────────────────────────────────────────────────────
+
+
+def test_template_exists_with_managed_banner() -> None:
+    """The workflow ships and carries the managed-file banner."""
+    assert TEMPLATE.is_file()
+    assert TEMPLATE.read_text(encoding="utf-8").startswith("# Managed by vigOS devkit")
+
+
+def test_triggers_are_weekly_cron_and_dispatch_version() -> None:
+    """Schedule (weekly Monday) + workflow_dispatch with a version input."""
+    doc = yaml.safe_load(TEMPLATE.read_text(encoding="utf-8"))
+    on = doc.get("on", doc.get(True))
+    assert isinstance(on, dict)
+    crons = [c["cron"] for c in on["schedule"]]
+    assert any(c.endswith("* * 1") for c in crons), crons
+    assert "version" in on["workflow_dispatch"]["inputs"]
+
+
+def test_schedule_path_gated_on_auto_upgrade_and_queries_latest() -> None:
+    """Schedule path reads DEVKIT_AUTO_UPGRADE and queries the public latest."""
+    text = TEMPLATE.read_text(encoding="utf-8")
+    assert "DEVKIT_AUTO_UPGRADE" in text
+    assert "repos/vig-os/devkit/releases/latest" in text
+
+
+def test_version_compare_is_prerelease_aware() -> None:
+    """A semver compare exists and accounts for prerelease suffixes."""
+    text = TEMPLATE.read_text(encoding="utf-8")
+    assert "version_ge" in text
+    # No-op when current or AHEAD: prerelease handling is load-bearing so a
+    # consumer on an rc of a newer train is never downgraded.
+    assert "prerelease" in text.lower()
+
+
+def test_requires_dedicated_token_and_never_uses_github_token_for_pr() -> None:
+    """A missing DEVKIT_UPGRADE_TOKEN fails fast; the PR uses the dedicated token."""
+    text = TEMPLATE.read_text(encoding="utf-8")
+    assert "secrets.DEVKIT_UPGRADE_TOKEN" in text
+    # A clear fail-fast guard when the secret is absent.
+    assert "DEVKIT_UPGRADE_TOKEN secret is not configured" in text
+    # The PR step authenticates gh with the dedicated token (not github.token),
+    # otherwise the created PR would not trigger CI.
+    steps = _steps(text)
+    pr_steps = [s for s in steps if "gh pr create" in str(s.get("run", ""))]
+    assert pr_steps, "no PR-creating step found"
+    for s in pr_steps:
+        assert s.get("env", {}).get("GH_TOKEN") == "${{ secrets.DEVKIT_UPGRADE_TOKEN }}"
+
+
+def test_bootstraps_installsh_and_commits_in_project_shell() -> None:
+    """The upgrade runs install.sh --force --version and commits inside nix develop."""
+    text = TEMPLATE.read_text(encoding="utf-8")
+    assert "raw.githubusercontent.com/vig-os/devkit/main/install.sh" in text
+    assert "--force" in text and "--version" in text
+    assert "nix develop -c git commit" in text
+    # A nix installer action provides the `flake update vigos` leg.
+    assert "install-nix-action" in text
+
+
+def test_reset_excluded_paths_and_closes_issue() -> None:
+    """DEVKIT_UPGRADE_EXCLUDE paths are reset and the PR closes its adoption issue."""
+    text = TEMPLATE.read_text(encoding="utf-8")
+    assert "DEVKIT_UPGRADE_EXCLUDE" in text
+    assert "git checkout --" in text
+    assert "Closes #" in text
+
+
+# ── security: no template injection (zizmor) ──────────────────────────────────
+
+
+def test_no_run_block_interpolates_untrusted_input() -> None:
+    """No ``run:`` interpolates a dispatch input or event field directly (#1279/#1287)."""
+    offenders: list[str] = []
+    for step in _steps(TEMPLATE.read_text(encoding="utf-8")):
+        run = str(step.get("run", ""))
+        if "${{ github.event" in run or "${{ inputs." in run:
+            offenders.append(step.get("name", "<unnamed>"))
+    assert not offenders, (
+        f"run blocks interpolate untrusted input directly (route through env): {offenders}"
+    )
+
+
+# ── base-branch awareness (workflow model) ────────────────────────────────────
+
+
+def test_gitflow_base_branch_is_dev(tmp_path: Path) -> None:
+    """A gitflow scaffold checks out and targets `dev`."""
+    text = _rendered(tmp_path)
+    assert "ref: dev" in text
+    assert "BASE: dev" in text
+
+
+def test_trunk_base_branch_is_main(tmp_path: Path) -> None:
+    """A trunk scaffold retargets the base branch dev -> main (#1205)."""
+    text = _rendered(tmp_path, workflow="trunk")
+    assert "ref: main" in text
+    assert "BASE: main" in text
+    assert "ref: dev" not in text
+    assert "BASE: dev" not in text
+
+
+# ── feature opt-out (#1284) ───────────────────────────────────────────────────
+
+
+def test_disabling_feature_omits_the_workflow(tmp_path: Path) -> None:
+    """DEVKIT_FEATURES_DISABLED=devkit-upgrade keeps the file out of the scaffold."""
+    seed = tmp_path / "seed"
+    seed.mkdir()
+    (seed / ".vig-os").write_text(
+        "DEVKIT_FEATURES_DISABLED=devkit-upgrade\n", encoding="utf-8"
+    )
+    proc = scaffold(tmp_path, seed=seed, name="disabled")
+    assert proc.returncode == 0, proc.stderr
+    assert not (tmp_path / "disabled" / REL).exists()
+    # A non-disabled workflow still ships.
+    assert (tmp_path / "disabled" / ".github/workflows/ci.yml").exists()
+
+
+def test_valid_feature_group_default_ships_the_workflow(tmp_path: Path) -> None:
+    """With no opt-out, the workflow is scaffolded."""
+    tree = scaffold_tree(tmp_path)
+    assert (tree / REL).is_file()

--- a/zizmor.yml
+++ b/zizmor.yml
@@ -32,7 +32,8 @@
 # Residual (baselined below), why each is intentional:
 #   - artipacked        → checkouts that push or fetch from a private remote and
 #                         therefore rely on the persisted git credential
-#                         (ci.yml commit-checks, all release/sync branch work).
+#                         (ci.yml commit-checks, all release/sync branch work,
+#                         devkit-upgrade's self-upgrade branch push).
 #   - dangerous-triggers → renovate-changelog-commit.yml runs on `workflow_run`
 #                         by design (it commits the built changelog).
 #   - github-app        → create-github-app-token intentionally mints a
@@ -48,6 +49,7 @@ rules:
   artipacked:
     ignore:
       - ci.yml
+      - devkit-upgrade.yml
       - prepare-release.yml
       - promote-release.yml
       - release-core.yml


### PR DESCRIPTION
Closes #1296

## Summary

Scaffolds a self-polling `devkit-upgrade.yml` workflow into consumers: weekly (Monday 06:00, aligned with the Renovate window) it queries devkit's `releases/latest`, and when the repo's `.vig-os` pin is behind it runs the full-fidelity `install.sh --force --version <X>` upgrade — pin + `flake.lock` `vigos` node + scaffold regeneration move together — commits inside the project shell so consumer hooks run (dist rebuild, trailer strip, commit-msg validation), and opens the adoption PR. `workflow_dispatch` with an explicit `version` input (final or rc) is the release-train / lane-re-bump path. Merging stays human. Depends on the #1295 drift gate (PR #1297) as its safety net.

## Design

- **Feature group**: new `devkit-upgrade` group in the #1284 opt-out mechanism (never ship the file at all), composing with the runtime knobs:
- **`DEVKIT_AUTO_UPGRADE`** (`.vig-os`, default enabled): gates the *schedule path only*; manual dispatch always runs. **`DEVKIT_UPGRADE_EXCLUDE`**: comma-separated paths reset before the adoption commit (e.g. vault's generated-doc churn). Both round-trip across `--force` upgrades.
- **Version logic**: `releases/latest` excludes prereleases/drafts, so cron never proposes an rc; a prerelease-aware compare makes the schedule a no-op when the pin is current **or ahead** (an rc of a newer train is never downgraded). Resolved versions are strictly semver-validated before reaching any shell/gh sink.
- **Train keying**: adoption issue/branch/PR key on the train (`chore/<issue>-devkit-1-5-0`, dots→dashes for the branch guard), so rc1→rc2→final reuse one issue/branch/PR force-updated; commit + PR title carry the exact version.
- **Base branch**: ships `dev` literals, retargeted to `main` at scaffold time for trunk repos via `render_workflow_model` (the sync-issues.yml precedent).
- **Token**: dedicated `DEVKIT_UPGRADE_TOKEN` secret (fail-fast with a clear error when absent) — the default `GITHUB_TOKEN` is used only for the read-only release query, since PRs it creates don't trigger CI. Commit identity configurable via `vars.DEVKIT_UPGRADE_AUTHOR_NAME/EMAIL`; the default avoids the agent-blocklist.
- **Security**: every untrusted value (dispatch input, event fields, API responses) routed through `env:`; actions SHA-pinned; `permissions: {}` at workflow level, `contents: read` on the job. One deliberate zizmor `artipacked` baseline entry (the checkout persists the dedicated token because the branch push needs it), commented in `zizmor.yml`.

## Test evidence

- `tests/test_workflow_devkit_upgrade.py` (new, 15 tests; RED-first) + workflow-model/sync-settings/scaffold-lint/zizmor-baseline/ci-runner suites: 121 passed
- `tests/bats/init-workspace.bats` (feature-group assertions): 275/275 pass
- `zizmor --offline` over the workspace templates: no findings
- `prek run --all-files`: green (both hook layers)

## Reviewer notes

- **Provisioning is deliberately out of code scope**: the `DEVKIT_UPGRADE_TOKEN` App/PAT identity (and optional `DEVKIT_UPGRADE_AUTHOR_*` variables) must be created per the #1296 checklist before the workflow can act; until then it fails fast with a pointer. The default author email is a placeholder — set the real identity at provisioning.
- **Live proof requires a consumer**: this template never executes in devkit's own CI; first end-to-end validation comes with the first consumer adoption (worth exercising via `workflow_dispatch` on one lane during the 1.5.0 rollout).
- The `nix develop -c git commit` step assumes a flake-bearing (direnv/both) consumer — true for all five current consumers; bare/devcontainer-only consumers are out of scope per the issue.
- Untracked files matching `DEVKIT_UPGRADE_EXCLUDE` are not reset (`git checkout --` only restores tracked paths) — acceptable for the known use case (tracked generated PDFs).
- Merge-order note: this PR and #1297 both touch `CHANGELOG.md`, `.vig-os`, and `init-workspace.sh`; whichever merges second needs a trivial conflict resolution (GitHub merges don't apply the changelog union driver).

Refs: #1296
