### PR TITLE
fix(install): prune scaffold paths retired since the consumer pin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Upgrades prune scaffold paths retired since the consumer's pin** ([#1348](https://github.com/vig-os/devkit/issues/1348))
+  - `install.sh --force` regenerated what the *current* scaffold manages and
+    pruned what the current mode / workflow model / feature set excludes — but a
+    path an **old** devkit shipped and a later one **retired** was claimed by
+    neither and rode along through every upgrade. Going 0.3.4 → 1.6.0 preserved
+    `.cursor/`, `.github/actions/resolve-image/`,
+    `.github/workflows/renovate-changelog.yml` and `.hadolint.yaml`. The
+    workflow file is the sharp one: left in place it is live, duplicates the
+    `renovate-changelog-build`/`-commit` pair that replaced it, and calls the
+    pruned `resolve-image` action — so it breaks at its next trigger rather
+    than at upgrade time.
+  - A cumulative retired-paths manifest (version → paths that version stopped
+    shipping) is now consulted against the pin `.vig-os` carried **before** the
+    run — the legacy `DEVCONTAINER_VERSION` key included, since repos still on
+    it are precisely the oldest. Each prune is announced on stdout and listed
+    under `DELETED` in the `--force --preview` report.
+  - The prune is gated on that pin: a repo pinned at or past the retiring
+    version was never shipped the path, so an identically named `.cursor/` or
+    `.hadolint.yaml` there is the consumer's own and is left untouched. A repo
+    that already upgraded past a retirement before this fix keeps its
+    leftovers — a one-time manual cleanup, documented in `docs/MIGRATION.md`.
+
 ### Security
 
 ## [1.6.0](https://github.com/vig-os/devkit/releases/tag/1.6.0) - 2026-08-04

--- a/assets/init-workspace.sh
+++ b/assets/init-workspace.sh
@@ -353,6 +353,16 @@ MANIFEST_AUTO_UPGRADE="$(read_manifest_value "$VIG_OS_MANIFEST" DEVKIT_AUTO_UPGR
 MANIFEST_UPGRADE_EXCLUDE="$(read_manifest_value "$VIG_OS_MANIFEST" DEVKIT_UPGRADE_EXCLUDE || true)"
 MANIFEST_DRIFT_CHECK="$(read_manifest_value "$VIG_OS_MANIFEST" DEVKIT_DRIFT_CHECK || true)"
 
+# The pin this workspace carried BEFORE this run rewrites it (#1348). Read here,
+# far ahead of the #852 rewrite further down, because it is the only evidence of
+# which devkit generation produced the tree we are upgrading — and the
+# retired-paths prune is gated on it. The legacy pre-#781 DEVCONTAINER_VERSION
+# key counts: repos still on it are the oldest ones, i.e. exactly the population
+# carrying the oldest leftovers. Empty on a fresh install (no manifest yet),
+# which disables the prune — no evidence, no deletion.
+PREVIOUS_PIN="$(read_manifest_value "$VIG_OS_MANIFEST" DEVKIT_VERSION \
+    || read_manifest_value "$VIG_OS_MANIFEST" DEVCONTAINER_VERSION || true)"
+
 # The OWNER/REPO placeholder (written when no origin was resolvable) must not
 # mask a now-detectable git origin on a later upgrade.
 [[ "$MANIFEST_REPO" == "OWNER/REPO" ]] && MANIFEST_REPO=""
@@ -1223,6 +1233,95 @@ feature_paths() {
     esac
 }
 
