### PR TITLE
fix(action): strip store paths and stdenv machinery from the env forward

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     only behind the shellHook's own `/etc/NIXOS` guard, so it never reaches a
     hosted runner and is the correct value on a NixOS self-hosted one — left
     forwardable. Nothing else the builder sets is host-specific.
+- **shellHook env forward stops leaking Nix-host state** ([#1358](https://github.com/vig-os/devkit/issues/1358))
+  - `PYTHONPATH` is now forwarded **component-wise**: the direnv-mode preamble
+    splits it on `:`, drops every `/nix/store` entry and forwards what remains,
+    skipping the var when nothing is left. With `python` in the dev-shell
+    `packages` the nixpkgs setup hook fills `PYTHONPATH` with store
+    site-packages dirs; forwarded whole, those Nix-built `cp3xx` packages joined
+    the `sys.path` of the *downloaded* manylinux CPython — same ABI tag,
+    importable, the same mixed-loader shape as #1353's
+    `ImportError: libstdc++.so.6`. A blanket deny was not an option: a
+    `shellHook` exporting `PYTHONPATH=$PWD/src` is a legitimate #1180 use case
+    and still arrives on CI intact.
+  - The denylist gained the stdenv machinery it was still missing —
+    `_PYTHON_HOST_PLATFORM`, `_PYTHON_SYSCONFIGDATA_NAME`, `DETERMINISTIC_BUILD`,
+    `CONFIG_SHELL`, the `do[A-Z]*` build flags (`doCheck`, `doInstallCheck`,
+    `doDist`; the symmetric partner of the already-denied `dont*`) — and the
+    stdenv cc/binutils hook names `AR AS CC CXX LD NM OBJCOPY OBJDUMP RANLIB
+    READELF SIZE STRINGS STRIP`. stdenv sets those toolchain names in **every**
+    dev shell as bare commands (`CC=gcc`), so every direnv consumer was shipping
+    them to its whole CI job. Inside dev-shell context the wrapped toolchain
+    already wins via `PATH` after #1351; for a step that runs outside it
+    (`setup-python` plus `pip` building a C extension) a forwarded `CC`
+    resolving to the Nix wrapper recreates the #1353 mixed-toolchain hazard.
+    This deliberately supersedes the `shellHook` `CC`/`CXX` forward that
+    vig-os/h5v used pre-#1351 — #1351 removed the need for it. The `native`
+    module's generic `CC=cc`/`CXX=c++` exports likewise no longer reach CI; they
+    exist so build backends fall back to `PATH` discovery (#879/#893), which the
+    forwarded dev-shell `PATH` still provides. A CI step that needs a specific
+    compiler should set it in the workflow. Patterns are case-sensitive, so
+    `DOCKER_*`/`DO_SOMETHING` are unaffected.
+  - `IN_NIX_SHELL` is denied too: forwarding `IN_NIX_SHELL=impure` made every
+    subsequent CI step claim to be running inside a nix shell.
+  - The related NixOS-self-hosted-runner gap in the CPython `PATH` filter is
+    tracked separately in
+    [#1360](https://github.com/vig-os/devkit/issues/1360).
 - **Prefixed-tag releases publish their changelog notes** ([#1355](https://github.com/vig-os/devkit/issues/1355))
   - In a consumer that sets `DEVKIT_TAG_PREFIX`, the release pipeline wrote one
     changelog heading and read back another. `release-core.yml` finalizes with

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -102,6 +102,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     only behind the shellHook's own `/etc/NIXOS` guard, so it never reaches a
     hosted runner and is the correct value on a NixOS self-hosted one — left
     forwardable. Nothing else the builder sets is host-specific.
+- **shellHook env forward stops leaking Nix-host state** ([#1358](https://github.com/vig-os/devkit/issues/1358))
+  - `PYTHONPATH` is now forwarded **component-wise**: the direnv-mode preamble
+    splits it on `:`, drops every `/nix/store` entry and forwards what remains,
+    skipping the var when nothing is left. With `python` in the dev-shell
+    `packages` the nixpkgs setup hook fills `PYTHONPATH` with store
+    site-packages dirs; forwarded whole, those Nix-built `cp3xx` packages joined
+    the `sys.path` of the *downloaded* manylinux CPython — same ABI tag,
+    importable, the same mixed-loader shape as #1353's
+    `ImportError: libstdc++.so.6`. A blanket deny was not an option: a
+    `shellHook` exporting `PYTHONPATH=$PWD/src` is a legitimate #1180 use case
+    and still arrives on CI intact.
+  - The denylist gained the stdenv machinery it was still missing —
+    `_PYTHON_HOST_PLATFORM`, `_PYTHON_SYSCONFIGDATA_NAME`, `DETERMINISTIC_BUILD`,
+    `CONFIG_SHELL`, the `do[A-Z]*` build flags (`doCheck`, `doInstallCheck`,
+    `doDist`; the symmetric partner of the already-denied `dont*`) — and the
+    stdenv cc/binutils hook names `AR AS CC CXX LD NM OBJCOPY OBJDUMP RANLIB
+    READELF SIZE STRINGS STRIP`. stdenv sets those toolchain names in **every**
+    dev shell as bare commands (`CC=gcc`), so every direnv consumer was shipping
+    them to its whole CI job. Inside dev-shell context the wrapped toolchain
+    already wins via `PATH` after #1351; for a step that runs outside it
+    (`setup-python` plus `pip` building a C extension) a forwarded `CC`
+    resolving to the Nix wrapper recreates the #1353 mixed-toolchain hazard.
+    This deliberately supersedes the `shellHook` `CC`/`CXX` forward that
+    vig-os/h5v used pre-#1351 — #1351 removed the need for it. The `native`
+    module's generic `CC=cc`/`CXX=c++` exports likewise no longer reach CI; they
+    exist so build backends fall back to `PATH` discovery (#879/#893), which the
+    forwarded dev-shell `PATH` still provides. A CI step that needs a specific
+    compiler should set it in the workflow. Patterns are case-sensitive, so
+    `DOCKER_*`/`DO_SOMETHING` are unaffected.
+  - `IN_NIX_SHELL` is denied too: forwarding `IN_NIX_SHELL=impure` made every
+    subsequent CI step claim to be running inside a nix shell.
+  - The related NixOS-self-hosted-runner gap in the CPython `PATH` filter is
+    tracked separately in
+    [#1360](https://github.com/vig-os/devkit/issues/1360).
 - **Prefixed-tag releases publish their changelog notes** ([#1355](https://github.com/vig-os/devkit/issues/1355))
   - In a consumer that sets `DEVKIT_TAG_PREFIX`, the release pipeline wrote one
     changelog heading and read back another. `release-core.yml` finalizes with

--- a/assets/workspace/.github/actions/setup-devkit-toolchain/action.yml
+++ b/assets/workspace/.github/actions/setup-devkit-toolchain/action.yml
@@ -235,17 +235,30 @@ runs:
         # wheel died under the Nix loader with `ImportError: libstdc++.so.6:
         # cannot open shared object file` (#698/#703/#729, #1353). Exact
         # patterns: UV_PYTHON_DOWNLOADS_JSON_URL must still forward.
+        # The stdenv cc/binutils hook names (AR…STRIP) go too (#1358): stdenv
+        # sets them in EVERY dev shell as bare command names (`CC=gcc`), so
+        # every consumer shipped them to the whole CI job. Inside dev-shell
+        # context the wrapped toolchain already wins via PATH (#1351); for steps
+        # that run OUTSIDE it (setup-python + pip building a C extension) a
+        # forwarded `CC` resolves to the Nix wrapper and recreates the #1353
+        # mixed-toolchain hazard. A step that needs a specific compiler sets it
+        # in the workflow. `do[A-Z]*` (doCheck/doInstallCheck/doDist) is the
+        # symmetric partner of `dont*`; case patterns are case-sensitive, so
+        # DOCKER_*/DO_SOMETHING are untouched (a consumer var literally spelled
+        # `doSomething` would be denied — accepted).
         devkit_env_denied() {
           case "$1" in
             PATH|HOME|USER|LOGNAME|SHELL|TERM|PWD|OLDPWD|SHLVL|IFS|_) return 0 ;;
             TMPDIR|TMP|TEMP|TEMPDIR) return 0 ;;
             UV_PYTHON|UV_PYTHON_DOWNLOADS) return 0 ;;
-            NIX_*) return 0 ;;
+            NIX_*|IN_NIX_SHELL) return 0 ;;
             out|outputs|src|stdenv|system|builder|name|pname|version|shell|shellHook) return 0 ;;
             buildInputs|nativeBuildInputs|propagatedBuildInputs|propagatedNativeBuildInputs) return 0 ;;
-            deps*|*Phase|phases|dont*) return 0 ;;
+            deps*|*Phase|phases|dont*|do[A-Z]*) return 0 ;;
             configureFlags|cmakeFlags|mesonFlags|makeFlags|patches|strictDeps|enableParallelBuilding) return 0 ;;
             SOURCE_DATE_EPOCH|HOST_PATH|__structuredAttrs|outputHash*|preferLocalBuild|allowSubstitutes|cmakeDir) return 0 ;;
+            _PYTHON_HOST_PLATFORM|_PYTHON_SYSCONFIGDATA_NAME|DETERMINISTIC_BUILD|CONFIG_SHELL) return 0 ;;
+            AR|AS|CC|CXX|LD|NM|OBJCOPY|OBJDUMP|RANLIB|READELF|SIZE|STRINGS|STRIP) return 0 ;;
             *) return 1 ;;
           esac
         }
