### PR TITLE
docs(migration): point the env-forward denylist at its source of truth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -176,6 +176,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     `prepare` wrote — matching only the composed tag would have moved the empty
     notes onto the candidate path. Only prefixed repos were affected; an empty
     prefix makes the two forms the same string.
+- **MIGRATION.md env-forward denylist prose replaced by an SSoT pointer** ([#1362](https://github.com/vig-os/devkit/issues/1362))
+  - The "direnv mode: `shellHook` environment forwarding" section enumerated the
+    denylist by hand and had fallen behind the shipped action: it predated the
+    `UV_PYTHON`/`UV_PYTHON_DOWNLOADS` denial (#1353), the stdenv additions and
+    the cc/binutils hook names (#1358), and the NixOS-runner exception that
+    forwards those uv pins after all (#1360) — and its two-bullet shape could
+    not express the `PYTHONPATH` store-component strip, which is a transform
+    rather than a deny.
+  - The enumeration is replaced by a description of the denied *categories* with
+    representative examples, the `PYTHONPATH` transform, and a pointer to the
+    `devkit_env_denied` function in the consumer's own
+    `.github/actions/setup-devkit-toolchain/action.yml` as the single source of
+    truth. The surrounding narrative is unchanged.
 
 ### Security
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -176,6 +176,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     `prepare` wrote — matching only the composed tag would have moved the empty
     notes onto the candidate path. Only prefixed repos were affected; an empty
     prefix makes the two forms the same string.
+- **MIGRATION.md env-forward denylist prose replaced by an SSoT pointer** ([#1362](https://github.com/vig-os/devkit/issues/1362))
+  - The "direnv mode: `shellHook` environment forwarding" section enumerated the
+    denylist by hand and had fallen behind the shipped action: it predated the
+    `UV_PYTHON`/`UV_PYTHON_DOWNLOADS` denial (#1353), the stdenv additions and
+    the cc/binutils hook names (#1358), and the NixOS-runner exception that
+    forwards those uv pins after all (#1360) — and its two-bullet shape could
+    not express the `PYTHONPATH` store-component strip, which is a transform
+    rather than a deny.
+  - The enumeration is replaced by a description of the denied *categories* with
+    representative examples, the `PYTHONPATH` transform, and a pointer to the
+    `devkit_env_denied` function in the consumer's own
+    `.github/actions/setup-devkit-toolchain/action.yml` as the single source of
+    truth. The surrounding narrative is unchanged.
 
 ### Security
 

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -143,18 +143,27 @@ host secrets — already in the runner env, unchanged inside the shell — out o
 delimiter so they survive intact.
 
 A denylist keeps shell-session state and Nix/stdenv build machinery from leaking
-into the CI environment. Never forwarded:
+into the CI environment. It covers three categories: **shell session state**
+(`PATH` — already handled via `GITHUB_PATH` — plus `HOME`, `TMPDIR` and the rest
+of the session/runtime set); **Nix/stdenv build machinery** (everything `NIX_*`,
+`IN_NIX_SHELL`, the stdenv attributes and phase controls, and the cc/binutils
+hook names stdenv sets in every dev shell, `CC`/`LD` among them); and
+**Nix-host interpreter pins** (`UV_PYTHON`, `UV_PYTHON_DOWNLOADS`), which name a
+store CPython a normal runner cannot execute — except on a **NixOS self-hosted
+runner**, where those pins are exactly correct and *are* forwarded
+([#1360](https://github.com/vig-os/devkit/issues/1360)).
 
-- **Session/runtime shell state** — `PATH` (already handled via `GITHUB_PATH`),
-  `HOME`, `USER`, `LOGNAME`, `SHELL`, `TERM`, `PWD`, `OLDPWD`, `SHLVL`, `IFS`,
-  `TMPDIR`/`TMP`/`TEMP`/`TEMPDIR`.
-- **Nix/stdenv build internals** — everything `NIX_*`; the stdenv scalars/lists
-  `out`, `outputs`, `src`, `stdenv`, `system`, `builder`, `name`, `pname`,
-  `version`, `shell`, `shellHook`, `buildInputs`, `nativeBuildInputs`,
-  `propagatedBuildInputs`, `propagatedNativeBuildInputs`, `SOURCE_DATE_EPOCH`,
-  `HOST_PATH`; and the build-machinery patterns `deps*`, `*Phase`, `phases`,
-  `dont*`, `configureFlags`/`cmakeFlags`/`mesonFlags`/`makeFlags`, `patches`,
-  `strictDeps`, `outputHash*`.
+One variable is transformed rather than denied: `PYTHONPATH` is forwarded with
+its `/nix/store` components removed — they would otherwise land on the `sys.path`
+of the downloaded CPython that CI runs — and skipped entirely when nothing is
+left ([#1358](https://github.com/vig-os/devkit/issues/1358)). A `shellHook`'s own
+`export PYTHONPATH="$PWD/src"` still arrives intact.
+
+The authoritative list is the `devkit_env_denied` function in your repo's
+`.github/actions/setup-devkit-toolchain/action.yml` (devkit source:
+`assets/workspace/.github/actions/setup-devkit-toolchain/action.yml`). That
+function is the single source of truth for what is denied, transformed or
+forwarded, and this document deliberately does not duplicate it — read it there.
 
 This is why the diff-plus-denylist approach is used instead of forwarding
 `nix print-dev-env` wholesale: that dumps the full build machinery, none of which


### PR DESCRIPTION
## Summary

The "direnv mode: `shellHook` environment forwarding" section of `docs/MIGRATION.md` enumerated the env-forward denylist by hand and had drifted three merged changes behind the shipped action: it predated the `UV_PYTHON`/`UV_PYTHON_DOWNLOADS` denial (#1353), the stdenv/cc-binutils additions (#1358), the NixOS-runner exception that forwards the uv pins after all (#1360) — and its two-bullet shape could not express the `PYTHONPATH` store-component strip, which is a transform rather than a deny.

The enumeration is replaced with a category description (shell session state; Nix/stdenv build machinery; Nix-host interpreter pins with the NixOS exception; the `PYTHONPATH` transform with the preserved `$PWD/src` use case) and an SSoT pointer to the `devkit_env_denied` function — at the path a consumer actually has (`.github/actions/setup-devkit-toolchain/action.yml` in their scaffolded repo), with the devkit source path alongside. The doc now states explicitly that the function is the single source of truth and deliberately isn't duplicated, so it stops going stale on every denylist change.

Surrounding narrative audited against the current action (ambient-diff/secrets claim, heredoc delimiters, `nix print-dev-env` rationale): all still accurate, untouched. The `UV_PYTHON` mention in the `mkProjectShell` override section is about the local dev shell and remains correct.

## Test plan

Docs-only change (TDD exception). `prek run --all-files` green (verified independently by reviewer), including pymarkdown over the edited section.

Refs: #1362