### PR TITLE
fix(action): deny UV_PYTHON in the shellHook env forward

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     unwrapped-compiler signature `ld.bfd: cannot find Scrt1.o` /
     `cannot find -lc`, while the same build stayed green locally under
     `nix develop` (first hit: `vig-os/h5v`'s vendored HDF5 build).
+- **shellHook env forward no longer ships `UV_PYTHON` to CI** ([#1353](https://github.com/vig-os/devkit/issues/1353))
+  - Two correct mechanisms in the direnv-mode `setup-devkit-toolchain` cancelled
+    out. The step drops the bare Nix CPython from the exported `PATH` and
+    forwards `UV_PYTHON_DOWNLOADS_JSON_URL` so `uv sync` builds the runner venv
+    from a downloaded manylinux CPython (#698/#703/#729) — but the shellHook env
+    forward (#1180) diffs the dev-shell env against the ambient one and shipped
+    every added var, `mkProjectShell`'s `UV_PYTHON` store-path pin included.
+    `UV_PYTHON` beats PATH resolution, so the venv was built on the Nix
+    interpreter regardless and any C-extension wheel then failed under the Nix
+    loader on Ubuntu with `ImportError: libstdc++.so.6: cannot open shared
+    object file`. Existing direnv Python consumers were green only because their
+    test dependencies are pure-Python; first live hit
+    `exo-pet/playground-carlos#9` (numpy 2.4.4).
+  - `UV_PYTHON` and `UV_PYTHON_DOWNLOADS` are now denied by name in that
+    forward's denylist. Both are Nix-host-only by construction, and the second
+    is required for the first: on its own, a forwarded
+    `UV_PYTHON_DOWNLOADS=never` would forbid the very managed-CPython download
+    the `_JSON_URL` forward exists to enable, turning the wheel `ImportError`
+    into "no interpreter found". The patterns are exact, so the deliberate
+    `UV_PYTHON_DOWNLOADS_JSON_URL` forward is untouched — now pinned by a test.
+  - Audit of the other vars `mkProjectShell` puts in the dev-shell env: kept
+    `BATS_LIB_PATH` (a store path, but the store is realized on the runner and
+    `bats` runs from the dev-shell `PATH` there), `NVIM_APPNAME` (portable
+    config) and `UV_PYTHON_DOWNLOADS_JSON_URL`. `LD_LIBRARY_PATH` is exported
+    only behind the shellHook's own `/etc/NIXOS` guard, so it never reaches a
+    hosted runner and is the correct value on a NixOS self-hosted one — left
+    forwardable. Nothing else the builder sets is host-specific.
 
 ### Security
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -75,6 +75,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     unwrapped-compiler signature `ld.bfd: cannot find Scrt1.o` /
     `cannot find -lc`, while the same build stayed green locally under
     `nix develop` (first hit: `vig-os/h5v`'s vendored HDF5 build).
+- **shellHook env forward no longer ships `UV_PYTHON` to CI** ([#1353](https://github.com/vig-os/devkit/issues/1353))
+  - Two correct mechanisms in the direnv-mode `setup-devkit-toolchain` cancelled
+    out. The step drops the bare Nix CPython from the exported `PATH` and
+    forwards `UV_PYTHON_DOWNLOADS_JSON_URL` so `uv sync` builds the runner venv
+    from a downloaded manylinux CPython (#698/#703/#729) — but the shellHook env
+    forward (#1180) diffs the dev-shell env against the ambient one and shipped
+    every added var, `mkProjectShell`'s `UV_PYTHON` store-path pin included.
+    `UV_PYTHON` beats PATH resolution, so the venv was built on the Nix
+    interpreter regardless and any C-extension wheel then failed under the Nix
+    loader on Ubuntu with `ImportError: libstdc++.so.6: cannot open shared
+    object file`. Existing direnv Python consumers were green only because their
+    test dependencies are pure-Python; first live hit
+    `exo-pet/playground-carlos#9` (numpy 2.4.4).
+  - `UV_PYTHON` and `UV_PYTHON_DOWNLOADS` are now denied by name in that
+    forward's denylist. Both are Nix-host-only by construction, and the second
+    is required for the first: on its own, a forwarded
+    `UV_PYTHON_DOWNLOADS=never` would forbid the very managed-CPython download
+    the `_JSON_URL` forward exists to enable, turning the wheel `ImportError`
+    into "no interpreter found". The patterns are exact, so the deliberate
+    `UV_PYTHON_DOWNLOADS_JSON_URL` forward is untouched — now pinned by a test.
+  - Audit of the other vars `mkProjectShell` puts in the dev-shell env: kept
+    `BATS_LIB_PATH` (a store path, but the store is realized on the runner and
+    `bats` runs from the dev-shell `PATH` there), `NVIM_APPNAME` (portable
+    config) and `UV_PYTHON_DOWNLOADS_JSON_URL`. `LD_LIBRARY_PATH` is exported
+    only behind the shellHook's own `/etc/NIXOS` guard, so it never reaches a
+    hosted runner and is the correct value on a NixOS self-hosted one — left
+    forwardable. Nothing else the builder sets is host-specific.
 
 ### Security
 

--- a/assets/workspace/.github/actions/setup-devkit-toolchain/action.yml
+++ b/assets/workspace/.github/actions/setup-devkit-toolchain/action.yml
@@ -225,10 +225,21 @@ runs:
 
         # Denylist: shell session state (must never override the CI shell) and
         # Nix/stdenv build machinery (PATH is already handled via GITHUB_PATH).
+        # mkProjectShell's uv interpreter pins go with them: `UV_PYTHON` (a store
+        # CPython) and `UV_PYTHON_DOWNLOADS=never` are Nix-host-only by
+        # construction — a NixOS host cannot run a downloaded managed CPython —
+        # and forwarding them cancels the mitigation above, since UV_PYTHON beats
+        # PATH resolution and `never` forbids the very download the
+        # UV_PYTHON_DOWNLOADS_JSON_URL forward exists to enable. `uv sync` then
+        # built the runner venv on the Nix interpreter and every C-extension
+        # wheel died under the Nix loader with `ImportError: libstdc++.so.6:
+        # cannot open shared object file` (#698/#703/#729, #1353). Exact
+        # patterns: UV_PYTHON_DOWNLOADS_JSON_URL must still forward.
         devkit_env_denied() {
           case "$1" in
             PATH|HOME|USER|LOGNAME|SHELL|TERM|PWD|OLDPWD|SHLVL|IFS|_) return 0 ;;
             TMPDIR|TMP|TEMP|TEMPDIR) return 0 ;;
+            UV_PYTHON|UV_PYTHON_DOWNLOADS) return 0 ;;
             NIX_*) return 0 ;;
             out|outputs|src|stdenv|system|builder|name|pname|version|shell|shellHook) return 0 ;;
             buildInputs|nativeBuildInputs|propagatedBuildInputs|propagatedNativeBuildInputs) return 0 ;;

--- a/tests/test_setup_toolchain_env.py
+++ b/tests/test_setup_toolchain_env.py
@@ -71,6 +71,14 @@ _DEVSHELL_ENV = [
     ("dontUnpack", "1"),
     ("configurePhase", ":"),
     ("depsBuildBuild", ""),
+    # mkProjectShell's uv interpreter pins — Nix-host-only, must be denied
+    # (#1353). Kept next to their deliberate counterpart below, which must
+    # survive: the denylist matches names exactly, so `UV_PYTHON` cannot swallow
+    # `UV_PYTHON_DOWNLOADS_JSON_URL`.
+    ("UV_PYTHON", "/nix/store/pppppppp-python3-3.14.6/bin/python3.14"),
+    ("UV_PYTHON_DOWNLOADS", "never"),
+    # Forwarded ON PURPOSE by the same step (#632/#683/#1028) — must survive.
+    ("UV_PYTHON_DOWNLOADS_JSON_URL", "https://example.invalid/downloads.json"),
     # Shell session state — must be denied.
     ("PATH", "/nix/store/aaaaaaaa-foo/bin:/usr/bin"),
     ("HOME", "/home/dev-shell"),
@@ -206,6 +214,12 @@ def _exec_devshell_step(
         # Ambient var that the dev-shell leaves unchanged: must be filtered out.
         "AMBIENT_SHARED": "same-on-both-sides",
     }
+    # A CI runner carries none of the dev-shell's uv pins, but this test process
+    # is itself launched from a dev-shell (`nix develop -c uv run pytest`), which
+    # would make them ambient — and the step's unchanged-var filter would then
+    # mask the denylist behavior under test. Scrub them (#1353).
+    for uv_var in ("UV_PYTHON", "UV_PYTHON_DOWNLOADS", "UV_PYTHON_DOWNLOADS_JSON_URL"):
+        env.pop(uv_var, None)
 
     proc = subprocess.run(
         ["bash", "-c", script],
@@ -291,6 +305,9 @@ def test_multiline_value_survives_via_heredoc(tmp_path: Path) -> None:
         "dontUnpack",
         "configurePhase",
         "depsBuildBuild",
+        # Nix-host interpreter pins (#1353).
+        "UV_PYTHON",
+        "UV_PYTHON_DOWNLOADS",
         # Shell session state.
         "PATH",
         "HOME",
@@ -302,6 +319,34 @@ def test_denylisted_vars_are_not_forwarded(tmp_path: Path, denied: str) -> None:
     """Build machinery and shell session state never leak into GITHUB_ENV."""
     env = _run_devshell_step(tmp_path)
     assert denied not in env, f"{denied} must not be forwarded to GITHUB_ENV"
+
+
+def test_uv_interpreter_pins_do_not_defeat_the_manylinux_path(
+    tmp_path: Path,
+) -> None:
+    """The dev-shell's uv interpreter pins must not reach the CI environment.
+
+    Two correct mechanisms cancelled out: the step drops the bare Nix CPython
+    from the exported PATH and forwards ``UV_PYTHON_DOWNLOADS_JSON_URL`` so
+    ``uv sync`` builds the runner venv from a downloaded manylinux CPython
+    (#698/#703/#729), while the shellHook env forward (#1180) shipped
+    ``UV_PYTHON`` (mkProjectShell's store-path pin) and
+    ``UV_PYTHON_DOWNLOADS=never`` alongside it. ``UV_PYTHON`` wins over PATH
+    resolution, so the venv was built on the Nix interpreter anyway and every
+    C-extension wheel died under the Nix loader on Ubuntu with
+    ``ImportError: libstdc++.so.6: cannot open shared object file``
+    (exo-pet/playground-carlos#9, numpy 2.4.4). ``UV_PYTHON_DOWNLOADS=never``
+    goes with it: on its own it would forbid the very download the URL forward
+    exists to enable.
+
+    Refs: #1353
+    """
+    env = _run_devshell_step(tmp_path)
+    assert "UV_PYTHON" not in env
+    assert "UV_PYTHON_DOWNLOADS" not in env
+    assert env.get("UV_PYTHON_DOWNLOADS_JSON_URL") == (
+        "https://example.invalid/downloads.json"
+    ), "the deliberate uv download-metadata forward must survive the denylist"
 
 
 def test_unchanged_ambient_var_is_not_reforwarded(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Two correct mechanisms in the direnv-mode `setup-devkit-toolchain` cancelled out. The step drops the bare Nix CPython from the exported PATH and forwards `UV_PYTHON_DOWNLOADS_JSON_URL` so `uv sync` builds the runner venv from a downloaded manylinux CPython (#698/#703/#729) — but the shellHook env forward (#1180) diffs the dev-shell env against the ambient env and shipped every added var, including `mkProjectShell`'s `UV_PYTHON` store-path pin. `UV_PYTHON` beats PATH resolution, so the CI venv was built on the Nix interpreter anyway and any C-extension wheel failed under the Nix loader on Ubuntu (`ImportError: libstdc++.so.6`). First live hit: exo-pet/playground-carlos#9 (numpy 2.4.4, run 31163316165); existing direnv Python consumers were green only because their test deps are pure-Python.

`UV_PYTHON` and `UV_PYTHON_DOWNLOADS` are now denied by name in the forward's denylist. The second is required for the first: forwarded on its own, `UV_PYTHON_DOWNLOADS=never` (also set by `mkProjectShell`) would forbid the very managed-CPython download the JSON-URL forward exists to enable, turning the wheel ImportError into "no interpreter found". Patterns are exact matches, so the deliberate `UV_PYTHON_DOWNLOADS_JSON_URL` forward is untouched — and now pinned by a test.

## Denylist audit (per the issue)

Everything else `mkProjectShell` sets was reviewed: `BATS_LIB_PATH` kept (the store is realized on the runner in direnv mode), `NVIM_APPNAME` kept (portable), `LD_LIBRARY_PATH` kept (exported only behind the shellHook's own `/etc/NIXOS` guard, never reaches a hosted runner). `UV_PROJECT_ENVIRONMENT` / `UV_PYTHON_PREFERENCE` / `LOCALE_ARCHIVE` are image-path-only, not dev-shell exports. Pre-existing leaks outside this issue's scope (`PYTHONPATH` store components, `IN_NIX_SHELL`, missed stdenv machinery like `doCheck`/`CC`/`LD`) → follow-up issue.

## Test plan

- `_DEVSHELL_ENV` now carries all three uv vars; `UV_PYTHON` + `UV_PYTHON_DOWNLOADS` added to the parametrized denylist test (RED before the fix: `3 failed, 25 passed`, with `UV_PYTHON` visibly landing in GITHUB_ENV).
- New `test_uv_interpreter_pins_do_not_defeat_the_manylinux_path`: both pins absent AND `UV_PYTHON_DOWNLOADS_JSON_URL` still forwarded — the survival assertion did not exist before.
- Harness fix: the test subprocess env is scrubbed of ambient uv vars (pytest itself runs under `nix develop`, which made one parametrize case pass spuriously via the unchanged-var filter).
- Full `tests/test_setup_toolchain_env.py`: 28/28 green (verified independently by reviewer); `test_renovate_preset_managed_exclusion.py` 31/31; `prek run --all-files` green.

Refs: #1353