@@ -275,6 +288,29 @@ runs:
           fi
           if devkit_env_denied "$devkit_name"; then
             continue
+          fi
+          # PYTHONPATH: forward the consumer's own components only (#1358). The
+          # nixpkgs python setup hook fills it with store site-packages dirs, and
+          # on CI those land on the sys.path of the *downloaded* manylinux
+          # CPython — same ABI tag, importable, exactly the mixed-loader shape
+          # behind the `ImportError: libstdc++.so.6` of #1353. A blanket deny
+          # would be wrong: `export PYTHONPATH=$PWD/src` in a shellHook is the
+          # #1180 use case. So drop the /nix/store components, keep the rest, and
+          # skip the var entirely when nothing is left. PYTHONPATH only, by
+          # design — the same split-and-filter fits any other path-like var that
+          # ever shows this leak.
+          if [[ "$devkit_name" == PYTHONPATH ]]; then
+            devkit_kept=()
+            IFS=':' read -r -a devkit_parts <<< "$devkit_value"
+            for devkit_part in "${devkit_parts[@]}"; do
+              if [[ "$devkit_part" != /nix/store/* ]]; then
+                devkit_kept+=("$devkit_part")
+              fi
+            done
+            if [[ "${#devkit_kept[@]}" -eq 0 ]]; then
+              continue
+            fi
+            devkit_value="$(IFS=':'; printf '%s' "${devkit_kept[*]}")"
           fi
           # Random heredoc delimiter: multi-line and special-character values
           # survive intact and cannot break GITHUB_ENV parsing (GitHub's own

--- a/tests/test_setup_toolchain_env.py
+++ b/tests/test_setup_toolchain_env.py
@@ -50,6 +50,13 @@ DEVSHELL_STEP_NAME = "Build repo flake dev-shell and export PATH"
 # pipeline (#1189).
 BANNER = "devcontainer dev environment loaded (nix)"
 
+# A PYTHONPATH exactly as the nixpkgs python setup hook builds it inside the
+# dev-shell: store site-packages dirs only, no consumer component (#1358).
+STORE_ONLY_PYTHONPATH = (
+    "/nix/store/pppppppp-python3.14-vig-utils-0.1.0/lib/python3.14/site-packages:"
+    "/nix/store/qqqqqqqq-python3-3.14.6/lib/python3.14/site-packages"
+)
+
 # The simulated dev-shell environment the stub `nix` emits (null-delimited). It
 # mixes shellHook exports (must forward), Nix/stdenv build machinery (must be
 # denied), shell session state (must be denied), and an ambient var unchanged
@@ -79,6 +86,21 @@ _DEVSHELL_ENV = [
     ("UV_PYTHON_DOWNLOADS", "never"),
     # Forwarded ON PURPOSE by the same step (#632/#683/#1028) — must survive.
     ("UV_PYTHON_DOWNLOADS_JSON_URL", "https://example.invalid/downloads.json"),
+    # stdenv machinery and Nix-shell session state the forward still leaked
+    # after #1353 — same family, every one must be denied (#1358). The
+    # toolchain hook names are bare commands (`CC=gcc`), so stdenv sets them in
+    # EVERY dev shell and the forward shipped them to the whole CI job.
+    ("_PYTHON_HOST_PLATFORM", "linux-x86_64"),
+    ("_PYTHON_SYSCONFIGDATA_NAME", "_sysconfigdata__linux_x86_64-linux-gnu"),
+    ("DETERMINISTIC_BUILD", "1"),
+    ("CONFIG_SHELL", "/nix/store/cccccccc-bash-5.3p9/bin/bash"),
+    ("doCheck", "1"),
+    ("CC", "gcc"),
+    ("LD", "ld"),
+    ("IN_NIX_SHELL", "impure"),
+    # The nixpkgs python setup hook's PYTHONPATH: store components only, so
+    # nothing survives the store strip and the var must not be forwarded at all.
+    ("PYTHONPATH", STORE_ONLY_PYTHONPATH),
     # Shell session state — must be denied.
     ("PATH", "/nix/store/aaaaaaaa-foo/bin:/usr/bin"),
     ("HOME", "/home/dev-shell"),
@@ -87,6 +109,19 @@ _DEVSHELL_ENV = [
     # Ambient var, unchanged from the host env — must not be re-forwarded.
     ("AMBIENT_SHARED", "same-on-both-sides"),
 ]
+
+# Names to scrub from the harness subprocess environment. A CI runner carries
+# none of the simulated dev-shell's vars, but this test process runs inside
+# `nix develop`, where stdenv and mkProjectShell export many of them ambiently
+# (`CC`, `PYTHONPATH`, `IN_NIX_SHELL`, `UV_PYTHON`, …). Left in place, the
+# step's unchanged-var filter would drop them before the denylist ever ran and
+# every denial assertion would pass for the wrong reason (#1353, #1358). The
+# session state the subprocess genuinely needs, plus the var that is ambient on
+# purpose, are kept.
+_AMBIENT_ON_PURPOSE = frozenset({"PATH", "HOME", "SHLVL", "TMPDIR", "AMBIENT_SHARED"})
+_SCRUBBED_AMBIENT_VARS = tuple(
+    name for name, _ in _DEVSHELL_ENV if name not in _AMBIENT_ON_PURPOSE
+)
 
 # The simulated dev-shell `$PATH` the stub `nix` reports, in dev-shell priority
 # order (highest first). It carries a wrapper/raw toolchain pair — the shape
@@ -112,7 +147,12 @@ def _devshell_step_script() -> str:
     raise AssertionError(f"step {DEVSHELL_STEP_NAME!r} not found in {ACTION}")
 
 
-def _write_nix_stub(bin_dir: Path, *, banner: bool = False) -> None:
+def _write_nix_stub(
+    bin_dir: Path,
+    *,
+    banner: bool = False,
+    devshell_env: list[tuple[str, str]] | None = None,
+) -> None:
     """A fake `nix` covering every invocation the devshell step makes.
 
     - `nix develop … --command true`                  -> exit 0 (profile build)
@@ -123,7 +163,10 @@ def _write_nix_stub(bin_dir: Path, *, banner: bool = False) -> None:
 
     With ``banner=True`` the stub echoes the shellHook banner to stdout on
     every invocation, exactly as the real scaffolded flake does (#1189).
+    ``devshell_env`` replaces the simulated dev-shell env records, so a test can
+    pin one var's exact value (used for the PYTHONPATH cases, #1358).
     """
+    records = _DEVSHELL_ENV if devshell_env is None else devshell_env
     bin_dir.mkdir(parents=True, exist_ok=True)
     lines = [
         "#!/usr/bin/env bash",
@@ -147,7 +190,7 @@ def _write_nix_stub(bin_dir: Path, *, banner: bool = False) -> None:
         '  target="${cmd[-1]}"',
         '  : > "$target"',
     ]
-    for name, value in _DEVSHELL_ENV:
+    for name, value in records:
         lines.append(
             f"  printf '%s\\0' {_bash_squote(name + '=' + value)} >> \"$target\""
         )
@@ -156,7 +199,7 @@ def _write_nix_stub(bin_dir: Path, *, banner: bool = False) -> None:
         "fi",
         'if [ "${cmd[0]:-}" = "env" ]; then',
     ]
-    for name, value in _DEVSHELL_ENV:
+    for name, value in records:
         lines.append(f"  printf '%s\\0' {_bash_squote(name + '=' + value)}")
     lines += [
         "  exit 0",
@@ -179,24 +222,29 @@ def _bash_squote(s: str) -> str:
     return "'" + s.replace("'", "'\\''") + "'"
 
 
-def _run_devshell_step(tmp_path: Path) -> dict[str, str]:
+def _run_devshell_step(
+    tmp_path: Path, *, devshell_env: list[tuple[str, str]] | None = None
+) -> dict[str, str]:
     """Execute the devshell step and return the parsed GITHUB_ENV map.
 
     Multi-line heredoc values are collapsed with `\\n` joins so a caller can
     assert on them; the presence of a heredoc is asserted separately on the raw
     text where it matters.
     """
-    return _exec_devshell_step(tmp_path)[0]
+    return _exec_devshell_step(tmp_path, devshell_env=devshell_env)[0]
 
 
 def _exec_devshell_step(
-    tmp_path: Path, *, banner: bool = False
+    tmp_path: Path,
+    *,
+    banner: bool = False,
+    devshell_env: list[tuple[str, str]] | None = None,
 ) -> tuple[dict[str, str], str]:
     """Execute the devshell step; return (parsed GITHUB_ENV map, raw text)."""
     script = _devshell_step_script()
 
     bin_dir = tmp_path / "stub-bin"
-    _write_nix_stub(bin_dir, banner=banner)
+    _write_nix_stub(bin_dir, banner=banner, devshell_env=devshell_env)
 
     github_env = tmp_path / "github_env"
     github_path = tmp_path / "github_path"
@@ -214,12 +262,13 @@ def _exec_devshell_step(
         # Ambient var that the dev-shell leaves unchanged: must be filtered out.
         "AMBIENT_SHARED": "same-on-both-sides",
     }
-    # A CI runner carries none of the dev-shell's uv pins, but this test process
-    # is itself launched from a dev-shell (`nix develop -c uv run pytest`), which
-    # would make them ambient — and the step's unchanged-var filter would then
-    # mask the denylist behavior under test. Scrub them (#1353).
-    for uv_var in ("UV_PYTHON", "UV_PYTHON_DOWNLOADS", "UV_PYTHON_DOWNLOADS_JSON_URL"):
-        env.pop(uv_var, None)
+    # A CI runner carries none of the dev-shell's uv pins or stdenv machinery,
+    # but this test process is itself launched from a dev-shell
+    # (`nix develop -c uv run pytest`), which would make them ambient — and the
+    # step's unchanged-var filter would then mask the denylist behavior under
+    # test. Scrub them (#1353, #1358).
+    for ambient_var in _SCRUBBED_AMBIENT_VARS:
+        env.pop(ambient_var, None)
 
     proc = subprocess.run(
         ["bash", "-c", script],
@@ -308,6 +357,17 @@ def test_multiline_value_survives_via_heredoc(tmp_path: Path) -> None:
         # Nix-host interpreter pins (#1353).
         "UV_PYTHON",
         "UV_PYTHON_DOWNLOADS",
+        # stdenv machinery and Nix-shell session state (#1358), one per family:
+        # exact stdenv scalars, the `do*` build-flag glob (partner of `dont*`),
+        # the stdenv cc/binutils hook names, and the nix-shell marker.
+        "_PYTHON_HOST_PLATFORM",
+        "_PYTHON_SYSCONFIGDATA_NAME",
+        "DETERMINISTIC_BUILD",
+        "CONFIG_SHELL",
+        "doCheck",
+        "CC",
+        "LD",
+        "IN_NIX_SHELL",
         # Shell session state.
         "PATH",
         "HOME",
@@ -347,6 +407,48 @@ def test_uv_interpreter_pins_do_not_defeat_the_manylinux_path(
     assert env.get("UV_PYTHON_DOWNLOADS_JSON_URL") == (
         "https://example.invalid/downloads.json"
     ), "the deliberate uv download-metadata forward must survive the denylist"
+
+
+def test_store_only_pythonpath_is_not_forwarded(tmp_path: Path) -> None:
+    """A PYTHONPATH made only of store paths must not reach GITHUB_ENV.
+
+    ``python`` in the dev-shell ``packages`` makes the nixpkgs python setup hook
+    export ``PYTHONPATH=/nix/store/…/site-packages:…``. Forwarded to CI, those
+    Nix-built ``cp3xx`` site-packages land on the ``sys.path`` of the
+    *downloaded* manylinux CPython — same ABI tag, importable, exactly the
+    mixed-loader shape behind #1353's ``ImportError: libstdc++.so.6``.
+
+    Refs: #1358
+    """
+    env = _run_devshell_step(tmp_path)
+    assert "PYTHONPATH" not in env, (
+        "a store-only PYTHONPATH must not be forwarded to GITHUB_ENV"
+    )
+
+
+def test_pythonpath_keeps_consumer_components_and_drops_store_ones(
+    tmp_path: Path,
+) -> None:
+    """A mixed PYTHONPATH forwards only the consumer's own components.
+
+    A blanket deny would be wrong: ``export PYTHONPATH=$PWD/src`` in a
+    ``shellHook`` is exactly the #1180 use case. Only the ``/nix/store``
+    components are dropped.
+
+    Refs: #1358
+    """
+    env = _run_devshell_step(
+        tmp_path,
+        devshell_env=[("PYTHONPATH", f"{STORE_ONLY_PYTHONPATH}:/workspace/src")],
+    )
+    assert env.get("PYTHONPATH") == "/workspace/src"
+
+
+def test_consumer_only_pythonpath_is_forwarded_verbatim(tmp_path: Path) -> None:
+    """A PYTHONPATH with no store component is forwarded unchanged (#1358)."""
+    value = "/workspace/src:/workspace/lib"
+    env = _run_devshell_step(tmp_path, devshell_env=[("PYTHONPATH", value)])
+    assert env.get("PYTHONPATH") == value
 
 
 def test_unchanged_ambient_var_is_not_reforwarded(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Follow-up to the #1353 denylist audit: the shellHook env forward (#1180) still shipped Nix-host state to `GITHUB_ENV`. Three leaks closed:

- **`PYTHONPATH` store components are stripped, not blanket-denied.** The nixpkgs python setup hook fills `PYTHONPATH` with store site-packages dirs; forwarded to CI they land on the sys.path of the *downloaded* manylinux CPython — same ABI tag, importable, exactly the mixed-loader shape behind #1353's `ImportError: libstdc++.so.6`. The forward loop now splits the value on `:`, drops `/nix/store/*` components, forwards the remainder, and skips the var when nothing is left — so the legitimate `export PYTHONPATH=$PWD/src` shellHook use case survives verbatim. PYTHONPATH only, by design; the pattern is noted as reusable.
- **stdenv machinery the denylist missed**: `_PYTHON_HOST_PLATFORM`, `_PYTHON_SYSCONFIGDATA_NAME`, `DETERMINISTIC_BUILD`, `CONFIG_SHELL`, `do[A-Z]*` (the symmetric partner of the existing `dont*`), and the cc/binutils hook names `AR AS CC CXX LD NM OBJCOPY OBJDUMP RANLIB READELF SIZE STRINGS STRIP`. stdenv sets those in every dev shell as bare names (`CC=gcc`); inside dev-shell context the wrapped toolchain already wins via PATH (#1351), while for steps running outside it a forwarded `CC` recreates the mixed-toolchain hazard. Two known collisions, both assessed and accepted: the pre-#1351 h5v CC/CXX shellHook workaround (superseded — #1351 removed the need) and the `native` capability module's `CC=cc`/`CXX=c++` exports (those generic names exist precisely so build backends fall back to PATH discovery, which `GITHUB_PATH` already provides on CI).
- **`IN_NIX_SHELL`** — no CI step should claim to run inside a nix shell. The `.githooks` guard that reads it is local-only (no scaffold workflow commits through it).

The NixOS-self-hosted PATH-filter gap found in the same audit is split out as #1360 and untouched here, as are the `UV_PYTHON*` entries (#1353) and the `GITHUB_PATH` write (#1351).

## Test plan

- 8 new parametrized denylist cases + 3 PYTHONPATH value tests (store-only → dropped; mixed → forwarded as exactly the consumer components; consumer-only → verbatim, the #1180 regression guard). RED before the fix: `10 failed, 29 passed`, each var visibly landing in GITHUB_ENV.
- Test-harness hardening that the RED run itself justified: pytest runs inside `nix develop`, where stdenv exports `CC`, `CONFIG_SHELL`, `PYTHONPATH`, `IN_NIX_SHELL`, … ambiently — the step's unchanged-var filter would have masked the denylist under test. The subprocess env scrub is now derived from the fixture list instead of a hand-kept 3-var set.
- Full `tests/test_setup_toolchain_env.py` + `test_renovate_preset_managed_exclusion.py`: 42/42 green (verified independently by reviewer); rendered-workflow actionlint bats 5/5; `prek run --all-files` green.

## Follow-up candidate

`docs/MIGRATION.md` enumerates the denylist in prose and is now stale for both #1353 and #1358 — left untouched per minimal-diff scope; happy to file a docs issue.

Refs: #1358