### PR TITLE
fix(workspace): compare template copies by checksum so same-size changes land

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Upgrades no longer skip same-size template changes on previously scaffolded consumers** ([#1344](https://github.com/vig-os/devkit/issues/1344))
+  - The scaffold's template copy (`rsync -avL`) relied on rsync's size+mtime
+    quick-check. The dereferenced template files carry the Nix store's canonical
+    epoch+1 mtime, and `-a` (`-t`) stamps that same mtime onto the workspace
+    copies — so a later template change that keeps the byte count identical (a
+    digest-for-digest action bump, like #1330's `codeql-action` update in
+    `scorecard.yml`) matched the consumer file on both size and mtime and was
+    silently never delivered by host-side upgrades of previously nix-scaffolded
+    consumers. CI paths were unaffected (fresh checkouts have current mtimes),
+    which is how the scaffold-drift gate (#1295) caught the divergence on its
+    first live exercise: four of five 1.6.0-rc1 consumer lanes went red on a
+    scaffold the upgrade itself had produced.
+  - All three template `rsync` invocations (consumer upgrade, smoke clean
+    deploy, smoke overlay) now pass `--checksum`, so delivery is decided by
+    content, not size+mtime coincidence.
 - **The nightly scan keeps its SBOM when the vulnix gate goes red** ([#1342](https://github.com/vig-os/devkit/issues/1342))
   - `security-scan.yml` generated the CycloneDX SBOM and ran the Trivy
     defence-in-depth view *after* the blocking `vulnix-gate` step, with no `if:`

--- a/assets/init-workspace.sh
+++ b/assets/init-workspace.sh
@@ -1710,14 +1710,22 @@ echo "Copying files from $TEMPLATE_DIR to $WORKSPACE_DIR..."
 # Note: Excluding .venv - it is used directly from the container image
 # via UV_PROJECT_ENVIRONMENT environment variable (set in docker-compose.yml)
 # Pre-commit cache is now at /opt/pre-commit-cache (not in assets/workspace)
+#
+# --checksum on every template copy (#1344): the dereferenced (-L) template
+# files carry the Nix store's canonical epoch+1 mtime, and -a (-t) stamps that
+# same mtime onto the workspace copies — so on the NEXT upgrade a template
+# change that keeps the byte count identical (a digest-for-digest action bump)
+# matches the consumer file on both size and mtime and rsync's quick-check
+# silently skips it. Content comparison is the only sound check here; the
+# template is small, so the cost is negligible.
 if [[ "$SMOKE_TEST" == "true" ]]; then
     # Smoke mode: clean deploy (--delete removes stale files), then overlay smoke-test assets
-    rsync -avL --delete --exclude='.git' --exclude='.venv' --exclude='docs/issues/' --exclude='docs/pull-requests/' "$TEMPLATE_DIR/" "$WORKSPACE_DIR/"
+    rsync -avL --checksum --delete --exclude='.git' --exclude='.venv' --exclude='docs/issues/' --exclude='docs/pull-requests/' "$TEMPLATE_DIR/" "$WORKSPACE_DIR/"
 
     SMOKE_TEST_DIR="$SCRIPT_DIR/smoke-test"
     if [[ -d "$SMOKE_TEST_DIR" ]]; then
         echo "Deploying smoke-test-specific files..."
-        rsync -avL "$SMOKE_TEST_DIR/" "$WORKSPACE_DIR/"
+        rsync -avL --checksum "$SMOKE_TEST_DIR/" "$WORKSPACE_DIR/"
     else
         echo "Warning: Smoke-test directory not found at $SMOKE_TEST_DIR" >&2
     fi
@@ -1781,7 +1789,7 @@ else
         EXCLUDE_ARGS+=("--exclude=/.github/workflows/sync-main-to-dev.yml")
     fi
 
-    rsync -avL --exclude='.git' --exclude='.venv' "${EXCLUDE_ARGS[@]}" "$TEMPLATE_DIR/" "$WORKSPACE_DIR/"
+    rsync -avL --checksum --exclude='.git' --exclude='.venv' "${EXCLUDE_ARGS[@]}" "$TEMPLATE_DIR/" "$WORKSPACE_DIR/"
 
     # ci.yml is a single mode-aware workflow (#991): it resolves DEVKIT_MODE at
     # run time via the resolve-toolchain job + setup-devkit-toolchain composite,

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -77,6 +77,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Upgrades no longer skip same-size template changes on previously scaffolded consumers** ([#1344](https://github.com/vig-os/devkit/issues/1344))
+  - The scaffold's template copy (`rsync -avL`) relied on rsync's size+mtime
+    quick-check. The dereferenced template files carry the Nix store's canonical
+    epoch+1 mtime, and `-a` (`-t`) stamps that same mtime onto the workspace
+    copies — so a later template change that keeps the byte count identical (a
+    digest-for-digest action bump, like #1330's `codeql-action` update in
+    `scorecard.yml`) matched the consumer file on both size and mtime and was
+    silently never delivered by host-side upgrades of previously nix-scaffolded
+    consumers. CI paths were unaffected (fresh checkouts have current mtimes),
+    which is how the scaffold-drift gate (#1295) caught the divergence on its
+    first live exercise: four of five 1.6.0-rc1 consumer lanes went red on a
+    scaffold the upgrade itself had produced.
+  - All three template `rsync` invocations (consumer upgrade, smoke clean
+    deploy, smoke overlay) now pass `--checksum`, so delivery is decided by
+    content, not size+mtime coincidence.
 - **The nightly scan keeps its SBOM when the vulnix gate goes red** ([#1342](https://github.com/vig-os/devkit/issues/1342))
   - `security-scan.yml` generated the CycloneDX SBOM and ran the Trivy
     defence-in-depth view *after* the blocking `vulnix-gate` step, with no `if:`

--- a/tests/bats/init-workspace.bats
+++ b/tests/bats/init-workspace.bats
@@ -894,12 +894,12 @@ _preview_symlinked_template_venv() {
 }
 
 @test "init-workspace.sh smoke mode uses rsync --delete for clean deploy" {
-    run grep 'rsync -avL --delete' "$INIT_WORKSPACE_SH"
+    run grep 'rsync -avL --checksum --delete' "$INIT_WORKSPACE_SH"
     assert_success
 }
 
 @test "init-workspace.sh smoke mode excludes synced docs directories from delete" {
-    run grep -A1 'rsync -avL --delete' "$INIT_WORKSPACE_SH"
+    run grep -A1 'rsync -avL --checksum --delete' "$INIT_WORKSPACE_SH"
     assert_success
     assert_output --partial "--exclude='docs/issues/'"
     assert_output --partial "--exclude='docs/pull-requests/'"

--- a/tests/bats/init-workspace.bats
+++ b/tests/bats/init-workspace.bats
@@ -288,6 +288,53 @@ _scaffold() {
     assert_success
 }
 
+@test "upgrade delivers same-size template changes on epoch-mtime trees (#1344)" {
+    # A consumer scaffolded by a previous nix-image devkit carries managed files
+    # whose mtimes rsync -t stamped to the store's canonical epoch+1 — the same
+    # mtime every later template ships. A template change that keeps the byte
+    # count identical (a digest-for-digest action bump, #1330) then matches the
+    # consumer copy on BOTH size and mtime, and rsync's quick-check silently
+    # skips the transfer: the upgrade claims success but never delivers the
+    # change. Caught live by the scaffold-drift gate on 4 of 5 1.6.0-rc1 lanes.
+    tmpl="$BATS_TEST_TMPDIR/tmpl-1344"
+    cp -r "$PROJECT_ROOT/assets/workspace" "$tmpl"
+    ws="$BATS_TEST_TMPDIR/ws-1344"
+    mkdir -p "$ws"
+    stub="$BATS_TEST_TMPDIR/stub-bin"
+    mkdir -p "$stub"
+    printf '#!/usr/bin/env bash\nexit 0\n' >"$stub/just"
+    chmod +x "$stub/just"
+
+    # First scaffold: the consumer adopts the current template.
+    env PATH="$stub:$PATH" \
+        TEMPLATE_DIR="$tmpl" \
+        WORKSPACE_DIR="$ws" \
+        SHORT_NAME=testproj \
+        GITHUB_REPOSITORY=test/repo \
+        bash "$INIT_WORKSPACE_SH" --force --no-prompts --mode direnv
+    assert [ -f "$ws/.github/workflows/scorecard.yml" ]
+
+    # Upstream ships a same-length change to a managed file (digest swap class).
+    sed -i 's/sarif_file/sarif_fil3/' "$tmpl/.github/workflows/scorecard.yml"
+    run diff "$tmpl/.github/workflows/scorecard.yml" "$ws/.github/workflows/scorecard.yml"
+    assert_failure
+
+    # Both sides sit at the Nix store's epoch+1 — template by construction,
+    # consumer stamped by the previous scaffold's rsync -t.
+    touch -d '@1' "$tmpl/.github/workflows/scorecard.yml" \
+        "$ws/.github/workflows/scorecard.yml"
+
+    # Second scaffold (the upgrade) must still deliver the change.
+    env PATH="$stub:$PATH" \
+        TEMPLATE_DIR="$tmpl" \
+        WORKSPACE_DIR="$ws" \
+        SHORT_NAME=testproj \
+        GITHUB_REPOSITORY=test/repo \
+        bash "$INIT_WORKSPACE_SH" --force --no-prompts --mode direnv
+    run diff "$tmpl/.github/workflows/scorecard.yml" "$ws/.github/workflows/scorecard.yml"
+    assert_success
+}
+
 @test "init-workspace --mode=direnv yields a justfile that still loads (#641)" {
     # Regression guard: direnv mode prunes .devcontainer/, so the scaffolded
     # justfile's .devcontainer imports must be optional or `just` fails to parse.


### PR DESCRIPTION
Closes #1344.

## What

Adds `--checksum` to all three template `rsync -avL` invocations in `assets/init-workspace.sh` (consumer upgrade copy, smoke clean deploy, smoke overlay), so template delivery is decided by content rather than rsync's size+mtime quick-check.

## Why

The dereferenced template files carry the Nix store's canonical epoch+1 mtime, and `-a` (`-t`) stamps that mtime onto workspace copies at scaffold time. A later template change that keeps the byte count identical — the digest-for-digest `codeql-action` bump from #1330 in `scorecard.yml` is the live case — then matches the consumer copy on both size and mtime, and rsync silently skips it: the upgrade claims success but never delivers the change. Fresh checkouts (CI) are unaffected, which is exactly how the scaffold-drift gate (#1295) caught it on its first live exercise: 4 of 5 1.6.0-rc1 consumer lanes went red on scaffolds the host-side upgrade itself had produced (org-config#85, sync-issues-action#160, commit-action#124, exo-fleet#268; vault#48 ran from a fresh worktree and passed).

## How verified

- TDD: new bats test scaffolds a workspace, ships a same-length template change with both sides at mtime epoch+1, and asserts the re-scaffold delivers it — RED before the fix (rsync itemize shows `.f...p.....`, no transfer), GREEN after.
- Full `tests/bats/init-workspace.bats` suite: 279/279 pass (two tests pinning the literal smoke rsync invocation updated to the new flag string).
- Full pre-commit suite green.

Release-train blocker for 1.6.0 → cut rc2 after merge, then re-bump the five lanes.