### PR TITLE
feat(workflow): detect smoke-tag immutability tombstone and fail with the real cause

### DIFF
--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -269,6 +269,13 @@ jobs:
               echo "$LAST_ERROR"
             fi
             echo "Wait for the smoke-test workflow to publish its final release, then retry."
+            echo ""
+            echo "EXCEPTION: if a PUBLISHED smoke-test release for $VERSION was deleted, waiting is"
+            echo "futile — release immutability permanently tombstones the tag name, so smoke-test"
+            echo "can never re-publish it (its release run fails with GH013 'creations restricted';"
+            echo "check the latest devkit-smoke-test release run for that signature). In that case"
+            echo "the version is burned — re-cut the content as the next patch version. See"
+            echo "docs/RELEASE_CYCLE.md: 'Restarting a Finalized Release — the Point of No Return'."
             exit 1
           fi
           IS_DRAFT=$(printf '%s' "$RELEASE_JSON" | jq -r '.draft')

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Tombstoned tag names fail with the real cause** ([#1319](https://github.com/vig-os/devkit/issues/1319))
+  - The downstream `release-publish.yml` template now recognizes the `GH013`
+    "creations restricted" signature on tag push and release creation — the mark
+    of a tag name permanently retired because its published release was deleted
+    under org-enforced immutability — and fails with a "version burned — re-cut
+    required" diagnosis instead of a generic push/create error.
+  - Devkit's `promote-release.yml` cross-repo gate no longer only advises
+    "wait and retry" when no downstream release exists: it names the tombstone
+    as a possible cause and points at the point-of-no-return runbook.
+
 ### Changed
 
 - **Release runbook: restart point of no return** ([#1318](https://github.com/vig-os/devkit/issues/1318))

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Tombstoned tag names fail with the real cause** ([#1319](https://github.com/vig-os/devkit/issues/1319))
+  - The downstream `release-publish.yml` template now recognizes the `GH013`
+    "creations restricted" signature on tag push and release creation — the mark
+    of a tag name permanently retired because its published release was deleted
+    under org-enforced immutability — and fails with a "version burned — re-cut
+    required" diagnosis instead of a generic push/create error.
+  - Devkit's `promote-release.yml` cross-repo gate no longer only advises
+    "wait and retry" when no downstream release exists: it names the tombstone
+    as a possible cause and points at the point-of-no-return runbook.
+
 ### Changed
 
 - **Release runbook: restart point of no return** ([#1318](https://github.com/vig-os/devkit/issues/1318))

--- a/assets/workspace/.github/workflows/release-publish.yml
+++ b/assets/workspace/.github/workflows/release-publish.yml
@@ -178,7 +178,18 @@ jobs:
           # Compose the actual tag name (prefix + bare publish version) (#1044).
           PUBLISH_TAG="${TAG_PREFIX}${PUBLISH_VERSION}"
           git tag -a "$PUBLISH_TAG" -m "Release $PUBLISH_TAG"
-          if ! retry --retries 3 --backoff 5 --max-backoff 30 -- git push origin "$PUBLISH_TAG"; then
+          if ! PUSH_OUTPUT=$(retry --retries 3 --backoff 5 --max-backoff 30 -- git push origin "$PUBLISH_TAG" 2>&1); then
+            printf '%s\n' "$PUSH_OUTPUT"
+            # A tag name whose published release was deleted under release
+            # immutability is permanently retired; pushing it is rejected with
+            # GH013 and no retry or wait can ever succeed.
+            if printf '%s' "$PUSH_OUTPUT" | grep -Eqi "GH013|creations restricted"; then
+              echo "ERROR: Tag name $PUBLISH_TAG is tombstoned by release immutability:"
+              echo "a published GitHub Release for this tag was deleted, permanently retiring the name."
+              echo "This version is burned — re-cut the content as the next patch version."
+              echo "See https://github.com/vig-os/devkit/blob/main/docs/RELEASE_CYCLE.md ('Restarting a Finalized Release — the Point of No Return')."
+              exit 1
+            fi
             if retry --retries 3 --backoff 5 --max-backoff 30 -- git ls-remote --tags --refs origin "$PUBLISH_TAG" | grep -q "refs/tags/$PUBLISH_TAG$"; then
               LOCAL_TAG_TARGET_SHA=$(git rev-parse "$PUBLISH_TAG^{}")
               REMOTE_TAG_TARGET_SHA=$(retry --retries 3 --backoff 5 --max-backoff 30 -- git ls-remote --tags origin "refs/tags/$PUBLISH_TAG^{}" | awk '{print $1}')
@@ -243,19 +254,25 @@ jobs:
             echo "ERROR: Published (non-draft) GitHub Release already exists for tag $PUBLISH_TAG"
             exit 1
           fi
+          CREATE_ARGS=(--title "$PUBLISH_TAG" --notes-file /tmp/release-notes.md --verify-tag --draft)
           if [ "$RELEASE_KIND" = "candidate" ]; then
-            retry --retries 3 --backoff 5 --max-backoff 30 -- gh release create "$PUBLISH_TAG" \
-              --title "$PUBLISH_TAG" \
-              --notes-file /tmp/release-notes.md \
-              --verify-tag \
-              --draft \
-              --prerelease
-          else
-            retry --retries 3 --backoff 5 --max-backoff 30 -- gh release create "$PUBLISH_TAG" \
-              --title "$PUBLISH_TAG" \
-              --notes-file /tmp/release-notes.md \
-              --verify-tag \
-              --draft
+            CREATE_ARGS+=(--prerelease)
+          fi
+          if ! CREATE_OUTPUT=$(retry --retries 3 --backoff 5 --max-backoff 30 -- gh release create "$PUBLISH_TAG" "${CREATE_ARGS[@]}" 2>&1); then
+            printf '%s\n' "$CREATE_OUTPUT"
+            # A tag name whose published release was deleted under release
+            # immutability is retired forever: release creation for it fails
+            # with GH013 and no retry or wait can ever succeed.
+            if printf '%s' "$CREATE_OUTPUT" | grep -Eqi "GH013|creations restricted"; then
+              echo "ERROR: Tag name $PUBLISH_TAG is tombstoned by release immutability:"
+              echo "a published GitHub Release for this tag was deleted, permanently retiring the name."
+              echo "This version is burned — re-cut the content as the next patch version."
+              echo "See https://github.com/vig-os/devkit/blob/main/docs/RELEASE_CYCLE.md ('Restarting a Finalized Release — the Point of No Return')."
+            fi
+            exit 1
+          fi
+          printf '%s\n' "$CREATE_OUTPUT"
+          if [ "$RELEASE_KIND" = "final" ]; then
             echo "Draft GitHub Release created; publish from ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/releases when review is complete."
           fi
 

--- a/tests/test_release_tombstone_detection.py
+++ b/tests/test_release_tombstone_detection.py
@@ -1,0 +1,83 @@
+"""Workflow-shape test: tombstoned tag names fail with the real cause.
+
+Issue #1319 (lesson from the 1.5.0 ghost, #1301): with org-enforced release
+immutability, deleting a *published* GitHub Release permanently retires
+(tombstones) its tag name — re-creating the tag or a release for it fails with
+``GH013: ... creations restricted``. Two workflow surfaces previously reported
+this state misleadingly:
+
+- the downstream ``release-publish.yml`` template died with a generic
+  "Failed to push tag" / raw ``gh`` error, hiding that the version is burned;
+- devkit's ``promote-release.yml`` cross-repo gate said "wait for the
+  smoke-test workflow to publish its final release, then retry" — futile
+  advice when the smoke tag is tombstoned and can never be re-published.
+
+This pins the detection: the publish steps must recognize the GH013 signature
+and fail with a "version burned — re-cut required" diagnosis, and the gate's
+no-downstream-release error must name the tombstone as a possible cause. The
+live GH013 path is only provable on a real tombstone, so these tests assert
+the script shape, not the choreography.
+
+Refs: #1319
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+TEMPLATE_WORKFLOWS = REPO_ROOT / "assets" / "workspace" / ".github" / "workflows"
+DEVKIT_WORKFLOWS = REPO_ROOT / ".github" / "workflows"
+
+
+def _load(path: Path) -> dict:
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def _step_run(workflow_path: Path, job: str, step_name: str) -> str:
+    workflow = _load(workflow_path)
+    steps = workflow["jobs"][job]["steps"]
+    step = next(s for s in steps if s.get("name") == step_name)
+    return step["run"]
+
+
+def _publish_step_run(step_name: str) -> str:
+    workflow = _load(TEMPLATE_WORKFLOWS / "release-publish.yml")
+    (job,) = workflow["jobs"].values()
+    step = next(s for s in job["steps"] if s.get("name") == step_name)
+    return step["run"]
+
+
+def test_tag_push_detects_tombstone() -> None:
+    """A GH013-rejected tag push is diagnosed as a tombstone, not a generic failure."""
+    run = _publish_step_run("Create and push tag")
+    assert "GH013" in run
+    assert "creations restricted" in run
+    assert "burned" in run
+
+
+def test_release_create_detects_tombstone() -> None:
+    """A GH013-rejected release create is diagnosed as a tombstone."""
+    run = _publish_step_run("Create GitHub Release")
+    assert "GH013" in run
+    assert "burned" in run
+
+
+def test_tombstone_diagnosis_points_at_runbook() -> None:
+    """The burned-version diagnosis points at the point-of-no-return runbook."""
+    run = _publish_step_run("Create and push tag")
+    assert "Point of No Return" in run
+
+
+def test_promote_gate_names_tombstone_cause() -> None:
+    """The cross-repo gate's no-release error names the tombstone as a cause."""
+    run = _step_run(
+        DEVKIT_WORKFLOWS / "promote-release.yml",
+        "validate",
+        "Verify downstream published final release",
+    )
+    assert "tombstone" in run
+    assert "GH013" in run
+    assert "burned" in run


### PR DESCRIPTION
## Description

Lesson from the 1.5.0 ghost (#1301): under org-enforced release immutability, deleting a *published* release permanently tombstones its tag name. The workflows reported this state misleadingly — the downstream publish died with a generic "Failed to push tag" / raw `gh` error, and devkit's promote gate advised "wait for the smoke-test workflow to publish its final release, then retry", which is futile when the tag can never be re-published. This PR makes both surfaces name the real cause: **version burned — re-cut required**.

> **Stacked on #1320** (branched from `feature/1318-unfreeze-runbook` to avoid a CHANGELOG conflict; merge #1320 first, after which this PR shows only its own diff). The error messages point at the runbook section #1320 adds.

## Type of Change

- [x] `feat` -- New feature

## Changes Made

- `assets/workspace/.github/workflows/release-publish.yml` (template, ships to consumers incl. `devkit-smoke-test`):
  - **Create and push tag**: the push output is captured; a `GH013` / "creations restricted" rejection is diagnosed as a tombstoned tag name with a burned-version message and runbook URL, instead of falling through to the generic push error.
  - **Create GitHub Release**: the two `gh release create` branches (identical except `--prerelease`) are folded into one args-array invocation whose failure output gets the same `GH013` diagnosis.
- `.github/workflows/promote-release.yml` (devkit): the cross-repo gate's no-downstream-release error now names the tombstone as a possible cause (with the `GH013` signature to look for in the smoke-test release run) and points at the runbook. The gate itself cannot distinguish a tombstone from a not-yet-published draft — both are a 404 on `/releases/tags/:tag` — which is why the authoritative detection lives at the creation sites.
- New workflow-shape test `tests/test_release_tombstone_detection.py` (RED committed first per TDD) pinning the `GH013` detection in both template steps and the gate message.

## Changelog Entry

### Added

- **Tombstoned tag names fail with the real cause** ([#1319](https://github.com/vig-os/devkit/issues/1319))
  - The downstream `release-publish.yml` template now recognizes the `GH013` "creations restricted" signature on tag push and release creation — the mark of a tag name permanently retired because its published release was deleted under org-enforced immutability — and fails with a "version burned — re-cut required" diagnosis instead of a generic push/create error.
  - Devkit's `promote-release.yml` cross-repo gate no longer only advises "wait and retry" when no downstream release exists: it names the tombstone as a possible cause and points at the point-of-no-return runbook.

## Testing

- [x] `tests/test_release_tombstone_detection.py`: 4 failing tests committed first (RED), all green after implementation
- [x] Workflow-shape + scaffold suites green: `test_release_tag_prefix`, `test_promote_mergeability`, `test_scaffold_lint` (caught an unshipped-path reference — doc pointer rewritten to absolute URL), `test_scaffold_drift`, `test_workflow_model`, `test_floating_tags`, `test_release_core_*`, `test_transforms` — 135 passed
- [x] Rendered-workflow actionlint bats (#995): all 5 modes green (devcontainer/direnv/bare/both/smoke-test), incl. bundled shellcheck over the new run-block bash
- [x] `just precommit` green on all files

### Manual Testing Details

The live `GH013` path is only provable on a real tombstone; the tests pin the script shape. The template change reaches `devkit-smoke-test` at the next devkit release + re-scaffold, so it ships dormant until then.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have updated the documentation accordingly (runbook lands in #1320)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

Devkit's own `release.yml` tag push (`release.yml:982`) has the same theoretical exposure, but devkit's 1.5.0 draft was never published so it was not tombstoned in the incident; left out per issue scope — can file a follow-up if wanted.

Closes #1319

Refs: #1319

https://claude.ai/code/session_01MiPJmV8hXX6RPiggZAMZwg