### PR TITLE
chore(security): anchor exception-register expiries to a Wednesday grid

### DIFF
--- a/.github/dependency-review-allow.txt
+++ b/.github/dependency-review-allow.txt
@@ -2,6 +2,9 @@
 # Allowed GitHub Security Advisories (GHSAs) for dependency-review-action.
 # Mirrors .trivyignore conventions: each GHSA entry requires an Expiration
 # directive. Expired exceptions cause CI to fail, forcing periodic review.
+# Expiration dates land on a Wednesday, per the expiry grid documented in
+# docs/CONTAINER_SECURITY.md (#1337); the date below was snapped onto that grid
+# on 2026-08-04 (+1 day), leaving its risk assessment unchanged.
 #
 # Format:
 #   # <GHSA-ID>: <short description>
@@ -18,5 +21,5 @@
 # - Upstream package.json has never updated its version field from 0.2.0
 # - The lock file records 0.2.0 regardless of which git tag is used
 # Mitigation: Source is verified GitHub repository, not npm registry
-Expiration: 2026-09-01
+Expiration: 2026-09-02
 GHSA-wvrr-2x4r-394v

--- a/.trivyignore
+++ b/.trivyignore
@@ -6,6 +6,13 @@
 #
 # Each entry requires an Expiration date. Expired entries cause CI to fail,
 # forcing periodic review. Tracking: https://github.com/vig-os/devkit/issues/512
+#
+# EXPIRY GRID (#1337): every `Expiration:` date lands on a WEDNESDAY so the
+# entry turns red on a Thursday, after the week's remediation data has landed
+# and with two working days before the weekend. Rationale and the snapping rule
+# (nearest Wednesday, shift <= 3 days) live in docs/CONTAINER_SECURITY.md. The
+# dates below were snapped onto that grid on 2026-08-04, each extended by 1 day;
+# no risk assessment was re-opened or changed by the snap.
 
 # CVE-2026-42504: Go stdlib MIME header DoS in gh binary
 # Risk Assessment: LOW (devcontainer context)
@@ -14,7 +21,7 @@
 # - Latest gh v2.93.0 (2026-05-27) still embeds Go 1.26.3; fix requires Go 1.26.4 rebuild
 # - Fresh image build (gh 2.93.0, uv 0.11.19) cleared all other bundled-tool HIGH findings
 # - Tracking: https://github.com/vig-os/devkit/issues/512, #564
-Expiration: 2026-09-01
+Expiration: 2026-09-02
 CVE-2026-42504
 
 # jwt-token: Trivy secret scan false positive
@@ -22,7 +29,7 @@ CVE-2026-42504
 # - JWT-like string in typos crate test fixtures under /opt/pre-commit-cache
 # - Not a live credential; embedded test data only
 # - Tracking: https://github.com/vig-os/devkit/issues/512
-Expiration: 2026-09-01
+Expiration: 2026-09-02
 jwt-token
 
 # CVE-2026-32316, CVE-2026-40164: jq DoS / potential arbitrary code execution
@@ -33,6 +40,6 @@ jwt-token
 #   Time-box the ignore until the Nix image ships.
 # - jq processes trusted local JSON in devcontainer workflows, not untrusted input
 # - Tracking: https://github.com/vig-os/devkit/issues/805, #512
-Expiration: 2026-09-01
+Expiration: 2026-09-02
 CVE-2026-32316
 CVE-2026-40164

--- a/.vulnixignore
+++ b/.vulnixignore
@@ -20,6 +20,19 @@
 # Each accepted entry should record WHY (patched-in-nixpkgs / not-exploitable /
 # awaiting-upstream) per docs/CONTAINER_SECURITY.md.
 #
+# EXPIRY GRID (#1337): every `Expiration:` date lands on a WEDNESDAY, so the
+# entry turns red on the Thursday AFTER the week's Renovate nixpkgs bump has
+# merged and the first nightly scan has produced a findings delta against the
+# new closure — the moment a review can delete entries instead of extending
+# them. Rationale and the snapping rule (nearest Wednesday, shift <= 3 days)
+# live in docs/CONTAINER_SECURITY.md; it is a convention enforced by review,
+# not by `check-expirations`.
+#
+# All dates below were snapped onto that grid on 2026-08-04 (#1337): one block
+# shortened by 3 days, five extended by 2, two by 1. A snap is a scheduling
+# adjustment ONLY — no risk assessment below was re-opened, re-verified or
+# changed by it, and every rationale stands as previously written.
+#
 # Tracking: https://github.com/vig-os/devkit/issues/637
 
 # ============================================================================
