### PR TITLE
chore: unfreeze 1.5.0 — pull in #1305 (runtime auto-detection fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
-## [1.5.0](https://github.com/vig-os/devkit/releases/tag/1.5.0) - 2026-07-30
+## [1.5.0] - TBD
 
 ### Added
 
@@ -112,6 +112,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     their feature is disabled — they are left in place with a notice.
 
 ### Fixed
+
+- **`install.sh` prefers a responsive docker over podman in runtime auto-detection** ([#1305](https://github.com/vig-os/devkit/issues/1305))
+  - With both runtimes on PATH (GitHub `ubuntu-latest` runners), auto-detection
+    picked the preinstalled podman, whose stale system crun rejects podman ≥ 5's
+    OCI configs (`crun: unknown version specified`) — the first live
+    `devkit-upgrade` dispatch died at the install step on exactly this.
+    Detection now prefers docker when its daemon responds and falls back to
+    podman: podman-only hosts are unchanged, a dead docker daemon still yields
+    podman, and explicit `--docker`/`--podman` keep overriding. The
+    `devkit-upgrade.yml` template also passes `--docker` explicitly, so the
+    choice rides in the scaffold independent of the fetched installer.
 
 - **`just test` no longer fails a Python repo with zero collected tests** ([#1281](https://github.com/vig-os/devkit/issues/1281))
   - The scaffolded `justfile.project` `test`/`test-cov` recipes gate on

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ For detailed command descriptions, run `just --list --unsorted` or `just --help`
 - **Registry**: `ghcr.io/vig-os/devcontainer`
 - **Architecture**: Multi-platform support (AMD64, ARM64)
 - **License**: Apache
-- **Latest Version**: [1.5.0](https://github.com/vig-os/devkit/releases/tag/1.5.0) - 2026-07-30
+- **Latest Version**: [1.4.2](https://github.com/vig-os/devkit/releases/tag/1.4.2) - 2026-07-26
 - **Image tags**: bare semver (`0.2.1`, `latest`) — git tags use `v` prefix (`v0.2.1`) but image tags do not
 
 ## Features

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
-## [1.5.0](https://github.com/vig-os/devkit/releases/tag/1.5.0) - 2026-07-30
+## [1.5.0] - TBD
 
 ### Added
 
@@ -112,6 +112,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     their feature is disabled — they are left in place with a notice.
 
 ### Fixed
+
+- **`install.sh` prefers a responsive docker over podman in runtime auto-detection** ([#1305](https://github.com/vig-os/devkit/issues/1305))
+  - With both runtimes on PATH (GitHub `ubuntu-latest` runners), auto-detection
+    picked the preinstalled podman, whose stale system crun rejects podman ≥ 5's
+    OCI configs (`crun: unknown version specified`) — the first live
+    `devkit-upgrade` dispatch died at the install step on exactly this.
+    Detection now prefers docker when its daemon responds and falls back to
+    podman: podman-only hosts are unchanged, a dead docker daemon still yields
+    podman, and explicit `--docker`/`--podman` keep overriding. The
+    `devkit-upgrade.yml` template also passes `--docker` explicitly, so the
+    choice rides in the scaffold independent of the fetched installer.
 
 - **`just test` no longer fails a Python repo with zero collected tests** ([#1281](https://github.com/vig-os/devkit/issues/1281))
   - The scaffolded `justfile.project` `test`/`test-cov` recipes gate on

--- a/assets/workspace/.github/workflows/devkit-upgrade.yml
+++ b/assets/workspace/.github/workflows/devkit-upgrade.yml
@@ -206,8 +206,12 @@ jobs:
           # docker is present on ubuntu-latest (install.sh auto-detects it); nix
           # (installed above) advances the floating `vigos` flake.lock node. The
           # workflow owns the branch, so bypass install.sh's own preflight guard.
+          # --docker pins the runner's first-class runtime explicitly: the
+          # preinstalled podman can pair with a stale system crun that rejects
+          # podman >= 5's OCI configs (#1305) — auto-detection now prefers a
+          # responsive docker anyway, this makes the choice self-documenting.
           curl -sSfL https://raw.githubusercontent.com/vig-os/devkit/main/install.sh \
-            | bash -s -- --force --version "$TARGET" --skip-preflight .
+            | bash -s -- --force --version "$TARGET" --skip-preflight --docker .
 
       - name: Reset excluded paths
         if: steps.resolve.outputs.proceed == 'true'

--- a/install.sh
+++ b/install.sh
@@ -159,7 +159,16 @@ detect_runtime() {
         return
     fi
 
-    if command -v podman &> /dev/null; then
+    # Prefer a docker whose daemon responds, then podman (#1305). With both on
+    # PATH (GitHub ubuntu-latest runners), the preinstalled podman can pair
+    # with a stale system crun that rejects podman >= 5's OCI configs
+    # ("crun: unknown version specified") — the #1299 runner regression on the
+    # consumer side, where devkit's own setup-env crun pin does not apply.
+    # The daemon probe keeps a both-present host with a dead docker daemon on
+    # podman; podman-only hosts are unchanged. --docker/--podman still win.
+    if command -v docker &> /dev/null && docker info &> /dev/null; then
+        echo "docker"
+    elif command -v podman &> /dev/null; then
         echo "podman"
     elif command -v docker &> /dev/null; then
         echo "docker"

--- a/tests/bats/install.bats
+++ b/tests/bats/install.bats
@@ -191,14 +191,53 @@ setup() {
     assert_success
 }
 
-@test "install.sh prefers podman over docker" {
+@test "install.sh auto-detection guards docker behind a daemon probe (#1305)" {
+    run grep 'docker info' "$INSTALL_SH"
+    assert_success
+}
+
+@test "install.sh falls back to podman if docker unavailable (#1305)" {
     run grep 'command -v podman' "$INSTALL_SH"
     assert_success
 }
 
-@test "install.sh falls back to docker if podman unavailable" {
-    run grep 'command -v docker' "$INSTALL_SH"
+# ── runtime auto-detection order (#1305) ──────────────────────────────────────
+# ubuntu-latest runners pair a preinstalled podman with a stale system crun
+# that rejects podman >= 5's OCI configs ("crun: unknown version specified"),
+# so with both runtimes on PATH auto-detection must prefer a docker whose
+# daemon responds — the #1299 regression on the consumer side, where the
+# setup-env crun pin does not apply. Podman-only hosts are unchanged, and a
+# dead docker daemon still falls back to podman. Explicit --docker/--podman
+# keep overriding. Exercised end to end against PATH stubs (nothing pulled).
+_run_install_autodetect() {
+    local dir="$1" docker_stub="$2"
+    local stub="$BATS_TEST_TMPDIR/stub-rt"
+    rm -rf "$stub"
+    mkdir -p "$stub"
+    printf '%s\n' "$docker_stub" >"$stub/docker"
+    printf '#!/usr/bin/env bash\nexit 0\n' >"$stub/podman"
+    chmod +x "$stub/docker" "$stub/podman"
+    _make_repo "$dir"
+    run env PATH="$stub:$PATH" bash "$INSTALL_SH" \
+        --skip-pull --mode direnv "$dir" </dev/null
+}
+
+@test "auto-detection prefers docker with a responsive daemon over podman (#1305)" {
+    _run_install_autodetect "$BATS_TEST_TMPDIR/rt-docker" \
+        '#!/usr/bin/env bash
+exit 0'
     assert_success
+    assert_output --partial "Using docker"
+}
+
+@test "auto-detection falls back to podman when the docker daemon is dead (#1305)" {
+    # shellcheck disable=SC2016  # stub body is a literal script, no expansion
+    _run_install_autodetect "$BATS_TEST_TMPDIR/rt-podman" \
+        '#!/usr/bin/env bash
+[ "$1" = "info" ] && exit 1
+exit 0'
+    assert_success
+    assert_output --partial "Using podman"
 }
 
 # ── os detection ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Restart of the 1.5.0 finalization (maintainer-approved): the first live `devkit-upgrade` dispatch exposed #1305 (runtime auto-detection picks the runner's broken podman → `crun: unknown version specified` at the install step). Since nothing consumed the final (draft release deleted, tag deleted, `latest`/`main`/promote untouched), the fix ships **within 1.5.0** instead of a same-day 1.5.1.

- Merge `dev` (PR #1306: docker-first daemon-probed detection + `--docker` in the upgrade template) into `release/1.5.0` — clean merge, App-era template keeps all #1302/#1304 content plus the new flag.
- `prepare-changelog reset-version` restores the `- TBD` heading (finalize will re-stamp).
- #1305 changelog entry added to the frozen 1.5.0 section (was missed in #1306 — dev's Unreleased stays empty since the fix ships here).

Precedent: 1.4.0 unfreeze (PR #1215). After merge: rc3, focused revalidation (delta is #1305 only), re-approve, re-finalize.

Refs: #1305