### PR TITLE
fix(release): publish the release tag as a lightweight ref

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,16 +39,6 @@ on:  # yamllint disable-line rule:truthy
         required: false
         default: false
         type: boolean
-      git-user-name:
-        description: 'Git user name for commits'
-        required: false
-        default: 'vigOS Release Bot'
-        type: string
-      git-user-email:
-        description: 'Git user email for commits'
-        required: false
-        default: 'release@vig-os.local'
-        type: string
 
 concurrency:
   # Prevent multiple releases from running simultaneously (race conditions on tags/manifests)
@@ -938,7 +928,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     permissions:
-      contents: write       # create and push tags
+      contents: write       # create the release tag ref
       packages: write       # push images to GHCR
       id-token: write       # keyless cosign signing via OIDC
       attestations: write   # build provenance attestations
@@ -965,28 +955,24 @@ jobs:
           cachix-cache: ${{ vars.CACHIX_CACHE }}
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
-      - name: Configure git
-        env:
-          GIT_USER_NAME: ${{ github.event.inputs.git-user-name }}
-          GIT_USER_EMAIL: ${{ github.event.inputs.git-user-email }}
-        run: |
-          git config user.name "$GIT_USER_NAME"
-          git config user.email "$GIT_USER_EMAIL"
-
-      - name: Create annotated tag
+      # The release tag is a LIGHTWEIGHT tag: a plain `refs/tags/<version>` ref
+      # POSTed straight at the release commit, with no tag object behind it.
+      # `git tag -a` (what this step used to do) writes a tag object carrying a
+      # tagger identity that nothing can sign: the tag is published under the
+      # Release App installation token, and a GitHub App has no registrable
+      # GPG/SSH key — nor does the server-side `POST /git/tags` route sign what
+      # it stores. Every tag produced that way reported `verification.reason:
+      # "unsigned"` forever (#1370). A lightweight tag has no tagger and no
+      # payload, so there is nothing left to be unsigned, and the commit the ref
+      # resolves to is the GitHub-verified release commit. Tag immutability is a
+      # separate concern, owned by the repository's Tag ruleset.
+      - name: Create release tag
         if: ${{ needs.finalize.outputs.tag_already_exists != 'true' }}
         env:
-          PUBLISH_VERSION: ${{ needs.validate.outputs.publish_version }}
-        run: |
-          set -euo pipefail
-          git tag -a "$PUBLISH_VERSION" -m "Release $PUBLISH_VERSION"
-          echo "✓ Tag created: $PUBLISH_VERSION"
-
-      - name: Push tag
-        if: ${{ needs.finalize.outputs.tag_already_exists != 'true' }}
-        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           PUBLISH_VERSION: ${{ needs.validate.outputs.publish_version }}
           RELEASE_KIND: ${{ needs.validate.outputs.release_kind }}
+          FINALIZE_SHA: ${{ needs.finalize.outputs.finalize_sha }}
         run: |
           set -euo pipefail
           if [ "$RELEASE_KIND" = "candidate" ]; then
@@ -997,30 +983,36 @@ jobs:
             fi
           fi
 
