### PR TITLE
feat(workspace): exclude devkit-managed workflows from consumer renovate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Consumer Renovate ignores devkit-managed workflows and actions** ([#1332](https://github.com/vig-os/devkit/issues/1332))
+  - The shipped preset (`.github/renovate-default.json`) now disables Renovate
+    for the managed workflow set and the two managed composite actions
+    (`setup-devkit-toolchain`, `resolve-toolchain`) via a trailing
+    `enabled: false` packageRule. Their SHA-pinned action digests advance
+    upstream in devkit and ship with each release, so downstream Renovate no
+    longer opens duplicate pin-bump PRs that the next `devkit-upgrade` clobbers.
+  - The rule is last, so a consumer can opt a specific managed file back in from
+    their preserved `renovate.json` (later rules win). Devkit's own root
+    `renovate.json` re-enables its root workflows/actions so devkit keeps
+    advancing the pins it owns.
 - **Renovate: update `aquasecurity/trivy` from `v0.72.0` to `v0.73.0`** ([#1331](https://github.com/vig-os/devkit/pull/1331))
 - **Renovate: update `github-backup` from `==0.65.0` to `==0.65.1`** ([#1324](https://github.com/vig-os/devkit/pull/1324))
 - **Release runbook: restart point of no return** ([#1318](https://github.com/vig-os/devkit/issues/1318))

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -21,6 +21,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Consumer Renovate ignores devkit-managed workflows and actions** ([#1332](https://github.com/vig-os/devkit/issues/1332))
+  - The shipped preset (`.github/renovate-default.json`) now disables Renovate
+    for the managed workflow set and the two managed composite actions
+    (`setup-devkit-toolchain`, `resolve-toolchain`) via a trailing
+    `enabled: false` packageRule. Their SHA-pinned action digests advance
+    upstream in devkit and ship with each release, so downstream Renovate no
+    longer opens duplicate pin-bump PRs that the next `devkit-upgrade` clobbers.
+  - The rule is last, so a consumer can opt a specific managed file back in from
+    their preserved `renovate.json` (later rules win). Devkit's own root
+    `renovate.json` re-enables its root workflows/actions so devkit keeps
+    advancing the pins it owns.
 - **Renovate: update `aquasecurity/trivy` from `v0.72.0` to `v0.73.0`** ([#1331](https://github.com/vig-os/devkit/pull/1331))
 - **Renovate: update `github-backup` from `==0.65.0` to `==0.65.1`** ([#1324](https://github.com/vig-os/devkit/pull/1324))
 - **Release runbook: restart point of no return** ([#1318](https://github.com/vig-os/devkit/issues/1318))

--- a/assets/workspace/.github/renovate-default.json
+++ b/assets/workspace/.github/renovate-default.json
@@ -64,6 +64,27 @@
       "matchDepTypes": ["dependencies"],
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "npm (minor and patch)"
+    },
+    {
+      "description": "Devkit-managed workflows and composite actions are regenerated wholesale on every devkit upgrade, so their SHA-pinned action digests are advanced upstream by devkit's own Renovate and shipped with each devkit release — never here. Disabling them stops duplicate/clobbering pin-bump PRs in consumer repos. This rule is intentionally last so a consumer's own later packageRules (in their preserved renovate.json) win: a consumer that wants to manage a specific managed file can re-enable it there. Refs vig-os/devkit#1332.",
+      "matchFileNames": [
+        ".github/workflows/ci.yml",
+        ".github/workflows/codeql.yml",
+        ".github/workflows/devkit-upgrade.yml",
+        ".github/workflows/prepare-release.yml",
+        ".github/workflows/promote-release.yml",
+        ".github/workflows/release-core.yml",
+        ".github/workflows/release-publish.yml",
+        ".github/workflows/release.yml",
+        ".github/workflows/renovate-changelog-build.yml",
+        ".github/workflows/renovate-changelog-commit.yml",
+        ".github/workflows/scorecard.yml",
+        ".github/workflows/sync-issues.yml",
+        ".github/workflows/sync-main-to-dev.yml",
+        ".github/actions/setup-devkit-toolchain/**",
+        ".github/actions/resolve-toolchain/**"
+      ],
+      "enabled": false
     }
   ]
 }

--- a/docs/WORKFLOW_SECURITY.md
+++ b/docs/WORKFLOW_SECURITY.md
@@ -67,3 +67,51 @@ zizmor audit surfaces, update `zizmor.yml` (or fix the workflow) in the same PR.
 The zizmor version in the CI gate is pinned deliberately: a floating version
 would let a newly-released audit break CI unpredictably, so version bumps are an
 explicit, reviewed change that re-baselines any new findings at the same time.
+
+## Dependency maintenance for managed files (Renovate)
+
+The managed workflows and the two managed composite actions
+(`.github/actions/setup-devkit-toolchain`, `.github/actions/resolve-toolchain`)
+carry SHA-pinned third-party `uses:`. Because these files are devkit-owned and
+regenerated wholesale on every `devkit-upgrade`, **their dependency maintenance
+sits upstream in devkit, not in the consumer.** Devkit's own Renovate advances
+the digests and ships them with each release; the consumer picks them up on the
+next upgrade.
+
+To stop consumers from opening duplicate pin-bump PRs against files the next
+upgrade clobbers, the shipped preset
+([`assets/workspace/.github/renovate-default.json`](../assets/workspace/.github/renovate-default.json))
+ends with an `enabled: false` `packageRule` naming exactly the managed set (all
+shipped workflows **minus** the consumer-owned seams `release-extension.yml` and
+`prepare-release-extension.yml`, plus the two managed action directories). The
+enumeration is drift-gated by
+[`tests/test_renovate_preset_managed_exclusion.py`](../tests/test_renovate_preset_managed_exclusion.py)
+so a new or renamed managed workflow cannot silently reopen the gap.
+
+Accepted trade-off: disabling updates for managed files also suppresses
+Renovate's vulnerability PRs for those pins downstream. This is consistent with
+the doctrine that devkit is the patch channel for managed files — an emergency
+hand-bump downstream still works, and the next upgrade re-converges.
+
+**Opting back in.** The exclusion is the *last* rule in the preset, so a
+consumer's own later `packageRules` win. A consumer that deliberately wants to
+manage a specific managed file adds a re-enabling rule to its preserved root
+`renovate.json`, for example:
+
+```json
+{
+  "packageRules": [
+    {
+      "description": "Manage pins in this workflow locally despite the devkit preset",
+      "matchFileNames": [".github/workflows/ci.yml"],
+      "enabled": true
+    }
+  ]
+}
+```
+
+Devkit itself uses exactly this mechanism: it extends the same preset, so its
+root `renovate.json` re-enables `.github/workflows/**` and `.github/actions/**`
+to keep advancing the pins it owns (the shipped copies under `assets/workspace/`
+are unaffected — the preset's rooted `matchFileNames` globs do not match nested
+paths).

--- a/renovate.json
+++ b/renovate.json
@@ -30,6 +30,11 @@
       "matchDepNames": ["pip-licenses"],
       "semanticCommitType": "build",
       "semanticCommitScope": "nix"
+    },
+    {
+      "description": "Re-enable Renovate for devkit's OWN root workflows and composite actions. The extended preset (renovate-default) disables the managed set by rooted path so consumers stop bumping devkit-owned pins; devkit is the source of those files, so it must keep advancing them here. This rule merges after the preset's and wins; it is last so nothing shadows it. Refs #1332.",
+      "matchFileNames": [".github/workflows/**", ".github/actions/**"],
+      "enabled": true
     }
   ]
 }

--- a/tests/test_renovate_preset_managed_exclusion.py
+++ b/tests/test_renovate_preset_managed_exclusion.py
@@ -1,0 +1,108 @@
+"""Drift gate: the shipped renovate preset disables the managed workflow set.
+
+Issue #1332: consumers scaffolded by devkit ran Renovate's ``github-actions``
+manager over the devkit-**managed** workflows and composite actions, opening
+duplicate/clobbering pin-bump PRs for files the next ``devkit-upgrade``
+regenerates wholesale. The shipped preset
+(``assets/workspace/.github/renovate-default.json``) now carries a trailing
+``enabled: false`` packageRule covering exactly the managed set; devkit's own
+root ``renovate.json`` re-enables its root paths with a later ``enabled: true``
+rule (the extending config's rules merge after the preset's and win).
+
+These tests pin the enumeration without invoking Renovate: the disabled list is
+derived from the shipped workflow directory minus the ``PRESERVE_FILES`` seams
+(SSoT in ``assets/init-workspace.sh``) plus the two managed composite actions, so
+adding or renaming a managed workflow cannot silently reopen the gap.
+
+Refs: #1332
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PRESET = REPO_ROOT / "assets" / "workspace" / ".github" / "renovate-default.json"
+ROOT_RENOVATE = REPO_ROOT / "renovate.json"
+MANAGED_WORKFLOWS = REPO_ROOT / "assets" / "workspace" / ".github" / "workflows"
+INIT_WORKSPACE = REPO_ROOT / "assets" / "init-workspace.sh"
+
+# The managed composite actions that carry SHA-pinned third-party `uses:` and
+# are regenerated on upgrade like the workflows.
+MANAGED_ACTION_GLOBS = {
+    ".github/actions/setup-devkit-toolchain/**",
+    ".github/actions/resolve-toolchain/**",
+}
+
+
+def _load_preserve_files() -> set[str]:
+    """Reuse the SSoT parser in scripts/sync_manifest.py (PRESERVE_FILES)."""
+    scripts_dir = REPO_ROOT / "scripts"
+    if str(REPO_ROOT) not in sys.path:
+        sys.path.insert(0, str(REPO_ROOT))
+    spec = importlib.util.spec_from_file_location(
+        "sync_manifest", scripts_dir / "sync_manifest.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["sync_manifest"] = module
+    spec.loader.exec_module(module)
+    return module.load_preserve_files(INIT_WORKSPACE)
+
+
+def _package_rules(path: Path) -> list[dict]:
+    return json.loads(path.read_text(encoding="utf-8"))["packageRules"]
+
+
+def _expected_managed_filenames() -> set[str]:
+    """Managed workflows (dir listing minus preserved seams) + managed actions."""
+    preserve_files = _load_preserve_files()
+    preserved_workflow_names = {
+        Path(rel).name for rel in preserve_files if rel.startswith(".github/workflows/")
+    }
+    shipped = {p.name for p in MANAGED_WORKFLOWS.iterdir() if p.is_file()}
+    managed = shipped - preserved_workflow_names
+    return {f".github/workflows/{name}" for name in managed} | MANAGED_ACTION_GLOBS
+
+
+def test_preset_disables_exactly_the_managed_set() -> None:
+    """The preset's trailing enabled:false rule covers exactly the managed set."""
+    rules = _package_rules(PRESET)
+    disabled = [r for r in rules if r.get("enabled") is False and "matchFileNames" in r]
+    assert len(disabled) == 1, (
+        "expected exactly one enabled:false matchFileNames rule in the preset, "
+        f"found {len(disabled)}"
+    )
+    rule = disabled[0]
+    assert set(rule["matchFileNames"]) == _expected_managed_filenames()
+
+
+def test_preset_disable_rule_is_last() -> None:
+    """Ordering is load-bearing: the exclusion must be the final preset rule.
+
+    Renovate merges packageRules in order and a consumer's own later rules win,
+    so the exclusion must sit last in the preset for the consumer opt-back-in
+    (and devkit's own root re-enable) to override it.
+    """
+    rules = _package_rules(PRESET)
+    last = rules[-1]
+    assert last.get("enabled") is False and "matchFileNames" in last
+
+
+def test_root_renovate_reenables_devkit_own_paths() -> None:
+    """Devkit's root config re-enables its own root workflows/actions, last."""
+    rules = _package_rules(ROOT_RENOVATE)
+    reenable = [r for r in rules if r.get("enabled") is True and "matchFileNames" in r]
+    assert len(reenable) == 1, (
+        "expected exactly one enabled:true matchFileNames rule in root "
+        f"renovate.json, found {len(reenable)}"
+    )
+    rule = reenable[0]
+    assert {".github/workflows/**", ".github/actions/**"}.issubset(
+        set(rule["matchFileNames"])
+    )
+    # Must merge after the preset's exclusion — being a root rule already places
+    # it later, but keep it last so no other root rule can shadow it either.
+    assert rules[-1] is rule


### PR DESCRIPTION
## Description

Consumer repos scaffolded by devkit run Renovate against the devkit-**managed** workflows and composite actions, opening duplicate pin-bump PRs that the next `devkit-upgrade` regenerates over (and, when a consumer ran ahead of a devkit train, actively downgrades). This PR makes the shipped preset the single decision point: consumer Renovate now ignores the managed set; devkit's own Renovate remains the sole channel that advances those pins, shipping them with each release.

## Type of Change

- [x] `feat` -- New feature

## Changes Made

- **`assets/workspace/.github/renovate-default.json`** (managed preset, rolls out on upgrade): trailing `enabled: false` packageRule enumerating the 13 managed workflows (all shipped minus the consumer-owned seams `release-extension.yml` / `prepare-release-extension.yml`) plus `.github/actions/setup-devkit-toolchain/**` and `.github/actions/resolve-toolchain/**`. Last on purpose: a consumer's own later `packageRules` (preserved root `renovate.json`) win, so opting back in stays possible.
- **`renovate.json`** (devkit root): trailing `enabled: true` rule for `.github/workflows/**` and `.github/actions/**` — devkit extends the same preset and shares those rooted paths, so it re-enables its own files. The shipped copies under `assets/workspace/` were never caught (rooted `matchFileNames` globs don't match nested paths).
- **`tests/test_renovate_preset_managed_exclusion.py`**: drift gate — derives the managed set from the workflow directory listing minus `PRESERVE_FILES` (via `sync_manifest.load_preserve_files`, nothing hardcoded) and asserts both rules exist and are last (ordering is load-bearing).
- **`docs/WORKFLOW_SECURITY.md`**: new section on upstream dependency responsibility for managed files, the vulnerability-PR trade-off, and the consumer opt-back-in recipe.
- `assets/workspace/.devcontainer/CHANGELOG.md`: generated sync-manifest mirror of the CHANGELOG edit.

## Changelog Entry

### Changed
- **Consumer Renovate ignores devkit-managed workflows and actions** ([#1332](https://github.com/vig-os/devkit/issues/1332))
  - The shipped preset (`.github/renovate-default.json`) now disables Renovate for the managed workflow set and the two managed composite actions via a trailing `enabled: false` packageRule. Their SHA-pinned action digests advance upstream in devkit and ship with each release, so downstream Renovate no longer opens duplicate pin-bump PRs that the next `devkit-upgrade` clobbers.
  - The rule is last, so a consumer can opt a specific managed file back in from their preserved `renovate.json` (later rules win). Devkit's own root `renovate.json` re-enables its root workflows/actions so devkit keeps advancing the pins it owns.

## Testing

- [x] Tests pass locally (`just test`)
- [x] Manual testing performed (describe below)

### Manual Testing Details

- TDD: drift-gate test committed RED first (3 failed), GREEN after the config change (3 passed).
- Related unit subset (renovate preset, zizmor baseline, private-repo guard, release/prepare extension, scaffold drift, workflow model): 76 passed, exit 0.
- `prek run --all-files`: fully green (51 hooks, exit 0).
- `renovate-config-validator` not runnable offline (renovate is not an npm dep of this repo); JSON validity hook-checked, CI's `renovate-validate` workflow covers schema validation.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

- Live behavior lands in consumers with the next release train via `devkit-upgrade` (the preset is a managed file). One-time step at rollout: close any open downstream renovate PRs touching managed workflows — they will not be recreated.
- The issue's `baseBranchPatterns` sanity check confirmed a **separate** pre-existing bug for trunk-model consumers (preset hardcodes `["dev"]`; trunk repos have no `dev`, leaving Renovate inert there) — reported on #1332 and filed independently; not addressed here (minimal diff).
- Merge-order note: #1334 also touches root `renovate.json` (its `extends` line); whichever merges second may need a trivial rebase.

Closes #1332

Refs: #1332
