### PR TITLE
fix(security): advance nixpkgs pin and drop the gawk exception block

### DIFF
--- a/.vulnixignore
+++ b/.vulnixignore
@@ -149,6 +149,9 @@ Expiration: 2026-08-19
 # Re-verified 2026-07-28 (#1273): the pin was advanced to nixos-26.05 @
 #   2026-07-26 (rev 8623c4c2) and rebuilt; the closure still ships fzf 0.72.0
 #   (0.73.1 has not reached the pinned channel), so this block is retained.
+# Re-verified 2026-08-04 (#1328): the pin was advanced to nixos-26.05 @
+#   2026-08-03 (rev 531670d8) and rebuilt; the closure still ships fzf 0.72.0,
+#   so this block is retained.
 CVE-2026-53432
 CVE-2026-53433
 
@@ -166,6 +169,9 @@ Expiration: 2026-09-02
 # Re-verified 2026-07-28 (#1273): the pin was advanced to nixos-26.05 @
 #   2026-07-26 (rev 8623c4c2) and rebuilt; libssh2 is still 1.11.1 with no
 #   upstream fix, so this exception is retained.
+# Re-verified 2026-08-04 (#1328): the pin was advanced to nixos-26.05 @
+#   2026-08-03 (rev 531670d8) and rebuilt; libssh2 is still 1.11.1, so this
+#   exception is retained.
 CVE-2026-58050
 
 # ============================================================================
@@ -195,52 +201,22 @@ Expiration: 2026-09-02
 #   untouched since 2026-07-20 — the rev-advance lever still has nowhere to
 #   land. Expiry extended 2026-08-06 -> 2026-08-31 to align with the libssh2
 #   and unbound blocks, so the register gets one combined re-review pass.
+# Re-verified 2026-08-04 (#1328): the pin was advanced to nixos-26.05 @
+#   2026-08-03 (rev 531670d8) and rebuilt; the closure still ships podman 5.8.2,
+#   so this is retained.
 CVE-2026-57231
 
 # ============================================================================
-# Triage 2026-07-14 — gawk 5.4.0 CERT-PL batch (release-cycle fix, #1071).
-# Published 2026-07-13 (https://cert.pl/en/posts/2026/07/CVE-2026-40467/);
-# surfaced in the vulnix feed 2026-07-14 and failed the 1.2.0-rc1 publish at
-# the vulnix gate (run 29346662524). Verified ONLINE against CERT-PL, NVD, the
-# upstream gawk release, and the nixpkgs branch contents (nixos-26.05,
-# release-26.05, staging-26.05, master, nixpkgs-unstable) on 2026-07-14. Real
-# product match (GNU gawk, no CPE collision). All four are fixed upstream in
-# gawk 5.4.1; the nixpkgs bump (NixOS/nixpkgs#540158) merged to *staging* on
-# 2026-07-12 (gawk is a stdenv mass-rebuild) and has NOT reached nixos-26.05 —
-# every release branch and even master/unstable still ship 5.4.0 — so the
-# "advance the rev" lever has nowhere to land today. gawk is a stdenv closure
-# member; it processes developer/CI-chosen awk programs and inputs only (no
-# untrusted-input path in the single-user dev model). Flip to a nixpkgs
-# rev-advance once 5.4.1 lands in the pinned channel; short expiry to force
-# near-term re-check.
-# Re-verified 2026-07-21 (#1240): nixos-26.05 and release-26.05 still ship gawk
-# 5.4.0; the staging fix (5.4.1) has not yet propagated to the pinned channel,
-# so the rev-advance lever still has nowhere to land. Expiry extended to
-# 2026-08-18 (another short window) pending that propagation.
-# Re-verified 2026-07-28 (#1273): the pin was advanced to nixos-26.05 @
-# 2026-07-26 (rev 8623c4c2) and rebuilt; the closure still ships gawk 5.4.0
-# (5.4.1 still not in the pinned channel), so this block is retained.
+# (The 2026-07-14 gawk 5.4.0 CERT-PL block — CVE-2026-40467, -40468, -40469 and
+#  -40553 (#1071) — was removed on 2026-08-04 (#1328) rather than renewed a
+#  third time. It only ever existed because the fix (gawk 5.4.1) sat in nixpkgs
+#  *staging* as a stdenv mass-rebuild, leaving the "advance the rev" lever with
+#  nowhere to land — the reason it was extended at #1240 and again at the #1273
+#  pin advance. 5.4.1 reached nixos-26.05 on 2026-08-03, so #1328 advanced the
+#  pin 8623c4c2 (2026-07-26) -> 531670d8 (2026-08-03); the rebuilt closure
+#  ships gawk 5.4.1 and vulnix reports none of the four CVEs. They are the ONLY
+#  delta in the before/after findings diff (59 -> 55 unique CVEs, nothing new).)
 # ============================================================================
