### PR TITLE
fix(action): keep the Nix CPython and uv pins on NixOS runners

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,6 +136,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The related NixOS-self-hosted-runner gap in the CPython `PATH` filter is
     tracked separately in
     [#1360](https://github.com/vig-os/devkit/issues/1360).
+- **Python consumers work on NixOS self-hosted runners** ([#1360](https://github.com/vig-os/devkit/issues/1360))
+  - The direnv-mode preamble dropped the bare Nix CPython from the exported
+    `PATH` whenever `pyproject.toml` was present — unconditionally. That is
+    right on a hosted FHS runner, where `uv` downloads a managed manylinux
+    CPython (#698/#703/#729), and wrong by construction on a **NixOS**
+    self-hosted runner, where such a download cannot execute at all. #1353 made
+    the gap reachable: the `UV_PYTHON` pin it stopped forwarding was what had
+    accidentally masked it. No consumer matched the combination yet (the one
+    NixOS-runner consumer has no `pyproject.toml`), so this was a latent
+    landmine rather than a live break.
+  - The step now probes the runner's own OS via `/etc/NIXOS` — the same marker
+    `mkProjectShell`'s `shellHook` uses to gate `LD_LIBRARY_PATH` — and takes
+    the matching branch. On a NixOS runner the `pyproject.toml`-gated CPython
+    exclusion is skipped, so the store interpreter stays on `PATH`, **and**
+    `mkProjectShell`'s `UV_PYTHON` / `UV_PYTHON_DOWNLOADS=never` pins are
+    forwarded instead of denied. Both halves are needed: `PATH` alone leaves
+    `uv`'s python-preference free to prefer a managed download, and the pins
+    are what make it use the Nix interpreter deterministically. The podman
+    exclusion stays unconditional, and `UV_PYTHON_DOWNLOADS_JSON_URL` is still
+    forwarded (harmless once the pin wins).
+  - On every non-NixOS runner the behavior is byte-identical to before,
+    #1353's denial of the same two pins included.
 - **Prefixed-tag releases publish their changelog notes** ([#1355](https://github.com/vig-os/devkit/issues/1355))
   - In a consumer that sets `DEVKIT_TAG_PREFIX`, the release pipeline wrote one
     changelog heading and read back another. `release-core.yml` finalizes with

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -136,6 +136,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The related NixOS-self-hosted-runner gap in the CPython `PATH` filter is
     tracked separately in
     [#1360](https://github.com/vig-os/devkit/issues/1360).
+- **Python consumers work on NixOS self-hosted runners** ([#1360](https://github.com/vig-os/devkit/issues/1360))
+  - The direnv-mode preamble dropped the bare Nix CPython from the exported
+    `PATH` whenever `pyproject.toml` was present — unconditionally. That is
+    right on a hosted FHS runner, where `uv` downloads a managed manylinux
+    CPython (#698/#703/#729), and wrong by construction on a **NixOS**
+    self-hosted runner, where such a download cannot execute at all. #1353 made
+    the gap reachable: the `UV_PYTHON` pin it stopped forwarding was what had
+    accidentally masked it. No consumer matched the combination yet (the one
+    NixOS-runner consumer has no `pyproject.toml`), so this was a latent
+    landmine rather than a live break.
+  - The step now probes the runner's own OS via `/etc/NIXOS` — the same marker
+    `mkProjectShell`'s `shellHook` uses to gate `LD_LIBRARY_PATH` — and takes
+    the matching branch. On a NixOS runner the `pyproject.toml`-gated CPython
+    exclusion is skipped, so the store interpreter stays on `PATH`, **and**
+    `mkProjectShell`'s `UV_PYTHON` / `UV_PYTHON_DOWNLOADS=never` pins are
+    forwarded instead of denied. Both halves are needed: `PATH` alone leaves
+    `uv`'s python-preference free to prefer a managed download, and the pins
+    are what make it use the Nix interpreter deterministically. The podman
+    exclusion stays unconditional, and `UV_PYTHON_DOWNLOADS_JSON_URL` is still
+    forwarded (harmless once the pin wins).
+  - On every non-NixOS runner the behavior is byte-identical to before,
+    #1353's denial of the same two pins included.
 - **Prefixed-tag releases publish their changelog notes** ([#1355](https://github.com/vig-os/devkit/issues/1355))
   - In a consumer that sets `DEVKIT_TAG_PREFIX`, the release pipeline wrote one
     changelog heading and read back another. `release-core.yml` finalizes with

--- a/assets/workspace/.github/actions/setup-devkit-toolchain/action.yml
+++ b/assets/workspace/.github/actions/setup-devkit-toolchain/action.yml
@@ -154,6 +154,19 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
+        # Is the runner itself NixOS? In direnv mode this step runs on the
+        # runner host, so this is the host OS, and it decides two things below:
+        # whether a downloaded manylinux CPython could run here at all (#1360).
+        # `/etc/NIXOS` is the established probe — mkProjectShell's own shellHook
+        # uses it to gate LD_LIBRARY_PATH (#698). DEVKIT_NIXOS_MARKER exists
+        # SOLELY so the test harness can point the probe at a fixture path; CI
+        # never sets it, and neither should a consumer.
+        devkit_runner_is_nixos=false
+        if [ -e "${DEVKIT_NIXOS_MARKER:-/etc/NIXOS}" ]; then
+          devkit_runner_is_nixos=true
+        fi
+        echo "Runner is NixOS: $devkit_runner_is_nixos"
+
         # Build the consumer repo's own dev-shell (repo root flake) into a gcroot
         # profile — a warm Cachix pull — then prepend its nix-store bin dirs to
         # GITHUB_PATH so every following step runs as if inside `nix develop`.
@@ -171,10 +184,15 @@ runs:
         # manylinux CPython, not the Nix loader — the #698/#703/#729 libstdc++
         # regression. Library pkgs (python3.<ver>-<pkg>) are unaffected. On a
         # non-Python repo the Nix python stays on PATH (#1028).
+        # Not on a NixOS runner (#1360): there the exclusion is wrong by
+        # construction, since a downloaded manylinux CPython cannot execute on
+        # NixOS at all — dropping the store interpreter would leave the job with
+        # no usable Python. The Nix loader is the *only* one that works here, so
+        # the CPython stays and the uv pins below stay with it.
         STORE_BINS="$(printf '%s' "$SHELL_PATH" | tr ':' '\n' \
           | grep '^/nix/store' \
           | grep -v '/nix/store/[^/]*-podman[^/]*/bin')"
-        if [[ -f pyproject.toml ]]; then
+        if [[ -f pyproject.toml && "$devkit_runner_is_nixos" != true ]]; then
           STORE_BINS="$(printf '%s\n' "$STORE_BINS" \
             | grep -Ev '/nix/store/[^/]*-python3-[0-9][^/]*/bin')"
         fi
@@ -235,6 +253,12 @@ runs:
         # wheel died under the Nix loader with `ImportError: libstdc++.so.6:
         # cannot open shared object file` (#698/#703/#729, #1353). Exact
         # patterns: UV_PYTHON_DOWNLOADS_JSON_URL must still forward.
+        # On a NixOS runner both pins are instead exactly correct and are
+        # forwarded (#1360): UV_PYTHON names a store interpreter the runner can
+        # execute, and `never` stops uv preferring a managed download that could
+        # not run there. Keeping the CPython on PATH above is not sufficient on
+        # its own — uv's python-preference can still pick the download — so the
+        # two halves of the NixOS branch go together.
         # The stdenv cc/binutils hook names (AR…STRIP) go too (#1358): stdenv
         # sets them in EVERY dev shell as bare command names (`CC=gcc`), so
         # every consumer shipped them to the whole CI job. Inside dev-shell
@@ -250,7 +274,11 @@ runs:
           case "$1" in
             PATH|HOME|USER|LOGNAME|SHELL|TERM|PWD|OLDPWD|SHLVL|IFS|_) return 0 ;;
             TMPDIR|TMP|TEMP|TEMPDIR) return 0 ;;
-            UV_PYTHON|UV_PYTHON_DOWNLOADS) return 0 ;;
+            UV_PYTHON|UV_PYTHON_DOWNLOADS)
+              if [ "$devkit_runner_is_nixos" = true ]; then
+                return 1
+              fi
+              return 0 ;;
             NIX_*|IN_NIX_SHELL) return 0 ;;
             out|outputs|src|stdenv|system|builder|name|pname|version|shell|shellHook) return 0 ;;
             buildInputs|nativeBuildInputs|propagatedBuildInputs|propagatedNativeBuildInputs) return 0 ;;

--- a/tests/test_setup_toolchain_env.py
+++ b/tests/test_setup_toolchain_env.py
@@ -57,6 +57,13 @@ STORE_ONLY_PYTHONPATH = (
     "/nix/store/qqqqqqqq-python3-3.14.6/lib/python3.14/site-packages"
 )
 
+# The bare Nix CPython the #1028 PATH filter targets on a Python consumer, and
+# mkProjectShell's matching `UV_PYTHON` pin into it. Declared here because the
+# simulated dev-shell env below needs the pin; the bin dir also takes its place
+# in the simulated dev-shell `$PATH` further down.
+PYTHON3_STORE_BIN = "/nix/store/pppppppp-python3-3.14.6/bin"
+UV_PYTHON_PIN = f"{PYTHON3_STORE_BIN}/python3.14"
+
 # The simulated dev-shell environment the stub `nix` emits (null-delimited). It
 # mixes shellHook exports (must forward), Nix/stdenv build machinery (must be
 # denied), shell session state (must be denied), and an ambient var unchanged
@@ -78,11 +85,11 @@ _DEVSHELL_ENV = [
     ("dontUnpack", "1"),
     ("configurePhase", ":"),
     ("depsBuildBuild", ""),
-    # mkProjectShell's uv interpreter pins — Nix-host-only, must be denied
-    # (#1353). Kept next to their deliberate counterpart below, which must
-    # survive: the denylist matches names exactly, so `UV_PYTHON` cannot swallow
-    # `UV_PYTHON_DOWNLOADS_JSON_URL`.
-    ("UV_PYTHON", "/nix/store/pppppppp-python3-3.14.6/bin/python3.14"),
+    # mkProjectShell's uv interpreter pins — denied on an FHS runner (#1353),
+    # forwarded on a NixOS one (#1360). Kept next to their deliberate
+    # counterpart below, which must survive on both: the denylist matches names
+    # exactly, so `UV_PYTHON` cannot swallow `UV_PYTHON_DOWNLOADS_JSON_URL`.
+    ("UV_PYTHON", UV_PYTHON_PIN),
     ("UV_PYTHON_DOWNLOADS", "never"),
     # Forwarded ON PURPOSE by the same step (#632/#683/#1028) — must survive.
     ("UV_PYTHON_DOWNLOADS_JSON_URL", "https://example.invalid/downloads.json"),
@@ -127,13 +134,16 @@ _SCRUBBED_AMBIENT_VARS = tuple(
 # order (highest first). It carries a wrapper/raw toolchain pair — the shape
 # every Nix stdenv shell has and the one that made the GITHUB_PATH ordering bug
 # visible: with the two dirs swapped, the raw compiler shadows its wrapper and
-# every C build dies with the unwrapped-gcc signature (#1351).
+# every C build dies with the unwrapped-gcc signature (#1351) — plus the bare
+# Nix CPython the pyproject-gated filter drops on an FHS runner and keeps on a
+# NixOS one (#1028, #1360).
 GCC_WRAPPER_BIN = "/nix/store/wwwwwwww-gcc-wrapper-13/bin"
 GCC_RAW_BIN = "/nix/store/gggggggg-gcc-13/bin"
 STORE_BINS_IN_ORDER = [
     "/nix/store/aaaaaaaa-foo/bin",
     GCC_WRAPPER_BIN,
     GCC_RAW_BIN,
+    PYTHON3_STORE_BIN,
     "/nix/store/bbbbbbbb-bar/bin",
 ]
 DEVSHELL_PATH = ":".join([*STORE_BINS_IN_ORDER, "/usr/bin"])
@@ -223,7 +233,11 @@ def _bash_squote(s: str) -> str:
 
 
 def _run_devshell_step(
-    tmp_path: Path, *, devshell_env: list[tuple[str, str]] | None = None
+    tmp_path: Path,
+    *,
+    devshell_env: list[tuple[str, str]] | None = None,
+    pyproject: bool = False,
+    nixos: bool = False,
 ) -> dict[str, str]:
     """Execute the devshell step and return the parsed GITHUB_ENV map.
 
@@ -231,7 +245,9 @@ def _run_devshell_step(
     assert on them; the presence of a heredoc is asserted separately on the raw
     text where it matters.
     """
-    return _exec_devshell_step(tmp_path, devshell_env=devshell_env)[0]
+    return _exec_devshell_step(
+        tmp_path, devshell_env=devshell_env, pyproject=pyproject, nixos=nixos
+    )[0]
 
 
 def _exec_devshell_step(
@@ -239,8 +255,15 @@ def _exec_devshell_step(
     *,
     banner: bool = False,
     devshell_env: list[tuple[str, str]] | None = None,
+    pyproject: bool = False,
+    nixos: bool = False,
 ) -> tuple[dict[str, str], str]:
-    """Execute the devshell step; return (parsed GITHUB_ENV map, raw text)."""
+    """Execute the devshell step; return (parsed GITHUB_ENV map, raw text).
+
+    ``pyproject`` writes a ``pyproject.toml`` into the step's cwd, which is what
+    the step reads to decide it is running for a Python consumer (#1028).
+    ``nixos`` creates the file the runner-OS probe looks for (#1360).
+    """
     script = _devshell_step_script()
 
     bin_dir = tmp_path / "stub-bin"
@@ -253,12 +276,28 @@ def _exec_devshell_step(
     github_path.touch()
     runner_temp.mkdir()
 
+    if pyproject:
+        (tmp_path / "pyproject.toml").write_text(
+            '[project]\nname = "consumer"\nversion = "0.0.0"\n', encoding="utf-8"
+        )
+
+    # The runner-OS probe fixture (#1360). The step probes `/etc/NIXOS` — the
+    # established NixOS marker — through `DEVKIT_NIXOS_MARKER`, an override that
+    # exists for this harness only and is never set on CI. Pinning it here to a
+    # tmp_path file is what makes the tests hermetic: the default probe would
+    # otherwise fire on a NixOS *development* machine (where `/etc/NIXOS` really
+    # exists) and silently run every FHS-branch test against the NixOS branch.
+    nixos_marker = tmp_path / "etc-NIXOS"
+    if nixos:
+        nixos_marker.write_text("", encoding="utf-8")
+
     env = {
         **os.environ,
         "PATH": f"{bin_dir}:{os.environ['PATH']}",
         "GITHUB_ENV": str(github_env),
         "GITHUB_PATH": str(github_path),
         "RUNNER_TEMP": str(runner_temp),
+        "DEVKIT_NIXOS_MARKER": str(nixos_marker),
         # Ambient var that the dev-shell leaves unchanged: must be filtered out.
         "AMBIENT_SHARED": "same-on-both-sides",
     }
@@ -272,7 +311,7 @@ def _exec_devshell_step(
 
     proc = subprocess.run(
         ["bash", "-c", script],
-        cwd=tmp_path,  # no pyproject.toml -> non-Python consumer path
+        cwd=tmp_path,  # pyproject.toml here (or not) picks the consumer path
         env=env,
         capture_output=True,
         text=True,
@@ -399,6 +438,9 @@ def test_uv_interpreter_pins_do_not_defeat_the_manylinux_path(
     goes with it: on its own it would forbid the very download the URL forward
     exists to enable.
 
+    Hosted (FHS) runners only — on a NixOS runner the same pins are correct and
+    must survive (#1360, pinned separately).
+
     Refs: #1353
     """
     env = _run_devshell_step(tmp_path)
@@ -494,6 +536,78 @@ def test_devshell_path_priority_survives_github_path(tmp_path: Path) -> None:
     assert [p for p in path if p.startswith("/nix/store")] == STORE_BINS_IN_ORDER, (
         f"dev-shell PATH priority order not preserved on the runner: {path}"
     )
+
+
+# ── Python consumers on a NixOS self-hosted runner (#1360) ───────────────────
+
+
+def _exported_runner_path(tmp_path: Path) -> list[str]:
+    """The runner PATH the executed step's GITHUB_PATH file produces."""
+    return _runner_path((tmp_path / "github_path").read_text(encoding="utf-8"))
+
+
+def test_python_consumer_on_an_fhs_runner_drops_the_nix_cpython(
+    tmp_path: Path,
+) -> None:
+    """The regression bar: on a hosted (FHS) runner nothing about #1028 changes.
+
+    A downloaded manylinux CPython runs fine there, so the bare Nix CPython is
+    dropped from the exported PATH and `uv sync` builds the venv on the
+    download (#698/#703/#729). Only the CPython goes — the rest of the
+    dev-shell PATH, priority order included, is untouched.
+
+    Refs: #1360
+    """
+    _run_devshell_step(tmp_path, pyproject=True)
+    path = _exported_runner_path(tmp_path)
+
+    assert PYTHON3_STORE_BIN not in path, (
+        f"the bare Nix CPython must not survive on an FHS runner: {path}"
+    )
+    expected = [p for p in STORE_BINS_IN_ORDER if p != PYTHON3_STORE_BIN]
+    assert [p for p in path if p.startswith("/nix/store")] == expected, (
+        f"only the CPython bin dir may be dropped: {path}"
+    )
+
+
+def test_python_consumer_on_a_nixos_runner_keeps_the_nix_cpython(
+    tmp_path: Path,
+) -> None:
+    """On a NixOS self-hosted runner the #1028 exclusion is wrong by design.
+
+    A downloaded manylinux CPython cannot execute on NixOS, so dropping the
+    store interpreter from PATH leaves a Python consumer with no usable
+    interpreter at all. The runner-OS probe (`/etc/NIXOS`) must keep it.
+
+    Refs: #1360
+    """
+    _run_devshell_step(tmp_path, pyproject=True, nixos=True)
+    path = _exported_runner_path(tmp_path)
+
+    assert PYTHON3_STORE_BIN in path, (
+        f"the Nix CPython must stay on PATH on a NixOS runner: {path}"
+    )
+    assert [p for p in path if p.startswith("/nix/store")] == STORE_BINS_IN_ORDER, (
+        f"dev-shell PATH priority order not preserved on the runner: {path}"
+    )
+
+
+def test_uv_interpreter_pins_are_forwarded_on_a_nixos_runner(tmp_path: Path) -> None:
+    """On a NixOS runner `mkProjectShell`'s uv pins are exactly right.
+
+    Keeping the interpreter on PATH is not enough on its own: uv's
+    python-preference can still favour a managed download, which is precisely
+    what cannot run here. `UV_PYTHON` points at a store interpreter the runner
+    *can* execute and `UV_PYTHON_DOWNLOADS=never` forbids the download — the
+    pair is Nix-host-*only* by construction, so the #1353 denial that fixed
+    hosted runners must not apply to this one.
+
+    Refs: #1360
+    """
+    env = _run_devshell_step(tmp_path, pyproject=True, nixos=True)
+
+    assert env.get("UV_PYTHON") == UV_PYTHON_PIN
+    assert env.get("UV_PYTHON_DOWNLOADS") == "never"
 
 
 # ── Self-hosted runners with preinstalled Nix (#1192) ────────────────────────


### PR DESCRIPTION
## Summary

The direnv-mode `setup-devkit-toolchain` PATH filter (#1028) drops the bare Nix CPython whenever `pyproject.toml` is present — unconditionally. On hosted FHS runners that is correct (`uv` builds the venv from a downloaded manylinux CPython). On a **NixOS self-hosted runner** it is wrong by construction: a manylinux CPython cannot execute there, and after #1353 the `UV_PYTHON`/`UV_PYTHON_DOWNLOADS` pins that used to accidentally mask this no longer reach CI. No current consumer hits the combination — this defuses the landmine before the first Python consumer targets a NixOS runner.

The step now probes the runner host once (`/etc/NIXOS`, the probe mkProjectShell's own shellHook already uses; `DEVKIT_NIXOS_MARKER` overrides it solely for the test harness) and branches:
- **NixOS runner**: the CPython exclusion is skipped (the store interpreter is the only one that can run) AND the `UV_PYTHON`/`UV_PYTHON_DOWNLOADS` forwards are allowed (the mkProjectShell pins are exactly correct there). Both halves are needed — keeping the interpreter on PATH alone is not enough, since uv's python-preference can still pick a managed download.
- **FHS runner**: byte-identical to today, pinned by a new regression-bar test (the #1028 exclusion previously had no test at all).

## Test plan

- Stub dev-shell PATH now carries a `python3-3.14.6/bin` store dir; harness gained `pyproject`/`nixos` knobs.
- New tests: FHS drops exactly the CPython dir and nothing else (green throughout — the regression bar); NixOS keeps it (RED→GREEN); NixOS forwards both uv pins (RED→GREEN). RED run: exactly the two NixOS tests failed.
- **Hermeticity**: the harness always pins `DEVKIT_NIXOS_MARKER` to a per-test path whose existence is the switch. This machine IS NixOS, and the pin was proven load-bearing: removing it flips 4 FHS-branch tests red (including the pre-existing #1353 denial tests, which would otherwise silently test the wrong branch on any NixOS host).
- Full `tests/test_setup_toolchain_env.py` + renovate-preset file: 45/45 green (verified independently by reviewer); rendered-workflow actionlint bats 5/5; `prek run --all-files` green.

Refs: #1360
