### PR TITLE
docs: refresh CLAUDE.md and add green-CI dispatch rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Refresh `CLAUDE.md` and add the green-CI dispatch rule** ([#1411](https://github.com/vig-os/devkit/issues/1411))
+  - `CLAUDE.md`: correct the project title to `vig-os/devkit`, add the missing
+    `/solve-and-pr` command row, and add a lean "Release Operations" section
+    pointing at the release doc set plus the agent-behavioral hard rules
+    (green-CI-before-dispatch, immutable-release forward-fix, automated
+    consumer adoption — no per-consumer lane dispatch)
+  - `docs/RELEASE_CYCLE.md` Phase 2: state the hard rule that `release.yml`
+    must never be dispatched until the release-branch PR CI is fully green —
+    the release PR opening is not the go-signal
+
 - **Document the smoke-test final-release human-approval gate** ([#1409](https://github.com/vig-os/devkit/issues/1409))
   - `docs/CROSS_REPO_RELEASE_GATE.md` now describes the approval gate shipped
     in 1.7.0 (candidates leave the smoke release PR unapproved; the final

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# Project: vigOS Devcontainer
+# Project: vigOS Devkit (`vig-os/devkit`)
 
 ## Custom Commands
 
@@ -26,6 +26,7 @@ Available slash commands (SSoT: `.claude/skills/`):
 | `/pr_create` | Prepare and submit a pull request |
 | `/pr_post-merge` | Cleanup after PR merge |
 | `/pr_solve` | Diagnose PR failures, plan fixes, execute them |
+| `/solve-and-pr` | Launch the autonomous worktree pipeline for an issue via `just worktree-start` |
 | `/worktree_ci-check` | Autonomous CI check -- polls until completion, triggers fix on failure |
 | `/worktree_ci-fix` | Autonomous CI fix -- diagnose, post diagnosis, fix, push, re-check |
 | `/worktree_brainstorm` | Autonomous design -- reads issue, posts design, never blocks |
@@ -111,3 +112,21 @@ See the `tdd` skill (`.claude/skills/tdd/SKILL.md`) for the scenario checklist a
 All commits must follow the Commit Message Standard. Never use `--no-verify`.
 
 Each phase gets its own commit. Do not write implementation before its test. Skip TDD only for non-testable changes (config, templates, docs) -- note why.
+
+---
+
+## Release Operations
+
+The recurring heavy workflow in this repo is the release train. The SSoT is
+[`docs/RELEASE_CYCLE.md`](docs/RELEASE_CYCLE.md); start there. Companion docs:
+
+- [`docs/CROSS_REPO_RELEASE_GATE.md`](docs/CROSS_REPO_RELEASE_GATE.md) -- smoke-test dispatch contract; the **final** dispatch pauses on a human approval of the smoke release PR
+- [`docs/DOWNSTREAM_RELEASE.md`](docs/DOWNSTREAM_RELEASE.md) -- release workflows in consumer repos
+- [`docs/MIGRATION.md`](docs/MIGRATION.md) and [`docs/SOLO_ADOPTION.md`](docs/SOLO_ADOPTION.md) -- consumer adoption paths
+- [`docs/WORKFLOW_SECURITY.md`](docs/WORKFLOW_SECURITY.md) -- App/token model behind the workflows
+
+Hard rules (rationale and detail live in the docs above, not here):
+
+1. **Never dispatch `release.yml` (candidate or final) until the release-branch PR CI is fully green.** The draft PR opening is not the go-signal.
+2. **Published releases are immutable org-wide; fix forward.** Deleting a published release tombstones its tag name permanently. Never delete published releases or tags -- cut the next RC or patch version instead.
+3. **Consumer rollout is automated.** `devkit-upgrade` opens adoption PRs in consumer repos on a schedule; release trains do not dispatch per-consumer lanes.

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -24,6 +24,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Refresh `CLAUDE.md` and add the green-CI dispatch rule** ([#1411](https://github.com/vig-os/devkit/issues/1411))
+  - `CLAUDE.md`: correct the project title to `vig-os/devkit`, add the missing
+    `/solve-and-pr` command row, and add a lean "Release Operations" section
+    pointing at the release doc set plus the agent-behavioral hard rules
+    (green-CI-before-dispatch, immutable-release forward-fix, automated
+    consumer adoption — no per-consumer lane dispatch)
+  - `docs/RELEASE_CYCLE.md` Phase 2: state the hard rule that `release.yml`
+    must never be dispatched until the release-branch PR CI is fully green —
+    the release PR opening is not the go-signal
+
 - **Document the smoke-test final-release human-approval gate** ([#1409](https://github.com/vig-os/devkit/issues/1409))
   - `docs/CROSS_REPO_RELEASE_GATE.md` now describes the approval gate shipped
     in 1.7.0 (candidates leave the smoke release PR unapproved; the final

--- a/docs/RELEASE_CYCLE.md
+++ b/docs/RELEASE_CYCLE.md
@@ -317,6 +317,17 @@ This is the main quality gate. The release branch and draft PR serve as the coor
    create no GitHub Release, and are pruned at promote. Iterate freely until the
    image behaves as intended.
 
+   **Hard rule: never dispatch `release.yml` — candidate or final — until the
+   release-branch PR's CI is fully green.** The release PR being opened by
+   `prepare-release` is **not** the go-signal; CI is still running at that
+   point, and a dispatch against a red or still-running branch wastes a full
+   build/publish round-trip (and, for finals, risks publishing from an
+   unverified commit). Check first:
+
+   ```bash
+   gh pr checks <PR_NUMBER> --watch
+   ```
+
 4. **Local Testing** (optional)
 
    ```bash


### PR DESCRIPTION
## Description

Refreshes `CLAUDE.md` — stale since the 1.4.0 era — and lands the one hard release rule that existed only as tribal knowledge. Follows the same agent-docs review as #1409/#1410.

Closes #1411

## Type of Change

- [x] `docs` -- Documentation only

## Changes Made

- **`CLAUDE.md`**
  - Title corrected: "vigOS Devcontainer" → "vigOS Devkit (`vig-os/devkit`)" (stale pre-rename names have already caused a real bug, #1396)
  - `/solve-and-pr` added to the command table (was in `.claude/skills/` but unlisted)
  - New lean **Release Operations** section: pointers to `RELEASE_CYCLE.md`, `CROSS_REPO_RELEASE_GATE.md`, `DOWNSTREAM_RELEASE.md`, `MIGRATION.md`/`SOLO_ADOPTION.md`, `WORKFLOW_SECURITY.md`, plus three hard rules (green-CI-before-dispatch, immutable-release forward-fix, adoption is automated — no per-consumer lane dispatch). Pointers only; docs remain SSoT.
- **`docs/RELEASE_CYCLE.md`** Phase 2 (Publish Candidates): hard rule that `release.yml` must never be dispatched — candidate or final — until the release-branch PR CI is fully green; the release PR opening is not the go-signal. This mistake recurred across trains and was previously written down nowhere in the repo.
- `CHANGELOG.md` (+ synced workspace asset copy via `sync-manifest` hook)

## Changelog Entry

### Changed

- **Refresh `CLAUDE.md` and add the green-CI dispatch rule** ([#1411](https://github.com/vig-os/devkit/issues/1411))
  - `CLAUDE.md`: correct the project title to `vig-os/devkit`, add the missing `/solve-and-pr` command row, and add a lean "Release Operations" section pointing at the release doc set plus the agent-behavioral hard rules
  - `docs/RELEASE_CYCLE.md` Phase 2: state the hard rule that `release.yml` must never be dispatched until the release-branch PR CI is fully green

## Testing

- [x] Manual testing performed (describe below)

### Manual Testing Details

Docs-only — TDD not applicable. Full `just precommit` suite green locally. Command-table row verified against `.claude/skills/solve-and-pr/SKILL.md`; hard rules cross-checked against `RELEASE_CYCLE.md` (immutability/forward-fix policy) and the 1.7.0 train record (automated adoption, #1404/#1405).

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
