### PR TITLE
feat(workflow): publish the devkit-upgrade adoption commit via API (verified)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
-## [1.5.0](https://github.com/vig-os/devkit/releases/tag/1.5.0) - 2026-07-30
+## [1.5.0] - TBD
 
 ### Added
 
@@ -48,6 +48,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     user-bound, expiring, single-owner). The workflow fails fast with a clear
     message when the secrets are absent, and the commit identity is configurable
     and kept off the agent blocklist.
+  - The published adoption commit is **GitHub-signed**
+    ([#1308](https://github.com/vig-os/devkit/issues/1308)): the in-shell commit
+    stays a staging artifact (hooks run, message validated) and its tree is
+    replayed through the git-data API with the App token — blobs → tree (with
+    explicit per-entry modes, so executable bits survive) → commit → ref, with
+    deletions as null-sha entries and a force-updated branch ref for the
+    within-train reuse semantics. Consumers' Signed-commits rulesets stay fully
+    enforced; no bypass actors are needed anywhere.
 - **Scaffold-drift CI gate (DEVKIT_DRIFT_CHECK)** ([#1295](https://github.com/vig-os/devkit/issues/1295))
   - The scaffolded `ci.yml` gains a `scaffold-drift` job that re-runs the pinned
     devkit version's scaffold over the checkout and fails a PR whose managed

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ For detailed command descriptions, run `just --list --unsorted` or `just --help`
 - **Registry**: `ghcr.io/vig-os/devcontainer`
 - **Architecture**: Multi-platform support (AMD64, ARM64)
 - **License**: Apache
-- **Latest Version**: [1.5.0](https://github.com/vig-os/devkit/releases/tag/1.5.0) - 2026-07-30
+- **Latest Version**: [1.4.2](https://github.com/vig-os/devkit/releases/tag/1.4.2) - 2026-07-26
 - **Image tags**: bare semver (`0.2.1`, `latest`) — git tags use `v` prefix (`v0.2.1`) but image tags do not
 
 ## Features

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
-## [1.5.0](https://github.com/vig-os/devkit/releases/tag/1.5.0) - 2026-07-30
+## [1.5.0] - TBD
 
 ### Added
 
@@ -48,6 +48,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     user-bound, expiring, single-owner). The workflow fails fast with a clear
     message when the secrets are absent, and the commit identity is configurable
     and kept off the agent blocklist.
+  - The published adoption commit is **GitHub-signed**
+    ([#1308](https://github.com/vig-os/devkit/issues/1308)): the in-shell commit
+    stays a staging artifact (hooks run, message validated) and its tree is
+    replayed through the git-data API with the App token — blobs → tree (with
+    explicit per-entry modes, so executable bits survive) → commit → ref, with
+    deletions as null-sha entries and a force-updated branch ref for the
+    within-train reuse semantics. Consumers' Signed-commits rulesets stay fully
+    enforced; no bypass actors are needed anywhere.
 - **Scaffold-drift CI gate (DEVKIT_DRIFT_CHECK)** ([#1295](https://github.com/vig-os/devkit/issues/1295))
   - The scaffolded `ci.yml` gains a `scaffold-drift` job that re-runs the pinned
     devkit version's scaffold over the checkout and fails a PR whose managed

--- a/assets/workspace/.github/workflows/devkit-upgrade.yml
+++ b/assets/workspace/.github/workflows/devkit-upgrade.yml
@@ -270,20 +270,80 @@ jobs:
           fi
           # Commit INSIDE the project shell so consumer hooks run (dist rebuild in
           # commit-action, trailer strip, validate-commit-msg). chore is
-          # Refs-exempt but include it for traceability.
+          # Refs-exempt but include it for traceability. This LOCAL commit is a
+          # staging artifact only — the next step replays its tree through the
+          # API as a GitHub-signed commit; the unsigned one never leaves the
+          # runner (#1308).
           printf 'chore: adopt devkit %s\n\nRefs: #%s\n' "$TARGET" "$ISSUE" > "${RUNNER_TEMP}/commit-msg"
           nix develop -c git commit -F "${RUNNER_TEMP}/commit-msg"
           echo "changed=true" >> "$GITHUB_OUTPUT"
 
-      - name: Push the upgrade branch
+      - name: Publish the adoption commit via API (verified)
         if: steps.resolve.outputs.proceed == 'true' && steps.commit.outputs.changed == 'true'
         env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           BRANCH: ${{ steps.branch.outputs.name }}
         run: |
           set -euo pipefail
-          # Force-update: within a train an earlier rc may already have pushed
-          # this branch; the PR is refreshed to the latest bump.
-          git push --force origin "HEAD:${BRANCH}"
+          # The in-shell commit above is a STAGING artifact — hooks ran and the
+          # message validated, but a worktree commit is unsigned and consumers'
+          # Signed-commits rulesets rightfully reject it. Replay its tree
+          # through the git-data API with the App token instead: API-created
+          # commits are signed by GitHub as the App, so the published commit is
+          # verified and no ruleset needs a bypass (#1308). The tree API also
+          # carries an explicit mode per entry, so executable bits survive —
+          # createCommitOnBranch would silently drop them.
+          REPO="${GITHUB_REPOSITORY}"
+          MESSAGE="$(git log -1 --format=%B)"
+          BASE_SHA="$(git rev-parse HEAD^)"
+          BASE_TREE="$(gh api "repos/${REPO}/git/commits/${BASE_SHA}" --jq .tree.sha)"
+
+          # One tree entry per path the staging commit touched. --no-renames
+          # keeps the status alphabet to A/M/D (a rename becomes A + D).
+          entries='[]'
+          while IFS=$'\t' read -r status path; do
+            [ -n "$path" ] || continue
+            if [ "$status" = "D" ]; then
+              # Deletion: a null-sha entry removes the path from the tree.
+              entries="$(jq --arg p "$path" \
+                '. + [{path: $p, mode: "100644", type: "blob", sha: null}]' \
+                <<<"$entries")"
+            else
+              mode=100644
+              [ -x "$path" ] && mode=100755
+              blob="$(gh api -X POST "repos/${REPO}/git/blobs" \
+                -f content="$(base64 -w0 "$path")" -f encoding=base64 --jq .sha)"
+              entries="$(jq --arg p "$path" --arg m "$mode" --arg s "$blob" \
+                '. + [{path: $p, mode: $m, type: "blob", sha: $s}]' \
+                <<<"$entries")"
+            fi
+          done < <(git diff --name-status --no-renames "${BASE_SHA}" HEAD)
+
+          COUNT="$(jq length <<<"$entries")"
+          if [ "$COUNT" -eq 0 ]; then
+            echo "Empty delta after staging; nothing to publish."
+            exit 0
+          fi
+          echo "Publishing ${COUNT} tree entries..."
+
+          TREE="$(jq -n --argjson t "$entries" --arg b "$BASE_TREE" \
+            '{base_tree: $b, tree: $t}' \
+            | gh api -X POST "repos/${REPO}/git/trees" --input - --jq .sha)"
+          COMMIT="$(jq -n --arg m "$MESSAGE" --arg t "$TREE" --arg p "$BASE_SHA" \
+            '{message: $m, tree: $t, parents: [$p]}' \
+            | gh api -X POST "repos/${REPO}/git/commits" --input - --jq .sha)"
+
+          # Create the branch ref on first use; force-update within a train so
+          # rc -> rc -> final reuse refreshes the same branch/PR to the latest
+          # bump (the semantics the old force-push provided).
+          if gh api "repos/${REPO}/git/ref/heads/${BRANCH}" >/dev/null 2>&1; then
+            gh api -X PATCH "repos/${REPO}/git/refs/heads/${BRANCH}" \
+              -f sha="$COMMIT" -F force=true >/dev/null
+          else
+            gh api -X POST "repos/${REPO}/git/refs" \
+              -f ref="refs/heads/${BRANCH}" -f sha="$COMMIT" >/dev/null
+          fi
+          echo "Published verified commit ${COMMIT} to ${BRANCH}."
 
       - name: Open or update the adoption PR
         if: steps.resolve.outputs.proceed == 'true' && steps.commit.outputs.changed == 'true'

--- a/tests/test_workflow_devkit_upgrade.py
+++ b/tests/test_workflow_devkit_upgrade.py
@@ -172,6 +172,37 @@ def test_requires_app_identity_and_never_uses_github_token_for_pr() -> None:
         )
 
 
+def test_publishes_a_verified_commit_via_api_not_git_push() -> None:
+    """The adoption commit reaching the remote must be GitHub-signed (#1308):
+    the in-shell commit is a staging artifact, its tree is replayed through
+    the git-data API (blobs -> tree -> commit -> ref) with the App token, so
+    consumers' Signed-commits rulesets stay fully enforced — no bypasses."""
+    text = TEMPLATE.read_text(encoding="utf-8")
+    # The staging commit must never be pushed directly.
+    assert "git push" not in text
+    steps = _steps(text)
+    publish_steps = [s for s in steps if "git/commits" in str(s.get("run", ""))]
+    assert publish_steps, "no API publish step found"
+    (publish,) = publish_steps
+    run = str(publish["run"])
+    # Full git-data flow with the minted App token.
+    assert publish.get("env", {}).get("GH_TOKEN") == (
+        "${{ steps.app-token.outputs.token }}"
+    )
+    assert "git/blobs" in run
+    assert "git/trees" in run
+    assert "git/refs" in run
+    # Deletions are replayed as null-sha tree entries (the scaffold prunes
+    # files; commit-action v0.3.x cannot express this, hence inline REST).
+    assert "sha:null" in run.replace(" ", "")
+    # Executable bits survive the replay (createCommitOnBranch would drop
+    # them; the tree API carries an explicit mode per entry).
+    assert "100755" in run
+    # The branch ref is created on first use and force-updated within a train
+    # (rc -> rc -> final reuse semantics).
+    assert "force" in run
+
+
 def test_bootstraps_installsh_and_commits_in_project_shell() -> None:
     """The upgrade runs install.sh --force --version and commits inside nix develop."""
     text = TEMPLATE.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

Closes #1308 — third and final 1.5.0 restart item (maintainer-approved): the adoption commit that reaches consumers is now **GitHub-signed as the App**. The in-shell commit stays exactly as designed (hooks run, message validated) but becomes a staging artifact; its tree is replayed through the git-data API with the minted App token — blobs → tree → commit → ref.

Design decisions:
- **Inline REST, not commit-action**: v0.3.x `statSync`s every path (no deletions — the scaffold prunes files) and has no branch bootstrap; extending it would put a cross-repo TS release on the critical path. Follow-up candidate: teach commit-action deletions and migrate.
- **Not `createCommitOnBranch`**: it drops executable modes; the tree API carries an explicit mode per entry (`100755` preserved).
- Deletions = null-sha tree entries; branch ref created on first use and force-updated within a train (preserves rc→rc→final reuse).
- `git push` is gone from the template; Signed-commits rulesets stay fully enforced with **zero bypass actors**.
- Changelog: `- TBD` heading restored (re-finalize re-stamps); #1308 sub-bullet added under the #1296 entry.

## Verification

TDD: `test_publishes_a_verified_commit_via_api_not_git_push` RED at be910369 → GREEN (16/16); zizmor 1.25.2 clean; full pre-commit suite green. Live proof at rc4: pin-gap harness dispatch on devkit-smoke-test must yield an adoption PR whose commit shows **Verified** — the last unproven leg of the feature.

Refs: #1308