@@ -68,7 +81,7 @@ CVE-2022-36883
 #   closure, so unconditionally present; most glibc CVEs need a specific local
 #   vector (crafted input/locale/regex), mitigated by the single-user model but
 #   NOT individually verified here.
-Expiration: 2026-08-15
+Expiration: 2026-08-12
 # CVE-2025-15281 — glibc (base libc, loaded everywhere); specifics unverified offline.
 CVE-2025-15281
 # CVE-2026-4046 — glibc (base libc, loaded everywhere); specifics unverified offline.
@@ -84,7 +97,7 @@ CVE-2026-5928
 
 # Remaining lower-reachability components (provenance per note). Specifics
 # unverified offline; medium-near expiry to force re-review.
-Expiration: 2026-08-31
+Expiration: 2026-09-02
 # zlib 1.3.2 — ubiquitous compression dep (curl, openssh, git, nix, python).
 #   Reachable on any decompression path; specifics unverified offline.
 CVE-2026-27820
@@ -124,7 +137,7 @@ CVE-2025-62689
 #      2026-07-28 "no fix in the pinned channel" note was already stale.
 #    - CVE-2026-56123: the pin ships socat 1.8.1.3, past the 1.8.1.2 fix.)
 
-Expiration: 2026-08-17
+Expiration: 2026-08-19
 # (gzip CVE-2026-41992 removed 2026-08-04 (#1327): contrary to the "no nixpkgs
 #   patch yet" note above, the pinned rev applies CVE-2026-41992.patch to gzip
 #   1.14, so vulnix no longer reports it.)
@@ -139,7 +152,7 @@ Expiration: 2026-08-17
 CVE-2026-53432
 CVE-2026-53433
 
-Expiration: 2026-09-01
+Expiration: 2026-09-02
 # (libxml2 CVE-2026-11979 removed 2026-08-04 (#1327): the pinned rev applies
 #   CVE-2026-11979.patch to both libxml2 attrs (2.13.9 and 2.15.3), so vulnix
 #   no longer reports it.)
@@ -162,7 +175,7 @@ CVE-2026-58050
 # 2026-07-07. Real product match (no CPE collision).
 # ============================================================================
 
-Expiration: 2026-08-31
+Expiration: 2026-09-02
 # podman 5.8.2 — container engine, a direct devTools member (nix/devtools.nix)
 #   and the binary backing the docker->podman shim (flake.nix). CVE-2026-57231
 #   (CVSS 7.5 HIGH): a malicious image manifest with malformed `Env` entries (a
@@ -209,7 +222,7 @@ CVE-2026-57231
 # (5.4.1 still not in the pinned channel), so this block is retained.
 # ============================================================================
 
-Expiration: 2026-08-18
+Expiration: 2026-08-19
 # gawk 5.4.0 — CVE-2026-40468 (9.1): integer overflow in builtin.c; memory
 #   exhaustion / heap-metadata overwrite with attacker-controlled bytes.
 #   Requires gawk to run a crafted awk program or input — developer-chosen
@@ -255,7 +268,7 @@ CVE-2026-40553
 # (the 1.25.2 fix has not reached the pinned channel), so this block is retained.
 # ============================================================================
 
-Expiration: 2026-08-31
+Expiration: 2026-09-02
 # unbound 1.25.1 — CVE-2026-50252 (NVD 9.3 CRITICAL; upstream rates Medium):
 #   cache poisoning via per-thread source-port population under SO_REUSEPORT —
 #   resolver daemon behavior; no daemon runs here.
@@ -302,7 +315,7 @@ CVE-2026-55973
 # out on their own once it does. Short expiry to force near-term re-check.
 # ============================================================================
 
