### PR TITLE
fix(smoke-test): mint notify App token for renamed devkit repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Smoke-test failure-notify job can mint its upstream App token again** ([#1396](https://github.com/vig-os/devkit/issues/1396))
+  - The listener's notify job requested an installation token for the
+    pre-rename `vig-os/devcontainer` repository, so the mint failed with 404
+    and no upstream failure issue was ever filed. It now targets
+    `vig-os/devkit`.
+
 ### Security
 
 ## [1.7.0](https://github.com/vig-os/devkit/releases/tag/1.7.0) - 2026-08-07

--- a/assets/smoke-test/.github/workflows/repository-dispatch.yml
+++ b/assets/smoke-test/.github/workflows/repository-dispatch.yml
@@ -1,7 +1,7 @@
 name: Repository Dispatch Listener
 #
 # Purpose:
-# - Handle cross-repo `repository_dispatch` events from vig-os/devcontainer.
+# - Handle cross-repo `repository_dispatch` events from vig-os/devkit.
 # - Deploy the requested tag into the smoke-test repo.
 # - Always create a `chore/deploy-<tag>` branch and PR to `dev`.
 # - Create signed deploy commits via `vig-os/commit-action`.
@@ -1035,7 +1035,7 @@ jobs:
           client-id: ${{ secrets.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
           owner: vig-os
-          repositories: devcontainer
+          repositories: devkit
 
       - name: Create upstream failure issue
         env:

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Smoke-test failure-notify job can mint its upstream App token again** ([#1396](https://github.com/vig-os/devkit/issues/1396))
+  - The listener's notify job requested an installation token for the
+    pre-rename `vig-os/devcontainer` repository, so the mint failed with 404
+    and no upstream failure issue was ever filed. It now targets
+    `vig-os/devkit`.
+
 ### Security
 
 ## [1.7.0](https://github.com/vig-os/devkit/releases/tag/1.7.0) - 2026-08-07


### PR DESCRIPTION
## Summary

Fixes the smoke-test listener's `notify-failure` job, which could never mint its upstream App token: it requested an installation token for the pre-rename `vig-os/devcontainer` repository, and the App-installation lookup (`GET /repos/{owner}/{repo}/installation`) does not follow rename redirects, so every mint failed with 404 and no upstream failure issue was ever filed (observed on all 1.7.0-train listener failures: runs 31207370105, 31217441944, 31275371280).

## Changes

- `assets/smoke-test/.github/workflows/repository-dispatch.yml`: notify job now mints for `repositories: devkit` (matching the `gh issue create --repo vig-os/devkit` it feeds); stale repo name in the header comment updated too.
- `CHANGELOG.md`: Unreleased > Fixed entry (mirrored to `assets/workspace/.devcontainer/CHANGELOG.md` by sync-manifest).

No new secrets or installs needed: `vig-os-release-app` is installed org-wide, and it already exercises issues:write (label creation in the same workflow).

The fixed listener will additionally be hot-deployed to `devkit-smoke-test` `main` (where the listener actually executes from) and live-proven with a synthetic failing dispatch.

Refs: #1396