### PR TITLE
fix(workflows): move floating tags via git push with explicit App token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Floating tags move via `git push` — first release of a new level no longer fails** ([#1377](https://github.com/vig-os/devkit/issues/1377))
+  - The scaffolded `promote-release.yml` created brand-new floating levels via
+    `POST /git/refs`, the one ref-mutation path where GitHub does not honor the
+    Release App's Integration ruleset bypass for the `creation` rule — so the
+    first release of every new `<prefix>X` / `<prefix>X.Y` level died with the
+    opaque `Reference does not exist` (HTTP 422) despite the App holding an
+    `always` bypass on the whole Tag ruleset (hit on `commit-action` 0.3.1 and
+    `sync-issues-action` 0.5.0).
+  - `move_tag()` now force-pushes `TARGET_SHA:refs/tags/<name>` over git with
+    the App installation token plumbed explicitly into the push URL (checkout's
+    persisted credentials are the default `github.token`, which has no bypass)
+    — the exact path `release-publish.yml` already uses to create release tags,
+    empirically bypassed fine. Create and move collapse into one branch-free
+    path; the idempotence read-and-skip guard and the loud `::error` +
+    MIGRATION.md fallback from #1158 stay, with the moot "grant a creation
+    bypass" remediation rewritten (the bypass already exists — the REST create
+    path simply ignores it).
 - **A no-diff devkit upgrade no longer strands its adoption issue** ([#1347](https://github.com/vig-os/devkit/issues/1347))
   - The scaffolded `devkit-upgrade.yml` opens the adoption issue *before*
     `install.sh --force` runs (the branch name embeds its number and the

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -57,6 +57,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Floating tags move via `git push` — first release of a new level no longer fails** ([#1377](https://github.com/vig-os/devkit/issues/1377))
+  - The scaffolded `promote-release.yml` created brand-new floating levels via
+    `POST /git/refs`, the one ref-mutation path where GitHub does not honor the
+    Release App's Integration ruleset bypass for the `creation` rule — so the
+    first release of every new `<prefix>X` / `<prefix>X.Y` level died with the
+    opaque `Reference does not exist` (HTTP 422) despite the App holding an
+    `always` bypass on the whole Tag ruleset (hit on `commit-action` 0.3.1 and
+    `sync-issues-action` 0.5.0).
+  - `move_tag()` now force-pushes `TARGET_SHA:refs/tags/<name>` over git with
+    the App installation token plumbed explicitly into the push URL (checkout's
+    persisted credentials are the default `github.token`, which has no bypass)
+    — the exact path `release-publish.yml` already uses to create release tags,
+    empirically bypassed fine. Create and move collapse into one branch-free
+    path; the idempotence read-and-skip guard and the loud `::error` +
+    MIGRATION.md fallback from #1158 stay, with the moot "grant a creation
+    bypass" remediation rewritten (the bypass already exists — the REST create
+    path simply ignores it).
 - **A no-diff devkit upgrade no longer strands its adoption issue** ([#1347](https://github.com/vig-os/devkit/issues/1347))
   - The scaffolded `devkit-upgrade.yml` opens the adoption issue *before*
     `install.sh --force` runs (the branch name embeds its number and the

--- a/assets/workspace/.github/workflows/promote-release.yml
+++ b/assets/workspace/.github/workflows/promote-release.yml
@@ -661,6 +661,17 @@ jobs:
           REST="${VERSION#*.}"
           MINOR="${REST%%.*}"
 
+          # Tag pushes must authenticate as the Release App EXPLICITLY: the
+          # checkout step's persisted credentials are the default github.token,
+          # which is not a bypass actor for the Tag ruleset.
+          REMOTE_URL="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+
+          # `git push <sha>:<ref>` requires the commit object locally, and the
+          # checkout above is a shallow clone of the workflow head — fetch the
+          # release tag so its peeled commit is available to push.
+          retry --retries 3 --backoff 5 --max-backoff 30 -- \
+            git fetch --no-tags --depth 1 "$REMOTE_URL" "refs/tags/${RELEASE_TAG}"
+
           # Create-or-update a lightweight floating tag at the release commit,
           # idempotently (skip when it already points there). Force is required
           # because a floating tag is mutable by design (#1045).
@@ -671,28 +682,23 @@ jobs:
               echo "Floating tag ${name} already at ${TARGET_SHA}; skipping"
               return 0
             fi
-            if [ -n "$current" ]; then
-              retry --retries 3 --backoff 5 --max-backoff 30 -- \
-                gh api -X PATCH "repos/${GITHUB_REPOSITORY}/git/refs/tags/${name}" \
-                -f sha="$TARGET_SHA" -F force=true >/dev/null
-              echo "Moved floating tag ${name} -> ${TARGET_SHA}"
-            else
-              # First time this floating level is published: promote must
-              # CREATE the ref (POST /git/refs), not move it. The Tag ruleset
-              # denies creation to everyone but the Release App, so if the app
-              # is not an effective bypass actor for the ruleset's `creation`
-              # rule the call is refused — surfaced as the opaque "Reference
-              # does not exist" / HTTP 422 (#1157). Publish + merge already
-              # succeeded, so fail loud with actionable remediation rather than
-              # leaving the advertised `@${name}` pin silently missing.
-              if ! retry --retries 3 --backoff 5 --max-backoff 30 -- \
-                  gh api "repos/${GITHUB_REPOSITORY}/git/refs" \
-                  -f ref="refs/tags/${name}" -f sha="$TARGET_SHA" >/dev/null; then
-                echo "::error title=Floating tag ${name} not created::Could not create floating tag '${name}' at ${TARGET_SHA} (first release of this floating level). The repo Tag ruleset restricts tag creation; if the Release App is not a bypass actor for the ruleset's 'creation' rule the POST /git/refs is denied as 'Reference does not exist' (HTTP 422). The GitHub Release is published and the release PR merged — only this floating tag is missing, which silently breaks the advertised 'uses: ...@${name}' pin. Remediate once by hand (temporarily bypass the ruleset, create refs/tags/${name} -> ${TARGET_SHA}, then revert), or grant the Release App a 'creation' bypass so future levels move automatically. See https://github.com/vig-os/devkit/blob/main/docs/MIGRATION.md#first-release-floating-tags."
-                return 1
-              fi
-              echo "Created floating tag ${name} -> ${TARGET_SHA}"
+            # Mutate the ref via `git push`, NEVER via the REST refs API:
+            # GitHub does not honor the Release App's Integration ruleset
+            # bypass on `POST /git/refs` for the `creation` rule, so the first
+            # release of every new floating level was refused as the opaque
+            # "Reference does not exist" (HTTP 422) with no rule-suite entry
+            # (#1157, #1377) — while the very same installation token pushing
+            # tags over git is bypassed fine (exactly how release-publish.yml
+            # creates the release tags). Push also unifies create and move
+            # into one branch-free path. Publish + merge already succeeded, so
+            # on failure fail loud with actionable remediation rather than
+            # leaving the advertised `@${name}` pin silently missing or stale.
+            if ! retry --retries 3 --backoff 5 --max-backoff 30 -- \
+                git push --force "$REMOTE_URL" "${TARGET_SHA}:refs/tags/${name}"; then
+              echo "::error title=Floating tag ${name} not moved::Could not force-push floating tag '${name}' to ${TARGET_SHA}. The GitHub Release is published and the release PR merged — only this floating tag is missing or stale, which silently breaks the advertised 'uses: ...@${name}' pin. The push authenticates as the Release App, which the repo Tag ruleset must list as a bypass actor; verify the ruleset's bypass list and the RELEASE_APP_CLIENT_ID / RELEASE_APP_PRIVATE_KEY secrets, or remediate once by hand (temporarily add an admin bypass to the ruleset, force-move refs/tags/${name} -> ${TARGET_SHA}, then revert). See https://github.com/vig-os/devkit/blob/main/docs/MIGRATION.md#first-release-floating-tags."
+              return 1
             fi
+            echo "Floating tag ${name} -> ${TARGET_SHA}"
           }
 
           IFS=',' read -ra LEVELS <<< "$FLOATING_TAGS"

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -999,18 +999,22 @@ release and `<prefix>X.Y` is missing — silently breaking the advertised
 `uses: owner/repo@<prefix>X` pin. The one-off bootstrap is to bypass the ruleset,
 move the tags, then revert:
 
-> **The same one-off recurs when a _new_ floating level first appears in steady
-> state** ([#1157](https://github.com/vig-os/devkit/issues/1157)). Once the
-> workflow is live it force-**updates** existing levels with the app token, but
-> the first release of a new level must **create** the ref (`POST /git/refs`),
-> and if the Tag ruleset does not bypass the Release App for its `creation` rule
-> that create is denied — surfaced as the opaque `Reference does not exist`
-> (HTTP 422). Example: a repo already carrying `<prefix>0` cuts its first
-> `<prefix>0.Y` release. `promote-release.yml` now fails loud with a `::error::`
-> naming the tag, target commit, and this remediation instead of a bare `gh`
-> error. Apply the same bypass-create-revert below (using the **create** call in
-> step 2), or grant the Release App a `creation` bypass so future levels move
-> automatically.
+> **On devkit versions before the git-push fix
+> ([#1377](https://github.com/vig-os/devkit/issues/1377)), the same one-off
+> recurs when a _new_ floating level first appears in steady state**
+> ([#1157](https://github.com/vig-os/devkit/issues/1157)). Those workflows
+> mutate tags via the REST refs API, and GitHub does not honor the Release
+> App's Integration ruleset bypass on `POST /git/refs` for the `creation`
+> rule — the first release of a new level (say a repo already carrying
+> `<prefix>0` cuts its first `<prefix>0.Y`) is denied as the opaque
+> `Reference does not exist` (HTTP 422), even though the App **is** a bypass
+> actor; granting further bypasses does not help, the REST create path simply
+> ignores them. The very same token pushing tags over git is bypassed fine,
+> so current `promote-release.yml` force-pushes the floating tags instead and
+> new levels move automatically. On a pre-fix version the workflow fails loud
+> with a `::error::` naming the tag, target commit, and this remediation —
+> apply the bypass-create-revert below (using the **create** call in step 2),
+> or upgrade devkit.
 
 1. **Temporarily grant repository admins a bypass.** In **Settings → Rules →
    Rulesets → (the Tag ruleset) → Bypass list**, add **Repository admin**

--- a/tests/test_floating_tags.py
+++ b/tests/test_floating_tags.py
@@ -79,17 +79,55 @@ def _move_step_script() -> str:
     return move["run"]
 
 
-def test_create_failure_emits_actionable_error() -> None:
-    """A first-time floating-level create that the ruleset denies must fail loud.
+def test_move_tag_force_pushes_with_explicit_app_token() -> None:
+    """Floating tags are mutated via ``git push --force`` with the App token.
 
-    #1157: the create path (``POST /git/refs`` for a brand-new ``<prefix>X.Y``)
-    is denied ``422`` when the Tag ruleset does not bypass the Release App for
-    the ``creation`` rule. The bare ``gh`` error is undiagnosable, so the step
-    must surface a ``::error::`` annotation and point at the documented one-off
-    remediation instead of a cryptic ``Reference does not exist``.
+    #1377: ``POST /git/refs`` does not honor the Release App's Integration
+    ruleset bypass for the ``creation`` rule (first release of every new
+    floating level fails HTTP 422), while the very same installation token
+    creating tags via ``git push`` is bypassed fine. The token must be plumbed
+    explicitly into the push URL — the checkout step's persisted credentials
+    are the default ``github.token``, which has no bypass.
+    """
+    script = _move_step_script()
+    assert "git push" in script
+    assert "--force" in script
+    # Explicit App-token auth, not checkout's persisted credentials.
+    assert "x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}" in script
+
+
+def test_move_tag_never_mutates_refs_via_rest() -> None:
+    """No REST ref mutation remains, but the trap is documented in a comment.
+
+    The ``PATCH /git/refs/tags`` move and the ``POST /git/refs`` create are
+    both replaced by the single branch-free push path. A comment must still
+    name ``POST /git/refs`` and why it is avoided, so the REST trap is not
+    reintroduced (#1377).
+    """
+    script = _move_step_script()
+    assert "-X PATCH" not in script  # no REST tag move
+    assert "-f ref=" not in script  # no REST tag create
+    assert "POST /git/refs" in script  # the why-not comment stays
+
+
+def test_move_tag_idempotence_check_retained() -> None:
+    """The read-and-skip guard survives the push rewrite (re-run safe)."""
+    script = _move_step_script()
+    assert "git/ref/tags/${name}" in script  # gh api GET of the current ref
+    assert "skipping" in script
+
+
+def test_push_failure_emits_actionable_error() -> None:
+    """A denied or failed tag push must still fail loud with remediation.
+
+    #1157/#1158 introduced the ``::error`` annotation + MIGRATION.md fallback;
+    #1377 keeps both but drops the moot "grant a creation bypass" remediation —
+    the bypass already exists, and the push path honors it.
     """
     script = _move_step_script()
     assert "::error" in script  # a GitHub error annotation, not a bare echo
     # Names the ruleset root cause and the documented remediation.
     assert "ruleset" in script.lower()
     assert "first-release-floating-tags" in script
+    # The old remediation is moot: the App already has the bypass.
+    assert "grant the Release App a 'creation' bypass" not in script


### PR DESCRIPTION
## Summary

The `floating-tags` job in the scaffolded `promote-release.yml` created brand-new
floating levels via `POST /git/refs` — the one ref-mutation path where GitHub
does **not** honor the Release App's Integration ruleset bypass for the
`creation` rule. The first release of every new `<prefix>X` / `<prefix>X.Y`
level therefore died with the opaque `Reference does not exist` (HTTP 422) and
no rule-suite entry at all, despite the App holding an `always` bypass on the
whole Tag ruleset (hit live on `commit-action` 0.3.1 and `sync-issues-action`
0.5.0).

`move_tag()` now mutates floating tags via
`git push --force "${TARGET_SHA}:refs/tags/${name}"` — the exact path
`release-publish.yml` already uses to create the release tags, empirically
proven to be bypassed — with the App installation token plumbed **explicitly**
into the push URL (`https://x-access-token:${GH_TOKEN}@github.com/...`).
Checkout's persisted credentials are deliberately not relied on: those are the
default `github.token`, which has no bypass. Create and move collapse into one
branch-free path.

## Preserved from #1157/#1158

- **Idempotence**: the `gh api` GET + skip-when-already-at-target guard stays,
  so re-runs are safe.
- **Loud failure**: the `::error` annotation + `docs/MIGRATION.md`
  `#first-release-floating-tags` fallback stays for pushes that fail for other
  reasons; its wording is updated now that the "grant a creation bypass"
  remediation is moot (the bypass already exists — the REST create path simply
  ignores it) and points at verifying the ruleset bypass list and the
  `RELEASE_APP_CLIENT_ID` / `RELEASE_APP_PRIVATE_KEY` secrets instead.
- **The trap is documented in-script**: a comment explains why push is used
  instead of `POST /git/refs`, so the REST path is not reintroduced.

## Changes

- `assets/workspace/.github/workflows/promote-release.yml` — push-based
  `move_tag()`, explicit-token remote URL, and a `git fetch` of the release tag
  so the peeled commit object is available locally to push (the checkout is a
  shallow clone of the workflow head, which need not contain it).
- `tests/test_floating_tags.py` — new shape tests pin the push path, the
  explicit token, the absence of REST ref mutation, the surviving idempotence
  guard, and the updated annotation (TDD: committed failing first).
- `docs/MIGRATION.md` — the #1157 steady-state note now describes the REST
  bypass asymmetry, scopes the one-off remediation to pre-fix devkit versions,
  and recommends upgrading.
- `CHANGELOG.md` (+ synced workspace mirror) — Fixed entry under Unreleased.

## Verification

- `uv run pytest tests/test_floating_tags.py` — 9 passed (3 new tests failed
  RED before the fix).
- `uv run pytest tests` (minus image/integration, which need a built image) —
  483 passed; the single failure (`test_flake_hooks` pymarkdown
  `CONTRIBUTE.md`/`CONTRIBUTING.md` exclude drift) pre-exists on `dev` from the
  #1372 rename and is untouched by this PR (separate issue to follow).
- `just precommit` (full `prek run --all-files`) — all green.
- `just test-bats` — full suite green, including the rendered-workflow
  actionlint checks over `promote-release.yml` (#995).
- Live proof lands with the next first-of-a-new-level consumer release, per the
  issue's acceptance criteria.

Out of scope, per the issue: reporting the `POST /git/refs` bypass asymmetry
upstream, the optional org-config `exempt`-mode hardening, and shrinking the
MIGRATION.md runbook to a historical note.

Closes #1377