+# ── retired scaffold paths (#1348) ────────────────────────────────────────────
+# An upgrade regenerates what the CURRENT scaffold manages and prunes what the
+# current mode / workflow model / feature set excludes. A path that an OLD devkit
+# shipped and a later devkit RETIRED is managed by neither, so it rode along
+# through every upgrade — observed going 0.3.4 -> 1.6.0 in
+# exo-pet/playground-carlos#9. The `renovate-changelog.yml` case shows why this
+# is not merely cosmetic: the retired workflow coexists with the build/commit
+# pair that replaced it AND references the pruned `resolve-image` action, so it
+# breaks at its next trigger rather than at upgrade time.
+#
+# The cumulative manifest below is the missing knowledge — "version V no longer
+# ships path P" — and PREVIOUS_PIN says which generation produced this tree.
+#
+# Adding an entry: one `<version> <path>` line per path, `<version>` being the
+# first release that stopped shipping it. Paths are workspace-relative; a
+# directory prunes recursively. Sibling of the never-migrate denylist in
+# migrate_root_gitignore (#1145) — same "the template used to own this" spirit,
+# extended across versions instead of within one tree.
+#
+# NOT listed here: `.devcontainer/justfile.base` (also retired in 0.4.0). Its
+# prune is mode-guarded — a direnv/bare consumer's own .devcontainer/ is never
+# touched (#738) — which this version-only manifest cannot express, so it keeps
+# its dedicated block further down.
+retired_paths() {
+    # Split into the build/commit pair; the leftover referenced resolve-image.
+    printf '%s\n' '0.3.5 .github/workflows/renovate-changelog.yml'
+    # Agent rules/skills moved to .claude/ (the SSoT since 0.4.0).
+    printf '%s\n' '0.4.0 .cursor'
+    # Debian build path decommissioned: no Dockerfile-like artifact remains.
+    printf '%s\n' '0.4.0 .hadolint.yaml'
+    # Superseded by the mode-aware resolve-toolchain composite action.
+    printf '%s\n' '1.1.0 .github/actions/resolve-image'
+}
+
+# True (0) when semver $1 is STRICTLY lower than $2. Prerelease-aware in the one
+# direction that matters here: X.Y.Z-rcN sorts below X.Y.Z, so a consumer pinned
+# to an rc of the very release that retires a path is still pruned.
+version_lt() {
+    local a="$1" b="$2"
+    local acore="${a%%-*}" bcore="${b%%-*}"
+    local -a av bv
+    local i ai bi
+    IFS='.' read -ra av <<< "$acore"
+    IFS='.' read -ra bv <<< "$bcore"
+    for i in 0 1 2; do
+        ai="${av[$i]:-0}"; bi="${bv[$i]:-0}"
+        # 10# guards a zero-padded segment from being read as octal.
+        (( 10#$ai < 10#$bi )) && return 0
+        (( 10#$ai > 10#$bi )) && return 1
+    done
+    # Equal cores: a prerelease is lower than its release. Two prereleases of
+    # the same core are not ordered here — no retirement version is a
+    # prerelease, so that comparison never arises.
+    [[ "$a" != "$acore" && "$b" == "$bcore" ]]
+}
+
+# Emit (one workspace-relative path per line) the retired paths this upgrade
+# should delete. Consulted by BOTH the --preview DELETIONS report and the
+# post-copy prune, so the report can never lie about what the run removes.
+#
+# Four gates, each load-bearing:
+#  - a pin is present and semver-shaped. No pin (fresh install, hand-made tree)
+#    or a malformed one means no evidence about this tree's provenance, so
+#    nothing is deleted;
+#  - the pin PREDATES the retirement. This is the safety property: `.cursor/`
+#    and `.hadolint.yaml` are generic names, and a repo pinned at or past the
+#    retiring version was never shipped them by devkit — an identically named
+#    path there is the consumer's own. Under-pruning a repo that already
+#    upgraded past the retirement without this fix is the deliberate trade;
+#    those are cleaned by hand once (see #1348);
+#  - the current template does not ship the path. Defence in depth: a path can
+#    never be both retired and current, and if that invariant ever breaks the
+#    upgrade must not delete a file it is about to write;
+#  - the path is not consumer-owned (PRESERVE_FILES).
+retired_prune_paths() {
+    local ver path
+    [[ -n "$PREVIOUS_PIN" ]] || return 0
+    [[ "$PREVIOUS_PIN" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]] || return 0
+    while read -r ver path; do
+        [[ -n "$ver" && -n "$path" ]] || continue
+        version_lt "$PREVIOUS_PIN" "$ver" || continue
+        path_present "$WORKSPACE_DIR/$path" || continue
+        [[ ! -e "$TEMPLATE_DIR/$path" ]] || continue
+        if ! is_preserved_file "$path"; then
+            printf '%s\n' "$path"
+        fi
+    done < <(retired_paths)
+}
+
 # Feature opt-outs (#1284): append each disabled feature's paths to
 # MODE_CONFIG_EXCLUDES, which both the --preview ADDED classifier and the rsync
 # copy consult — so a disabled feature is never shipped and never advertised.
@@ -1584,6 +1683,13 @@ if [[ "$FORCE" == "true" ]]; then
         done < <(feature_paths "$_feat")
     done
 
+    # Retired scaffold paths (#1348): shipped by the consumer's old devkit,
+    # managed by no current mechanism. Reported like every other deletion so
+    # --preview shows them before anything is touched.
+    while IFS= read -r _p; do
+        [[ -n "$_p" ]] && DELETIONS+=("$_p (retired scaffold path — #1348)")
+    done < <(retired_prune_paths)
+
     # Show preserved files
     if [[ ${#PRESERVED[@]} -gt 0 ]]; then
         echo ""
@@ -1927,6 +2033,16 @@ for _feat in "${DISABLED_FEATURES[@]}"; do
         rm -rf "${WORKSPACE_DIR:?}/$_p"
     done < <(feature_paths "$_feat")
 done
+
+# Retired scaffold paths (#1348): delete what an older devkit shipped into this
+# tree and no current mechanism manages. Gating and rationale live in
+# retired_prune_paths above; this is purely its executor, so the --preview
+# report and the real run can never disagree.
+while IFS= read -r _p; do
+    [[ -n "$_p" ]] || continue
+    echo "Pruning retired scaffold path $_p (shipped before this repo's ${PREVIOUS_PIN} pin, #1348)..."
+    rm -rf "${WORKSPACE_DIR:?}/$_p"
+done < <(retired_prune_paths)
 
 # 0.4.0 retired .devcontainer/justfile.base (recipes relocated to
 # justfile.project), so drop the stale copy an upgraded 0.3.x repo carries —

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -17,6 +17,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Upgrades prune scaffold paths retired since the consumer's pin** ([#1348](https://github.com/vig-os/devkit/issues/1348))
+  - `install.sh --force` regenerated what the *current* scaffold manages and
+    pruned what the current mode / workflow model / feature set excludes — but a
+    path an **old** devkit shipped and a later one **retired** was claimed by
+    neither and rode along through every upgrade. Going 0.3.4 → 1.6.0 preserved
+    `.cursor/`, `.github/actions/resolve-image/`,
+    `.github/workflows/renovate-changelog.yml` and `.hadolint.yaml`. The
+    workflow file is the sharp one: left in place it is live, duplicates the
+    `renovate-changelog-build`/`-commit` pair that replaced it, and calls the
+    pruned `resolve-image` action — so it breaks at its next trigger rather
+    than at upgrade time.
+  - A cumulative retired-paths manifest (version → paths that version stopped
+    shipping) is now consulted against the pin `.vig-os` carried **before** the
+    run — the legacy `DEVCONTAINER_VERSION` key included, since repos still on
+    it are precisely the oldest. Each prune is announced on stdout and listed
+    under `DELETED` in the `--force --preview` report.
+  - The prune is gated on that pin: a repo pinned at or past the retiring
+    version was never shipped the path, so an identically named `.cursor/` or
+    `.hadolint.yaml` there is the consumer's own and is left untouched. A repo
+    that already upgraded past a retirement before this fix keeps its
+    leftovers — a one-time manual cleanup, documented in `docs/MIGRATION.md`.
+
 ### Security
 
 ## [1.6.0](https://github.com/vig-os/devkit/releases/tag/1.6.0) - 2026-08-04

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -868,6 +868,32 @@ re-scaffold:
    from the current directory/`--name`; template-origin files (e.g.
    `tests/test_example.py`) may be rewritten to a name that differs from your
    original scaffold. Review the diff before committing.
+8. **Retired scaffold paths are pruned for you**
+   ([#1348](https://github.com/vig-os/devkit/issues/1348)) — files an *older*
+   devkit shipped and a later one retired used to survive every upgrade,
+   because no current mechanism claimed them. `--force` now consults a
+   cumulative retired-paths manifest against the pin your `.vig-os` carried
+   **before** the run and deletes what that old scaffold shipped:
+
+   | Path | Retired in | Superseded by |
+   |------|-----------|---------------|
+   | `.github/workflows/renovate-changelog.yml` | 0.3.5 | `renovate-changelog-build.yml` + `renovate-changelog-commit.yml` |
+   | `.cursor/` | 0.4.0 | `.claude/` |
+   | `.hadolint.yaml` | 0.4.0 | — (the Debian build path is gone) |
+   | `.github/actions/resolve-image/` | 1.1.0 | `resolve-toolchain` |
+
+   The stale `renovate-changelog.yml` is the one that bites: left in place it
+   is a **live** workflow that both duplicates its replacements and calls the
+   pruned `resolve-image` action, so it fails at its next trigger rather than
+   at upgrade time.
+
+   Every prune is listed under `DELETED` in the `--force --preview` report, so
+   you can see it before anything is touched. The prune is **gated on the
+   previous pin**: a repo pinned at or past the retiring version was never
+   shipped that path by devkit, so an identically named `.cursor/` or
+   `.hadolint.yaml` there is yours and is left alone. The flip side is that a
+   repo which already upgraded past a retirement *before* this fix keeps its
+   leftovers — delete those once by hand.
 
 ## First release after migrating to devkit
 

--- a/tests/test_scaffold_retired_paths.py
+++ b/tests/test_scaffold_retired_paths.py
@@ -1,0 +1,124 @@
+"""Retired-scaffold-path pruning on ``--force`` upgrades (#1348).
+
+``install.sh --force`` regenerates the paths the *current* scaffold manages and
+prunes what the current mode / workflow model / feature set excludes — but a
+path that an OLD devkit shipped and a later devkit RETIRED is managed by
+neither, so it survived every upgrade. Observed going 0.3.4 -> 1.6.0
+(exo-pet/playground-carlos#9): ``.cursor/``, ``.github/actions/resolve-image/``,
+``.github/workflows/renovate-changelog.yml`` and ``.hadolint.yaml`` all rode
+along. The workflow file is the sharp one — it coexists with the
+``renovate-changelog-build``/``-commit`` pair that replaced it and references a
+pruned action, so it breaks at its next trigger rather than at upgrade time.
+
+The fix is a cumulative retired-paths manifest (version -> paths retired in it)
+consulted against the consumer's PREVIOUS pin, which the upgrade reads from
+``.vig-os`` before rewriting it. Version gating is the safety property: a repo
+whose pin already post-dates the retirement never had the path shipped to it, so
+an identically named file there is the consumer's own and must not be deleted.
+
+Refs: #1348
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from tests.workflow_scaffold import INIT_WORKSPACE, scaffold
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+# Every path the manifest retires, with the version that retired it. Kept here
+# as the test's own copy so a silent edit of the shell manifest fails loudly.
+RETIRED = {
+    ".github/workflows/renovate-changelog.yml": "0.3.5",
+    ".cursor": "0.4.0",
+    ".hadolint.yaml": "0.4.0",
+    ".github/actions/resolve-image": "1.1.0",
+}
+
+
+def _seed(tmp_path: Path, pin: str | None, *, paths: tuple[str, ...]) -> Path:
+    """Build a consumer tree pinned at ``pin`` carrying the given stale paths."""
+    seed = tmp_path / "seed"
+    seed.mkdir()
+    if pin is not None:
+        (seed / ".vig-os").write_text(f"DEVKIT_VERSION={pin}\n", encoding="utf-8")
+    for rel in paths:
+        target = seed / rel
+        if rel.endswith((".yml", ".yaml")):
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text("# stale scaffold leftover\n", encoding="utf-8")
+        else:
+            target.mkdir(parents=True, exist_ok=True)
+            (target / "leftover.txt").write_text("stale\n", encoding="utf-8")
+    return seed
+
+
+def test_manifest_declares_every_known_retired_path() -> None:
+    """The shell manifest carries each retired path with its retiring version."""
+    init = INIT_WORKSPACE.read_text(encoding="utf-8")
+    assert "retired_paths()" in init
+    for rel, version in RETIRED.items():
+        assert f"{version} {rel}" in init, f"missing manifest entry: {version} {rel}"
+
+
+def test_upgrade_from_an_old_pin_prunes_retired_paths(tmp_path: Path) -> None:
+    """A 0.3.4 consumer loses every path retired after its pin."""
+    seed = _seed(tmp_path, "0.3.4", paths=tuple(RETIRED))
+    proc = scaffold(tmp_path, seed=seed, name="old-pin")
+    assert proc.returncode == 0, proc.stderr
+    tree = tmp_path / "old-pin"
+    for rel in RETIRED:
+        assert not (tree / rel).exists(), f"{rel} survived the upgrade"
+    # The prune announces itself — a silent deletion is not reviewable.
+    assert "#1348" in proc.stdout
+
+
+def test_legacy_devcontainer_version_pin_is_honored(tmp_path: Path) -> None:
+    """The pre-#781 DEVCONTAINER_VERSION key gates the prune just the same.
+
+    Repos still on the legacy key are exactly the oldest ones, i.e. those most
+    likely to carry the leftovers, so reading only DEVKIT_VERSION would miss
+    the whole population this fix targets.
+    """
+    seed = tmp_path / "seed"
+    seed.mkdir()
+    (seed / ".vig-os").write_text("DEVCONTAINER_VERSION=0.3.4\n", encoding="utf-8")
+    (seed / ".hadolint.yaml").write_text("# stale\n", encoding="utf-8")
+    proc = scaffold(tmp_path, seed=seed, name="legacy-pin")
+    assert proc.returncode == 0, proc.stderr
+    assert not (tmp_path / "legacy-pin" / ".hadolint.yaml").exists()
+
+
+def test_pin_past_the_retirement_keeps_the_path(tmp_path: Path) -> None:
+    """A current consumer's identically named files are the consumer's own.
+
+    Version gating is what makes the prune safe: ``.cursor/`` and
+    ``.hadolint.yaml`` are generic names a repo pinned past 0.4.0 may own
+    outright, and deleting those would be data loss.
+    """
+    seed = _seed(tmp_path, "1.6.0", paths=(".cursor", ".hadolint.yaml"))
+    proc = scaffold(tmp_path, seed=seed, name="new-pin")
+    assert proc.returncode == 0, proc.stderr
+    tree = tmp_path / "new-pin"
+    assert (tree / ".cursor").is_dir()
+    assert (tree / ".hadolint.yaml").is_file()
+
+
+def test_unpinned_workspace_prunes_nothing(tmp_path: Path) -> None:
+    """No pin (fresh install, or a manifest-less tree) means no evidence."""
+    seed = _seed(tmp_path, None, paths=(".cursor",))
+    proc = scaffold(tmp_path, seed=seed, name="no-pin")
+    assert proc.returncode == 0, proc.stderr
+    assert (tmp_path / "no-pin" / ".cursor").is_dir()
+
+
+def test_preview_reports_retired_paths_without_deleting(tmp_path: Path) -> None:
+    """--preview lists the prune under DELETIONS and mutates nothing (#886)."""
+    seed = _seed(tmp_path, "0.3.4", paths=(".hadolint.yaml",))
+    proc = scaffold(tmp_path, seed=seed, name="preview", preview=True)
+    assert proc.returncode == 0, proc.stderr
+    assert "DELETED" in proc.stdout
+    assert ".hadolint.yaml" in proc.stdout
+    assert (tmp_path / "preview" / ".hadolint.yaml").is_file()

--- a/tests/workflow_scaffold.py
+++ b/tests/workflow_scaffold.py
@@ -32,12 +32,15 @@ def scaffold(
     seed: Path | None = None,
     name: str = "workspace",
     check: bool = True,
+    preview: bool = False,
 ) -> subprocess.CompletedProcess[str]:
     """Scaffold a workspace by executing the real init-workspace.sh.
 
     A ``just`` stub on PATH keeps the final ``just sync`` step a fast no-op;
     ``workflow`` appends ``--workflow``; ``seed`` pre-populates the workspace
-    (to exercise the upgrade path). Returns the CompletedProcess so callers can
+    (to exercise the upgrade path); ``preview`` appends ``--preview`` so the
+    run reports the add/overwrite/preserve/delete plan and exits without
+    touching the tree (#886). Returns the CompletedProcess so callers can
     assert on exit code / stderr.
     """
     dest = tmp_path / name
@@ -63,6 +66,8 @@ def scaffold(
     args = ["bash", str(INIT_WORKSPACE), "--force", "--no-prompts", "--mode", "both"]
     if workflow is not None:
         args += ["--workflow", workflow]
+    if preview:
+        args.append("--preview")
 
     return subprocess.run(args, env=env, check=check, capture_output=True, text=True)
 


### PR DESCRIPTION
## Summary

`install.sh --force` regenerates what the **current** scaffold manages and
prunes what the current mode / workflow model / feature set excludes. A path an
**old** devkit shipped and a later devkit **retired** is claimed by neither, so
it rode along through every upgrade. Observed going 0.3.4 → 1.6.0
(`exo-pet/playground-carlos#9`): `.cursor/`, `.github/actions/resolve-image/`,
`.github/workflows/renovate-changelog.yml` and `.hadolint.yaml` all survived.

`renovate-changelog.yml` is the sharp one — left in place it is a **live**
workflow that duplicates the `renovate-changelog-build`/`-commit` pair that
replaced it *and* calls the pruned `resolve-image` action, so it fails at its
next trigger rather than at upgrade time.

## Change

`assets/init-workspace.sh`:

- `PREVIOUS_PIN` — the pin `.vig-os` carried *before* this run rewrites it, read
  alongside the other manifest values, far ahead of the #852 rewrite. Legacy
  `DEVCONTAINER_VERSION` included: repos still on that key are the oldest ones,
  i.e. exactly the population carrying the leftovers.
- `retired_paths()` — the cumulative manifest, one `<version> <path>` line per
  path, `<version>` being the first release that stopped shipping it:

  | Path | Retired in | Superseded by |
  |------|-----------|---------------|
  | `.github/workflows/renovate-changelog.yml` | 0.3.5 | the build/commit pair |
  | `.cursor/` | 0.4.0 | `.claude/` |
  | `.hadolint.yaml` | 0.4.0 | — (Debian build path decommissioned) |
  | `.github/actions/resolve-image/` | 1.1.0 | `resolve-toolchain` |

- `version_lt()` — prerelease-aware in the direction that matters (`X.Y.Z-rcN`
  sorts below `X.Y.Z`, so an rc of the retiring release is still pruned).
- `retired_prune_paths()` — the single resolver consulted by **both** the
  `--preview` `DELETIONS` report and the post-copy prune, so the report can
  never disagree with what the run does. Four gates: a present, semver-shaped
  pin; the pin predates the retirement; the current template does not ship the
  path; the path is not in `PRESERVE_FILES`.

`.devcontainer/justfile.base` (also retired in 0.4.0) deliberately keeps its
dedicated block: its prune is mode-guarded (#738 never touches a direnv/bare
consumer's own `.devcontainer/`), which a version-only manifest cannot express.

### The version gate is the safety property

`.cursor/` and `.hadolint.yaml` are generic names. A repo pinned at or past the
retiring version was never shipped them by devkit, so an identically named path
there is the consumer's own — deleting it would be data loss. The deliberate
trade is under-pruning a repo that already upgraded past a retirement before
this fix; those are cleaned once by hand, and `docs/MIGRATION.md` says so.

## Testing

- New `tests/test_scaffold_retired_paths.py` (RED → GREEN, committed
  separately) — 6 tests over the real `init-workspace.sh`: manifest contents,
  prune from an old pin, legacy `DEVCONTAINER_VERSION` pin, **no** prune past
  the retirement, **no** prune without a pin, and `--preview` reporting without
  mutating. `tests/workflow_scaffold.py` gained a `preview` passthrough.
- `uv run pytest` (excluding the image/integration suites, which need the
  container) — **987 passed, 1 skipped**.
- `just test-bats` — 9 pre-existing `IN_CONTAINER` githooks failures, verified
  identical on a clean `origin/dev` worktree; unrelated to this change.
- `just precommit` (full suite, all files) green locally.

Closes #1348