-
-Expiration: 2026-08-19
-# gawk 5.4.0 — CVE-2026-40468 (9.1): integer overflow in builtin.c; memory
-#   exhaustion / heap-metadata overwrite with attacker-controlled bytes.
-#   Requires gawk to run a crafted awk program or input — developer-chosen
-#   inputs only here.
-CVE-2026-40468
-# gawk 5.4.0 — CVE-2026-40469 (9.1): integer overflow in builtin.c do_sub();
-#   heap corruption -> crash. Affects 32-BIT builds only per the CERT-PL
-#   advisory — this image is 64-bit, so effectively not applicable (kept
-#   short-dated with the batch rather than yearly, pending NVD settling).
-CVE-2026-40469
-# gawk 5.4.0 — CVE-2026-40467 (7.5): use-after-free in io.c
-#   do_getline_redir(); crash (availability only).
-CVE-2026-40467
-# gawk 5.4.0 — CVE-2026-40553 (7.5): stack buffer overflow in
-#   extension/readdir.c ftype(); crash, code execution unconfirmed. Only
-#   reachable when the opt-in readdir extension is loaded (`-l readdir`) on a
-#   crafted directory tree — not used by any tooling here.
-CVE-2026-40553
 
 # ============================================================================
 # Triage 2026-07-26 — unbound 1.25.2 security batch (nightly-scan fix, #1264).
@@ -266,6 +242,9 @@ CVE-2026-40553
 # Re-verified 2026-07-28 (#1273): the pin was advanced to nixos-26.05 @
 # 2026-07-26 (rev 8623c4c2) and rebuilt; the closure still ships unbound 1.25.1
 # (the 1.25.2 fix has not reached the pinned channel), so this block is retained.
+# Re-verified 2026-08-04 (#1328): the pin was advanced to nixos-26.05 @
+# 2026-08-03 (rev 531670d8) and rebuilt; the closure still ships unbound 1.25.1,
+# so this block is retained.
 # ============================================================================
 
 Expiration: 2026-09-02
@@ -313,6 +292,9 @@ CVE-2026-55973
 # patch. Flip to a rev-advance once the patched derivation reaches the pinned
 # channel — vulnix credits CVE-named `patches` entries, so the findings drop
 # out on their own once it does. Short expiry to force near-term re-check.
