### PR TITLE
feat: changelog entries for devkit adoption PRs

### DIFF
--- a/.github/workflows/renovate-changelog-commit.yml
+++ b/.github/workflows/renovate-changelog-commit.yml
@@ -1,4 +1,5 @@
-# Privileged commit for Renovate changelog updates (Refs: #506, #562).
+# Privileged commit for Renovate and devkit-adoption changelog updates
+# (Refs: #506, #562, vig-os/devkit#1404).
 # Runs from default branch via workflow_run; never checks out PR-head code.
 
 name: Renovate changelog commit
@@ -63,7 +64,7 @@ jobs:
           TARGET_BRANCH: refs/heads/${{ steps.metadata.outputs.head_ref }}
           MAX_ATTEMPTS: "3"
           COMMIT_MESSAGE: |-
-            docs(changelog): add unreleased entry for renovate PR ${{ steps.metadata.outputs.pr_number }}
+            docs(changelog): add unreleased entry for PR ${{ steps.metadata.outputs.pr_number }}
 
             Refs: #${{ steps.metadata.outputs.pr_number }}
           FILE_PATHS: CHANGELOG.md,assets/workspace/.devcontainer/CHANGELOG.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Changelog entries for devkit adoption PRs** ([#1404](https://github.com/vig-os/devkit/issues/1404))
+  - The scaffolded `renovate-changelog-build.yml` now also accepts PRs opened
+    by the devkit-upgrade App (`vigos-devkit-upgrade[bot]`), so an adoption PR
+    gets an `Adopt vigOS devkit X.Y.Z` entry under `## Unreleased` →
+    `### Changed`, linking the PR and the devkit release notes — the same
+    pipeline Renovate PRs already use
+  - `renovate-changelog-pr` branches on the PR title
+    (`chore: adopt devkit X.Y.Z[-rcN]`) and skips the Renovate dependency
+    parser for adoption PRs; it also no-ops instead of crashing when the
+    consumer has no `CHANGELOG.md`
+  - The privileged commit message is generalized to
+    `docs(changelog): add unreleased entry for PR N`
+
 ### Changed
 
 ### Deprecated

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Changelog entries for devkit adoption PRs** ([#1404](https://github.com/vig-os/devkit/issues/1404))
+  - The scaffolded `renovate-changelog-build.yml` now also accepts PRs opened
+    by the devkit-upgrade App (`vigos-devkit-upgrade[bot]`), so an adoption PR
+    gets an `Adopt vigOS devkit X.Y.Z` entry under `## Unreleased` →
+    `### Changed`, linking the PR and the devkit release notes — the same
+    pipeline Renovate PRs already use
+  - `renovate-changelog-pr` branches on the PR title
+    (`chore: adopt devkit X.Y.Z[-rcN]`) and skips the Renovate dependency
+    parser for adoption PRs; it also no-ops instead of crashing when the
+    consumer has no `CHANGELOG.md`
+  - The privileged commit message is generalized to
+    `docs(changelog): add unreleased entry for PR N`
+
 ### Changed
 
 ### Deprecated

--- a/assets/workspace/.github/workflows/renovate-changelog-build.yml
+++ b/assets/workspace/.github/workflows/renovate-changelog-build.yml
@@ -1,10 +1,16 @@
 # Managed by vigOS devkit — regenerated on upgrade; local edits are lost.
 # Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues
 
-# Append Keep-a-Changelog Unreleased entries for Renovate dependency PRs (Refs: #506, #562, #863).
+# Append Keep-a-Changelog Unreleased entries for Renovate dependency PRs (Refs: #506, #562, #863)
+# and for devkit adoption PRs opened by the devkit-upgrade workflow (Refs: vig-os/devkit#1404) —
+# the CLI branches on the PR title. The workflow name predates the adoption case and stays
+# unchanged: the commit workflow references it by name from the default branch, so a rename
+# would strand in-flight PRs during the transition.
 # Read-only build on pull_request; privileged commit runs via workflow_run from default branch.
 # The sender-login guard skips synchronize events raised by the changelog commit bot's own
 # push (which uses an app token that re-triggers workflows), breaking the self-commit loop.
+# An rc -> final re-bump force-updates the adoption branch (wiping the changelog commit), but
+# the synchronize event it raises re-runs this build, which re-adds the entry — self-healing.
 
 name: Renovate changelog build
 
@@ -18,7 +24,8 @@ jobs:
   resolve-toolchain:
     name: Resolve toolchain
     if: >-
-      github.event.pull_request.user.login == 'renovate[bot]' &&
+      contains(fromJSON('["renovate[bot]", "vigos-devkit-upgrade[bot]"]'),
+        github.event.pull_request.user.login) &&
       github.event.sender.login != 'commit-action-bot[bot]' &&
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-24.04
@@ -52,7 +59,8 @@ jobs:
   build:
     name: Build changelog artifact
     if: >-
-      github.event.pull_request.user.login == 'renovate[bot]' &&
+      contains(fromJSON('["renovate[bot]", "vigos-devkit-upgrade[bot]"]'),
+        github.event.pull_request.user.login) &&
       github.event.sender.login != 'commit-action-bot[bot]' &&
       github.event.pull_request.head.repo.full_name == github.repository
     needs: [resolve-toolchain]

--- a/assets/workspace/.github/workflows/renovate-changelog-commit.yml
+++ b/assets/workspace/.github/workflows/renovate-changelog-commit.yml
@@ -1,7 +1,8 @@
 # Managed by vigOS devkit — regenerated on upgrade; local edits are lost.
 # Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues
 
-# Privileged commit for Renovate changelog updates (Refs: #506, #562).
+# Privileged commit for Renovate and devkit-adoption changelog updates
+# (Refs: #506, #562, vig-os/devkit#1404).
 # Runs from default branch via workflow_run; never checks out PR-head code.
 
 name: Renovate changelog commit
@@ -66,7 +67,7 @@ jobs:
           TARGET_BRANCH: refs/heads/${{ steps.metadata.outputs.head_ref }}
           MAX_ATTEMPTS: "3"
           COMMIT_MESSAGE: |-
-            docs(changelog): add unreleased entry for renovate PR ${{ steps.metadata.outputs.pr_number }}
+            docs(changelog): add unreleased entry for PR ${{ steps.metadata.outputs.pr_number }}
 
             Refs: #${{ steps.metadata.outputs.pr_number }}
           FILE_PATHS: CHANGELOG.md

--- a/packages/vig-utils/src/vig_utils/renovate_changelog_pr.py
+++ b/packages/vig-utils/src/vig_utils/renovate_changelog_pr.py
@@ -1,4 +1,9 @@
-"""Parse Renovate PR metadata and insert a Keep-a-Changelog entry (Refs: #506)."""
+"""Parse Renovate PR metadata and insert a Keep-a-Changelog entry (Refs: #506).
+
+Also handles devkit adoption PRs opened by the devkit-upgrade workflow: a title
+of the exact shape ``chore: adopt devkit X.Y.Z[-rcN]`` produces an "Adopt vigOS
+devkit" entry instead of running the Renovate dependency parser (Refs: #1404).
+"""
 
 from __future__ import annotations
 
@@ -7,6 +12,34 @@ import os
 import re
 import sys
 from pathlib import Path
+
+# The devkit-upgrade workflow's PR title, verbatim: bare semver with an
+# optional prerelease (devkit tags carry no `v` prefix). Anchored so arbitrary
+# chore titles never masquerade as adoptions.
+_ADOPTION_TITLE_RE = re.compile(
+    r"^chore: adopt devkit (\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)$"
+)
+
+
+def parse_adoption_title(title: str) -> str | None:
+    """Return the devkit version from an adoption PR title, or None."""
+    m = _ADOPTION_TITLE_RE.match(title.strip())
+    if m:
+        return m.group(1)
+    return None
+
+
+def format_adoption_entry(
+    pr_number: int,
+    repo_html_url: str,
+    version: str,
+) -> str:
+    base = repo_html_url.rstrip("/")
+    pr_link = f"[#{pr_number}]({base}/pull/{pr_number})"
+    notes_link = (
+        f"[release notes](https://github.com/vig-os/devkit/releases/tag/{version})"
+    )
+    return f"- **Adopt vigOS devkit {version}** ({pr_link}) — {notes_link}\n"
 
 
 def _strip_md_link(cell: str) -> str:
@@ -219,15 +252,29 @@ def main(argv: list[str] | None = None) -> int:
     if not args.repo_url:
         print("GITHUB_REPOSITORY_URL must be set", file=sys.stderr)
         return 1
-    body = args.body
-    if args.body_file:
-        body = Path(args.body_file).read_text(encoding="utf-8")
-    updates = parse_renovate_pr_updates(args.title, body)
-    if not updates:
-        print("No dependency updates parsed; skipping changelog edit", file=sys.stderr)
-        return 0
-    entry = format_changelog_entry(args.pr_number, args.repo_url, updates)
     path = Path(args.changelog)
+    if not path.is_file():
+        # Consumers without a changelog (e.g. trunk repos) are a no-op, not an
+        # error — the build workflow runs unconditionally where scaffolded.
+        print(f"{path} not found; skipping changelog edit", file=sys.stderr)
+        return 0
+    adoption_version = parse_adoption_title(args.title)
+    if adoption_version is not None:
+        # Devkit adoption PR (#1404): the body is workflow boilerplate, never
+        # a Renovate dependency table — format the entry from the title alone.
+        entry = format_adoption_entry(args.pr_number, args.repo_url, adoption_version)
+    else:
+        body = args.body
+        if args.body_file:
+            body = Path(args.body_file).read_text(encoding="utf-8")
+        updates = parse_renovate_pr_updates(args.title, body)
+        if not updates:
+            print(
+                "No dependency updates parsed; skipping changelog edit",
+                file=sys.stderr,
+            )
+            return 0
+        entry = format_changelog_entry(args.pr_number, args.repo_url, updates)
     text = path.read_text(encoding="utf-8")
     new_text, did = insert_renovate_changelog_entry(text, args.pr_number, entry)
     if not did:

--- a/packages/vig-utils/tests/test_renovate_changelog_pr.py
+++ b/packages/vig-utils/tests/test_renovate_changelog_pr.py
@@ -3,13 +3,20 @@
 from __future__ import annotations
 
 import textwrap
+from typing import TYPE_CHECKING
 
 import pytest
 from vig_utils.renovate_changelog_pr import (
+    format_adoption_entry,
     format_changelog_entry,
     insert_renovate_changelog_entry,
+    main,
+    parse_adoption_title,
     parse_renovate_pr_updates,
 )
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 def test_parse_title_single_dependency_digest() -> None:
@@ -248,3 +255,151 @@ def test_insert_empty_changed_section(changelog: str) -> None:
     assert "### Changed" in new_content
     # Keep-a-Changelog: blank line between ### Changed heading and first list item
     assert "### Changed\n\n- **X**" in new_content
+
+
+# ---------------------------------------------------------------------------
+# Devkit adoption PRs (Refs: #1404)
+# ---------------------------------------------------------------------------
+
+
+def test_parse_adoption_title_final() -> None:
+    assert parse_adoption_title("chore: adopt devkit 1.7.0") == "1.7.0"
+
+
+def test_parse_adoption_title_rc() -> None:
+    assert parse_adoption_title("chore: adopt devkit 1.8.0-rc2") == "1.8.0-rc2"
+
+
+@pytest.mark.parametrize(
+    "title",
+    [
+        "build(pip): update dependency urllib3 to v2.6.3",
+        "chore: adopt devkit",
+        "chore: adopt devkit v1.7.0",
+        "feat: adopt devkit 1.7.0",
+        "chore: adopt devkit 1.7.0 and more",
+    ],
+)
+def test_parse_adoption_title_rejects_non_adoption(title: str) -> None:
+    assert parse_adoption_title(title) is None
+
+
+def test_format_adoption_entry() -> None:
+    entry = format_adoption_entry(
+        141, "https://github.com/vig-os/commit-action", "1.7.0"
+    )
+    assert entry.startswith("- **Adopt vigOS devkit 1.7.0**")
+    assert "[#141](https://github.com/vig-os/commit-action/pull/141)" in entry
+    assert (
+        "[release notes](https://github.com/vig-os/devkit/releases/tag/1.7.0)" in entry
+    )
+    assert entry.endswith("\n")
+
+
+def test_adoption_entry_inserts_and_dedups() -> None:
+    changelog = textwrap.dedent(
+        """\
+        ## Unreleased
+
+        ### Changed
+
+        - **Existing** ([#1](https://github.com/o/r/pull/1))
+
+        ### Deprecated
+        """
+    )
+    entry = format_adoption_entry(141, "https://github.com/o/r", "1.7.0")
+    new_content, did = insert_renovate_changelog_entry(changelog, 141, entry)
+    assert did is True
+    assert new_content.index("Adopt vigOS devkit 1.7.0") < new_content.index(
+        "**Existing**"
+    )
+    again, did2 = insert_renovate_changelog_entry(new_content, 141, entry)
+    assert did2 is False
+    assert again == new_content
+
+
+def test_main_adoption_end_to_end(tmp_path: Path) -> None:
+    changelog = tmp_path / "CHANGELOG.md"
+    changelog.write_text(
+        textwrap.dedent(
+            """\
+            ## Unreleased
+
+            ### Changed
+
+            ### Deprecated
+            """
+        ),
+        encoding="utf-8",
+    )
+    rc = main(
+        [
+            "--changelog",
+            str(changelog),
+            "--pr-number",
+            "141",
+            "--title",
+            "chore: adopt devkit 1.7.0",
+            "--repo-url",
+            "https://github.com/vig-os/commit-action",
+        ]
+    )
+    assert rc == 0
+    text = changelog.read_text(encoding="utf-8")
+    assert "### Changed\n\n- **Adopt vigOS devkit 1.7.0**" in text
+    assert "[#141](https://github.com/vig-os/commit-action/pull/141)" in text
+
+
+def test_main_adoption_ignores_body(tmp_path: Path) -> None:
+    """An adoption PR body must not be fed through the Renovate table parser."""
+    changelog = tmp_path / "CHANGELOG.md"
+    changelog.write_text(
+        textwrap.dedent(
+            """\
+            ## Unreleased
+
+            ### Changed
+
+            ### Deprecated
+            """
+        ),
+        encoding="utf-8",
+    )
+    body = "| Package | Change |\n|---|---|\n| [x](https://x) | `1` -> `2` |"
+    rc = main(
+        [
+            "--changelog",
+            str(changelog),
+            "--pr-number",
+            "7",
+            "--title",
+            "chore: adopt devkit 1.8.0-rc1",
+            "--body",
+            body,
+            "--repo-url",
+            "https://github.com/o/r",
+        ]
+    )
+    assert rc == 0
+    text = changelog.read_text(encoding="utf-8")
+    assert "Adopt vigOS devkit 1.8.0-rc1" in text
+    assert "Renovate" not in text
+
+
+def test_main_missing_changelog_is_noop(tmp_path: Path) -> None:
+    """Consumers without a CHANGELOG.md (trunk repos) must no-op, not crash."""
+    rc = main(
+        [
+            "--changelog",
+            str(tmp_path / "CHANGELOG.md"),
+            "--pr-number",
+            "141",
+            "--title",
+            "chore: adopt devkit 1.7.0",
+            "--repo-url",
+            "https://github.com/o/r",
+        ]
+    )
+    assert rc == 0
+    assert not (tmp_path / "CHANGELOG.md").exists()


### PR DESCRIPTION
## Summary

Adoption PRs opened by the devkit-upgrade workflow now get a `CHANGELOG.md` entry, exactly like Renovate PRs (option B from the design discussion on #1404):

- **`vig-utils`**: `renovate-changelog-pr` branches on the PR title — `chore: adopt devkit X.Y.Z[-rcN]` produces `- **Adopt vigOS devkit X.Y.Z** ([#PR](…)) — [release notes](…)` at the top of `## Unreleased` → `### Changed`, via the existing insertion helper (dedup on the PR link). The body is never fed through the Renovate table parser. The CLI also no-ops instead of crashing when `CHANGELOG.md` is absent (trunk consumers).
- **Scaffold `renovate-changelog-build.yml`**: the author filter accepts `vigos-devkit-upgrade[bot]` alongside `renovate[bot]`. Workflow names are deliberately unchanged (a `workflow_run` rename has a default-branch transition hazard). Devkit's own de-coupled copy (#996) is untouched — devkit never receives adoption PRs.
- **`renovate-changelog-commit.yml`** (root + manifest-derived scaffold): commit message generalized to `docs(changelog): add unreleased entry for PR N`.

rc → final force-updates wipe the changelog commit, but the resulting `synchronize` event re-runs the build (sender guard only excludes `commit-action-bot[bot]`), so the entry is re-added with the new version.

## Verification

- TDD: failing tests committed first (`dbf2de14`), implementation after (`22ee7f27`); 26/26 in `test_renovate_changelog_pr.py`
- `just precommit` (all files), 666 pytest (vig-utils + transforms + scaffold lint/drift), 590 bats — all green
- Insertion spike validated against commit-action's real `CHANGELOG.md` (clean insert, idempotent re-run)

Closes #1404