### PR TITLE
chore(ci): point renovate preset extends at vig-os/devkit slug

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "github>vig-os/devcontainer//assets/workspace/.github/renovate-default"
+    "github>vig-os/devkit//assets/workspace/.github/renovate-default"
   ],
   "enabledManagers": ["github-actions", "pep621", "npm", "nix", "custom.regex"],
   "customManagers": [


### PR DESCRIPTION
## Description

Devkit's root `renovate.json` still extended the shared preset via the pre-rename repo slug (`github>vig-os/devcontainer//...`), working only through GitHub's rename redirect (#781). This points it at the current slug, `github>vig-os/devkit//...`, removing the silent-breakage risk if the old name is ever reclaimed.

## Type of Change

- [x] `chore` -- Maintenance task (deps, config, etc.)

## Changes Made

- `renovate.json`: `extends` preset reference updated `vig-os/devcontainer` → `vig-os/devkit`. One line; nothing else touched.
- Repo-wide audit of remaining `vig-os/devcontainer` hits performed and classified (image-name references are the GHCR image's real name and stay; other repo-slug references — flake-template URLs, docs prose, test fixtures — are listed on the issue as follow-up candidates, out of scope here).

## Changelog Entry

No changelog needed -- internal CI configuration chore with no user-visible impact (root `renovate.json` is devkit-own, not a shipped asset).

## Testing

- [x] Tests pass locally (`prek run --all-files` green, both hook groups)
- [x] Manual testing performed (describe below)

### Manual Testing Details

- `renovate-config-validator` is not available offline (renovate is not an npm dependency of this repo); JSON well-formedness verified, and the repo's `renovate-validate` workflow covers validation in CI.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

TDD skipped: non-testable one-line config change.

Closes #1333

Refs: #1333