-          if ! retry --retries 3 --backoff 5 --max-backoff 30 -- git push origin "$PUBLISH_VERSION"; then
-            if retry --retries 3 --backoff 5 --max-backoff 30 -- git ls-remote --tags --refs origin "$PUBLISH_VERSION" | grep -q "refs/tags/$PUBLISH_VERSION$"; then
-              LOCAL_TAG_TARGET_SHA=$(git rev-parse "$PUBLISH_VERSION^{}")
-              REMOTE_TAG_TARGET_SHA=$(retry --retries 3 --backoff 5 --max-backoff 30 -- git ls-remote --tags origin "refs/tags/$PUBLISH_VERSION^{}" | awk '{print $1}')
-              if [ -z "$REMOTE_TAG_TARGET_SHA" ]; then
-                REMOTE_TAG_TARGET_SHA=$(retry --retries 3 --backoff 5 --max-backoff 30 -- git ls-remote --tags origin "refs/tags/$PUBLISH_VERSION" | awk '{print $1}')
-              fi
-              if [ -z "$REMOTE_TAG_TARGET_SHA" ]; then
-                echo "ERROR: Remote tag exists but target SHA could not be resolved: $PUBLISH_VERSION"
-                exit 1
-              fi
-              if [ "$REMOTE_TAG_TARGET_SHA" != "$LOCAL_TAG_TARGET_SHA" ]; then
-                echo "ERROR: Remote tag target SHA mismatch for $PUBLISH_VERSION"
-                echo "Local tag target:  $LOCAL_TAG_TARGET_SHA"
-                echo "Remote tag target: $REMOTE_TAG_TARGET_SHA"
-                exit 1
-              fi
-              echo "Tag already present on origin with matching target SHA: $PUBLISH_VERSION"
-            else
-              echo "ERROR: Failed to push tag $PUBLISH_VERSION"
-              exit 1
-            fi
+          CREATE_OUTPUT=""
+          if CREATE_OUTPUT=$(retry --retries 3 --backoff 5 --max-backoff 30 -- \
+            gh api -X POST "repos/${GITHUB_REPOSITORY}/git/refs" \
+              -f ref="refs/tags/${PUBLISH_VERSION}" \
+              -f sha="$FINALIZE_SHA" 2>&1); then
+            echo "✓ Tag created: $PUBLISH_VERSION -> $FINALIZE_SHA"
+            exit 0
           fi