-Expiration: 2026-08-31
+Expiration: 2026-09-02
 # libssh2 1.11.1 — CVE-2026-66033 (7.5): pre-auth integer underflow in
 #   ssh2_cipher_crypt() (src/openssl.c); a malicious server negotiating AES-GCM
 #   triggers an OOB read and a memcpy with a near-SIZE_MAX length, crashing the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Security exception expiries land on a Wednesday** ([#1337](https://github.com/vig-os/devkit/issues/1337))
+  - `docs/CONTAINER_SECURITY.md` now documents an expiry grid for the exception
+    registers: every `Expiration:` date is picked on a Wednesday, so an entry
+    turns red on the Thursday *after* the week's Renovate `nixpkgs` bump has
+    merged and the first nightly scan has produced a findings delta against the
+    new closure — the point at which a review can delete entries instead of
+    blindly extending them. Earlier weekdays force that blind extension (or, on
+    a Sunday, take unrelated PRs red before the week's Renovate PRs even open);
+    later ones lapse over an unattended weekend, blocking every commit.
+  - All 12 non-conforming dates across `.vulnixignore`, `.trivyignore` and
+    `.github/dependency-review-allow.txt` were snapped onto the grid (shift
+    ≤ 3 days each). This is a scheduling change only — no risk assessment was
+    re-opened or altered. Notably the glibc block no longer expires on a
+    Saturday, where it would have turned red unattended on Sunday 2026-08-16.
+  - Convention enforced by review, not by `check-expirations`: the validator is
+    unchanged, since it is scaffolded into consumer repos whose release cadence
+    may differ.
 - **Consumer Renovate ignores devkit-managed workflows and actions** ([#1332](https://github.com/vig-os/devkit/issues/1332))
   - The shipped preset (`.github/renovate-default.json`) now disables Renovate
     for the managed workflow set and the two managed composite actions

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -21,6 +21,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Security exception expiries land on a Wednesday** ([#1337](https://github.com/vig-os/devkit/issues/1337))
+  - `docs/CONTAINER_SECURITY.md` now documents an expiry grid for the exception
+    registers: every `Expiration:` date is picked on a Wednesday, so an entry
+    turns red on the Thursday *after* the week's Renovate `nixpkgs` bump has
+    merged and the first nightly scan has produced a findings delta against the
+    new closure — the point at which a review can delete entries instead of
+    blindly extending them. Earlier weekdays force that blind extension (or, on
+    a Sunday, take unrelated PRs red before the week's Renovate PRs even open);
+    later ones lapse over an unattended weekend, blocking every commit.
+  - All 12 non-conforming dates across `.vulnixignore`, `.trivyignore` and
+    `.github/dependency-review-allow.txt` were snapped onto the grid (shift
+    ≤ 3 days each). This is a scheduling change only — no risk assessment was
+    re-opened or altered. Notably the glibc block no longer expires on a
+    Saturday, where it would have turned red unattended on Sunday 2026-08-16.
+  - Convention enforced by review, not by `check-expirations`: the validator is
+    unchanged, since it is scaffolded into consumer repos whose release cadence
+    may differ.
 - **Consumer Renovate ignores devkit-managed workflows and actions** ([#1332](https://github.com/vig-os/devkit/issues/1332))
   - The shipped preset (`.github/renovate-default.json`) now disables Renovate
     for the managed workflow set and the two managed composite actions

--- a/docs/CONTAINER_SECURITY.md
+++ b/docs/CONTAINER_SECURITY.md
@@ -128,6 +128,49 @@ Both use the `Expiration: YYYY-MM-DD` directive format and are validated by
 `check-expirations` (pre-commit hook and CI). Expired entries fail CI, forcing
 periodic review consistent with the IEC 62304 exception-register model.
 
+#### Expiry dates land on a Wednesday
+
+**Convention:** pick every `Expiration:` date on a **Wednesday** — in both
+registers above and in the `.github/dependency-review-allow.txt` allow-list,
+which shares the format. This is a
+convention enforced by review, not by `check-expirations` — the validator only
+checks that a date has passed, and it is scaffolded into consumer repos whose
+release cadence may differ.
+
+`check-expirations` fails when `today > expiration`, so an entry dated `D` is
+valid through `D` and turns red on `D+1`. Wednesday is chosen so that `D+1` is
+the Thursday *after* the week's remediation data has arrived:
+
+1. Renovate opens the `nixpkgs`/`flake.lock` bump — the primary remediation
+   lever — in its Monday window (`schedule: ["before 9am on monday"]`, UTC, in
+   [`assets/workspace/.github/renovate-default.json`](../assets/workspace/.github/renovate-default.json);
+   **if that schedule changes, this convention should be re-derived**).
+2. The bump merges to `dev` on Monday or Tuesday. PR CI does **not** run
+   `vulnix` (the authoritative CVE gate is the nightly scan), so the PR itself
+   reveals nothing about which exceptions have gone dead.
+3. The first nightly `security-scan` after the merge (05:00 UTC, Tuesday or
+   Wednesday) produces the findings delta against the new closure.
+4. The register is reconciled against that delta — entries the bump fixed are
+   deleted rather than blindly extended.
+
+A Wednesday expiry therefore turns red on Thursday, once that data exists and
+with two working days before the weekend. Earlier weekdays force a blind
+extension or, at worst (Sunday), a register that is already red when the week's
+Renovate PRs open — which is how [#550](https://github.com/vig-os/devkit/issues/550)
+took 16 unrelated PRs red at once. Later weekdays lapse over an unattended
+weekend, blocking every commit (`check-expirations` runs in all PR CI, in
+pre-commit, and in the release train).
+
+**Snapping rule.** When renewing or adding an entry, choose the intended window,
+then move to the nearest Wednesday, shifting at most **3 days** and preferring
+the shorter window on ties. A snap is a scheduling adjustment only: it never
+re-opens the risk assessment, and the entry's rationale must stay as written.
+
+**Stagger across weeks, not weekdays.** Sharing one date gives the register a
+single combined re-review pass, which is the intent; but every block on the
+*same* Wednesday means one stalled review blocks the whole register. Spread
+renewals over different Wednesdays by choosing different week-multiples.
+
 ## Why pin `nixpkgs` (and not track an unpinned channel)?
 
 Building from an unpinned/rolling input has the same drawbacks the old


### PR DESCRIPTION
## Description

Adopts a documented **Wednesday expiry grid** for the security exception
registers and re-schedules every current entry onto it.

Expiry dates were previously picked ad hoc and landed on arbitrary weekdays
(Sat ×1, Mon ×5, Tue ×6, Wed ×1). Since `check-expirations` runs in every PR CI,
in pre-commit, in the release train and in both nightly scan legs, a lapse
blocks all work in the repo — as it has four times already (#550, #1257, #1260,
#1327).

## Type of Change

- [x] `chore` -- Maintenance task (deps, config, etc.)

### Modifiers

- [ ] Breaking change (`!`)

## Changes Made

**`docs/CONTAINER_SECURITY.md` §5** — new "Expiry dates land on a Wednesday"
subsection (SSoT for the convention; `SECURITY.md` keeps linking here rather
than restating it):

- Wednesday is chosen from the mechanics, not from the Renovate window alone.
  `check-expirations` fails when `today > expiration`, so a Wednesday entry
  turns red on Thursday — *after* the week's Renovate `nixpkgs` bump (Monday
  window) has merged and the first nightly scan has produced a findings delta
  against the new closure. PR CI does not run `vulnix`, so the bump PR itself
  reveals nothing; the delta is what lets a review **delete** entries instead of
  blindly extending them.
- Earlier weekdays force that blind extension, or — on a Sunday — leave the
  register red before the week's Renovate PRs even open, which is exactly how
  #550 took 16 unrelated PRs red at once. Later weekdays lapse over an
  unattended weekend.
- Documents the snapping rule (nearest Wednesday, shift ≤ 3 days, prefer the
  shorter window on ties), the explicit dependency on the Renovate `schedule`
  so the rationale cannot silently rot, and a "stagger across weeks, not
  weekdays" note.

**Registers** — all 12 non-conforming dates snapped onto the grid, each with a
header note recording the snap and that no risk assessment was re-opened:

| File | Change |
|---|---|
| `.vulnixignore` | glibc `08-15` (Sat) → `08-12` (−3); fzf `08-17` → `08-19` (+2); gawk `08-18` → `08-19` (+1); libssh2 `09-01` → `09-02` (+1); four `08-31` blocks (zlib/sqlite/libmicrohttpd, podman, unbound, libssh2 6603x) → `09-02` (+2). The Class-1 CPE-mismatch block (`2027-06-23`) was already a Wednesday and is untouched. |
| `.trivyignore` | three blocks `09-01` → `09-02` (+1) |
| `.github/dependency-review-allow.txt` | `09-01` → `09-02` (+1) |

**Not changed, deliberately:** `check_expirations.py`. The validator is
scaffolded into consumer repos (`assets/workspace/.pre-commit-config.yaml`)
whose Renovate schedule can be overridden — hard-enforcing a weekday would push
devkit's cadence org-wide and add a new failure class to the very tool whose
failures this reduces. The convention is enforced by review.

## Changelog Entry

```
### Changed

- **Security exception expiries land on a Wednesday** ([#1337](https://github.com/vig-os/devkit/issues/1337))
  - `docs/CONTAINER_SECURITY.md` now documents an expiry grid for the exception
    registers: every `Expiration:` date is picked on a Wednesday, so an entry
    turns red on the Thursday *after* the week's Renovate `nixpkgs` bump has
    merged and the first nightly scan has produced a findings delta against the
    new closure — the point at which a review can delete entries instead of
    blindly extending them. Earlier weekdays force that blind extension (or, on
    a Sunday, take unrelated PRs red before the week's Renovate PRs even open);
    later ones lapse over an unattended weekend, blocking every commit.
  - All 12 non-conforming dates across `.vulnixignore`, `.trivyignore` and
    `.github/dependency-review-allow.txt` were snapped onto the grid (shift
    ≤ 3 days each). This is a scheduling change only — no risk assessment was
    re-opened or altered. Notably the glibc block no longer expires on a
    Saturday, where it would have turned red unattended on Sunday 2026-08-16.
  - Convention enforced by review, not by `check-expirations`: the validator is
    unchanged, since it is scaffolded into consumer repos whose release cadence
    may differ.
```

## Testing

- [x] Tests pass locally
- [x] Manual testing performed (below)

### Manual Testing Details

- `just precommit` — **full suite green** (`EXIT=0`), including
  `check-expirations`, `pymarkdown`, `typos` and `sync-manifest`.
- `uv run check-expirations .trivyignore .vulnixignore` → `Validated 35
  exception(s) across 2 file(s)`, exit 0.
- `uv run check-expirations .github/dependency-review-allow.txt` → `Validated 1
  exception(s) across 1 file(s)`, exit 0.
- Every `Expiration:` directive verified against `date -d <date> +%A`: all 13
  (9 + 3 + 1) resolve to **Wednesday**.

No unit tests added: this is a documentation and register-data change, and
`check_expirations.py` — the only executable component involved — is unchanged
and already covered by `packages/vig-utils/tests/test_check_expirations.py`.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [ ] I have added tests — n/a, see Manual Testing Details
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

Three follow-ups worth knowing about, none blocking:

1. **The Saturday entry was the urgent one.** The glibc block would have turned
   red unattended on **Sunday 2026-08-16 at 05:00 UTC**, blocking every commit
   until renewed. It now lapses on a Thursday.
2. **The gawk block may be deleted rather than renewed.** #1328 reports gawk
   5.4.1 has landed in `nixos-26.05`; if that pin advance merges first, drop the
   block instead of carrying its new `08-19` date.
3. **Eight of thirteen directives now share `2026-09-02`.** That is the intended
   combined re-review pass, but it means one stalled review blocks the whole
   register. De-clustering should happen at each block's *next* renewal by
   choosing different week-multiples — doing it now would either exceed the ±3
   day cap or pull unrelated reviews forward.

`assets/workspace/.devcontainer/CHANGELOG.md` is in the diff because
`sync-manifest` mirrors the root changelog; it is not a hand edit.

Closes #1337

Refs: #1337
