### PR TITLE
fix(workspace): retarget renovate preset baseBranchPatterns to main in trunk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Trunk consumers' Renovate preset now targets `main`** ([#1336](https://github.com/vig-os/devkit/issues/1336))
+  - The trunk render (`render_workflow_model`) retargets `baseBranchPatterns`
+    from `["dev"]` to `["main"]` in the scaffolded `.github/renovate-default.json`.
+    Previously a `DEVKIT_WORKFLOW=trunk` consumer kept `["dev"]` while having no
+    `dev` branch, leaving Renovate with nothing to operate on — effectively
+    inert. Existing trunk repos self-heal on their next `devkit-upgrade`.
+
 ### Security
 
 - **vulnix register: except the libssh2 malicious-server batch, prune five dead exceptions** ([#1327](https://github.com/vig-os/devkit/issues/1327), [#1322](https://github.com/vig-os/devkit/issues/1322), [#1323](https://github.com/vig-os/devkit/issues/1323))

--- a/assets/init-workspace.sh
+++ b/assets/init-workspace.sh
@@ -1352,6 +1352,16 @@ render_workflow_model() {
         sed -i 's|(?!dev$)||' "$pc"
     fi
 
+    # renovate-default.json — retarget baseBranchPatterns dev -> main: Renovate
+    # restricted to a base-branch pattern matching no existing branch has
+    # nothing to operate on, so a trunk consumer keeping the gitflow-shaped
+    # ["dev"] runs no updates at all (#1336). Anchored to the exact preset
+    # line; the consumer-owned root renovate.json is preserved and untouched.
+    local rd="$WORKSPACE_DIR/.github/renovate-default.json"
+    if [[ -f "$rd" ]]; then
+        sed -i 's|"baseBranchPatterns": \["dev"\]|"baseBranchPatterns": ["main"]|' "$rd"
+    fi
+
     echo "Rendered workflow model: trunk (anchored dev -> main retarget)"
 }
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -50,6 +50,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Trunk consumers' Renovate preset now targets `main`** ([#1336](https://github.com/vig-os/devkit/issues/1336))
+  - The trunk render (`render_workflow_model`) retargets `baseBranchPatterns`
+    from `["dev"]` to `["main"]` in the scaffolded `.github/renovate-default.json`.
+    Previously a `DEVKIT_WORKFLOW=trunk` consumer kept `["dev"]` while having no
+    `dev` branch, leaving Renovate with nothing to operate on — effectively
+    inert. Existing trunk repos self-heal on their next `devkit-upgrade`.
+
 ### Security
 
 - **vulnix register: except the libssh2 malicious-server batch, prune five dead exceptions** ([#1327](https://github.com/vig-os/devkit/issues/1327), [#1322](https://github.com/vig-os/devkit/issues/1322), [#1323](https://github.com/vig-os/devkit/issues/1323))

--- a/tests/test_workflow_model.py
+++ b/tests/test_workflow_model.py
@@ -39,6 +39,7 @@ NO_PLACEHOLDER_RENDER_FILES = (
     ".github/workflows/promote-release.yml",
     ".github/workflows/ci.yml",
     ".github/workflows/sync-issues.yml",
+    ".github/renovate-default.json",
     ".claude/skills/branch-naming/SKILL.md",
     ".pre-commit-config.yaml",
 )
@@ -249,6 +250,20 @@ def test_trunk_precommit_drops_dev_clause(tmp_path: Path) -> None:
     text = (rendered / ".pre-commit-config.yaml").read_text(encoding="utf-8")
     assert "(?!dev$)" not in text
     assert "(?!main$)" in text
+
+
+def test_trunk_renovate_preset_targets_main(tmp_path: Path) -> None:
+    """renovate-default.json baseBranchPatterns dev -> main (#1336).
+
+    Renovate restricted to a base-branch pattern that matches no existing
+    branch has nothing to operate on, so a trunk consumer keeping the
+    gitflow-shaped ``["dev"]`` runs no updates at all. The trunk render must
+    retarget the shipped preset to main.
+    """
+    rendered = _tree(tmp_path, "trunk")
+    text = (rendered / ".github" / "renovate-default.json").read_text(encoding="utf-8")
+    assert '"baseBranchPatterns": ["main"]' in text
+    assert '["dev"]' not in text
 
 
 def test_trunk_flake_forwards_workflow_to_hooks(tmp_path: Path) -> None:


### PR DESCRIPTION
## Description

Trunk-model consumers (`DEVKIT_WORKFLOW=trunk`) keep the gitflow-shaped `baseBranchPatterns: ["dev"]` in their scaffolded `.github/renovate-default.json` — but have no `dev` branch, so Renovate has nothing to operate on and runs no updates at all (verified live on `exo-pet/vault` and `vig-os/org-config`). The trunk render now retargets the preset to `["main"]`, mirroring the existing dev→main retarget for workflows.

## Type of Change

- [x] `fix` -- Bug fix

## Changes Made

- **`assets/init-workspace.sh`** (`render_workflow_model`): new anchored sed rewrites `"baseBranchPatterns": ["dev"]` → `["main"]` in the scaffolded `.github/renovate-default.json` under trunk; gitflow remains a byte-for-byte no-op. The consumer-owned root `renovate.json` is preserved and untouched.
- **`tests/test_workflow_model.py`**: new `test_trunk_renovate_preset_targets_main` (drives the real `init-workspace.sh` end-to-end, like the rest of the suite), and `.github/renovate-default.json` added to `NO_PLACEHOLDER_RENDER_FILES` so the gitflow byte-identical guard covers the new render target.
- `CHANGELOG.md` + `.devcontainer` mirror.

## Changelog Entry

### Fixed
- **Trunk consumers' Renovate preset now targets `main`** ([#1336](https://github.com/vig-os/devkit/issues/1336))
  - The trunk render (`render_workflow_model`) retargets `baseBranchPatterns` from `["dev"]` to `["main"]` in the scaffolded `.github/renovate-default.json`. Previously a `DEVKIT_WORKFLOW=trunk` consumer kept `["dev"]` while having no `dev` branch, leaving Renovate with nothing to operate on — effectively inert. Existing trunk repos self-heal on their next `devkit-upgrade`.

## Testing

- [x] Tests pass locally (`just test`)
- [x] Manual testing performed (describe below)

### Manual Testing Details

- TDD: test committed RED first (trunk scaffold keeps `["dev"]`), GREEN after the render change.
- `tests/test_workflow_model.py`: 23 passed (includes the gitflow no-op guards — gitflow output stays byte-identical to the template).
- `bats tests/bats/init-workspace.bats`: 278 ok, exit 0.
- `prek run --all-files`: green, exit 0.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

Rollout: the preset is a managed file, so vault, org-config, and exo-fleet self-heal on their next `devkit-upgrade` after this ships — no manual consumer action. Their first Renovate run after that upgrade will open the accumulated update PRs (including the #1332 managed-file exclusion taking effect for the first time on trunk repos, since Renovate was inert there until now).

Closes #1336

Refs: #1336
