### PR TITLE
fix(release): extract release notes with the composed tag heading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     only behind the shellHook's own `/etc/NIXOS` guard, so it never reaches a
     hosted runner and is the correct value on a NixOS self-hosted one — left
     forwardable. Nothing else the builder sets is host-specific.
+- **Prefixed-tag releases publish their changelog notes** ([#1355](https://github.com/vig-os/devkit/issues/1355))
+  - In a consumer that sets `DEVKIT_TAG_PREFIX`, the release pipeline wrote one
+    changelog heading and read back another. `release-core.yml` finalizes with
+    `prepare-changelog finalize … --tag-prefix "$TAG_PREFIX"`, which composes the
+    prefix into the heading (`## [v1.0.0](…/releases/tag/v1.0.0) - …`), while
+    `release-publish.yml` extracted the notes by matching `## [$VERSION]` on the
+    *bare* semver — a match that can never land on a prefixed heading.
+  - It failed soft: the empty extraction hit the fallback path, so the release
+    was published with the literal body `No changelog notes found for X.Y.Z`.
+    The tag and the release object were both correct and nothing went red, which
+    is why it survived (observed releasing `vig-os/org-config` `v1.0.0`).
+  - The extraction step now takes `tag_prefix` and accepts the composed tag
+    `## [${TAG_PREFIX}${VERSION}]` alongside the bare one. Both are needed: a
+    candidate publishes *before* the finalize step (which is gated on a final
+    `release_kind`), so its heading is still the unprefixed `## [X.Y.Z] - TBD` that
+    `prepare` wrote — matching only the composed tag would have moved the empty
+    notes onto the candidate path. Only prefixed repos were affected; an empty
+    prefix makes the two forms the same string.
 
 ### Security
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -102,6 +102,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     only behind the shellHook's own `/etc/NIXOS` guard, so it never reaches a
     hosted runner and is the correct value on a NixOS self-hosted one — left
     forwardable. Nothing else the builder sets is host-specific.
+- **Prefixed-tag releases publish their changelog notes** ([#1355](https://github.com/vig-os/devkit/issues/1355))
+  - In a consumer that sets `DEVKIT_TAG_PREFIX`, the release pipeline wrote one
+    changelog heading and read back another. `release-core.yml` finalizes with
+    `prepare-changelog finalize … --tag-prefix "$TAG_PREFIX"`, which composes the
+    prefix into the heading (`## [v1.0.0](…/releases/tag/v1.0.0) - …`), while
+    `release-publish.yml` extracted the notes by matching `## [$VERSION]` on the
+    *bare* semver — a match that can never land on a prefixed heading.
+  - It failed soft: the empty extraction hit the fallback path, so the release
+    was published with the literal body `No changelog notes found for X.Y.Z`.
+    The tag and the release object were both correct and nothing went red, which
+    is why it survived (observed releasing `vig-os/org-config` `v1.0.0`).
+  - The extraction step now takes `tag_prefix` and accepts the composed tag
+    `## [${TAG_PREFIX}${VERSION}]` alongside the bare one. Both are needed: a
+    candidate publishes *before* the finalize step (which is gated on a final
+    `release_kind`), so its heading is still the unprefixed `## [X.Y.Z] - TBD` that
+    `prepare` wrote — matching only the composed tag would have moved the empty
+    notes onto the candidate path. Only prefixed repos were affected; an empty
+    prefix makes the two forms the same string.
 
 ### Security
 

--- a/assets/workspace/.github/workflows/release-publish.yml
+++ b/assets/workspace/.github/workflows/release-publish.yml
@@ -216,10 +216,18 @@ jobs:
       - name: Extract release notes from CHANGELOG
         env:
           VERSION: ${{ inputs.version }}
+          TAG_PREFIX: ${{ inputs.tag_prefix }}
         run: |
           set -euo pipefail
-          awk -v version="$VERSION" '
-            index($0, "## [" version "]") == 1 {found=1; next}
+          # A final release reads the heading `prepare-changelog finalize
+          # --tag-prefix` just wrote, which carries the prefix
+          # (`## [v1.0.0](…)`); matching the bare version found nothing there and
+          # published the fallback body (#1355). A candidate publishes before
+          # finalize runs, so its heading is still the bare `## [1.0.0] - TBD`.
+          # Accept both; with an empty prefix the two are the same string.
+          RELEASE_HEADING_TAG="${TAG_PREFIX}${VERSION}"
+          awk -v tag="$RELEASE_HEADING_TAG" -v version="$VERSION" '
+            index($0, "## [" tag "]") == 1 || index($0, "## [" version "]") == 1 {found=1; next}
             /^## \[/ && found {found=0}
             found
           ' CHANGELOG.md > /tmp/release-notes.md

--- a/tests/test_release_tag_prefix.py
+++ b/tests/test_release_tag_prefix.py
@@ -13,8 +13,11 @@ Refs: #1044
 
 from __future__ import annotations
 
+import os
+import subprocess
 from pathlib import Path
 
+import pytest
 import yaml
 
 # Repository root (tests/ -> repo root).
@@ -55,3 +58,112 @@ def test_reusable_children_declare_tag_prefix_input() -> None:
         # PyYAML parses the bare ``on`` key as the boolean True.
         call_inputs = workflow[True]["workflow_call"]["inputs"]
         assert "tag_prefix" in call_inputs
+
+
+# ── Release-notes extraction must read the heading finalize wrote (#1355) ─────
+
+EXTRACT_STEP_NAME = "Extract release notes from CHANGELOG"
+
+# The literal sink the extraction step writes; the test redirects it into
+# ``tmp_path`` so the awk logic stays verbatim without touching a shared path.
+NOTES_PATH = "/tmp/release-notes.md"
+
+RELEASED_ENTRY = "- **Released thing** ([#1](https://example.invalid/issues/1))"
+OLDER_ENTRY = "- **Older thing** ([#0](https://example.invalid/issues/0))"
+
+
+def _extract_step_run() -> str:
+    workflow = _load(WORKFLOWS / "release-publish.yml")
+    (job,) = workflow["jobs"].values()
+    step = next(s for s in job["steps"] if s.get("name") == EXTRACT_STEP_NAME)
+    return step["run"]
+
+
+def _changelog(tag_prefix: str, *, finalized: bool) -> str:
+    """The CHANGELOG the publish job checks out, in either writer state.
+
+    ``finalized=True`` is what ``prepare-changelog finalize --tag-prefix`` writes
+    for a *final* release: the prefix composed into both the displayed version
+    and the release link. ``finalized=False`` is the *candidate* state — publish
+    runs before the finalize step (which is gated on ``release_kind == 'final'``),
+    so the heading is still the bare ``## [X.Y.Z] - TBD`` ``prepare`` wrote, with
+    no prefix in it even in a prefixed repo.
+    """
+
+    def heading(version: str, date: str) -> str:
+        if not finalized:
+            return f"## [{version}] - TBD"
+        tag = f"{tag_prefix}{version}"
+        return f"## [{tag}](https://example.invalid/releases/tag/{tag}) - {date}"
+
+    return "\n".join(
+        [
+            "# Changelog",
+            "",
+            "## Unreleased",
+            "",
+            heading("1.0.0", "2026-08-06"),
+            "",
+            "### Fixed",
+            "",
+            RELEASED_ENTRY,
+            "",
+            heading("0.9.0", "2026-07-01"),
+            "",
+            "### Added",
+            "",
+            OLDER_ENTRY,
+            "",
+        ]
+    )
+
+
+@pytest.mark.parametrize("tag_prefix", ["", "v"])
+@pytest.mark.parametrize("finalized", [True, False], ids=["final", "candidate"])
+def test_release_notes_extraction_reads_the_heading_on_disk(
+    tmp_path: Path, tag_prefix: str, finalized: bool
+) -> None:
+    """The publish step must find the section whichever writer state it meets.
+
+    ``prepare-changelog finalize`` composes ``DEVKIT_TAG_PREFIX`` into the
+    heading (``## [v1.0.0](…)``) while ``inputs.version`` stays bare, so an
+    extraction matching ``## [1.0.0]`` never matched in a prefixed repo and the
+    release was published with the ``No changelog notes found`` fallback body —
+    a soft failure that leaves the release green and empty (#1355).
+
+    A candidate publishes before finalize runs, so its heading is the bare
+    ``## [1.0.0] - TBD`` regardless of the prefix: matching only the composed tag
+    would move the empty-notes bug onto the candidate path instead of fixing it.
+
+    Refs: #1355
+    """
+    script = _extract_step_run()
+    assert NOTES_PATH in script, f"extraction step no longer writes {NOTES_PATH}"
+    notes = tmp_path / "release-notes.md"
+    script = script.replace(NOTES_PATH, str(notes))
+
+    (tmp_path / "CHANGELOG.md").write_text(
+        _changelog(tag_prefix, finalized=finalized), encoding="utf-8"
+    )
+
+    proc = subprocess.run(
+        ["bash", "-c", script],
+        cwd=tmp_path,
+        env={
+            **os.environ,
+            "VERSION": "1.0.0",
+            "TAG_PREFIX": tag_prefix,
+        },
+        capture_output=True,
+        text=True,
+    )
+    assert proc.returncode == 0, f"STDOUT:\n{proc.stdout}\nSTDERR:\n{proc.stderr}"
+
+    body = notes.read_text(encoding="utf-8")
+    assert "No changelog notes found" not in body, (
+        f"fallback body published instead of the release notes:\n{body}"
+    )
+    assert RELEASED_ENTRY in body, f"released section missing from notes:\n{body}"
+    assert OLDER_ENTRY not in body, (
+        f"extraction ran past the next version heading:\n{body}"
+    )


### PR DESCRIPTION
## Summary

In a consumer with a tag prefix, the release pipeline wrote one changelog heading and read back another: `release-core.yml` finalizes with `prepare-changelog finalize … --tag-prefix "$TAG_PREFIX"`, composing the prefix into the heading (`## [v1.0.0](…/releases/tag/v1.0.0) - …`), while `release-publish.yml` extracted the notes by matching `## [$VERSION]` on the bare semver — which can never land on a prefixed heading. It failed soft: the empty extraction hit the fallback and the release published with the literal body `No changelog notes found for X.Y.Z` (tag and release object both correct, nothing red). Observed releasing vig-os/org-config v1.0.0; unprefixed repos were never affected.

The extraction step now takes the already-threaded `tag_prefix` input (#1044) and accepts the composed tag `## [${TAG_PREFIX}${VERSION}]` **alongside** the bare form. Both are needed — the issue's prefix-only suggestion would have moved the bug rather than fixed it: a candidate publishes *before* the finalize step (gated on `release_kind == 'final'`), so its heading is still the unprefixed `## [X.Y.Z] - TBD` that `prepare` wrote. With an empty prefix the two forms are the same string, so unprefixed repos see a byte-identical match.

Other readers audited (grep over scaffold + devkit's own workflows for version-heading matches): `prepare-release.yml`'s PR-body sed runs pre-finalize (always bare, correct as-is); devkit's bespoke `release.yml` extractions have no tag-prefix surface at all. Nothing else changed.

## Test plan

- New `test_release_notes_extraction_reads_the_heading_on_disk` in `tests/test_release_tag_prefix.py`, parametrized `tag_prefix ∈ {"", "v"}` × writer state `{final, candidate}`: executes the real `run:` block from the workflow YAML under bash against a synthetic CHANGELOG and asserts the notes are the bounded section body, not the fallback. RED before the fix on exactly the `[final-v]` case (fallback body published); the candidate cases are regression guards against the prefix-only fix.
- Full release-workflow pytest set (`test_release_tag_prefix`, tombstone, scaffold lint/drift, dist-gitignore, sync-dispatch, release-extension): 72/72 green.
- `tests/bats/init-workspace.bats` (renders + actionlints the scaffold): 280/280 green.
- `prek run --all-files` green (verified independently by reviewer).

Refs: #1355