### PR TITLE
feat(workflow): mint a GitHub App token in devkit-upgrade (App-only identity)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,10 +40,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     (manual dispatch still works); `DEVKIT_UPGRADE_EXCLUDE` lists paths reset
     before the adoption commit. The whole file opts out via the new
     `devkit-upgrade` feature group (`DEVKIT_FEATURES_DISABLED`).
-  - Requires a dedicated `DEVKIT_UPGRADE_TOKEN` secret (the default
-    `GITHUB_TOKEN` cannot open a PR that triggers CI); the workflow fails fast
-    with a clear message when it is absent, and the commit identity is
-    configurable and kept off the agent blocklist.
+  - Requires a dedicated GitHub App identity
+    ([#1302](https://github.com/vig-os/devkit/issues/1302)): the
+    `DEVKIT_UPGRADE_APP_ID` and `DEVKIT_UPGRADE_APP_PRIVATE_KEY` secrets feed a
+    per-run installation token minted in-workflow (the default `GITHUB_TOKEN`
+    cannot open a PR that triggers CI, and a static PAT is not supported —
+    user-bound, expiring, single-owner). The workflow fails fast with a clear
+    message when the secrets are absent, and the commit identity is configurable
+    and kept off the agent blocklist.
 - **Scaffold-drift CI gate (DEVKIT_DRIFT_CHECK)** ([#1295](https://github.com/vig-os/devkit/issues/1295))
   - The scaffolded `ci.yml` gains a `scaffold-drift` job that re-runs the pinned
     devkit version's scaffold over the checkout and fails a PR whose managed

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -40,10 +40,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     (manual dispatch still works); `DEVKIT_UPGRADE_EXCLUDE` lists paths reset
     before the adoption commit. The whole file opts out via the new
     `devkit-upgrade` feature group (`DEVKIT_FEATURES_DISABLED`).
-  - Requires a dedicated `DEVKIT_UPGRADE_TOKEN` secret (the default
-    `GITHUB_TOKEN` cannot open a PR that triggers CI); the workflow fails fast
-    with a clear message when it is absent, and the commit identity is
-    configurable and kept off the agent blocklist.
+  - Requires a dedicated GitHub App identity
+    ([#1302](https://github.com/vig-os/devkit/issues/1302)): the
+    `DEVKIT_UPGRADE_APP_ID` and `DEVKIT_UPGRADE_APP_PRIVATE_KEY` secrets feed a
+    per-run installation token minted in-workflow (the default `GITHUB_TOKEN`
+    cannot open a PR that triggers CI, and a static PAT is not supported —
+    user-bound, expiring, single-owner). The workflow fails fast with a clear
+    message when the secrets are absent, and the commit identity is configurable
+    and kept off the agent blocklist.
 - **Scaffold-drift CI gate (DEVKIT_DRIFT_CHECK)** ([#1295](https://github.com/vig-os/devkit/issues/1295))
   - The scaffolded `ci.yml` gains a `scaffold-drift` job that re-runs the pinned
     devkit version's scaffold over the checkout and fails a PR whose managed

--- a/assets/workspace/.github/workflows/devkit-upgrade.yml
+++ b/assets/workspace/.github/workflows/devkit-upgrade.yml
@@ -8,11 +8,14 @@
 # project shell so consumer hooks run — then opens the adoption PR. Renovate-style
 # pull: no devkit-side action at release time, no consumer registry.
 #
-# Requires the DEVKIT_UPGRADE_TOKEN secret — a dedicated identity (fine-grained
-# PAT or GitHub App token with contents:write + pull-requests:write +
-# issues:write). The default GITHUB_TOKEN cannot open the PR: PRs it creates do
-# not trigger CI. The workflow fails fast when the secret is absent. Provisioning
-# + rotation: https://github.com/vig-os/devkit/issues/1296
+# Requires a dedicated GitHub App identity: DEVKIT_UPGRADE_APP_ID +
+# DEVKIT_UPGRADE_APP_PRIVATE_KEY (repo or org secrets) feed a per-run
+# installation token minted in-workflow — contents:write + pull-requests:write +
+# issues:write + workflows:write on this repo. The default GITHUB_TOKEN cannot
+# open the PR: PRs it creates do not trigger CI. A static PAT is not supported
+# (#1302: user-bound, expiring, single-owner). The workflow fails fast when the
+# secrets are absent. App provisioning + rotation:
+# https://github.com/vig-os/devkit/issues/1302
 
 name: Devkit Upgrade
 
@@ -42,20 +45,28 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
-      # The branch, issue and PR are all created with DEVKIT_UPGRADE_TOKEN (a
+      # The branch, issue and PR are all created with the minted App token (a
       # dedicated identity, so the PR triggers CI); the default token stays
       # read-only for the public releases/latest query.
       contents: read
     steps:
-      - name: Require the dedicated upgrade token
+      - name: Require the upgrade App identity
         env:
-          DEVKIT_UPGRADE_TOKEN: ${{ secrets.DEVKIT_UPGRADE_TOKEN }}
+          APP_ID: ${{ secrets.DEVKIT_UPGRADE_APP_ID }}
+          APP_PRIVATE_KEY: ${{ secrets.DEVKIT_UPGRADE_APP_PRIVATE_KEY }}
         run: |
           set -euo pipefail
-          if [ -z "${DEVKIT_UPGRADE_TOKEN}" ]; then
-            echo "::error::DEVKIT_UPGRADE_TOKEN secret is not configured. This workflow needs a dedicated identity (fine-grained PAT or GitHub App token with contents:write + pull-requests:write + issues:write): the default GITHUB_TOKEN cannot open a PR that triggers CI. See https://github.com/vig-os/devkit/issues/1296."
+          if [ -z "${APP_ID}" ] || [ -z "${APP_PRIVATE_KEY}" ]; then
+            echo "::error::DEVKIT_UPGRADE_APP_ID / DEVKIT_UPGRADE_APP_PRIVATE_KEY secrets are not configured. This workflow needs a dedicated GitHub App identity (contents:write + pull-requests:write + issues:write + workflows:write): the default GITHUB_TOKEN cannot open a PR that triggers CI, and a static PAT is not supported. See https://github.com/vig-os/devkit/issues/1302."
             exit 1
           fi
+
+      - name: Mint the upgrade App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3
+        with:
+          app-id: ${{ secrets.DEVKIT_UPGRADE_APP_ID }}
+          private-key: ${{ secrets.DEVKIT_UPGRADE_APP_PRIVATE_KEY }}
 
       - name: Checkout base branch
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
@@ -63,9 +74,9 @@ jobs:
           # Base branch per workflow model: gitflow -> dev, trunk -> main
           # (retargeted to `main` at scaffold time for a trunk repo).
           ref: dev
-          # Persist the dedicated token so the later push authenticates as the
+          # Persist the minted token so the later push authenticates as the
           # upgrade identity (whose PR triggers CI).
-          token: ${{ secrets.DEVKIT_UPGRADE_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
 
       - name: Resolve target version
@@ -158,7 +169,7 @@ jobs:
         id: issue
         if: steps.resolve.outputs.proceed == 'true'
         env:
-          GH_TOKEN: ${{ secrets.DEVKIT_UPGRADE_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           TRAIN: ${{ steps.resolve.outputs.train }}
         run: |
           set -euo pipefail
@@ -266,7 +277,7 @@ jobs:
       - name: Open or update the adoption PR
         if: steps.resolve.outputs.proceed == 'true' && steps.commit.outputs.changed == 'true'
         env:
-          GH_TOKEN: ${{ secrets.DEVKIT_UPGRADE_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           TARGET: ${{ steps.resolve.outputs.target }}
           ISSUE: ${{ steps.issue.outputs.number }}
           BRANCH: ${{ steps.branch.outputs.name }}

--- a/assets/workspace/.github/workflows/devkit-upgrade.yml
+++ b/assets/workspace/.github/workflows/devkit-upgrade.yml
@@ -67,6 +67,13 @@ jobs:
         with:
           app-id: ${{ secrets.DEVKIT_UPGRADE_APP_ID }}
           private-key: ${{ secrets.DEVKIT_UPGRADE_APP_PRIVATE_KEY }}
+          # Least-privilege mint (zizmor github-app): the token carries exactly
+          # the four permissions this workflow exercises, independent of any
+          # broader grants on the App installation.
+          permission-contents: write
+          permission-pull-requests: write
+          permission-issues: write
+          permission-workflows: write
 
       - name: Checkout base branch
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1

--- a/tests/test_workflow_devkit_upgrade.py
+++ b/tests/test_workflow_devkit_upgrade.py
@@ -10,9 +10,10 @@ release time. These tests pin the deliverable without executing the workflow:
   commit), both shipping empty;
 - the template carries the managed banner, both triggers, the public
   ``releases/latest`` version check with prerelease-aware compare, the dedicated
-  ``DEVKIT_UPGRADE_TOKEN`` (fail-fast when absent; never the default
-  ``GITHUB_TOKEN`` for the PR), the ``install.sh`` bootstrap and the
-  ``nix develop`` commit;
+  GitHub App identity (a per-run installation token minted from
+  ``DEVKIT_UPGRADE_APP_ID`` + ``DEVKIT_UPGRADE_APP_PRIVATE_KEY``, fail-fast when
+  absent; never the default ``GITHUB_TOKEN`` for the PR — #1302), the
+  ``install.sh`` bootstrap and the ``nix develop`` commit;
 - no ``run:`` block interpolates a dispatch input or event field directly
   (zizmor template-injection: every such value is routed through ``env:``);
 - the base branch is workflow-model aware (``dev`` gitflow / ``main`` trunk),
@@ -24,6 +25,7 @@ Refs: #1296
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import yaml
@@ -122,19 +124,42 @@ def test_version_compare_is_prerelease_aware() -> None:
     assert "prerelease" in text.lower()
 
 
-def test_requires_dedicated_token_and_never_uses_github_token_for_pr() -> None:
-    """A missing DEVKIT_UPGRADE_TOKEN fails fast; the PR uses the dedicated token."""
+def test_requires_app_identity_and_never_uses_github_token_for_pr() -> None:
+    """The GitHub App is the ONLY identity: a per-run installation token is
+    minted from DEVKIT_UPGRADE_APP_ID + DEVKIT_UPGRADE_APP_PRIVATE_KEY
+    (fail-fast when absent), and no static token secret remains (#1302)."""
     text = TEMPLATE.read_text(encoding="utf-8")
-    assert "secrets.DEVKIT_UPGRADE_TOKEN" in text
-    # A clear fail-fast guard when the secret is absent.
-    assert "DEVKIT_UPGRADE_TOKEN secret is not configured" in text
-    # The PR step authenticates gh with the dedicated token (not github.token),
-    # otherwise the created PR would not trigger CI.
+    assert "secrets.DEVKIT_UPGRADE_APP_ID" in text
+    assert "secrets.DEVKIT_UPGRADE_APP_PRIVATE_KEY" in text
+    # The static-secret path is gone entirely — App-only, no PAT fallback.
+    assert "DEVKIT_UPGRADE_TOKEN" not in text
+    # A clear fail-fast guard when either secret is absent.
+    assert "not configured" in text
     steps = _steps(text)
+    # A SHA-pinned create-github-app-token step mints the per-run token.
+    mint_steps = [
+        s for s in steps if "create-github-app-token" in str(s.get("uses", ""))
+    ]
+    assert mint_steps, "no create-github-app-token step found"
+    for s in mint_steps:
+        assert re.search(r"create-github-app-token@[0-9a-f]{40}", s["uses"]), (
+            "app-token action must be SHA-pinned"
+        )
+    # The PR step authenticates gh with the minted token (not github.token),
+    # otherwise the created PR would not trigger CI.
     pr_steps = [s for s in steps if "gh pr create" in str(s.get("run", ""))]
     assert pr_steps, "no PR-creating step found"
     for s in pr_steps:
-        assert s.get("env", {}).get("GH_TOKEN") == "${{ secrets.DEVKIT_UPGRADE_TOKEN }}"
+        assert s.get("env", {}).get("GH_TOKEN") == (
+            "${{ steps.app-token.outputs.token }}"
+        )
+    # Checkout persists the minted token so the push authenticates as the App.
+    checkout_steps = [s for s in steps if "actions/checkout" in str(s.get("uses", ""))]
+    assert checkout_steps, "no checkout step found"
+    for s in checkout_steps:
+        assert s.get("with", {}).get("token") == (
+            "${{ steps.app-token.outputs.token }}"
+        )
 
 
 def test_bootstraps_installsh_and_commits_in_project_shell() -> None:

--- a/tests/test_workflow_devkit_upgrade.py
+++ b/tests/test_workflow_devkit_upgrade.py
@@ -145,6 +145,16 @@ def test_requires_app_identity_and_never_uses_github_token_for_pr() -> None:
         assert re.search(r"create-github-app-token@[0-9a-f]{40}", s["uses"]), (
             "app-token action must be SHA-pinned"
         )
+        # Least-privilege mint (zizmor github-app audit): the token must be
+        # scoped to exactly the permissions the workflow exercises.
+        with_block = s.get("with", {})
+        for perm in (
+            "permission-contents",
+            "permission-pull-requests",
+            "permission-issues",
+            "permission-workflows",
+        ):
+            assert with_block.get(perm) == "write", f"missing {perm}: write"
     # The PR step authenticates gh with the minted token (not github.token),
     # otherwise the created PR would not trigger CI.
     pr_steps = [s for s in steps if "gh pr create" in str(s.get("run", ""))]


### PR DESCRIPTION
## Summary

Closes #1302 — the devkit-upgrade workflow (#1296, unreleased) now authenticates **exclusively** via a dedicated GitHub App: a per-run installation token is minted from the `DEVKIT_UPGRADE_APP_ID` + `DEVKIT_UPGRADE_APP_PRIVATE_KEY` secrets with SHA-pinned `actions/create-github-app-token` (the exact pattern devkit's own `prepare-release.yml` uses). The static `DEVKIT_UPGRADE_TOKEN` secret is removed with no fallback: a PAT is user-bound, expiring, and single-owner across the vig-os / exoma-ch / exo-pet consumer orgs.

- Fail-fast step names both secrets and the required App permissions (contents, PRs, issues, workflows — all RW).
- Checkout persists the minted token, so the scaffold push, adoption issue, and PR all act as the App and the PR triggers CI.
- Changelog: the frozen `[1.5.0] - TBD` entry for #1296 is updated in place (unreleased section; `.devcontainer/CHANGELOG.md` copy synced by the hook).

Targeted at `release/1.5.0`: #1296 has never shipped, so 1.5.0 ships App-only with zero migration debt.

## Verification

TDD: `test_requires_app_identity_and_never_uses_github_token_for_pr` rewritten first (RED at 0e3a57cc), template reworked to GREEN (15/15 in `tests/test_workflow_devkit_upgrade.py`); 278 bats ok incl. rendered-template actionlint; full pre-commit suite green. Live dispatch proof lands with the RC validation plan (App provisioning per #1302).

Refs: #1302