### PR TITLE
fix(security): except CVE-2026-66032 in the vulnix register

### DIFF
--- a/.vulnixignore
+++ b/.vulnixignore
@@ -295,9 +295,25 @@ CVE-2026-55973
 # Re-verified 2026-08-04 (#1328): the pin was advanced to nixos-26.05 @
 # 2026-08-03 (rev 531670d8) and rebuilt; libssh2 is still 1.11.1 and carries no
 # 6603x patch, so this block is retained.
+#
+# Extended 2026-08-07 (#1386): CVE-2026-66032 (8.8) — the fourth member of the
+# same upstream batch — was absent from the 2026-08-04 findings (published on
+# NVD 2026-07-24 but scored/ingested later) and first surfaced as the sole
+# blocker in the 1.7.0-rc1 Vulnix CVE Gate. Same closure provenance and
+# reachability class as the three below. nixpkgs status re-checked online
+# 2026-08-07: NixOS/nixpkgs#547491 merged to *master* 12:41Z that day, but the
+# 26.05 backport NixOS/nixpkgs#550166 targets staging-26.05 and is still open,
+# so the patched derivation has NOT reached the pinned nixos-26.05 channel.
+# Same expiry as the batch; the whole block drops on the rev-advance.
 # ============================================================================
 
 Expiration: 2026-09-02
+# libssh2 1.11.1 — CVE-2026-66032 (8.8): double-free in sftp_open()
+#   (src/sftp.c); a malicious server answers SSH_FXP_OPEN with an FX_OK status
+#   and a follow-up oversized packet, making the client free the same response
+#   buffer twice and corrupting the authenticated client's heap. Reachable
+#   only through curl's sftp:// backend against a hostile server.
+CVE-2026-66032
 # libssh2 1.11.1 — CVE-2026-66033 (7.5): pre-auth integer underflow in
 #   ssh2_cipher_crypt() (src/openssl.c); a malicious server negotiating AES-GCM
 #   triggers an OOB read and a memcpy with a near-SIZE_MAX length, crashing the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -318,6 +318,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     corrected wording. Existing annotated tags are left as they are
     (forward-fix policy); the change reaches consumers on their next devkit
     upgrade.
+- **vulnix register: except CVE-2026-66032, completing the libssh2 malicious-server batch** ([#1386](https://github.com/vig-os/devkit/issues/1386))
+  - The 1.7.0-rc1 Vulnix CVE Gate blocked on CVE-2026-66032 (CVSS 8.8, a
+    double-free in libssh2's `sftp_open()`), the fourth member of the upstream
+    batch whose siblings CVE-2026-66033/66034/66035 were already excepted in
+    the 2026-09-02 block ([#1327](https://github.com/vig-os/devkit/issues/1327)) —
+    it was absent from the findings when that block was triaged on 2026-08-04
+    and surfaced in the feed later.
+  - Same closure provenance and reachability as its siblings: libssh2 enters
+    the image only as curl's scp/sftp backend, and the flaw requires an
+    authenticated SFTP session against a malicious SSH server. Excepted in the
+    same 2026-09-02 block; the whole block drops on a nixpkgs rev-advance once
+    the merged upstream patches (NixOS/nixpkgs#547491) reach the pinned
+    nixos-26.05 channel via the still-open staging-26.05 backport.
 
 ## [1.6.0](https://github.com/vig-os/devkit/releases/tag/1.6.0) - 2026-08-04
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -318,6 +318,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     corrected wording. Existing annotated tags are left as they are
     (forward-fix policy); the change reaches consumers on their next devkit
     upgrade.
+- **vulnix register: except CVE-2026-66032, completing the libssh2 malicious-server batch** ([#1386](https://github.com/vig-os/devkit/issues/1386))
+  - The 1.7.0-rc1 Vulnix CVE Gate blocked on CVE-2026-66032 (CVSS 8.8, a
+    double-free in libssh2's `sftp_open()`), the fourth member of the upstream
+    batch whose siblings CVE-2026-66033/66034/66035 were already excepted in
+    the 2026-09-02 block ([#1327](https://github.com/vig-os/devkit/issues/1327)) —
+    it was absent from the findings when that block was triaged on 2026-08-04
+    and surfaced in the feed later.
+  - Same closure provenance and reachability as its siblings: libssh2 enters
+    the image only as curl's scp/sftp backend, and the flaw requires an
+    authenticated SFTP session against a malicious SSH server. Excepted in the
+    same 2026-09-02 block; the whole block drops on a nixpkgs rev-advance once
+    the merged upstream patches (NixOS/nixpkgs#547491) reach the pinned
+    nixos-26.05 channel via the still-open staging-26.05 backport.
 
 ## [1.6.0](https://github.com/vig-os/devkit/releases/tag/1.6.0) - 2026-08-04
 


### PR DESCRIPTION
## Summary

The 1.7.0-rc1 candidate run ([31200317431](https://github.com/vig-os/devkit/actions/runs/31200317431)) was blocked by the Vulnix CVE Gate on **CVE-2026-66032** (CVSS 8.8, double-free in libssh2 `sftp_open()`) — the fourth member of the libssh2 malicious-server batch whose siblings (CVE-2026-66033/66034/66035) are already excepted in the 2026-09-02 block (#1327). It was absent from the findings at the 2026-08-04 triage (published on NVD 2026-07-24, scored/ingested later).

- `.vulnixignore`: add CVE-2026-66032 to the existing 2026-09-02 block with a dated triage note. Same closure provenance (libssh2 enters only as curl's scp/sftp backend) and reachability (authenticated SFTP session to a malicious server) as the siblings.
- nixpkgs status re-checked online 2026-08-07: NixOS/nixpkgs#547491 (debian patches for CVE-2026-6603[2345]) merged to **master** 12:41Z, but the 26.05 backport NixOS/nixpkgs#550166 targets staging-26.05 and is still open — the patched derivation has not reached the pinned `nixos-26.05` channel, so exception is the only lever today. The whole block drops on the next effective rev-advance.
- `CHANGELOG.md`: Security entry in the frozen `## [1.7.0]` section (+ managed mirror via sync-manifest).

## Testing

Config/register change — no code path to test (`check-expirations` validates the register in pre-commit + CI). Full `just precommit` suite green locally. Proof of fix is the re-dispatched candidate's Vulnix CVE Gate.

Refs: #1386