-          echo "✓ Tag pushed: $PUBLISH_VERSION"
+
+          # Creating the ref failed. The benign case is losing a race with a
+          # concurrent publish (or a response lost after the ref landed), which
+          # is only acceptable when the ref already resolves to this very commit.
+          echo "Tag ref creation did not succeed; verifying remote state:"
+          echo "$CREATE_OUTPUT"
+
+          REMOTE_TAG_TARGET_SHA=$(retry --retries 3 --backoff 5 --max-backoff 30 -- git ls-remote --tags origin "refs/tags/$PUBLISH_VERSION^{}" | awk '{print $1}')
+          if [ -z "$REMOTE_TAG_TARGET_SHA" ]; then
+            REMOTE_TAG_TARGET_SHA=$(retry --retries 3 --backoff 5 --max-backoff 30 -- git ls-remote --tags origin "refs/tags/$PUBLISH_VERSION" | awk '{print $1}')
+          fi
+          if [ -z "$REMOTE_TAG_TARGET_SHA" ]; then
+            echo "ERROR: Failed to create tag $PUBLISH_VERSION and no remote tag is present"
+            exit 1
+          fi
+          if [ "$REMOTE_TAG_TARGET_SHA" != "$FINALIZE_SHA" ]; then
+            echo "ERROR: Remote tag target SHA mismatch for $PUBLISH_VERSION"
+            echo "Expected (release commit): $FINALIZE_SHA"
+            echo "Remote tag target:         $REMOTE_TAG_TARGET_SHA"
+            exit 1
+          fi
+          echo "✓ Tag already present on origin at the release commit: $PUBLISH_VERSION"
 
       - name: Generate final release notes from CHANGELOG
         if: needs.validate.outputs.release_kind == 'final'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -198,6 +198,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **Release tags are lightweight refs, so no unsigned object remains in the release chain** ([#1370](https://github.com/vig-os/devkit/issues/1370))
+  - `release.yml` created the tag with `git tag -a` under
+    `vigOS Release Bot <release@vig-os.local>`, producing an **annotated tag
+    object** whose tagger was permanently unverifiable — live tag `1.6.0`
+    reports `verification.reason: "unsigned"`. Signing it was never reachable:
+    the tag is written under the Release **App** installation token and a GitHub
+    App has no registrable GPG/SSH key, while the server-side `POST /git/tags`
+    route stores the payload verbatim without signing it either.
+  - The publish job now creates the tag as a plain `refs/tags/<version>` ref at
+    the release commit (`POST /git/refs`). A lightweight tag has no tagger and
+    no payload, so there is nothing left that can report `unsigned`, and the
+    commit the ref resolves to is the GitHub-verified release commit. The
+    candidate-collision guard and the "already tagged at the finalize SHA"
+    skip are unchanged; the now-unused `git-user-name` / `git-user-email`
+    dispatch inputs are removed from `release.yml` (`prepare-release.yml`, which
+    actually writes commits, keeps its own).
+
 ## [1.6.0](https://github.com/vig-os/devkit/releases/tag/1.6.0) - 2026-08-04
 
 ### Added

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -198,6 +198,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **Release tags are lightweight refs, so no unsigned object remains in the release chain** ([#1370](https://github.com/vig-os/devkit/issues/1370))
+  - `release.yml` created the tag with `git tag -a` under
+    `vigOS Release Bot <release@vig-os.local>`, producing an **annotated tag
+    object** whose tagger was permanently unverifiable — live tag `1.6.0`
+    reports `verification.reason: "unsigned"`. Signing it was never reachable:
+    the tag is written under the Release **App** installation token and a GitHub
+    App has no registrable GPG/SSH key, while the server-side `POST /git/tags`
+    route stores the payload verbatim without signing it either.
+  - The publish job now creates the tag as a plain `refs/tags/<version>` ref at
+    the release commit (`POST /git/refs`). A lightweight tag has no tagger and
+    no payload, so there is nothing left that can report `unsigned`, and the
+    commit the ref resolves to is the GitHub-verified release commit. The
+    candidate-collision guard and the "already tagged at the finalize SHA"
+    skip are unchanged; the now-unused `git-user-name` / `git-user-email`
+    dispatch inputs are removed from `release.yml` (`prepare-release.yml`, which
+    actually writes commits, keeps its own).
+
 ## [1.6.0](https://github.com/vig-os/devkit/releases/tag/1.6.0) - 2026-08-04
 
 ### Added

--- a/docs/RELEASE_CYCLE.md
+++ b/docs/RELEASE_CYCLE.md
@@ -426,9 +426,9 @@ The `release.yml` workflow performs the entire remaining release process. Behavi
    - If ANY test fails: entire workflow stops and triggers rollback
 
 4. ✅ **Publish** job (runs only if all builds/tests pass)
-   - Candidate mode: infers next `rcN`, creates annotated tag `X.Y.Z-rcN`, publishes candidate manifests
-   - Final mode: creates annotated tag `X.Y.Z` (or skips create/push if the tag already points at the finalized commit), publishes final manifests
-   - Pushes tag to origin when needed
+   - Candidate mode: infers next `rcN`, creates lightweight tag `X.Y.Z-rcN`, publishes candidate manifests
+   - Final mode: creates lightweight tag `X.Y.Z` (or skips creation if the tag already points at the finalized commit), publishes final manifests
+   - Tags are created as plain `refs/tags/<version>` refs at the release commit (`POST /git/refs`), never as annotated tag objects: a tag object written by the Release App would carry an unsignable bot tagger, whereas a lightweight tag has no tagger at all and resolves straight to the GitHub-verified release commit ([#1370](https://github.com/vig-os/devkit/issues/1370))
    - Final mode only: extracts release notes from finalized `CHANGELOG.md` and creates a **draft** GitHub Release for `X.Y.Z`
    - Downloads tested images from artifacts
    - Logs in to GitHub Container Registry

--- a/tests/test_workflow_release_lightweight_tag.py
+++ b/tests/test_workflow_release_lightweight_tag.py
@@ -1,0 +1,87 @@
+"""Workflow-shape tests: release tags are lightweight refs, never tag objects.
+
+Issue #1370: the publish job created the release tag with ``git tag -a`` under
+the ``vigOS Release Bot <release@vig-os.local>`` identity, producing an
+**annotated tag object** whose tagger is permanently ``unsigned`` (live evidence:
+tag ``1.6.0``). Signing it is not reachable — the tag is written under a GitHub
+**App** installation token, and an App has no registrable GPG/SSH key; the
+server-side ``POST /git/tags`` route is not signed by GitHub either.
+
+The fix is to create no tag object at all: ``POST /git/refs`` writes
+``refs/tags/<version>`` straight at the release commit. A lightweight tag has no
+tagger and no payload, so nothing in the chain can report ``unsigned``, and the
+commit the ref resolves to is the GitHub-verified release commit.
+
+Refs: #1370
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+# Repository root (tests/ -> repo root).
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+RELEASE_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "release.yml"
+
+
+def _publish_steps() -> list[dict]:
+    workflow = yaml.safe_load(RELEASE_WORKFLOW.read_text(encoding="utf-8"))
+    return workflow["jobs"]["publish"]["steps"]
+
+
+def _publish_run_text() -> str:
+    return "\n".join(step.get("run", "") for step in _publish_steps())
+
+
+def test_publish_creates_no_annotated_tag_object() -> None:
+    """No `git tag` invocation survives — an annotated object cannot be signed."""
+    run = _publish_run_text()
+    for forbidden in ("git tag -a", "git tag -s", "git tag "):
+        assert forbidden not in run, (
+            f"publish must not run {forbidden!r}: a tag object written by the "
+            "release App is unsigned and unsignable (#1370)"
+        )
+
+
+def test_publish_creates_the_tag_as_a_ref_at_the_release_commit() -> None:
+    """The tag is a plain ref POSTed to the Git Data refs endpoint."""
+    run = _publish_run_text()
+    assert "git/refs" in run, "publish must create the tag via POST /git/refs"
+    assert 'ref="refs/tags/${PUBLISH_VERSION}"' in run, (
+        "the created ref must be refs/tags/<publish version>"
+    )
+    assert 'sha="$FINALIZE_SHA"' in run, (
+        "the tag ref must point at the finalize (release) commit SHA"
+    )
+
+
+def test_publish_does_not_stamp_a_git_identity() -> None:
+    """The bot identity existed only to be the tagger; nothing needs it now."""
+    run = _publish_run_text()
+    assert "git config user." not in run, (
+        "publish no longer writes git objects, so it must not configure an identity"
+    )
+
+
+def test_publish_still_guards_candidate_tag_collisions() -> None:
+    """A concurrent RC publish must still be caught before the tag is written."""
+    run = _publish_run_text()
+    assert 'RELEASE_KIND" = "candidate"' in run, (
+        "the candidate collision guard must survive the tag-creation rewrite"
+    )
+
+
+def test_publish_tag_step_is_skipped_when_the_tag_already_exists() -> None:
+    """Re-running a release over an existing tag at the finalize SHA is a no-op."""
+    steps = [
+        step
+        for step in _publish_steps()
+        if "git/refs" in step.get("run", "") and "refs/tags/" in step.get("run", "")
+    ]
+    assert len(steps) == 1, "exactly one publish step may create the release tag"
+    assert (
+        steps[0]["if"] == "${{ needs.finalize.outputs.tag_already_exists != 'true' }}"
+    )


### PR DESCRIPTION
## Description

Every release tag devkit publishes is an **annotated tag object with an unsigned
tagger**. `release.yml` created it with `git tag -a` under
`vigOS Release Bot <release@vig-os.local>` and pushed it. Live evidence on tag
`1.6.0`:

```console
$ gh api repos/vig-os/devkit/git/refs/tags/1.6.0 --jq '.object.type'
tag
$ gh api repos/vig-os/devkit/git/tags/bad7b6a18ae645ccc19b4cb838c57c4e80543963 \
    --jq '.verification.reason'
unsigned
$ gh api repos/vig-os/devkit/commits/b590198a6956eb0bf75aec706d12b9d16728153e \
    --jq '.commit.verification.reason'
valid
```

The release commit is GitHub-verified; the tag pointing at it is not.

Signing that tag object is not reachable. It is written under the Release
**GitHub App** installation token, and an App has no registrable GPG/SSH key, so
no `git tag -s` variant can ever render as *Verified*. Creating the object
server-side with `POST /git/tags` does not help either — that Git Data route
stores the payload verbatim and GitHub does not sign it, so the result is again
`reason: "unsigned"`.

So the fix is to stop creating a tag object at all.

## Type of Change

- [x] `fix` -- Bug fix

## Changes Made

- `.github/workflows/release.yml`
  - "Create annotated tag" + "Push tag" are replaced by a single **Create
    release tag** step that POSTs `refs/tags/<version>` at
    `needs.finalize.outputs.finalize_sha` via
    `gh api -X POST repos/{owner}/{repo}/git/refs`, using the Release App token
    the job already generates. A **lightweight** tag has no tagger and no
    payload, so there is nothing left that can report `unsigned`; the object the
    ref resolves to is the GitHub-verified release commit.
  - Behaviour preserved: the step is still skipped when
    `finalize.outputs.tag_already_exists == 'true'`; a **candidate** run still
    fails when the RC tag already exists on origin (concurrent-publish
    detection); a failed create is still accepted only when the remote ref
    already resolves to the finalize SHA, and errors loudly on a mismatch.
  - The publish job's "Configure git" step is removed — that identity existed
    solely to be the tagger — and with it the now-unreferenced
    `git-user-name` / `git-user-email` `workflow_dispatch` inputs.
    `prepare-release.yml`, which actually writes commits, keeps its own.
    `justfile.gh` never passed them.
- `docs/RELEASE_CYCLE.md` — the publish-job description no longer claims an
  annotated tag and records why.
- `tests/test_workflow_release_lightweight_tag.py` — new workflow-shape test
  (committed RED first).

Checked and left alone, because they are already annotation-agnostic:
`prepare-release.yml` (existence check only), `promote-release.yml` (deletes RC
tags by ref; devkit has no floating tags), `prepare-release-extension.yml` (no
tag handling). `release.yml`'s own `tag_already_exists` probe and the create
fallback already peel `refs/tags/<v>^{}` and fall back to the plain ref, so both
tag shapes resolve. No `git describe` anywhere in the repo.

`SECURITY.md` needed no change — it never claimed signed tags (it advertises
cosign image signatures, SLSA provenance and SBOM attestation, all unaffected).

## Out of scope

- The **scaffold** shipped to consumers
  (`assets/workspace/.github/workflows/release-publish.yml`) still runs
  `git tag -a`, and `docs/MIGRATION.md` documents peeling its annotated tags.
  Worth a follow-up; changing it here would drift every consumer for a fix that
  is about devkit's own release chain.
- **Tag immutability** is a ruleset concern. A tag ruleset is being added
  separately in `vig-os/org-config`; nothing in this PR depends on it.

## Changelog Entry

```markdown
### Security

- **Release tags are lightweight refs, so no unsigned object remains in the release chain** ([#1370](https://github.com/vig-os/devkit/issues/1370))
  - `release.yml` created the tag with `git tag -a` under
    `vigOS Release Bot <release@vig-os.local>`, producing an **annotated tag
    object** whose tagger was permanently unverifiable — live tag `1.6.0`
    reports `verification.reason: "unsigned"`. Signing it was never reachable:
    the tag is written under the Release **App** installation token and a GitHub
    App has no registrable GPG/SSH key, while the server-side `POST /git/tags`
    route stores the payload verbatim without signing it either.
  - The publish job now creates the tag as a plain `refs/tags/<version>` ref at
    the release commit (`POST /git/refs`). A lightweight tag has no tagger and
    no payload, so there is nothing left that can report `unsigned`, and the
    commit the ref resolves to is the GitHub-verified release commit. The
    candidate-collision guard and the "already tagged at the finalize SHA"
    skip are unchanged; the now-unused `git-user-name` / `git-user-email`
    dispatch inputs are removed from `release.yml` (`prepare-release.yml`, which
    actually writes commits, keeps its own).
```

## Testing

- [x] Tests pass locally
- [x] Manual testing performed (describe below)

### Manual Testing Details

- `uv run pytest tests/test_workflow_release_lightweight_tag.py` — RED (4 failed)
  before the workflow change, GREEN (5 passed) after.
- Full lightweight suite: `uv run pytest tests/ <CI ignore set>
  packages/vig-utils/tests` — 909 passed.
- `prek run --all-files` — green (actionlint, shellcheck, yamllint,
  check-action-pins, sync-manifest all clean).
- The release path itself is only exercised by a real release; the next
  candidate publish is the acceptance test —
  `gh api repos/vig-os/devkit/git/refs/tags/<version> --jq '.object.type'` must
  report `commit`, not `tag`.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

Refs: #1370
