### PR TITLE
fix(ci): fail Test Summary when a needed job is cancelled

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -523,52 +523,58 @@ jobs:
           echo "Dependency Review: ${{ needs.dependency-review.result }}"
           echo ""
 
-          # Check if any job that ran has failed (skip 'skipped' jobs)
+          # Fail on 'failure' AND on 'cancelled': a cancelled job (timeout,
+          # concurrency cancel, runner eviction) produced no verdict, and this
+          # aggregate is the only required check on dev — treating it as green
+          # would let an unfinished CI run merge (#1371).
+          # 'skipped' stays tolerated: workflow_dispatch takes a `test-suite`
+          # subset input every job is gated on, and commit-checks /
+          # dependency-review are pull-request only.
           FAILED=false
 
-          if [ "${{ needs.build-image.result }}" = "failure" ]; then
-            echo "ERROR: Build image failed"
+          if [ "${{ needs.build-image.result }}" = "failure" ] || [ "${{ needs.build-image.result }}" = "cancelled" ]; then
+            echo "ERROR: Build image failed or was cancelled"
             FAILED=true
           fi
 
-          if [ "${{ needs.test-image.result }}" = "failure" ]; then
-            echo "ERROR: Image tests failed"
+          if [ "${{ needs.test-image.result }}" = "failure" ] || [ "${{ needs.test-image.result }}" = "cancelled" ]; then
+            echo "ERROR: Image tests failed or were cancelled"
             FAILED=true
           fi
 
-          if [ "${{ needs.test-integration.result }}" = "failure" ]; then
-            echo "ERROR: Integration tests failed"
+          if [ "${{ needs.test-integration.result }}" = "failure" ] || [ "${{ needs.test-integration.result }}" = "cancelled" ]; then
+            echo "ERROR: Integration tests failed or were cancelled"
             FAILED=true
           fi
 
-          if [ "${{ needs.project-checks.result }}" = "failure" ]; then
-            echo "ERROR: Project checks failed"
+          if [ "${{ needs.project-checks.result }}" = "failure" ] || [ "${{ needs.project-checks.result }}" = "cancelled" ]; then
+            echo "ERROR: Project checks failed or were cancelled"
             FAILED=true
           fi
 
-          if [ "${{ needs.commit-checks.result }}" = "failure" ]; then
-            echo "ERROR: Commit message checks failed"
+          if [ "${{ needs.commit-checks.result }}" = "failure" ] || [ "${{ needs.commit-checks.result }}" = "cancelled" ]; then
+            echo "ERROR: Commit message checks failed or were cancelled"
             FAILED=true
           fi
 
-          if [ "${{ needs.python-security.result }}" = "failure" ]; then
-            echo "ERROR: Python security scan failed"
+          if [ "${{ needs.python-security.result }}" = "failure" ] || [ "${{ needs.python-security.result }}" = "cancelled" ]; then
+            echo "ERROR: Python security scan failed or was cancelled"
             FAILED=true
           fi
 
-          if [ "${{ needs.security-scan.result }}" = "failure" ]; then
-            echo "ERROR: Security scan failed"
+          if [ "${{ needs.security-scan.result }}" = "failure" ] || [ "${{ needs.security-scan.result }}" = "cancelled" ]; then
+            echo "ERROR: Security scan failed or was cancelled"
             FAILED=true
           fi
 
-          if [ "${{ needs.dependency-review.result }}" = "failure" ]; then
-            echo "ERROR: Dependency review failed"
+          if [ "${{ needs.dependency-review.result }}" = "failure" ] || [ "${{ needs.dependency-review.result }}" = "cancelled" ]; then
+            echo "ERROR: Dependency review failed or was cancelled"
             FAILED=true
           fi
 
           if [ "$FAILED" = "true" ]; then
             echo ""
-            echo "One or more test suites failed"
+            echo "One or more test suites failed or were cancelled"
             exit 1
           fi
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -195,6 +195,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     `devkit_env_denied` function in the consumer's own
     `.github/actions/setup-devkit-toolchain/action.yml` as the single source of
     truth. The surrounding narrative is unchanged.
