### PR TITLE
fix(scaffold): fail consumer CI summary on cancelled required checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Scaffolded CI summary gate now fails on cancelled required checks** ([#1414](https://github.com/vig-os/devkit/issues/1414))
+  - The consumer `ci.yml` summary treated a cancelled `lint`, `test`,
+    `commit-checks`, `scaffold-drift`, or `dependency-review` job as green
+    (only `resolve-toolchain` had the cancelled leg), so a PR whose CI run was
+    cancelled could still merge — the #1371 doctrine now applies to every
+    needed job in both the devkit and scaffolded copies, pinned by a
+    parametrized shape test
 - **Automated main→dev sync PR no longer opens conflicted on every release** ([#1403](https://github.com/vig-os/devkit/issues/1403))
   - `sync-main-to-dev` now auto-resolves add/add conflicts on generated
     `docs/issues/` / `docs/pull-requests/` snapshots: a GitHub-signed

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -65,6 +65,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Scaffolded CI summary gate now fails on cancelled required checks** ([#1414](https://github.com/vig-os/devkit/issues/1414))
+  - The consumer `ci.yml` summary treated a cancelled `lint`, `test`,
+    `commit-checks`, `scaffold-drift`, or `dependency-review` job as green
+    (only `resolve-toolchain` had the cancelled leg), so a PR whose CI run was
+    cancelled could still merge — the #1371 doctrine now applies to every
+    needed job in both the devkit and scaffolded copies, pinned by a
+    parametrized shape test
 - **Automated main→dev sync PR no longer opens conflicted on every release** ([#1403](https://github.com/vig-os/devkit/issues/1403))
   - `sync-main-to-dev` now auto-resolves add/add conflicts on generated
     `docs/issues/` / `docs/pull-requests/` snapshots: a GitHub-signed

--- a/assets/workspace/.github/workflows/ci.yml
+++ b/assets/workspace/.github/workflows/ci.yml
@@ -406,39 +406,45 @@ jobs:
           echo "Dependency review: ${{ needs.dependency-review.result }}"
           echo ""
 
+          # Fail on 'failure' AND on 'cancelled': a cancelled job (timeout,
+          # concurrency cancel, runner eviction) produced no verdict, and this
+          # aggregate is the required check — treating it as green would let an
+          # unfinished CI run merge (#1371, #1414). 'skipped' stays tolerated:
+          # push/dispatch runs and PR-only jobs skip legitimately.
           FAILED=false
 
           if [ "${{ needs.resolve-toolchain.result }}" = "failure" ] || [ "${{ needs.resolve-toolchain.result }}" = "cancelled" ]; then
-            echo "ERROR: Toolchain resolution failed"
+            echo "ERROR: Toolchain resolution failed or was cancelled"
             FAILED=true
           fi
 
-          if [ "${{ needs.lint.result }}" = "failure" ]; then
-            echo "ERROR: Lint checks failed"
+          if [ "${{ needs.lint.result }}" = "failure" ] || [ "${{ needs.lint.result }}" = "cancelled" ]; then
+            echo "ERROR: Lint checks failed or were cancelled"
             FAILED=true
           fi
 
-          if [ "${{ needs.test.result }}" = "failure" ]; then
-            echo "ERROR: Tests failed"
+          if [ "${{ needs.test.result }}" = "failure" ] || [ "${{ needs.test.result }}" = "cancelled" ]; then
+            echo "ERROR: Tests failed or were cancelled"
             FAILED=true
           fi
 
-          if [ "${{ needs.commit-checks.result }}" = "failure" ]; then
-            echo "ERROR: Commit message checks failed"
+          if [ "${{ needs.commit-checks.result }}" = "failure" ] || [ "${{ needs.commit-checks.result }}" = "cancelled" ]; then
+            echo "ERROR: Commit message checks failed or were cancelled"
             FAILED=true
           fi
 
-          # Skipped on push/dispatch and when DEVKIT_DRIFT_CHECK=false; only a
-          # genuine failure (managed-file drift) trips the gate.
-          if [ "${{ needs.scaffold-drift.result }}" = "failure" ]; then
-            echo "ERROR: Scaffold drift detected"
+          # Skipped on push/dispatch and when DEVKIT_DRIFT_CHECK=false; a
+          # genuine failure (managed-file drift) or a cancel trips the gate.
+          if [ "${{ needs.scaffold-drift.result }}" = "failure" ] || [ "${{ needs.scaffold-drift.result }}" = "cancelled" ]; then
+            echo "ERROR: Scaffold drift detected or check cancelled"
             FAILED=true
           fi
 
           # Skipped on push/dispatch and on private repos (same skip-is-OK
-          # treatment as commit-checks); only a genuine failure trips the gate.
-          if [ "${{ needs.dependency-review.result }}" = "failure" ]; then
-            echo "ERROR: Dependency review failed"
+          # treatment as commit-checks); a genuine failure or a cancel trips
+          # the gate.
+          if [ "${{ needs.dependency-review.result }}" = "failure" ] || [ "${{ needs.dependency-review.result }}" = "cancelled" ]; then
+            echo "ERROR: Dependency review failed or was cancelled"
             FAILED=true
           fi
 

--- a/tests/test_workflow_summary_gate.py
+++ b/tests/test_workflow_summary_gate.py
@@ -1,18 +1,22 @@
-"""Workflow-shape tests: the CI ``Test Summary`` gate must not pass on cancel.
+"""Workflow-shape tests: the CI summary gates must not pass on cancel.
 
-Issue #1371: ``Test Summary`` (the ``summary`` job in ``.github/workflows/ci.yml``)
-is the only required status check on ``dev``. It aggregates its ``needs:`` jobs
-but originally set ``FAILED=true`` only on ``result == "failure"``, so a
-**cancelled** job — job timeout, concurrency cancel, runner eviction, a manual
-"Cancel workflow" — left the required check green and a PR whose CI never
-finished was mergeable.
+Issue #1371: the summary job is the only required status check on the default
+merge target (``dev`` here; ``main`` for trunk consumers). It aggregates its
+``needs:`` jobs but originally set ``FAILED=true`` only on
+``result == "failure"``, so a **cancelled** job — job timeout, concurrency
+cancel, runner eviction, a manual "Cancel workflow" — left the required check
+green and a PR whose CI never finished was mergeable.
 
-``skipped`` stays tolerated on purpose: ``workflow_dispatch`` takes a
-``test-suite`` input (``all``/``image``/``integration``/``project``) that every
-job is gated on, and ``commit-checks``/``dependency-review`` are pull-request
-only, so a skipped job is a legitimate outcome rather than a missing result.
+Issue #1414: the scaffolded consumer copy shipped the cancelled leg only for
+``resolve-toolchain``; every needed job in *both* copies must trip the gate on
+cancel, so the doctrine is pinned parametrically over the two files.
 
-Refs: #1371
+``skipped`` stays tolerated on purpose: dispatch subsets and PR-only jobs
+(``commit-checks``/``dependency-review``, and the scaffold's push-skipped
+``scaffold-drift``) make a skipped job a legitimate outcome rather than a
+missing result.
+
+Refs: #1371, #1414
 """
 
 from __future__ import annotations
@@ -20,62 +24,89 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
-import yaml
+
+from tests.workflow_scaffold import WORKSPACE, load_workflow, run_text_of_job
 
 # Repository root (tests/ -> repo root).
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
-CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+# copy id -> (workflow path, display name, full needs set of the summary job)
+SUMMARY_COPIES: dict[str, tuple[Path, str, set[str]]] = {
+    "devkit": (
+        REPO_ROOT / ".github" / "workflows" / "ci.yml",
+        "Test Summary",
+        {
+            "build-image",
+            "test-image",
+            "test-integration",
+            "project-checks",
+            "commit-checks",
+            "python-security",
+            "security-scan",
+            "dependency-review",
+        },
+    ),
+    "scaffold": (
+        WORKSPACE / ".github" / "workflows" / "ci.yml",
+        "CI Summary",
+        {
+            "resolve-toolchain",
+            "lint",
+            "test",
+            "commit-checks",
+            "scaffold-drift",
+            "dependency-review",
+        },
+    ),
+}
 
 
-def _summary_job() -> dict:
-    workflow = yaml.safe_load(CI_WORKFLOW.read_text(encoding="utf-8"))
-    return workflow["jobs"]["summary"]
+def _summary_job(copy: str) -> dict:
+    path, _, _ = SUMMARY_COPIES[copy]
+    return load_workflow(path)["jobs"]["summary"]
 
 
-def _summary_run() -> str:
-    return _summary_job()["steps"][0]["run"]
+def _summary_run(copy: str) -> str:
+    return run_text_of_job(_summary_job(copy))
 
 
-def _needed_jobs() -> list[str]:
-    return list(_summary_job()["needs"])
+# (copy, job) pairs for every needed job of every copy, with stable test ids.
+_COPY_JOB_PAIRS = [
+    pytest.param(copy, job, id=f"{copy}-{job}")
+    for copy, (_, _, needed) in SUMMARY_COPIES.items()
+    for job in sorted(needed)
+]
 
 
-def test_summary_is_the_required_check_over_every_test_job() -> None:
+@pytest.mark.parametrize("copy", sorted(SUMMARY_COPIES))
+def test_summary_is_the_required_check_over_every_job(copy: str) -> None:
     """The aggregate still fans in over the full job set it is meant to gate."""
-    assert _summary_job()["name"] == "Test Summary"
-    assert set(_needed_jobs()) == {
-        "build-image",
-        "test-image",
-        "test-integration",
-        "project-checks",
-        "commit-checks",
-        "python-security",
-        "security-scan",
-        "dependency-review",
-    }
+    _, name, needed = SUMMARY_COPIES[copy]
+    job = _summary_job(copy)
+    assert job["name"] == name
+    assert set(job["needs"]) == needed
 
 
-@pytest.mark.parametrize("job", _needed_jobs())
-def test_summary_fails_on_failure(job: str) -> None:
+@pytest.mark.parametrize(("copy", "job"), _COPY_JOB_PAIRS)
+def test_summary_fails_on_failure(copy: str, job: str) -> None:
     """Every needed job trips the gate when it fails."""
-    assert f'needs.{job}.result }}}}" = "failure"' in _summary_run(), (
-        f"summary must fail when {job} result is failure"
+    assert f'needs.{job}.result }}}}" = "failure"' in _summary_run(copy), (
+        f"{copy} summary must fail when {job} result is failure"
     )
 
 
-@pytest.mark.parametrize("job", _needed_jobs())
-def test_summary_fails_on_cancelled(job: str) -> None:
-    """Every needed job trips the gate when it is cancelled (#1371)."""
-    assert f'needs.{job}.result }}}}" = "cancelled"' in _summary_run(), (
-        f"summary must fail when {job} result is cancelled — a cancelled job is "
-        "an unfinished check, not a passing one"
+@pytest.mark.parametrize(("copy", "job"), _COPY_JOB_PAIRS)
+def test_summary_fails_on_cancelled(copy: str, job: str) -> None:
+    """Every needed job trips the gate when it is cancelled (#1371, #1414)."""
+    assert f'needs.{job}.result }}}}" = "cancelled"' in _summary_run(copy), (
+        f"{copy} summary must fail when {job} result is cancelled — a "
+        "cancelled job is an unfinished check, not a passing one"
     )
 
 
-@pytest.mark.parametrize("job", _needed_jobs())
-def test_summary_tolerates_skipped(job: str) -> None:
+@pytest.mark.parametrize(("copy", "job"), _COPY_JOB_PAIRS)
+def test_summary_tolerates_skipped(copy: str, job: str) -> None:
     """A skipped job is legitimate (dispatch subset, PR-only jobs) — never fatal."""
-    assert f'needs.{job}.result }}}}" = "skipped"' not in _summary_run(), (
-        f"{job} skipped must not trip the summary"
+    assert f'needs.{job}.result }}}}" = "skipped"' not in _summary_run(copy), (
+        f"{copy}: {job} skipped must not trip the summary"
     )


### PR DESCRIPTION
## Summary

Fixes #1414: the scaffolded consumer `ci.yml` summary gate treated a **cancelled** `lint`, `test`, `commit-checks`, `scaffold-drift`, or `dependency-review` job as green — only `resolve-toolchain` had the cancelled leg — so a consumer PR whose CI run was cancelled (timeout, concurrency cancel, runner eviction) could still merge. The devkit copy has handled this since #1371.

## Changes

- `assets/workspace/.github/workflows/ci.yml`: every needed job of the summary now trips the gate on `cancelled` as well as `failure`, with the #1371 doctrine comment; `skipped` stays tolerated (dispatch subsets, PR-only jobs, drift-check knob). Synced `CHANGELOG.md` copy updated by the manifest hook.
- `tests/test_workflow_summary_gate.py`: parametrized over **both** `ci.yml` copies (devkit + scaffold) on the shared workflow helpers — failure legs, cancelled legs, and skipped tolerance are now pinned per (copy, job). Written test-first: the five scaffold cancelled legs were red before the template fix.
- `CHANGELOG.md`: `Unreleased` → `Fixed` entry.

## Verification

- `tests/test_workflow_summary_gate.py` + `tests/test_workflow_private_repo_guard.py`: **52 passed** (was 5 failed on the scaffold cancelled legs before the fix).
- Scaffold `ci.yml` shape suites (`zizmor_baseline`, `ci_runner`, `workflow_model`, `scaffold_drift`, `scaffold_lint`): **89 passed**; zizmor audit over `assets/workspace/.github/workflows/`: no findings.
- Full prek hook suite on all files: green.

Closes #1414
