### PR TITLE
docs: complete the GitHub community profile

### DIFF
--- a/.github/ISSUE_TEMPLATE/docs.yml
+++ b/.github/ISSUE_TEMPLATE/docs.yml
@@ -10,7 +10,7 @@ body:
       value: |
         Use this template for documentation changes. Important: editable
         documentation lives in `docs/templates/`. Generated files like
-        `CONTRIBUTE.md` and `README.md` must not be edited directly —
+        `CONTRIBUTING.md` and `README.md` must not be edited directly —
         run `just docs` to regenerate them after editing the template.
   - type: textarea
     id: description
@@ -41,7 +41,7 @@ body:
         Which files need to be modified? Remember: edit templates in
         `docs/templates/`, not generated files.
       placeholder: |
-        - https://github.com/vig-os/devkit/blob/main/docs/templates/CONTRIBUTE.md.j2 (source template)
+        - https://github.com/vig-os/devkit/blob/main/docs/templates/CONTRIBUTING.md.j2 (source template)
         - https://github.com/vig-os/devkit/blob/main/docs/RELEASE_CYCLE.md
     validations:
       required: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -577,7 +577,7 @@ jobs:
           echo "file_paths=$FILE_PATHS" >> "$GITHUB_OUTPUT"
           echo "Finalization files: $FILE_PATHS"
 
-          for expected_doc in README.md CONTRIBUTE.md TESTING.md docs/SKILL_PIPELINE.md; do
+          for expected_doc in README.md CONTRIBUTING.md TESTING.md docs/SKILL_PIPELINE.md; do
             if git diff --quiet -- "$expected_doc"; then
               continue
             fi

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -126,7 +126,7 @@ repos:
         language: system
         types: [markdown]
         args: ["-c", ".pymarkdown", "fix"]
