### PR TITLE
fix(install): dereference symlinked templates in preserved-file diffs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     `.hadolint.yaml` there is the consumer's own and is left untouched. A repo
     that already upgraded past a retirement before this fix keeps its
     leftovers — a one-time manual cleanup, documented in `docs/MIGRATION.md`.
+- **Preserved-file diffs show template content, not a symlink typechange** ([#1349](https://github.com/vig-os/devkit/issues/1349))
+  - A `--force` upgrade prints the divergence between each preserved consumer
+    file and the incoming template so the consumer can fold in template
+    evolution deliberately. In the shipped image the devkit assets are
+    `/nix/store` symlinks, so `git diff --no-index` compared the *link* against
+    the consumer's regular file and rendered a typechange — "symlink deleted /
+    file added", with the store path as its only line — instead of the content
+    diff. Seen on the `vig-os/scitadel` 0.3.3 → 1.6.0 migration.
+  - The template side is now dereferenced before the comparison, so the hunk
+    shows the actual template changes. A template symlink whose target does not
+    resolve is still treated as a missing template (no diff, no error), and the
+    diff header keeps naming the file rather than an opaque store path.
 
 ### Security
 

--- a/assets/init-workspace.sh
+++ b/assets/init-workspace.sh
@@ -728,21 +728,46 @@ is_preserved_file() {
 # (#1197). `GIT_DIR=/dev/null` pins the git dir explicitly, so git skips
 # discovery entirely and the pure file comparison runs regardless of any
 # broken/foreign `.git` in the cwd.
+#
+# In the shipped image the devkit assets are /nix/store SYMLINKS (#1349), so
+# `git diff --no-index` compared the LINK against the consumer's regular file
+# and rendered a typechange (symlink deleted / file added) whose only "content"
+# was the store path — hiding the very divergence this preview exists for.
+# Dereference the template side first. The `-f` gate below already follows the
+# link, so a template symlink whose target does NOT resolve is treated as a
+# missing template (return 1) and never reaches the copy.
 print_preserved_template_diff() {
     local rel="$1"
     local preserved="$WORKSPACE_DIR/$rel"
     local template="$TEMPLATE_DIR/$rel"
     [[ -f "$preserved" && -f "$template" ]] || return 1
-    if GIT_DIR=/dev/null git diff --no-index --quiet -- "$template" "$preserved" \
-        > /dev/null 2>&1; then
-        return 1  # identical: nothing to surface
+    # Materialize the dereferenced content under the file's own name in a temp
+    # dir rather than diffing the resolved path directly: the diff header then
+    # still identifies the file instead of naming an opaque store path.
+    local scratch=""
+    if [[ -L "$template" ]]; then
+        scratch="$(mktemp -d)" || return 1
+        if ! mkdir -p "$scratch/$(dirname "$rel")" \
+            || ! cat "$template" > "$scratch/$rel"; then
+            rm -rf "$scratch"
+            return 1
+        fi
+        template="$scratch/$rel"
     fi
-    echo "Preserved $rel differs from the template (yours was kept)."
-    echo "Template changes NOT applied (fold in what you need, see MIGRATION.md):"
-    echo "─────────────────────────────────────────────────────────────"
-    GIT_DIR=/dev/null git diff --no-index -- "$template" "$preserved" || true
-    echo "─────────────────────────────────────────────────────────────"
-    return 0
+    local rc=1  # stays 1 when the files are identical: nothing to surface
+    if ! GIT_DIR=/dev/null git diff --no-index --quiet -- "$template" "$preserved" \
+        > /dev/null 2>&1; then
+        echo "Preserved $rel differs from the template (yours was kept)."
+        echo "Template changes NOT applied (fold in what you need, see MIGRATION.md):"
+        echo "─────────────────────────────────────────────────────────────"
+        GIT_DIR=/dev/null git diff --no-index -- "$template" "$preserved" || true
+        echo "─────────────────────────────────────────────────────────────"
+        rc=0
+    fi
+    if [[ -n "$scratch" ]]; then
+        rm -rf "$scratch"
+    fi
+    return "$rc"
 }
 
 # Record whether the consumer already had a populated .devcontainer/ before the

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -51,6 +51,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     `.hadolint.yaml` there is the consumer's own and is left untouched. A repo
     that already upgraded past a retirement before this fix keeps its
     leftovers — a one-time manual cleanup, documented in `docs/MIGRATION.md`.
+- **Preserved-file diffs show template content, not a symlink typechange** ([#1349](https://github.com/vig-os/devkit/issues/1349))
+  - A `--force` upgrade prints the divergence between each preserved consumer
+    file and the incoming template so the consumer can fold in template
+    evolution deliberately. In the shipped image the devkit assets are
+    `/nix/store` symlinks, so `git diff --no-index` compared the *link* against
+    the consumer's regular file and rendered a typechange — "symlink deleted /
+    file added", with the store path as its only line — instead of the content
+    diff. Seen on the `vig-os/scitadel` 0.3.3 → 1.6.0 migration.
+  - The template side is now dereferenced before the comparison, so the hunk
+    shows the actual template changes. A template symlink whose target does not
+    resolve is still treated as a missing template (no diff, no error), and the
+    diff header keeps naming the file rather than an opaque store path.
 
 ### Security
 

--- a/tests/bats/init-workspace.bats
+++ b/tests/bats/init-workspace.bats
@@ -1695,6 +1695,51 @@ EOF
     assert_output --partial 'default_language_version'
 }
 
+# ── preserved diff must dereference a symlinked template file (#1349) ─────────
+# In the shipped image the devkit assets are /nix/store SYMLINKS, so
+# `git diff --no-index <template-link> <consumer-file>` compares the LINK
+# against a regular file: git renders a typechange (deleted mode 120000 /
+# new file 100644) whose only "content" is the store path the link points at,
+# and the operator never sees the template evolution the preview exists for.
+# Observed live on the vig-os/scitadel 0.3.3 -> 1.6.0 migration. The template
+# side must be dereferenced so the diff compares CONTENT.
+
+@test "preserved diff dereferences a symlinked template file (#1349)" {
+    ws="$BATS_TEST_TMPDIR/e2e-1349-ws"
+    tpl="$BATS_TEST_TMPDIR/e2e-1349-tpl"
+    store="$BATS_TEST_TMPDIR/e2e-1349-store"
+    mkdir -p "$ws" "$store"
+    # Image-shaped template tree: a copy of the real one whose preserved file
+    # is a symlink to content living elsewhere (stand-in for /nix/store).
+    cp -a "$PROJECT_ROOT/assets/workspace" "$tpl"
+    cat > "$store/pre-commit-config.yaml" <<'EOF'
+# SENTINEL-1349 template hook config
+default_language_version:
+    python: python3.12
+repos: []
+EOF
+    ln -sfn "$store/pre-commit-config.yaml" "$tpl/.pre-commit-config.yaml"
+    _custom_precommit_config "$ws"
+    local stub="$BATS_TEST_TMPDIR/stub-1349"
+    mkdir -p "$stub"
+    printf '#!/usr/bin/env bash\nexit 0\n' >"$stub/uv"
+    chmod +x "$stub/uv"
+    run env PATH="$stub:$PATH" \
+        TEMPLATE_DIR="$tpl" \
+        WORKSPACE_DIR="$ws" \
+        SHORT_NAME=testproj \
+        GITHUB_REPOSITORY=test/repo \
+        bash "$INIT_WORKSPACE_SH" --force --no-prompts --mode both
+    assert_success
+    assert_output --partial 'Preserved .pre-commit-config.yaml differs from the template'
+    # the template CONTENT is what shows...
+    assert_output --partial 'SENTINEL-1349 template hook config'
+    assert_output --partial 'default_language_version'
+    # ...not a typechange rendering the link target as the whole diff.
+    refute_output --partial '120000'
+    refute_output --partial "$store/pre-commit-config.yaml"
+}
+
 # ── upgrade must preserve a customized .typos.toml, no dual configs (#913) ────
 # The typos hook reads a project's spell-check exceptions; a consumer curates
 # repo-specific extend-words/extend-exclude that a template overwrite silently


### PR DESCRIPTION
## Summary

On `--force` upgrades the installer prints a diff between each preserved consumer file and the incoming template so template evolution can be folded in deliberately. In the shipped image the devkit assets are `/nix/store` **symlinks**, so `git diff --no-index` compared the link itself against the consumer's regular file and rendered a useless typechange ("symlink deleted / file added", with the store path as its only content line). Observed live on the vig-os/scitadel 0.3.3 → 1.6.0 migration.

`print_preserved_template_diff` now dereferences the template side before comparing: the resolved content is materialized under the file's own name in a temp dir, so the diff header keeps identifying the file rather than an opaque store path. A template symlink whose target does not resolve is still treated as a missing template (`[[ -f ]]` follows the link), so the function returns 1 with no output, as before. Constraints from #916 (`git diff --no-index`, no `diff(1)`/`cmp(1)` in the image) and #1197 (`GIT_DIR=/dev/null`) are preserved.

## Test plan

- New bats test `preserved diff dereferences a symlinked template file (#1349)`: image-shaped template tree with the preserved file as a symlink to out-of-tree content; asserts the printed diff shows the template content and refutes the typechange rendering (RED before the fix, reproducing the exact live failure shape).
- Full `tests/bats/init-workspace.bats`: 280/280 green, including the #878/#913/#916/#1197 preserved-diff relatives.
- `prek run --all-files` green.

Refs: #1349