### PR TITLE
fix(install): prefer a responsive docker over podman in runtime auto-detection

### DIFF
--- a/assets/workspace/.github/workflows/devkit-upgrade.yml
+++ b/assets/workspace/.github/workflows/devkit-upgrade.yml
@@ -206,8 +206,12 @@ jobs:
           # docker is present on ubuntu-latest (install.sh auto-detects it); nix
           # (installed above) advances the floating `vigos` flake.lock node. The
           # workflow owns the branch, so bypass install.sh's own preflight guard.
+          # --docker pins the runner's first-class runtime explicitly: the
+          # preinstalled podman can pair with a stale system crun that rejects
+          # podman >= 5's OCI configs (#1305) — auto-detection now prefers a
+          # responsive docker anyway, this makes the choice self-documenting.
           curl -sSfL https://raw.githubusercontent.com/vig-os/devkit/main/install.sh \
-            | bash -s -- --force --version "$TARGET" --skip-preflight .
+            | bash -s -- --force --version "$TARGET" --skip-preflight --docker .
 
       - name: Reset excluded paths
         if: steps.resolve.outputs.proceed == 'true'

--- a/install.sh
+++ b/install.sh
@@ -159,7 +159,16 @@ detect_runtime() {
         return
     fi
 
-    if command -v podman &> /dev/null; then
+    # Prefer a docker whose daemon responds, then podman (#1305). With both on
+    # PATH (GitHub ubuntu-latest runners), the preinstalled podman can pair
+    # with a stale system crun that rejects podman >= 5's OCI configs
+    # ("crun: unknown version specified") — the #1299 runner regression on the
+    # consumer side, where devkit's own setup-env crun pin does not apply.
+    # The daemon probe keeps a both-present host with a dead docker daemon on
+    # podman; podman-only hosts are unchanged. --docker/--podman still win.
+    if command -v docker &> /dev/null && docker info &> /dev/null; then
+        echo "docker"
+    elif command -v podman &> /dev/null; then
         echo "podman"
     elif command -v docker &> /dev/null; then
         echo "docker"

--- a/tests/bats/install.bats
+++ b/tests/bats/install.bats
@@ -191,14 +191,53 @@ setup() {
     assert_success
 }
 
-@test "install.sh prefers podman over docker" {
+@test "install.sh auto-detection guards docker behind a daemon probe (#1305)" {
+    run grep 'docker info' "$INSTALL_SH"
+    assert_success
+}
+
+@test "install.sh falls back to podman if docker unavailable (#1305)" {
     run grep 'command -v podman' "$INSTALL_SH"
     assert_success
 }
 
-@test "install.sh falls back to docker if podman unavailable" {
-    run grep 'command -v docker' "$INSTALL_SH"
+# ── runtime auto-detection order (#1305) ──────────────────────────────────────
+# ubuntu-latest runners pair a preinstalled podman with a stale system crun
+# that rejects podman >= 5's OCI configs ("crun: unknown version specified"),
+# so with both runtimes on PATH auto-detection must prefer a docker whose
+# daemon responds — the #1299 regression on the consumer side, where the
+# setup-env crun pin does not apply. Podman-only hosts are unchanged, and a
+# dead docker daemon still falls back to podman. Explicit --docker/--podman
+# keep overriding. Exercised end to end against PATH stubs (nothing pulled).
+_run_install_autodetect() {
+    local dir="$1" docker_stub="$2"
+    local stub="$BATS_TEST_TMPDIR/stub-rt"
+    rm -rf "$stub"
+    mkdir -p "$stub"
+    printf '%s\n' "$docker_stub" >"$stub/docker"
+    printf '#!/usr/bin/env bash\nexit 0\n' >"$stub/podman"
+    chmod +x "$stub/docker" "$stub/podman"
+    _make_repo "$dir"
+    run env PATH="$stub:$PATH" bash "$INSTALL_SH" \
+        --skip-pull --mode direnv "$dir" </dev/null
+}
+
+@test "auto-detection prefers docker with a responsive daemon over podman (#1305)" {
+    _run_install_autodetect "$BATS_TEST_TMPDIR/rt-docker" \
+        '#!/usr/bin/env bash
+exit 0'
     assert_success
+    assert_output --partial "Using docker"
+}
+
+@test "auto-detection falls back to podman when the docker daemon is dead (#1305)" {
+    # shellcheck disable=SC2016  # stub body is a literal script, no expansion
+    _run_install_autodetect "$BATS_TEST_TMPDIR/rt-podman" \
+        '#!/usr/bin/env bash
+[ "$1" = "info" ] && exit 1
+exit 0'
+    assert_success
+    assert_output --partial "Using podman"
 }
 
 # ── os detection ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Closes #1305 — the first live `devkit-upgrade` dispatch ([smoke-test run 30543470753](https://github.com/vig-os/devkit-smoke-test/actions/runs/30543470753)) proved the whole App identity path (fail-fast, mint, adoption issue opened by `app/vigos-devkit-upgrade`) and then died in `install.sh`: runtime auto-detection picked the runner's preinstalled podman 5.8.4, whose stale system crun rejects podman ≥ 5 OCI configs (`crun: unknown version specified`) — the #1299 regression on the consumer side, where devkit's own `setup-env` crun pin doesn't apply.

- `detect_runtime()` now prefers docker **when its daemon responds** (`docker info`), falling back to podman. Podman-only hosts (vigOS machines) are unchanged; a both-present host with a dead docker daemon still gets podman; explicit `--docker`/`--podman` keep overriding.
- The `devkit-upgrade.yml` template passes `--docker` explicitly (the runner's first-class runtime; self-documenting).

Delivery property: consumers fetch `install.sh` from `main`, so the detection fix heals **every existing scaffold** at the next promote with no re-scaffold; the next train's adoption dispatch doubles as the live proof of the workflow's remaining push/PR legs.

## Verification

TDD: stub-based bats (docker+podman on PATH → docker; dead docker daemon → podman) committed RED at 4885de4a, fix turns them GREEN; full `install.bats` 117 ok; template tests 15 passed; full pre-commit suite green.

Refs: #1305