-        exclude: ^(README\.md|CONTRIBUTE\.md|TESTING\.md)
+        exclude: ^(README\.md|CONTRIBUTING\.md|TESTING\.md)
 
   # Justfile formatting
   - repo: local

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`CODE_OF_CONDUCT.md`** ([#1372](https://github.com/vig-os/devkit/issues/1372))
+  - Contributor Covenant 2.1 at the repository root. Enforcement reports go
+    through the same [GitHub Private Vulnerability Reporting](https://github.com/vig-os/devkit/security/advisories/new)
+    channel `SECURITY.md` already designates, so there is one private route to
+    the maintainers rather than two.
+
 ### Changed
 
+- **`CONTRIBUTE.md` renamed to `CONTRIBUTING.md`** ([#1372](https://github.com/vig-os/devkit/issues/1372))
+  - GitHub's community profile only recognises `CONTRIBUTING.md`, so the guide
+    was invisible to it and no "Contributing guidelines" link appeared on new
+    issues and pull requests.
+  - The file is generated, so the rename covers the whole chain:
+    `docs/templates/CONTRIBUTE.md.j2` -> `docs/templates/CONTRIBUTING.md.j2`,
+    `docs/generate.py`, the pymarkdown exclude in `.pre-commit-config.yaml`, the
+    `expected_doc` guard in `release.yml`, the `README.md` link (and its
+    template), `docs/NIX.md`, and the `docs.yml` issue template. Historical
+    records — released changelog entries, `docs/issues/`, `docs/pull-requests/`
+    — keep the old name.
 - **Renovate: update `github/codeql-action` from `d1ba80a` to `5595cca`** ([#1367](https://github.com/vig-os/devkit/pull/1367))
 - **Renovate dependency update** ([#1368](https://github.com/vig-os/devkit/pull/1368))
   - Update `actions/attest` from `v4.2.1` to `v4.2.2`

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,134 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement through
+[GitHub Private Vulnerability Reporting](https://github.com/vig-os/devkit/security/advisories/new)
+— the same private channel `SECURITY.md` designates for reaching the
+maintainers. All complaints will be reviewed and investigated promptly and
+fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][mozilla-coc].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][faq]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[mozilla-coc]: https://github.com/mozilla/diversity
+[faq]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,8 @@
-{# CONTRIBUTE.md.j2 - Template for contributor documentation
-   Generated from: just --list output (toolchain SSoT is flake.nix devTools)
-   DO NOT EDIT CONTRIBUTE.md directly - edit this template instead #}
-<!-- Auto-generated from docs/templates/CONTRIBUTE.md.j2 - DO NOT EDIT DIRECTLY -->
+
+<!-- Auto-generated from docs/templates/CONTRIBUTING.md.j2 - DO NOT EDIT DIRECTLY -->
 <!-- Run 'just docs' to regenerate -->
 
-# Contributing to {{ project_name }}
+# Contributing to vigOS Development Environment
 
 This guide explains how to develop, build, test, and release the vigOS development container image.
 
@@ -155,7 +153,71 @@ When contributing to this project, follow this workflow:
 ## Just Recipes
 
 ```text
-{{ just_help_output }}
+Available recipes:
+    [build]
+    build no_cache=""                          # Build local development image
+    clean version="dev"                        # Remove image (default: dev)
+    clean-test-containers                      # Clean up lingering test containers
+
+    [git]
+    gh-branch                                  # Show current branch + list recent branches
+    gh-log                                     # Pretty one-line git log (last 20 commits)
+
+    [github]
+    gh-issues                                  # List open issues and PRs grouped by milestone [alias: gh-i]
+
+    [info]
+    default                                    # Show available commands (default)
+    docs                                       # Generate documentation from templates
+    help                                       # Show available commands
+    info                                       # Show image information
+    init *args                                 # Gate Nix prerequisites and bootstrap the project (venv, git hooks, pre-commit)
+    login                                      # Test login to GHCR
+    sync-workspace                             # Sync workspace templates from repo root to assets/workspace/
+
+    [podman]
+    podman-kill name                           # Stop and remove a container by name or ID [alias: pdm-kill]
+    podman-kill-all                            # Stop and remove all containers (with confirmation) [alias: pdm-kill-all]
+    podman-kill-project                        # Stop and remove project-related containers [alias: pdm-kill-project]
+    podman-prune                               # Prune unused containers, images, networks, and volumes [alias: pdm-prune]
+    podman-prune-all                           # Full cleanup: prune including volumes [alias: pdm-prune-all]
+    podman-ps *args                            # List containers/images (--all for all podman resources) [alias: pdm-ps]
+    podman-rmi image                           # Remove an image by name, tag, or ID [alias: pdm-rmi]
+    podman-rmi-all                             # Remove all images (with confirmation) [alias: pdm-rmi-all]
+    podman-rmi-dangling                        # Remove dangling images (untagged) [alias: pdm-rmi-dangling]
+    podman-rmi-project                         # Remove project-related images [alias: pdm-rmi-project]
+
+    [quality]
+    format                                     # Format code
+    lint                                       # Run all linters
+    precommit                                  # Run pre-commit hooks on all files
+
+    [release]
+    finalize-release version ref="" *flags     # Finalize and publish release via GitHub Actions workflow (step 3, after testing)
+    prepare-release version ref="" *flags      # Prepare release branch for testing (step 1)
+    promote-release version ref="" *flags      # Promote final release: GHCR :latest, publish draft GitHub Release, merge release PR (after downstream smoke-test final release)
+    publish-candidate version ref="" *flags    # Publish release candidate via GitHub Actions workflow
+    pull version="latest"                      # Pull image from registry (default: latest)
+    reset-changelog                            # Reset CHANGELOG Unreleased section (after merging release to dev)
+
+    [test]
+    test version="dev"                         # Run all test suites
+    test-bats                                  # Run BATS shell script tests
+    test-image version="dev"                   # Run image tests only
+    test-install                               # Run install script tests only
+    test-integration version="dev"             # Run integration tests only
+    test-renovate                              # Validate tracked Renovate configs with renovate-config-validator --strict
+    test-utils                                 # Run utils tests only
+    test-validate-commit-msg                   # Run validate commit msg tests only
+    test-vig-utils                             # Run check action pins tests only
+
+    [worktree]
+    worktree-attach issue                      # before attaching. See tests/bats/worktree.bats for integration tests. [alias: wt-attach]
+    worktree-clean mode=""                     # Default (no args): clean only stopped worktrees. Use 'all' to clean everything. [alias: wt-clean]
+    worktree-list                              # List active worktrees and their tmux sessions [alias: wt-list]
+    worktree-start issue prompt="" reviewer="" # Create a worktree for an issue, open tmux session, launch the claude CLI [alias: wt-start]
+    worktree-stop issue                        # Stop a worktree's tmux session and remove the worktree [alias: wt-stop]
+
 ```
 
 ## Release Workflow
@@ -208,7 +270,7 @@ reference, see [docs/RELEASE_CYCLE.md](docs/RELEASE_CYCLE.md).
 
 ## Version Tagging
 
-{{ project_name }} uses **Semantic Versioning** ([SemVer](https://semver.org/)) to manage both GHCR tags and git tags:
+vigOS Development Environment uses **Semantic Versioning** ([SemVer](https://semver.org/)) to manage both GHCR tags and git tags:
 
 - **Development versions** (`dev`):
   - Only local, without time stamp or git reference
@@ -225,7 +287,7 @@ This ensures that `:latest` always points to the latest stable release, and git 
 
 ## Multi-Architecture Support
 
-{{ project_name }} supports both **AMD64** (x86_64) and **ARM64** (Apple Silicon) architectures:
+vigOS Development Environment supports both **AMD64** (x86_64) and **ARM64** (Apple Silicon) architectures:
 
 - **Local builds** (`just build` and `just test`): Build and test for your native platform (ARM64 on macOS, AMD64 on Linux)
 - **Releases** (GitHub Actions on version tags): The publish workflow builds and pushes multi-arch manifests (amd64, arm64) to GHCR
@@ -235,5 +297,5 @@ This allows development on any supported platform and consistent multi-arch imag
 
 ## Testing
 
-{{ project_name }} relies on comprehensive tests to verify both container images and devcontainer functionality.
+vigOS Development Environment relies on comprehensive tests to verify both container images and devcontainer functionality.
 For detailed information about the testing strategy, test structure, and how to develop tests, see the [Testing Guide](TESTING.md).

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ For detailed command descriptions, run `just --list --unsorted` or `just --help`
 
 ## Contributing
 
-If you want to contribute to the development of this devcontainer image, see [CONTRIBUTE.md](CONTRIBUTE.md) for information about:
+If you want to contribute to the development of this devcontainer image, see [CONTRIBUTING.md](CONTRIBUTING.md) for information about:
 
 - Requirements and setup
 - Building and testing the image

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -9,8 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`CODE_OF_CONDUCT.md`** ([#1372](https://github.com/vig-os/devkit/issues/1372))
+  - Contributor Covenant 2.1 at the repository root. Enforcement reports go
+    through the same [GitHub Private Vulnerability Reporting](https://github.com/vig-os/devkit/security/advisories/new)
+    channel `SECURITY.md` already designates, so there is one private route to
+    the maintainers rather than two.
+
 ### Changed
 
+- **`CONTRIBUTE.md` renamed to `CONTRIBUTING.md`** ([#1372](https://github.com/vig-os/devkit/issues/1372))
+  - GitHub's community profile only recognises `CONTRIBUTING.md`, so the guide
+    was invisible to it and no "Contributing guidelines" link appeared on new
+    issues and pull requests.
+  - The file is generated, so the rename covers the whole chain:
+    `docs/templates/CONTRIBUTE.md.j2` -> `docs/templates/CONTRIBUTING.md.j2`,
+    `docs/generate.py`, the pymarkdown exclude in `.pre-commit-config.yaml`, the
+    `expected_doc` guard in `release.yml`, the `README.md` link (and its
+    template), `docs/NIX.md`, and the `docs.yml` issue template. Historical
+    records — released changelog entries, `docs/issues/`, `docs/pull-requests/`
+    — keep the old name.
 - **Renovate: update `github/codeql-action` from `d1ba80a` to `5595cca`** ([#1367](https://github.com/vig-os/devkit/pull/1367))
 - **Renovate dependency update** ([#1368](https://github.com/vig-os/devkit/pull/1368))
   - Update `actions/attest` from `v4.2.1` to `v4.2.2`

--- a/assets/workspace/.github/ISSUE_TEMPLATE/docs.yml
+++ b/assets/workspace/.github/ISSUE_TEMPLATE/docs.yml
@@ -13,7 +13,7 @@ body:
       value: |
         Use this template for documentation changes. Important: editable
         documentation lives in `docs/templates/`. Generated files like
-        `CONTRIBUTE.md` and `README.md` must not be edited directly —
+        `CONTRIBUTING.md` and `README.md` must not be edited directly —
         run `just docs` to regenerate them after editing the template.
   - type: textarea
     id: description
@@ -44,7 +44,7 @@ body:
         Which files need to be modified? Remember: edit templates in
         `docs/templates/`, not generated files.
       placeholder: |
-        - https://github.com/vig-os/devkit/blob/main/docs/templates/CONTRIBUTE.md.j2 (source template)
+        - https://github.com/vig-os/devkit/blob/main/docs/templates/CONTRIBUTING.md.j2 (source template)
         - https://github.com/vig-os/devkit/blob/main/docs/RELEASE_CYCLE.md
     validations:
       required: true

--- a/docs/NIX.md
+++ b/docs/NIX.md
@@ -5,7 +5,7 @@ of truth for the development toolchain *and* the basis of the built devcontainer
 image, so the dev-shell and the image can never drift. This document is the
 consolidated reference for how the flake is structured and why. For day-one
 onboarding (clone → `direnv allow`) see the fast path in
-[`CONTRIBUTE.md`](../CONTRIBUTE.md); for the downstream production-image pattern
+[`CONTRIBUTING.md`](../CONTRIBUTING.md); for the downstream production-image pattern
 see [`docs/NIX2CONTAINER.md`](NIX2CONTAINER.md).
 
 ## The flake as the toolchain SSoT
@@ -538,7 +538,7 @@ re-entry is instant and the closure is never garbage-collected. nix-direnv
 self-bootstraps the pinned library on first allow, or uses your
 `~/.config/direnv/direnvrc` installation if you already source it; it falls back
 to bare `use flake` when unavailable. The full fast path lives in
-[`CONTRIBUTE.md`](../CONTRIBUTE.md).
+[`CONTRIBUTING.md`](../CONTRIBUTING.md).
 
 ### Image closures are cache-backed too (blocking push)
 
@@ -594,7 +594,7 @@ is the go/no-go signal for it.
   the org uses `pkgs.mkShell` + `nix-direnv` (not `devenv`/`devshell`), the
   three-axis framing (activation / shell definition / local services), and the
   `process-compose` + `services-flake` decision for local dev services.
-- [`CONTRIBUTE.md`](../CONTRIBUTE.md) — onboarding fast path (clone → `direnv allow`).
+- [`CONTRIBUTING.md`](../CONTRIBUTING.md) — onboarding fast path (clone → `direnv allow`).
 - [`docs/NIX2CONTAINER.md`](NIX2CONTAINER.md) — the downstream production-image
   pattern with `nix2container` (distinct from this image's `buildLayeredImage`).
 - [`docs/CONTAINER_SECURITY.md`](CONTAINER_SECURITY.md) — the full CVE-patching

--- a/docs/generate.py
+++ b/docs/generate.py
@@ -205,7 +205,7 @@ def generate_docs() -> bool:
     # Generate each template
     templates_to_generate = [
         ("README.md.j2", "README.md"),
-        ("CONTRIBUTE.md.j2", "CONTRIBUTE.md"),
+        ("CONTRIBUTING.md.j2", "CONTRIBUTING.md"),
         ("TESTING.md.j2", "TESTING.md"),
         ("SKILL_PIPELINE.md.j2", "docs/SKILL_PIPELINE.md"),
     ]

--- a/docs/templates/CONTRIBUTING.md.j2
+++ b/docs/templates/CONTRIBUTING.md.j2
@@ -1,8 +1,10 @@
-
-<!-- Auto-generated from docs/templates/CONTRIBUTE.md.j2 - DO NOT EDIT DIRECTLY -->
+{# CONTRIBUTING.md.j2 - Template for contributor documentation
+   Generated from: just --list output (toolchain SSoT is flake.nix devTools)
+   DO NOT EDIT CONTRIBUTING.md directly - edit this template instead #}
+<!-- Auto-generated from docs/templates/CONTRIBUTING.md.j2 - DO NOT EDIT DIRECTLY -->
 <!-- Run 'just docs' to regenerate -->
 
-# Contributing to vigOS Development Environment
+# Contributing to {{ project_name }}
 
 This guide explains how to develop, build, test, and release the vigOS development container image.
 
@@ -153,71 +155,7 @@ When contributing to this project, follow this workflow:
 ## Just Recipes
 
 ```text
-Available recipes:
-    [build]
-    build no_cache=""                          # Build local development image
-    clean version="dev"                        # Remove image (default: dev)
-    clean-test-containers                      # Clean up lingering test containers
-
-    [git]
-    gh-branch                                  # Show current branch + list recent branches
-    gh-log                                     # Pretty one-line git log (last 20 commits)
-
-    [github]
-    gh-issues                                  # List open issues and PRs grouped by milestone [alias: gh-i]
-
-    [info]
-    default                                    # Show available commands (default)
-    docs                                       # Generate documentation from templates
-    help                                       # Show available commands
-    info                                       # Show image information
-    init *args                                 # Gate Nix prerequisites and bootstrap the project (venv, git hooks, pre-commit)
-    login                                      # Test login to GHCR
-    sync-workspace                             # Sync workspace templates from repo root to assets/workspace/
-
-    [podman]
-    podman-kill name                           # Stop and remove a container by name or ID [alias: pdm-kill]
-    podman-kill-all                            # Stop and remove all containers (with confirmation) [alias: pdm-kill-all]
-    podman-kill-project                        # Stop and remove project-related containers [alias: pdm-kill-project]
-    podman-prune                               # Prune unused containers, images, networks, and volumes [alias: pdm-prune]
-    podman-prune-all                           # Full cleanup: prune including volumes [alias: pdm-prune-all]
-    podman-ps *args                            # List containers/images (--all for all podman resources) [alias: pdm-ps]
-    podman-rmi image                           # Remove an image by name, tag, or ID [alias: pdm-rmi]
-    podman-rmi-all                             # Remove all images (with confirmation) [alias: pdm-rmi-all]
-    podman-rmi-dangling                        # Remove dangling images (untagged) [alias: pdm-rmi-dangling]
-    podman-rmi-project                         # Remove project-related images [alias: pdm-rmi-project]
-
-    [quality]
-    format                                     # Format code
-    lint                                       # Run all linters
-    precommit                                  # Run pre-commit hooks on all files
-
-    [release]
-    finalize-release version ref="" *flags     # Finalize and publish release via GitHub Actions workflow (step 3, after testing)
-    prepare-release version ref="" *flags      # Prepare release branch for testing (step 1)
-    promote-release version ref="" *flags      # Promote final release: GHCR :latest, publish draft GitHub Release, merge release PR (after downstream smoke-test final release)
-    publish-candidate version ref="" *flags    # Publish release candidate via GitHub Actions workflow
-    pull version="latest"                      # Pull image from registry (default: latest)
-    reset-changelog                            # Reset CHANGELOG Unreleased section (after merging release to dev)
-
-    [test]
-    test version="dev"                         # Run all test suites
-    test-bats                                  # Run BATS shell script tests
-    test-image version="dev"                   # Run image tests only
-    test-install                               # Run install script tests only
-    test-integration version="dev"             # Run integration tests only
-    test-renovate                              # Validate tracked Renovate configs with renovate-config-validator --strict
-    test-utils                                 # Run utils tests only
-    test-validate-commit-msg                   # Run validate commit msg tests only
-    test-vig-utils                             # Run check action pins tests only
-
-    [worktree]
-    worktree-attach issue                      # before attaching. See tests/bats/worktree.bats for integration tests. [alias: wt-attach]
-    worktree-clean mode=""                     # Default (no args): clean only stopped worktrees. Use 'all' to clean everything. [alias: wt-clean]
-    worktree-list                              # List active worktrees and their tmux sessions [alias: wt-list]
-    worktree-start issue prompt="" reviewer="" # Create a worktree for an issue, open tmux session, launch the claude CLI [alias: wt-start]
-    worktree-stop issue                        # Stop a worktree's tmux session and remove the worktree [alias: wt-stop]
-
+{{ just_help_output }}
 ```
 
 ## Release Workflow
@@ -270,7 +208,7 @@ reference, see [docs/RELEASE_CYCLE.md](docs/RELEASE_CYCLE.md).
 
 ## Version Tagging
 
-vigOS Development Environment uses **Semantic Versioning** ([SemVer](https://semver.org/)) to manage both GHCR tags and git tags:
+{{ project_name }} uses **Semantic Versioning** ([SemVer](https://semver.org/)) to manage both GHCR tags and git tags:
 
 - **Development versions** (`dev`):
   - Only local, without time stamp or git reference
@@ -287,7 +225,7 @@ This ensures that `:latest` always points to the latest stable release, and git 
 
 ## Multi-Architecture Support
 
-vigOS Development Environment supports both **AMD64** (x86_64) and **ARM64** (Apple Silicon) architectures:
+{{ project_name }} supports both **AMD64** (x86_64) and **ARM64** (Apple Silicon) architectures:
 
 - **Local builds** (`just build` and `just test`): Build and test for your native platform (ARM64 on macOS, AMD64 on Linux)
 - **Releases** (GitHub Actions on version tags): The publish workflow builds and pushes multi-arch manifests (amd64, arm64) to GHCR
@@ -297,5 +235,5 @@ This allows development on any supported platform and consistent multi-arch imag
 
 ## Testing
 
-vigOS Development Environment relies on comprehensive tests to verify both container images and devcontainer functionality.
+{{ project_name }} relies on comprehensive tests to verify both container images and devcontainer functionality.
 For detailed information about the testing strategy, test structure, and how to develop tests, see the [Testing Guide](TESTING.md).

--- a/docs/templates/README.md.j2
+++ b/docs/templates/README.md.j2
@@ -180,7 +180,7 @@ For detailed command descriptions, run `just --list --unsorted` or `just --help`
 
 ## Contributing
 
-If you want to contribute to the development of this devcontainer image, see [CONTRIBUTE.md](CONTRIBUTE.md) for information about:
+If you want to contribute to the development of this devcontainer image, see [CONTRIBUTING.md](CONTRIBUTING.md) for information about:
 
 - Requirements and setup
 - Building and testing the image


### PR DESCRIPTION
## Description

Two rows of `repos/vig-os/devkit/community/profile` were unchecked
(`health_percentage: 62`): the contributing guide was named `CONTRIBUTE.md`,
which GitHub does not recognise, and there was no code of conduct at all.

## Type of Change

- [x] `docs` -- Documentation only

## Changes Made

**(a) `CONTRIBUTE.md` -> `CONTRIBUTING.md`** (`git mv`, history preserved). The
file is generated, so the rename covers the whole chain:

- `docs/templates/CONTRIBUTE.md.j2` -> `docs/templates/CONTRIBUTING.md.j2`
  (`git mv`), including its own "auto-generated / do not edit" banner
- `docs/generate.py` — the `templates_to_generate` entry
- `.pre-commit-config.yaml` — the pymarkdown `exclude` for generated docs
- `.github/workflows/release.yml` — the `expected_doc` guard in "Collect
  finalization files"
- `docs/templates/README.md.j2` + the regenerated `README.md` — the contributing
  link
- `docs/NIX.md` — three cross-references
- `.github/ISSUE_TEMPLATE/docs.yml` — the "generated docs must not be edited
  directly" note and the source-template URL; the manifest-synced
  `assets/workspace/.github/ISSUE_TEMPLATE/docs.yml` follows automatically via
  the `sync-manifest` hook

**(b) `CODE_OF_CONDUCT.md`** — Contributor Covenant 2.1 standard text at the
repository root. The enforcement contact is the
[GitHub Private Vulnerability Reporting](https://github.com/vig-os/devkit/security/advisories/new)
channel `SECURITY.md` already designates, so there is a single private route to
the maintainers rather than a second one to keep in sync.

### Deliberately untouched

- Historical records keep the old name: released `CHANGELOG.md` entries,
  `docs/issues/*.md`, `docs/pull-requests/*.md`.
- `assets/workspace/.pre-commit-config.yaml` still excludes `CONTRIBUTE.md` from
  pymarkdown. That is the **consumer** scaffold's own exclude list, not devkit's
  community profile; devkit never generates a contributing guide for consumers,
  so editing it would drift every consumer for no benefit here.

## Changelog Entry

```markdown
### Added

- **`CODE_OF_CONDUCT.md`** ([#1372](https://github.com/vig-os/devkit/issues/1372))
  - Contributor Covenant 2.1 at the repository root. Enforcement reports go
    through the same [GitHub Private Vulnerability Reporting](https://github.com/vig-os/devkit/security/advisories/new)
    channel `SECURITY.md` already designates, so there is one private route to
    the maintainers rather than two.

### Changed

- **`CONTRIBUTE.md` renamed to `CONTRIBUTING.md`** ([#1372](https://github.com/vig-os/devkit/issues/1372))
  - GitHub's community profile only recognises `CONTRIBUTING.md`, so the guide
    was invisible to it and no "Contributing guidelines" link appeared on new
    issues and pull requests.
  - The file is generated, so the rename covers the whole chain:
    `docs/templates/CONTRIBUTE.md.j2` -> `docs/templates/CONTRIBUTING.md.j2`,
    `docs/generate.py`, the pymarkdown exclude in `.pre-commit-config.yaml`, the
    `expected_doc` guard in `release.yml`, the `README.md` link (and its
    template), `docs/NIX.md`, and the `docs.yml` issue template. Historical
    records — released changelog entries, `docs/issues/`, `docs/pull-requests/`
    — keep the old name.
```

## Testing

- [x] Tests pass locally
- [x] Manual testing performed (describe below)

### Manual Testing Details

- `prek run --all-files` — green; the `generate-docs` hook is a **no-op** on a
  second run, confirming `docs/generate.py` resolves the renamed template and
  `CONTRIBUTING.md` regenerates byte-identically.
- Full lightweight suite: `uv run pytest tests/ <CI ignore set>
  packages/vig-utils/tests` — 904 passed.
- Repo-wide grep for `CONTRIBUTE.md` leaves only historical archives and the
  consumer scaffold exclude noted above.
- No TDD cycle: the change is a file rename plus static documentation, with no
  behaviour to drive from a test. The `generate-docs` and `sync-manifest` hooks
  are the executable guard.
- `gh api repos/vig-os/devkit/community/profile` will only reflect this after
  the merge lands on the default branch, and GitHub caches that endpoint —
  verified post-merge, noted rather than asserted here.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective (n/a — see above)
- [x] New and existing unit tests pass locally with my changes

Refs: #1372
