### PR TITLE
fix(ci): generate the SBOM before the blocking vulnix gate

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -155,13 +155,11 @@ jobs:
           nix run .#vulnix -- --mirror "$NVD_MIRROR" --closure ./result | tee vulnix-report.txt || rc=$?
           [ "$rc" -le 2 ] || { echo "::error::vulnix report failed (exit $rc)"; exit "$rc"; }
 
-      - name: Gate on unexcepted HIGH/CRITICAL vulnix findings
-        id: vulnix-gate
-        # BLOCKING (#639): fails the nightly scan on any HIGH/CRITICAL not covered
-        # by a non-expired entry in .vulnixignore. This is the go/no-go gate for
-        # the publish-cutover.
-        run: uv run vulnix-gate vulnix-findings.json --register .vulnixignore
-
+      # SBOM generation runs BEFORE the gate (#1342). These steps carry no `if:`,
+      # so scheduling them after the blocking gate meant a red gate ended the job
+      # first and the uploaded artifact lost its SBOM and Trivy view — exactly
+      # the runs where that evidence is needed to triage the finding. Ordering
+      # fixes it without conditions, keeping the gate the job's last word.
       - name: Build the Nix image for SBOM generation
         run: |
           set -euo pipefail
@@ -186,6 +184,15 @@ jobs:
           format: 'table'
           severity: 'HIGH,CRITICAL'
           exit-code: '0'
+
+      - name: Gate on unexcepted HIGH/CRITICAL vulnix findings
+        id: vulnix-gate
+        # BLOCKING (#639): fails the nightly scan on any HIGH/CRITICAL not covered
+        # by a non-expired entry in .vulnixignore. This is the go/no-go gate for
+        # the publish-cutover. Deliberately LAST of the checking steps (#1342) so
+        # it stays the job's unambiguous verdict and nothing it fails can skip
+        # evidence collection; only the always() upload and summary follow it.
+        run: uv run vulnix-gate vulnix-findings.json --register .vulnixignore
 
       - name: Upload vulnix findings + SBOM (Trivy-vs-vulnix overlap evidence)
         # always(): a red vulnix-gate is exactly when the findings are needed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The nightly scan keeps its SBOM when the vulnix gate goes red** ([#1342](https://github.com/vig-os/devkit/issues/1342))
