### PR TITLE
fix(workflows): publish the scaffold release tag as a lightweight ref

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -259,6 +259,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     skip are unchanged; the now-unused `git-user-name` / `git-user-email`
     dispatch inputs are removed from `release.yml` (`prepare-release.yml`, which
     actually writes commits, keeps its own).
+- **Consumer release tags are lightweight refs too — the scaffold stops publishing unsigned tag objects** ([#1378](https://github.com/vig-os/devkit/issues/1378))
+  - The scaffold's `release-publish.yml` still created every consumer's
+    `X.Y.Z` tag with `git tag -a` under a GitHub App identity — an **annotated
+    tag object** reporting `verification.reason: "unsigned"` forever, for the
+    same unreachable-signature reasons as [#1370](https://github.com/vig-os/devkit/issues/1370).
+    The scaffold was internally inconsistent: `promote-release.yml` already
+    creates the *floating* tags (`vX`, `vX.Y`) as lightweight refs, while the
+    version tag — the one users pin and audit — was an unsigned object.
+  - The publish step now POSTs `refs/tags/<prefix><version>` straight at the
+    release commit (`POST /git/refs`). Preserved behaviours: the
+    `tag_already_exists` skip, the create-race verification (a lost race is
+    accepted only when the existing ref already resolves to the release
+    commit), `TAG_PREFIX` composition ([#1044](https://github.com/vig-os/devkit/issues/1044)),
+    and the tombstone diagnosis ([#1319](https://github.com/vig-os/devkit/issues/1319))
+    — its signature match re-derived against the `POST /git/refs` HTTP 422
+    rule-violation error shape.
+  - The dead `git_user_name` / `git_user_email` `workflow_call` inputs are
+    removed from `release-publish.yml` and their pass-throughs from the
+    scaffold `release.yml` publish call; the scaffold's `git-user-name` /
+    `git-user-email` **dispatch** inputs stay — the rollback job still writes
+    commits with that identity.
+  - `promote-release.yml` and `docs/MIGRATION.md` keep the annotated-tag peel
+    as backward compatibility for tags published by older scaffolds, with
+    corrected wording. Existing annotated tags are left as they are
+    (forward-fix policy); the change reaches consumers on their next devkit
+    upgrade.
 
 ## [1.6.0](https://github.com/vig-os/devkit/releases/tag/1.6.0) - 2026-08-04
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -259,6 +259,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     skip are unchanged; the now-unused `git-user-name` / `git-user-email`
     dispatch inputs are removed from `release.yml` (`prepare-release.yml`, which
     actually writes commits, keeps its own).
+- **Consumer release tags are lightweight refs too — the scaffold stops publishing unsigned tag objects** ([#1378](https://github.com/vig-os/devkit/issues/1378))
+  - The scaffold's `release-publish.yml` still created every consumer's
+    `X.Y.Z` tag with `git tag -a` under a GitHub App identity — an **annotated
+    tag object** reporting `verification.reason: "unsigned"` forever, for the
+    same unreachable-signature reasons as [#1370](https://github.com/vig-os/devkit/issues/1370).
+    The scaffold was internally inconsistent: `promote-release.yml` already
+    creates the *floating* tags (`vX`, `vX.Y`) as lightweight refs, while the
+    version tag — the one users pin and audit — was an unsigned object.
+  - The publish step now POSTs `refs/tags/<prefix><version>` straight at the
+    release commit (`POST /git/refs`). Preserved behaviours: the
+    `tag_already_exists` skip, the create-race verification (a lost race is
+    accepted only when the existing ref already resolves to the release
+    commit), `TAG_PREFIX` composition ([#1044](https://github.com/vig-os/devkit/issues/1044)),
+    and the tombstone diagnosis ([#1319](https://github.com/vig-os/devkit/issues/1319))
+    — its signature match re-derived against the `POST /git/refs` HTTP 422
+    rule-violation error shape.
+  - The dead `git_user_name` / `git_user_email` `workflow_call` inputs are
+    removed from `release-publish.yml` and their pass-throughs from the
+    scaffold `release.yml` publish call; the scaffold's `git-user-name` /
+    `git-user-email` **dispatch** inputs stay — the rollback job still writes
+    commits with that identity.
+  - `promote-release.yml` and `docs/MIGRATION.md` keep the annotated-tag peel
+    as backward compatibility for tags published by older scaffolds, with
+    corrected wording. Existing annotated tags are left as they are
+    (forward-fix policy); the change reaches consumers on their next devkit
+    upgrade.
 
 ## [1.6.0](https://github.com/vig-os/devkit/releases/tag/1.6.0) - 2026-08-04
 

--- a/assets/workspace/.github/workflows/promote-release.yml
+++ b/assets/workspace/.github/workflows/promote-release.yml
@@ -642,8 +642,10 @@ jobs:
           RELEASE_TAG="${TAG_PREFIX}${VERSION}"
 
           # Resolve the commit the release tag points at. release-publish.yml
-          # creates an ANNOTATED tag, so peel it (object.type == "tag") to the
-          # underlying commit; floating tags then point straight at the commit.
+          # creates a LIGHTWEIGHT tag (a plain ref at the release commit), but
+          # releases published by older scaffolds created an ANNOTATED tag, so
+          # keep peeling it (object.type == "tag") to the underlying commit;
+          # floating tags then point straight at the commit.
           REF_JSON=$(retry --retries 3 --backoff 5 --max-backoff 30 -- \
             gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${RELEASE_TAG}")
           TARGET_SHA=$(printf '%s' "$REF_JSON" | jq -r '.object.sha')

--- a/assets/workspace/.github/workflows/release-publish.yml
+++ b/assets/workspace/.github/workflows/release-publish.yml
@@ -28,16 +28,6 @@ on:  # yamllint disable-line rule:truthy
         description: "Release kind (candidate or final)"
         required: true
         type: string
-      git_user_name:
-        description: "Git user name for release tag operations"
-        required: false
-        default: "github-actions[bot]"
-        type: string
-      git_user_email:
-        description: "Git user email for release tag operations"
-        required: false
-        default: "41898282+github-actions[bot]@users.noreply.github.com"
-        type: string
       tag_already_exists:
         description: "Skip tag create/push when remote tag already points at finalize SHA"
         required: false
@@ -160,58 +150,72 @@ jobs:
           mode: ${{ inputs.toolchain_mode }}
           devkit-version: ${{ inputs.devkit_version }}
 
-      - name: Configure git
-        env:
-          GIT_USER_NAME: ${{ inputs.git_user_name }}
-          GIT_USER_EMAIL: ${{ inputs.git_user_email }}
-        run: |
-          git config user.name "$GIT_USER_NAME"
-          git config user.email "$GIT_USER_EMAIL"
-
-      - name: Create and push tag
+      # The release tag is a LIGHTWEIGHT tag: a plain `refs/tags/<tag>` ref
+      # POSTed straight at the release commit, with no tag object behind it.
+      # `git tag -a` (what this step used to do) writes a tag object carrying a
+      # tagger identity that nothing can sign: the tag is published under a
+      # GitHub App installation token, and an App has no registrable GPG/SSH
+      # key — nor does the server-side `POST /git/tags` route sign what it
+      # stores. Every tag produced that way reported `verification.reason:
+      # "unsigned"` forever (#1378, downstream of #1370). A lightweight tag has
+      # no tagger and no payload, so there is nothing left to be unsigned, and
+      # the commit the ref resolves to is the release commit.
+      - name: Create release tag
         if: ${{ !inputs.tag_already_exists }}
         env:
+          GH_TOKEN: ${{ steps.auth.outputs.token }}
           PUBLISH_VERSION: ${{ inputs.publish_version }}
           TAG_PREFIX: ${{ inputs.tag_prefix }}
+          FINALIZE_SHA: ${{ inputs.finalize_sha }}
         run: |
           set -euo pipefail
           # Compose the actual tag name (prefix + bare publish version) (#1044).
           PUBLISH_TAG="${TAG_PREFIX}${PUBLISH_VERSION}"
-          git tag -a "$PUBLISH_TAG" -m "Release $PUBLISH_TAG"
-          if ! PUSH_OUTPUT=$(retry --retries 3 --backoff 5 --max-backoff 30 -- git push origin "$PUBLISH_TAG" 2>&1); then
-            printf '%s\n' "$PUSH_OUTPUT"
-            # A tag name whose published release was deleted under release
-            # immutability is permanently retired; pushing it is rejected with
-            # GH013 and no retry or wait can ever succeed.
-            if printf '%s' "$PUSH_OUTPUT" | grep -Eqi "GH013|creations restricted"; then
-              echo "ERROR: Tag name $PUBLISH_TAG is tombstoned by release immutability:"
-              echo "a published GitHub Release for this tag was deleted, permanently retiring the name."
-              echo "This version is burned — re-cut the content as the next patch version."
-              echo "See https://github.com/vig-os/devkit/blob/main/docs/RELEASE_CYCLE.md ('Restarting a Finalized Release — the Point of No Return')."
-              exit 1
-            fi
-            if retry --retries 3 --backoff 5 --max-backoff 30 -- git ls-remote --tags --refs origin "$PUBLISH_TAG" | grep -q "refs/tags/$PUBLISH_TAG$"; then
-              LOCAL_TAG_TARGET_SHA=$(git rev-parse "$PUBLISH_TAG^{}")
-              REMOTE_TAG_TARGET_SHA=$(retry --retries 3 --backoff 5 --max-backoff 30 -- git ls-remote --tags origin "refs/tags/$PUBLISH_TAG^{}" | awk '{print $1}')
-              if [ -z "$REMOTE_TAG_TARGET_SHA" ]; then
-                REMOTE_TAG_TARGET_SHA=$(retry --retries 3 --backoff 5 --max-backoff 30 -- git ls-remote --tags origin "refs/tags/$PUBLISH_TAG" | awk '{print $1}')
-              fi
-              if [ -z "$REMOTE_TAG_TARGET_SHA" ]; then
-                echo "ERROR: Remote tag exists but target SHA could not be resolved: $PUBLISH_TAG"
-                exit 1
-              fi
-              if [ "$REMOTE_TAG_TARGET_SHA" != "$LOCAL_TAG_TARGET_SHA" ]; then
-                echo "ERROR: Remote tag target SHA mismatch for $PUBLISH_TAG"
-                echo "Local tag target:  $LOCAL_TAG_TARGET_SHA"
-                echo "Remote tag target: $REMOTE_TAG_TARGET_SHA"
-                exit 1
-              fi
-              echo "Tag already present on origin with matching target SHA: $PUBLISH_TAG"
-            else
-              echo "ERROR: Failed to push tag $PUBLISH_TAG"
-              exit 1
-            fi
+
+          CREATE_OUTPUT=""
+          if CREATE_OUTPUT=$(retry --retries 3 --backoff 5 --max-backoff 30 -- \
+            gh api -X POST "repos/${GITHUB_REPOSITORY}/git/refs" \
+              -f ref="refs/tags/${PUBLISH_TAG}" \
+              -f sha="$FINALIZE_SHA" 2>&1); then
+            echo "Tag created: $PUBLISH_TAG -> $FINALIZE_SHA"
+            exit 0
           fi
+          printf '%s\n' "$CREATE_OUTPUT"
+
+          # A tag name whose published release was deleted under release
+          # immutability is permanently retired; creating the ref is rejected
+          # with a repository-rule violation (HTTP 422 "creations being
+          # restricted" from the API; `GH013 ... creations restricted` over
+          # git) and no retry or wait can ever succeed.
+          if printf '%s' "$CREATE_OUTPUT" | grep -Eqi "GH013|creations?( being)? restricted"; then
+            echo "ERROR: Tag name $PUBLISH_TAG is tombstoned by release immutability:"
+            echo "a published GitHub Release for this tag was deleted, permanently retiring the name."
+            echo "This version is burned — re-cut the content as the next patch version."
+            echo "See https://github.com/vig-os/devkit/blob/main/docs/RELEASE_CYCLE.md ('Restarting a Finalized Release — the Point of No Return')."
+            exit 1
+          fi
+
+          # Creating the ref failed for another reason. The benign case is
+          # losing a race with a concurrent publish (or a response lost after
+          # the ref landed), which is only acceptable when the ref already
+          # resolves to this very commit. Peel `^{}` first so annotated tags
+          # published before this change still resolve.
+          echo "Tag ref creation did not succeed; verifying remote state:"
+          REMOTE_TAG_TARGET_SHA=$(retry --retries 3 --backoff 5 --max-backoff 30 -- git ls-remote --tags origin "refs/tags/$PUBLISH_TAG^{}" | awk '{print $1}')
+          if [ -z "$REMOTE_TAG_TARGET_SHA" ]; then
+            REMOTE_TAG_TARGET_SHA=$(retry --retries 3 --backoff 5 --max-backoff 30 -- git ls-remote --tags origin "refs/tags/$PUBLISH_TAG" | awk '{print $1}')
+          fi
+          if [ -z "$REMOTE_TAG_TARGET_SHA" ]; then
+            echo "ERROR: Failed to create tag $PUBLISH_TAG and no remote tag is present"
+            exit 1
+          fi
+          if [ "$REMOTE_TAG_TARGET_SHA" != "$FINALIZE_SHA" ]; then
+            echo "ERROR: Remote tag target SHA mismatch for $PUBLISH_TAG"
+            echo "Expected (release commit): $FINALIZE_SHA"
+            echo "Remote tag target:         $REMOTE_TAG_TARGET_SHA"
+            exit 1
+          fi
+          echo "Tag already present on origin at the release commit: $PUBLISH_TAG"
 
       - name: Extract release notes from CHANGELOG
         env:

--- a/assets/workspace/.github/workflows/release.yml
+++ b/assets/workspace/.github/workflows/release.yml
@@ -140,8 +140,6 @@ jobs:
       release_date: ${{ needs.core.outputs.release_date }}
       publish_version: ${{ needs.core.outputs.publish_version }}
       release_kind: ${{ needs.core.outputs.release_kind }}
-      git_user_name: ${{ inputs.git-user-name }}
-      git_user_email: ${{ inputs.git-user-email }}
       tag_already_exists: ${{ needs.core.outputs.tag_already_exists == 'true' }}
       create_release: ${{ inputs.create-release }}
       toolchain_mode: ${{ needs.resolve-toolchain.outputs.mode }}

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -1025,7 +1025,9 @@ move the tags, then revert:
 
 2. **Move the floating tags to the peeled release commit** — the same
    `move_tag` semantics as `promote-release.yml`. `release-publish.yml` creates
-   an **annotated** tag, so peel it to the underlying commit first:
+   a **lightweight** tag (a plain ref at the release commit), but releases
+   published by older scaffolds created an **annotated** tag, so peel it to the
+   underlying commit first (the snippet handles both):
 
    ```bash
    PREFIX=v; VERSION=X.Y.Z            # DEVKIT_TAG_PREFIX and the release version

--- a/tests/test_release_tombstone_detection.py
+++ b/tests/test_release_tombstone_detection.py
@@ -18,11 +18,19 @@ no-downstream-release error must name the tombstone as a possible cause. The
 live GH013 path is only provable on a real tombstone, so these tests assert
 the script shape, not the choreography.
 
+Since #1378 the tag is created via ``POST /git/refs`` instead of ``git push``,
+so the tag-side signature is matched against the API error surface (HTTP 422
+JSON body, ``Cannot create ref due to creations being restricted.``) as well as
+the git-protocol ``GH013`` shape. The extracted grep pattern is exercised
+against both shapes — and against the benign lost-race shape, which must NOT
+match — so the detection cannot silently rot into matching neither.
+
 Refs: #1319
 """
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import yaml
@@ -50,12 +58,43 @@ def _publish_step_run(step_name: str) -> str:
     return step["run"]
 
 
-def test_tag_push_detects_tombstone() -> None:
-    """A GH013-rejected tag push is diagnosed as a tombstone, not a generic failure."""
-    run = _publish_step_run("Create and push tag")
-    assert "GH013" in run
-    assert "creations restricted" in run
+# Observed error surfaces for a tombstoned tag name. The git-protocol shape is
+# live evidence from the 1.5.0 ghost (#1301); the API shape is the repository
+# rules engine's 422 body for a rule-rejected `POST /git/refs`, as `gh api`
+# prints it. The race shape ("Reference already exists") must NOT match: it is
+# the benign lost-race case, resolved by the remote-state verification instead.
+TOMBSTONE_GIT_SHAPE = (
+    "remote: error: GH013: Repository rule violations found for refs/tags/1.5.0.\n"
+    "remote: - Cannot create ref due to creations being restricted."
+)
+TOMBSTONE_API_SHAPE = (
+    "gh: Repository rule violations found\n"
+    "Cannot create ref due to creations being restricted. (HTTP 422)"
+)
+BENIGN_RACE_SHAPE = "gh: Reference already exists (HTTP 422)"
+
+
+def _extract_grep_pattern(run: str) -> str:
+    """Pull the tombstone signature out of the step's ``grep -Eqi`` line."""
+    match = re.search(r'grep -Eqi "([^"]+)"', run)
+    assert match, "the step must grep the captured output for the tombstone signature"
+    return match.group(1)
+
+
+def test_tag_create_detects_tombstone() -> None:
+    """A rule-rejected tag ref creation is diagnosed as a tombstone."""
+    run = _publish_step_run("Create release tag")
     assert "burned" in run
+    pattern = re.compile(_extract_grep_pattern(run), re.IGNORECASE)
+    assert pattern.search(TOMBSTONE_GIT_SHAPE), (
+        "the signature must still match the git-protocol GH013 shape"
+    )
+    assert pattern.search(TOMBSTONE_API_SHAPE), (
+        "the signature must match the POST /git/refs 422 rule-violation shape"
+    )
+    assert not pattern.search(BENIGN_RACE_SHAPE), (
+        "a benign lost race must not be diagnosed as a tombstone"
+    )
 
 
 def test_release_create_detects_tombstone() -> None:
@@ -67,7 +106,7 @@ def test_release_create_detects_tombstone() -> None:
 
 def test_tombstone_diagnosis_points_at_runbook() -> None:
     """The burned-version diagnosis points at the point-of-no-return runbook."""
-    run = _publish_step_run("Create and push tag")
+    run = _publish_step_run("Create release tag")
     assert "Point of No Return" in run
 
 

--- a/tests/test_workflow_release_publish_lightweight_tag.py
+++ b/tests/test_workflow_release_publish_lightweight_tag.py
@@ -1,0 +1,150 @@
+"""Workflow-shape tests: scaffold release tags are lightweight refs, never tag objects.
+
+Issue #1378 (downstream of #1370): the consumer scaffold's
+``release-publish.yml`` created the release tag with ``git tag -a`` under a
+GitHub App identity, producing an **annotated tag object** whose tagger is
+permanently ``unsigned``. Signing it is not reachable — an App has no
+registrable GPG/SSH key, and the server-side ``POST /git/tags`` route is not
+signed by GitHub either. The same scaffold's ``promote-release.yml`` already
+creates the *floating* tags as lightweight refs (#1045/#1157), so only the
+version tag — the one users pin and audit — was an unsigned object.
+
+The fix mirrors devkit's own ``release.yml`` (PR #1374): ``POST /git/refs``
+writes ``refs/tags/<prefix><version>`` straight at the release commit. A
+lightweight tag has no tagger and no payload, so nothing in the chain can
+report ``unsigned``.
+
+Mirrors ``tests/test_workflow_release_lightweight_tag.py`` for the scaffold.
+
+Refs: #1378
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+# Repository root (tests/ -> repo root).
+REPO_ROOT = Path(__file__).resolve().parent.parent
+TEMPLATE_WORKFLOWS = REPO_ROOT / "assets" / "workspace" / ".github" / "workflows"
+
+PUBLISH_WORKFLOW = TEMPLATE_WORKFLOWS / "release-publish.yml"
+ORCHESTRATOR_WORKFLOW = TEMPLATE_WORKFLOWS / "release.yml"
+
+
+def _load(path: Path) -> dict:
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def _publish_steps() -> list[dict]:
+    workflow = _load(PUBLISH_WORKFLOW)
+    (job,) = workflow["jobs"].values()
+    return job["steps"]
+
+
+def _publish_run_text() -> str:
+    return "\n".join(step.get("run", "") for step in _publish_steps())
+
+
+def test_publish_creates_no_annotated_tag_object() -> None:
+    """No `git tag` invocation survives — an annotated object cannot be signed."""
+    run = _publish_run_text()
+    for forbidden in ("git tag -a", "git tag -s", "git tag "):
+        assert forbidden not in run, (
+            f"the scaffold publish must not run {forbidden!r}: a tag object "
+            "written by the release App is unsigned and unsignable (#1378)"
+        )
+
+
+def test_publish_creates_the_tag_as_a_ref_at_the_release_commit() -> None:
+    """The tag is a plain ref POSTed to the Git Data refs endpoint."""
+    run = _publish_run_text()
+    assert "git/refs" in run, "publish must create the tag via POST /git/refs"
+    assert 'ref="refs/tags/${PUBLISH_TAG}"' in run, (
+        "the created ref must be refs/tags/<prefixed publish version>"
+    )
+    assert 'sha="$FINALIZE_SHA"' in run, (
+        "the tag ref must point at the finalize (release) commit SHA"
+    )
+
+
+def test_publish_composes_the_tag_prefix() -> None:
+    """The tag name is TAG_PREFIX + publish version, never the bare version (#1044)."""
+    create_step = _create_tag_step()
+    assert 'PUBLISH_TAG="${TAG_PREFIX}${PUBLISH_VERSION}"' in create_step["run"], (
+        "the create step must compose the prefixed tag name (#1044)"
+    )
+    env = create_step.get("env", {})
+    assert env.get("TAG_PREFIX") == "${{ inputs.tag_prefix }}"
+    assert env.get("FINALIZE_SHA") == "${{ inputs.finalize_sha }}"
+
+
+def test_publish_does_not_stamp_a_git_identity() -> None:
+    """The bot identity existed only to be the tagger; nothing needs it now."""
+    run = _publish_run_text()
+    assert "git config user." not in run, (
+        "publish no longer writes git objects, so it must not configure an identity"
+    )
+
+
+def test_publish_drops_the_dead_git_identity_inputs() -> None:
+    """The workflow_call identity inputs are dead once no tagger exists."""
+    workflow = _load(PUBLISH_WORKFLOW)
+    # PyYAML parses the bare ``on`` key as the boolean True.
+    call_inputs = workflow[True]["workflow_call"]["inputs"]
+    for dead in ("git_user_name", "git_user_email"):
+        assert dead not in call_inputs, (
+            f"release-publish.yml must not declare the dead input {dead!r} (#1378)"
+        )
+
+
+def test_orchestrator_drops_the_publish_identity_pass_throughs() -> None:
+    """release.yml no longer threads the identity into the publish call."""
+    workflow = _load(ORCHESTRATOR_WORKFLOW)
+    publish_with = workflow["jobs"]["publish"]["with"]
+    for dead in ("git_user_name", "git_user_email"):
+        assert dead not in publish_with, (
+            f"release.yml must not pass the dead input {dead!r} to release-publish"
+        )
+
+
+def test_orchestrator_keeps_the_rollback_identity() -> None:
+    """The dispatch identity inputs survive: the rollback job still commits."""
+    workflow = _load(ORCHESTRATOR_WORKFLOW)
+    dispatch_inputs = workflow[True]["workflow_dispatch"]["inputs"]
+    for kept in ("git-user-name", "git-user-email"):
+        assert kept in dispatch_inputs, (
+            f"release.yml must keep the {kept!r} dispatch input: the rollback "
+            "job checks out the release branch and writes with that identity"
+        )
+    rollback_steps = workflow["jobs"]["rollback"]["steps"]
+    configure = next(s for s in rollback_steps if s.get("name") == "Configure git")
+    assert configure["env"]["GIT_USER_NAME"] == "${{ inputs.git-user-name }}"
+
+
+def _create_tag_step() -> dict:
+    steps = [
+        step
+        for step in _publish_steps()
+        if "git/refs" in step.get("run", "") and "refs/tags/" in step.get("run", "")
+    ]
+    assert len(steps) == 1, "exactly one publish step may create the release tag"
+    return steps[0]
+
+
+def test_publish_tag_step_is_skipped_when_the_tag_already_exists() -> None:
+    """Re-running a release over an existing tag at the finalize SHA is a no-op."""
+    step = _create_tag_step()
+    assert step["if"] == "${{ !inputs.tag_already_exists }}"
+
+
+def test_publish_accepts_a_lost_race_only_at_the_release_commit() -> None:
+    """A failed create is benign only when the ref already resolves to the commit."""
+    run = _create_tag_step()["run"]
+    # Peeled-then-plain resolution keeps pre-lightweight annotated tags readable.
+    assert "^{}" in run, "race verification must still peel annotated tags"
+    assert 'REMOTE_TAG_TARGET_SHA" != "$FINALIZE_SHA"' in run, (
+        "a lost race is acceptable only when the existing ref resolves to the "
+        "release commit"
+    )


### PR DESCRIPTION
## Description

Every repo devkit scaffolds published its `X.Y.Z` release tag through
`assets/workspace/.github/workflows/release-publish.yml`, which ran
`git config user.*` + `git tag -a` + `git push` under a GitHub App identity —
an **annotated tag object** whose tagger reports
`verification.reason: "unsigned"` permanently. The reasoning from #1370
transfers unchanged: an App has no registrable GPG/SSH key, and
`POST /git/tags` is not signed server-side either, so the only fix is to not
create a tag object at all. The scaffold was also internally inconsistent:
`promote-release.yml` already creates the *floating* tags (`vX`, `vX.Y`) as
lightweight refs (#1045/#1157), leaving only the version tag — the one users
pin and audit — unsigned.

## Type of Change

- [x] `fix` -- Bug fix

## Changes Made

- `assets/workspace/.github/workflows/release-publish.yml`
  - "Configure git" + "Create and push tag" are replaced by a single
    **Create release tag** step mirroring devkit's own `release.yml` from
    PR #1374: `gh api -X POST repos/{owner}/{repo}/git/refs` writes
    `refs/tags/<prefix><version>` straight at `inputs.finalize_sha`, using the
    same resolved auth token (`secrets.token` or the Release App token).
  - Behaviours carried over, per the issue's acceptance criteria:
    - the `tag_already_exists` skip (`if: ${{ !inputs.tag_already_exists }}`)
      is unchanged;
    - the create-race verification accepts a lost race **only** when the
      existing ref already resolves to the release commit (peeled `^{}` first,
      plain ref fallback, so pre-change annotated tags still resolve);
    - `TAG_PREFIX` composition (#1044): the created ref is
      `refs/tags/${TAG_PREFIX}${PUBLISH_VERSION}`;
    - **GH013 tombstone diagnosis** (#1319): the signature match is re-derived
      against the `POST /git/refs` error surface — the repository-rules 422
      body says `Cannot create ref due to creations being restricted.` while
      the git-protocol shape stays `GH013 ... creations restricted`, so the
      grep is now `GH013|creations?( being)? restricted`. The shape test
      exercises the extracted pattern against both shapes and asserts the
      benign lost-race shape (`Reference already exists`) does NOT match.
  - The dead `git_user_name` / `git_user_email` `workflow_call` inputs are
    removed.
- `assets/workspace/.github/workflows/release.yml` — the two identity
  pass-throughs in the `publish` call are removed. The `git-user-name` /
  `git-user-email` **`workflow_dispatch` inputs stay**, as the issue requires:
  the rollback job still checks out the release branch and writes with that
  identity (the asymmetry with #1374).
- `assets/workspace/.github/workflows/promote-release.yml` — the "creates an
  ANNOTATED tag" comment is corrected; the `object.type == "tag"` peel itself
  stays as backward compatibility for tags published by older scaffolds.
- `docs/MIGRATION.md` — same treatment for the first-release floating-tags
  runbook (~L1028): claim corrected, peel snippet kept (it handles both
  shapes).
- `tests/test_workflow_release_publish_lightweight_tag.py` — new workflow-shape
  test mirroring `tests/test_workflow_release_lightweight_tag.py` for the
  scaffold (committed RED first).
- `tests/test_release_tombstone_detection.py` — tag-side tests re-pointed at
  the **Create release tag** step and upgraded to execute the extracted grep
  pattern against the observed error shapes instead of asserting substrings.

## Out of scope

- The optional `persist-credentials` cleanup from the issue is deliberately
  **not** bundled: after this change the publish job still runs
  `git ls-remote origin` for the create-race verification, which needs the
  persisted checkout credential on private consumer repos — the credential is
  not dead. Same situation in devkit's own `release.yml` post-#1374. If it is
  to be dropped, the verification must move to `gh api` first; that is its own
  change.
- Existing annotated consumer tags are left as they are (forward-fix policy;
  immutable releases lock them anyway). The change reaches consumers on their
  next `devkit-upgrade` / re-scaffold; until then `scaffold-drift` flags them.

## Changelog Entry

Added under `## Unreleased` → `### Security`, directly after the sibling #1370
entry (mirrored into `assets/workspace/.devcontainer/CHANGELOG.md` by
`sync-manifest`).

## Testing

- `uv run pytest tests/test_workflow_release_publish_lightweight_tag.py tests/test_release_tombstone_detection.py`
  — RED before the workflow change (10 failed / 3 passed), GREEN after
  (13 passed).
- Full lightweight suite (CI `test-project` scope + `packages/vig-utils/tests`):
  **950 passed**.
- Full bats suite: 575 ok; the 9 `githooks.bats` IN_CONTAINER-guard failures
  are environmental (the runner shell exports `IN_NIX_SHELL`, which the guard
  sanctions) — all 12 pass with `env -u IN_NIX_SHELL bats tests/bats/githooks.bats`.
  The rendered-template actionlint tests passed.
- `just precommit` (`prek run --all-files`) — fully green.
- The live path is only provable on a real release: acceptance is
  `gh api repos/vig-os/devkit-smoke-test/git/refs/tags/<tag> --jq '.object.type'`
  reporting `commit`, not `tag`, on the next smoke-test release.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes

Closes #1378
