### PR TITLE
ci(release): wait out transparency-log outages before retrying attestation

### DIFF
--- a/.github/scripts/wait-for-rekor.sh
+++ b/.github/scripts/wait-for-rekor.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Wait for the Sigstore transparency log before retrying an attestation (#1399).
+#
+# `actions/attest` already retries internally: @actions/attest hardcodes
+# DEFAULT_TIMEOUT = 10000 and DEFAULT_RETRIES = 3 into the Rekor witness, so a
+# single action step makes 4 Rekor attempts (0/+1/+2/+4s) over roughly 47s. It
+# exposes no input to widen that, which leaves the gap between our two attempts
+# as the only lever we control. A fixed `sleep 30` there capped the whole
+# envelope at about 2 minutes -- shorter than the Sigstore incident that took
+# down 1.7.0-rc1 and rc2 (#1390).
+#
+# Rather than copy-pasting more attempts (Actions cannot loop over a `uses:`
+# step), this waits until the log answers again, up to a minutes-scale
+# deadline. That both covers a longer outage and returns as soon as the service
+# is actually back, instead of burning a fixed interval either way.
+#
+# Always exits 0. Deciding the release's fate belongs to the retry step; a
+# non-zero exit here would abort the job before that retry ever ran.
+#
+# Env:
+#   REKOR_URL             transparency log base URL (default: public good instance)
+#   REKOR_SETTLE_SECONDS  quiet period before the first probe (default: 30)
+#   REKOR_PROBE_INTERVAL  seconds between probes (default: 30)
+#   REKOR_WAIT_SECONDS    total budget before giving up and retrying anyway
+#                         (default: 600)
+
+set -uo pipefail
+
+REKOR_URL="${REKOR_URL:-https://rekor.sigstore.dev}"
+REKOR_SETTLE_SECONDS="${REKOR_SETTLE_SECONDS:-30}"
+REKOR_PROBE_INTERVAL="${REKOR_PROBE_INTERVAL:-30}"
+REKOR_WAIT_SECONDS="${REKOR_WAIT_SECONDS:-600}"
+
+probe_url="${REKOR_URL%/}/api/v1/log"
+
+# The attestation may have failed for a reason that has nothing to do with the
+# log being down, in which case an immediate probe would succeed and we would
+# retry straight back into the same broken state. Settle first, always.
+echo "Attestation failed; settling ${REKOR_SETTLE_SECONDS}s before probing ${probe_url}"
+sleep "$REKOR_SETTLE_SECONDS"
+waited="$REKOR_SETTLE_SECONDS"
+
+while true; do
+  if curl -fsS --max-time 10 -o /dev/null "$probe_url"; then
+    echo "✓ Transparency log responding after ${waited}s -- retrying attestation"
+    exit 0
+  fi
+
+  if [ "$waited" -ge "$REKOR_WAIT_SECONDS" ]; then
+    echo "Transparency log still unreachable after ${waited}s -- retrying anyway"
+    exit 0
+  fi
+
+  echo "Transparency log unreachable after ${waited}s; probing again in ${REKOR_PROBE_INTERVAL}s"
+  sleep "$REKOR_PROBE_INTERVAL"
+  waited=$((waited + REKOR_PROBE_INTERVAL))
+done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -926,7 +926,9 @@ jobs:
     name: Publish Release
     needs: [validate, finalize, build-and-test, vulnix-gate]
     runs-on: ubuntu-24.04
-    timeout-minutes: 30
+    # Publishing runs ~5min; the headroom is for the two attestation waits,
+    # which can spend up to 10min each riding out a Rekor outage (#1399).
+    timeout-minutes: 45
     permissions:
       contents: write       # create the release tag ref
       packages: write       # push images to GHCR
@@ -1198,9 +1200,13 @@ jobs:
           subject-digest: ${{ steps.digest.outputs.digest }}
           push-to-registry: true
 
-      - name: Wait before retrying build provenance attestation
+      # The action's own Rekor retries cover only ~47s (#1399); wait for the
+      # transparency log to come back rather than burning a fixed interval.
+      - name: Wait for the transparency log before retrying provenance
         if: steps.attest_provenance.outcome == 'failure'
-        run: sleep 30
+        env:
+          REKOR_WAIT_SECONDS: '600'
+        run: bash "${GITHUB_WORKSPACE}/.github/scripts/wait-for-rekor.sh"
 
       - name: Attest build provenance (retry)
         if: steps.attest_provenance.outcome == 'failure'
@@ -1220,9 +1226,11 @@ jobs:
           sbom-path: /tmp/sbom.spdx.json
           push-to-registry: true
 
-      - name: Wait before retrying SBOM attestation
+      - name: Wait for the transparency log before retrying SBOM attestation
         if: steps.attest_sbom.outcome == 'failure'
-        run: sleep 30
+        env:
+          REKOR_WAIT_SECONDS: '600'
+        run: bash "${GITHUB_WORKSPACE}/.github/scripts/wait-for-rekor.sh"
 
       - name: Attest SBOM (retry)
         if: steps.attest_sbom.outcome == 'failure'

--- a/tests/bats/wait-for-rekor.bats
+++ b/tests/bats/wait-for-rekor.bats
@@ -1,0 +1,102 @@
+#!/usr/bin/env bats
+# BATS tests for the attestation backoff helper (#1399).
+#
+# The helper stands between a failed attestation attempt and its retry. It must
+# wait for the transparency log to actually come back rather than sleeping a
+# fixed interval, and it must never fail the step itself -- failing the release
+# is the retry step's job, not the wait's.
+
+setup() {
+  load test_helper
+  SCRIPT="${PROJECT_ROOT}/.github/scripts/wait-for-rekor.sh"
+
+  STUB_DIR="${BATS_TEST_TMPDIR}/stubs"
+  mkdir -p "$STUB_DIR"
+
+  # Simulated clock: sleeps return immediately so the deadline logic is
+  # exercised without spending real seconds.
+  cat >"${STUB_DIR}/sleep" <<'STUB'
+#!/usr/bin/env bash
+echo "sleep $1" >>"${SLEEP_LOG}"
+STUB
+  chmod +x "${STUB_DIR}/sleep"
+
+  export SLEEP_LOG="${BATS_TEST_TMPDIR}/sleeps"
+  export CURL_LOG="${BATS_TEST_TMPDIR}/curls"
+  : >"$SLEEP_LOG"
+  : >"$CURL_LOG"
+
+  export PATH="${STUB_DIR}:${PATH}"
+  export REKOR_SETTLE_SECONDS=30
+  export REKOR_PROBE_INTERVAL=30
+  export REKOR_WAIT_SECONDS=600
+}
+
+# Install a curl stub that fails $1 times before succeeding.
+stub_curl_failing_times() {
+  cat >"${STUB_DIR}/curl" <<STUB
+#!/usr/bin/env bash
+echo "\$*" >>"\${CURL_LOG}"
+attempts=\$(wc -l <"\${CURL_LOG}")
+[ "\$attempts" -gt "$1" ]
+STUB
+  chmod +x "${STUB_DIR}/curl"
+}
+
+@test "wait-for-rekor returns as soon as the transparency log answers" {
+  stub_curl_failing_times 0
+
+  run bash "$SCRIPT"
+  assert_success
+  assert_output --partial "responding"
+
+  # One settle sleep, then a successful probe -- no further waiting.
+  assert_equal 1 "$(wc -l <"$SLEEP_LOG")"
+}
+
+@test "wait-for-rekor keeps probing while the log is down" {
+  stub_curl_failing_times 3
+
+  run bash "$SCRIPT"
+  assert_success
+  assert_output --partial "responding"
+
+  # Four probes: three refused, the fourth answered.
+  assert_equal 4 "$(wc -l <"$CURL_LOG")"
+}
+
+@test "wait-for-rekor gives up at the deadline without failing the step" {
+  stub_curl_failing_times 9999
+  export REKOR_WAIT_SECONDS=120
+
+  run bash "$SCRIPT"
+  # Never non-zero: the retry step is what decides the release's fate. A
+  # failing wait would abort the job before the retry ever ran.
+  assert_success
+  assert_output --partial "still unreachable"
+
+  # Settle (30) + probes at 60/90/120 -- bounded by the deadline, not endless.
+  assert_equal 4 "$(wc -l <"$SLEEP_LOG")"
+}
+
+@test "wait-for-rekor probes the configured transparency log" {
+  stub_curl_failing_times 0
+  export REKOR_URL="https://rekor.example.test"
+
+  run bash "$SCRIPT"
+  assert_success
+  assert_output --partial "https://rekor.example.test/api/v1/log"
+  run cat "$CURL_LOG"
+  assert_output --partial "https://rekor.example.test/api/v1/log"
+}
+
+@test "wait-for-rekor settles before its first probe" {
+  # The failure may not have been Rekor at all; probing instantly would retry
+  # into the same broken state.
+  stub_curl_failing_times 0
+
+  run bash "$SCRIPT"
+  assert_success
+  run head -n 1 "$SLEEP_LOG"
+  assert_output "sleep 30"
+}

--- a/tests/test_workflow_attest_retry_backoff.py
+++ b/tests/test_workflow_attest_retry_backoff.py
@@ -38,9 +38,13 @@ ATTEMPT_IDS = ("attest_provenance", "attest_sbom")
 MINIMUM_WAIT_SECONDS = 300
 
 
-def _publish_steps() -> list[dict]:
+def _publish_job() -> dict:
     workflow = yaml.safe_load(RELEASE_WORKFLOW.read_text(encoding="utf-8"))
-    return workflow["jobs"]["publish"]["steps"]
+    return workflow["jobs"]["publish"]
+
+
+def _publish_steps() -> list[dict]:
+    return _publish_job()["steps"]
 
 
 def _triple(attempt_id: str) -> tuple[dict, dict, dict]:
@@ -83,6 +87,23 @@ def test_attestation_waits_span_minutes() -> None:
             f"the wait after {attempt_id} allows only {deadline}s; a Rekor "
             f"incident needs at least {MINIMUM_WAIT_SECONDS}s of cover (#1399)"
         )
