### PR TITLE
fix(sync): auto-resolve post-release main->dev sync conflicts

### DIFF
--- a/.github/workflows/sync-main-to-dev.yml
+++ b/.github/workflows/sync-main-to-dev.yml
@@ -9,6 +9,9 @@
 #   sync  - clean up stale sync branches
 #         - merge-tree (in-memory) merge to detect conflicts
 #         - create chore/sync-main-to-dev-<run>-<attempt> branch via git push
+#         - auto-resolve conflicts confined to generated doc snapshots
+#           (docs/issues, docs/pull-requests) by committing dev's copies to the
+#           sync branch via commit-action (signed), then re-verify (#1403)
 #         - open PR; enable auto-merge when clean, or label "merge-conflict" with
 #           resolution instructions when conflicts exist
 #
@@ -211,12 +214,131 @@ jobs:
             git push origin "${SYNC_BRANCH}"
           echo "Sync branch ${SYNC_BRANCH} pushed from main at ${MAIN_SHA}"
 
+      # docs/issues and docs/pull-requests snapshots are generated
+      # independently on dev (nightly sync-issues) and on the release branch
+      # (release-time sync-issues), so a release produces add/add conflicts on
+      # paths absent at the merge base (#1403). The signed-commits ruleset
+      # forbids a plain runner merge commit, so resolution is a single-parent
+      # commit-action commit that sets the sync branch's copy of each
+      # conflicted snapshot to DEV's content: with both sides identical the
+      # conflict vanishes, and dev's possibly-staler snapshot self-heals at
+      # the next nightly sync-issues run. Anything outside the snapshot dirs
+      # (or a delete/modify conflict) falls back to the manual path.
+      - name: Auto-resolve generated doc snapshot conflicts
+        if: >-
+          steps.existing-pr.outputs.count == '0'
+          && steps.recheck.outputs.up_to_date != 'true'
+          && steps.merge-check.outputs.conflict == 'true'
+        id: auto-resolve
+        run: |
+          set -euo pipefail
+          # Re-probe with --name-only to enumerate conflicted paths. Exit 1
+          # (conflict) is the expected outcome; anything else is a real error.
+          if merge_out="$(git merge-tree --write-tree --name-only origin/dev origin/main)"; then
+            echo "eligible=false" >> "$GITHUB_OUTPUT"
+            echo "Merge is clean on re-probe; nothing to auto-resolve."
+            exit 0
+          else
+            merge_rc=$?
+            if [ "${merge_rc}" -ne 1 ]; then
+              echo "::error::git merge-tree failed with exit code ${merge_rc}"
+              echo "${merge_out}"
+              exit "${merge_rc}"
+            fi
+          fi
+
+          # Output shape: line 1 = tree OID, then one conflicted path per
+          # line until the first blank line (informational messages follow).
+          mapfile -t conflicted < <(printf '%s\n' "${merge_out}" | sed -n '2,/^$/p' | sed '/^$/d' | sort -u)
+
+          if [ "${#conflicted[@]}" -eq 0 ]; then
+            echo "eligible=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::merge-tree reported a conflict but no conflicted paths were parsed."
+            exit 0
+          fi
+
+          # Only generated snapshots are eligible, and only when dev still
+          # carries the path: a delete/modify conflict cannot be expressed as
+          # a working-tree file commit, so it stays on the manual path.
+          eligible=true
+          for path in "${conflicted[@]}"; do
+            case "${path}" in
+              docs/issues/*|docs/pull-requests/*) ;;
+              *)
+                echo "Conflicted path outside the snapshot allowlist: ${path}"
+                eligible=false
+                break
+                ;;
+            esac
+            if ! git cat-file -e "origin/dev:${path}" 2>/dev/null; then
+              echo "Conflicted path missing from origin/dev (delete/modify): ${path}"
+              eligible=false
+              break
+            fi
+          done
+
+          if [ "${eligible}" != "true" ]; then
+            echo "eligible=false" >> "$GITHUB_OUTPUT"
+            echo "Conflicts are not limited to dev-side doc snapshots; keeping the manual-resolution path."
+            exit 0
+          fi
+
+          # Materialize dev's side in the working tree (checked out on the
+          # sync branch). commit-action reads these files and commits them to
+          # the remote branch as a GitHub-signed single-parent commit.
+          git checkout origin/dev -- "${conflicted[@]}"
+
+          {
+            echo "file_paths<<PATHS_EOF"
+            printf '%s\n' "${conflicted[@]}"
+            echo "PATHS_EOF"
+          } >> "$GITHUB_OUTPUT"
+          echo "eligible=true" >> "$GITHUB_OUTPUT"
+          echo "Auto-resolving ${#conflicted[@]} snapshot path(s) to dev's content."
+
+      - name: Commit dev-side doc snapshots
+        if: steps.auto-resolve.outputs.eligible == 'true'
+        uses: vig-os/commit-action@0361e9aa65b64711a18286ac5dfdcba7cc7a2ac7  # v0.3.2
+        env:
+          GH_TOKEN: ${{ steps.commit-app-token.outputs.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          TARGET_BRANCH: refs/heads/${{ env.SYNC_BRANCH }}
+          MAX_ATTEMPTS: "3"
+          ALLOW_EMPTY: "true"
+          COMMIT_MESSAGE: "chore: align generated doc snapshots with dev for a clean sync"
+          FILE_PATHS: ${{ steps.auto-resolve.outputs.file_paths }}
+
+      - name: Re-verify merge after auto-resolve
+        if: steps.auto-resolve.outputs.eligible == 'true'
+        id: reverify
+        run: |
+          set -euo pipefail
+          retry --retries 3 --backoff 3 --max-backoff 20 -- git fetch origin "${SYNC_BRANCH}" dev
+          if merge_out="$(git merge-tree --write-tree origin/dev "origin/${SYNC_BRANCH}" 2>&1)"; then
+            echo "conflict=false" >> "$GITHUB_OUTPUT"
+            echo "Auto-resolve verified: origin/dev merges cleanly into origin/${SYNC_BRANCH}."
+          else
+            merge_rc=$?
+            if [ "${merge_rc}" -eq 1 ]; then
+              echo "conflict=true" >> "$GITHUB_OUTPUT"
+              echo "::warning::Conflicts remain after auto-resolve; falling back to manual resolution."
+              echo "${merge_out}"
+            else
+              echo "::error::git merge-tree failed with exit code ${merge_rc}"
+              echo "${merge_out}"
+              exit "${merge_rc}"
+            fi
+          fi
+
       - name: Create PR
         if: steps.existing-pr.outputs.count == '0' && steps.recheck.outputs.up_to_date != 'true'
         id: create-pr
         env:
           GH_TOKEN: ${{ steps.release-app-token.outputs.token }}
-          CONFLICT: ${{ steps.merge-check.outputs.conflict }}
+          # reverify's output is '' when auto-resolve was skipped or
+          # ineligible, so this falls back to merge-check — the manual
+          # path is preserved bit-for-bit for non-snapshot conflicts.
+          CONFLICT: ${{ steps.reverify.outputs.conflict || steps.merge-check.outputs.conflict }}
         run: |
           set -euo pipefail
 
@@ -266,7 +388,7 @@ jobs:
       - name: Enable auto-merge
         if: >-
           steps.create-pr.outputs.pr_url != ''
-          && steps.merge-check.outputs.conflict != 'true'
+          && (steps.reverify.outputs.conflict || steps.merge-check.outputs.conflict) != 'true'
         env:
           GH_TOKEN: ${{ steps.release-app-token.outputs.token }}
           PR_URL: ${{ steps.create-pr.outputs.pr_url }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Automated main→dev sync PR no longer opens conflicted on every release** ([#1403](https://github.com/vig-os/devkit/issues/1403))
+  - `sync-main-to-dev` now auto-resolves add/add conflicts on generated
+    `docs/issues/` / `docs/pull-requests/` snapshots: a GitHub-signed
+    commit-action commit aligns the sync branch with dev's copies (the
+    signed-commits ruleset forbids a runner merge commit; dev self-heals at
+    the next nightly sync-issues run), the merge is re-verified with
+    `git merge-tree`, and only then is auto-merge enabled. Any other
+    conflict keeps the manual `merge-conflict` path. Applied to both the
+    canonical workflow and the workspace template.
+  - Smoke deploys preserve the consumer's root `CHANGELOG.md` (root-anchored
+    rsync exclude; the scaffold skeleton is bootstrapped only when absent)
+    instead of overwriting it with devkit's release history — the old copy
+    rewrote the consumer's frozen `## [X.Y.Z] - TBD` heading with devkit's
+    dated release line, guaranteeing a sync conflict at every smoke release.
+  - The smoke-test deploy-entry seeding awk is bounded at the next release
+    heading and synthesizes `### Changed` when `## Unreleased` lacks one.
 - **Smoke-test failure-notify job can mint its upstream App token again** ([#1396](https://github.com/vig-os/devkit/issues/1396))
   - The listener's notify job requested an installation token for the
     pre-rename `vig-os/devcontainer` repository, so the mint failed with 404

--- a/assets/init-workspace.sh
+++ b/assets/init-workspace.sh
@@ -1850,8 +1850,13 @@ echo "Copying files from $TEMPLATE_DIR to $WORKSPACE_DIR..."
 # silently skips it. Content comparison is the only sound check here; the
 # template is small, so the cost is negligible.
 if [[ "$SMOKE_TEST" == "true" ]]; then
-    # Smoke mode: clean deploy (--delete removes stale files), then overlay smoke-test assets
-    rsync -avL --checksum --delete --exclude='.git' --exclude='.venv' --exclude='docs/issues/' --exclude='docs/pull-requests/' "$TEMPLATE_DIR/" "$WORKSPACE_DIR/"
+    # Smoke mode: clean deploy (--delete removes stale files), then overlay
+    # smoke-test assets. /CHANGELOG.md is root-anchored (#953 semantics): the
+    # consumer's ROOT changelog is consumer state — its own frozen release
+    # history (## [X.Y.Z] - TBD) must survive re-deploys (#1403). The anchor
+    # keeps .devcontainer/CHANGELOG.md (devkit's manifest mirror) syncing, and
+    # the exclude also shields the root file from --delete.
+    rsync -avL --checksum --delete --exclude='.git' --exclude='.venv' --exclude='/CHANGELOG.md' --exclude='docs/issues/' --exclude='docs/pull-requests/' "$TEMPLATE_DIR/" "$WORKSPACE_DIR/"
 
     SMOKE_TEST_DIR="$SCRIPT_DIR/smoke-test"
     if [[ -d "$SMOKE_TEST_DIR" ]]; then
@@ -1861,16 +1866,17 @@ if [[ "$SMOKE_TEST" == "true" ]]; then
         echo "Warning: Smoke-test directory not found at $SMOKE_TEST_DIR" >&2
     fi
 
-    # Workspace scaffold CHANGELOG is empty; copy devcontainer changelog and
-    # rename top ## [version] - … to ## Unreleased for downstream prepare-release.
-    if [[ -f "$WORKSPACE_DIR/.devcontainer/CHANGELOG.md" ]]; then
-        echo "Syncing workspace CHANGELOG from .devcontainer/CHANGELOG.md (smoke-test)..."
-        cp "$WORKSPACE_DIR/.devcontainer/CHANGELOG.md" "$WORKSPACE_DIR/CHANGELOG.md"
-        if ! command -v prepare-changelog >/dev/null 2>&1; then
-            echo "ERROR: prepare-changelog not found (required for smoke-test CHANGELOG sync)" >&2
-            exit 1
-        fi
-        prepare-changelog unprepare "$WORKSPACE_DIR/CHANGELOG.md"
+    # First deploy only: bootstrap the workspace scaffold CHANGELOG
+    # (## Unreleased skeleton). Later deploys never touch the consumer's
+    # changelog; devkit's own history lives in .devcontainer/CHANGELOG.md.
+    # The old cp + `prepare-changelog unprepare` here rewrote the consumer's
+    # frozen ## [X.Y.Z] - TBD heading with devkit's dated release line
+    # (unprepare no-ops since #590 — the first heading is always
+    # ## Unreleased), guaranteeing a main<->dev sync conflict at every smoke
+    # release (#1403).
+    if [[ ! -f "$WORKSPACE_DIR/CHANGELOG.md" ]]; then
+        echo "Bootstrapping workspace CHANGELOG.md from template scaffold..."
+        cp -L "$TEMPLATE_DIR/CHANGELOG.md" "$WORKSPACE_DIR/CHANGELOG.md"
     fi
 else
     # Build exclude list for preserved files that already exist

--- a/assets/smoke-test/.github/workflows/repository-dispatch.yml
+++ b/assets/smoke-test/.github/workflows/repository-dispatch.yml
@@ -274,13 +274,39 @@ jobs:
             exit 0
           fi
           tmp="$(mktemp)"
+          # Bounded at the next ^## [ heading (#1403): the old version never
+          # cleared in_unreleased, so with an empty Unreleased the bullet
+          # leaked into the first ### Changed of a RELEASED section. When
+          # Unreleased lacks a ### Changed subheading, synthesize one so the
+          # bullet still lands inside Unreleased (defensive: prepare-changelog
+          # always emits the full category skeleton).
           awk -v tag="$TAG" '
-            { print }
-            /^## Unreleased$/ {in_unreleased=1; next}
-            in_unreleased && /^### Changed$/ {
+            function emit_entry() {
               print ""
               print "- **Smoke-test deploy of " tag "** -- automated devcontainer release-pipeline validation; no functional changes"
+              seeded=1
+            }
+            /^## Unreleased$/ {print; in_unreleased=1; next}
+            in_unreleased && !seeded && /^## \[/ {
+              print "### Changed"
+              emit_entry()
+              print ""
               in_unreleased=0
+              print
+              next
+            }
+            in_unreleased && !seeded && /^### Changed$/ {
+              print
+              emit_entry()
+              in_unreleased=0
+              next
+            }
+            { print }
+            END {
+              if (in_unreleased && !seeded) {
+                print "### Changed"
+                emit_entry()
+              }
             }
           ' CHANGELOG.md > "$tmp"
           mv "$tmp" CHANGELOG.md

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -17,6 +17,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Automated main→dev sync PR no longer opens conflicted on every release** ([#1403](https://github.com/vig-os/devkit/issues/1403))
+  - `sync-main-to-dev` now auto-resolves add/add conflicts on generated
+    `docs/issues/` / `docs/pull-requests/` snapshots: a GitHub-signed
+    commit-action commit aligns the sync branch with dev's copies (the
+    signed-commits ruleset forbids a runner merge commit; dev self-heals at
+    the next nightly sync-issues run), the merge is re-verified with
+    `git merge-tree`, and only then is auto-merge enabled. Any other
+    conflict keeps the manual `merge-conflict` path. Applied to both the
+    canonical workflow and the workspace template.
+  - Smoke deploys preserve the consumer's root `CHANGELOG.md` (root-anchored
+    rsync exclude; the scaffold skeleton is bootstrapped only when absent)
+    instead of overwriting it with devkit's release history — the old copy
+    rewrote the consumer's frozen `## [X.Y.Z] - TBD` heading with devkit's
+    dated release line, guaranteeing a sync conflict at every smoke release.
+  - The smoke-test deploy-entry seeding awk is bounded at the next release
+    heading and synthesizes `### Changed` when `## Unreleased` lacks one.
 - **Smoke-test failure-notify job can mint its upstream App token again** ([#1396](https://github.com/vig-os/devkit/issues/1396))
   - The listener's notify job requested an installation token for the
     pre-rename `vig-os/devcontainer` repository, so the mint failed with 404

--- a/assets/workspace/.github/workflows/sync-main-to-dev.yml
+++ b/assets/workspace/.github/workflows/sync-main-to-dev.yml
@@ -12,6 +12,9 @@
 #   sync  - clean up stale sync branches
 #         - merge-tree (in-memory) merge to detect conflicts
 #         - create chore/sync-main-to-dev-<run>-<attempt> branch via git push
+#         - auto-resolve conflicts confined to generated doc snapshots
+#           (docs/issues, docs/pull-requests) by committing dev's copies to the
+#           sync branch via commit-action (signed), then re-verify (#1403)
 #         - open PR; enable auto-merge when clean, or label "merge-conflict" with
 #           resolution instructions when conflicts exist
 #
@@ -253,12 +256,131 @@ jobs:
             git push origin "${SYNC_BRANCH}"
           echo "Sync branch ${SYNC_BRANCH} pushed from main at ${MAIN_SHA}"
 
+      # docs/issues and docs/pull-requests snapshots are generated
+      # independently on dev (nightly sync-issues) and on the release branch
+      # (release-time sync-issues), so a release produces add/add conflicts on
+      # paths absent at the merge base (#1403). The signed-commits ruleset
+      # forbids a plain runner merge commit, so resolution is a single-parent
+      # commit-action commit that sets the sync branch's copy of each
+      # conflicted snapshot to DEV's content: with both sides identical the
+      # conflict vanishes, and dev's possibly-staler snapshot self-heals at
+      # the next nightly sync-issues run. Anything outside the snapshot dirs
+      # (or a delete/modify conflict) falls back to the manual path.
+      - name: Auto-resolve generated doc snapshot conflicts
+        if: >-
+          steps.existing-pr.outputs.count == '0'
+          && steps.recheck.outputs.up_to_date != 'true'
+          && steps.merge-check.outputs.conflict == 'true'
+        id: auto-resolve
+        run: |
+          set -euo pipefail
+          # Re-probe with --name-only to enumerate conflicted paths. Exit 1
+          # (conflict) is the expected outcome; anything else is a real error.
+          if merge_out="$(git merge-tree --write-tree --name-only origin/dev origin/main)"; then
+            echo "eligible=false" >> "$GITHUB_OUTPUT"
+            echo "Merge is clean on re-probe; nothing to auto-resolve."
+            exit 0
+          else
+            merge_rc=$?
+            if [ "${merge_rc}" -ne 1 ]; then
+              echo "::error::git merge-tree failed with exit code ${merge_rc}"
+              echo "${merge_out}"
+              exit "${merge_rc}"
+            fi
+          fi
+
+          # Output shape: line 1 = tree OID, then one conflicted path per
+          # line until the first blank line (informational messages follow).
+          mapfile -t conflicted < <(printf '%s\n' "${merge_out}" | sed -n '2,/^$/p' | sed '/^$/d' | sort -u)
+
+          if [ "${#conflicted[@]}" -eq 0 ]; then
+            echo "eligible=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::merge-tree reported a conflict but no conflicted paths were parsed."
+            exit 0
+          fi
+
+          # Only generated snapshots are eligible, and only when dev still
+          # carries the path: a delete/modify conflict cannot be expressed as
+          # a working-tree file commit, so it stays on the manual path.
+          eligible=true
+          for path in "${conflicted[@]}"; do
+            case "${path}" in
+              docs/issues/*|docs/pull-requests/*) ;;
+              *)
+                echo "Conflicted path outside the snapshot allowlist: ${path}"
+                eligible=false
+                break
+                ;;
+            esac
+            if ! git cat-file -e "origin/dev:${path}" 2>/dev/null; then
+              echo "Conflicted path missing from origin/dev (delete/modify): ${path}"
+              eligible=false
+              break
+            fi
+          done
+
+          if [ "${eligible}" != "true" ]; then
+            echo "eligible=false" >> "$GITHUB_OUTPUT"
+            echo "Conflicts are not limited to dev-side doc snapshots; keeping the manual-resolution path."
+            exit 0
+          fi
+
+          # Materialize dev's side in the working tree (checked out on the
+          # sync branch). commit-action reads these files and commits them to
+          # the remote branch as a GitHub-signed single-parent commit.
+          git checkout origin/dev -- "${conflicted[@]}"
+
+          {
+            echo "file_paths<<PATHS_EOF"
+            printf '%s\n' "${conflicted[@]}"
+            echo "PATHS_EOF"
+          } >> "$GITHUB_OUTPUT"
+          echo "eligible=true" >> "$GITHUB_OUTPUT"
+          echo "Auto-resolving ${#conflicted[@]} snapshot path(s) to dev's content."
+
+      - name: Commit dev-side doc snapshots
+        if: steps.auto-resolve.outputs.eligible == 'true'
+        uses: vig-os/commit-action@0361e9aa65b64711a18286ac5dfdcba7cc7a2ac7  # v0.3.2
+        env:
+          GH_TOKEN: ${{ steps.commit-app-token.outputs.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          TARGET_BRANCH: refs/heads/${{ env.SYNC_BRANCH }}
+          MAX_ATTEMPTS: "3"
+          ALLOW_EMPTY: "true"
+          COMMIT_MESSAGE: "chore: align generated doc snapshots with dev for a clean sync"
+          FILE_PATHS: ${{ steps.auto-resolve.outputs.file_paths }}
+
+      - name: Re-verify merge after auto-resolve
+        if: steps.auto-resolve.outputs.eligible == 'true'
+        id: reverify
+        run: |
+          set -euo pipefail
+          retry --retries 3 --backoff 3 --max-backoff 20 -- git fetch origin "${SYNC_BRANCH}" dev
+          if merge_out="$(git merge-tree --write-tree origin/dev "origin/${SYNC_BRANCH}" 2>&1)"; then
+            echo "conflict=false" >> "$GITHUB_OUTPUT"
+            echo "Auto-resolve verified: origin/dev merges cleanly into origin/${SYNC_BRANCH}."
+          else
+            merge_rc=$?
+            if [ "${merge_rc}" -eq 1 ]; then
+              echo "conflict=true" >> "$GITHUB_OUTPUT"
+              echo "::warning::Conflicts remain after auto-resolve; falling back to manual resolution."
+              echo "${merge_out}"
+            else
+              echo "::error::git merge-tree failed with exit code ${merge_rc}"
+              echo "${merge_out}"
+              exit "${merge_rc}"
+            fi
+          fi
+
       - name: Create PR
         if: steps.existing-pr.outputs.count == '0' && steps.recheck.outputs.up_to_date != 'true'
         id: create-pr
         env:
           GH_TOKEN: ${{ steps.release-app-token.outputs.token }}
-          CONFLICT: ${{ steps.merge-check.outputs.conflict }}
+          # reverify's output is '' when auto-resolve was skipped or
+          # ineligible, so this falls back to merge-check — the manual
+          # path is preserved bit-for-bit for non-snapshot conflicts.
+          CONFLICT: ${{ steps.reverify.outputs.conflict || steps.merge-check.outputs.conflict }}
         run: |
           set -euo pipefail
 
@@ -308,7 +430,7 @@ jobs:
       - name: Enable auto-merge
         if: >-
           steps.create-pr.outputs.pr_url != ''
-          && steps.merge-check.outputs.conflict != 'true'
+          && (steps.reverify.outputs.conflict || steps.merge-check.outputs.conflict) != 'true'
         env:
           GH_TOKEN: ${{ steps.release-app-token.outputs.token }}
           PR_URL: ${{ steps.create-pr.outputs.pr_url }}

--- a/tests/bats/init-workspace.bats
+++ b/tests/bats/init-workspace.bats
@@ -905,6 +905,81 @@ _preview_symlinked_template_venv() {
     assert_output --partial "--exclude='docs/pull-requests/'"
 }
 
+# ── Smoke deploys preserve the consumer's root CHANGELOG (#1403) ───────────────
+# The smoke rsync used to clobber the consumer's root CHANGELOG.md and then cp
+# devkit's own changelog over it; the `prepare-changelog unprepare` safety valve
+# no-ops since #590 (first heading is always ## Unreleased), so devkit's dated
+# `## [X.Y.Z](…devkit…)` headings replaced the consumer's frozen
+# `## [X.Y.Z] - TBD` heading — a guaranteed main<->dev sync conflict whenever
+# the versions coincide (structural for devkit-smoke-test). The root changelog
+# is consumer state: root-anchored exclude preserves it (and shields it from
+# --delete); the scaffold skeleton is bootstrapped only when the file is absent.
+
+_smoke_deploy() {
+    local ws="$1"
+    local stub="$BATS_TEST_TMPDIR/stub-smoke-bin"
+    mkdir -p "$stub"
+    printf '#!/usr/bin/env bash\nexit 0\n' >"$stub/just"
+    printf '#!/usr/bin/env bash\nexit 0\n' >"$stub/uv"
+    chmod +x "$stub/just" "$stub/uv"
+    env PATH="$stub:$PATH" \
+        TEMPLATE_DIR="$PROJECT_ROOT/assets/workspace" \
+        WORKSPACE_DIR="$ws" \
+        SHORT_NAME=testproj \
+        GITHUB_REPOSITORY=test/repo \
+        bash "$INIT_WORKSPACE_SH" --smoke-test --mode both
+}
+
+@test "smoke rsync root-anchors a CHANGELOG.md exclude (#1403)" {
+    run grep -A1 'rsync -avL --checksum --delete' "$INIT_WORKSPACE_SH"
+    assert_success
+    assert_output --partial "--exclude='/CHANGELOG.md'"
+}
+
+@test "smoke deploy preserves the consumer's root CHANGELOG.md (#1403)" {
+    ws="$BATS_TEST_TMPDIR/e2e-1403-preserve"
+    mkdir -p "$ws"
+    cat >"$ws/CHANGELOG.md" <<'EOF'
+# Changelog
+
+SENTINEL-1403 consumer changelog body
+
+## Unreleased
+
+### Changed
+
+## [9.9.9] - TBD
+
+### Changed
+
+- **Smoke-test deploy of 9.9.8** -- previous deploy entry
+EOF
+    run _smoke_deploy "$ws"
+    assert_success
+    # consumer content survives byte-relevant intact: sentinel + frozen heading
+    run grep -q 'SENTINEL-1403 consumer changelog body' "$ws/CHANGELOG.md"
+    assert_success
+    run grep -q '^## \[9\.9\.9\] - TBD$' "$ws/CHANGELOG.md"
+    assert_success
+    # no devkit release history leaked into the consumer file
+    run grep -q 'releases/tag' "$ws/CHANGELOG.md"
+    assert_failure
+}
+
+@test "smoke deploy bootstraps the scaffold CHANGELOG.md when absent (#1403)" {
+    ws="$BATS_TEST_TMPDIR/e2e-1403-bootstrap"
+    mkdir -p "$ws"
+    run _smoke_deploy "$ws"
+    assert_success
+    run test -f "$ws/CHANGELOG.md"
+    assert_success
+    # scaffold skeleton: first ## heading is Unreleased, no release sections
+    first_h2=$(grep -m1 '^## ' "$ws/CHANGELOG.md")
+    [ "$first_h2" = "## Unreleased" ]
+    run grep -E '^## \[[0-9]+\.[0-9]+\.[0-9]+\]' "$ws/CHANGELOG.md"
+    assert_failure
+}
+
 # ── Nix-image scaffold: real, writable files (#664) ───────────────────────────
 # The Nix image bakes the template as read-only /nix/store symlinks. The scaffold
 # rsync must --copy-links (-L) so a new workspace gets real files (not dangling

--- a/tests/bats/just.bats
+++ b/tests/bats/just.bats
@@ -185,6 +185,14 @@ EOF
     assert_success
 }
 
+@test "smoke-test dispatch seeding awk is bounded and synthesizes ### Changed (#1403)" {
+    # The seeding awk must clear its Unreleased state at the next release
+    # heading (the old version leaked in_unreleased into released sections)
+    # and must synthesize a ### Changed heading when Unreleased lacks one.
+    run bash -lc 'grep -Fq -- "in_unreleased && !seeded && /^## \[/" assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- "print \"### Changed\"" assets/smoke-test/.github/workflows/repository-dispatch.yml'
+    assert_success
+}
+
 @test "smoke-test dispatch repairs ownership when installer leaves root-owned files" {
     run bash -lc 'grep -Fq -- "NEEDS_CHOWN=false" assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- "sudo chown -R" assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- "OWNER_UID_GID=\"\$(id -u):\$(id -g)\"" assets/smoke-test/.github/workflows/repository-dispatch.yml'
     assert_success

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -931,15 +931,23 @@ class TestSmokeRepo:
         root_content = root_changelog.read_text(encoding="utf-8")
         devcontainer_content = devcontainer_changelog.read_text(encoding="utf-8")
 
-        # Root changelog is a copy of .devcontainer/CHANGELOG.md with the top semver
-        # heading renamed via prepare-changelog unprepare; older release sections stay.
+        # The root changelog is the CONSUMER's own history: on a fresh deploy it
+        # is bootstrapped from the workspace scaffold (## Unreleased skeleton,
+        # no release sections). It must NOT be a copy of devkit's changelog —
+        # deploying devkit's dated/linked ## [X.Y.Z] headings into the consumer
+        # rewrites its frozen release sections and guarantees a main<->dev sync
+        # conflict at every smoke release (#1403).
         first_h2 = re.search(r"^## .+$", root_content, re.MULTILINE)
         assert first_h2 is not None, "Root changelog should have a top-level ## heading"
         assert first_h2.group(0).rstrip("\r\n") == "## Unreleased", (
-            "Root changelog top section should be ## Unreleased after smoke-test unprepare"
+            "Root changelog top section should be ## Unreleased"
         )
-        assert re.search(r"^## \[\d+\.\d+\.\d+\]", root_content, re.MULTILINE), (
-            "Root changelog should retain semver release sections below Unreleased"
+        assert not re.search(r"^## \[\d+\.\d+\.\d+\]", root_content, re.MULTILINE), (
+            "Root changelog must not carry devkit release sections (#1403); "
+            "a fresh smoke deploy bootstraps the scaffold skeleton only"
+        )
+        assert root_content != devcontainer_content, (
+            "Root changelog must not be a byte copy of devkit's changelog (#1403)"
         )
         assert re.search(
             r"^## \[\d+\.\d+\.\d+\]", devcontainer_content, re.MULTILINE

--- a/tests/test_workflow_sync_autoresolve.py
+++ b/tests/test_workflow_sync_autoresolve.py
@@ -1,0 +1,164 @@
+"""Workflow-shape tests: sync-main-to-dev auto-resolves doc snapshot conflicts.
+
+Issue #1403: ``docs/issues/*.md`` and ``docs/pull-requests/*.md`` are generated
+independently on ``dev`` (nightly sync-issues) and on the release branch
+(release-time sync-issues), so every release produces add/add conflicts on
+paths absent at the merge base — and the post-release ``main -> dev`` sync PR
+opens conflicted every time.
+
+The signed-commits ruleset (all refs, no bypass actors) forbids a plain runner
+merge commit, so the workflow resolves these conflicts with a single-parent
+GitHub-signed commit-action commit that aligns the sync branch's copy of each
+conflicted snapshot with DEV's content: with both merge sides identical the
+conflict vanishes, and dev's possibly-staler snapshot self-heals at the next
+nightly sync-issues run. Any conflict outside the snapshot dirs (or a
+delete/modify conflict) keeps the existing manual ``merge-conflict`` path.
+
+These assertions pin the auto-resolve pipeline shape for both copies: devkit's
+own workflow and the scaffold template shipped to consumers (intentionally
+decoupled files — no manifest derives one from the other).
+
+Refs: #1403
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests.test_workflow_sync_checkout import SYNC_WORKFLOWS, _load, _steps_of_job
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+COMMIT_ACTION_PIN = "vig-os/commit-action@0361e9aa65b64711a18286ac5dfdcba7cc7a2ac7"
+EFFECTIVE_CONFLICT = (
+    "steps.reverify.outputs.conflict || steps.merge-check.outputs.conflict"
+)
+
+parametrized = pytest.mark.parametrize(
+    "path", SYNC_WORKFLOWS, ids=lambda p: str(p.relative_to(REPO_ROOT))
+)
+
+
+def _step_by_id(steps: list[dict], step_id: str) -> dict:
+    matches = [s for s in steps if s.get("id") == step_id]
+    assert matches, f"no step with id {step_id!r}"
+    return matches[0]
+
+
+def _step_by_name(steps: list[dict], fragment: str) -> dict:
+    matches = [s for s in steps if fragment in str(s.get("name", ""))]
+    assert matches, f"no step with name containing {fragment!r}"
+    return matches[0]
+
+
+def _index_of(steps: list[dict], step: dict) -> int:
+    return steps.index(step)
+
+
+@parametrized
+def test_auto_resolve_step_shape_and_order(path: Path) -> None:
+    """auto-resolve runs on the pushed sync branch, before the PR opens."""
+    steps = _steps_of_job(_load(path), "sync")
+
+    create_branch = _step_by_name(steps, "Create sync branch from main")
+    auto_resolve = _step_by_id(steps, "auto-resolve")
+    create_pr = _step_by_id(steps, "create-pr")
+
+    # commit-action commits to the REMOTE branch, so the branch must already
+    # be pushed; the PR must open only after the resolution commit landed.
+    assert (
+        _index_of(steps, create_branch)
+        < _index_of(steps, auto_resolve)
+        < _index_of(steps, create_pr)
+    ), "auto-resolve must sit between branch push and PR creation"
+
+    condition = str(auto_resolve.get("if", ""))
+    assert "steps.merge-check.outputs.conflict == 'true'" in condition, (
+        "auto-resolve must only run when merge-check detected a conflict"
+    )
+
+    run = str(auto_resolve.get("run", ""))
+    assert "--name-only" in run, "must enumerate conflicted paths via merge-tree"
+    assert "docs/issues/" in run and "docs/pull-requests/" in run, (
+        "must allowlist only the generated snapshot dirs"
+    )
+    assert "git cat-file -e" in run, (
+        "must guard delete/modify conflicts (path missing from dev)"
+    )
+    assert "git checkout origin/dev --" in run, (
+        "must materialize dev's side of the conflicted snapshots"
+    )
+
+
+@parametrized
+def test_signed_commit_via_commit_action(path: Path) -> None:
+    """The resolution commit must be GitHub-signed (ruleset: all refs)."""
+    steps = _steps_of_job(_load(path), "sync")
+    commit = _step_by_name(steps, "Commit dev-side doc snapshots")
+
+    assert str(commit.get("uses", "")).startswith(COMMIT_ACTION_PIN), (
+        "resolution must use the pinned commit-action (GraphQL signed commit)"
+    )
+    assert "steps.auto-resolve.outputs.eligible == 'true'" in str(
+        commit.get("if", "")
+    ), "commit must be gated on auto-resolve eligibility"
+
+    env = commit.get("env", {})
+    assert env.get("GH_TOKEN") == "${{ steps.commit-app-token.outputs.token }}", (
+        "content commits use the COMMIT_APP identity (workflow header doctrine)"
+    )
+    assert env.get("TARGET_BRANCH") == "refs/heads/${{ env.SYNC_BRANCH }}", (
+        "commit must target the pushed sync branch"
+    )
+    assert env.get("FILE_PATHS") == "${{ steps.auto-resolve.outputs.file_paths }}", (
+        "commit must take exactly the conflicted paths auto-resolve emitted"
+    )
+
+
+@parametrized
+def test_reverify_step(path: Path) -> None:
+    """After the signed commit, the merge must be re-proven clean."""
+    steps = _steps_of_job(_load(path), "sync")
+    reverify = _step_by_id(steps, "reverify")
+
+    assert "steps.auto-resolve.outputs.eligible == 'true'" in str(
+        reverify.get("if", "")
+    ), "reverify must be gated on auto-resolve eligibility"
+
+    run = str(reverify.get("run", ""))
+    assert "git fetch origin" in run, "must refetch the sync branch after the commit"
+    assert "merge-tree --write-tree" in run, "must re-run the in-memory merge probe"
+    assert 'origin/${SYNC_BRANCH}"' in run, (
+        "must probe origin/dev against the UPDATED sync branch, not origin/main"
+    )
+
+
+@parametrized
+def test_effective_conflict_flag_wiring(path: Path) -> None:
+    """PR body/label and auto-merge must consume the post-resolve flag."""
+    steps = _steps_of_job(_load(path), "sync")
+
+    create_pr = _step_by_id(steps, "create-pr")
+    assert (
+        create_pr.get("env", {}).get("CONFLICT") == "${{ " + EFFECTIVE_CONFLICT + " }}"
+    ), "Create PR must consume the effective (post-resolve) conflict flag"
+
+    auto_merge = _step_by_name(steps, "Enable auto-merge")
+    assert "(" + EFFECTIVE_CONFLICT + ") != 'true'" in str(auto_merge.get("if", "")), (
+        "auto-merge must be gated on the effective (post-resolve) conflict flag"
+    )
+
+
+def test_new_steps_identical_across_copies() -> None:
+    """The decoupled copies must not drift on the auto-resolve block."""
+    own, template = (_steps_of_job(_load(p), "sync") for p in SYNC_WORKFLOWS)
+    for locate in (
+        lambda steps: _step_by_id(steps, "auto-resolve"),
+        lambda steps: _step_by_name(steps, "Commit dev-side doc snapshots"),
+        lambda steps: _step_by_id(steps, "reverify"),
+    ):
+        assert locate(own) == locate(template), (
+            "auto-resolve steps must stay byte-identical across the two copies"
+        )


### PR DESCRIPTION
## Summary

Fixes the deterministic conflicts that make the post-release `main → dev` sync PR open red on every train (devkit#1395, smoke-test#351). Both root causes from #1403 are addressed; the `merge-conflict` manual path remains for genuine conflicts.

### Cause B — issue/PR snapshot add/add conflicts (every gitflow repo)

`sync-main-to-dev.yml` (both the canonical copy and the workspace template, kept byte-identical and pinned by a new cross-copy test) gains three steps between branch push and PR creation:

1. **Auto-resolve** — re-probes with `git merge-tree --write-tree --name-only`, parses the conflicted paths, and proceeds only when *every* conflicted path is a generated snapshot (`docs/issues/`, `docs/pull-requests/`) still present on dev (delete/modify stays manual). It materializes dev's side of exactly those paths in the working tree.
2. **Signed commit** — `vig-os/commit-action` (COMMIT_APP token) commits them to the pushed sync branch.
3. **Re-verify** — refetches and re-runs `merge-tree` against the updated branch; only a proven-clean result flips the effective conflict flag consumed by `Create PR` and `Enable auto-merge` (falsy-fallback expression keeps today's manual path bit-for-bit when auto-resolve is skipped or ineligible).

**Why dev-side wins (deviation from the issue's "main side" suggestion):** the `Signed commits` ruleset (`~ALL` refs, no bypass actors) means the runner can only produce single-parent GitHub-signed commits via GraphQL — a merge commit taking main's side is impossible. Aligning the sync branch to dev's content makes both merge sides identical, so the conflict vanishes; snapshots are derived artifacts of live GitHub state, and dev's next nightly sync-issues run re-captures anything main had (its updated-since cutoff predates the release-time sync), so nothing is lost beyond a ≤24 h staleness window. Only paths merge-tree reports as conflicted are touched — a snapshot changed only on main still merges cleanly.

### Cause A — smoke deploy clobbered the consumer changelog (smoke-test only)

The smoke branch of `init-workspace.sh` rsynced with `--delete` and no preserve excludes, then copied devkit's entire changelog over the consumer's root `CHANGELOG.md`; the `prepare-changelog unprepare` safety valve no-ops since #590 (first heading is always `## Unreleased`). Devkit's dated `## [X.Y.Z](…devkit…)` heading replaced the consumer's frozen `## [X.Y.Z] - TBD`, colliding with main's finalize rewrite whenever versions coincide — structural for devkit-smoke-test.

Now: root-anchored `--exclude='/CHANGELOG.md'` (consumer state preserved; `.devcontainer/CHANGELOG.md` still syncs), scaffold skeleton bootstrapped only when the file is absent, cp+unprepare block deleted. `prepare-changelog unprepare` loses its only production caller; the vig-utils CLI surface is deliberately untouched (removing a subcommand is out of scope here).

Also fixes the latent unbounded seeding awk in `repository-dispatch.yml`: the deploy bullet is now bounded at the next `## [` heading and a `### Changed` subheading is synthesized when `## Unreleased` lacks one.

## Rollout timing (corrected)

An earlier draft of this PR claimed the fix only goes live one release late. That was wrong: **push-triggered workflows execute the workflow file at the pushed commit**, and devkit's own run history proves it — the 1.7.0 promote's sync run executed at `headSha bcb0a257`, the promote merge commit itself. Since this fix flows dev → `release/1.7.1` → main, the 1.7.1 merge commit on main *contains* the new workflow, so **the very sync run fired by the 1.7.1 promote is already the auto-resolving version** — full live proof arrives with the next ordinary release, no extra train needed. Cause A proves even earlier, at the first 1.7.1-rc smoke deploy (the installer runs from the tagged tree). The smoke-test's already-copied changelog history is preserved as-is and converges over subsequent releases.

## Zero-release proof: replay against the real 1.7.0 conflict

The pre-resolution state of devkit#1395 still exists in history (`dc25bfbb`'s parents: `bcb0a257` = main, `665a0901` = dev). Replaying the new auto-resolve pipeline against it:

- `git merge-tree --write-tree --name-only` exits 1 and the output matches the parser's format assumption exactly (tree OID, conflicted paths, blank line, informational messages).
- Parsed conflicted paths: `docs/issues/issue-1386.md`, `docs/issues/issue-1391.md`, `docs/issues/issue-529.md`, `docs/pull-requests/pr-1385.md` — all inside the allowlist, and `issue-529.md` is a **content** conflict (not add/add), confirming both classes are covered.
- Eligibility loop passes (all paths present on dev).
- The automated dev-side result is **byte-identical on all four files to the actual manual resolution** committed in `dc25bfbb`.

## Verification

- TDD: each fix landed as a failing-test commit followed by the implementation (see commit sequence).
- `tests/test_workflow_sync_autoresolve.py` (new, parametrized over both workflow copies incl. cross-copy identity) — 9 passed.
- Rewritten `test_smoke_workspace_changelog_available_in_devcontainer_and_root` passed against a freshly built dev image.
- New bats: smoke deploy preserves a pre-seeded consumer changelog (sentinel + frozen `## [9.9.9] - TBD` survive) and bootstraps the scaffold when absent; seeding-awk shape pinned in `just.bats`. The new awk was additionally exercised against three fixtures (skeleton present / missing `### Changed` before a released section / Unreleased at EOF) — bullet lands inside Unreleased in all three.
- Full local gates: `pre-commit run --all-files` green; fast pytest 510 passed; vig-utils 566 passed (untouched); `just.bats` 54/54; rendered-template + smoke actionlint (#995) green; full `init-workspace.bats` green.

Refs: #1403
