### PR TITLE
fix(action): write store bin dirs to GITHUB_PATH in reverse order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     shows the actual template changes. A template symlink whose target does not
     resolve is still treated as a missing template (no diff, no error), and the
     diff header keeps naming the file rather than an opaque store path.
+- **CI dev-shell PATH keeps its priority order** ([#1351](https://github.com/vig-os/devkit/issues/1351))
+  - The direnv-mode `setup-devkit-toolchain` wrote the dev-shell's `/nix/store`
+    bin dirs to `GITHUB_PATH` highest-priority-first, but the runner *prepends*
+    every line in file order — so the following steps ran with the dev-shell
+    PATH exactly reversed. The dirs are now written reversed, and the per-line
+    prepend rebuilds the dev-shell order verbatim.
+  - Only multi-store-path toolchains were affected: with one tool per store
+    path the order is unobservable. A stdenv toolchain is not — the raw `gcc`
+    shadowed `gcc-wrapper` (likewise `binutils`) and C builds failed with the
+    unwrapped-compiler signature `ld.bfd: cannot find Scrt1.o` /
+    `cannot find -lc`, while the same build stayed green locally under
+    `nix develop` (first hit: `vig-os/h5v`'s vendored HDF5 build).
 
 ### Security
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -63,6 +63,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     shows the actual template changes. A template symlink whose target does not
     resolve is still treated as a missing template (no diff, no error), and the
     diff header keeps naming the file rather than an opaque store path.
+- **CI dev-shell PATH keeps its priority order** ([#1351](https://github.com/vig-os/devkit/issues/1351))
+  - The direnv-mode `setup-devkit-toolchain` wrote the dev-shell's `/nix/store`
+    bin dirs to `GITHUB_PATH` highest-priority-first, but the runner *prepends*
+    every line in file order — so the following steps ran with the dev-shell
+    PATH exactly reversed. The dirs are now written reversed, and the per-line
+    prepend rebuilds the dev-shell order verbatim.
+  - Only multi-store-path toolchains were affected: with one tool per store
+    path the order is unobservable. A stdenv toolchain is not — the raw `gcc`
+    shadowed `gcc-wrapper` (likewise `binutils`) and C builds failed with the
+    unwrapped-compiler signature `ld.bfd: cannot find Scrt1.o` /
+    `cannot find -lc`, while the same build stayed green locally under
+    `nix develop` (first hit: `vig-os/h5v`'s vendored HDF5 build).
 
 ### Security
 

--- a/assets/workspace/.github/actions/setup-devkit-toolchain/action.yml
+++ b/assets/workspace/.github/actions/setup-devkit-toolchain/action.yml
@@ -178,7 +178,17 @@ runs:
           STORE_BINS="$(printf '%s\n' "$STORE_BINS" \
             | grep -Ev '/nix/store/[^/]*-python3-[0-9][^/]*/bin')"
         fi
-        printf '%s\n' "$STORE_BINS" >> "$GITHUB_PATH"
+        # Reversed on purpose: the runner *prepends* every GITHUB_PATH line to
+        # PATH in file order, so the line written last ends up first. STORE_BINS
+        # holds the dev-shell order (highest priority first), so writing it as
+        # is handed the following steps a PATH in reverse dev-shell priority.
+        # Harmless while one tool means one store path, fatal for a stdenv
+        # toolchain: raw gcc then shadows gcc-wrapper (likewise binutils) and
+        # every C build fails with `cannot find Scrt1.o` / `cannot find -lc`
+        # while the same build is green locally under `nix develop` (#1351,
+        # vig-os/h5v#2). `tac` makes the per-line prepend rebuild the dev-shell
+        # order verbatim.
+        printf '%s\n' "$STORE_BINS" | tac >> "$GITHUB_PATH"
 
         # Forward the dev-shell's uv Python-download metadata URL (GITHUB_PATH
         # carries PATH only): `uv sync` needs it to fetch the project's pinned

--- a/tests/test_setup_toolchain_env.py
+++ b/tests/test_setup_toolchain_env.py
@@ -80,6 +80,21 @@ _DEVSHELL_ENV = [
     ("AMBIENT_SHARED", "same-on-both-sides"),
 ]
 
+# The simulated dev-shell `$PATH` the stub `nix` reports, in dev-shell priority
+# order (highest first). It carries a wrapper/raw toolchain pair — the shape
+# every Nix stdenv shell has and the one that made the GITHUB_PATH ordering bug
+# visible: with the two dirs swapped, the raw compiler shadows its wrapper and
+# every C build dies with the unwrapped-gcc signature (#1351).
+GCC_WRAPPER_BIN = "/nix/store/wwwwwwww-gcc-wrapper-13/bin"
+GCC_RAW_BIN = "/nix/store/gggggggg-gcc-13/bin"
+STORE_BINS_IN_ORDER = [
+    "/nix/store/aaaaaaaa-foo/bin",
+    GCC_WRAPPER_BIN,
+    GCC_RAW_BIN,
+    "/nix/store/bbbbbbbb-bar/bin",
+]
+DEVSHELL_PATH = ":".join([*STORE_BINS_IN_ORDER, "/usr/bin"])
+
 
 def _devshell_step_script() -> str:
     action = yaml.safe_load(ACTION.read_text(encoding="utf-8"))
@@ -140,7 +155,7 @@ def _write_nix_stub(bin_dir: Path, *, banner: bool = False) -> None:
         "fi",
         'case "$joined" in',
         '  *"printf \\"%s\\" \\"\\$PATH\\""*)',
-        "    printf '%s' '/nix/store/aaaaaaaa-foo/bin:/nix/store/bbbbbbbb-bar/bin:/usr/bin'; exit 0 ;;",
+        f"    printf '%s' {_bash_squote(DEVSHELL_PATH)}; exit 0 ;;",
         "  *UV_PYTHON_DOWNLOADS_JSON_URL*)",
         "    printf 'UV_PYTHON_DOWNLOADS_JSON_URL=https://example.invalid/downloads.json\\n'; exit 0 ;;",
         "esac",
@@ -204,6 +219,21 @@ def _exec_devshell_step(
     )
     raw = github_env.read_text(encoding="utf-8")
     return _parse_github_env(raw), raw
+
+
+def _runner_path(github_path_text: str, base_path: str = "/usr/bin") -> list[str]:
+    """Reconstruct the runner PATH a GITHUB_PATH file produces.
+
+    The Actions runner reads the file top to bottom and *prepends* every
+    non-empty line to the PATH of the following steps, so the entry written
+    last in the file ends up first in PATH.
+    """
+    path = [base_path]
+    for line in github_path_text.splitlines():
+        if not line:
+            continue
+        path.insert(0, line)
+    return path
 
 
 def _parse_github_env(text: str) -> dict[str, str]:
@@ -292,6 +322,31 @@ def test_shellhook_stdout_banner_never_reaches_github_env(tmp_path: Path) -> Non
     assert BANNER not in raw, "shellHook stdout leaked into GITHUB_ENV"
     # The first env record must survive intact, not be eaten by the banner.
     assert env.get("OTTERDOG_TOKEN") == "placeholder-set-by-shellhook"
+
+
+def test_devshell_path_priority_survives_github_path(tmp_path: Path) -> None:
+    """The runner PATH must keep the dev-shell's own priority order.
+
+    The runner prepends every GITHUB_PATH line, so lines written first land
+    last in PATH: writing the dev-shell bin dirs highest-priority-first
+    reversed them on CI. Invisible while one tool means one store path, fatal
+    for a stdenv toolchain — the raw gcc shadowed gcc-wrapper and vig-os/h5v#2
+    failed its vendored HDF5 build with `ld.bfd: cannot find Scrt1.o`, while
+    the same build was green locally under `nix develop`.
+
+    Refs: #1351
+    """
+    _run_devshell_step(tmp_path)
+    path = _runner_path((tmp_path / "github_path").read_text(encoding="utf-8"))
+
+    for store_bin in STORE_BINS_IN_ORDER:
+        assert store_bin in path, f"{store_bin} missing from the runner PATH"
+    assert path.index(GCC_WRAPPER_BIN) < path.index(GCC_RAW_BIN), (
+        f"raw gcc shadows gcc-wrapper on the runner PATH: {path}"
+    )
+    assert [p for p in path if p.startswith("/nix/store")] == STORE_BINS_IN_ORDER, (
+        f"dev-shell PATH priority order not preserved on the runner: {path}"
+    )
 
 
 # ── Self-hosted runners with preinstalled Nix (#1192) ────────────────────────


### PR DESCRIPTION
## Summary

The direnv-mode `setup-devkit-toolchain` step extracts the consumer dev-shell `$PATH`, filters the `/nix/store` bin dirs, and wrote them to `GITHUB_PATH` highest-priority-first. The Actions runner *prepends* every `GITHUB_PATH` line in file order (the prepend list is joined reversed when composing the next step's PATH), so following steps ran with the dev-shell PATH exactly reversed.

Invisible while one tool means one store path — which is why every Python/TS consumer stayed green — but fatal for a stdenv toolchain: raw `gcc` shadowed `gcc-wrapper` (likewise `binutils`) and C builds failed with the unwrapped-compiler signature `ld.bfd: cannot find Scrt1.o` / `cannot find -lc`, while the same build was green locally under `nix develop`. First live hit: vig-os/h5v#2 (vendored HDF5 cmake build, run 31160809242).

The store bin dirs are now piped through `tac` before the write, so the runner's per-line prepend rebuilds the dev-shell order verbatim. Bare-mode's single-line `uv tool dir --bin` write is unaffected; the env-forward denylist is untouched (that's #1353).

## Test plan

- New test `test_devshell_path_priority_survives_github_path`: the fake dev-shell PATH now carries a `gcc-wrapper-13/bin` → `gcc-13/bin` pair; a `_runner_path` helper replays the runner's per-line prepend and the test asserts the wrapper precedes the raw compiler AND the full store-bin subsequence equals the dev-shell order — semantics-pinned, no coupling to `tac`. RED on the old code with the whole order inverted, exactly the issue shape.
- Full `tests/test_setup_toolchain_env.py`: 25/25 green (verified independently by reviewer).
- `tests/bats/init-workspace.bats` (renders + actionlints the scaffold): 280/280 green.
- `prek run --all-files` green.

Refs: #1351