+
+
+def test_job_timeout_outlasts_both_waits() -> None:
+    """A wait longer than the job timeout would just fail the release later."""
+    job = _publish_job()
+    waits = sum(
+        int(_triple(attempt_id)[1]["env"]["REKOR_WAIT_SECONDS"])
+        for attempt_id in ATTEMPT_IDS
+    )
+    # Publishing itself runs ~5 minutes (measured across the 1.7.0 candidates);
+    # the rest is headroom for the attempts either side of each wait.
+    required = waits / 60 + 15
+    assert job["timeout-minutes"] >= required, (
+        f"publish times out after {job['timeout-minutes']}min but both waits "
+        f"can burn {waits / 60:.0f}min; the job needs >= {required:.0f}min or "
+        "the widened backoff dies on the timeout instead (#1399)"
+    )
 
 
 def test_wait_runs_only_when_the_first_attempt_failed() -> None:

--- a/tests/test_workflow_attest_retry_backoff.py
+++ b/tests/test_workflow_attest_retry_backoff.py
@@ -1,0 +1,136 @@
+"""Workflow-shape tests: the attestation retry envelope survives a Rekor outage.
+
+Issue #1399 (follow-up from #1390): 1.7.0-rc1 and rc2 both died in ``publish``
+when the public-good Sigstore transparency log timed out. The action already
+retries internally -- ``@actions/attest`` hardcodes ``DEFAULT_TIMEOUT = 10000``
+and ``DEFAULT_RETRIES = 3`` into the Rekor witness, giving 4 attempts at
+0/+1/+2/+4s, roughly 47s per action step -- and exposes no input to widen that.
+The outer retry in this workflow is therefore the only lever we control, and a
+fixed ``sleep 30`` brought the whole envelope to about 2 minutes, shorter than a
+typical Sigstore incident.
+
+The fix keeps exactly two attempts per attestation (GitHub Actions cannot loop
+over a ``uses:`` step, so more attempts would mean more copy-paste) and instead
+makes the wait between them adaptive: poll the transparency log until it answers
+again, up to a minutes-scale deadline.
+
+Refs: #1399
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+# Repository root (tests/ -> repo root).
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+RELEASE_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "release.yml"
+WAIT_SCRIPT = REPO_ROOT / ".github" / "scripts" / "wait-for-rekor.sh"
+
+# Each attestation is a triple: attempt (soft-failing) -> wait -> retry (hard).
+# Keyed by the id of the first attempt.
+ATTEMPT_IDS = ("attest_provenance", "attest_sbom")
+
+# The outer wait must be measured in minutes: a Sigstore incident outlasts the
+# ~47s the action already spends on its own internal retries.
+MINIMUM_WAIT_SECONDS = 300
+
+
+def _publish_steps() -> list[dict]:
+    workflow = yaml.safe_load(RELEASE_WORKFLOW.read_text(encoding="utf-8"))
+    return workflow["jobs"]["publish"]["steps"]
+
+
+def _triple(attempt_id: str) -> tuple[dict, dict, dict]:
+    """Return the (attempt, wait, retry) steps for one attestation."""
+    steps = _publish_steps()
+    index = next(i for i, step in enumerate(steps) if step.get("id") == attempt_id)
+    attempt, wait, retry = steps[index : index + 3]
+    return attempt, wait, retry
+
+
+def test_wait_script_exists() -> None:
+    """The shared wait helper is what both attestations call."""
+    assert WAIT_SCRIPT.is_file(), (
+        f"{WAIT_SCRIPT.relative_to(REPO_ROOT)} must exist: both attestation "
+        "waits source their backoff from it (#1399)"
+    )
+
+
+def test_attestation_waits_poll_the_transparency_log() -> None:
+    """No fixed `sleep` — the wait probes Rekor until it recovers."""
+    for attempt_id in ATTEMPT_IDS:
+        _, wait, _ = _triple(attempt_id)
+        run = wait.get("run", "")
+        assert "wait-for-rekor.sh" in run, (
+            f"the wait after {attempt_id} must call wait-for-rekor.sh, not "
+            f"sleep a fixed interval; got {run!r} (#1399)"
+        )
+        assert "sleep" not in run, (
+            f"the wait after {attempt_id} must not hardcode a sleep: a fixed "
+            "30s gap is shorter than a Sigstore incident (#1399)"
+        )
+
+
+def test_attestation_waits_span_minutes() -> None:
+    """The deadline is minutes-scale, not the old 30 seconds."""
+    for attempt_id in ATTEMPT_IDS:
+        _, wait, _ = _triple(attempt_id)
+        deadline = int(wait.get("env", {})["REKOR_WAIT_SECONDS"])
+        assert deadline >= MINIMUM_WAIT_SECONDS, (
+            f"the wait after {attempt_id} allows only {deadline}s; a Rekor "
+            f"incident needs at least {MINIMUM_WAIT_SECONDS}s of cover (#1399)"
+        )
+
+
+def test_wait_runs_only_when_the_first_attempt_failed() -> None:
+    """The happy path stays fast: no wait when attempt 1 succeeded."""
+    for attempt_id in ATTEMPT_IDS:
+        _, wait, retry = _triple(attempt_id)
+        guard = f"steps.{attempt_id}.outcome == 'failure'"
+        for step in (wait, retry):
+            assert guard in step.get("if", ""), (
+                f"{step.get('name')!r} must be guarded by {guard!r} so a green "
+                "first attempt costs nothing (#1399)"
+            )
+
+
+def test_first_attempt_is_soft_and_the_retry_is_final() -> None:
+    """Attempt 1 may fail quietly; the retry must still fail the job."""
+    for attempt_id in ATTEMPT_IDS:
+        attempt, _, retry = _triple(attempt_id)
+        assert attempt.get("continue-on-error") is True, (
+            f"{attempt_id} must be continue-on-error so the wait can run (#1399)"
+        )
+        assert "continue-on-error" not in retry, (
+            f"the retry after {attempt_id} must fail the job: a release must "
+            "never be published with a silently skipped attestation (#1399)"
+        )
+
+
+def test_retry_attests_exactly_what_the_first_attempt_did() -> None:
+    """Retry and attempt stay in lockstep — same action, same subject."""
+    for attempt_id in ATTEMPT_IDS:
+        attempt, _, retry = _triple(attempt_id)
+        assert retry["uses"] == attempt["uses"], (
+            f"the retry after {attempt_id} must use the same pinned action"
+        )
+        assert retry["with"] == attempt["with"], (
+            f"the retry after {attempt_id} must attest the same subject"
+        )
+
+
+def test_no_third_copy_of_the_attestation_steps() -> None:
+    """Widening the envelope must not mean more copy-pasted `uses:` blocks."""
+    attest_steps = [
+        step
+        for step in _publish_steps()
+        if str(step.get("uses", "")).startswith("actions/attest")
+    ]
+    assert len(attest_steps) == 2 * len(ATTEMPT_IDS), (
+        "expected exactly one attempt and one retry per attestation; extra "
+        "copies mean the backoff was widened by duplication instead of by "
+        "polling (#1399)"
+    )


### PR DESCRIPTION
## Summary

1.7.0-rc1 and rc2 both died in `publish` when the public-good Sigstore
transparency log timed out. The outer retry we had — `sleep 30` between two
attempts — capped the whole envelope at about 2 minutes, shorter than the
incident that hit us.

The action already retries internally, so widening had to happen on our side:
`@actions/attest` hardcodes `DEFAULT_TIMEOUT = 10000` and `DEFAULT_RETRIES = 3`
into the Rekor witness (4 attempts at 0/+1/+2/+4s, ~47s per step) and exposes no
input to change it. Confirmed against the pinned bundle; `OCI_TIMEOUT` /
`OCI_RETRY` apply to the registry push, not to Rekor.

Since Actions cannot loop over a `uses:` step, more attempts would have meant a
third and fourth copy of each attestation block. Instead the **wait** got
smarter: it polls the transparency log until it answers again, up to a 10-minute
budget, and returns the moment the service is actually back.

## Changes

- **`.github/scripts/wait-for-rekor.sh`** (new) — settles 30s, then probes
  `${REKOR_URL}/api/v1/log` every 30s until it responds or the budget runs out.
  Always exits 0: deciding the release's fate is the retry step's job, and a
  non-zero exit here would abort the job before that retry ever ran. Tunable via
  `REKOR_URL` / `REKOR_SETTLE_SECONDS` / `REKOR_PROBE_INTERVAL` /
  `REKOR_WAIT_SECONDS`.
- **`release.yml`** — both attestation waits (provenance and SBOM) call the
  helper with a 600s budget instead of `sleep 30`. Attempt/retry structure is
  otherwise untouched: attempt 1 stays `continue-on-error`, the retry still
  fails the job.
- **`release.yml`** — `publish` timeout raised 30 → 45 min. Publishing itself
  runs ~5 min (measured across the 1.7.0 candidates); two full waits could burn
  20 min, which would have hit the old ceiling and failed the release on the
  timeout instead.

Coverage goes from ~2 minutes to ~12 per attestation, and the common case gets
*faster* — a 40-second blip no longer costs a flat 30-second sleep.

## Testing

- `tests/bats/wait-for-rekor.bats` (new, 5 tests) — stubs `curl` and `sleep` to
  drive a simulated clock: returns as soon as the log answers, keeps probing
  while it is down, gives up at the deadline **without failing the step**,
  probes the configured URL, and always settles before the first probe.
- `tests/test_workflow_attest_retry_backoff.py` (new, 8 tests) — workflow shape:
  waits poll rather than sleep, the budget is minutes-scale, the guards keep the
  happy path free, attempt 1 is soft and the retry is final, retry and attempt
  stay in lockstep, no third copy of the `uses:` blocks, and the job timeout
  outlasts both waits.
- Full local suite green: 590 bats, 462 pytest (docker/image/integration
  deselected locally, CI covers them), `just precommit` clean including
  actionlint and shellcheck.

## Notes

The remaining acceptance criterion — exercising this on a release candidate — is
inherently deferred to the next train; the path only runs when an attestation
actually fails, so it cannot be proven green in PR CI.

Out of scope, recorded on the issue: the undocumented `private-signing` input
would sidestep public-good Rekor entirely but destroys public verifiability, and
decoupling SBOM attestation from the publish critical path is a larger design
change that deserves its own issue if this proves insufficient.

Closes #1399
