### PR TITLE
docs: document smoke-test final-release human-approval gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Document the smoke-test final-release human-approval gate** ([#1409](https://github.com/vig-os/devkit/issues/1409))
+  - `docs/CROSS_REPO_RELEASE_GATE.md` now describes the approval gate shipped
+    in 1.7.0 (candidates leave the smoke release PR unapproved; the final
+    dispatch polls `reviewDecision` for a human approval, 30-minute window)
+    and its two contract dependencies: required reviews on smoke-test `main`
+    (org-config-owned) and default-branch listener execution (asset SSoT,
+    hotfix-main + mirror procedure)
+  - `docs/RELEASE_CYCLE.md` Phase 5 gains the explicit operator step: approve
+    the freshly created smoke-test release PR while the final dispatch is
+    paused at the gate, with timeout recovery (approve, then re-run failed
+    jobs)
+
 - **`devkit-upgrade` no longer opens a per-train adoption issue** ([#1405](https://github.com/vig-os/devkit/issues/1405))
   - Adoption PRs are bot PRs like Renovate's: the PR is the traceable
     artifact and the changelog entry ([#1404](https://github.com/vig-os/devkit/issues/1404))

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -24,6 +24,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Document the smoke-test final-release human-approval gate** ([#1409](https://github.com/vig-os/devkit/issues/1409))
+  - `docs/CROSS_REPO_RELEASE_GATE.md` now describes the approval gate shipped
+    in 1.7.0 (candidates leave the smoke release PR unapproved; the final
+    dispatch polls `reviewDecision` for a human approval, 30-minute window)
+    and its two contract dependencies: required reviews on smoke-test `main`
+    (org-config-owned) and default-branch listener execution (asset SSoT,
+    hotfix-main + mirror procedure)
+  - `docs/RELEASE_CYCLE.md` Phase 5 gains the explicit operator step: approve
+    the freshly created smoke-test release PR while the final dispatch is
+    paused at the gate, with timeout recovery (approve, then re-run failed
+    jobs)
+
 - **`devkit-upgrade` no longer opens a per-train adoption issue** ([#1405](https://github.com/vig-os/devkit/issues/1405))
   - Adoption PRs are bot PRs like Renovate's: the PR is the traceable
     artifact and the changelog entry ([#1404](https://github.com/vig-os/devkit/issues/1404))

--- a/docs/CROSS_REPO_RELEASE_GATE.md
+++ b/docs/CROSS_REPO_RELEASE_GATE.md
@@ -57,8 +57,14 @@ The receiver workflow (`assets/smoke-test/.github/workflows/repository-dispatch.
    - final tag -> GitHub release (draft until promoted)
 4. idempotency checks when a release object already exists
 5. preflight validation that required downstream workflow IDs are resolvable on the dispatch ref before orchestration starts
-6. after downstream `release.yml` completes: wait until required checks on the release PR are green (candidate and final)
-7. **final only:** dispatch downstream `promote-release.yml` on `dev` with `version` set to the base semver so the draft GitHub Release is published, the release PR is merged to `main`, and RC git tags are cleaned up (see workspace `promote-release.yml`). **Candidate:** the release PR stays open after checks pass; it is not merged by the receiver.
+6. release PR approval gate (`Gate final release on human approval of release PR`), before the downstream `release.yml` is triggered:
+   - **candidate:** the freshly created release PR is intentionally left **unapproved** — approval gates the final release only (deferred-approval model, [#902](https://github.com/vig-os/devkit/issues/902)), so the candidate chain runs green end-to-end with no human step
+   - **final:** the gate polls the PR's `reviewDecision` (20 s interval, up to 30 min) until a **human** approves the freshly created release PR; workflow-token self-approval is blocked org-wide and cannot be used (see [Contract dependencies](#contract-dependencies))
+   - on timeout the gate fails the run; **recovery:** approve the release PR, then re-run the failed jobs of the same listener run to resume the final release
+7. after downstream `release.yml` completes: wait until required checks on the release PR are green (candidate and final)
+8. **final only:** dispatch downstream `promote-release.yml` on `dev` with `version` set to the base semver so the draft GitHub Release is published, the release PR is merged to `main`, and RC git tags are cleaned up (see workspace `promote-release.yml`). **Candidate:** the release PR stays open after checks pass; it is not merged by the receiver.
+
+Every dispatch (each RC and the final) recreates the release branch and PR from scratch (cleanup-recreate semantics), so an up-front approval cannot survive to the final dispatch — the human approval necessarily happens **while the final dispatch is paused at the gate**. Operator step: [RELEASE_CYCLE.md, Phase 5](RELEASE_CYCLE.md#phase-5-post-release-cleanup).
 
 If the validation repository also runs the shipped workspace `release.yml` workflow for a **candidate** (separate from publishing a release for the dispatched tag), pass workflow input `rc-number` set to the numeric RC suffix of `client_payload.tag` (for example `21` for `0.3.1-rc21`). That keeps the downstream candidate tag aligned with the upstream publish tag. The smoke-test template exposes this value as job output `needs.validate.outputs.rc_number`.
 
@@ -69,6 +75,13 @@ If the validation repository also runs the shipped workspace `release.yml` workf
 **`vig-os/devcontainer` `promote-release.yml`:** Before updating GHCR `:latest`, publishing the draft GitHub Release, and merging the release PR, the `validate` job requires a **published** downstream release for the final version tag on `vig-os/devkit-smoke-test` that is **not** a draft and **not** a pre-release (`Verify downstream published final release`). For the canonical smoke-test flow, the receiver dispatches downstream `promote-release.yml` after `release.yml` and required release PR checks succeed, which publishes the downstream final release so this gate is satisfied without a manual publish step on the smoke-test repo.
 
 If promote validation fails, retry after the downstream release is in the expected state; `release.yml` rollback handling applies only to failures within that workflow.
+
+### Contract dependencies
+
+The approval gate has two external dependencies that are part of this contract. Both were discovered the hard way on the 1.7.0 train ([#1391](https://github.com/vig-os/devkit/issues/1391)):
+
+1. **Smoke-test `main` must require at least one approving review.** The gate polls `reviewDecision`, which GitHub only computes when the PR's base branch *requires* reviews — with a review count of 0, a human approval never surfaces as `reviewDecision=APPROVED` and the gate times out. The setting is owned by `vig-os/org-config` (`devkit-smoke-test` → `Main protection` → `required_approving_review_count: 1`, applied by [org-config#127](https://github.com/vig-os/org-config/issues/127) and guarded by an inline comment in `vig-os.jsonnet`). Workflow-token approvals are blocked org-wide ([org-config#122](https://github.com/vig-os/org-config/pull/122), `actions_can_approve_pull_request_reviews: false`, not overridable per-repo), so the required review is necessarily human.
+2. **The listener executes from the smoke-test repo's default branch (`main`).** `repository_dispatch` always runs the workflow version on the default branch — changes to `repository-dispatch.yml` that have only reached smoke-test `dev` are **not** live. The devkit asset (`assets/smoke-test/.github/workflows/repository-dispatch.yml`) is the source of truth; it reaches smoke-test `main` through the smoke repo's own release cycle. For urgent listener fixes, hotfix smoke-test `main` directly **and** mirror the change in the devkit asset so the next scaffold deploy converges rather than reverts (precedents: [devkit-smoke-test#345](https://github.com/vig-os/devkit-smoke-test/pull/345), [#353](https://github.com/vig-os/devkit-smoke-test/pull/353)).
 
 **Immutable releases:** Where **immutable releases** are enabled, a **published** GitHub Release (including a published **pre-release**) locks its **linked** tag and assets; they cannot be rewritten via normal GitHub UI/API. Downstream and smoke-test flows should fix forward with a new RC or version rather than deleting tags or releases. See [Immutable releases, tag rulesets, and forward-fix policy](RELEASE_CYCLE.md#immutable-releases-tag-rulesets-and-forward-fix-policy) for full policy and recovery procedures (including tags without a published release and the forward-fix no-delete policy).
 
@@ -106,6 +119,7 @@ Common failure patterns:
 - malformed/insufficient dispatch payload
 - downstream workflow failure prior to release artifact publication
 - workflow contract drift (required workflow ID missing on expected dispatch ref), which must fail fast in preflight
+- **final only:** `Timed out waiting for human approval of release PR` — either nobody approved the smoke release PR within the 30-minute gate window, or the approval never computed as `reviewDecision=APPROVED` because required reviews on smoke-test `main` were dropped (see [Contract dependencies](#contract-dependencies)). Recovery for the former: approve the PR, then re-run the failed jobs of the listener run. The latter is config drift and must be fixed in `vig-os/org-config` first.
 
 ## Operational Verification
 

--- a/docs/RELEASE_CYCLE.md
+++ b/docs/RELEASE_CYCLE.md
@@ -474,13 +474,27 @@ Release Summary:
 
 Cross-repository validation gate rationale, mechanics, payload contract, and pass/fail interpretation are documented in `docs/CROSS_REPO_RELEASE_GATE.md`.
 
+Automated with one exception: on the **final** dispatch the smoke-test listener pauses at a human-approval gate and waits (up to 30 minutes) for a maintainer to approve the smoke-test release PR. Since this repo's `release.yml` does not block on downstream state, nothing on the devkit side signals that the listener is waiting — the operator step is part of the Phase 5 runbook below.
+
 ### Phase 5: Post-Release Cleanup
 
 **This repository (`vig-os/devcontainer`) — manual promote path:**
 
-1. Verify the workflow run succeeded and smoke-test dispatch completed as expected.
-2. **Migrate RC-pinned consumers to the final tag** ([#880](https://github.com/vig-os/devkit/issues/880)): consumers pin the devcontainer image via their `.vig-os` file (`DEVCONTAINER_VERSION=X.Y.Z-rcN`). The **`cleanup`** job ("Cleanup RC artifacts") in `promote-release.yml` deletes all `X.Y.Z-rc*` git tags and GHCR image versions, so any consumer still pinned to an RC (e.g. field-validation repos) can no longer pull its image. Bump those pins to `DEVCONTAINER_VERSION=X.Y.Z` before running promote (preferred), or immediately after — the RC images and tags are gone once the cleanup job has run.
-3. After smoke-test has published its **final** GitHub Release for `X.Y.Z`, run **`promote-release.yml`** (e.g. `just promote-release X.Y.Z`), which updates GHCR `:latest`, publishes the draft release, merges the release PR, and runs best-effort RC cleanup. See [Release Phases](#release-phases) step 6 and [`docs/CROSS_REPO_RELEASE_GATE.md`](CROSS_REPO_RELEASE_GATE.md).
+1. Verify the workflow run succeeded and the smoke-test dispatch was triggered.
+2. **Approve the smoke-test release PR** (final dispatch only): the smoke-test listener recreates the smoke release PR from scratch and pauses at its `Gate final release on human approval of release PR` step, polling for a **human** approval for up to 30 minutes (workflow self-approval is blocked org-wide — [org-config#122](https://github.com/vig-os/org-config/pull/122); candidates run with the PR deliberately unapproved). Find and approve the freshly created PR while the gate is waiting:
+
+   ```bash
+   # Locate the waiting listener run and the release PR it created
+   gh -R vig-os/devkit-smoke-test run list --workflow repository-dispatch.yml --limit 1
+   gh -R vig-os/devkit-smoke-test pr list --label release-kind:final
+
+   # Approve it (must be a human account, not the PR author)
+   gh -R vig-os/devkit-smoke-test pr review <PR_NUMBER> --approve
+   ```
+
+   If the gate already timed out, approve the PR and **re-run the failed jobs** of that listener run to resume the final release. Full gate contract and failure modes: [`docs/CROSS_REPO_RELEASE_GATE.md`](CROSS_REPO_RELEASE_GATE.md).
+3. **Migrate RC-pinned consumers to the final tag** ([#880](https://github.com/vig-os/devkit/issues/880)): consumers pin the devcontainer image via their `.vig-os` file (`DEVCONTAINER_VERSION=X.Y.Z-rcN`). The **`cleanup`** job ("Cleanup RC artifacts") in `promote-release.yml` deletes all `X.Y.Z-rc*` git tags and GHCR image versions, so any consumer still pinned to an RC (e.g. field-validation repos) can no longer pull its image. Bump those pins to `DEVCONTAINER_VERSION=X.Y.Z` before running promote (preferred), or immediately after — the RC images and tags are gone once the cleanup job has run.
+4. After smoke-test has published its **final** GitHub Release for `X.Y.Z`, run **`promote-release.yml`** (e.g. `just promote-release X.Y.Z`), which updates GHCR `:latest`, publishes the draft release, merges the release PR, and runs best-effort RC cleanup. See [Release Phases](#release-phases) step 6 and [`docs/CROSS_REPO_RELEASE_GATE.md`](CROSS_REPO_RELEASE_GATE.md).
 
 **Consumer projects** using templates from `assets/workspace/` follow [Downstream release workflows](DOWNSTREAM_RELEASE.md): final `release.yml` leaves a **draft** GitHub Release; run **`promote-release.yml`** (or `just promote-release X.Y.Z`) to publish the release and merge to `main` (no upstream GHCR/smoke-test gate in that template).
 


### PR DESCRIPTION
## Description

Documents the smoke-test final-release human-approval gate shipped in 1.7.0 (#1391 / PR #1392). The mechanism is live-proven, but its operational contract lived only in issue threads and workflow comments — an operator following the current docs at the next final leg would hit a silent 30-minute stall, because devkit's `release.yml` does not block on downstream state and nothing signals that the smoke listener is waiting for an approval.

Closes #1409

## Type of Change

- [x] `docs` -- Documentation only

## Changes Made

- **`docs/CROSS_REPO_RELEASE_GATE.md`**
  - Receiver Responsibilities: new step for the approval gate — candidates leave the smoke release PR unapproved (deferred-approval model, #902); the final dispatch polls `reviewDecision` (20 s interval, 30 min) for a human approval; cleanup-recreate semantics explain why the approval must happen while the gate is waiting
  - New **Contract dependencies** section: (1) smoke-test `main` must require ≥1 approving review or `reviewDecision` never computes (org-config-owned, org-config#127; workflow approvals blocked org-wide by org-config#122); (2) the listener executes from the smoke repo's default branch — asset is SSoT, urgent fixes are hotfixed to smoke main and mirrored (precedents devkit-smoke-test#345/#353)
  - Failure Signals: gate timeout added, distinguishing "nobody approved" (approve + re-run failed jobs) from "required reviews dropped" (org-config drift)
- **`docs/RELEASE_CYCLE.md`**
  - Phase 4: notes the one human exception in the otherwise automated gate
  - Phase 5 runbook: explicit operator step 2 — locate the waiting listener run, approve the freshly created smoke release PR (`gh` commands included), timeout recovery; subsequent steps renumbered
- `CHANGELOG.md` (+ synced `assets/workspace/.devcontainer/CHANGELOG.md` copy, propagated by the `sync-manifest` hook)

## Changelog Entry

### Changed

- **Document the smoke-test final-release human-approval gate** ([#1409](https://github.com/vig-os/devkit/issues/1409))
  - `docs/CROSS_REPO_RELEASE_GATE.md` now describes the approval gate shipped in 1.7.0 and its two contract dependencies: required reviews on smoke-test `main` (org-config-owned) and default-branch listener execution (asset SSoT, hotfix-main + mirror procedure)
  - `docs/RELEASE_CYCLE.md` Phase 5 gains the explicit operator step: approve the freshly created smoke-test release PR while the final dispatch is paused at the gate, with timeout recovery

## Testing

- [x] Manual testing performed (describe below)

### Manual Testing Details

Docs-only change — TDD not applicable. Full `just precommit` suite green locally (the `sync-manifest` hook propagated the changelog to the workspace asset; committed). Content verified against the shipped gate implementation (`assets/smoke-test/.github/workflows/repository-dispatch.yml`, `Gate final release on human approval of release PR`), the org-config live config (`vig-os.jsonnet` devkit-smoke-test `Main protection`), and the 1.7.0 train record (#1391, org-config#122/#127, smoke run 31221248513).

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
