### PR TITLE
fix(upgrade): close the adoption issue a no-diff run created

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A no-diff devkit upgrade no longer strands its adoption issue** ([#1347](https://github.com/vig-os/devkit/issues/1347))
+  - The scaffolded `devkit-upgrade.yml` opens the adoption issue *before*
+    `install.sh --force` runs (the branch name embeds its number and the
+    in-shell commit needs the `Refs:` line), so a `workflow_dispatch` against an
+    already-current consumer created an issue, found zero diff, skipped publish
+    and PR, and exited green — leaving an issue open with no PR ever attached.
+    Every credential probe or repair run against a current consumer left one
+    behind.
+  - The find-or-create step now reports which branch it took, and a final
+    cleanup step on the no-diff path **closes an issue this run created** (with
+    a "no diff at `<version>`" comment) while **leaving a reused one open** — a
+    mid-train `rc1 → rc2 → final` issue can legitimately see a no-op bump, and
+    auto-closing it would be wrong. Comment only in that case.
+
 ### Security
 
 ## [1.6.0](https://github.com/vig-os/devkit/releases/tag/1.6.0) - 2026-08-04

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -17,6 +17,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A no-diff devkit upgrade no longer strands its adoption issue** ([#1347](https://github.com/vig-os/devkit/issues/1347))
+  - The scaffolded `devkit-upgrade.yml` opens the adoption issue *before*
+    `install.sh --force` runs (the branch name embeds its number and the
+    in-shell commit needs the `Refs:` line), so a `workflow_dispatch` against an
+    already-current consumer created an issue, found zero diff, skipped publish
+    and PR, and exited green — leaving an issue open with no PR ever attached.
+    Every credential probe or repair run against a current consumer left one
+    behind.
+  - The find-or-create step now reports which branch it took, and a final
+    cleanup step on the no-diff path **closes an issue this run created** (with
+    a "no diff at `<version>`" comment) while **leaving a reused one open** — a
+    mid-train `rc1 → rc2 → final` issue can legitimately see a no-op bump, and
+    auto-closing it would be wrong. Comment only in that case.
+
 ### Security
 
 ## [1.6.0](https://github.com/vig-os/devkit/releases/tag/1.6.0) - 2026-08-04

--- a/assets/workspace/.github/workflows/devkit-upgrade.yml
+++ b/assets/workspace/.github/workflows/devkit-upgrade.yml
@@ -189,8 +189,12 @@ jobs:
               --body "Automated adoption of devkit ${TRAIN}. Opened by the devkit-upgrade workflow (#1296).")"
             NUMBER="${URL##*/}"
             echo "Created adoption issue #${NUMBER}."
+            # Which branch was taken decides the no-diff cleanup below (#1347):
+            # only an issue THIS run created may be auto-closed.
+            echo "created=true" >> "$GITHUB_OUTPUT"
           else
             echo "Reusing open adoption issue #${NUMBER}."
+            echo "created=false" >> "$GITHUB_OUTPUT"
           fi
           echo "number=${NUMBER}" >> "$GITHUB_OUTPUT"
 
@@ -364,4 +368,33 @@ jobs:
           else
             gh pr create --base "$BASE" --head "$BRANCH" --title "$TITLE" --body "$BODY"
             echo "Opened the adoption PR."
+          fi
+
+      - name: Clean up the adoption issue on a no-diff run
+        if: steps.resolve.outputs.proceed == 'true' && steps.commit.outputs.changed != 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          TARGET: ${{ steps.resolve.outputs.target }}
+          ISSUE: ${{ steps.issue.outputs.number }}
+          CREATED: ${{ steps.issue.outputs.created }}
+        run: |
+          set -euo pipefail
+          # The adoption issue is opened BEFORE install.sh runs — the branch name
+          # embeds its number and the in-shell commit needs the `Refs:` line — so
+          # a run that finds no diff (any dispatch against an already-current
+          # consumer; cron no-ops earlier on "current or ahead") skips publish +
+          # PR and would strand the issue with no PR ever attached (#1347).
+          #
+          # Only an issue THIS run created is closed. A REUSED one belongs to a
+          # live train (rc1 -> rc2 -> final, where an interim bump can legitimately
+          # be a no-op) and must stay open — comment only.
+          if [ "$CREATED" = "true" ]; then
+            gh issue close "$ISSUE" \
+              --comment "No diff at ${TARGET}: this repository's scaffold is already current, so no adoption PR was opened. Closing the issue this run created (#1347)." \
+              --reason "not planned"
+            echo "Closed the adoption issue #${ISSUE} it created (no diff)."
+          else
+            gh issue comment "$ISSUE" \
+              --body "No diff at ${TARGET}: the scaffold is already current, so no adoption PR was opened by this run. Leaving this issue open — it predates this run (#1347)."
+            echo "Left the pre-existing adoption issue #${ISSUE} open (no diff)."
           fi

--- a/tests/test_workflow_devkit_upgrade.py
+++ b/tests/test_workflow_devkit_upgrade.py
@@ -221,6 +221,53 @@ def test_reset_excluded_paths_and_closes_issue() -> None:
     assert "Closes #" in text
 
 
+def test_no_diff_dispatch_cleans_up_the_issue_it_created() -> None:
+    """A no-diff run must not strand the adoption issue it opened (#1347).
+
+    The issue is created BEFORE install.sh runs (the branch name embeds its
+    number and the in-shell commit needs the ``Refs:`` line), so a dispatch
+    against an already-current consumer creates an issue, finds zero diff and
+    skips publish + PR — leaving it open forever. The find-or-create step must
+    expose which branch it took, and a final cleanup step gated on the no-diff
+    path must close a *freshly created* issue while leaving a *reused* one open
+    (auto-closing a live mid-train issue would be wrong).
+    """
+    text = TEMPLATE.read_text(encoding="utf-8")
+    steps = _steps(text)
+
+    # The find-or-create step exposes the branch it took as a step output.
+    issue_steps = [s for s in steps if s.get("id") == "issue"]
+    assert issue_steps, "no `issue` step found"
+    (issue_step,) = issue_steps
+    assert "created=true" in str(issue_step["run"])
+    assert "created=false" in str(issue_step["run"])
+
+    # A cleanup step runs on the no-diff path only.
+    cleanup_steps = [
+        s
+        for s in steps
+        if "gh issue close" in str(s.get("run", "")) and s.get("id") != "issue"
+    ]
+    assert cleanup_steps, "no no-diff cleanup step found"
+    (cleanup,) = cleanup_steps
+    cond = str(cleanup.get("if", ""))
+    assert "steps.resolve.outputs.proceed == 'true'" in cond
+    assert "steps.commit.outputs.changed != 'true'" in cond
+    # It authenticates as the App (the identity that owns the issue).
+    assert cleanup.get("env", {}).get("GH_TOKEN") == (
+        "${{ steps.app-token.outputs.token }}"
+    )
+    run = str(cleanup["run"])
+    # Only a freshly created issue is closed; a reused one is left open.
+    assert "steps.issue.outputs.created" not in run, (
+        "route the step output through env, never inline into run:"
+    )
+    assert cleanup.get("env", {}).get("CREATED") == (
+        "${{ steps.issue.outputs.created }}"
+    )
+    assert 'CREATED" = "true"' in run or 'CREATED" != "true"' in run
+
+
 # ── security: no template injection (zizmor) ──────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

A `workflow_dispatch` of the scaffolded `devkit-upgrade.yml` against an
already-current consumer stranded the adoption issue it had just opened: the
issue is necessarily created **before** `install.sh --force` runs (the branch
name embeds its number, the in-shell commit needs the `Refs:` line), so a
zero-diff run correctly skipped publish + PR and exited green — with an open
issue no PR would ever close.

Live occurrence: `exo-pet/exo-fleet#270`, run 30986580730.

## Change

- `Find or create the adoption issue` now exposes a `created` step output
  (`true` on the create branch, `false` on the reuse branch).
- A new final step, gated on `proceed == 'true' && changed != 'true'`:
  - **created this run** → `gh issue close` with a "no diff at `<version>`"
    comment and `--reason "not planned"`;
  - **reused** (mid-train `rc1 → rc2 → final`, where an interim bump can
    legitimately be a no-op) → comment only, issue left open.

The `created` output is routed through `env:` like every other value the
workflow's `run:` blocks consume (zizmor template-injection rule).

## Testing

- New `test_no_diff_dispatch_cleans_up_the_issue_it_created` in
  `tests/test_workflow_devkit_upgrade.py` (RED → GREEN, committed separately).
- `uv run pytest tests/test_workflow_devkit_upgrade.py tests/test_scaffold_drift.py tests/test_scaffold_lint.py` — 68 passed.
- `just precommit` (full suite, all files) green locally, incl. actionlint and
  yamllint on the changed template.

Closes #1347