+# Re-verified 2026-08-04 (#1328): the pin was advanced to nixos-26.05 @
+# 2026-08-03 (rev 531670d8) and rebuilt; libssh2 is still 1.11.1 and carries no
+# 6603x patch, so this block is retained.
 # ============================================================================
 
 Expiration: 2026-09-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **Advance the nixpkgs pin and drop the gawk exception block** ([#1328](https://github.com/vig-os/devkit/issues/1328))
+  - Advanced the pinned `nixpkgs` rev (`flake.lock`) from nixos-26.05
+    @ `8623c4c2` (2026-07-26) to @ `531670d8` (2026-08-03), which is the first
+    pinned-channel rev to ship **gawk 5.4.1**. The rebuilt closure confirms it.
+  - Removed the gawk 5.4.0 CERT-PL block (CVE-2026-40467, -40468, -40469,
+    -40553) instead of renewing it a third time. It had been extended at #1240
+    and again at the #1273 pin advance only because the fix sat in nixpkgs
+    `staging` as a stdenv mass-rebuild, leaving the "advance the rev" lever with
+    nowhere to land.
+  - The before/after `vulnix` closure diff is exactly those four CVEs
+    (59 → 55 unique advisories) with nothing new appearing, and the gate passes
+    on 27 exceptions (down from 31).
+  - The rest of the register was re-verified against the new rev and nothing
+    else became droppable: fzf (0.72.0), libssh2 (1.11.1, still carrying no
+    6603x patch), unbound (1.25.1) and podman (5.8.2) are all unchanged, so
+    those blocks are retained with a 2026-08-04 re-verification note.
 - **vulnix register: except the libssh2 malicious-server batch, prune five dead exceptions** ([#1327](https://github.com/vig-os/devkit/issues/1327), [#1322](https://github.com/vig-os/devkit/issues/1322), [#1323](https://github.com/vig-os/devkit/issues/1323))
   - New time-boxed `.vulnixignore` block (expires 2026-08-31) for the three
     HIGH libssh2 1.11.1 CVEs disclosed 2026-07-24 (CVE-2026-66033, -66034,

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -76,6 +76,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **Advance the nixpkgs pin and drop the gawk exception block** ([#1328](https://github.com/vig-os/devkit/issues/1328))
+  - Advanced the pinned `nixpkgs` rev (`flake.lock`) from nixos-26.05
+    @ `8623c4c2` (2026-07-26) to @ `531670d8` (2026-08-03), which is the first
+    pinned-channel rev to ship **gawk 5.4.1**. The rebuilt closure confirms it.
+  - Removed the gawk 5.4.0 CERT-PL block (CVE-2026-40467, -40468, -40469,
+    -40553) instead of renewing it a third time. It had been extended at #1240
+    and again at the #1273 pin advance only because the fix sat in nixpkgs
+    `staging` as a stdenv mass-rebuild, leaving the "advance the rev" lever with
+    nowhere to land.
+  - The before/after `vulnix` closure diff is exactly those four CVEs
+    (59 → 55 unique advisories) with nothing new appearing, and the gate passes
+    on 27 exceptions (down from 31).
+  - The rest of the register was re-verified against the new rev and nothing
+    else became droppable: fzf (0.72.0), libssh2 (1.11.1, still carrying no
+    6603x patch), unbound (1.25.1) and podman (5.8.2) are all unchanged, so
+    those blocks are retained with a 2026-08-04 re-verification note.
 - **vulnix register: except the libssh2 malicious-server batch, prune five dead exceptions** ([#1327](https://github.com/vig-os/devkit/issues/1327), [#1322](https://github.com/vig-os/devkit/issues/1322), [#1323](https://github.com/vig-os/devkit/issues/1323))
   - New time-boxed `.vulnixignore` block (expires 2026-08-31) for the three
     HIGH libssh2 1.11.1 CVEs disclosed 2026-07-24 (CVE-2026-66033, -66034,

--- a/flake.lock
+++ b/flake.lock
@@ -100,11 +100,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1785104993,
-        "narHash": "sha256-eKbrvPoAOFutbYMdbB3r5EQVmFxKv24iKqHPPUXA0gM=",
+        "lastModified": 1785734586,
+        "narHash": "sha256-ODZkEK9Gy50yg6h98u7KkitZ3oc/uuTFK00bh1CRdNA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8623c4c20aa4ca2f5fb81510d2944066c3fb0d96",
+        "rev": "531670d871c0e29724a02f3cbcac170adc65b58c",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Description

Advances the pinned `nixpkgs` rev so the gawk exception block can be **deleted
rather than renewed a third time**, per #1328.

`nixos-26.05` started shipping gawk **5.4.1** on 2026-08-03. The block
(CVE-2026-40467, -40468, -40469, -40553, from the 2026-07-14 CERT-PL batch,
#1071) only ever existed because the fix sat in nixpkgs `staging` as a stdenv
mass-rebuild, leaving the "advance the rev" lever with nowhere to land — which
is why it was extended at #1240 and again at the #1273 pin advance. The lever is
now available, and the block would have lapsed on 2026-08-19.

Closes #1328

## Type of Change

- [x] `fix` -- Bug fix
- [x] `build` -- Build system or dependency changes

### Modifiers

- [ ] Breaking change (`!`)

## Changes Made

- `flake.lock`: `nixpkgs` (nixos-26.05) `8623c4c2` (2026-07-26) → `531670d8`
  (2026-08-03). Only the `nixpkgs` node moves (3 lines).
- `.vulnixignore`: the gawk block is removed and replaced with a tombstone note
  recording why, matching the convention #1327 used for the entries it pruned.
- `.vulnixignore`: the four retained "awaiting upstream" blocks get a 2026-08-04
  re-verification line against the new rev.
- `CHANGELOG.md` + the `assets/workspace/.devcontainer/` mirror (via
  `just sync-workspace`).

## Changelog Entry

```markdown
### Security

- **Advance the nixpkgs pin and drop the gawk exception block** ([#1328](https://github.com/vig-os/devkit/issues/1328))
  - Advanced the pinned `nixpkgs` rev (`flake.lock`) from nixos-26.05
    @ `8623c4c2` (2026-07-26) to @ `531670d8` (2026-08-03), which is the first
    pinned-channel rev to ship **gawk 5.4.1**. The rebuilt closure confirms it.
  - Removed the gawk 5.4.0 CERT-PL block (CVE-2026-40467, -40468, -40469,
    -40553) instead of renewing it a third time. It had been extended at #1240
    and again at the #1273 pin advance only because the fix sat in nixpkgs
    `staging` as a stdenv mass-rebuild, leaving the "advance the rev" lever with
    nowhere to land.
  - The before/after `vulnix` closure diff is exactly those four CVEs
    (59 → 55 unique advisories) with nothing new appearing, and the gate passes
    on 27 exceptions (down from 31).
  - The rest of the register was re-verified against the new rev and nothing
    else became droppable: fzf (0.72.0), libssh2 (1.11.1, still carrying no
    6603x patch), unbound (1.25.1) and podman (5.8.2) are all unchanged, so
    those blocks are retained with a 2026-08-04 re-verification note.
```

## Testing

- [x] Manual testing performed (below)

### Manual Testing Details

Both closures were built locally and scanned with the same command the nightly
`security-scan.yml` runs (`vulnix --mirror https://vig-os.github.io/nvd-mirror/
--closure ...`).

**Closure contents**

| Package | Old pin `8623c4c2` | New pin `531670d8` |
|---------|--------------------|--------------------|
| gawk    | 5.4.0              | **5.4.1**          |
| fzf     | 0.72.0             | 0.72.0             |
| libssh2 | 1.11.1             | 1.11.1             |
| unbound | 1.25.1             | 1.25.1             |
| podman  | 5.8.2              | 5.8.2              |

**Findings diff** (`nix build .#devkitImageEnv` on each pin)

- Before: 18 finding groups / 59 unique CVEs
- After: 16 finding groups / 55 unique CVEs
- Dropped: `CVE-2026-40467`, `CVE-2026-40468`, `CVE-2026-40469`, `CVE-2026-40553`
- Added: *(none)*

**Gates**

- `uv run check-expirations .vulnixignore` → `Validated 27 exception(s)`
- `uv run vulnix-gate vulnix-after.json --register .vulnixignore` →
  `No unexcepted HIGH/CRITICAL findings (CVSS >= 7.0); 27 exception(s) applied`
  (was 31 exceptions before the prune)
- `nix build .#devkitImage` succeeds on the new pin
- `just precommit` (full suite, all files) green

## Checklist

- [x] I have performed a self-review of my code
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective — n/a, this is a
      dependency-pin and exception-register change; the `vulnix` gate and
      `check-expirations` are the tests, and both are exercised above and in CI.

## Additional Notes

The register is otherwise unchanged. The three `git` CPE-mismatch entries stay
even though vulnix does not currently report them — #1327 deliberately keeps
Class-1 false positives on a yearly re-check in case the NVD CPE data is
corrected.

Note this is a stdenv mass-rebuild, so the image layers change wholesale even
though only gawk moves version; CI will need to repopulate cachix.

Refs: #1328
