### PR TITLE
refactor: drop the per-train adoption issue from devkit-upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`devkit-upgrade` no longer opens a per-train adoption issue** ([#1405](https://github.com/vig-os/devkit/issues/1405))
+  - Adoption PRs are bot PRs like Renovate's: the PR is the traceable
+    artifact and the changelog entry ([#1404](https://github.com/vig-os/devkit/issues/1404))
+    links it. On gitflow consumers the dev-targeted `Closes #N` never
+    auto-closed anyway, stranding an open issue every train
+  - The upgrade branch becomes `chore/devkit-<train>` (the guard-legal
+    issue-less shape), the staging commit drops its `Refs:` line (`chore` is
+    exempt), and the PR body links the devkit release notes
+  - The #1347 no-diff cleanup step and the token's `issues: write` grant are
+    removed — a no-diff run now strands nothing by construction
+  - One-time migration: close any adoption issues left open by earlier
+    trains on the consumers
+
 ### Deprecated
 
 ### Removed

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -11,6 +11,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`devkit-upgrade` no longer opens a per-train adoption issue** ([#1405](https://github.com/vig-os/devkit/issues/1405))
+  - Adoption PRs are bot PRs like Renovate's: the PR is the traceable
+    artifact and the changelog entry ([#1404](https://github.com/vig-os/devkit/issues/1404))
+    links it. On gitflow consumers the dev-targeted `Closes #N` never
+    auto-closed anyway, stranding an open issue every train
+  - The upgrade branch becomes `chore/devkit-<train>` (the guard-legal
+    issue-less shape), the staging commit drops its `Refs:` line (`chore` is
+    exempt), and the PR body links the devkit release notes
+  - The #1347 no-diff cleanup step and the token's `issues: write` grant are
+    removed — a no-diff run now strands nothing by construction
+  - One-time migration: close any adoption issues left open by earlier
+    trains on the consumers
+
 ### Deprecated
 
 ### Removed

--- a/assets/workspace/.github/workflows/devkit-upgrade.yml
+++ b/assets/workspace/.github/workflows/devkit-upgrade.yml
@@ -6,12 +6,14 @@
 # `install.sh --force` upgrade — the .vig-os pin, the flake.lock `vigos` node and
 # the full scaffold regeneration move together, with the commit made inside the
 # project shell so consumer hooks run — then opens the adoption PR. Renovate-style
-# pull: no devkit-side action at release time, no consumer registry.
+# pull: no devkit-side action at release time, no consumer registry, and no
+# adoption issue (vig-os/devkit#1405) — like a Renovate PR, the bot PR is the
+# traceable artifact and the changelog entry (vig-os/devkit#1404) links it.
 #
 # Requires a dedicated GitHub App identity: DEVKIT_UPGRADE_APP_CLIENT_ID +
 # DEVKIT_UPGRADE_APP_PRIVATE_KEY (repo or org secrets) feed a per-run
 # installation token minted in-workflow — contents:write + pull-requests:write +
-# issues:write + workflows:write on this repo. The legacy numeric
+# workflows:write on this repo. The legacy numeric
 # DEVKIT_UPGRADE_APP_ID still works this release (either value is a valid App
 # JWT issuer); vig-os/devkit#1366 retires it. The default GITHUB_TOKEN cannot
 # open the PR: PRs it creates do not trigger CI. A static PAT is not supported
@@ -47,9 +49,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
-      # The branch, issue and PR are all created with the minted App token (a
-      # dedicated identity, so the PR triggers CI); the default token stays
-      # read-only for the public releases/latest query.
+      # The branch and PR are created with the minted App token (a dedicated
+      # identity, so the PR triggers CI); the default token stays read-only
+      # for the public releases/latest query.
       contents: read
     steps:
       - name: Require the upgrade App identity
@@ -60,7 +62,7 @@ jobs:
         run: |
           set -euo pipefail
           if { [ -z "${APP_CLIENT_ID}" ] && [ -z "${APP_ID_LEGACY}" ]; } || [ -z "${APP_PRIVATE_KEY}" ]; then
-            echo "::error::DEVKIT_UPGRADE_APP_CLIENT_ID / DEVKIT_UPGRADE_APP_PRIVATE_KEY secrets are not configured. This workflow needs a dedicated GitHub App identity (contents:write + pull-requests:write + issues:write + workflows:write): the default GITHUB_TOKEN cannot open a PR that triggers CI, and a static PAT is not supported. See https://github.com/vig-os/devkit/issues/1302."
+            echo "::error::DEVKIT_UPGRADE_APP_CLIENT_ID / DEVKIT_UPGRADE_APP_PRIVATE_KEY secrets are not configured. This workflow needs a dedicated GitHub App identity (contents:write + pull-requests:write + workflows:write): the default GITHUB_TOKEN cannot open a PR that triggers CI, and a static PAT is not supported. See https://github.com/vig-os/devkit/issues/1302."
             exit 1
           fi
           if [ -z "${APP_CLIENT_ID}" ]; then
@@ -76,11 +78,10 @@ jobs:
           client-id: ${{ secrets.DEVKIT_UPGRADE_APP_CLIENT_ID || secrets.DEVKIT_UPGRADE_APP_ID }}
           private-key: ${{ secrets.DEVKIT_UPGRADE_APP_PRIVATE_KEY }}
           # Least-privilege mint (zizmor github-app): the token carries exactly
-          # the four permissions this workflow exercises, independent of any
+          # the three permissions this workflow exercises, independent of any
           # broader grants on the App installation.
           permission-contents: write
           permission-pull-requests: write
-          permission-issues: write
           permission-workflows: write
 
       - name: Checkout base branch
@@ -169,8 +170,8 @@ jobs:
             exit 0
           fi
 
-          # The adoption issue + branch key on the TRAIN (prerelease stripped) so
-          # rc1 -> rc2 -> final within a train reuse the same issue/branch/PR; the
+          # The adoption branch keys on the TRAIN (prerelease stripped) so
+          # rc1 -> rc2 -> final within a train reuse the same branch/PR; the
           # commit + PR title carry the exact installed version.
           TRAIN="${TARGET%%-*}"
           {
@@ -180,43 +181,17 @@ jobs:
             echo "branch-suffix=$(echo "${TRAIN}" | tr '.' '-')"
           } >> "$GITHUB_OUTPUT"
 
-      - name: Find or create the adoption issue
-        id: issue
-        if: steps.resolve.outputs.proceed == 'true'
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          TRAIN: ${{ steps.resolve.outputs.train }}
-        run: |
-          set -euo pipefail
-          TITLE="chore: adopt devkit ${TRAIN}"
-          NUMBER="$(gh issue list --state open --search "${TITLE} in:title" \
-            --json number,title \
-            --jq "map(select(.title == \"${TITLE}\")) | .[0].number // empty")"
-          if [ -z "$NUMBER" ]; then
-            URL="$(gh issue create --title "${TITLE}" \
-              --body "Automated adoption of devkit ${TRAIN}. Opened by the devkit-upgrade workflow (#1296).")"
-            NUMBER="${URL##*/}"
-            echo "Created adoption issue #${NUMBER}."
-            # Which branch was taken decides the no-diff cleanup below (#1347):
-            # only an issue THIS run created may be auto-closed.
-            echo "created=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "Reusing open adoption issue #${NUMBER}."
-            echo "created=false" >> "$GITHUB_OUTPUT"
-          fi
-          echo "number=${NUMBER}" >> "$GITHUB_OUTPUT"
-
       - name: Create the upgrade branch
         id: branch
         if: steps.resolve.outputs.proceed == 'true'
         env:
-          ISSUE: ${{ steps.issue.outputs.number }}
           SUFFIX: ${{ steps.resolve.outputs.branch-suffix }}
         run: |
           set -euo pipefail
           # Dots -> dashes: the consumer branch guard rejects dots and any
-          # prefix outside its allowlist (chore/ is allowed).
-          BRANCH="chore/${ISSUE}-devkit-${SUFFIX}"
+          # prefix outside its allowlist (the issue-less chore/<summary> shape
+          # is explicitly allowed — no adoption issue exists, #1405).
+          BRANCH="chore/devkit-${SUFFIX}"
           git switch -c "$BRANCH" 2>/dev/null || git switch "$BRANCH"
           echo "name=${BRANCH}" >> "$GITHUB_OUTPUT"
 
@@ -264,7 +239,6 @@ jobs:
         if: steps.resolve.outputs.proceed == 'true'
         env:
           TARGET: ${{ steps.resolve.outputs.target }}
-          ISSUE: ${{ steps.issue.outputs.number }}
           # Commit identity (configurable via repo variables). Must not match
           # .github/agent-blocklist.toml — the default avoids github-actions[bot]
           # and any AI-agent fingerprint.
@@ -282,11 +256,11 @@ jobs:
           fi
           # Commit INSIDE the project shell so consumer hooks run (dist rebuild in
           # commit-action, trailer strip, validate-commit-msg). chore is
-          # Refs-exempt but include it for traceability. This LOCAL commit is a
-          # staging artifact only — the next step replays its tree through the
-          # API as a GitHub-signed commit; the unsigned one never leaves the
-          # runner (#1308).
-          printf 'chore: adopt devkit %s\n\nRefs: #%s\n' "$TARGET" "$ISSUE" > "${RUNNER_TEMP}/commit-msg"
+          # Refs-exempt and no adoption issue exists (#1405) — the PR is the
+          # traceable artifact. This LOCAL commit is a staging artifact only —
+          # the next step replays its tree through the API as a GitHub-signed
+          # commit; the unsigned one never leaves the runner (#1308).
+          printf 'chore: adopt devkit %s\n' "$TARGET" > "${RUNNER_TEMP}/commit-msg"
           nix develop -c git commit -F "${RUNNER_TEMP}/commit-msg"
           echo "changed=true" >> "$GITHUB_OUTPUT"
 
@@ -362,47 +336,20 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           TARGET: ${{ steps.resolve.outputs.target }}
-          ISSUE: ${{ steps.issue.outputs.number }}
           BRANCH: ${{ steps.branch.outputs.name }}
           # PR base per workflow model (retargeted dev -> main at scaffold time).
           BASE: dev
         run: |
           set -euo pipefail
+          # No adoption issue and no auto-close marker (#1405): a no-diff run
+          # now simply skips publish + PR with nothing to garbage-collect (the
+          # stranded-issue cleanup this replaced was #1347).
           TITLE="chore: adopt devkit ${TARGET}"
-          BODY="$(printf 'Automated devkit upgrade to %s via install.sh --force.\n\nReview the scaffold + flake.lock diff and merge. Closes #%s\n' "$TARGET" "$ISSUE")"
+          BODY="$(printf 'Automated devkit upgrade to %s via install.sh --force.\n\nReview the scaffold + flake.lock diff and merge. Release notes: https://github.com/vig-os/devkit/releases/tag/%s\n' "$TARGET" "$TARGET")"
           if gh pr view "$BRANCH" --json number >/dev/null 2>&1; then
             gh pr edit "$BRANCH" --title "$TITLE" --body "$BODY"
             echo "Updated the existing adoption PR."
           else
             gh pr create --base "$BASE" --head "$BRANCH" --title "$TITLE" --body "$BODY"
             echo "Opened the adoption PR."
-          fi
-
-      - name: Clean up the adoption issue on a no-diff run
-        if: steps.resolve.outputs.proceed == 'true' && steps.commit.outputs.changed != 'true'
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          TARGET: ${{ steps.resolve.outputs.target }}
-          ISSUE: ${{ steps.issue.outputs.number }}
-          CREATED: ${{ steps.issue.outputs.created }}
-        run: |
-          set -euo pipefail
-          # The adoption issue is opened BEFORE install.sh runs — the branch name
-          # embeds its number and the in-shell commit needs the `Refs:` line — so
-          # a run that finds no diff (any dispatch against an already-current
-          # consumer; cron no-ops earlier on "current or ahead") skips publish +
-          # PR and would strand the issue with no PR ever attached (#1347).
-          #
-          # Only an issue THIS run created is closed. A REUSED one belongs to a
-          # live train (rc1 -> rc2 -> final, where an interim bump can legitimately
-          # be a no-op) and must stay open — comment only.
-          if [ "$CREATED" = "true" ]; then
-            gh issue close "$ISSUE" \
-              --comment "No diff at ${TARGET}: this repository's scaffold is already current, so no adoption PR was opened. Closing the issue this run created (#1347)." \
-              --reason "not planned"
-            echo "Closed the adoption issue #${ISSUE} it created (no diff)."
-          else
-            gh issue comment "$ISSUE" \
-              --body "No diff at ${TARGET}: the scaffold is already current, so no adoption PR was opened by this run. Leaving this issue open — it predates this run (#1347)."
-            echo "Left the pre-existing adoption issue #${ISSUE} open (no diff)."
           fi

--- a/tests/test_workflow_devkit_upgrade.py
+++ b/tests/test_workflow_devkit_upgrade.py
@@ -154,14 +154,15 @@ def test_requires_app_identity_and_never_uses_github_token_for_pr() -> None:
         )
         assert "app-id" not in with_block
         # Least-privilege mint (zizmor github-app audit): the token must be
-        # scoped to exactly the permissions the workflow exercises.
+        # scoped to exactly the permissions the workflow exercises. With the
+        # adoption issue gone (#1405) no issues permission remains.
         for perm in (
             "permission-contents",
             "permission-pull-requests",
-            "permission-issues",
             "permission-workflows",
         ):
             assert with_block.get(perm) == "write", f"missing {perm}: write"
+        assert "permission-issues" not in with_block
     # The PR step authenticates gh with the minted token (not github.token),
     # otherwise the created PR would not trigger CI.
     pr_steps = [s for s in steps if "gh pr create" in str(s.get("run", ""))]
@@ -238,59 +239,32 @@ def test_bootstraps_installsh_and_commits_in_project_shell() -> None:
     assert "install-nix-action" in text
 
 
-def test_reset_excluded_paths_and_closes_issue() -> None:
-    """DEVKIT_UPGRADE_EXCLUDE paths are reset and the PR closes its adoption issue."""
+def test_reset_excluded_paths() -> None:
+    """DEVKIT_UPGRADE_EXCLUDE paths are reset to the base branch before commit."""
     text = TEMPLATE.read_text(encoding="utf-8")
     assert "DEVKIT_UPGRADE_EXCLUDE" in text
     assert "git checkout --" in text
-    assert "Closes #" in text
 
 
-def test_no_diff_dispatch_cleans_up_the_issue_it_created() -> None:
-    """A no-diff run must not strand the adoption issue it opened (#1347).
+def test_no_adoption_issue_lifecycle() -> None:
+    """The workflow manages no adoption issue at all (#1405).
 
-    The issue is created BEFORE install.sh runs (the branch name embeds its
-    number and the in-shell commit needs the ``Refs:`` line), so a dispatch
-    against an already-current consumer creates an issue, finds zero diff and
-    skips publish + PR — leaving it open forever. The find-or-create step must
-    expose which branch it took, and a final cleanup step gated on the no-diff
-    path must close a *freshly created* issue while leaving a *reused* one open
-    (auto-closing a live mid-train issue would be wrong).
+    Adoption PRs are bot PRs like Renovate's: the PR is the traceable
+    artifact and the changelog entry (#1404) links it. Dropping the issue
+    removes the whole lifecycle — creation, the ``Refs:`` line, the
+    ``Closes #`` body marker, the issues:write grant, and the #1347 no-diff
+    cleanup step that existed only to garbage-collect stranded issues
+    (`Closes #` never auto-closes on a dev-targeted PR anyway).
     """
     text = TEMPLATE.read_text(encoding="utf-8")
-    steps = _steps(text)
-
-    # The find-or-create step exposes the branch it took as a step output.
-    issue_steps = [s for s in steps if s.get("id") == "issue"]
-    assert issue_steps, "no `issue` step found"
-    (issue_step,) = issue_steps
-    assert "created=true" in str(issue_step["run"])
-    assert "created=false" in str(issue_step["run"])
-
-    # A cleanup step runs on the no-diff path only.
-    cleanup_steps = [
-        s
-        for s in steps
-        if "gh issue close" in str(s.get("run", "")) and s.get("id") != "issue"
-    ]
-    assert cleanup_steps, "no no-diff cleanup step found"
-    (cleanup,) = cleanup_steps
-    cond = str(cleanup.get("if", ""))
-    assert "steps.resolve.outputs.proceed == 'true'" in cond
-    assert "steps.commit.outputs.changed != 'true'" in cond
-    # It authenticates as the App (the identity that owns the issue).
-    assert cleanup.get("env", {}).get("GH_TOKEN") == (
-        "${{ steps.app-token.outputs.token }}"
-    )
-    run = str(cleanup["run"])
-    # Only a freshly created issue is closed; a reused one is left open.
-    assert "steps.issue.outputs.created" not in run, (
-        "route the step output through env, never inline into run:"
-    )
-    assert cleanup.get("env", {}).get("CREATED") == (
-        "${{ steps.issue.outputs.created }}"
-    )
-    assert 'CREATED" = "true"' in run or 'CREATED" != "true"' in run
+    # No issue commands, no Refs/Closes markers, no issue-numbered branch.
+    assert "gh issue" not in text
+    assert "Refs: #" not in text
+    assert "Closes #" not in text
+    # The branch is the guard-legal chore/<summary> shape, keyed on the train.
+    assert 'BRANCH="chore/devkit-${SUFFIX}"' in text
+    # The PR body points reviewers at the devkit release notes instead.
+    assert "releases/tag/" in text
 
 
 # ── security: no template injection (zizmor) ──────────────────────────────────


### PR DESCRIPTION
## Summary

The devkit-upgrade workflow no longer creates, reuses, or garbage-collects a per-train adoption issue — adoption PRs become bot PRs exactly like Renovate's, with the PR as the traceable artifact and the changelog entry (#1404 / PR #1407) linking it.

Motivation (live evidence): on gitflow consumers the dev-targeted `Closes #N` never auto-closes, so every train strands an open issue (e.g. vig-os/commit-action#140, still open after its PR merged). The #1347 cleanup step existed only to garbage-collect issues the workflow itself created.

Changes in `assets/workspace/.github/workflows/devkit-upgrade.yml`:

- "Find or create the adoption issue" step and the entire #1347 no-diff cleanup step removed — a no-diff run now strands nothing by construction
- Branch: `chore/devkit-<train-suffix>` (the branch guard explicitly allows the issue-less `chore/<summary>` shape; still keyed on the train so rc → final reuse the same branch/PR)
- Staging commit: `chore: adopt devkit X.Y.Z` with no `Refs:` line (`chore` is exempt; hooks still validate in the project shell)
- PR body: links the devkit release notes instead of an auto-close marker
- Token mint: `permission-issues: write` dropped (three-permission least-privilege mint); preflight error message and header docstring updated

## Rollout notes

- Takes effect one train after shipping (the workflow runs from the consumer's base branch)
- One-time migration: close adoption issues left open by earlier trains on the consumers (commit-action#140 et al.)

## Verification

- TDD: failing tests committed first (`880c7d32`), workflow refactor after (`cf47f622`); 18/18 in `test_workflow_devkit_upgrade.py` incl. new `test_no_adoption_issue_lifecycle` (no `gh issue`, no `Refs:`/auto-close markers, chore-shape branch, release-notes link) and the tightened least-privilege mint assertion
- `just precommit` (all files), 695 pytest (vig-utils + workflow/scaffold/transform/model), full bats — all green
- `docs/issues/*.md` mentions of the old flow are frozen historical records and deliberately untouched

Closes #1405