### PR TITLE
fix(smoke-test): gate final release on human PR approval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -318,6 +318,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     corrected wording. Existing annotated tags are left as they are
     (forward-fix policy); the change reaches consumers on their next devkit
     upgrade.
+- **Smoke-test orchestration gates the final release on a human approval instead of self-approving** ([#1391](https://github.com/vig-os/devkit/issues/1391))
+  - The dispatch listener approved its own release PR with the workflow token,
+    which the org now forbids (vig-os/org-config#122 sets
+    `can_approve_pull_request_reviews: false` org-wide) — the 1.7.0-rc3 smoke
+    chain died at that step.
+  - The approve step is replaced by a kind-aware gate: candidate dispatches
+    leave the PR unapproved (approval gates the final release only, matching
+    the deferred-approval model of [#902](https://github.com/vig-os/devkit/issues/902)),
+    while the final dispatch polls up to 30 minutes for a human to approve the
+    freshly created release PR before triggering the final release workflow,
+    and fails with re-run guidance if nobody does. Every dispatch still
+    recreates the smoke release branch and PR from scratch, by design.
 - **vulnix register: except CVE-2026-66032, completing the libssh2 malicious-server batch** ([#1386](https://github.com/vig-os/devkit/issues/1386))
   - The 1.7.0-rc1 Vulnix CVE Gate blocked on CVE-2026-66032 (CVSS 8.8, a
     double-free in libssh2's `sftp_open()`), the fourth member of the upstream

--- a/assets/smoke-test/.github/workflows/repository-dispatch.yml
+++ b/assets/smoke-test/.github/workflows/repository-dispatch.yml
@@ -614,17 +614,40 @@ jobs:
           gh pr edit "${PR_NUMBER}" --remove-label "release-kind:final" >/dev/null 2>&1 || true
           gh pr edit "${PR_NUMBER}" --add-label "${LABEL}"
 
-      - name: Approve release PR for automated dispatch
+      - name: Gate final release on human approval of release PR
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.generate_release_token.outputs.token }}
           PR_NUMBER: ${{ steps.locate_release_pr.outputs.release_pr }}
+          PR_URL: ${{ steps.locate_release_pr.outputs.release_pr_url }}
+          RELEASE_KIND: ${{ needs.validate.outputs.release_kind }}
         run: |
           set -euo pipefail
-          gh pr review "${PR_NUMBER}" --approve \
-            --body "Automated approval by smoke-test dispatch orchestration." || {
-            echo "::error::Auto-approve failed. If you see a permissions error, enable repository (or organization) setting 'Allow GitHub Actions to create and approve pull requests'. See this PR description for context."
-            exit 1
-          }
+          # The org blocks workflow-token PR approvals (vig-os/org-config#122),
+          # and every dispatch recreates the release branch and PR from scratch,
+          # so an up-front human approval cannot survive to this point. Candidate
+          # dispatches follow the deferred-approval model (approval gates the
+          # final release only) and leave the PR unapproved; the final dispatch
+          # pauses here until a human approves the freshly created PR. See
+          # vig-os/devkit#1391.
+          if [ "${RELEASE_KIND}" != "final" ]; then
+            echo "Candidate dispatch: release PR #${PR_NUMBER} intentionally left unapproved (human approval gates the final release only)."
+            exit 0
+          fi
+          TIMEOUT=1800
+          INTERVAL=20
+          ELAPSED=0
+          echo "Final dispatch: waiting up to $((TIMEOUT / 60)) minutes for a human to approve release PR #${PR_NUMBER}: ${PR_URL}"
+          while [ "${ELAPSED}" -lt "${TIMEOUT}" ]; do
+            DECISION="$(gh pr view "${PR_NUMBER}" --json reviewDecision --jq '.reviewDecision // empty' 2>/dev/null || true)"
+            if [ "${DECISION}" = "APPROVED" ]; then
+              echo "Release PR #${PR_NUMBER} approved by a human reviewer."
+              exit 0
+            fi
+            sleep "${INTERVAL}"
+            ELAPSED=$((ELAPSED + INTERVAL))
+          done
+          echo "::error::Timed out waiting for human approval of release PR #${PR_NUMBER} (${PR_URL}). Approve the PR, then re-run the failed jobs of this workflow run to resume the final release."
+          exit 1
 
   trigger-release:
     name: Trigger and wait for release workflow

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -318,6 +318,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     corrected wording. Existing annotated tags are left as they are
     (forward-fix policy); the change reaches consumers on their next devkit
     upgrade.
+- **Smoke-test orchestration gates the final release on a human approval instead of self-approving** ([#1391](https://github.com/vig-os/devkit/issues/1391))
+  - The dispatch listener approved its own release PR with the workflow token,
+    which the org now forbids (vig-os/org-config#122 sets
+    `can_approve_pull_request_reviews: false` org-wide) — the 1.7.0-rc3 smoke
+    chain died at that step.
+  - The approve step is replaced by a kind-aware gate: candidate dispatches
+    leave the PR unapproved (approval gates the final release only, matching
+    the deferred-approval model of [#902](https://github.com/vig-os/devkit/issues/902)),
+    while the final dispatch polls up to 30 minutes for a human to approve the
+    freshly created release PR before triggering the final release workflow,
+    and fails with re-run guidance if nobody does. Every dispatch still
+    recreates the smoke release branch and PR from scratch, by design.
 - **vulnix register: except CVE-2026-66032, completing the libssh2 malicious-server batch** ([#1386](https://github.com/vig-os/devkit/issues/1386))
   - The 1.7.0-rc1 Vulnix CVE Gate blocked on CVE-2026-66032 (CVSS 8.8, a
     double-free in libssh2's `sftp_open()`), the fourth member of the upstream

--- a/tests/bats/just.bats
+++ b/tests/bats/just.bats
@@ -210,6 +210,11 @@ EOF
     assert_success
 }
 
+@test "smoke-test dispatch gates the final release on human PR approval instead of self-approving" {
+    run bash -lc "grep -Fq -- 'Gate final release on human approval of release PR' assets/smoke-test/.github/workflows/repository-dispatch.yml && ! grep -Fq -- 'gh pr review' assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- 'reviewDecision' assets/smoke-test/.github/workflows/repository-dispatch.yml"
+    assert_success
+}
+
 @test "smoke-test dispatch preflight validates required workflow contract" {
     run bash -lc "grep -Fq -- 'Preflight check required release workflows on dispatch ref' assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- 'REQUIRED_WORKFLOWS=(prepare-release.yml release.yml promote-release.yml)' assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- 'for workflow_file in \"\${REQUIRED_WORKFLOWS[@]}\"; do' assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- 'WORKFLOW_CHECK_OUTPUT=\"\$(gh workflow view \"\${workflow_file}\" --ref \"\${WORKFLOW_REF}\" --yaml 2>&1 >/dev/null)\"' assets/smoke-test/.github/workflows/repository-dispatch.yml"
     assert_success


### PR DESCRIPTION
## Summary

Fixes the smoke-test dispatch orchestration break found at 1.7.0-rc3 (#1391): the listener approved its own release PR with `github.token`, which vig-os/org-config#122 (2026-08-07) now forbids org-wide (`can_approve_pull_request_reviews: false`, not overridable per-repo).

Design per maintainer decision:

- **Cleanup-recreate semantics unchanged**: every dispatch (each RC and the final) still closes the same-version release PR, deletes the release branch, and re-runs prepare-release from scratch.
- **Candidate dispatches** leave the fresh release PR unapproved — approval gates the final release only (deferred-approval model, #902), so the candidate chain runs green end-to-end with no human step.
- **Final dispatch** pauses at a new `Gate final release on human approval of release PR` step: polls `reviewDecision` up to 30 min (20 s interval, inside the job's 35-min timeout) for a human to approve the freshly created PR, then proceeds to the final release workflow; on timeout it fails with re-run guidance (approve, then re-run failed jobs).
- The gate reads the PR with the Release App token (same as the job's other steps), not the workflow token.

The secondary #1391 bug (failure-notify App-token mint 404) is **not** addressed here — it stays open in #1391.

## Testing

TDD: new bats pin `smoke-test dispatch gates the final release on human PR approval instead of self-approving` committed RED first (asserts the gate step exists, `gh pr review` is gone, `reviewDecision` is polled), GREEN after the change. All 18 `smoke-test dispatch` bats pins pass; `actionlint` clean on the edited asset; full `just precommit` green.

Live proof plan: mirror to smoke-test dev, then dispatch rc4 — the candidate chain (deploy → cleanup-recreate → prepare → no-approval → candidate release → checks) must go green autonomously; the final-kind poll path is exercised at the real final dispatch.

Refs: #1391