### PR TITLE
chore: merge release/1.5.0 into dev and unprepare for the 1.5.1 re-cut

### DIFF
--- a/.vig-os
+++ b/.vig-os
@@ -1,4 +1,4 @@
 # vig-os devkit configuration
-DEVKIT_VERSION=1.4.2
+DEVKIT_VERSION=1.5.0
 # The devkit itself develops via its own flake + .envrc (no .devcontainer/) — #989.
 DEVKIT_MODE=direnv

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
-## [1.5.0] - TBD
+## [1.5.0](https://github.com/vig-os/devkit/releases/tag/1.5.0) - 2026-07-30
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
-## [1.5.0](https://github.com/vig-os/devkit/releases/tag/1.5.0) - 2026-07-30
+## [1.5.0] - TBD
 
 ### Added
 
@@ -112,6 +112,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     their feature is disabled — they are left in place with a notice.
 
 ### Fixed
+
+- **`install.sh` prefers a responsive docker over podman in runtime auto-detection** ([#1305](https://github.com/vig-os/devkit/issues/1305))
+  - With both runtimes on PATH (GitHub `ubuntu-latest` runners), auto-detection
+    picked the preinstalled podman, whose stale system crun rejects podman ≥ 5's
+    OCI configs (`crun: unknown version specified`) — the first live
+    `devkit-upgrade` dispatch died at the install step on exactly this.
+    Detection now prefers docker when its daemon responds and falls back to
+    podman: podman-only hosts are unchanged, a dead docker daemon still yields
+    podman, and explicit `--docker`/`--podman` keep overriding. The
+    `devkit-upgrade.yml` template also passes `--docker` explicitly, so the
+    choice rides in the scaffold independent of the fetched installer.
 
 - **`just test` no longer fails a Python repo with zero collected tests** ([#1281](https://github.com/vig-os/devkit/issues/1281))
   - The scaffolded `justfile.project` `test`/`test-cov` recipes gate on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,10 +40,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     (manual dispatch still works); `DEVKIT_UPGRADE_EXCLUDE` lists paths reset
     before the adoption commit. The whole file opts out via the new
     `devkit-upgrade` feature group (`DEVKIT_FEATURES_DISABLED`).
-  - Requires a dedicated `DEVKIT_UPGRADE_TOKEN` secret (the default
-    `GITHUB_TOKEN` cannot open a PR that triggers CI); the workflow fails fast
-    with a clear message when it is absent, and the commit identity is
-    configurable and kept off the agent blocklist.
+  - Requires a dedicated GitHub App identity
+    ([#1302](https://github.com/vig-os/devkit/issues/1302)): the
+    `DEVKIT_UPGRADE_APP_ID` and `DEVKIT_UPGRADE_APP_PRIVATE_KEY` secrets feed a
+    per-run installation token minted in-workflow (the default `GITHUB_TOKEN`
+    cannot open a PR that triggers CI, and a static PAT is not supported —
+    user-bound, expiring, single-owner). The workflow fails fast with a clear
+    message when the secrets are absent, and the commit identity is configurable
+    and kept off the agent blocklist.
 - **Scaffold-drift CI gate (DEVKIT_DRIFT_CHECK)** ([#1295](https://github.com/vig-os/devkit/issues/1295))
   - The scaffolded `ci.yml` gains a `scaffold-drift` job that re-runs the pinned
     devkit version's scaffold over the checkout and fails a PR whose managed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
-## [1.5.0](https://github.com/vig-os/devkit/releases/tag/1.5.0) - 2026-07-30
+## [1.5.0] - TBD
 
 ### Added
 
@@ -48,6 +48,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     user-bound, expiring, single-owner). The workflow fails fast with a clear
     message when the secrets are absent, and the commit identity is configurable
     and kept off the agent blocklist.
+  - The published adoption commit is **GitHub-signed**
+    ([#1308](https://github.com/vig-os/devkit/issues/1308)): the in-shell commit
+    stays a staging artifact (hooks run, message validated) and its tree is
+    replayed through the git-data API with the App token — blobs → tree (with
+    explicit per-entry modes, so executable bits survive) → commit → ref, with
+    deletions as null-sha entries and a force-updated branch ref for the
+    within-train reuse semantics. Consumers' Signed-commits rulesets stay fully
+    enforced; no bypass actors are needed anywhere.
 - **Scaffold-drift CI gate (DEVKIT_DRIFT_CHECK)** ([#1295](https://github.com/vig-os/devkit/issues/1295))
   - The scaffolded `ci.yml` gains a `scaffold-drift` job that re-runs the pinned
     devkit version's scaffold over the checkout and fails a PR whose managed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,20 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-### Changed
-
-### Deprecated
-
-### Removed
-
-### Fixed
-
-### Security
-
-## [1.5.0](https://github.com/vig-os/devkit/releases/tag/1.5.0) - 2026-07-30
-
-### Added
-
 - **Self-polling devkit-upgrade workflow** ([#1296](https://github.com/vig-os/devkit/issues/1296))
   - New managed `devkit-upgrade.yml` scaffolded into every consumer: a weekly
     schedule (Monday, aligned with the Renovate window) polls devkit's public

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ For detailed command descriptions, run `just --list --unsorted` or `just --help`
 - **Registry**: `ghcr.io/vig-os/devcontainer`
 - **Architecture**: Multi-platform support (AMD64, ARM64)
 - **License**: Apache
-- **Latest Version**: [1.5.0](https://github.com/vig-os/devkit/releases/tag/1.5.0) - 2026-07-30
+- **Latest Version**: [1.4.2](https://github.com/vig-os/devkit/releases/tag/1.4.2) - 2026-07-26
 - **Image tags**: bare semver (`0.2.1`, `latest`) — git tags use `v` prefix (`v0.2.1`) but image tags do not
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ For detailed command descriptions, run `just --list --unsorted` or `just --help`
 - **Registry**: `ghcr.io/vig-os/devcontainer`
 - **Architecture**: Multi-platform support (AMD64, ARM64)
 - **License**: Apache
-- **Latest Version**: [1.4.2](https://github.com/vig-os/devkit/releases/tag/1.4.2) - 2026-07-26
+- **Latest Version**: [1.5.0](https://github.com/vig-os/devkit/releases/tag/1.5.0) - 2026-07-30
 - **Image tags**: bare semver (`0.2.1`, `latest`) — git tags use `v` prefix (`v0.2.1`) but image tags do not
 
 ## Features

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
-## [1.5.0] - TBD
+## [1.5.0](https://github.com/vig-os/devkit/releases/tag/1.5.0) - 2026-07-30
 
 ### Added
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
-## [1.5.0](https://github.com/vig-os/devkit/releases/tag/1.5.0) - 2026-07-30
+## [1.5.0] - TBD
 
 ### Added
 
@@ -112,6 +112,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     their feature is disabled — they are left in place with a notice.
 
 ### Fixed
+
+- **`install.sh` prefers a responsive docker over podman in runtime auto-detection** ([#1305](https://github.com/vig-os/devkit/issues/1305))
+  - With both runtimes on PATH (GitHub `ubuntu-latest` runners), auto-detection
+    picked the preinstalled podman, whose stale system crun rejects podman ≥ 5's
+    OCI configs (`crun: unknown version specified`) — the first live
+    `devkit-upgrade` dispatch died at the install step on exactly this.
+    Detection now prefers docker when its daemon responds and falls back to
+    podman: podman-only hosts are unchanged, a dead docker daemon still yields
+    podman, and explicit `--docker`/`--podman` keep overriding. The
+    `devkit-upgrade.yml` template also passes `--docker` explicitly, so the
+    choice rides in the scaffold independent of the fetched installer.
 
 - **`just test` no longer fails a Python repo with zero collected tests** ([#1281](https://github.com/vig-os/devkit/issues/1281))
   - The scaffolded `justfile.project` `test`/`test-cov` recipes gate on

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -40,10 +40,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     (manual dispatch still works); `DEVKIT_UPGRADE_EXCLUDE` lists paths reset
     before the adoption commit. The whole file opts out via the new
     `devkit-upgrade` feature group (`DEVKIT_FEATURES_DISABLED`).
-  - Requires a dedicated `DEVKIT_UPGRADE_TOKEN` secret (the default
-    `GITHUB_TOKEN` cannot open a PR that triggers CI); the workflow fails fast
-    with a clear message when it is absent, and the commit identity is
-    configurable and kept off the agent blocklist.
+  - Requires a dedicated GitHub App identity
+    ([#1302](https://github.com/vig-os/devkit/issues/1302)): the
+    `DEVKIT_UPGRADE_APP_ID` and `DEVKIT_UPGRADE_APP_PRIVATE_KEY` secrets feed a
+    per-run installation token minted in-workflow (the default `GITHUB_TOKEN`
+    cannot open a PR that triggers CI, and a static PAT is not supported —
+    user-bound, expiring, single-owner). The workflow fails fast with a clear
+    message when the secrets are absent, and the commit identity is configurable
+    and kept off the agent blocklist.
 - **Scaffold-drift CI gate (DEVKIT_DRIFT_CHECK)** ([#1295](https://github.com/vig-os/devkit/issues/1295))
   - The scaffolded `ci.yml` gains a `scaffold-drift` job that re-runs the pinned
     devkit version's scaffold over the checkout and fails a PR whose managed

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
-## [1.5.0](https://github.com/vig-os/devkit/releases/tag/1.5.0) - 2026-07-30
+## [1.5.0] - TBD
 
 ### Added
 
@@ -48,6 +48,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     user-bound, expiring, single-owner). The workflow fails fast with a clear
     message when the secrets are absent, and the commit identity is configurable
     and kept off the agent blocklist.
+  - The published adoption commit is **GitHub-signed**
+    ([#1308](https://github.com/vig-os/devkit/issues/1308)): the in-shell commit
+    stays a staging artifact (hooks run, message validated) and its tree is
+    replayed through the git-data API with the App token — blobs → tree (with
+    explicit per-entry modes, so executable bits survive) → commit → ref, with
+    deletions as null-sha entries and a force-updated branch ref for the
+    within-train reuse semantics. Consumers' Signed-commits rulesets stay fully
+    enforced; no bypass actors are needed anywhere.
 - **Scaffold-drift CI gate (DEVKIT_DRIFT_CHECK)** ([#1295](https://github.com/vig-os/devkit/issues/1295))
   - The scaffolded `ci.yml` gains a `scaffold-drift` job that re-runs the pinned
     devkit version's scaffold over the checkout and fails a PR whose managed

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -9,20 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-### Changed
-
-### Deprecated
-
-### Removed
-
-### Fixed
-
-### Security
-
-## [1.5.0](https://github.com/vig-os/devkit/releases/tag/1.5.0) - 2026-07-30
-
-### Added
-
 - **Self-polling devkit-upgrade workflow** ([#1296](https://github.com/vig-os/devkit/issues/1296))
   - New managed `devkit-upgrade.yml` scaffolded into every consumer: a weekly
     schedule (Monday, aligned with the Renovate window) polls devkit's public

--- a/assets/workspace/.github/workflows/devkit-upgrade.yml
+++ b/assets/workspace/.github/workflows/devkit-upgrade.yml
@@ -8,11 +8,14 @@
 # project shell so consumer hooks run — then opens the adoption PR. Renovate-style
 # pull: no devkit-side action at release time, no consumer registry.
 #
-# Requires the DEVKIT_UPGRADE_TOKEN secret — a dedicated identity (fine-grained
-# PAT or GitHub App token with contents:write + pull-requests:write +
-# issues:write). The default GITHUB_TOKEN cannot open the PR: PRs it creates do
-# not trigger CI. The workflow fails fast when the secret is absent. Provisioning
-# + rotation: https://github.com/vig-os/devkit/issues/1296
+# Requires a dedicated GitHub App identity: DEVKIT_UPGRADE_APP_ID +
+# DEVKIT_UPGRADE_APP_PRIVATE_KEY (repo or org secrets) feed a per-run
+# installation token minted in-workflow — contents:write + pull-requests:write +
+# issues:write + workflows:write on this repo. The default GITHUB_TOKEN cannot
+# open the PR: PRs it creates do not trigger CI. A static PAT is not supported
+# (#1302: user-bound, expiring, single-owner). The workflow fails fast when the
+# secrets are absent. App provisioning + rotation:
+# https://github.com/vig-os/devkit/issues/1302
 
 name: Devkit Upgrade
 
@@ -42,20 +45,28 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
-      # The branch, issue and PR are all created with DEVKIT_UPGRADE_TOKEN (a
+      # The branch, issue and PR are all created with the minted App token (a
       # dedicated identity, so the PR triggers CI); the default token stays
       # read-only for the public releases/latest query.
       contents: read
     steps:
-      - name: Require the dedicated upgrade token
+      - name: Require the upgrade App identity
         env:
-          DEVKIT_UPGRADE_TOKEN: ${{ secrets.DEVKIT_UPGRADE_TOKEN }}
+          APP_ID: ${{ secrets.DEVKIT_UPGRADE_APP_ID }}
+          APP_PRIVATE_KEY: ${{ secrets.DEVKIT_UPGRADE_APP_PRIVATE_KEY }}
         run: |
           set -euo pipefail
-          if [ -z "${DEVKIT_UPGRADE_TOKEN}" ]; then
-            echo "::error::DEVKIT_UPGRADE_TOKEN secret is not configured. This workflow needs a dedicated identity (fine-grained PAT or GitHub App token with contents:write + pull-requests:write + issues:write): the default GITHUB_TOKEN cannot open a PR that triggers CI. See https://github.com/vig-os/devkit/issues/1296."
+          if [ -z "${APP_ID}" ] || [ -z "${APP_PRIVATE_KEY}" ]; then
+            echo "::error::DEVKIT_UPGRADE_APP_ID / DEVKIT_UPGRADE_APP_PRIVATE_KEY secrets are not configured. This workflow needs a dedicated GitHub App identity (contents:write + pull-requests:write + issues:write + workflows:write): the default GITHUB_TOKEN cannot open a PR that triggers CI, and a static PAT is not supported. See https://github.com/vig-os/devkit/issues/1302."
             exit 1
           fi
+
+      - name: Mint the upgrade App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3
+        with:
+          app-id: ${{ secrets.DEVKIT_UPGRADE_APP_ID }}
+          private-key: ${{ secrets.DEVKIT_UPGRADE_APP_PRIVATE_KEY }}
 
       - name: Checkout base branch
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
@@ -63,9 +74,9 @@ jobs:
           # Base branch per workflow model: gitflow -> dev, trunk -> main
           # (retargeted to `main` at scaffold time for a trunk repo).
           ref: dev
-          # Persist the dedicated token so the later push authenticates as the
+          # Persist the minted token so the later push authenticates as the
           # upgrade identity (whose PR triggers CI).
-          token: ${{ secrets.DEVKIT_UPGRADE_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
 
       - name: Resolve target version
@@ -158,7 +169,7 @@ jobs:
         id: issue
         if: steps.resolve.outputs.proceed == 'true'
         env:
-          GH_TOKEN: ${{ secrets.DEVKIT_UPGRADE_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           TRAIN: ${{ steps.resolve.outputs.train }}
         run: |
           set -euo pipefail
@@ -266,7 +277,7 @@ jobs:
       - name: Open or update the adoption PR
         if: steps.resolve.outputs.proceed == 'true' && steps.commit.outputs.changed == 'true'
         env:
-          GH_TOKEN: ${{ secrets.DEVKIT_UPGRADE_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           TARGET: ${{ steps.resolve.outputs.target }}
           ISSUE: ${{ steps.issue.outputs.number }}
           BRANCH: ${{ steps.branch.outputs.name }}

--- a/assets/workspace/.github/workflows/devkit-upgrade.yml
+++ b/assets/workspace/.github/workflows/devkit-upgrade.yml
@@ -67,6 +67,13 @@ jobs:
         with:
           app-id: ${{ secrets.DEVKIT_UPGRADE_APP_ID }}
           private-key: ${{ secrets.DEVKIT_UPGRADE_APP_PRIVATE_KEY }}
+          # Least-privilege mint (zizmor github-app): the token carries exactly
+          # the four permissions this workflow exercises, independent of any
+          # broader grants on the App installation.
+          permission-contents: write
+          permission-pull-requests: write
+          permission-issues: write
+          permission-workflows: write
 
       - name: Checkout base branch
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1

--- a/assets/workspace/.github/workflows/devkit-upgrade.yml
+++ b/assets/workspace/.github/workflows/devkit-upgrade.yml
@@ -270,20 +270,80 @@ jobs:
           fi
           # Commit INSIDE the project shell so consumer hooks run (dist rebuild in
           # commit-action, trailer strip, validate-commit-msg). chore is
-          # Refs-exempt but include it for traceability.
+          # Refs-exempt but include it for traceability. This LOCAL commit is a
+          # staging artifact only — the next step replays its tree through the
+          # API as a GitHub-signed commit; the unsigned one never leaves the
+          # runner (#1308).
           printf 'chore: adopt devkit %s\n\nRefs: #%s\n' "$TARGET" "$ISSUE" > "${RUNNER_TEMP}/commit-msg"
           nix develop -c git commit -F "${RUNNER_TEMP}/commit-msg"
           echo "changed=true" >> "$GITHUB_OUTPUT"
 
-      - name: Push the upgrade branch
+      - name: Publish the adoption commit via API (verified)
         if: steps.resolve.outputs.proceed == 'true' && steps.commit.outputs.changed == 'true'
         env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           BRANCH: ${{ steps.branch.outputs.name }}
         run: |
           set -euo pipefail
-          # Force-update: within a train an earlier rc may already have pushed
-          # this branch; the PR is refreshed to the latest bump.
-          git push --force origin "HEAD:${BRANCH}"
+          # The in-shell commit above is a STAGING artifact — hooks ran and the
+          # message validated, but a worktree commit is unsigned and consumers'
+          # Signed-commits rulesets rightfully reject it. Replay its tree
+          # through the git-data API with the App token instead: API-created
+          # commits are signed by GitHub as the App, so the published commit is
+          # verified and no ruleset needs a bypass (#1308). The tree API also
+          # carries an explicit mode per entry, so executable bits survive —
+          # createCommitOnBranch would silently drop them.
+          REPO="${GITHUB_REPOSITORY}"
+          MESSAGE="$(git log -1 --format=%B)"
+          BASE_SHA="$(git rev-parse HEAD^)"
+          BASE_TREE="$(gh api "repos/${REPO}/git/commits/${BASE_SHA}" --jq .tree.sha)"
+
+          # One tree entry per path the staging commit touched. --no-renames
+          # keeps the status alphabet to A/M/D (a rename becomes A + D).
+          entries='[]'
+          while IFS=$'\t' read -r status path; do
+            [ -n "$path" ] || continue
+            if [ "$status" = "D" ]; then
+              # Deletion: a null-sha entry removes the path from the tree.
+              entries="$(jq --arg p "$path" \
+                '. + [{path: $p, mode: "100644", type: "blob", sha: null}]' \
+                <<<"$entries")"
+            else
+              mode=100644
+              [ -x "$path" ] && mode=100755
+              blob="$(gh api -X POST "repos/${REPO}/git/blobs" \
+                -f content="$(base64 -w0 "$path")" -f encoding=base64 --jq .sha)"
+              entries="$(jq --arg p "$path" --arg m "$mode" --arg s "$blob" \
+                '. + [{path: $p, mode: $m, type: "blob", sha: $s}]' \
+                <<<"$entries")"
+            fi
+          done < <(git diff --name-status --no-renames "${BASE_SHA}" HEAD)
+
+          COUNT="$(jq length <<<"$entries")"
+          if [ "$COUNT" -eq 0 ]; then
+            echo "Empty delta after staging; nothing to publish."
+            exit 0
+          fi
+          echo "Publishing ${COUNT} tree entries..."
+
+          TREE="$(jq -n --argjson t "$entries" --arg b "$BASE_TREE" \
+            '{base_tree: $b, tree: $t}' \
+            | gh api -X POST "repos/${REPO}/git/trees" --input - --jq .sha)"
+          COMMIT="$(jq -n --arg m "$MESSAGE" --arg t "$TREE" --arg p "$BASE_SHA" \
+            '{message: $m, tree: $t, parents: [$p]}' \
+            | gh api -X POST "repos/${REPO}/git/commits" --input - --jq .sha)"
+
+          # Create the branch ref on first use; force-update within a train so
+          # rc -> rc -> final reuse refreshes the same branch/PR to the latest
+          # bump (the semantics the old force-push provided).
+          if gh api "repos/${REPO}/git/ref/heads/${BRANCH}" >/dev/null 2>&1; then
+            gh api -X PATCH "repos/${REPO}/git/refs/heads/${BRANCH}" \
+              -f sha="$COMMIT" -F force=true >/dev/null
+          else
+            gh api -X POST "repos/${REPO}/git/refs" \
+              -f ref="refs/heads/${BRANCH}" -f sha="$COMMIT" >/dev/null
+          fi
+          echo "Published verified commit ${COMMIT} to ${BRANCH}."
 
       - name: Open or update the adoption PR
         if: steps.resolve.outputs.proceed == 'true' && steps.commit.outputs.changed == 'true'

--- a/docs/issues/issue-1295.md
+++ b/docs/issues/issue-1295.md
@@ -1,19 +1,19 @@
 ---
 type: issue
-state: open
+state: closed
 created: 2026-07-29T13:33:54Z
-updated: 2026-07-29T13:33:54Z
+updated: 2026-07-30T08:54:39Z
 author: c-vigo
 author_url: https://github.com/c-vigo
 url: https://github.com/vig-os/devkit/issues/1295
-comments: 0
+comments: 1
 labels: feature, priority:high, area:workflow, effort:medium, semver:minor
 assignees: none
 milestone: 1.5.0
 projects: none
 parent: none
 children: none
-synced: 2026-07-30T05:15:33.766Z
+synced: 2026-07-30T11:51:50.975Z
 ---
 
 # [Issue 1295]: [feat(workflow): scaffold-drift check in consumer CI (pin bumped without re-scaffold)](https://github.com/vig-os/devkit/issues/1295)
@@ -47,4 +47,12 @@ Consumers gain a hard gate against skewed upgrades; devkit's own repo is unaffec
 ### Changelog Category
 
 Added
+
+---
+
+# [Comment #1]() by [c-vigo]()
+
+_Posted on July 30, 2026 at 08:54 AM_
+
+Implemented in PR #1297, merged to dev @b8056ffe. Ships with 1.5.0.
 

--- a/docs/issues/issue-1296.md
+++ b/docs/issues/issue-1296.md
@@ -1,19 +1,19 @@
 ---
 type: issue
-state: open
+state: closed
 created: 2026-07-29T13:34:25Z
-updated: 2026-07-29T13:34:25Z
+updated: 2026-07-30T08:54:41Z
 author: c-vigo
 author_url: https://github.com/c-vigo
 url: https://github.com/vig-os/devkit/issues/1296
-comments: 0
+comments: 1
 labels: feature, priority:medium, area:workflow, effort:large, semver:minor
 assignees: none
 milestone: 1.5.0
 projects: none
 parent: none
 children: none
-synced: 2026-07-30T05:15:33.355Z
+synced: 2026-07-30T11:51:50.591Z
 ---
 
 # [Issue 1296]: [feat(workflow): self-polling devkit-upgrade workflow (auto adoption PR in consumers)](https://github.com/vig-os/devkit/issues/1296)
@@ -77,4 +77,12 @@ All 5 consumers; each adoption PR becomes review-and-merge. Steady-state upgrade
 ### Changelog Category
 
 Added
+
+---
+
+# [Comment #1]() by [c-vigo]()
+
+_Posted on July 30, 2026 at 08:54 AM_
+
+Implemented in PR #1298, merged to dev @4772c62f. Ships with 1.5.0.
 

--- a/docs/issues/issue-1299.md
+++ b/docs/issues/issue-1299.md
@@ -1,0 +1,46 @@
+---
+type: issue
+state: open
+created: 2026-07-30T09:02:32Z
+updated: 2026-07-30T09:02:32Z
+author: c-vigo
+author_url: https://github.com/c-vigo
+url: https://github.com/vig-os/devkit/issues/1299
+comments: 0
+labels: bug, priority:high, area:ci, effort:small, semver:patch
+assignees: none
+milestone: 1.5.0
+projects: none
+parent: none
+children: none
+synced: 2026-07-30T11:51:50.243Z
+---
+
+# [Issue 1299]: [ci: runner-image podman 5.8.4 + stale system crun breaks every podman run in image testinfra](https://github.com/vig-os/devkit/issues/1299)
+
+## Symptom
+
+Nix Image (discovery) run [30528291013](https://github.com/vig-os/devkit/actions/runs/30528291013) (dev @4772c62f, merge of #1298) failed on the **amd64** leg: all 116 portable testinfra tests errored at container start with
+
+```
+Error: OCI runtime error: crun: unknown version specified
+```
+
+The arm64 leg passed. The same commit's content is workflow-template-only — the image is unaffected.
+
+## Root cause
+
+The failure is a GitHub runner-image regression, not devkit code:
+
+- Last green dev run ([30516144283](https://github.com/vig-os/devkit/actions/runs/30516144283), 05:15Z): runner image `ubuntu-24.04 20260720.247.2`, preinstalled `podman 4.9.3`.
+- Failing run (08:50Z): runner image `ubuntu-24.04 20260726.254.1`, preinstalled `podman 5.8.4`.
+
+podman ≥ 5 writes OCI runtime-spec v1.2.x `config.json`, which crun < 1.14.3 rejects with exactly this error (containers/podman#27272). The updated runner image bumped podman but the system crun stayed at Ubuntu 24.04's stale apt version, so every `podman run` dies at container start. Rollout is per-runner: PR CI of #1298 (~08:00Z) still drew an old runner and passed, so red is probabilistic until the fleet converges — then deterministic.
+
+`setup-env` keeps podman on the host path by design (#632: rootless setuid newuidmap integration), so CI inherits whatever pairing the runner image ships.
+
+## Fix
+
+Pair the host podman with the flake's pinned crun instead of the runner's: the dev-shell closure already carries the crun that nixpkgs pairs with podman 5.8.x (crun 1.27.1, spec-v1.2-capable, backward-compatible with podman 4.x configs). In `setup-env`'s "Install podman" step, resolve `-crun-` from the dev-profile closure and write a rootless `containers.conf` drop-in (`~/.config/containers/containers.conf.d/`) pointing the `crun` runtime at that store path. The podman↔crun pairing is then pinned by `flake.lock`, immune to runner-image drift.
+
+Blocks the 1.5.0 release train (release.yml runs the same test-image action).

--- a/docs/issues/issue-1302.md
+++ b/docs/issues/issue-1302.md
@@ -1,0 +1,43 @@
+---
+type: issue
+state: open
+created: 2026-07-30T09:47:39Z
+updated: 2026-07-30T09:47:39Z
+author: c-vigo
+author_url: https://github.com/c-vigo
+url: https://github.com/vig-os/devkit/issues/1302
+comments: 0
+labels: feature, priority:high, area:workflow, effort:small, semver:minor
+assignees: none
+milestone: 1.5.0
+projects: none
+parent: none
+children: none
+synced: 2026-07-30T11:51:49.877Z
+---
+
+# [Issue 1302]: [feat(workflow): devkit-upgrade must authenticate via a dedicated GitHub App (drop the PAT path)](https://github.com/vig-os/devkit/issues/1302)
+
+## Context
+
+The devkit-upgrade workflow (#1296, unreleased — on `release/1.5.0`) reads a static `DEVKIT_UPGRADE_TOKEN` secret, which in practice forces a fine-grained PAT: App installation tokens live one hour and cannot be stored as secrets. PATs are user-bound, expire, and are single-owner (one per org across vig-os / exoma-ch / exo-pet), all rotated manually.
+
+## Decision
+
+A GitHub App is the **only** supported identity. The template mints a per-run installation token in-workflow — the same `actions/create-github-app-token` pattern devkit's own `prepare-release.yml` already uses:
+
+- Secrets: `DEVKIT_UPGRADE_APP_ID` + `DEVKIT_UPGRADE_APP_PRIVATE_KEY` (org-level secrets cover a whole org's consumers).
+- Fail-fast with a clear message when either secret is absent.
+- The minted token drives checkout/push, the adoption issue, and the PR (so the PR triggers CI); `DEVKIT_UPGRADE_TOKEN` is removed entirely.
+
+Since #1296 has never shipped, changing the contract now (on the release branch) means 1.5.0 ships App-only with no migration debt.
+
+## App provisioning (documented here as the SSoT)
+
+Dedicated App (do **not** reuse the release/commit App — its private key must stay confined to devkit; the upgrade key gets distributed to consumer orgs):
+
+- Name: `vigos-devkit-upgrade` (must not match the agent blocklist)
+- Repository permissions: Contents RW, Pull requests RW, Issues RW, Workflows RW, Metadata R
+- Webhook: disabled. Public (so exoma-ch / exo-pet orgs can install it later); installed per org on the consumer repos.
+
+Refs: #1296

--- a/docs/issues/issue-1302.md
+++ b/docs/issues/issue-1302.md
@@ -2,18 +2,18 @@
 type: issue
 state: open
 created: 2026-07-30T09:47:39Z
-updated: 2026-07-30T09:47:39Z
+updated: 2026-07-30T15:45:46Z
 author: c-vigo
 author_url: https://github.com/c-vigo
 url: https://github.com/vig-os/devkit/issues/1302
-comments: 0
+comments: 2
 labels: feature, priority:high, area:workflow, effort:small, semver:minor
 assignees: none
 milestone: 1.5.0
 projects: none
 parent: none
 children: none
-synced: 2026-07-30T11:51:49.877Z
+synced: 2026-07-30T17:15:04.387Z
 ---
 
 # [Issue 1302]: [feat(workflow): devkit-upgrade must authenticate via a dedicated GitHub App (drop the PAT path)](https://github.com/vig-os/devkit/issues/1302)
@@ -41,3 +41,19 @@ Dedicated App (do **not** reuse the release/commit App — its private key must 
 - Webhook: disabled. Public (so exoma-ch / exo-pet orgs can install it later); installed per org on the consumer repos.
 
 Refs: #1296
+---
+
+# [Comment #1]() by [c-vigo]()
+
+_Posted on July 30, 2026 at 02:34 PM_
+
+Provisioning addendum (live-proven 2026-07-30): consumers' **Signed commits** ruleset must grant the App (`vigos-devkit-upgrade`, id 4434545) a bypass (`bypass_mode: always`) — the workflow's in-shell worktree commit cannot be API-signed without losing hook fidelity. Applied by hand to devkit-smoke-test; fleet-wide rollout tracked in vig-os/org-config#81. With the bypass in place the full path is live-proven end to end: fail-fast → App token mint → adoption-issue reuse (devkit-smoke-test#310) → `install.sh --force` (docker-pinned, #1305) → in-shell commit → push → adoption PR devkit-smoke-test#316 opened by the App with CI triggering.
+
+---
+
+# [Comment #2]() by [c-vigo]()
+
+_Posted on July 30, 2026 at 03:45 PM_
+
+Correction to the provisioning addendum above (maintainer review): ruleset bypasses are **not** part of the provisioning model — verified signatures on protected branches are policy. The interim bypass on devkit-smoke-test is reverted and org-config#81 closed as superseded. The workflow will publish verified App-signed commits via API tree replay instead: #1308. Evidence standing from the live runs: every leg except the final publish is proven (fail-fast, mint, issue reuse, docker-pinned install with real diff, in-shell commit, PR mechanics); the publish leg's live proof lands with #1308.
+

--- a/docs/issues/issue-1303.md
+++ b/docs/issues/issue-1303.md
@@ -1,0 +1,54 @@
+---
+type: issue
+state: open
+created: 2026-07-30T09:48:56Z
+updated: 2026-07-30T09:48:56Z
+author: github-actions[bot]
+author_url: https://github.com/github-actions[bot]
+url: https://github.com/vig-os/devkit/issues/1303
+comments: 0
+labels: bug, area:ci
+assignees: none
+milestone: none
+projects: none
+parent: none
+children: none
+synced: 2026-07-30T11:51:49.577Z
+---
+
+# [Issue 1303]: [Release 1.5.0-rc1 failed -- automatic rollback](https://github.com/vig-os/devkit/issues/1303)
+
+
+Release 1.5.0-rc1 encountered an error during the automated release workflow.
+
+**Failed Jobs:** publish
+
+**Workflow Run:** [View logs](https://github.com/vig-os/devkit/actions/runs/30531160197)
+
+**Release PR:** #1301
+
+**Rollback Results:**
+- Branch rollback: success
+- PR body restoration: skipped
+
+**Tag status (forward-fix policy):**
+- Release tags are **not** deleted by automation (workflow choice; not the same as GitHub immutable-release lock-in).
+- If the tag was pushed before the failure, it remains on the remote; use a new release candidate to validate fixes, then re-run the final release when ready.
+
+**Actions Taken:**
+- Release branch reset to pre-finalization state (best-effort)
+- Release PR body restored to TBD / prepare-release format when applicable (best-effort)
+- This issue created for investigation
+
+**Manual Cleanup May Be Needed:**
+- If images were pushed to GHCR before the failure, they are **not** automatically deleted. Check `ghcr.io/vig-os/devcontainer:1.5.0-rc1-*` and remove any orphaned images manually.
+- If a **draft** GitHub Release exists for this tag, edit or manage it from the Releases UI (**publishing** locks the linked tag and assets when **immutable releases** are enabled).
+
+**Next Steps:**
+1. Review the workflow logs to identify the root cause
+2. Check rollback results above; fix any partial rollback manually
+3. Fix the issue on the release branch
+4. Publish a new release candidate to validate the fix; re-run the final workflow when ready
+
+For details, check the workflow run linked above.
+

--- a/docs/issues/issue-1305.md
+++ b/docs/issues/issue-1305.md
@@ -1,0 +1,40 @@
+---
+type: issue
+state: open
+created: 2026-07-30T12:43:01Z
+updated: 2026-07-30T12:43:01Z
+author: c-vigo
+author_url: https://github.com/c-vigo
+url: https://github.com/vig-os/devkit/issues/1305
+comments: 0
+labels: bug, priority:high, area:workspace, effort:small, semver:patch
+assignees: none
+milestone: Backlog
+projects: none
+parent: none
+children: none
+synced: 2026-07-30T14:03:13.110Z
+---
+
+# [Issue 1305]: [fix(install): runtime auto-detection picks the runner's broken podman over docker (crun mismatch breaks consumer upgrade flows)](https://github.com/vig-os/devkit/issues/1305)
+
+## Symptom
+
+First live `devkit-upgrade` dispatch (devkit-smoke-test [run 30543470753](https://github.com/vig-os/devkit-smoke-test/actions/runs/30543470753), version=1.5.0): the App path worked end-to-end (fail-fast, token mint, adoption issue vig-os/devkit-smoke-test#310 opened by `app/vigos-devkit-upgrade`), then `install.sh --force` died at "Initializing workspace" with
+
+```
+Error: OCI runtime error: crun: unknown version specified
+```
+
+## Root cause
+
+`detect_runtime()` prefers podman over docker. On `ubuntu-latest` both exist; runner images ≥ 20260726 pair preinstalled podman 5.8.4 with Ubuntu's stale crun (< 1.14.3), which rejects podman ≥ 5's OCI v1.2.x configs — the same regression as #1299, but on the **consumer** side, where devkit's `setup-env` crun pin (the #1299 fix) does not apply. The `devkit-upgrade.yml` comment even assumes docker ("docker is present on ubuntu-latest (install.sh auto-detects it)") — the detection contradicts it. As the runner fleet converges, every consumer's weekly upgrade run and the smoke deploy flow will fail at the install step.
+
+## Fix
+
+1. `detect_runtime()`: prefer **docker when its daemon responds** (`docker info`), falling back to podman — podman-only hosts (vigOS machines) unchanged; both-present hosts with a dead docker daemon still get podman. Explicit `--docker`/`--podman` flags keep overriding.
+2. `devkit-upgrade.yml` template: pass `--docker` explicitly (self-documenting; GH runners always have docker).
+
+Delivery: consumers curl `install.sh` from `main`, so the fix heals **all existing scaffolds** at the next promote with no re-scaffold. The 1.5.1 adoption dispatch then doubles as the live proof of the workflow's remaining push/PR legs (real version gap → full path).
+
+Refs: #1299, #1296, #1302

--- a/docs/issues/issue-1308.md
+++ b/docs/issues/issue-1308.md
@@ -1,0 +1,40 @@
+---
+type: issue
+state: open
+created: 2026-07-30T15:45:32Z
+updated: 2026-07-30T16:12:16Z
+author: c-vigo
+author_url: https://github.com/c-vigo
+url: https://github.com/vig-os/devkit/issues/1308
+comments: 0
+labels: feature, priority:high, area:workflow, effort:medium, semver:minor
+assignees: none
+milestone: 1.5.0
+projects: none
+parent: none
+children: none
+synced: 2026-07-30T17:15:04.025Z
+---
+
+# [Issue 1308]: [feat(workflow): devkit-upgrade must publish verified commits (API tree replay, commit-app pattern)](https://github.com/vig-os/devkit/issues/1308)
+
+## Problem
+
+The devkit-upgrade workflow's adoption commit is a worktree `git commit` (by design — inside `nix develop` so consumer hooks run: dist rebuilds, trailer strip, validate-commit-msg). That commit is unsigned, and consumers' **Signed commits** ruleset rightfully rejects it at push (first observed: devkit-smoke-test run 30551310266 / PR #316, closed unmerged). Bypassing the rule for the App was evaluated and rejected by the maintainer: verified signatures on `dev`/`main` are policy — this is exactly what the commit-app pattern exists for.
+
+## Fix
+
+Keep the in-shell commit for **hook fidelity**, then replay the result as a **verified commit** via the GitHub API using the upgrade App's token (GraphQL `createCommitOnBranch` — API commits are GitHub-signed as the App; same pattern as vig-os/commit-action):
+
+1. `install.sh --force` + excluded-path reset (unchanged).
+2. `nix develop -c git commit` locally — hooks run, files mutate, message validates. This commit is a **staging artifact, never pushed**.
+3. Create the remote branch and replay the commit's tree + message via `createCommitOnBranch` with the App token → verified `vigos-devkit-upgrade[bot]` commit.
+4. `gh pr create` as today.
+
+Force-update semantics within a train (rc→rc→final) carry over: the API path recreates the branch head each run.
+
+Consequences: no ruleset bypasses anywhere (the interim bypass on devkit-smoke-test has been reverted); vig-os/org-config#81's fleet-wide bypass rollout is superseded. The merging human's signature status is irrelevant since all incoming commits are verified.
+
+Live proof pending this fix: the push/publish leg of the upgrade workflow (everything else is proven — see vig-os/devkit#1302 evidence trail).
+
+Refs: #1296, #1302, #1305

--- a/docs/issues/issue-529.md
+++ b/docs/issues/issue-529.md
@@ -2,7 +2,7 @@
 type: issue
 state: open
 created: 2026-04-29T14:40:41Z
-updated: 2026-07-30T13:22:49Z
+updated: 2026-07-30T16:17:24Z
 author: renovate[bot]
 author_url: https://github.com/renovate[bot]
 url: https://github.com/vig-os/devkit/issues/529
@@ -13,7 +13,7 @@ milestone: none
 projects: none
 parent: none
 children: none
-synced: 2026-07-30T14:03:13.548Z
+synced: 2026-07-30T17:15:04.674Z
 ---
 
 # [Issue 529]: [Dependency Dashboard](https://github.com/vig-os/devkit/issues/529)
@@ -29,17 +29,6 @@ The following updates are awaiting their schedule. To get an update now, click o
  - [ ] <!-- unschedule-branch=renovate/python-(minor-and-patch) -->build(pip): update dependency github-backup to v0.65.0
  - [ ] <!-- unschedule-branch=renovate/lock-file-maintenance -->build(pip): lock file maintenance
  - [ ] <!-- create-all-awaiting-schedule-prs -->🔐 **Create all awaiting schedule PRs at once** 🔐
-
-
----
-
-> [!WARNING]
-> Renovate failed to look up the following dependencies: `Failed to look up github-releases package aquasecurity/trivy: no-result`.
-> 
-> Files affected: `.github/workflows/ci.yml`, `.github/workflows/release.yml`, `.github/workflows/security-scan.yml`
-
----
-
 
 ## Detected Dependencies
 

--- a/docs/issues/issue-529.md
+++ b/docs/issues/issue-529.md
@@ -2,7 +2,7 @@
 type: issue
 state: open
 created: 2026-04-29T14:40:41Z
-updated: 2026-07-29T21:16:01Z
+updated: 2026-07-30T09:59:19Z
 author: renovate[bot]
 author_url: https://github.com/renovate[bot]
 url: https://github.com/vig-os/devkit/issues/529
@@ -13,7 +13,7 @@ milestone: none
 projects: none
 parent: none
 children: none
-synced: 2026-07-30T05:15:37.616Z
+synced: 2026-07-30T11:51:52.759Z
 ---
 
 # [Issue 529]: [Dependency Dashboard](https://github.com/vig-os/devkit/issues/529)
@@ -24,6 +24,7 @@ This issue lists Renovate updates and detected dependencies. Read the [Dependenc
 
 The following updates are awaiting their schedule. To get an update now, click on a checkbox below.
 
+ - [ ] <!-- unschedule-branch=renovate/github-codeql-action-digest -->chore(deps): update github/codeql-action digest to f205ea1
  - [ ] <!-- unschedule-branch=renovate/github-actions-(minor-and-patch) -->ci(actions): update github-actions (minor and patch) (`actions/attest`, `docker/login-action`)
  - [ ] <!-- unschedule-branch=renovate/python-(minor-and-patch) -->build(pip): update dependency github-backup to v0.65.0
  - [ ] <!-- unschedule-branch=renovate/lock-file-maintenance -->build(pip): lock file maintenance
@@ -31,7 +32,7 @@ The following updates are awaiting their schedule. To get an update now, click o
 
 ## Detected Dependencies
 
-<details><summary>github-actions (39)</summary>
+<details><summary>github-actions (40)</summary>
 <blockquote>
 
 <details><summary>.github/actions/setup-env/action.yml (3)</summary>
@@ -99,8 +100,8 @@ The following updates are awaiting their schedule. To get an update now, click o
 <details><summary>.github/workflows/codeql.yml (4)</summary>
 
  - `actions/checkout v7.0.1@3d3c42e5aac5ba805825da76410c181273ba90b1`
- - `github/codeql-action v4@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81`
- - `github/codeql-action v4@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81`
+ - `github/codeql-action v4@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81` → [Updates: `v4`]
+ - `github/codeql-action v4@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81` → [Updates: `v4`]
  - `ubuntu 24.04`
 
 </details>
@@ -262,7 +263,7 @@ The following updates are awaiting their schedule. To get an update now, click o
 
  - `actions/checkout v7.0.1@3d3c42e5aac5ba805825da76410c181273ba90b1`
  - `ossf/scorecard-action v2.4.4@2d1146689b8cda280b9bc96326124645441f03bc`
- - `github/codeql-action v4@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81`
+ - `github/codeql-action v4@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81` → [Updates: `v4`]
  - `ubuntu 24.04`
 
 </details>
@@ -376,9 +377,16 @@ The following updates are awaiting their schedule. To get an update now, click o
 <details><summary>assets/workspace/.github/workflows/codeql.yml (4)</summary>
 
  - `actions/checkout v7.0.1@3d3c42e5aac5ba805825da76410c181273ba90b1`
- - `github/codeql-action v4@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81`
- - `github/codeql-action v4@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81`
+ - `github/codeql-action v4@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81` → [Updates: `v4`]
+ - `github/codeql-action v4@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81` → [Updates: `v4`]
  - `ubuntu 24.04`
+
+</details>
+
+<details><summary>assets/workspace/.github/workflows/devkit-upgrade.yml (2)</summary>
+
+ - `actions/checkout v7.0.1@3d3c42e5aac5ba805825da76410c181273ba90b1`
+ - `cachix/install-nix-action v31.11.0@630ae543ea3a38a9a4166f03376c02c50f408342`
 
 </details>
 
@@ -493,7 +501,7 @@ The following updates are awaiting their schedule. To get an update now, click o
 
  - `actions/checkout v7.0.1@3d3c42e5aac5ba805825da76410c181273ba90b1`
  - `ossf/scorecard-action v2.4.4@2d1146689b8cda280b9bc96326124645441f03bc`
- - `github/codeql-action v4@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81`
+ - `github/codeql-action v4@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81` → [Updates: `v4`]
  - `ubuntu 24.04`
 
 </details>

--- a/docs/issues/issue-529.md
+++ b/docs/issues/issue-529.md
@@ -2,7 +2,7 @@
 type: issue
 state: open
 created: 2026-04-29T14:40:41Z
-updated: 2026-07-30T09:59:19Z
+updated: 2026-07-30T13:22:49Z
 author: renovate[bot]
 author_url: https://github.com/renovate[bot]
 url: https://github.com/vig-os/devkit/issues/529
@@ -13,7 +13,7 @@ milestone: none
 projects: none
 parent: none
 children: none
-synced: 2026-07-30T11:51:52.759Z
+synced: 2026-07-30T14:03:13.548Z
 ---
 
 # [Issue 529]: [Dependency Dashboard](https://github.com/vig-os/devkit/issues/529)
@@ -29,6 +29,17 @@ The following updates are awaiting their schedule. To get an update now, click o
  - [ ] <!-- unschedule-branch=renovate/python-(minor-and-patch) -->build(pip): update dependency github-backup to v0.65.0
  - [ ] <!-- unschedule-branch=renovate/lock-file-maintenance -->build(pip): lock file maintenance
  - [ ] <!-- create-all-awaiting-schedule-prs -->🔐 **Create all awaiting schedule PRs at once** 🔐
+
+
+---
+
+> [!WARNING]
+> Renovate failed to look up the following dependencies: `Failed to look up github-releases package aquasecurity/trivy: no-result`.
+> 
+> Files affected: `.github/workflows/ci.yml`, `.github/workflows/release.yml`, `.github/workflows/security-scan.yml`
+
+---
+
 
 ## Detected Dependencies
 

--- a/docs/pull-requests/pr-1298.md
+++ b/docs/pull-requests/pr-1298.md
@@ -1,9 +1,9 @@
 ---
 type: pull_request
-state: open
+state: closed (merged)
 branch: feature/1296-devkit-upgrade-workflow → dev
 created: 2026-07-29T14:20:41Z
-updated: 2026-07-29T14:31:09Z
+updated: 2026-07-30T08:50:49Z
 author: c-vigo
 author_url: https://github.com/c-vigo
 url: https://github.com/vig-os/devkit/pull/1298
@@ -12,7 +12,8 @@ labels: none
 assignees: none
 milestone: none
 projects: none
-synced: 2026-07-30T05:15:40.947Z
+merged: 2026-07-30T08:50:46Z
+synced: 2026-07-30T11:52:03.391Z
 ---
 
 # [PR 1298](https://github.com/vig-os/devkit/pull/1298) feat(workflow): scaffold self-polling devkit-upgrade workflow
@@ -50,3 +51,21 @@ Scaffolds a self-polling `devkit-upgrade.yml` workflow into consumers: weekly (M
 
 Refs: #1296
 
+
+
+---
+---
+
+## Commits
+
+### Commit 1: [2e3e396](https://github.com/vig-os/devkit/commit/2e3e3962399619cc1ef1f2bb3f31cfaf9280fae0) by [c-vigo](https://github.com/c-vigo) on July 29, 2026 at 01:56 PM
+test(workflow): add devkit-upgrade scaffold and wiring tests, 212 files modified (tests/test_workflow_devkit_upgrade.py)
+
+### Commit 2: [d49416e](https://github.com/vig-os/devkit/commit/d49416ef31ee1c815c2caa1762b07f9e86485645) by [c-vigo](https://github.com/c-vigo) on July 29, 2026 at 02:04 PM
+feat(workflow): scaffold self-polling devkit-upgrade workflow, 407 files modified
+
+### Commit 3: [42a6da5](https://github.com/vig-os/devkit/commit/42a6da58a85daefe8ab1ede7aaca88abbcc83929) by [c-vigo](https://github.com/c-vigo) on July 29, 2026 at 02:30 PM
+style(workflow): group GITHUB_OUTPUT redirects in devkit-upgrade resolve step, 10 files modified (assets/workspace/.github/workflows/devkit-upgrade.yml)
+
+### Commit 4: [339cee2](https://github.com/vig-os/devkit/commit/339cee232b5800e26112b4bae590e8c2128c3008) by [c-vigo](https://github.com/c-vigo) on July 30, 2026 at 08:17 AM
+chore: merge dev into feature/1296-devkit-upgrade-workflow, 1264 files modified

--- a/docs/pull-requests/pr-1300.md
+++ b/docs/pull-requests/pr-1300.md
@@ -1,0 +1,40 @@
+---
+type: pull_request
+state: closed (merged)
+branch: bugfix/1299-runner-crun-pairing → dev
+created: 2026-07-30T09:03:41Z
+updated: 2026-07-30T09:14:21Z
+author: c-vigo
+author_url: https://github.com/c-vigo
+url: https://github.com/vig-os/devkit/pull/1300
+comments: 0
+labels: none
+assignees: none
+milestone: none
+projects: none
+merged: 2026-07-30T09:14:18Z
+synced: 2026-07-30T11:51:57.783Z
+---
+
+# [PR 1300](https://github.com/vig-os/devkit/pull/1300) ci(actions): pin podman OCI runtime to the flake's crun in setup-env
+
+## Summary
+
+Fixes #1299 — the 2026-07-26 `ubuntu-24.04` runner image bumped preinstalled podman 4.9.3 → 5.8.4 while keeping Ubuntu's stale system crun (< 1.14.3), which rejects the OCI runtime-spec v1.2.x `config.json` podman ≥ 5 writes (`crun: unknown version specified`). Every `podman run` in the image testinfra died at container start — [run 30528291013](https://github.com/vig-os/devkit/actions/runs/30528291013), 116/116 errors on the amd64 leg. Rollout is per-runner, so red is probabilistic until the fleet converges.
+
+`setup-env` now resolves crun from the flake dev-shell closure (the version nixpkgs pairs with podman 5.8.x, already pulled for the nix podman) and writes a rootless `containers.conf` drop-in pointing the `crun` runtime at that store path. Podman itself stays on the host path (#632 — rootless setuid newuidmap integration); only the OCI runtime it execs is pinned. The pairing is then governed by `flake.lock`, immune to runner-image drift, and backward-compatible with older host podman. If no crun is found in the closure the step warns and keeps the host runtime (no behavior change).
+
+## Verification
+
+No unit-test surface (devkit-internal composite action, not a scaffolded asset). Verified by this PR's own CI: the `Image Tests` job runs the same `test-image` → `setup-env` → `podman run` path, and the step log now prints the pinned crun version. Post-merge, the dev push triggers the full Nix Image (discovery) build + testinfra on both arches.
+
+Refs: #1299
+
+
+---
+---
+
+## Commits
+
+### Commit 1: [f58d4d6](https://github.com/vig-os/devkit/commit/f58d4d6177f7d28ad9ad9f2bd1d5788616b3c214) by [c-vigo](https://github.com/c-vigo) on July 30, 2026 at 09:03 AM
+ci(actions): pin podman OCI runtime to the flake's crun in setup-env, 24 files modified (.github/actions/setup-env/action.yml)

--- a/docs/pull-requests/pr-1301.md
+++ b/docs/pull-requests/pr-1301.md
@@ -1,0 +1,208 @@
+---
+type: pull_request
+state: open
+branch: release/1.5.0 → main
+created: 2026-07-30T09:22:38Z
+updated: 2026-07-30T11:50:48Z
+author: vig-os-release-app[bot]
+author_url: https://github.com/vig-os-release-app[bot]
+url: https://github.com/vig-os/devkit/pull/1301
+comments: 1
+labels: none
+assignees: none
+milestone: none
+projects: none
+synced: 2026-07-30T11:51:55.055Z
+---
+
+# [PR 1301](https://github.com/vig-os/devkit/pull/1301) chore: release 1.5.0
+
+# [Release 1.5.0](https://github.com/vig-os/devkit/releases/tag/1.5.0) - 2026-07-30
+
+This PR prepares release 1.5.0 for merge to main.
+
+## [1.5.0](https://github.com/vig-os/devkit/releases/tag/1.5.0) - 2026-07-30
+
+### Added
+
+- **Self-polling devkit-upgrade workflow** ([#1296](https://github.com/vig-os/devkit/issues/1296))
+  - New managed `devkit-upgrade.yml` scaffolded into every consumer: a weekly
+    schedule (Monday, aligned with the Renovate window) polls devkit's public
+    `releases/latest` and, when this repo's `DEVKIT_VERSION` is behind, runs the
+    full-fidelity `install.sh --force` upgrade — the `.vig-os` pin, the
+    `flake.lock` `vigos` node and the whole scaffold move together, committed
+    inside the project shell so consumer hooks run — then opens the adoption PR.
+    `workflow_dispatch` takes an explicit `version` (final or rc) for the
+    release-train / lane-re-bump path.
+  - The version check is prerelease-aware: a consumer on an rc of a newer train
+    is never downgraded (no-op when current **or ahead**). Within a train the
+    adoption issue, branch and PR are reused across rc→rc→final, force-updated to
+    the latest bump.
+  - Two `.vig-os` knobs: `DEVKIT_AUTO_UPGRADE=false` disables the schedule only
+    (manual dispatch still works); `DEVKIT_UPGRADE_EXCLUDE` lists paths reset
+    before the adoption commit. The whole file opts out via the new
+    `devkit-upgrade` feature group (`DEVKIT_FEATURES_DISABLED`).
+  - Requires a dedicated GitHub App identity
+    ([#1302](https://github.com/vig-os/devkit/issues/1302)): the
+    `DEVKIT_UPGRADE_APP_ID` and `DEVKIT_UPGRADE_APP_PRIVATE_KEY` secrets feed a
+    per-run installation token minted in-workflow (the default `GITHUB_TOKEN`
+    cannot open a PR that triggers CI, and a static PAT is not supported —
+    user-bound, expiring, single-owner). The workflow fails fast with a clear
+    message when the secrets are absent, and the commit identity is configurable
+    and kept off the agent blocklist.
+- **Scaffold-drift CI gate (DEVKIT_DRIFT_CHECK)** ([#1295](https://github.com/vig-os/devkit/issues/1295))
+  - The scaffolded `ci.yml` gains a `scaffold-drift` job that re-runs the pinned
+    devkit version's scaffold over the checkout and fails a PR whose managed
+    files diverge from it — `DEVKIT_VERSION` bumped without re-scaffolding, or a
+    managed file hand-edited. A pin-only bump otherwise merges green. `*.project`
+    files and persisted `.vig-os` values are exempt by construction (the scaffold
+    never overwrites them), and `.gitignore`d files (e.g. `*.local`) are ignored.
+  - Mechanism: re-scaffold + `git diff` (the `install.sh --preview` report
+    classifies OVERWRITTEN by path existence, not content, so it cannot tell
+    drift from an up-to-date file). The job `docker run`s the in-image scaffold on
+    the host so a direnv/bare consumer (which resolves an empty container image)
+    is covered too; `resolve-toolchain` emits the all-modes image ref.
+  - Opt-out via the new `.vig-os` key `DEVKIT_DRIFT_CHECK` (`true` default,
+    `false` disables). It is a runtime gate — CI reads it through
+    `resolve-toolchain`'s `drift-check` output, so flipping it needs no
+    re-scaffold — and the value round-trips across `--force` upgrades. Runs on
+    PRs only (the ~1.5 GiB image pull); an invalid value fails the scaffold.
+
+- **Solo/private-repo adoption profile** ([#1285](https://github.com/vig-os/devkit/issues/1285))
+  - New `docs/SOLO_ADOPTION.md`: the one document a single-user, private repo
+    follows to adopt devkit without the team/traceability layer, expressed as a
+    combination of existing `.vig-os` knobs (`--mode`/`--workflow`,
+    `DEVKIT_FEATURES_DISABLED`, `DEVKIT_REFS_POLICY`). States what is kept (hook
+    stack, commit-msg validation, agent-identity enforcement, managed upgrade
+    path, justfiles, dev environment) as clearly as what is dropped, calls out
+    the `renovate` judgment call and forward-drift on upgrades, and cross-links
+    the adoption notes that trip solo adopters (#1280, #1281, #1283). Linked
+    from the README install section and `docs/MIGRATION.md`.
+
+- **Scaffold-time Refs policy knob (DEVKIT_REFS_POLICY)** ([#1282](https://github.com/vig-os/devkit/issues/1282))
+  - A new `.vig-os` manifest key drives the `Refs:`-line enforcement of both the
+    `validate-commit-msg` pre-commit hook and CI's `validate-commit-range` from a
+    single value: `chore-optional` (default — only `chore` may omit `Refs:`,
+    today's behavior), `optional` (any approved type may omit it), and `required`
+    (every type, `chore` included, must carry a `Refs:` line). Absent key => a
+    byte-identical scaffold; the value round-trips across `--force` upgrades.
+
+- **Preflight abort on non-main default branches** ([#1283](https://github.com/vig-os/devkit/issues/1283))
+  - Scaffolding assumes the default branch is `main` (the branch-name hook,
+    `ci.yml` and its workflow triggers all key off it). On a legacy `master`
+    repo the scaffold used to succeed silently, then block every subsequent
+    commit with a confusing hook error. `install.sh` now detects a non-`main`
+    default branch (via `origin/HEAD`, a best-effort `gh api` lookup, or the
+    local branch) and refuses **before** writing anything, printing the rename
+    recipe. A topic/`dev` branch of a repo that already has `main` proceeds
+    unchanged; `--preview` warns without aborting; `--skip-preflight` bypasses.
+
+- **Manifest-driven scaffold feature opt-outs (DEVKIT_FEATURES_DISABLED)** ([#1284](https://github.com/vig-os/devkit/issues/1284))
+  - New `.vig-os` key: a comma-separated, whitespace-tolerant list of scaffold
+    feature groups a repo opts out of. Disabled groups are never scaffolded,
+    pruned if a prior scaffold left them, reported by `--preview`, and stable
+    across `--force` upgrades; clearing the key re-ships them. Absent/empty
+    scaffolds identically to before; an unknown name aborts loudly.
+  - Seven groups: `release` (the release/prepare/promote workflows + downstream
+    docs), `renovate` (renovate config + changelog workflows), `sync-issues`
+    (the sync workflow + label taxonomy), `scanning` (CodeQL + Scorecard),
+    `gh-templates` (issue templates + PR template), `skills` (every
+    `.claude/skills/` dir except `worktree_*`), and `worktree` (the
+    `worktree_*` skills + `justfile.worktree`).
+  - Consumer-owned extension seams (`release-extension.yml`,
+    `prepare-release-extension.yml`) and `renovate.json` are never pruned when
+    their feature is disabled — they are left in place with a notice.
+
+### Fixed
+
+- **`just test` no longer fails a Python repo with zero collected tests** ([#1281](https://github.com/vig-os/devkit/issues/1281))
+  - The scaffolded `justfile.project` `test`/`test-cov` recipes gate on
+    `pyproject.toml` presence, so a consumer with a `pyproject.toml` but no test
+    suite ran `uv run pytest` → exit 5 ("no tests collected") → red `just test`
+    and red CI out of the box. Both recipes now treat pytest's exit 5 as a green
+    no-op — "nothing to test" is not a failure, matching how non-Python
+    consumers silently skip — while every other nonzero exit still fails. This
+    is a template-only change; preserved consumer copies of `justfile.project`
+    keep their own recipes (the #877 repair only appends missing ones).
+
+- **Undotted `typos.toml` no longer collides with the template `.typos.toml`** ([#1280](https://github.com/vig-os/devkit/issues/1280))
+  - The `typos` tool reads config from `.typos.toml`, `_typos.toml`, or the
+    undotted `typos.toml`. The scaffold guarded the first two (a preserved
+    `.typos.toml` via the preserve list; a legacy `_typos.toml` via a copy-time
+    exclude) but not the undotted spelling, so a consumer carrying `typos.toml`
+    also received the template `.typos.toml` — two active configs, the curated
+    allowlist silently shadowed. An undotted `typos.toml` (with no `.typos.toml`)
+    is now treated exactly like the legacy `_typos.toml` case: the consumer file
+    stays the single active config, the template copy is not shipped, and the
+    skip is mirrored in `--preview` and named in the scaffold surface message.
+
+- **sync-issues cache cleanup no longer silently skips on early job failure** ([#1278](https://github.com/vig-os/devkit/issues/1278))
+  - The `if: always()` "Delete old cache" step calls the `retry` shim, which
+    only exists after toolchain setup. When the job died beforehand the shim
+    was absent and the `retry ... | head -1` assignment masked the
+    `command not found`, so the step took the "No cache found" branch. A
+    one-shot fallback shim now runs a single unretried attempt when `retry` is
+    missing; healthy runs still use the real wrapper.
+
+### Security
+
+- **Route the sync-issues bootstrap step's target input through env, not inline** ([#1279](https://github.com/vig-os/devkit/issues/1279))
+  - The scaffolded `sync-issues.yml` "Bootstrap sync target branch if absent"
+    step (rendered only when `DEVKIT_SYNC_TARGET` is set) interpolated the
+    `workflow_dispatch` `target-branch` input straight into its `run:` block,
+    which `zizmor` flags as a template-injection (High). The input is now
+    forwarded via a `TARGET_INPUT` env var and referenced as a shell parameter
+    expansion (`TARGET="${TARGET_INPUT:-<target>}"`), matching the template's
+    existing `TARGET_BRANCH` pattern; the allowlist-validated scaffold default
+    stays the safe literal fallback. First consumer hit: vig-os/org-config#80,
+    which carried a local forward-port of this fix until the template shipped it.
+
+- **Advance the nixpkgs pin and drop the propagated vulnix exception blocks** ([#1273](https://github.com/vig-os/devkit/issues/1273))
+  - Advanced the pinned `nixpkgs` rev (`flake.lock`) from nixos-26.05
+    @ `34268251` (2026-06-22) to @ `8623c4c2` (2026-07-26). The before/after
+    `vulnix` closure diff cut the reported CVE surface from 112 to 56 unique
+    advisories with no new HIGH/CRITICAL (CVSS ≥ 7.0) findings.
+  - Dropped four `.vulnixignore` blocks whose fixes reached the pinned channel:
+    openssl 3.6.2 → 3.6.3 (10 CVEs), curl 8.20.0 → 8.21.0 (17 CVEs),
+    openssh 10.3p1 → 10.4p1 (CVE-2026-60002), and the jq CVE-2026-49839 entry
+    (jq 1.8.1 → 1.8.2). jq 1.8.2 surfaces three unrelated sub-7.0 advisories
+    (CVE-2026-33948, -39979, -44777) that are awareness-only and do not gate.
+  - Retained the unbound (1.25.1), gawk (5.4.0), podman (5.8.2), fzf (0.72.0)
+    and libssh2 (1.11.1) blocks — the rebuilt closure confirms those fixes have
+    still not propagated to the pinned channel; their re-verification notes were
+    refreshed to 2026-07-28 with the new pin context.
+
+
+
+---
+---
+
+# Comments (1)
+
+## [Comment #1](https://github.com/vig-os/devkit/pull/1301#issuecomment-5130430560) by [@c-vigo](https://github.com/c-vigo)
+
+_Posted on July 30, 2026 at 11:47 AM_
+
+### RC validation evidence — 1.5.0-rc2 (plan approved & executed 2026-07-30)
+
+**Phase 0–2 (automated train):** release-PR CI fully green pre-dispatch (hard rule); rc2 release run green end-to-end (both-arch build+testinfra, vulnix gate, publish/SBOM, smoke dispatch); auto smoke chain green: deploy PR devkit-smoke-test#304 (Direnv Smoke PASS, **Scaffold Drift PASS** — #1295 green path live on a direnv consumer, auto-merged) → smoke release PR #305 green → smoke candidate Release run success. rc1's Publish failure was a transient CDN blip (same env green on 1.4.2; SBOM clean on rc2).
+
+**Phase 3 (image spot-checks):** nix 2.34.8 / uv / just / prek / en_US.UTF-8 sane; App-era `devkit-upgrade.yml` baked in scaffold assets; baked CHANGELOG shows 1.5.0; #1273 pin evidence exact: curl 8.21.0, OpenSSL 3.6.3.
+
+**Phase 4 (scaffold features, scratch consumers at rc2):**
+- #1283: `master`-default → refused **before writing anything**, rename recipe printed; `--preview` warns without aborting.
+- #1284: `release,scanning` disabled → groups absent; key cleared + `--force` → re-shipped; unknown group → loud abort listing valid groups.
+- #1282: `required` → chore w/o `Refs:` rejected; `optional` → feat w/o `Refs:` accepted, type validation still active; absent → chore-optional default. CI leg wired via `resolve-toolchain` runtime output.
+- #1280: undotted `typos.toml` stays the single active config, template withheld, named in scaffold output.
+- #1281: `just test` and `just test-cov` exit 0 on a zero-test Python consumer; genuine failures still fail.
+
+**Phase 4.5 (drift red path, live):** devkit-smoke-test#306 — hand-edited managed file → **Scaffold Drift FAIL**; `DEVKIT_DRIFT_CHECK=false` → job skipped, CI green (runtime opt-out, no re-scaffold). Closed unmerged.
+
+**Phase 4.6 (deferred, non-gating):** live `devkit-upgrade` dispatch runs post-finalize once smoke-test's own 1.5.0 release puts the workflow on its `main` (gitflow); App `vigos-devkit-upgrade` (id 4434545) + org secrets + installation already provisioned and verified.
+
+**Phase 5 (representative lane):** commit-action#122 (rc2 re-bump, adoption issue #121) — 15/15 green incl. **Scaffold Drift PASS on an upgraded consumer** and E2E Smoke; clean 6-file diff (pin, new knobs, drift gate, App-era upgrade workflow, sync-issues fixes, zizmor sync); `flake.lock` intentionally unchanged (floating input advances at promote).
+
+Verdict: all gating phases green → marking ready, approving per maintainer authorization, dispatching final release.
+
+---
+

--- a/docs/pull-requests/pr-1301.md
+++ b/docs/pull-requests/pr-1301.md
@@ -3,16 +3,16 @@ type: pull_request
 state: open
 branch: release/1.5.0 → main
 created: 2026-07-30T09:22:38Z
-updated: 2026-07-30T11:50:48Z
+updated: 2026-07-30T14:02:07Z
 author: vig-os-release-app[bot]
 author_url: https://github.com/vig-os-release-app[bot]
 url: https://github.com/vig-os/devkit/pull/1301
-comments: 1
+comments: 2
 labels: none
 assignees: none
 milestone: none
 projects: none
-synced: 2026-07-30T11:51:55.055Z
+synced: 2026-07-30T14:03:16.451Z
 ---
 
 # [PR 1301](https://github.com/vig-os/devkit/pull/1301) chore: release 1.5.0
@@ -115,6 +115,17 @@ This PR prepares release 1.5.0 for merge to main.
 
 ### Fixed
 
+- **`install.sh` prefers a responsive docker over podman in runtime auto-detection** ([#1305](https://github.com/vig-os/devkit/issues/1305))
+  - With both runtimes on PATH (GitHub `ubuntu-latest` runners), auto-detection
+    picked the preinstalled podman, whose stale system crun rejects podman ≥ 5's
+    OCI configs (`crun: unknown version specified`) — the first live
+    `devkit-upgrade` dispatch died at the install step on exactly this.
+    Detection now prefers docker when its daemon responds and falls back to
+    podman: podman-only hosts are unchanged, a dead docker daemon still yields
+    podman, and explicit `--docker`/`--podman` keep overriding. The
+    `devkit-upgrade.yml` template also passes `--docker` explicitly, so the
+    choice rides in the scaffold independent of the fetched installer.
+
 - **`just test` no longer fails a Python repo with zero collected tests** ([#1281](https://github.com/vig-os/devkit/issues/1281))
   - The scaffolded `justfile.project` `test`/`test-cov` recipes gate on
     `pyproject.toml` presence, so a consumer with a `pyproject.toml` but no test
@@ -177,7 +188,7 @@ This PR prepares release 1.5.0 for merge to main.
 ---
 ---
 
-# Comments (1)
+# Comments (2)
 
 ## [Comment #1](https://github.com/vig-os/devkit/pull/1301#issuecomment-5130430560) by [@c-vigo](https://github.com/c-vigo)
 
@@ -203,6 +214,20 @@ _Posted on July 30, 2026 at 11:47 AM_
 **Phase 5 (representative lane):** commit-action#122 (rc2 re-bump, adoption issue #121) — 15/15 green incl. **Scaffold Drift PASS on an upgraded consumer** and E2E Smoke; clean 6-file diff (pin, new knobs, drift gate, App-era upgrade workflow, sync-issues fixes, zizmor sync); `flake.lock` intentionally unchanged (floating input advances at promote).
 
 Verdict: all gating phases green → marking ready, approving per maintainer authorization, dispatching final release.
+
+---
+
+## [Comment #2](https://github.com/vig-os/devkit/pull/1301#issuecomment-5131786460) by [@c-vigo](https://github.com/c-vigo)
+
+_Posted on July 30, 2026 at 02:00 PM_
+
+### Restart addendum — rc3 (maintainer-approved unfreeze, #1305)
+
+Finalize was restarted before any external consumption (draft release + tags deleted, `latest`/`main`/promote untouched) to ship #1305 within 1.5.0: the first live devkit-upgrade dispatch exposed runtime auto-detection picking the runner's broken podman (`crun: unknown version specified") — fix merged via #1306 (dev) and pulled in via unfreeze PR #1307 (clean merge; changelog entry added; heading reset to TBD).
+
+**rc3 evidence:** release-PR CI fully green pre-dispatch (15 checks); rc3 release run green end-to-end; auto smoke chain green — deploy PR devkit-smoke-test#311 (CI + Direnv Smoke + auto-merge), smoke release PR + second Direnv Smoke green, smoke candidate Release run success. rc2→rc3 delta is #1305 only; all rc2 validation evidence above carries over. Post-finalize: `devkit-upgrade --ref dev version=1.5.0` dispatch completes the App-path live proof on the fixed template.
+
+Re-dispatching final.
 
 ---
 

--- a/docs/pull-requests/pr-1301.md
+++ b/docs/pull-requests/pr-1301.md
@@ -3,7 +3,7 @@ type: pull_request
 state: open
 branch: release/1.5.0 → main
 created: 2026-07-30T09:22:38Z
-updated: 2026-07-30T14:02:07Z
+updated: 2026-07-30T17:14:03Z
 author: vig-os-release-app[bot]
 author_url: https://github.com/vig-os-release-app[bot]
 url: https://github.com/vig-os/devkit/pull/1301
@@ -12,7 +12,7 @@ labels: none
 assignees: none
 milestone: none
 projects: none
-synced: 2026-07-30T14:03:16.451Z
+synced: 2026-07-30T17:15:06.890Z
 ---
 
 # [PR 1301](https://github.com/vig-os/devkit/pull/1301) chore: release 1.5.0
@@ -50,6 +50,14 @@ This PR prepares release 1.5.0 for merge to main.
     user-bound, expiring, single-owner). The workflow fails fast with a clear
     message when the secrets are absent, and the commit identity is configurable
     and kept off the agent blocklist.
+  - The published adoption commit is **GitHub-signed**
+    ([#1308](https://github.com/vig-os/devkit/issues/1308)): the in-shell commit
+    stays a staging artifact (hooks run, message validated) and its tree is
+    replayed through the git-data API with the App token — blobs → tree (with
+    explicit per-entry modes, so executable bits survive) → commit → ref, with
+    deletions as null-sha entries and a force-updated branch ref for the
+    within-train reuse semantics. Consumers' Signed-commits rulesets stay fully
+    enforced; no bypass actors are needed anywhere.
 - **Scaffold-drift CI gate (DEVKIT_DRIFT_CHECK)** ([#1295](https://github.com/vig-os/devkit/issues/1295))
   - The scaffolded `ci.yml` gains a `scaffold-drift` job that re-runs the pinned
     devkit version's scaffold over the checkout and fails a PR whose managed

--- a/docs/pull-requests/pr-1304.md
+++ b/docs/pull-requests/pr-1304.md
@@ -1,0 +1,50 @@
+---
+type: pull_request
+state: closed (merged)
+branch: bugfix/1302-devkit-upgrade-app-token → release/1.5.0
+created: 2026-07-30T09:58:37Z
+updated: 2026-07-30T10:20:08Z
+author: c-vigo
+author_url: https://github.com/c-vigo
+url: https://github.com/vig-os/devkit/pull/1304
+comments: 0
+labels: none
+assignees: none
+milestone: none
+projects: none
+merged: 2026-07-30T10:20:06Z
+synced: 2026-07-30T11:51:56.479Z
+---
+
+# [PR 1304](https://github.com/vig-os/devkit/pull/1304) feat(workflow): mint a GitHub App token in devkit-upgrade (App-only identity)
+
+## Summary
+
+Closes #1302 — the devkit-upgrade workflow (#1296, unreleased) now authenticates **exclusively** via a dedicated GitHub App: a per-run installation token is minted from the `DEVKIT_UPGRADE_APP_ID` + `DEVKIT_UPGRADE_APP_PRIVATE_KEY` secrets with SHA-pinned `actions/create-github-app-token` (the exact pattern devkit's own `prepare-release.yml` uses). The static `DEVKIT_UPGRADE_TOKEN` secret is removed with no fallback: a PAT is user-bound, expiring, and single-owner across the vig-os / exoma-ch / exo-pet consumer orgs.
+
+- Fail-fast step names both secrets and the required App permissions (contents, PRs, issues, workflows — all RW).
+- Checkout persists the minted token, so the scaffold push, adoption issue, and PR all act as the App and the PR triggers CI.
+- Changelog: the frozen `[1.5.0] - TBD` entry for #1296 is updated in place (unreleased section; `.devcontainer/CHANGELOG.md` copy synced by the hook).
+
+Targeted at `release/1.5.0`: #1296 has never shipped, so 1.5.0 ships App-only with zero migration debt.
+
+## Verification
+
+TDD: `test_requires_app_identity_and_never_uses_github_token_for_pr` rewritten first (RED at 0e3a57cc), template reworked to GREEN (15/15 in `tests/test_workflow_devkit_upgrade.py`); 278 bats ok incl. rendered-template actionlint; full pre-commit suite green. Live dispatch proof lands with the RC validation plan (App provisioning per #1302).
+
+Refs: #1302
+
+
+---
+---
+
+## Commits
+
+### Commit 1: [0e3a57c](https://github.com/vig-os/devkit/commit/0e3a57cc9251ca063c2649e4ae74f738c7f87fb8) by [c-vigo](https://github.com/c-vigo) on July 30, 2026 at 09:48 AM
+test(workflow): require App-only identity in devkit-upgrade template, 47 files modified (tests/test_workflow_devkit_upgrade.py)
+
+### Commit 2: [82a1e7c](https://github.com/vig-os/devkit/commit/82a1e7c6b80648e3cf4ae7c347f373fb3f8138b9) by [c-vigo](https://github.com/c-vigo) on July 30, 2026 at 09:54 AM
+feat(workflow): mint a GitHub App token in devkit-upgrade (App-only identity), 63 files modified (CHANGELOG.md, assets/workspace/.devcontainer/CHANGELOG.md, assets/workspace/.github/workflows/devkit-upgrade.yml)
+
+### Commit 3: [813bf4f](https://github.com/vig-os/devkit/commit/813bf4fdf5768d78a932156b6162e389a2264c56) by [c-vigo](https://github.com/c-vigo) on July 30, 2026 at 10:10 AM
+fix(workflow): scope the minted devkit-upgrade App token (zizmor github-app), 17 files modified (assets/workspace/.github/workflows/devkit-upgrade.yml, tests/test_workflow_devkit_upgrade.py)

--- a/docs/pull-requests/pr-1306.md
+++ b/docs/pull-requests/pr-1306.md
@@ -1,0 +1,46 @@
+---
+type: pull_request
+state: closed (merged)
+branch: bugfix/1305-runtime-detection-docker-first → dev
+created: 2026-07-30T12:48:00Z
+updated: 2026-07-30T13:04:52Z
+author: c-vigo
+author_url: https://github.com/c-vigo
+url: https://github.com/vig-os/devkit/pull/1306
+comments: 0
+labels: none
+assignees: none
+milestone: none
+projects: none
+merged: 2026-07-30T13:04:49Z
+synced: 2026-07-30T14:03:20.411Z
+---
+
+# [PR 1306](https://github.com/vig-os/devkit/pull/1306) fix(install): prefer a responsive docker over podman in runtime auto-detection
+
+## Summary
+
+Closes #1305 — the first live `devkit-upgrade` dispatch ([smoke-test run 30543470753](https://github.com/vig-os/devkit-smoke-test/actions/runs/30543470753)) proved the whole App identity path (fail-fast, mint, adoption issue opened by `app/vigos-devkit-upgrade`) and then died in `install.sh`: runtime auto-detection picked the runner's preinstalled podman 5.8.4, whose stale system crun rejects podman ≥ 5 OCI configs (`crun: unknown version specified`) — the #1299 regression on the consumer side, where devkit's own `setup-env` crun pin doesn't apply.
+
+- `detect_runtime()` now prefers docker **when its daemon responds** (`docker info`), falling back to podman. Podman-only hosts (vigOS machines) are unchanged; a both-present host with a dead docker daemon still gets podman; explicit `--docker`/`--podman` keep overriding.
+- The `devkit-upgrade.yml` template passes `--docker` explicitly (the runner's first-class runtime; self-documenting).
+
+Delivery property: consumers fetch `install.sh` from `main`, so the detection fix heals **every existing scaffold** at the next promote with no re-scaffold; the next train's adoption dispatch doubles as the live proof of the workflow's remaining push/PR legs.
+
+## Verification
+
+TDD: stub-based bats (docker+podman on PATH → docker; dead docker daemon → podman) committed RED at 4885de4a, fix turns them GREEN; full `install.bats` 117 ok; template tests 15 passed; full pre-commit suite green.
+
+Refs: #1305
+
+
+---
+---
+
+## Commits
+
+### Commit 1: [4885de4](https://github.com/vig-os/devkit/commit/4885de4a053b8705bdc8624305f32bf4bde642a7) by [c-vigo](https://github.com/c-vigo) on July 30, 2026 at 12:45 PM
+test(install): pin docker-first runtime auto-detection with daemon probe, 45 files modified (tests/bats/install.bats)
+
+### Commit 2: [3872465](https://github.com/vig-os/devkit/commit/3872465962eb2b3ebc9c44df9a7c275ccb569482) by [c-vigo](https://github.com/c-vigo) on July 30, 2026 at 12:47 PM
+fix(install): prefer a responsive docker over podman in runtime auto-detection, 17 files modified (assets/workspace/.github/workflows/devkit-upgrade.yml, install.sh)

--- a/docs/pull-requests/pr-1307.md
+++ b/docs/pull-requests/pr-1307.md
@@ -1,0 +1,52 @@
+---
+type: pull_request
+state: closed (merged)
+branch: chore/unfreeze-1305 → release/1.5.0
+created: 2026-07-30T13:13:10Z
+updated: 2026-07-30T13:22:09Z
+author: c-vigo
+author_url: https://github.com/c-vigo
+url: https://github.com/vig-os/devkit/pull/1307
+comments: 0
+labels: none
+assignees: none
+milestone: none
+projects: none
+merged: 2026-07-30T13:22:07Z
+synced: 2026-07-30T14:03:18.555Z
+---
+
+# [PR 1307](https://github.com/vig-os/devkit/pull/1307) chore: unfreeze 1.5.0 — pull in #1305 (runtime auto-detection fix)
+
+## Summary
+
+Restart of the 1.5.0 finalization (maintainer-approved): the first live `devkit-upgrade` dispatch exposed #1305 (runtime auto-detection picks the runner's broken podman → `crun: unknown version specified` at the install step). Since nothing consumed the final (draft release deleted, tag deleted, `latest`/`main`/promote untouched), the fix ships **within 1.5.0** instead of a same-day 1.5.1.
+
+- Merge `dev` (PR #1306: docker-first daemon-probed detection + `--docker` in the upgrade template) into `release/1.5.0` — clean merge, App-era template keeps all #1302/#1304 content plus the new flag.
+- `prepare-changelog reset-version` restores the `- TBD` heading (finalize will re-stamp).
+- #1305 changelog entry added to the frozen 1.5.0 section (was missed in #1306 — dev's Unreleased stays empty since the fix ships here).
+
+Precedent: 1.4.0 unfreeze (PR #1215). After merge: rc3, focused revalidation (delta is #1305 only), re-approve, re-finalize.
+
+Refs: #1305
+
+
+---
+---
+
+## Commits
+
+### Commit 1: [4885de4](https://github.com/vig-os/devkit/commit/4885de4a053b8705bdc8624305f32bf4bde642a7) by [c-vigo](https://github.com/c-vigo) on July 30, 2026 at 12:45 PM
+test(install): pin docker-first runtime auto-detection with daemon probe, 45 files modified (tests/bats/install.bats)
+
+### Commit 2: [3872465](https://github.com/vig-os/devkit/commit/3872465962eb2b3ebc9c44df9a7c275ccb569482) by [c-vigo](https://github.com/c-vigo) on July 30, 2026 at 12:47 PM
+fix(install): prefer a responsive docker over podman in runtime auto-detection, 17 files modified (assets/workspace/.github/workflows/devkit-upgrade.yml, install.sh)
+
+### Commit 3: [bbc1454](https://github.com/vig-os/devkit/commit/bbc145454809a95e5424bf0c030e390084d9b4a8) by [c-vigo](https://github.com/c-vigo) on July 30, 2026 at 01:04 PM
+fix(install): prefer a responsive docker over podman in runtime auto-detection (#1306), 62 files modified (assets/workspace/.github/workflows/devkit-upgrade.yml, install.sh, tests/bats/install.bats)
+
+### Commit 4: [765bf43](https://github.com/vig-os/devkit/commit/765bf43f9dc3058956e24747ca09c3a09d61c28d) by [c-vigo](https://github.com/c-vigo) on July 30, 2026 at 01:11 PM
+chore: merge dev into release/1.5.0 (unfreeze for #1305), 62 files modified (assets/workspace/.github/workflows/devkit-upgrade.yml, install.sh, tests/bats/install.bats)
+
+### Commit 5: [1fbc109](https://github.com/vig-os/devkit/commit/1fbc10994cc4a52cb8d4a8d0e70fb36d9d61307f) by [c-vigo](https://github.com/c-vigo) on July 30, 2026 at 01:12 PM
+chore: restore TBD heading and add #1305 entry to the 1.5.0 changelog, 28 files modified (CHANGELOG.md, README.md, assets/workspace/.devcontainer/CHANGELOG.md)

--- a/docs/pull-requests/pr-1309.md
+++ b/docs/pull-requests/pr-1309.md
@@ -1,0 +1,48 @@
+---
+type: pull_request
+state: closed (merged)
+branch: feature/1308-verified-commits → release/1.5.0
+created: 2026-07-30T16:16:16Z
+updated: 2026-07-30T16:25:17Z
+author: c-vigo
+author_url: https://github.com/c-vigo
+url: https://github.com/vig-os/devkit/pull/1309
+comments: 0
+labels: none
+assignees: none
+milestone: none
+projects: none
+merged: 2026-07-30T16:25:15Z
+synced: 2026-07-30T17:15:08.272Z
+---
+
+# [PR 1309](https://github.com/vig-os/devkit/pull/1309) feat(workflow): publish the devkit-upgrade adoption commit via API (verified)
+
+## Summary
+
+Closes #1308 — third and final 1.5.0 restart item (maintainer-approved): the adoption commit that reaches consumers is now **GitHub-signed as the App**. The in-shell commit stays exactly as designed (hooks run, message validated) but becomes a staging artifact; its tree is replayed through the git-data API with the minted App token — blobs → tree → commit → ref.
+
+Design decisions:
+- **Inline REST, not commit-action**: v0.3.x `statSync`s every path (no deletions — the scaffold prunes files) and has no branch bootstrap; extending it would put a cross-repo TS release on the critical path. Follow-up candidate: teach commit-action deletions and migrate.
+- **Not `createCommitOnBranch`**: it drops executable modes; the tree API carries an explicit mode per entry (`100755` preserved).
+- Deletions = null-sha tree entries; branch ref created on first use and force-updated within a train (preserves rc→rc→final reuse).
+- `git push` is gone from the template; Signed-commits rulesets stay fully enforced with **zero bypass actors**.
+- Changelog: `- TBD` heading restored (re-finalize re-stamps); #1308 sub-bullet added under the #1296 entry.
+
+## Verification
+
+TDD: `test_publishes_a_verified_commit_via_api_not_git_push` RED at be910369 → GREEN (16/16); zizmor 1.25.2 clean; full pre-commit suite green. Live proof at rc4: pin-gap harness dispatch on devkit-smoke-test must yield an adoption PR whose commit shows **Verified** — the last unproven leg of the feature.
+
+Refs: #1308
+
+
+---
+---
+
+## Commits
+
+### Commit 1: [be91036](https://github.com/vig-os/devkit/commit/be91036945eccaace0368588705d75070777bd03) by [c-vigo](https://github.com/c-vigo) on July 30, 2026 at 04:13 PM
+test(workflow): pin API-published verified adoption commits (no git push), 31 files modified (tests/test_workflow_devkit_upgrade.py)
+
+### Commit 2: [74cf938](https://github.com/vig-os/devkit/commit/74cf9381406889b6095f0d66b7bc24dcf602208a) by [c-vigo](https://github.com/c-vigo) on July 30, 2026 at 04:15 PM
+feat(workflow): publish the devkit-upgrade adoption commit via API (verified), 92 files modified (CHANGELOG.md, README.md, assets/workspace/.devcontainer/CHANGELOG.md, assets/workspace/.github/workflows/devkit-upgrade.yml)

--- a/tests/test_workflow_devkit_upgrade.py
+++ b/tests/test_workflow_devkit_upgrade.py
@@ -10,9 +10,10 @@ release time. These tests pin the deliverable without executing the workflow:
   commit), both shipping empty;
 - the template carries the managed banner, both triggers, the public
   ``releases/latest`` version check with prerelease-aware compare, the dedicated
-  ``DEVKIT_UPGRADE_TOKEN`` (fail-fast when absent; never the default
-  ``GITHUB_TOKEN`` for the PR), the ``install.sh`` bootstrap and the
-  ``nix develop`` commit;
+  GitHub App identity (a per-run installation token minted from
+  ``DEVKIT_UPGRADE_APP_ID`` + ``DEVKIT_UPGRADE_APP_PRIVATE_KEY``, fail-fast when
+  absent; never the default ``GITHUB_TOKEN`` for the PR — #1302), the
+  ``install.sh`` bootstrap and the ``nix develop`` commit;
 - no ``run:`` block interpolates a dispatch input or event field directly
   (zizmor template-injection: every such value is routed through ``env:``);
 - the base branch is workflow-model aware (``dev`` gitflow / ``main`` trunk),
@@ -24,6 +25,7 @@ Refs: #1296
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import yaml
@@ -122,19 +124,42 @@ def test_version_compare_is_prerelease_aware() -> None:
     assert "prerelease" in text.lower()
 
 
-def test_requires_dedicated_token_and_never_uses_github_token_for_pr() -> None:
-    """A missing DEVKIT_UPGRADE_TOKEN fails fast; the PR uses the dedicated token."""
+def test_requires_app_identity_and_never_uses_github_token_for_pr() -> None:
+    """The GitHub App is the ONLY identity: a per-run installation token is
+    minted from DEVKIT_UPGRADE_APP_ID + DEVKIT_UPGRADE_APP_PRIVATE_KEY
+    (fail-fast when absent), and no static token secret remains (#1302)."""
     text = TEMPLATE.read_text(encoding="utf-8")
-    assert "secrets.DEVKIT_UPGRADE_TOKEN" in text
-    # A clear fail-fast guard when the secret is absent.
-    assert "DEVKIT_UPGRADE_TOKEN secret is not configured" in text
-    # The PR step authenticates gh with the dedicated token (not github.token),
-    # otherwise the created PR would not trigger CI.
+    assert "secrets.DEVKIT_UPGRADE_APP_ID" in text
+    assert "secrets.DEVKIT_UPGRADE_APP_PRIVATE_KEY" in text
+    # The static-secret path is gone entirely — App-only, no PAT fallback.
+    assert "DEVKIT_UPGRADE_TOKEN" not in text
+    # A clear fail-fast guard when either secret is absent.
+    assert "not configured" in text
     steps = _steps(text)
+    # A SHA-pinned create-github-app-token step mints the per-run token.
+    mint_steps = [
+        s for s in steps if "create-github-app-token" in str(s.get("uses", ""))
+    ]
+    assert mint_steps, "no create-github-app-token step found"
+    for s in mint_steps:
+        assert re.search(r"create-github-app-token@[0-9a-f]{40}", s["uses"]), (
+            "app-token action must be SHA-pinned"
+        )
+    # The PR step authenticates gh with the minted token (not github.token),
+    # otherwise the created PR would not trigger CI.
     pr_steps = [s for s in steps if "gh pr create" in str(s.get("run", ""))]
     assert pr_steps, "no PR-creating step found"
     for s in pr_steps:
-        assert s.get("env", {}).get("GH_TOKEN") == "${{ secrets.DEVKIT_UPGRADE_TOKEN }}"
+        assert s.get("env", {}).get("GH_TOKEN") == (
+            "${{ steps.app-token.outputs.token }}"
+        )
+    # Checkout persists the minted token so the push authenticates as the App.
+    checkout_steps = [s for s in steps if "actions/checkout" in str(s.get("uses", ""))]
+    assert checkout_steps, "no checkout step found"
+    for s in checkout_steps:
+        assert s.get("with", {}).get("token") == (
+            "${{ steps.app-token.outputs.token }}"
+        )
 
 
 def test_bootstraps_installsh_and_commits_in_project_shell() -> None:

--- a/tests/test_workflow_devkit_upgrade.py
+++ b/tests/test_workflow_devkit_upgrade.py
@@ -145,6 +145,16 @@ def test_requires_app_identity_and_never_uses_github_token_for_pr() -> None:
         assert re.search(r"create-github-app-token@[0-9a-f]{40}", s["uses"]), (
             "app-token action must be SHA-pinned"
         )
+        # Least-privilege mint (zizmor github-app audit): the token must be
+        # scoped to exactly the permissions the workflow exercises.
+        with_block = s.get("with", {})
+        for perm in (
+            "permission-contents",
+            "permission-pull-requests",
+            "permission-issues",
+            "permission-workflows",
+        ):
+            assert with_block.get(perm) == "write", f"missing {perm}: write"
     # The PR step authenticates gh with the minted token (not github.token),
     # otherwise the created PR would not trigger CI.
     pr_steps = [s for s in steps if "gh pr create" in str(s.get("run", ""))]

--- a/tests/test_workflow_devkit_upgrade.py
+++ b/tests/test_workflow_devkit_upgrade.py
@@ -172,6 +172,37 @@ def test_requires_app_identity_and_never_uses_github_token_for_pr() -> None:
         )
 
 
+def test_publishes_a_verified_commit_via_api_not_git_push() -> None:
+    """The adoption commit reaching the remote must be GitHub-signed (#1308):
+    the in-shell commit is a staging artifact, its tree is replayed through
+    the git-data API (blobs -> tree -> commit -> ref) with the App token, so
+    consumers' Signed-commits rulesets stay fully enforced — no bypasses."""
+    text = TEMPLATE.read_text(encoding="utf-8")
+    # The staging commit must never be pushed directly.
+    assert "git push" not in text
+    steps = _steps(text)
+    publish_steps = [s for s in steps if "git/commits" in str(s.get("run", ""))]
+    assert publish_steps, "no API publish step found"
+    (publish,) = publish_steps
+    run = str(publish["run"])
+    # Full git-data flow with the minted App token.
+    assert publish.get("env", {}).get("GH_TOKEN") == (
+        "${{ steps.app-token.outputs.token }}"
+    )
+    assert "git/blobs" in run
+    assert "git/trees" in run
+    assert "git/refs" in run
+    # Deletions are replayed as null-sha tree entries (the scaffold prunes
+    # files; commit-action v0.3.x cannot express this, hence inline REST).
+    assert "sha:null" in run.replace(" ", "")
+    # Executable bits survive the replay (createCommitOnBranch would drop
+    # them; the tree API carries an explicit mode per entry).
+    assert "100755" in run
+    # The branch ref is created on first use and force-updated within a train
+    # (rc -> rc -> final reuse semantics).
+    assert "force" in run
+
+
 def test_bootstraps_installsh_and_commits_in_project_shell() -> None:
     """The upgrade runs install.sh --force --version and commits inside nix develop."""
     text = TEMPLATE.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

The 1.5.1 re-cut (maintainer decision): devkit-smoke-test's tag \`1.5.0\` is tombstoned by org-enforced release immutability (its 1.5.0 was published mid-train and deleted during restart #1), so the cross-repo promote gate can never pass for 1.5.0. The fully validated content re-releases as **1.5.1**; 1.5.0 becomes a ghost (devkit's never-published tag + draft get deleted).

- Merges \`release/1.5.0\` back into dev — the sync promote would have performed: #1302/#1304 (App-only auth), #1305 tail, #1308/#1309 (verified API publish), release-branch changelog state.
- Changelog: empty finalize scaffold excised, dated 1.5.0 section unprepared back to \`## Unreleased\` so \`prepare-release 1.5.1\` freezes it.

All rc4 validation evidence (devkit#1301 evidence trail) applies verbatim — 1.5.1's content is byte-identical apart from the version string.

Refs: #1308