### PR TITLE
fix(hooks): rename pymarkdown excludes to CONTRIBUTING.md in flake mirror

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     MIGRATION.md fallback from #1158 stay, with the moot "grant a creation
     bypass" remediation rewritten (the bypass already exists — the REST create
     path simply ignores it).
+- **Flake pymarkdown excludes follow the `CONTRIBUTING.md` rename** ([#1380](https://github.com/vig-os/devkit/issues/1380))
+  - `nix/hooks.nix` (runner, check, and consumer profiles) and the scaffold
+    template `assets/workspace/.pre-commit-config.yaml` still excluded the
+    removed `CONTRIBUTE.md`, drifting from the root `.pre-commit-config.yaml`
+    updated in [#1372](https://github.com/vig-os/devkit/issues/1372); the
+    renamed contributing guide was no longer excluded from pymarkdown.
 - **A no-diff devkit upgrade no longer strands its adoption issue** ([#1347](https://github.com/vig-os/devkit/issues/1347))
   - The scaffolded `devkit-upgrade.yml` opens the adoption issue *before*
     `install.sh --force` runs (the branch name embeds its number and the

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -74,6 +74,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     MIGRATION.md fallback from #1158 stay, with the moot "grant a creation
     bypass" remediation rewritten (the bypass already exists — the REST create
     path simply ignores it).
+- **Flake pymarkdown excludes follow the `CONTRIBUTING.md` rename** ([#1380](https://github.com/vig-os/devkit/issues/1380))
+  - `nix/hooks.nix` (runner, check, and consumer profiles) and the scaffold
+    template `assets/workspace/.pre-commit-config.yaml` still excluded the
+    removed `CONTRIBUTE.md`, drifting from the root `.pre-commit-config.yaml`
+    updated in [#1372](https://github.com/vig-os/devkit/issues/1372); the
+    renamed contributing guide was no longer excluded from pymarkdown.
 - **A no-diff devkit upgrade no longer strands its adoption issue** ([#1347](https://github.com/vig-os/devkit/issues/1347))
   - The scaffolded `devkit-upgrade.yml` opens the adoption issue *before*
     `install.sh --force` runs (the branch name embeds its number and the

--- a/assets/workspace/.pre-commit-config.yaml
+++ b/assets/workspace/.pre-commit-config.yaml
@@ -97,7 +97,7 @@ repos:
         language: system
         types: [markdown]
         args: ["-c", ".pymarkdown", "fix"]
-        exclude: ^(README\.md|CONTRIBUTE\.md|TESTING\.md)
+        exclude: ^(README\.md|CONTRIBUTING\.md|TESTING\.md)
 
   # Justfile formatting
   - repo: local

--- a/nix/hooks.nix
+++ b/nix/hooks.nix
@@ -433,7 +433,7 @@ let
     # (pymarkdownlnt packaged in nix/pymarkdown.nix, #1170), retiring the last
     # runner-only remote-repo residual of the hook SSoT (#883). All three
     # artifacts run the SAME `-c .pymarkdown fix` command over the SAME
-    # `.pymarkdown` JSON config and README/CONTRIBUTE/TESTING excludes.
+    # `.pymarkdown` JSON config and README/CONTRIBUTING/TESTING excludes.
     #
     # `fix` (not `scan`) is deliberate and matches the runner/CI: pymarkdown fix
     # rewrites auto-fixable violations and exits 0 while *tolerating* unfixable
@@ -454,7 +454,7 @@ let
           ".pymarkdown"
           "fix"
         ];
-        exclude = "^(README\\.md|CONTRIBUTE\\.md|TESTING\\.md)";
+        exclude = "^(README\\.md|CONTRIBUTING\\.md|TESTING\\.md)";
       };
       check =
         { pkgs, ... }:
@@ -464,7 +464,7 @@ let
           entry = "${import ./pymarkdown.nix pkgs}/bin/pymarkdown -c .pymarkdown fix";
           language = "system";
           types = [ "markdown" ];
-          excludes = [ "^(README\\.md|CONTRIBUTE\\.md|TESTING\\.md)" ];
+          excludes = [ "^(README\\.md|CONTRIBUTING\\.md|TESTING\\.md)" ];
         };
       consumer = pkgs: {
         enable = true;
@@ -472,7 +472,7 @@ let
         entry = "${import ./pymarkdown.nix pkgs}/bin/pymarkdown -c .pymarkdown fix";
         language = "system";
         types = [ "markdown" ];
-        excludes = [ "^(README\\.md|CONTRIBUTE\\.md|TESTING\\.md)" ];
+        excludes = [ "^(README\\.md|CONTRIBUTING\\.md|TESTING\\.md)" ];
       };
     };
     # just formats justfiles. The runner rewrites in place; the Nix gate


### PR DESCRIPTION
## Summary

PR #1376 (#1372) renamed `CONTRIBUTE.md` to `CONTRIBUTING.md` and updated the pymarkdown exclude in the root `.pre-commit-config.yaml`, but missed the flake-side mirror. This PR completes the rename:

- `nix/hooks.nix`: the three pymarkdown exclude patterns (runner `yaml`, `check`, and `consumer` profiles) and the line-436 comment now say `CONTRIBUTING`.
- `assets/workspace/.pre-commit-config.yaml`: the scaffold template's pymarkdown exclude — same rename fallout, and required for the scaffold half of the drift gate (`test_scaffold_render_matches_scaffold_config`) to stay green once the shared render in `nix/hooks.nix` is fixed.
- `CHANGELOG.md` `## Unreleased` → Fixed entry (plus its managed `assets/workspace/.devcontainer/CHANGELOG.md` mirror, updated by the `sync-manifest` hook).

## Testing

No new test: the existing drift gate `tests/test_flake_hooks.py::TestPortableRenderFidelity::test_runner_render_matches_committed_config` already fails on `origin/dev` and pins this fix (TDD RED pre-satisfied).

- Before: `uv run pytest tests/test_flake_hooks.py -k test_runner_render_matches_committed_config` → **FAILED** with `pymarkdown.exclude: rendered='^(README\\.md|CONTRIBUTE\\.md|TESTING\\.md)' committed='^(README\\.md|CONTRIBUTING\\.md|TESTING\\.md)'`.
- After: `uv run pytest tests/test_flake_hooks.py` → **36 passed**.
- `just precommit` (full suite, all files) green.

Closes #1380