### PR TITLE
test(bats): unset IN_NIX_SHELL in githooks guard-blocking cases

### DIFF
--- a/tests/bats/githooks.bats
+++ b/tests/bats/githooks.bats
@@ -15,19 +15,19 @@ setup() {
 # ── pre-commit ────────────────────────────────────────────────────────────────
 
 @test "pre-commit blocks when IN_CONTAINER is unset" {
-    run env -u IN_CONTAINER bash "$HOOKS_DIR/pre-commit"
+    run env -u IN_CONTAINER -u IN_NIX_SHELL bash "$HOOKS_DIR/pre-commit"
     assert_failure
     assert_output --partial "Please commit your changes within the dev container"
 }
 
 @test "pre-commit blocks when IN_CONTAINER is empty" {
-    run env IN_CONTAINER="" bash "$HOOKS_DIR/pre-commit"
+    run env -u IN_NIX_SHELL IN_CONTAINER="" bash "$HOOKS_DIR/pre-commit"
     assert_failure
     assert_output --partial "Please commit your changes within the dev container"
 }
 
 @test "pre-commit blocks when IN_CONTAINER is false" {
-    run env IN_CONTAINER="false" bash "$HOOKS_DIR/pre-commit"
+    run env -u IN_NIX_SHELL IN_CONTAINER="false" bash "$HOOKS_DIR/pre-commit"
     assert_failure
     assert_output --partial "Please commit your changes within the dev container"
 }
@@ -40,19 +40,19 @@ setup() {
 # ── prepare-commit-msg ────────────────────────────────────────────────────────
 
 @test "prepare-commit-msg blocks when IN_CONTAINER is unset" {
-    run env -u IN_CONTAINER bash "$HOOKS_DIR/prepare-commit-msg" /dev/null
+    run env -u IN_CONTAINER -u IN_NIX_SHELL bash "$HOOKS_DIR/prepare-commit-msg" /dev/null
     assert_failure
     assert_output --partial "Please commit your changes within the dev container"
 }
 
 @test "prepare-commit-msg blocks when IN_CONTAINER is empty" {
-    run env IN_CONTAINER="" bash "$HOOKS_DIR/prepare-commit-msg" /dev/null
+    run env -u IN_NIX_SHELL IN_CONTAINER="" bash "$HOOKS_DIR/prepare-commit-msg" /dev/null
     assert_failure
     assert_output --partial "Please commit your changes within the dev container"
 }
 
 @test "prepare-commit-msg blocks when IN_CONTAINER is false" {
-    run env IN_CONTAINER="false" bash "$HOOKS_DIR/prepare-commit-msg" /dev/null
+    run env -u IN_NIX_SHELL IN_CONTAINER="false" bash "$HOOKS_DIR/prepare-commit-msg" /dev/null
     assert_failure
     assert_output --partial "Please commit your changes within the dev container"
 }
@@ -65,19 +65,19 @@ setup() {
 # ── commit-msg ────────────────────────────────────────────────────────────────
 
 @test "commit-msg blocks when IN_CONTAINER is unset" {
-    run env -u IN_CONTAINER bash "$HOOKS_DIR/commit-msg" /dev/null
+    run env -u IN_CONTAINER -u IN_NIX_SHELL bash "$HOOKS_DIR/commit-msg" /dev/null
     assert_failure
     assert_output --partial "Please commit your changes within the dev container"
 }
 
 @test "commit-msg blocks when IN_CONTAINER is empty" {
-    run env IN_CONTAINER="" bash "$HOOKS_DIR/commit-msg" /dev/null
+    run env -u IN_NIX_SHELL IN_CONTAINER="" bash "$HOOKS_DIR/commit-msg" /dev/null
     assert_failure
     assert_output --partial "Please commit your changes within the dev container"
 }
 
 @test "commit-msg blocks when IN_CONTAINER is false" {
-    run env IN_CONTAINER="false" bash "$HOOKS_DIR/commit-msg" /dev/null
+    run env -u IN_NIX_SHELL IN_CONTAINER="false" bash "$HOOKS_DIR/commit-msg" /dev/null
     assert_failure
     assert_output --partial "Please commit your changes within the dev container"
 }


### PR DESCRIPTION
## Summary

The nine `githooks.bats` cases asserting the workspace githook guard *blocks* outside a devcontainer sanitized only `IN_CONTAINER` (`env -u IN_CONTAINER` / `IN_CONTAINER=\"\"` / `IN_CONTAINER=\"false\"`). The guard also legitimately passes when `IN_NIX_SHELL` is set, so running the suite from a `nix develop` shell (`IN_NIX_SHELL=impure`) failed 9/12 cases even though the code under test is correct.

This extends the env sanitization in those nine cases to also unset `IN_NIX_SHELL`, mirroring the existing `IN_CONTAINER` handling, making the suite deterministic regardless of the invoking shell.

Test-only change in a single `test(...)` commit: the guard implementation is correct, so the usual failing-test/implementation commit split does not apply — there is nothing to implement, only the test harness to fix. No changelog entry: no user-visible impact (CI never exports `IN_NIX_SHELL`; this is a local-DX fix).

## Testing

- Before (on `origin/dev`): `IN_NIX_SHELL=impure bats tests/bats/githooks.bats` → **9/12 failed** (all nine "blocks" cases: `command succeeded, but it was expected to fail`).
- After: `IN_NIX_SHELL=impure bats tests/bats/githooks.bats` → **12/12 ok**; `env -u IN_NIX_SHELL bats tests/bats/githooks.bats` → **12/12 ok**.
- `just precommit` (full suite, all files) green.

Closes #1381