### PR TITLE
feat: add just doctor diagnostics and close audit coverage gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`just doctor` host diagnostics + audit coverage gaps closed** ([#1418](https://github.com/vig-os/devkit/issues/1418))
+  - New `just doctor` recipe reports host prerequisites (git identity, commit
+    signing, ssh-agent, gh auth) as PASS/WARN diagnostics and always exits 0
+  - New tests for previously uncovered behavior: `docs/generate.py` skill
+    parsing/grouping units, image coverage for nvim/actionlint and locale
+    archive resolution, read-only token-ceiling pins for the scaffolded
+    release jobs, and stub-driven behavioral tests for the scaffolded
+    `devc-upgrade` recipe
 - **Changelog entries for devkit adoption PRs** ([#1404](https://github.com/vig-os/devkit/issues/1404))
   - The scaffolded `renovate-changelog-build.yml` now also accepts PRs opened
     by the devkit-upgrade App (`vigos-devkit-upgrade[bot]`), so an adoption PR

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -169,6 +169,7 @@ Available recipes:
     [info]
     default                                    # Show available commands (default)
     docs                                       # Generate documentation from templates
+    doctor                                     # Diagnose host prerequisites: git identity, commit signing, ssh-agent, gh auth
     help                                       # Show available commands
     info                                       # Show image information
     init *args                                 # Gate Nix prerequisites and bootstrap the project (venv, git hooks, pre-commit)

--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Available recipes:
     [info]
     default                                    # Show available commands (default)
     docs                                       # Generate documentation from templates
+    doctor                                     # Diagnose host prerequisites: git identity, commit signing, ssh-agent, gh auth
     help                                       # Show available commands
     info                                       # Show image information
     init *args                                 # Gate Nix prerequisites and bootstrap the project (venv, git hooks, pre-commit)

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`just doctor` host diagnostics + audit coverage gaps closed** ([#1418](https://github.com/vig-os/devkit/issues/1418))
+  - New `just doctor` recipe reports host prerequisites (git identity, commit
+    signing, ssh-agent, gh auth) as PASS/WARN diagnostics and always exits 0
+  - New tests for previously uncovered behavior: `docs/generate.py` skill
+    parsing/grouping units, image coverage for nvim/actionlint and locale
+    archive resolution, read-only token-ceiling pins for the scaffolded
+    release jobs, and stub-driven behavioral tests for the scaffolded
+    `devc-upgrade` recipe
 - **Changelog entries for devkit adoption PRs** ([#1404](https://github.com/vig-os/devkit/issues/1404))
   - The scaffolded `renovate-changelog-build.yml` now also accepts PRs opened
     by the devkit-upgrade App (`vigos-devkit-upgrade[bot]`), so an adoption PR

--- a/justfile
+++ b/justfile
@@ -42,6 +42,54 @@ format:
 precommit:
     prek run --all-files
 
+# Diagnostics only — always exits 0 (#1418; replaces the deleted
+# TestHostGitSignatureSetup skip-on-failure tests).
+# Diagnose host prerequisites: git identity, commit signing, ssh-agent, gh auth
+[group('info')]
+doctor:
+    #!/usr/bin/env bash
+    echo "vigOS devkit doctor"
+    echo "==================="
+
+    name="$(git config user.name || true)"
+    if [ -n "$name" ]; then
+        echo "PASS git user.name: $name"
+    else
+        echo "WARN git user.name: not set (git config --global user.name ...)"
+    fi
+
+    email="$(git config user.email || true)"
+    if [ -n "$email" ]; then
+        echo "PASS git user.email: $email"
+    else
+        echo "WARN git user.email: not set (git config --global user.email ...)"
+    fi
+
+    gpgsign="$(git config commit.gpgsign || true)"
+    format="$(git config gpg.format || true)"
+    signingkey="$(git config user.signingkey || true)"
+    if [ "$gpgsign" = "true" ] && [ -n "$signingkey" ] && \
+        { [ "$format" != "ssh" ] || [ -r "$signingkey" ] || \
+          [ "${signingkey#ssh-}" != "$signingkey" ]; }; then
+        echo "PASS commit signing: $format key $signingkey"
+    else
+        echo "WARN commit signing: incomplete (commit.gpgsign=$gpgsign, gpg.format=$format, user.signingkey=$signingkey)"
+    fi
+
+    if [ -n "${SSH_AUTH_SOCK:-}" ] && ssh-add -l >/dev/null 2>&1; then
+        echo "PASS ssh-agent: reachable with $(ssh-add -l | wc -l) key(s)"
+    else
+        echo "WARN ssh-agent: not reachable or no keys loaded"
+    fi
+
+    if gh auth status >/dev/null 2>&1; then
+        echo "PASS gh auth: logged in"
+    else
+        echo "WARN gh auth: not authenticated (run: gh auth login)"
+    fi
+
+    exit 0
+
 # Show image information
 [group('info')]
 info:

--- a/tests/bats/doctor.bats
+++ b/tests/bats/doctor.bats
@@ -1,0 +1,71 @@
+#!/usr/bin/env bats
+# BATS tests for the `just doctor` host-diagnostics recipe (#1418).
+#
+# `doctor` replaces the deleted TestHostGitSignatureSetup pytest class: instead
+# of tests that skip on the failures they were meant to catch, host
+# prerequisites (git identity, commit signing, ssh-agent, gh auth) are reported
+# as PASS/WARN diagnostic lines. Diagnostics are not a gate: the recipe always
+# exits 0. Tests drive the recipe under a controlled environment
+# (GIT_CONFIG_GLOBAL/SYSTEM, SSH_AUTH_SOCK, stub `gh`) so host state never
+# leaks in.
+
+setup() {
+    load test_helper
+    DOCTOR_WORK="$BATS_TEST_TMPDIR/host"
+    DOCTOR_STUBS="$BATS_TEST_TMPDIR/doctor-stubs"
+    GIT_GLOBAL="$BATS_TEST_TMPDIR/gitconfig"
+    mkdir -p "$DOCTOR_WORK" "$DOCTOR_STUBS"
+    : >"$GIT_GLOBAL"
+    # Stub gh: GH_STUB_RC controls `gh auth status` (default: not logged in).
+    cat >"$DOCTOR_STUBS/gh" <<'STUB'
+#!/usr/bin/env bash
+if [ "${GH_STUB_RC:-1}" -eq 0 ]; then
+    echo "Logged in to github.com"
+fi
+exit "${GH_STUB_RC:-1}"
+STUB
+    chmod +x "$DOCTOR_STUBS/gh"
+}
+
+_run_doctor() {
+    run env PATH="$DOCTOR_STUBS:$PATH" \
+        GIT_CONFIG_GLOBAL="$GIT_GLOBAL" GIT_CONFIG_SYSTEM=/dev/null \
+        -u SSH_AUTH_SOCK "$@" \
+        just --justfile "$PROJECT_ROOT/justfile" \
+        --working-directory "$DOCTOR_WORK" doctor
+}
+
+@test "doctor always exits 0 and warns on an unconfigured host" {
+    _run_doctor
+    assert_success
+    assert_output --partial "devkit doctor"
+    assert_output --partial "WARN git user.name"
+    assert_output --partial "WARN git user.email"
+    assert_output --partial "WARN commit signing"
+    assert_output --partial "WARN ssh-agent"
+    assert_output --partial "WARN gh auth"
+}
+
+@test "doctor reports PASS for configured git identity and signing" {
+    git config --file "$GIT_GLOBAL" user.name "Test User"
+    git config --file "$GIT_GLOBAL" user.email "test@example.com"
+    git config --file "$GIT_GLOBAL" gpg.format ssh
+    git config --file "$GIT_GLOBAL" commit.gpgsign true
+    git config --file "$GIT_GLOBAL" user.signingkey "$BATS_TEST_TMPDIR/key.pub"
+    printf 'ssh-ed25519 AAAA test\n' >"$BATS_TEST_TMPDIR/key.pub"
+    _run_doctor GH_STUB_RC=0
+    assert_success
+    assert_output --partial "PASS git user.name: Test User"
+    assert_output --partial "PASS git user.email: test@example.com"
+    assert_output --partial "PASS commit signing"
+    assert_output --partial "PASS gh auth"
+}
+
+@test "doctor warns when the signing key path does not exist" {
+    git config --file "$GIT_GLOBAL" commit.gpgsign true
+    git config --file "$GIT_GLOBAL" gpg.format ssh
+    git config --file "$GIT_GLOBAL" user.signingkey "$BATS_TEST_TMPDIR/missing.pub"
+    _run_doctor
+    assert_success
+    assert_output --partial "WARN commit signing"
+}

--- a/tests/bats/doctor.bats
+++ b/tests/bats/doctor.bats
@@ -28,9 +28,8 @@ STUB
 }
 
 _run_doctor() {
-    run env PATH="$DOCTOR_STUBS:$PATH" \
-        GIT_CONFIG_GLOBAL="$GIT_GLOBAL" GIT_CONFIG_SYSTEM=/dev/null \
-        -u SSH_AUTH_SOCK "$@" \
+    run env -u SSH_AUTH_SOCK PATH="$DOCTOR_STUBS:$PATH" \
+        GIT_CONFIG_GLOBAL="$GIT_GLOBAL" GIT_CONFIG_SYSTEM=/dev/null "$@" \
         just --justfile "$PROJECT_ROOT/justfile" \
         --working-directory "$DOCTOR_WORK" doctor
 }

--- a/tests/bats/just.bats
+++ b/tests/bats/just.bats
@@ -101,6 +101,98 @@ EOF
     assert_success
 }
 
+# ── devc-upgrade behavioral coverage (#1418) ──────────────────────────────────
+# The greps above pin the recipe text; these run the scaffolded recipe for real
+# against stub `curl`/`podman` binaries (the clean.bats pattern). The curl stub
+# logs its arguments and emits a fake install.sh body, so the `curl | bash -s`
+# pipe logs exactly what the installer would receive.
+
+_setup_devc_upgrade() {
+    DEVC_WORK="$BATS_TEST_TMPDIR/consumer"
+    DEVC_STUBS="$BATS_TEST_TMPDIR/devc-stubs"
+    DEVC_LOG="$BATS_TEST_TMPDIR/devc.log"
+    DEVC_JUSTFILE="$PROJECT_ROOT/assets/workspace/.devcontainer/justfile.devc"
+    mkdir -p "$DEVC_WORK" "$DEVC_STUBS"
+    cat >"$DEVC_STUBS/curl" <<'STUB'
+#!/usr/bin/env bash
+printf 'curl %s\n' "$*" >>"$DEVC_LOG"
+printf '%s\n' 'printf "install.sh %s\n" "$*" >>"$DEVC_LOG"'
+STUB
+    printf '#!/usr/bin/env bash\nexit 0\n' >"$DEVC_STUBS/podman"
+    chmod +x "$DEVC_STUBS/curl" "$DEVC_STUBS/podman"
+}
+
+_run_devc_upgrade() {
+    run env PATH="$DEVC_STUBS:$PATH" DEVC_LOG="$DEVC_LOG" \
+        just --justfile "$DEVC_JUSTFILE" --working-directory "$DEVC_WORK" \
+        devc-upgrade
+}
+
+@test "devc-upgrade upgrades to the DEVKIT_VERSION pin end-to-end (#854, #1418)" {
+    _setup_devc_upgrade
+    printf 'DEVKIT_VERSION="1.6.0"\n' >"$DEVC_WORK/.vig-os"
+    _run_devc_upgrade
+    assert_success
+    run grep -F 'vig-os/devkit/1.6.0/install.sh' "$DEVC_LOG"
+    assert_success
+    run grep -F 'install.sh --force --version 1.6.0 .' "$DEVC_LOG"
+    assert_success
+}
+
+@test "devc-upgrade honors the legacy DEVCONTAINER_VERSION pin end-to-end (#781, #1418)" {
+    _setup_devc_upgrade
+    printf 'DEVCONTAINER_VERSION="0.9.9"\n' >"$DEVC_WORK/.vig-os"
+    _run_devc_upgrade
+    assert_success
+    run grep -F 'vig-os/devkit/0.9.9/install.sh' "$DEVC_LOG"
+    assert_success
+    run grep -F 'install.sh --force --version 0.9.9 .' "$DEVC_LOG"
+    assert_success
+}
+
+@test "devc-upgrade without a pin stays on the floating main installer (#854, #1418)" {
+    _setup_devc_upgrade
+    _run_devc_upgrade
+    assert_success
+    run grep -F 'vig-os/devkit/main/install.sh' "$DEVC_LOG"
+    assert_success
+    run grep -F -- '--version' "$DEVC_LOG"
+    assert_failure
+}
+
+@test "devc-upgrade treats a latest pin as floating (#854, #1418)" {
+    _setup_devc_upgrade
+    printf 'DEVKIT_VERSION="latest"\n' >"$DEVC_WORK/.vig-os"
+    _run_devc_upgrade
+    assert_success
+    run grep -F 'vig-os/devkit/main/install.sh' "$DEVC_LOG"
+    assert_success
+}
+
+@test "devc-upgrade errors before curling when no container runtime exists (#1418)" {
+    _setup_devc_upgrade
+    # Minimal PATH: interpreter only — no podman/docker/curl resolvable.
+    minimal="$BATS_TEST_TMPDIR/minimal-bin"
+    mkdir -p "$minimal"
+    ln -s "$(command -v bash)" "$minimal/bash"
+    run env PATH="$minimal" DEVC_LOG="$DEVC_LOG" \
+        "$(command -v just)" --justfile "$DEVC_JUSTFILE" \
+        --working-directory "$DEVC_WORK" devc-upgrade
+    assert_failure
+    assert_output --partial "Neither podman nor docker is installed"
+    [ ! -s "$DEVC_LOG" ]
+}
+
+@test "devc-upgrade refuses to run inside a container (#1418)" {
+    _setup_devc_upgrade
+    run env PATH="$DEVC_STUBS:$PATH" DEVC_LOG="$DEVC_LOG" container=podman \
+        just --justfile "$DEVC_JUSTFILE" --working-directory "$DEVC_WORK" \
+        devc-upgrade
+    assert_failure
+    assert_output --partial "must be run from a HOST terminal"
+    [ ! -s "$DEVC_LOG" ]
+}
+
 @test "release recipes dispatch their workflow from the expected ref" {
     # recipe:expected-REF table; prepare-release cuts from dev, the rest act on
     # the release branch.

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -396,6 +396,12 @@ class TestSystemTools:
         """Test that nano is installed (path-agnostic, via --version)."""
         assert_tool_runs(host, "nano", "--version")
 
+    def test_nvim_runs(self, host):
+        """Test that neovim runs (devTools member with no image test before #1418)."""
+        result = host.run("nvim --version")
+        assert result.rc == 0, "nvim --version failed"
+        assert "nvim" in result.stdout.lower()
+
     def test_gh_version(self, host):
         """Test that gh runs (version is nixpkgs-pinned via flake.lock, not asserted)."""
         result = host.run("gh --version")
@@ -640,6 +646,11 @@ class TestDevelopmentTools:
             f"Expected ruff {expected}, got: {result.stdout}"
         )
 
+    def test_actionlint_runs(self, host):
+        """Test that actionlint runs (pre-commit hook tool, #995; no image test before #1418)."""
+        result = host.run("actionlint -version")
+        assert result.rc == 0, "actionlint -version failed"
+
     def test_pip_licenses_installed(self, host):
         """Test that pip-licenses is installed."""
         result = host.run("pip-licenses --version")
@@ -817,6 +828,35 @@ class TestEnvironmentVariables:
         assert result.rc == 0, f"Failed to read {name}"
         assert result.stdout.strip() == expected, (
             f"Expected {name}={expected}, got: {result.stdout.strip()}"
+        )
+
+    def test_locale_archive_points_at_shipped_archive(self, host):
+        """LOCALE_ARCHIVE targets an existing archive file (#1104, #1418).
+
+        The exact value is a Nix store path, so only the shape and the file's
+        existence are asserted, not the hash.
+        """
+        result = host.run("printenv LOCALE_ARCHIVE")
+        assert result.rc == 0, "LOCALE_ARCHIVE is not set"
+        archive = result.stdout.strip()
+        assert archive.endswith("/lib/locale/locale-archive"), (
+            f"Unexpected LOCALE_ARCHIVE shape: {archive}"
+        )
+        assert host.file(archive).exists, f"Locale archive missing: {archive}"
+
+    def test_locale_resolves_en_us_utf8(self, host):
+        """setlocale('') resolves en_US.UTF-8 from the slimmed archive (#1104).
+
+        The image ships a single-locale archive; if it were missing or lacked
+        en_US.UTF-8, glibc setlocale would fail and this exits non-zero.
+        """
+        result = host.run(
+            "python3 -c \"import locale; locale.setlocale(locale.LC_ALL, ''); "
+            'print(locale.getlocale())"'
+        )
+        assert result.rc == 0, f"setlocale failed: {result.stderr}"
+        assert "en_US" in result.stdout and "UTF-8" in result.stdout, (
+            f"Expected en_US UTF-8 locale, got: {result.stdout}"
         )
 
 

--- a/tests/test_release_core.py
+++ b/tests/test_release_core.py
@@ -93,3 +93,35 @@ def test_polls_filter_on_the_release_branch() -> None:
     run = _step("Wait for sync-issues")["run"]
     # --branch appears on both the status poll and the conclusion poll.
     assert run.count('--branch "release/$VERSION"') >= 2
+
+
+# ═════════════════════════════════════════════════════════════════════════════
+# Token ceilings (#1418): the release-core jobs are read-only by construction —
+# every write goes through a minted App token, never GITHUB_TOKEN. Pinning the
+# exact permission maps makes a silent widening fail loudly.
+# ═════════════════════════════════════════════════════════════════════════════
+
+
+def test_workflow_ceiling_is_read_only() -> None:
+    """The workflow-level GITHUB_TOKEN ceiling grants reads only."""
+    workflow = load_workflow(WORKFLOWS / "release-core.yml")
+    assert workflow["permissions"] == {"contents": "read", "packages": "read"}
+
+
+def test_job_ceilings_are_pinned_read_only() -> None:
+    """Each job's ceiling is the exact read-only map (test inherits the top)."""
+    jobs = load_workflow(WORKFLOWS / "release-core.yml")["jobs"]
+    assert jobs["validate"]["permissions"] == {
+        "contents": "read",
+        "pull-requests": "read",
+        "packages": "read",
+    }
+    assert jobs["finalize"]["permissions"] == {
+        "actions": "read",
+        "contents": "read",
+        "packages": "read",
+    }
+    assert "permissions" not in jobs["test"], (
+        "the test job inherits the read-only workflow ceiling; adding its own "
+        "block must be a deliberate, reviewed change"
+    )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -255,6 +255,144 @@ class TestGenerateDocs:
         assert "<!-- Missing: nonexistent.md -->" in content
 
 
+def _point_generate_to_temp_skills(
+    monkeypatch, tmp_path: Path, skill_files: dict[str, str]
+) -> None:
+    """Point load_skills() at a temp .claude/skills tree.
+
+    ``skill_files`` maps a skill directory name to its SKILL.md content. An
+    empty mapping leaves the skills directory absent to exercise the
+    missing-dir branch.
+    """
+    docs_path = tmp_path / "docs"
+    docs_path.mkdir(exist_ok=True)
+    fake_generate = docs_path / "generate.py"
+    fake_generate.write_text("# test helper\n")
+
+    for name, content in skill_files.items():
+        skill_dir = tmp_path / ".claude" / "skills" / name
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(content)
+
+    monkeypatch.setattr(generate, "__file__", str(fake_generate))
+
+
+class TestLoadSkills:
+    """Unit tests for load_skills() front-matter parsing (#1418)."""
+
+    def test_missing_skills_dir_returns_empty(self, tmp_path, monkeypatch, capsys):
+        """An absent .claude/skills directory yields [] plus a stderr warning."""
+        _point_generate_to_temp_skills(monkeypatch, tmp_path, {})
+        assert generate.load_skills() == []
+        assert "Skills directory not found" in capsys.readouterr().err
+
+    def test_parses_front_matter_fields(self, tmp_path, monkeypatch):
+        """name/description map to name, slash-trigger, description, group."""
+        _point_generate_to_temp_skills(
+            monkeypatch,
+            tmp_path,
+            {
+                "code_review": (
+                    "---\nname: code_review\ndescription: Review code\n---\nBody\n"
+                )
+            },
+        )
+        assert generate.load_skills() == [
+            {
+                "name": "code_review",
+                "trigger": "/code-review",
+                "description": "Review code",
+                "group": "code",
+            }
+        ]
+
+    def test_description_defaults_to_empty(self, tmp_path, monkeypatch):
+        """A skill without a description still loads, with description ''."""
+        _point_generate_to_temp_skills(
+            monkeypatch, tmp_path, {"ci_check": "---\nname: ci_check\n---\nBody\n"}
+        )
+        (skill,) = generate.load_skills()
+        assert skill["description"] == ""
+
+    def test_skips_file_without_front_matter(self, tmp_path, monkeypatch):
+        """A SKILL.md that does not open with --- is ignored."""
+        _point_generate_to_temp_skills(
+            monkeypatch, tmp_path, {"code_x": "# just a heading\nname: code_x\n"}
+        )
+        assert generate.load_skills() == []
+
+    def test_skips_unterminated_front_matter(self, tmp_path, monkeypatch):
+        """Front matter without a closing --- is ignored."""
+        _point_generate_to_temp_skills(
+            monkeypatch, tmp_path, {"code_x": "---\nname: code_x\n"}
+        )
+        assert generate.load_skills() == []
+
+    def test_skips_front_matter_without_name(self, tmp_path, monkeypatch):
+        """Front matter lacking a name key is ignored."""
+        _point_generate_to_temp_skills(
+            monkeypatch, tmp_path, {"code_x": "---\ndescription: no name\n---\n"}
+        )
+        assert generate.load_skills() == []
+
+    def test_entries_sorted_by_directory(self, tmp_path, monkeypatch):
+        """Skills come back in sorted path order regardless of creation order."""
+        _point_generate_to_temp_skills(
+            monkeypatch,
+            tmp_path,
+            {
+                "issue_triage": "---\nname: issue_triage\n---\n",
+                "ci_check": "---\nname: ci_check\n---\n",
+            },
+        )
+        assert [s["name"] for s in generate.load_skills()] == [
+            "ci_check",
+            "issue_triage",
+        ]
+
+
+class TestGroupSkills:
+    """Unit tests for group_skills() ordering and heading merges (#1418)."""
+
+    @staticmethod
+    def _skill(name: str) -> dict:
+        return {
+            "name": name,
+            "trigger": "/" + name.replace("_", "-"),
+            "description": "",
+            "group": name.split("_")[0],
+        }
+
+    def test_groups_follow_declared_order_and_drop_empty(self):
+        """Non-empty groups appear in SKILL_GROUP_ORDER order; empty ones drop."""
+        groups = generate.group_skills(
+            [self._skill("worktree_plan"), self._skill("issue_triage")]
+        )
+        assert [g["heading"] for g in groups] == [
+            "Issue Management",
+            "Autonomous Worktree Pipeline",
+        ]
+
+    def test_git_and_pr_share_one_heading(self):
+        """git and pr prefixes merge into the single Git & PR group."""
+        groups = generate.group_skills(
+            [self._skill("git_commit"), self._skill("pr_create")]
+        )
+        (group,) = groups
+        assert group["heading"] == "Git & PR (Interactive)"
+        assert [s["name"] for s in group["skills"]] == ["git_commit", "pr_create"]
+
+    def test_unknown_prefix_is_dropped(self):
+        """A skill whose prefix matches no declared group is not rendered."""
+        assert generate.group_skills([self._skill("zzz_orphan")]) == []
+
+    def test_intro_attached_and_prefixes_removed(self):
+        """Groups carry their intro text and no internal prefixes set."""
+        (group,) = generate.group_skills([self._skill("inception_explore")])
+        assert group["intro"] == generate.SKILL_GROUP_INTROS["inception"]
+        assert "prefixes" not in group
+
+
 class TestInstallScriptUnit:
     """Unit tests for install.sh dry-run side effects and name sanitization.
 

--- a/tests/test_workflow_release_publish.py
+++ b/tests/test_workflow_release_publish.py
@@ -186,3 +186,16 @@ def test_scaffold_publish_accepts_a_lost_race_only_at_the_release_commit() -> No
         "a lost race is acceptable only when the existing ref resolves to the "
         "release commit"
     )
+
+
+def test_scaffold_publish_ceiling_is_read_only() -> None:
+    """Workflow and publish-job ceilings grant reads only (#1418).
+
+    Tag creation and release publishing go through the minted App token, so
+    GITHUB_TOKEN never needs a write grant; a widening here must fail review.
+    """
+    workflow = load_workflow(SCAFFOLD_PUBLISH)
+    read_only = {"contents": "read", "packages": "read"}
+    assert workflow["permissions"] == read_only
+    (job,) = workflow["jobs"].values()
+    assert job["permissions"] == read_only


### PR DESCRIPTION
## Summary

Implements #1418: closes the coverage gaps surfaced by the #1413 test-suite audit and adds the `just doctor` host diagnostic that replaces the deleted skip-on-failure host-preflight tests.

## Changes

- **`docs/generate.py` units**: 11 new hermetic tests for `load_skills` (front-matter parsing, malformed/unterminated/missing-name skips, sort order, missing-dir warning) and `group_skills` (declared order, shared Git & PR heading, unknown-prefix drop, intro attachment), via the established `generate.__file__` repoint pattern.
- **Image coverage**: `nvim` and `actionlint` run-tests; `LOCALE_ARCHIVE` shape+existence and a `setlocale` round-trip proving the slimmed single-locale archive (#1104) resolves `en_US.UTF-8`. Every asserted fact verified against `flake.nix`/`nix/devtools.nix`.
- **Token ceilings**: exact read-only `permissions` maps pinned for `release-core.yml` (workflow + validate/finalize jobs, test-job inheritance) and `release-publish.yml` (workflow + publish job) — a silent widening now fails review.
- **`devc-upgrade` behavioral tests**: six stub-driven bats tests (logging `curl` emitting a fake installer + stub `podman`) proving the pin honor path end-to-end (DEVKIT_VERSION, legacy DEVCONTAINER_VERSION, unpinned/`latest` floating), the runtime-missing error before any download, and the in-container guard.
- **`just doctor`** (TDD, red-first): PASS/WARN diagnostics for git identity, commit signing (incl. unreadable ssh key path), ssh-agent, gh auth; always exits 0. New `tests/bats/doctor.bats` drives it under a controlled environment. Docs regenerated; changelog `Added` entry.

## Verification

- `tests/test_utils.py` + `test_release_core.py` + `test_workflow_release_publish.py`: **55 passed**.
- `tests/bats/just.bats` + `doctor.bats`: **59 tests, all pass**; devc-upgrade failure-attribution spot-checked (broken expectation → red → restored).
- `tests/test_image.py`: collect-clean (112 tests); the three new image tests execute in this PR's Image Tests lane.
- Full prek hook suite: green.

Closes #1418