+- **A cancelled CI job no longer leaves `Test Summary` green** ([#1371](https://github.com/vig-os/devkit/issues/1371))
+  - `Test Summary` is the only required status check on `dev`, and it flagged a
+    needed job only on `result == "failure"`. A job that was **cancelled** — job
+    timeout, concurrency cancel, runner eviction, a manual "Cancel workflow" —
+    produced no verdict at all, yet the aggregate printed "All executed test
+    suites passed" and exited 0, so a pull request whose CI never finished was
+    mergeable.
+  - All eight needed jobs now trip the gate on `cancelled` as well as `failure`.
+    `skipped` stays tolerated by design: `workflow_dispatch` takes a
+    `test-suite` subset input that every job is gated on, and
+    `commit-checks`/`dependency-review` are pull-request only.
 
 ### Security
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -195,6 +195,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     `devkit_env_denied` function in the consumer's own
     `.github/actions/setup-devkit-toolchain/action.yml` as the single source of
     truth. The surrounding narrative is unchanged.
+- **A cancelled CI job no longer leaves `Test Summary` green** ([#1371](https://github.com/vig-os/devkit/issues/1371))
+  - `Test Summary` is the only required status check on `dev`, and it flagged a
+    needed job only on `result == "failure"`. A job that was **cancelled** — job
+    timeout, concurrency cancel, runner eviction, a manual "Cancel workflow" —
+    produced no verdict at all, yet the aggregate printed "All executed test
+    suites passed" and exited 0, so a pull request whose CI never finished was
+    mergeable.
+  - All eight needed jobs now trip the gate on `cancelled` as well as `failure`.
+    `skipped` stays tolerated by design: `workflow_dispatch` takes a
+    `test-suite` subset input that every job is gated on, and
+    `commit-checks`/`dependency-review` are pull-request only.
 
 ### Security
 

--- a/tests/test_workflow_summary_gate.py
+++ b/tests/test_workflow_summary_gate.py
@@ -1,0 +1,81 @@
+"""Workflow-shape tests: the CI ``Test Summary`` gate must not pass on cancel.
+
+Issue #1371: ``Test Summary`` (the ``summary`` job in ``.github/workflows/ci.yml``)
+is the only required status check on ``dev``. It aggregates its ``needs:`` jobs
+but originally set ``FAILED=true`` only on ``result == "failure"``, so a
+**cancelled** job — job timeout, concurrency cancel, runner eviction, a manual
+"Cancel workflow" — left the required check green and a PR whose CI never
+finished was mergeable.
+
+``skipped`` stays tolerated on purpose: ``workflow_dispatch`` takes a
+``test-suite`` input (``all``/``image``/``integration``/``project``) that every
+job is gated on, and ``commit-checks``/``dependency-review`` are pull-request
+only, so a skipped job is a legitimate outcome rather than a missing result.
+
+Refs: #1371
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+# Repository root (tests/ -> repo root).
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+
+
+def _summary_job() -> dict:
+    workflow = yaml.safe_load(CI_WORKFLOW.read_text(encoding="utf-8"))
+    return workflow["jobs"]["summary"]
+
+
+def _summary_run() -> str:
+    return _summary_job()["steps"][0]["run"]
+
+
+def _needed_jobs() -> list[str]:
+    return list(_summary_job()["needs"])
+
+
+def test_summary_is_the_required_check_over_every_test_job() -> None:
+    """The aggregate still fans in over the full job set it is meant to gate."""
+    assert _summary_job()["name"] == "Test Summary"
+    assert set(_needed_jobs()) == {
+        "build-image",
+        "test-image",
+        "test-integration",
+        "project-checks",
+        "commit-checks",
+        "python-security",
+        "security-scan",
+        "dependency-review",
+    }
+
+
+@pytest.mark.parametrize("job", _needed_jobs())
+def test_summary_fails_on_failure(job: str) -> None:
+    """Every needed job trips the gate when it fails."""
+    assert f'needs.{job}.result }}}}" = "failure"' in _summary_run(), (
+        f"summary must fail when {job} result is failure"
+    )
+
+
+@pytest.mark.parametrize("job", _needed_jobs())
+def test_summary_fails_on_cancelled(job: str) -> None:
+    """Every needed job trips the gate when it is cancelled (#1371)."""
+    assert f'needs.{job}.result }}}}" = "cancelled"' in _summary_run(), (
+        f"summary must fail when {job} result is cancelled — a cancelled job is "
+        "an unfinished check, not a passing one"
+    )
+
+
+@pytest.mark.parametrize("job", _needed_jobs())
+def test_summary_tolerates_skipped(job: str) -> None:
+    """A skipped job is legitimate (dispatch subset, PR-only jobs) — never fatal."""
+    assert f'needs.{job}.result }}}}" = "skipped"' not in _summary_run(), (
+        f"{job} skipped must not trip the summary"
+    )


### PR DESCRIPTION
## Description

`Test Summary` is the only required status check on `dev`. Its `summary` job
runs with `if: always()` and flagged each of its eight `needs:` jobs **only** on
`result == "failure"`. A **cancelled** job — job timeout, concurrency cancel,
runner eviction, a manual "Cancel workflow" — produced no verdict at all, yet
the aggregate printed "All executed test suites passed" and exited 0. A pull
request whose CI never finished was therefore mergeable.

## Type of Change

- [x] `fix` -- Bug fix

## Changes Made

- `.github/workflows/ci.yml` — each of `build-image`, `test-image`,
  `test-integration`, `project-checks`, `commit-checks`, `python-security`,
  `security-scan`, `dependency-review` now sets `FAILED=true` on `cancelled` as
  well as `failure`. The per-job `echo`/`FAILED=true` idiom is unchanged; only
  the condition and the message ("failed or was cancelled") move.
- The comment above the block records the rationale, including why `skipped`
  stays tolerated.
- `tests/test_workflow_summary_gate.py` — new workflow-shape test (committed RED
  first): every needed job must trip the gate on `failure` **and** `cancelled`,
  and none may trip on `skipped`.

### Why `skipped` is deliberately still tolerated

`workflow_dispatch` takes a `test-suite` input (`all` / `image` / `integration` /
`project`) that every job is gated on, so a deliberate subset run legitimately
skips the rest; `commit-checks` and `dependency-review` are pull-request only.
Failing on `skipped` would break both. The same tolerance is pinned for the
**scaffold** copy by
`tests/test_workflow_private_repo_guard.py::test_summary_needs_dependency_review_with_skip_tolerance`.

This PR touches only devkit's **own** `ci.yml`, which is not manifest-synced to
`assets/workspace/`, so consumers are unaffected and no scaffold drift is
introduced.

## Changelog Entry

```markdown
### Fixed

- **A cancelled CI job no longer leaves `Test Summary` green** ([#1371](https://github.com/vig-os/devkit/issues/1371))
  - `Test Summary` is the only required status check on `dev`, and it flagged a
    needed job only on `result == "failure"`. A job that was **cancelled** — job
    timeout, concurrency cancel, runner eviction, a manual "Cancel workflow" —
    produced no verdict at all, yet the aggregate printed "All executed test
    suites passed" and exited 0, so a pull request whose CI never finished was
    mergeable.
  - All eight needed jobs now trip the gate on `cancelled` as well as `failure`.
    `skipped` stays tolerated by design: `workflow_dispatch` takes a
    `test-suite` subset input that every job is gated on, and
    `commit-checks`/`dependency-review` are pull-request only.
```

## Testing

- [x] Tests pass locally
- [x] Manual testing performed (describe below)

### Manual Testing Details

- `uv run pytest tests/test_workflow_summary_gate.py` — RED (8 failed, 17
  passed) before the workflow change, GREEN (25 passed) after.
- `prek run --all-files` — green (actionlint and yamllint included).

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

Refs: #1371
