### PR TITLE
feat(workflows): switch App credentials to client-id with legacy fallback

### DIFF
--- a/.github/workflows/sync-issues.yml
+++ b/.github/workflows/sync-issues.yml
@@ -137,7 +137,7 @@ jobs:
         id: sync
         uses: vig-os/sync-issues-action@b62c8eca72f4ee7177caee4f689ee080a5997164  # v0.5.0
         with:
-          app-id: ${{ secrets.COMMIT_APP_ID }}
+          client-id: ${{ secrets.COMMIT_APP_CLIENT_ID }}
           app-private-key: ${{ secrets.COMMIT_APP_PRIVATE_KEY }}
           output-dir: ${{ github.event.inputs.output-dir || 'docs' }}
           sync-issues: 'true'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Stamped workflows authenticate with App Client IDs — new org secret required** ([#1365](https://github.com/vig-os/devkit/issues/1365))
+  - **Action required before upgrading:** create a `DEVKIT_UPGRADE_APP_CLIENT_ID`
+    secret (org or repo) holding the upgrade App's Client ID (`Iv23li…`).
+    **Create the secret first, then upgrade** — config-first, always. For this
+    release the legacy numeric `DEVKIT_UPGRADE_APP_ID` still works as a
+    fallback (with a deprecation warning), so an upgrade that races the secret
+    is not bricked; the fallback is removed in a future release
+    ([#1366](https://github.com/vig-os/devkit/issues/1366)).
+  - `sync-issues.yml` now passes `COMMIT_APP_CLIENT_ID` through the `client-id`
+    input added in `vig-os/sync-issues-action` v0.5.0 — the numeric
+    `COMMIT_APP_ID` secret is no longer read anywhere and can be retired once
+    every consumer is on this release.
+  - `devkit-upgrade.yml` prefers `DEVKIT_UPGRADE_APP_CLIENT_ID` in its
+    preflight gate and `create-github-app-token` mint.
+  - Nothing in the auth path is numerically load-bearing: GitHub accepts either
+    the App ID or the Client ID as the App JWT issuer.
 - **`CONTRIBUTE.md` renamed to `CONTRIBUTING.md`** ([#1372](https://github.com/vig-os/devkit/issues/1372))
   - GitHub's community profile only recognises `CONTRIBUTING.md`, so the guide
     was invisible to it and no "Contributing guidelines" link appeared on new

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -17,6 +17,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Stamped workflows authenticate with App Client IDs — new org secret required** ([#1365](https://github.com/vig-os/devkit/issues/1365))
+  - **Action required before upgrading:** create a `DEVKIT_UPGRADE_APP_CLIENT_ID`
+    secret (org or repo) holding the upgrade App's Client ID (`Iv23li…`).
+    **Create the secret first, then upgrade** — config-first, always. For this
+    release the legacy numeric `DEVKIT_UPGRADE_APP_ID` still works as a
+    fallback (with a deprecation warning), so an upgrade that races the secret
+    is not bricked; the fallback is removed in a future release
+    ([#1366](https://github.com/vig-os/devkit/issues/1366)).
+  - `sync-issues.yml` now passes `COMMIT_APP_CLIENT_ID` through the `client-id`
+    input added in `vig-os/sync-issues-action` v0.5.0 — the numeric
+    `COMMIT_APP_ID` secret is no longer read anywhere and can be retired once
+    every consumer is on this release.
+  - `devkit-upgrade.yml` prefers `DEVKIT_UPGRADE_APP_CLIENT_ID` in its
+    preflight gate and `create-github-app-token` mint.
+  - Nothing in the auth path is numerically load-bearing: GitHub accepts either
+    the App ID or the Client ID as the App JWT issuer.
 - **`CONTRIBUTE.md` renamed to `CONTRIBUTING.md`** ([#1372](https://github.com/vig-os/devkit/issues/1372))
   - GitHub's community profile only recognises `CONTRIBUTING.md`, so the guide
     was invisible to it and no "Contributing guidelines" link appeared on new

--- a/assets/workspace/.github/workflows/devkit-upgrade.yml
+++ b/assets/workspace/.github/workflows/devkit-upgrade.yml
@@ -8,10 +8,12 @@
 # project shell so consumer hooks run — then opens the adoption PR. Renovate-style
 # pull: no devkit-side action at release time, no consumer registry.
 #
-# Requires a dedicated GitHub App identity: DEVKIT_UPGRADE_APP_ID +
+# Requires a dedicated GitHub App identity: DEVKIT_UPGRADE_APP_CLIENT_ID +
 # DEVKIT_UPGRADE_APP_PRIVATE_KEY (repo or org secrets) feed a per-run
 # installation token minted in-workflow — contents:write + pull-requests:write +
-# issues:write + workflows:write on this repo. The default GITHUB_TOKEN cannot
+# issues:write + workflows:write on this repo. The legacy numeric
+# DEVKIT_UPGRADE_APP_ID still works this release (either value is a valid App
+# JWT issuer); vig-os/devkit#1366 retires it. The default GITHUB_TOKEN cannot
 # open the PR: PRs it creates do not trigger CI. A static PAT is not supported
 # (#1302: user-bound, expiring, single-owner). The workflow fails fast when the
 # secrets are absent. App provisioning + rotation:
@@ -52,20 +54,26 @@ jobs:
     steps:
       - name: Require the upgrade App identity
         env:
-          APP_ID: ${{ secrets.DEVKIT_UPGRADE_APP_ID }}
+          APP_CLIENT_ID: ${{ secrets.DEVKIT_UPGRADE_APP_CLIENT_ID }}
+          APP_ID_LEGACY: ${{ secrets.DEVKIT_UPGRADE_APP_ID }}
           APP_PRIVATE_KEY: ${{ secrets.DEVKIT_UPGRADE_APP_PRIVATE_KEY }}
         run: |
           set -euo pipefail
-          if [ -z "${APP_ID}" ] || [ -z "${APP_PRIVATE_KEY}" ]; then
-            echo "::error::DEVKIT_UPGRADE_APP_ID / DEVKIT_UPGRADE_APP_PRIVATE_KEY secrets are not configured. This workflow needs a dedicated GitHub App identity (contents:write + pull-requests:write + issues:write + workflows:write): the default GITHUB_TOKEN cannot open a PR that triggers CI, and a static PAT is not supported. See https://github.com/vig-os/devkit/issues/1302."
+          if { [ -z "${APP_CLIENT_ID}" ] && [ -z "${APP_ID_LEGACY}" ]; } || [ -z "${APP_PRIVATE_KEY}" ]; then
+            echo "::error::DEVKIT_UPGRADE_APP_CLIENT_ID / DEVKIT_UPGRADE_APP_PRIVATE_KEY secrets are not configured. This workflow needs a dedicated GitHub App identity (contents:write + pull-requests:write + issues:write + workflows:write): the default GITHUB_TOKEN cannot open a PR that triggers CI, and a static PAT is not supported. See https://github.com/vig-os/devkit/issues/1302."
             exit 1
+          fi
+          if [ -z "${APP_CLIENT_ID}" ]; then
+            echo "::warning::DEVKIT_UPGRADE_APP_ID is deprecated; create a DEVKIT_UPGRADE_APP_CLIENT_ID secret with the App's Client ID. The numeric fallback is removed in a future release. See https://github.com/vig-os/devkit/issues/1366."
           fi
 
       - name: Mint the upgrade App token
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3
         with:
-          app-id: ${{ secrets.DEVKIT_UPGRADE_APP_ID }}
+          # Either secret works as the App JWT issuer; the legacy numeric
+          # fallback is retired by vig-os/devkit#1366.
+          client-id: ${{ secrets.DEVKIT_UPGRADE_APP_CLIENT_ID || secrets.DEVKIT_UPGRADE_APP_ID }}
           private-key: ${{ secrets.DEVKIT_UPGRADE_APP_PRIVATE_KEY }}
           # Least-privilege mint (zizmor github-app): the token carries exactly
           # the four permissions this workflow exercises, independent of any

--- a/assets/workspace/.github/workflows/sync-issues.yml
+++ b/assets/workspace/.github/workflows/sync-issues.yml
@@ -174,7 +174,7 @@ jobs:
         id: sync
         uses: vig-os/sync-issues-action@b62c8eca72f4ee7177caee4f689ee080a5997164  # v0.5.0
         with:
-          app-id: ${{ secrets.COMMIT_APP_ID }}
+          client-id: ${{ secrets.COMMIT_APP_CLIENT_ID }}
           app-private-key: ${{ secrets.COMMIT_APP_PRIVATE_KEY }}
           output-dir: ${{ github.event.inputs.output-dir || 'docs' }}
           sync-issues: 'true'

--- a/assets/workspace/docs/DOWNSTREAM_RELEASE.md
+++ b/assets/workspace/docs/DOWNSTREAM_RELEASE.md
@@ -124,7 +124,6 @@ in `prepare-release.yml` / `release-core.yml`); see
 
 Downstream repositories are expected to provide both app credentials:
 
-- `COMMIT_APP_ID` (required by `vig-os/sync-issues-action` in `sync-issues.yml`)
 - `COMMIT_APP_CLIENT_ID`
 - `COMMIT_APP_PRIVATE_KEY`
 - `RELEASE_APP_CLIENT_ID`

--- a/docs/DOWNSTREAM_RELEASE.md
+++ b/docs/DOWNSTREAM_RELEASE.md
@@ -121,7 +121,6 @@ in `prepare-release.yml` / `release-core.yml`); see
 
 Downstream repositories are expected to provide both app credentials:
 
-- `COMMIT_APP_ID` (required by `vig-os/sync-issues-action` in `sync-issues.yml`)
 - `COMMIT_APP_CLIENT_ID`
 - `COMMIT_APP_PRIVATE_KEY`
 - `RELEASE_APP_CLIENT_ID`

--- a/docs/RELEASE_CYCLE.md
+++ b/docs/RELEASE_CYCLE.md
@@ -605,7 +605,7 @@ Release automation relies on two GitHub Apps with different scopes:
 | App | Secrets | Permissions | Used by | Purpose |
 |-----|---------|-------------|---------|---------|
 | **RELEASE_APP** | `RELEASE_APP_CLIENT_ID`, `RELEASE_APP_PRIVATE_KEY` | Contents read/write, Issues read/write, Pull requests read/write, Actions read/write | `release.yml`, `prepare-release.yml`, `sync-main-to-dev.yml`, `promote-release.yml` | Release operations, PR creation/updates, rollback, cross-repo dispatch, and **promote-release** git RC tag cleanup (tag-ruleset bypass) |
-| **COMMIT_APP** | `COMMIT_APP_CLIENT_ID`, `COMMIT_APP_PRIVATE_KEY` (`COMMIT_APP_ID` still required by `vig-os/sync-issues-action` in `sync-issues.yml`) | Contents read/write, Issues read, Pull requests read | `sync-issues.yml`, `sync-main-to-dev.yml` | Commits to protected branches and git ref operations |
+| **COMMIT_APP** | `COMMIT_APP_CLIENT_ID`, `COMMIT_APP_PRIVATE_KEY` | Contents read/write, Issues read, Pull requests read | `sync-issues.yml`, `sync-main-to-dev.yml` | Commits to protected branches and git ref operations |
 
 #### Registry and cleanup tokens (upstream)
 

--- a/docs/security/ADR-secrets-management.md
+++ b/docs/security/ADR-secrets-management.md
@@ -53,7 +53,7 @@ provenance — no signing key is stored:
 |--------|-------------------|---------|
 | `CACHIX_AUTH_TOKEN` | `ci.yml:91,128,155,185`, `nix-cachix.yml:58`, `nix-image.yml:87`, `security-scan.yml:62`, `release.yml:767,827` | Push the Nix closure to the `vig-os` Cachix binary cache |
 | `RELEASE_APP_CLIENT_ID` / `RELEASE_APP_PRIVATE_KEY` | `release.yml:484`, `prepare-release.yml:169`, `promote-release.yml:219`, `sync-main-to-dev.yml:160` | GitHub App creds → short-lived installation token for PR/label/release ops |
-| `COMMIT_APP_CLIENT_ID` / `COMMIT_APP_PRIVATE_KEY` / `COMMIT_APP_ID` | `release.yml:491`, `prepare-release.yml:162`, `renovate-changelog-commit.yml:34`, `sync-issues.yml:84,130`, `sync-main-to-dev.yml:128` | GitHub App creds → short-lived installation token for least-privilege commit/ref identity |
+| `COMMIT_APP_CLIENT_ID` / `COMMIT_APP_PRIVATE_KEY` | `release.yml:491`, `prepare-release.yml:162`, `renovate-changelog-commit.yml:34`, `sync-issues.yml:60,140`, `sync-main-to-dev.yml:128` | GitHub App creds → short-lived installation token for least-privilege commit/ref identity |
 
 ## Decision — the pattern
 

--- a/tests/test_workflow_client_id_credentials.py
+++ b/tests/test_workflow_client_id_credentials.py
@@ -1,0 +1,81 @@
+"""Client-ID App credentials in the sync-issues workflows (#1365).
+
+The 2026-08-07 credential audit consolidates every GitHub-App secret pair to
+**Client ID only** — nothing in the auth path is numerically load-bearing. The
+``vig-os/sync-issues-action`` step was the last consumer forcing the numeric
+``COMMIT_APP_ID`` org secret to stay alive, purely through its input name;
+v0.5.0 (vig-os/sync-issues-action#168) adds the preferred ``client-id`` input.
+
+Both copies of the workflow — devkit's own and the scaffold stamped into every
+consumer — must pass ``COMMIT_APP_CLIENT_ID`` through ``client-id`` and never
+reference the numeric secret again, so the org secrets can be retired (#1366).
+The exo-pet org never had a ``COMMIT_APP_ID`` secret at all, so the stamped
+``app-id`` line was already passing an empty value there.
+
+Refs: #1365
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Both copies: devkit's own workflow and the scaffold shipped to consumers
+# (intentionally decoupled files, same credential contract).
+SYNC_WORKFLOWS = [
+    REPO_ROOT / ".github" / "workflows" / "sync-issues.yml",
+    REPO_ROOT / "assets" / "workspace" / ".github" / "workflows" / "sync-issues.yml",
+]
+
+_IDS = [str(p.relative_to(REPO_ROOT)) for p in SYNC_WORKFLOWS]
+
+
+def _sync_action_steps(path: Path) -> list[dict]:
+    doc = yaml.safe_load(path.read_text(encoding="utf-8"))
+    steps: list[dict] = []
+    for job in (doc.get("jobs") or {}).values():
+        for step in job.get("steps", []) or []:
+            if "sync-issues-action" in str(step.get("uses", "")):
+                steps.append(step)
+    return steps
+
+
+@pytest.mark.parametrize("path", SYNC_WORKFLOWS, ids=_IDS)
+def test_sync_step_authenticates_via_client_id(path: Path) -> None:
+    """The action step passes COMMIT_APP_CLIENT_ID via client-id, never app-id."""
+    steps = _sync_action_steps(path)
+    assert steps, f"{path} has no sync-issues-action step"
+    for step in steps:
+        with_block = step.get("with", {})
+        assert with_block.get("client-id") == ("${{ secrets.COMMIT_APP_CLIENT_ID }}")
+        # The deprecated numeric input must be gone, not merely superseded:
+        # the action errors when both are set.
+        assert "app-id" not in with_block
+
+
+@pytest.mark.parametrize("path", SYNC_WORKFLOWS, ids=_IDS)
+def test_action_pin_is_sha_pinned_client_id_capable_release(path: Path) -> None:
+    """The pin is a full SHA of a release that has the client-id input (>= 0.5.0)."""
+    match = re.search(
+        r"sync-issues-action@([0-9a-f]{40})\s+#\s*v(\d+)\.(\d+)",
+        path.read_text(encoding="utf-8"),
+    )
+    assert match, (
+        f"{path}: sync-issues-action must be SHA-pinned with a version comment"
+    )
+    major, minor = int(match.group(2)), int(match.group(3))
+    assert (major, minor) >= (0, 5), (
+        f"{path}: pinned sync-issues-action v{major}.{minor} predates the "
+        "client-id input (vig-os/sync-issues-action#168, v0.5.0)"
+    )
+
+
+@pytest.mark.parametrize("path", SYNC_WORKFLOWS, ids=_IDS)
+def test_numeric_commit_app_id_secret_is_gone(path: Path) -> None:
+    """No reference to the numeric COMMIT_APP_ID secret remains (retired by #1366)."""
+    assert "secrets.COMMIT_APP_ID" not in path.read_text(encoding="utf-8")

--- a/tests/test_workflow_devkit_upgrade.py
+++ b/tests/test_workflow_devkit_upgrade.py
@@ -11,8 +11,9 @@ release time. These tests pin the deliverable without executing the workflow:
 - the template carries the managed banner, both triggers, the public
   ``releases/latest`` version check with prerelease-aware compare, the dedicated
   GitHub App identity (a per-run installation token minted from
-  ``DEVKIT_UPGRADE_APP_ID`` + ``DEVKIT_UPGRADE_APP_PRIVATE_KEY``, fail-fast when
-  absent; never the default ``GITHUB_TOKEN`` for the PR — #1302), the
+  ``DEVKIT_UPGRADE_APP_CLIENT_ID`` + ``DEVKIT_UPGRADE_APP_PRIVATE_KEY``, with a
+  one-release legacy ``DEVKIT_UPGRADE_APP_ID`` fallback — #1365/#1366; fail-fast
+  when absent; never the default ``GITHUB_TOKEN`` for the PR — #1302), the
   ``install.sh`` bootstrap and the ``nix develop`` commit;
 - no ``run:`` block interpolates a dispatch input or event field directly
   (zizmor template-injection: every such value is routed through ``env:``);
@@ -126,10 +127,10 @@ def test_version_compare_is_prerelease_aware() -> None:
 
 def test_requires_app_identity_and_never_uses_github_token_for_pr() -> None:
     """The GitHub App is the ONLY identity: a per-run installation token is
-    minted from DEVKIT_UPGRADE_APP_ID + DEVKIT_UPGRADE_APP_PRIVATE_KEY
+    minted from DEVKIT_UPGRADE_APP_CLIENT_ID + DEVKIT_UPGRADE_APP_PRIVATE_KEY
     (fail-fast when absent), and no static token secret remains (#1302)."""
     text = TEMPLATE.read_text(encoding="utf-8")
-    assert "secrets.DEVKIT_UPGRADE_APP_ID" in text
+    assert "secrets.DEVKIT_UPGRADE_APP_CLIENT_ID" in text
     assert "secrets.DEVKIT_UPGRADE_APP_PRIVATE_KEY" in text
     # The static-secret path is gone entirely — App-only, no PAT fallback.
     assert "DEVKIT_UPGRADE_TOKEN" not in text
@@ -145,9 +146,15 @@ def test_requires_app_identity_and_never_uses_github_token_for_pr() -> None:
         assert re.search(r"create-github-app-token@[0-9a-f]{40}", s["uses"]), (
             "app-token action must be SHA-pinned"
         )
+        # The mint uses the preferred client-id input (with the one-release
+        # legacy fallback), never the deprecated numeric app-id input.
+        with_block = s.get("with", {})
+        assert with_block.get("client-id") == (
+            "${{ secrets.DEVKIT_UPGRADE_APP_CLIENT_ID || secrets.DEVKIT_UPGRADE_APP_ID }}"
+        )
+        assert "app-id" not in with_block
         # Least-privilege mint (zizmor github-app audit): the token must be
         # scoped to exactly the permissions the workflow exercises.
-        with_block = s.get("with", {})
         for perm in (
             "permission-contents",
             "permission-pull-requests",
@@ -170,6 +177,24 @@ def test_requires_app_identity_and_never_uses_github_token_for_pr() -> None:
         assert s.get("with", {}).get("token") == (
             "${{ steps.app-token.outputs.token }}"
         )
+
+
+def test_legacy_numeric_app_id_still_accepted_with_warning() -> None:
+    """The credential rename rides a minor (#1365): the legacy numeric
+    DEVKIT_UPGRADE_APP_ID keeps working for one release — GitHub accepts either
+    the App ID or the Client ID as the App JWT issuer, so the mint falls back to
+    it — the preflight gates on *either* name being present, and the legacy path
+    emits a deprecation warning. #1366 drops the fallback once the fleet has
+    upgraded; a consumer that upgrades before its org grew the new secret is
+    never bricked."""
+    text = TEMPLATE.read_text(encoding="utf-8")
+    # The fallback expression is the compatibility contract.
+    assert (
+        "secrets.DEVKIT_UPGRADE_APP_CLIENT_ID || secrets.DEVKIT_UPGRADE_APP_ID" in text
+    )
+    # The legacy path warns, pointing at the retirement issue.
+    assert "::warning::" in text
+    assert "1366" in text
 
 
 def test_publishes_a_verified_commit_via_api_not_git_push() -> None:


### PR DESCRIPTION
## Description

Switches the last two numeric-App-ID holdouts to Client-ID credentials, per the
2026-08-07 credential audit (#1365). Nothing in the auth path is numerically
load-bearing — GitHub accepts either the App ID or the Client ID as the App JWT
issuer — so the numeric `*_APP_ID` org secrets can be retired (#1366) once
every consumer is on this release.

## Type of Change

- [x] `feat` -- New feature
- [x] `test` -- Adding or updating tests
- [x] `docs` -- Documentation only

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

Deliberately **not** breaking: the rename rides a minor via a one-release
fallback (see below), per the triage decision on #1365.

## Changes Made

- **`sync-issues.yml` (both copies — devkit's own and the stamped scaffold):**
  `app-id: COMMIT_APP_ID` → `client-id: COMMIT_APP_CLIENT_ID`, using the
  `client-id` input added in `vig-os/sync-issues-action` v0.5.0
  (vig-os/sync-issues-action#168; the pin was already bumped to v0.5.0 by
  #1368). Devkit's own copy is included beyond the issue's stated scope because
  it was the last live `COMMIT_APP_ID` reference in vig-os — without it the
  secret cannot be retired and the ADR row would be wrong. Note: exo-pet never
  had a `COMMIT_APP_ID` org secret, so the stamped `app-id` line was passing an
  **empty value** there — this also closes that live gap.
- **`devkit-upgrade.yml` scaffold:** preflight gates on
  `DEVKIT_UPGRADE_APP_CLIENT_ID` **or** the legacy `DEVKIT_UPGRADE_APP_ID`
  (fail-fast only when both are absent), emits a deprecation `::warning::` on
  the legacy path pointing at #1366, and mints via
  `client-id: ${{ secrets.DEVKIT_UPGRADE_APP_CLIENT_ID || secrets.DEVKIT_UPGRADE_APP_ID }}`.
  A consumer that upgrades before its org grew the new secret keeps working —
  the bricking hazard called out in #1365's sequencing section is gone. The
  pinned `create-github-app-token@bcd2ba49…` (v3) already supports `client-id`
  (it is used with `client-id` elsewhere in the same scaffold) — no bump needed.
- **Tests:** new `tests/test_workflow_client_id_credentials.py` pins the
  credential contract for both sync-issues copies (client-id input, no app-id,
  SHA pin ≥ v0.5.0, no numeric secret reference);
  `tests/test_workflow_devkit_upgrade.py` asserts the new secret name, the
  `client-id` mint with the exact fallback expression, and the deprecation
  warning. TDD: failing tests committed first (78508caf), implementation second
  (49be474d).
- **Docs:** `RELEASE_CYCLE.md` COMMIT_APP row, `DOWNSTREAM_RELEASE.md`
  required-secrets list (repo + stamped copy), and the ADR secrets table no
  longer state a numeric App ID is required. The "rename the DEVKIT_UPGRADE
  entry" step from the issue was a no-op — no such entry exists in those docs.

Acceptance note: "no numeric `*_APP_ID` reference remains in
`assets/workspace/`" holds for `COMMIT_APP_ID`; the two remaining
`DEVKIT_UPGRADE_APP_ID` references are the deliberate one-release fallback,
removed by #1366. Hits in the stamped `.devcontainer/CHANGELOG.md` are
immutable released-entry history and exempt.

## Changelog Entry

### Changed

- **Stamped workflows authenticate with App Client IDs — new org secret required** ([#1365](https://github.com/vig-os/devkit/issues/1365))
  - **Action required before upgrading:** create a `DEVKIT_UPGRADE_APP_CLIENT_ID`
    secret (org or repo) holding the upgrade App's Client ID (`Iv23li…`).
    **Create the secret first, then upgrade** — config-first, always. For this
    release the legacy numeric `DEVKIT_UPGRADE_APP_ID` still works as a
    fallback (with a deprecation warning), so an upgrade that races the secret
    is not bricked; the fallback is removed in a future release
    ([#1366](https://github.com/vig-os/devkit/issues/1366)).
  - `sync-issues.yml` now passes `COMMIT_APP_CLIENT_ID` through the `client-id`
    input added in `vig-os/sync-issues-action` v0.5.0 — the numeric
    `COMMIT_APP_ID` secret is no longer read anywhere and can be retired once
    every consumer is on this release.
  - `devkit-upgrade.yml` prefers `DEVKIT_UPGRADE_APP_CLIENT_ID` in its
    preflight gate and `create-github-app-token` mint.
  - Nothing in the auth path is numerically load-bearing: GitHub accepts either
    the App ID or the Client ID as the App JWT issuer.

## Testing

- [x] Tests pass locally (`just test`)
- [x] Manual testing performed (describe below)

### Manual Testing Details

- RED → GREEN: the 6 new/changed assertions failed before the workflow edits,
  24/24 pass after.
- Full pytest: 1253 passed; the 4 failures
  (`test_uv_installed`, `test_manifest_files`, `test_smoke_test_flag_deploys_assets`,
  `test_github_cli_authentication`) reproduce identically on clean `origin/dev`
  in a separate worktree — stale local image / environment, not this change.
- `just precommit` (full suite, all files): green.
- `just test-bats`: 575 ok; the 9 `IN_CONTAINER` hook-guard failures reproduce
  identically on clean `origin/dev`. All five rendered-workflow actionlint
  tests (#995) pass over the changed templates.
- Both org secret sets verified live: `DEVKIT_UPGRADE_APP_CLIENT_ID` and
  `COMMIT_APP_CLIENT_ID` exist in `vig-os` and `exo-pet`.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

Release-note reminder for the train: the ordering rule (create
`DEVKIT_UPGRADE_APP_CLIENT_ID` before upgrading) must appear prominently in the
release notes per the acceptance criteria — the changelog entry above is
written to be lifted verbatim. Old-scaffold repos vig-os/h5v#6 and
vig-os/scitadel#209 need their bumps before they benefit; vig-os/tessera#364
migrates independently.

Refs: #1365