+  - `security-scan.yml` generated the CycloneDX SBOM and ran the Trivy
+    defence-in-depth view *after* the blocking `vulnix-gate` step, with no `if:`
+    condition, so a red gate ended the job before they ran. The uploaded
+    artifact was complete on green runs and stripped on red ones — the inverse
+    of what triage needs (17 kB on the red 2026-08-03 dev run vs ~466 kB on the
+    green 2026-07-30 one).
+  - The SBOM steps now run before the gate, which stays last, blocking and
+    unchanged — so it remains the job's verdict and the tracking-issue
+    automation that keys on its outcome is unaffected.
 - **Trunk consumers' Renovate preset now targets `main`** ([#1336](https://github.com/vig-os/devkit/issues/1336))
   - The trunk render (`render_workflow_model`) retargets `baseBranchPatterns`
     from `["dev"]` to `["main"]` in the scaffolded `.github/renovate-default.json`.

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -77,6 +77,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The nightly scan keeps its SBOM when the vulnix gate goes red** ([#1342](https://github.com/vig-os/devkit/issues/1342))
+  - `security-scan.yml` generated the CycloneDX SBOM and ran the Trivy
+    defence-in-depth view *after* the blocking `vulnix-gate` step, with no `if:`
+    condition, so a red gate ended the job before they ran. The uploaded
+    artifact was complete on green runs and stripped on red ones — the inverse
+    of what triage needs (17 kB on the red 2026-08-03 dev run vs ~466 kB on the
+    green 2026-07-30 one).
+  - The SBOM steps now run before the gate, which stays last, blocking and
+    unchanged — so it remains the job's verdict and the tracking-issue
+    automation that keys on its outcome is unaffected.
 - **Trunk consumers' Renovate preset now targets `main`** ([#1336](https://github.com/vig-os/devkit/issues/1336))
   - The trunk render (`render_workflow_model`) retargets `baseBranchPatterns`
     from `["dev"]` to `["main"]` in the scaffolded `.github/renovate-default.json`.

--- a/tests/test_workflow_sbom_ordering.py
+++ b/tests/test_workflow_sbom_ordering.py
@@ -1,0 +1,127 @@
+"""Workflow-shape tests for SBOM survival past a red vulnix gate.
+
+The nightly ``security-scan.yml`` uploads its artifact with ``if: always()``
+because, as that step's own comment says, "a red vulnix-gate is exactly when the
+findings are needed". But the two steps that *produce* half of that artifact —
+the image build and the CycloneDX SBOM generation — sat **after** the blocking
+gate with no condition, so a red gate ended the job before they ran. The
+artifact was therefore complete only on green runs and stripped on red ones,
+the inverse of what triage needs (#1342).
+
+The fix is ordering, not conditions: the SBOM steps move above the gate, leaving
+``vulnix-gate`` as the job's last step and unambiguous verdict.
+
+These are pure YAML-shape assertions (no ``nix``/``trivy`` needed).
+
+Refs: #1342
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+# Repository root (tests/ -> repo root).
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+SECURITY_SCAN_WF = REPO_ROOT / ".github" / "workflows" / "security-scan.yml"
+
+SCAN_JOB = "scan-nix-image"
+
+
+def _steps() -> list[dict]:
+    workflow = yaml.safe_load(SECURITY_SCAN_WF.read_text(encoding="utf-8"))
+    return workflow["jobs"][SCAN_JOB]["steps"]
+
+
+def _index_of(steps: list[dict], predicate) -> int:
+    """Position of the first step matching ``predicate`` (-1 when absent)."""
+    for position, step in enumerate(steps):
+        if predicate(step):
+            return position
+    return -1
+
+
+def _is_gate(step: dict) -> bool:
+    return step.get("id") == "vulnix-gate"
+
+
+def _is_sbom_image_build(step: dict) -> bool:
+    return "nix build .#devkitImage" in step.get("run", "")
+
+
+def _is_sbom_generate(step: dict) -> bool:
+    return step.get("with", {}).get("format") == "cyclonedx"
+
+
+def _is_upload(step: dict) -> bool:
+    return "upload-artifact" in step.get("uses", "")
+
+
+def test_sbom_steps_precede_the_blocking_gate() -> None:
+    """The SBOM producers run before the gate, so a red gate cannot skip them."""
+    steps = _steps()
+
+    gate = _index_of(steps, _is_gate)
+    image_build = _index_of(steps, _is_sbom_image_build)
+    sbom = _index_of(steps, _is_sbom_generate)
+
+    assert gate != -1, "the vulnix-gate step is missing"
+    assert image_build != -1, "the SBOM image-build step is missing"
+    assert sbom != -1, "the CycloneDX SBOM step is missing"
+
+    assert image_build < gate, (
+        "the SBOM image build must run BEFORE the blocking vulnix gate — after it, "
+        "a red gate ends the job and the artifact loses its SBOM exactly when it "
+        "is needed for triage (#1342)"
+    )
+    assert sbom < gate, (
+        "CycloneDX SBOM generation must run BEFORE the blocking vulnix gate (#1342)"
+    )
+
+
+def test_gate_is_the_last_verdict_step() -> None:
+    """Only the always-run upload may follow the gate.
+
+    Keeping the gate last preserves it as the job's unambiguous pass/fail
+    signal; anything scheduled after it must be unconditional, or it silently
+    inherits the gate's outcome the way the SBOM steps used to.
+    """
+    steps = _steps()
+    gate = _index_of(steps, _is_gate)
+
+    for step in steps[gate + 1 :]:
+        condition = str(step.get("if", ""))
+        assert "always()" in condition, (
+            f"step {step.get('name')!r} follows the blocking gate without "
+            f"`if: always()`, so a red gate would skip it (#1342)"
+        )
+
+
+def test_gate_stays_blocking() -> None:
+    """The gate must keep failing the job — the tracking automation depends on it.
+
+    ``security-scan.yml`` opens a deduplicated tracking issue keyed on
+    ``vulnix-gate.outcome == 'failure'`` (#965, #1237), so a fix that softened
+    the gate to keep the SBOM steps reachable would silently disable the
+    nightly's issue-opening path.
+    """
+    steps = _steps()
+    gate = steps[_index_of(steps, _is_gate)]
+
+    assert not gate.get("continue-on-error", False), (
+        "the vulnix gate must stay blocking (#639)"
+    )
+    assert "if" not in gate, "the vulnix gate must run unconditionally (#639)"
+
+
+def test_upload_still_runs_on_a_red_gate() -> None:
+    """The artifact upload keeps its `if: always()` guard."""
+    steps = _steps()
+    upload = steps[_index_of(steps, _is_upload)]
+
+    assert "always()" in str(upload.get("if", "")), (
+        "the artifact upload must stay `if: always()` — a red gate is when the "
+        "findings and SBOM are most needed"
+    )

--- a/tests/test_workflow_sbom_ordering.py
+++ b/tests/test_workflow_sbom_ordering.py
@@ -81,21 +81,22 @@ def test_sbom_steps_precede_the_blocking_gate() -> None:
     )
 
 
-def test_gate_is_the_last_verdict_step() -> None:
-    """Only the always-run upload may follow the gate.
+def test_nothing_unconditioned_follows_the_gate() -> None:
+    """Every step after the gate states its own run condition.
 
     Keeping the gate last preserves it as the job's unambiguous pass/fail
-    signal; anything scheduled after it must be unconditional, or it silently
-    inherits the gate's outcome the way the SBOM steps used to.
+    signal. A step scheduled after it with no ``if:`` silently inherits the
+    gate's outcome — the #1342 defect. The conditions themselves differ by
+    intent: the upload and summary use ``always()``, while the tracking-issue
+    step deliberately fires only on ``failure()``.
     """
     steps = _steps()
     gate = _index_of(steps, _is_gate)
 
     for step in steps[gate + 1 :]:
-        condition = str(step.get("if", ""))
-        assert "always()" in condition, (
-            f"step {step.get('name')!r} follows the blocking gate without "
-            f"`if: always()`, so a red gate would skip it (#1342)"
+        assert "if" in step, (
+            f"step {step.get('name')!r} follows the blocking gate with no `if:` "
+            f"condition, so a red gate would silently skip it (#1342)"
         )
 
 


### PR DESCRIPTION
## Description

The nightly scan's SBOM steps ran **after** the blocking `vulnix-gate` with no
`if:` condition, so a red gate ended the job before they executed. The artifact
— uploaded with `if: always()` precisely because "a red vulnix-gate is exactly
when the findings are needed" — therefore carried its CycloneDX SBOM and Trivy
defence-in-depth view only on **green** runs, and was stripped on red ones.

Targets **`release/1.6.0`**, not `dev`: the branch was cut minutes before this
was filed and no RC has been tagged yet, so the fix rides 1.6.0 rather than
waiting a train. `dev` picks it up via the release-merge PR.

Closes #1342

## Type of Change

- [x] `fix` -- Bug fix
- [x] `ci` -- CI/CD pipeline changes

## Changes Made

- **`.github/workflows/security-scan.yml`**: the three evidence steps (`Build
  the Nix image for SBOM generation`, `Generate Nix image SBOM (CycloneDX)`,
  `Trivy SBOM-mode scan`) move above `Gate on unexcepted HIGH/CRITICAL vulnix
  findings`. The gate is now the last checking step; only the `always()` upload
  and summary and the `failure()`-conditioned tracking-issue step follow it.
  The gate itself is byte-for-byte unchanged apart from a comment noting why it
  is deliberately last.
- **`tests/test_workflow_sbom_ordering.py`** (new): four YAML-shape assertions —
  the SBOM producers precede the gate; nothing after the gate is unconditioned;
  the gate stays blocking (no `continue-on-error`, no `if:`); the upload keeps
  `always()`.

Ordering was chosen over `if: !cancelled()` on the SBOM steps so the gate
remains the job's final, unambiguous verdict. The cost is that the image build
now runs before the gate on every run — but `nix build .#devkitImage` is largely
cache-warm after `devkitImageEnv` was built earlier in the same job.

## Changelog Entry

Added to the frozen `## [1.6.0] - TBD` section (this ships in 1.6.0, so it does
not belong under `## Unreleased`):

```markdown
### Fixed

- **The nightly scan keeps its SBOM when the vulnix gate goes red** ([#1342](https://github.com/vig-os/devkit/issues/1342))
  - `security-scan.yml` generated the CycloneDX SBOM and ran the Trivy
    defence-in-depth view *after* the blocking `vulnix-gate` step, with no `if:`
    condition, so a red gate ended the job before they ran. The uploaded
    artifact was complete on green runs and stripped on red ones — the inverse
    of what triage needs (17 kB on the red 2026-08-03 dev run vs ~466 kB on the
    green 2026-07-30 one).
  - The SBOM steps now run before the gate, which stays last, blocking and
    unchanged — so it remains the job's verdict and the tracking-issue
    automation that keys on its outcome is unaffected.
```

## Testing

- [x] Tests pass locally (`just test`)
- [x] Manual testing performed (describe below)

### Manual Testing Details

**TDD, red-first.** The test committed first (`ace02b53`) against the unmodified
workflow:

```
FAILED test_sbom_steps_precede_the_blocking_gate
FAILED test_nothing_unconditioned_follows_the_gate
2 failed, 2 passed
```

The two that passed are the guards that already held (gate blocking, upload
`always()`) — they are regression cover, not new behavior.

Re-verified after the fix by stashing only the workflow change, so the *final*
test file is proven red against the *original* workflow and green against the
fixed one:

```
$ git stash push .github/workflows/security-scan.yml && pytest   # 2 failed, 2 passed
$ git stash pop && pytest -v                                     # 4 passed
```

**Regression cover**: `pytest -k workflow` → **130 passed**, 529 deselected.

**Hooks**: `just precommit` (full suite, all files) green, exit 0, tree
unmodified by the run.

### Correction made mid-implementation

The first version of `test_nothing_unconditioned_follows_the_gate` asserted that
every step after the gate carries `always()`. That was over-specified and failed
against the correct workflow: `Open a tracking issue when the vulnix gate fails`
deliberately runs on `failure() && steps.vulnix-gate.outcome == 'failure'`. The
assertion now requires an *explicit* `if:` on anything following the gate, which
is the invariant that actually prevents #1342 — an unconditioned step silently
inherits the gate's outcome.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have updated `CHANGELOG.md` (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

Not a regression from anything in 1.6.0 — the ordering has been there since the
SBOM steps were added, and it only bites on a red gate, which was rare until the
libssh2 batch turned the nightly red on 2026-07-31 (#1322 / #1323).

The fix cannot be proven end-to-end without a genuinely red gate, which `dev`
no longer has after #1327 and #1328. The YAML-shape tests are the durable proof;
the next real red-gate run is the live confirmation.

Refs: #1342
