### PR TITLE
test: share scaffold fixtures and consolidate nix invocations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,22 +208,23 @@ jobs:
       - name: Validate flake output schema
         run: uv run pytest tests/test_flake_checks.py -k "not flake_check_succeeds" -v
 
-      # Guard the dev-shell <-> image parity: the dev-shell must expose
-      # `python3` (#729), carry the `prek` hook runner in the devTools SSoT
-      # (#778), must NOT leak the Nix C++ runtime onto an FHS host's
+      # Guard the dev-shell <-> image parity: the dev-shell's own PATH must
+      # provide `python3` + the vig-utils release scripts (#729/#993, one
+      # probe: own_path_binaries), carry the `prek` hook runner in the devTools
+      # SSoT (#778), must NOT leak the Nix C++ runtime onto an FHS host's
       # LD_LIBRARY_PATH (#703), and must provide the fixture-driven tool/env
       # contracts (bats + helper libs, prek binary hooks, pymarkdown, uv python
-      # pinning, agent-toolkit superset, vig-utils console scripts). These drive
-      # `nix develop` directly (not covered by `test-project`'s pytest scope),
-      # so run them explicitly here where Nix + the dev profile are warm. The
-      # NixOS-gated and build-heavy cases (per-tool sweep, python override
-      # matrix) stay local-only. Refs #729, #703, #778, #1413.
+      # pinning, agent-toolkit superset). These drive `nix develop` directly
+      # (not covered by `test-project`'s pytest scope), so run them explicitly
+      # here where Nix + the dev profile are warm. The NixOS-gated and
+      # build-heavy cases (per-tool sweep, python override matrix) stay
+      # local-only. Refs #729, #703, #778, #1413, #1417.
       - name: Check dev-shell contracts (parity, leak-guard, tool/env fixtures)
         run: |
           uv run pytest tests/test_flake_devshell.py \
-            -k "exposes_python3_and_precommit or hook_runner_is_prek or no_nix_cxx_runtime_leak \
+            -k "own_path_binaries or hook_runner_is_prek or no_nix_cxx_runtime_leak \
                 or provides_bats or provides_precommit_binary_hooks or provides_pymarkdown \
-                or bats_lib_path or uv_python or superset_of_agent_toolkit or console_scripts" -v
+                or bats_lib_path or uv_python or superset_of_agent_toolkit" -v
 
       # Run the git-hooks fidelity gate (nix/hooks.nix <-> committed YAML, the
       # consumer hooks/hooksExcludes surface, workflow branch-guards, gitleaks

--- a/tests/bats/init-workspace.bats
+++ b/tests/bats/init-workspace.bats
@@ -12,6 +12,36 @@ setup() {
     TEMPLATE_DIR="$PROJECT_ROOT/assets/workspace"
 }
 
+# Shared read-only per-mode scaffolds (#1417): rendered ONCE per file run and
+# reused by every test that only reads a rendered tree — tests that mutate a
+# workspace (upgrades, seeds, previews, prunes) keep their per-test scaffolds.
+setup_file() {
+    local root stub mode ws
+    root="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+    stub="$BATS_FILE_TMPDIR/shared-stub-bin"
+    mkdir -p "$stub"
+    printf '#!/usr/bin/env bash\nexit 0\n' >"$stub/just"
+    chmod +x "$stub/just"
+    for mode in devcontainer direnv both bare; do
+        ws="$BATS_FILE_TMPDIR/shared-$mode"
+        mkdir -p "$ws"
+        env PATH="$stub:$PATH" \
+            TEMPLATE_DIR="$root/assets/workspace" \
+            WORKSPACE_DIR="$ws" \
+            SHORT_NAME=testproj \
+            GITHUB_REPOSITORY=test/repo \
+            bash "$root/assets/init-workspace.sh" --force --no-prompts \
+            --mode "$mode" >"$ws.log" 2>&1 || {
+            echo "shared $mode scaffold failed:" >&2
+            cat "$ws.log" >&2
+            return 1
+        }
+    done
+}
+
+# Path of the shared read-only scaffold for delivery mode $1 (#1417).
+_shared_tree() { printf '%s/shared-%s' "$BATS_FILE_TMPDIR" "$1"; }
+
 # ── Claude-native template scaffold (#629) ────────────────────────────────────
 # init-workspace.sh rsyncs assets/workspace/ verbatim into a new workspace, so
 # asserting on the template tree is a faithful, build-free proxy for "what new
@@ -174,10 +204,7 @@ _scaffold() {
 }
 
 @test "init-workspace --mode=devcontainer scaffolds .devcontainer only (#641)" {
-    ws="$BATS_TEST_TMPDIR/e2e-devcontainer"
-    mkdir -p "$ws"
-    run _scaffold devcontainer "$ws"
-    assert_success
+    ws="$(_shared_tree devcontainer)"
     run test -d "$ws/.devcontainer"
     assert_success
     run test -e "$ws/flake.nix"
@@ -187,10 +214,7 @@ _scaffold() {
 }
 
 @test "init-workspace --mode=direnv scaffolds flake.nix + .envrc only (#641)" {
-    ws="$BATS_TEST_TMPDIR/e2e-direnv"
-    mkdir -p "$ws"
-    run _scaffold direnv "$ws"
-    assert_success
+    ws="$(_shared_tree direnv)"
     run test -f "$ws/flake.nix"
     assert_success
     run test -f "$ws/.envrc"
@@ -200,10 +224,7 @@ _scaffold() {
 }
 
 @test "init-workspace --mode=both scaffolds everything (#641)" {
-    ws="$BATS_TEST_TMPDIR/e2e-both"
-    mkdir -p "$ws"
-    run _scaffold both "$ws"
-    assert_success
+    ws="$(_shared_tree both)"
     run test -d "$ws/.devcontainer"
     assert_success
     run test -f "$ws/flake.nix"
@@ -2688,10 +2709,7 @@ _upgrade_legacy() {
 
 @test "rendered ci.yml is mode-aware and identical across modes (#991)" {
     for mode in devcontainer direnv bare both; do
-        ws="$BATS_TEST_TMPDIR/e2e-ci-$mode"
-        mkdir -p "$ws"
-        run _scaffold "$mode" "$ws"
-        assert_success
+        ws="$(_shared_tree "$mode")"
         f="$ws/.github/workflows/ci.yml"
         # both mode-aware composites are wired
         run grep -q './.github/actions/resolve-toolchain' "$f"
@@ -2878,10 +2896,7 @@ _referenced_secrets() {
 
 @test "resolve-toolchain and setup-devkit-toolchain ship in every mode (#994)" {
     for mode in devcontainer direnv both bare; do
-        ws="$BATS_TEST_TMPDIR/e2e-994-$mode"
-        mkdir -p "$ws"
-        run _scaffold "$mode" "$ws"
-        assert_success
+        ws="$(_shared_tree "$mode")"
         run test -f "$ws/.github/actions/resolve-toolchain/action.yml"
         assert_success
         run test -f "$ws/.github/actions/setup-devkit-toolchain/action.yml"
@@ -3130,10 +3145,7 @@ _RELEASE_RESOLVERS_991=(
 
 @test "resolve-image action is removed from every rendered mode tree (#991)" {
     for mode in devcontainer direnv both bare; do
-        ws="$BATS_TEST_TMPDIR/e2e-991-$mode"
-        mkdir -p "$ws"
-        run _scaffold "$mode" "$ws"
-        assert_success
+        ws="$(_shared_tree "$mode")"
         # the retired action directory must not be scaffolded into consumers.
         run test -d "$ws/.github/actions/resolve-image"
         assert_failure
@@ -3153,18 +3165,12 @@ _RELEASE_RESOLVERS_991=(
 
 @test "container-ci-quirks.md ships in devcontainer/both but not direnv/bare (#989)" {
     for mode in devcontainer both; do
-        ws="$BATS_TEST_TMPDIR/e2e-989-$mode"
-        mkdir -p "$ws"
-        run _scaffold "$mode" "$ws"
-        assert_success
+        ws="$(_shared_tree "$mode")"
         run test -f "$ws/docs/container-ci-quirks.md"
         assert_success
     done
     for mode in direnv bare; do
-        ws="$BATS_TEST_TMPDIR/e2e-989-$mode"
-        mkdir -p "$ws"
-        run _scaffold "$mode" "$ws"
-        assert_success
+        ws="$(_shared_tree "$mode")"
         run test -f "$ws/docs/container-ci-quirks.md"
         assert_failure
     done

--- a/tests/test_flake_devshell.py
+++ b/tests/test_flake_devshell.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import json
 import os
+import shlex
 import shutil
 import subprocess
 import sys
@@ -373,24 +374,32 @@ def test_devshell_bats_lib_path_resolves_helpers(dev_shell_env: dict[str, str]) 
         )
 
 
-@pytest.mark.parametrize("binary", ["python3"])
-def test_devshell_exposes_python3_and_precommit(binary: str) -> None:
-    """The dev-shell must put ``python3`` on PATH (#729).
+def test_devshell_own_path_binaries() -> None:
+    """The dev-shell's own PATH must provide python3 and the release scripts.
 
-    The image (``imageTools``) ships a Python interpreter (``pythonEnv``), but
-    ``mkProjectShell`` carried none: the downstream flake-input / direnv
-    dev-shell could reach Python only via ``uv run`` — a dev-shell ↔ image
-    parity gap. The hook runner (``prek``, #778) lives in the ``devTools`` SSoT,
-    so it is covered by ``devShellTools`` / ``test_each_tool_runs_in_devshell``
-    rather than here; only the bare interpreter — intentionally *not* in
-    ``devTools`` (it would collide with the image's ``pythonEnv``) — is asserted
-    explicitly.
+    ``python3`` (#729): the image (``imageTools``) ships a Python interpreter
+    (``pythonEnv``), but ``mkProjectShell`` carried none — a dev-shell ↔ image
+    parity gap. The interpreter is intentionally *not* in ``devTools`` (it
+    would collide with the image's ``pythonEnv``), so it is asserted here
+    rather than via the devTools sweep.
 
-    The check runs under ``nix develop --ignore-environment`` so it asserts the
-    dev-shell's *own* PATH contribution and is not satisfied by a host
-    ``python3`` leaking through the inherited environment (the exact way the gap
-    hid until #729).
+    ``prepare-changelog`` / ``renovate-changelog-pr`` (#993): console scripts
+    of ``packages/vig-utils``, baked into the image's ``pythonEnv`` but
+    historically absent from ``devTools``, so a consumer ``mkProjectShell``
+    dev-shell (direnv mode) lacked them — blocking the mode-aware release
+    workflows (#991) for the container-less modes.
+
+    One ``nix develop --ignore-environment`` entry probes all three (#1417),
+    so the check asserts the dev-shell's *own* PATH contribution and is not
+    satisfied by host binaries leaking through the inherited environment (the
+    exact way the python3 gap hid until #729). Failure attribution stays
+    per-binary via the probe's own output.
     """
+    binaries = ("python3", "prepare-changelog", "renovate-changelog-pr")
+    probe = "; ".join(
+        f'command -v {b} >/dev/null || {{ echo "MISSING {b}"; status=1; }}'
+        for b in binaries
+    )
     cmd = [
         "nix",
         "develop",
@@ -401,7 +410,7 @@ def test_devshell_exposes_python3_and_precommit(binary: str) -> None:
         "-c",
         "bash",
         "-c",
-        f"command -v {binary}",
+        f"status=0; {probe}; exit $status",
     ]
     proc = subprocess.run(
         cmd,
@@ -410,75 +419,43 @@ def test_devshell_exposes_python3_and_precommit(binary: str) -> None:
         env=_nix_env(),
         timeout=900,
     )
-    # `command -v` exits 0 iff the binary is on PATH; rely on the exit code
-    # (the shellHook's banner pollutes stdout, so it is not a presence signal).
+    missing = [ln for ln in proc.stdout.splitlines() if ln.startswith("MISSING ")]
     assert proc.returncode == 0, (
-        f"{binary} must be on the dev-shell's own PATH (#729): "
-        f"rc={proc.returncode} stdout={proc.stdout.strip()!r} "
-        f"stderr={proc.stderr.strip()[:200]}"
-    )
-
-
-@pytest.mark.parametrize("script", ["prepare-changelog", "renovate-changelog-pr"])
-def test_devshell_exposes_vig_utils_console_scripts(script: str) -> None:
-    """The dev-shell must expose vig-utils' release console scripts on PATH (#993).
-
-    ``prepare-changelog`` and ``renovate-changelog-pr`` are console scripts of
-    ``packages/vig-utils``. They are baked into the image's Python env
-    (``pythonEnv``) but were historically absent from the ``devTools`` SSoT, so a
-    consumer ``mkProjectShell`` dev-shell (direnv mode) lacked them — blocking
-    the mode-aware release workflows (#991) for the container-less modes. Adding
-    ``vig-utils`` to ``devTools`` delivers the scripts to the dev-shell as well.
-
-    The check runs under ``nix develop --ignore-environment`` so it asserts the
-    dev-shell's *own* PATH contribution and is not satisfied by a host script
-    leaking through the inherited environment.
-    """
-    cmd = [
-        "nix",
-        "develop",
-        "--ignore-environment",
-        "--keep",
-        "HOME",
-        str(REPO_ROOT),
-        "-c",
-        "bash",
-        "-c",
-        f"command -v {script}",
-    ]
-    proc = subprocess.run(
-        cmd,
-        capture_output=True,
-        text=True,
-        env=_nix_env(),
-        timeout=900,
-    )
-    assert proc.returncode == 0, (
-        f"{script} must be on the dev-shell's own PATH (#993): "
-        f"rc={proc.returncode} stdout={proc.stdout.strip()!r} "
-        f"stderr={proc.stderr.strip()[:200]}"
+        "binaries missing from the dev-shell's own PATH (#729/#993): "
+        f"{missing or proc.stderr.strip()[:200]}"
     )
 
 
 def test_each_tool_runs_in_devshell(dev_shell_tools: list[str]) -> None:
-    """Every tool in ``devTools`` is runnable inside ``nix develop``."""
-    failures: list[str] = []
+    """Every tool in ``devTools`` is runnable inside ``nix develop``.
+
+    One ``nix develop`` entry runs a generated probe over the whole tool list
+    (#1417) instead of one shell entry per tool; each failing tool is reported
+    with its exit code and first stderr lines, so attribution matches the old
+    per-tool loop.
+    """
+    lines = ["status=0"]
     for tool in dev_shell_tools:
         flag = VERSION_FLAG_OVERRIDES.get(tool, ["--version"])
-        cmd = ["nix", "develop", str(REPO_ROOT), "-c", tool, *flag]
-        proc = subprocess.run(
-            cmd,
-            capture_output=True,
-            text=True,
-            env=_nix_env(),
-            timeout=900,
+        quoted = " ".join(shlex.quote(a) for a in [tool, *flag])
+        lines.append(
+            f"out=$({quoted} 2>&1) || {{ status=1; "
+            f'echo "FAIL {shlex.quote(tool)} rc=$? ${{out:0:200}}"; }}'
         )
-        if proc.returncode != 0:
-            failures.append(
-                f"{tool} ({' '.join(flag)}) exited {proc.returncode}: "
-                f"{proc.stderr.strip()[:200]}"
-            )
-    assert not failures, "Tools failed inside nix develop:\n" + "\n".join(failures)
+    lines.append("exit $status")
+    cmd = ["nix", "develop", str(REPO_ROOT), "-c", "bash", "-c", "\n".join(lines)]
+    proc = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        env=_nix_env(),
+        timeout=900,
+    )
+    failures = [ln for ln in proc.stdout.splitlines() if ln.startswith("FAIL ")]
+    assert proc.returncode == 0 and not failures, (
+        "Tools failed inside nix develop:\n"
+        + ("\n".join(failures) or proc.stderr.strip()[:400])
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_flake_hooks.py
+++ b/tests/test_flake_hooks.py
@@ -24,6 +24,7 @@ Refs: #883
 
 from __future__ import annotations
 
+import functools
 import json
 import shlex
 import shutil
@@ -296,15 +297,21 @@ class TestCommitMsgHookContract:
         assert "check-agent-identity" in scaffold
 
 
-@pytest.fixture(scope="module")
-def consumer_config() -> dict[str, Any]:
-    """Build the generated config for a customized consumer shell."""
+@functools.cache
+def _consumer_config_set() -> dict[str, dict[str, Any]]:
+    """Build all three consumer hook configs in ONE nix build (#1417).
+
+    The customized, gitleaks-enabled, and trunk-workflow consumer shells are
+    independent ``mkProjectShell`` calls whose ``hooksConfigFile`` outputs are
+    collected into a single ``linkFarm``, so the suite pays one build instead
+    of three module-scoped ones. Cached for the whole pytest run.
+    """
     expr = f"""
     let
       flake = builtins.getFlake "path:{REPO_ROOT}";
       system = builtins.currentSystem;
       pkgs = import flake.inputs.nixpkgs {{ inherit system; }};
-      shell = flake.lib.mkProjectShell {{
+      customized = flake.lib.mkProjectShell {{
         inherit pkgs;
         hooks = {{
           typos.enable = false;
@@ -319,46 +326,50 @@ def consumer_config() -> dict[str, Any]:
         }};
         hooksExcludes = [ "^data/stopping/" ];
       }};
-    in
-    shell.hooksConfigFile
-    """
-    result = _run_nix(
-        ["build", "--impure", "--no-link", "--print-out-paths", "--expr", expr],
-        timeout=1800,
-    )
-    assert result.returncode == 0, (
-        "building the generated hook config failed:\n" + result.stderr
-    )
-    # The generated file is JSON preceded by "# …" comment lines; YAML is
-    # a JSON superset that treats them as comments, so parse with yaml.
-    return yaml.safe_load(Path(result.stdout.strip()).read_text())
-
-
-@pytest.fixture(scope="module")
-def gitleaks_enabled_config() -> dict[str, Any]:
-    """Generated config for a consumer that opts into the gitleaks hook (#1172)."""
-    expr = f"""
-    let
-      flake = builtins.getFlake "path:{REPO_ROOT}";
-      system = builtins.currentSystem;
-      pkgs = import flake.inputs.nixpkgs {{ inherit system; }};
-      shell = flake.lib.mkProjectShell {{
+      gitleaks = flake.lib.mkProjectShell {{
         inherit pkgs;
         hooks = {{
           gitleaks.enable = true;
         }};
       }};
+      trunk = flake.lib.mkProjectShell {{
+        inherit pkgs;
+        workflow = "trunk";
+        hooks = {{ }};
+      }};
     in
-    shell.hooksConfigFile
+    pkgs.linkFarm "consumer-hook-configs" [
+      {{ name = "customized"; path = customized.hooksConfigFile; }}
+      {{ name = "gitleaks"; path = gitleaks.hooksConfigFile; }}
+      {{ name = "trunk"; path = trunk.hooksConfigFile; }}
+    ]
     """
     result = _run_nix(
         ["build", "--impure", "--no-link", "--print-out-paths", "--expr", expr],
         timeout=1800,
     )
     assert result.returncode == 0, (
-        "building the gitleaks-enabled hook config failed:\n" + result.stderr
+        "building the consumer hook configs failed:\n" + result.stderr
     )
-    return yaml.safe_load(Path(result.stdout.strip()).read_text())
+    root = Path(result.stdout.strip())
+    # The generated files are JSON preceded by "# …" comment lines; YAML is
+    # a JSON superset that treats them as comments, so parse with yaml.
+    return {
+        name: yaml.safe_load((root / name).read_text())
+        for name in ("customized", "gitleaks", "trunk")
+    }
+
+
+@pytest.fixture(scope="module")
+def consumer_config() -> dict[str, Any]:
+    """The generated config for a customized consumer shell."""
+    return _consumer_config_set()["customized"]
+
+
+@pytest.fixture(scope="module")
+def gitleaks_enabled_config() -> dict[str, Any]:
+    """Generated config for a consumer that opts into the gitleaks hook (#1172)."""
+    return _consumer_config_set()["gitleaks"]
 
 
 class TestGitleaksOptInHook:
@@ -407,29 +418,10 @@ def trunk_consumer_config() -> dict[str, Any]:
     A ``DEVKIT_WORKFLOW=trunk`` workspace has no long-lived ``dev`` branch, so
     the flake-generated branch guard must drop the ``(?!dev$)`` clause — exactly
     what ``render_workflow_model`` does to the scaffolded YAML. Mirrors the
-    ``consumer_config`` fixture but threads ``workflow = "trunk"``.
+    ``consumer_config`` fixture but threads ``workflow = "trunk"`` (built in
+    the same single derivation set, #1417).
     """
-    expr = f"""
-    let
-      flake = builtins.getFlake "path:{REPO_ROOT}";
-      system = builtins.currentSystem;
-      pkgs = import flake.inputs.nixpkgs {{ inherit system; }};
-      shell = flake.lib.mkProjectShell {{
-        inherit pkgs;
-        workflow = "trunk";
-        hooks = {{ }};
-      }};
-    in
-    shell.hooksConfigFile
-    """
-    result = _run_nix(
-        ["build", "--impure", "--no-link", "--print-out-paths", "--expr", expr],
-        timeout=1800,
-    )
-    assert result.returncode == 0, (
-        "building the trunk-workflow hook config failed:\n" + result.stderr
-    )
-    return yaml.safe_load(Path(result.stdout.strip()).read_text())
+    return _consumer_config_set()["trunk"]
 
 
 class TestWorkflowModelBranchGuard:

--- a/tests/test_setup_toolchain_env.py
+++ b/tests/test_setup_toolchain_env.py
@@ -365,16 +365,29 @@ def _parse_github_env(text: str) -> dict[str, str]:
 # ── Behavior ─────────────────────────────────────────────────────────────────
 
 
-def test_shellhook_scalar_exports_are_forwarded(tmp_path: Path) -> None:
+@pytest.fixture(scope="module")
+def default_step_env(tmp_path_factory: pytest.TempPathFactory) -> dict[str, str]:
+    """One default-input step run shared by every default-invocation test (#1417).
+
+    The default stub inputs are byte-identical across those tests, so a single
+    execution carries all their assertions; tests with distinct inputs (banner,
+    devshell_env, pyproject, nixos) keep their own runs.
+    """
+    return _run_devshell_step(tmp_path_factory.mktemp("default-step"))
+
+
+def test_shellhook_scalar_exports_are_forwarded(
+    default_step_env: dict[str, str],
+) -> None:
     """Plain shellHook exports reach GITHUB_ENV (the org-config#40 regression)."""
-    env = _run_devshell_step(tmp_path)
+    env = default_step_env
     assert env.get("OTTERDOG_TOKEN") == "placeholder-set-by-shellhook"
     assert env.get("PROJECT_GREETING") == "hello world"
 
 
-def test_multiline_value_survives_via_heredoc(tmp_path: Path) -> None:
+def test_multiline_value_survives_via_heredoc(default_step_env: dict[str, str]) -> None:
     """A multi-line export is forwarded intact using the GITHUB_ENV heredoc."""
-    env = _run_devshell_step(tmp_path)
+    env = default_step_env
     assert env.get("MULTILINE_VAR") == "line-one\nline-two\nline-three"
 
 
@@ -414,14 +427,16 @@ def test_multiline_value_survives_via_heredoc(tmp_path: Path) -> None:
         "TMPDIR",
     ],
 )
-def test_denylisted_vars_are_not_forwarded(tmp_path: Path, denied: str) -> None:
+def test_denylisted_vars_are_not_forwarded(
+    default_step_env: dict[str, str], denied: str
+) -> None:
     """Build machinery and shell session state never leak into GITHUB_ENV."""
-    env = _run_devshell_step(tmp_path)
+    env = default_step_env
     assert denied not in env, f"{denied} must not be forwarded to GITHUB_ENV"
 
 
 def test_uv_interpreter_pins_do_not_defeat_the_manylinux_path(
-    tmp_path: Path,
+    default_step_env: dict[str, str],
 ) -> None:
     """The dev-shell's uv interpreter pins must not reach the CI environment.
 
@@ -443,7 +458,7 @@ def test_uv_interpreter_pins_do_not_defeat_the_manylinux_path(
 
     Refs: #1353
     """
-    env = _run_devshell_step(tmp_path)
+    env = default_step_env
     assert "UV_PYTHON" not in env
     assert "UV_PYTHON_DOWNLOADS" not in env
     assert env.get("UV_PYTHON_DOWNLOADS_JSON_URL") == (
@@ -451,7 +466,9 @@ def test_uv_interpreter_pins_do_not_defeat_the_manylinux_path(
     ), "the deliberate uv download-metadata forward must survive the denylist"
 
 
-def test_store_only_pythonpath_is_not_forwarded(tmp_path: Path) -> None:
+def test_store_only_pythonpath_is_not_forwarded(
+    default_step_env: dict[str, str],
+) -> None:
     """A PYTHONPATH made only of store paths must not reach GITHUB_ENV.
 
     ``python`` in the dev-shell ``packages`` makes the nixpkgs python setup hook
@@ -462,7 +479,7 @@ def test_store_only_pythonpath_is_not_forwarded(tmp_path: Path) -> None:
 
     Refs: #1358
     """
-    env = _run_devshell_step(tmp_path)
+    env = default_step_env
     assert "PYTHONPATH" not in env, (
         "a store-only PYTHONPATH must not be forwarded to GITHUB_ENV"
     )
@@ -493,9 +510,11 @@ def test_consumer_only_pythonpath_is_forwarded_verbatim(tmp_path: Path) -> None:
     assert env.get("PYTHONPATH") == value
 
 
-def test_unchanged_ambient_var_is_not_reforwarded(tmp_path: Path) -> None:
+def test_unchanged_ambient_var_is_not_reforwarded(
+    default_step_env: dict[str, str],
+) -> None:
     """A var identical to the host env is filtered — host secrets never re-leak."""
-    env = _run_devshell_step(tmp_path)
+    env = default_step_env
     assert "AMBIENT_SHARED" not in env
 
 

--- a/tests/test_sync_settings.py
+++ b/tests/test_sync_settings.py
@@ -27,6 +27,7 @@ import pytest
 
 from tests.workflow_scaffold import (
     INIT_WORKSPACE,
+    cached_tree,
     scaffold,
 )
 
@@ -34,6 +35,15 @@ from tests.workflow_scaffold import (
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
 MIRROR = "sync/issue-mirror"
+
+
+def _cached_sync_yaml(workflow: str | None) -> str:
+    """The rendered sync-issues.yml of the shared no-knobs scaffold (#1417)."""
+    return (
+        cached_tree(workflow) / ".github" / "workflows" / "sync-issues.yml"
+    ).read_text(encoding="utf-8")
+
+
 BOOTSTRAP_STEP = "Bootstrap sync target branch if absent"
 
 
@@ -84,18 +94,18 @@ def test_init_workspace_invokes_render_sync_settings() -> None:
 # ── unset = byte-for-byte today's behavior ────────────────────────────────────
 
 
-def test_unset_gitflow_keeps_dev_default_and_daily_cron(tmp_path: Path) -> None:
+def test_unset_gitflow_keeps_dev_default_and_daily_cron() -> None:
     """No keys on gitflow => today's `dev` target + daily cron, no bootstrap."""
-    text = _sync_yaml(tmp_path, name="gf-default")
+    text = _cached_sync_yaml(None)
     assert "default: 'dev'" in text
     assert "|| 'dev'" in text
     assert "cron: '0 2 * * *'" in text
     assert BOOTSTRAP_STEP not in text
 
 
-def test_unset_trunk_keeps_main_default(tmp_path: Path) -> None:
+def test_unset_trunk_keeps_main_default() -> None:
     """No keys on trunk => the workflow-model `main` default is untouched."""
-    text = _sync_yaml(tmp_path, name="tk-default", workflow="trunk")
+    text = _cached_sync_yaml("trunk")
     assert "default: 'main'" in text
     assert "|| 'main'" in text
     assert "|| 'dev'" not in text

--- a/tests/test_workflow_devkit_upgrade.py
+++ b/tests/test_workflow_devkit_upgrade.py
@@ -34,8 +34,8 @@ import yaml
 from tests.workflow_scaffold import (
     INIT_WORKSPACE,
     WORKSPACE,
+    cached_tree,
     scaffold,
-    scaffold_tree,
 )
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -43,9 +43,8 @@ TEMPLATE = WORKSPACE / ".github" / "workflows" / "devkit-upgrade.yml"
 REL = ".github/workflows/devkit-upgrade.yml"
 
 
-def _rendered(tmp_path: Path, workflow: str | None = None) -> str:
-    tree = scaffold_tree(tmp_path, workflow=workflow)
-    return (tree / REL).read_text(encoding="utf-8")
+def _rendered(workflow: str | None = None) -> str:
+    return (cached_tree(workflow) / REL).read_text(encoding="utf-8")
 
 
 def _steps(text: str) -> list[dict]:
@@ -272,16 +271,16 @@ def test_no_run_block_interpolates_untrusted_input() -> None:
 # ── base-branch awareness (workflow model) ────────────────────────────────────
 
 
-def test_gitflow_base_branch_is_dev(tmp_path: Path) -> None:
+def test_gitflow_base_branch_is_dev() -> None:
     """A gitflow scaffold checks out and targets `dev`."""
-    text = _rendered(tmp_path)
+    text = _rendered()
     assert "ref: dev" in text
     assert "BASE: dev" in text
 
 
-def test_trunk_base_branch_is_main(tmp_path: Path) -> None:
+def test_trunk_base_branch_is_main() -> None:
     """A trunk scaffold retargets the base branch dev -> main (#1205)."""
-    text = _rendered(tmp_path, workflow="trunk")
+    text = _rendered(workflow="trunk")
     assert "ref: main" in text
     assert "BASE: main" in text
     assert "ref: dev" not in text
@@ -305,7 +304,7 @@ def test_disabling_feature_omits_the_workflow(tmp_path: Path) -> None:
     assert (tmp_path / "disabled" / ".github/workflows/ci.yml").exists()
 
 
-def test_valid_feature_group_default_ships_the_workflow(tmp_path: Path) -> None:
+def test_valid_feature_group_default_ships_the_workflow() -> None:
     """With no opt-out, the workflow is scaffolded."""
-    tree = scaffold_tree(tmp_path)
+    tree = cached_tree(None)
     assert (tree / REL).is_file()

--- a/tests/test_workflow_model.py
+++ b/tests/test_workflow_model.py
@@ -25,6 +25,7 @@ from pathlib import Path
 from tests.workflow_scaffold import (
     INIT_WORKSPACE,
     WORKSPACE,
+    cached_tree,
     scaffold,
     scaffold_tree,
 )
@@ -53,45 +54,45 @@ def _wf(rendered: Path, name: str) -> str:
 # ── gitflow no-op guard (the load-bearing default-path invariant) ─────────────
 
 
-def test_gitflow_scaffold_matches_default_path(tmp_path: Path) -> None:
+def test_gitflow_scaffold_matches_default_path() -> None:
     """The gitflow path == the default (no --workflow) path, byte-for-byte.
 
     The knob must not perturb the default: an explicit ``--workflow gitflow``
     and an omitted ``--workflow`` produce identical trees.
     """
-    default = scaffold_tree(tmp_path, None, name="default")
-    gitflow = scaffold_tree(tmp_path, "gitflow", name="gitflow")
+    default = cached_tree(None)
+    gitflow = cached_tree("gitflow")
     diff = subprocess.run(
         ["diff", "-r", str(default), str(gitflow)], capture_output=True, text=True
     )
     assert diff.returncode == 0, f"gitflow != default:\n{diff.stdout}"
 
 
-def test_gitflow_render_files_are_byte_identical_to_template(tmp_path: Path) -> None:
+def test_gitflow_render_files_are_byte_identical_to_template() -> None:
     """gitflow leaves every render target byte-identical to today's template.
 
     render_workflow_model is a no-op for gitflow, so the dev-shaped template
     files copy through unchanged (placeholder-free files only; codeql.yml is
     rewritten by render_codeql_matrix in every mode and is excluded).
     """
-    rendered = scaffold_tree(tmp_path, "gitflow")
+    rendered = cached_tree("gitflow")
     for rel in NO_PLACEHOLDER_RENDER_FILES:
         assert (rendered / rel).read_bytes() == (WORKSPACE / rel).read_bytes(), rel
 
 
-def test_gitflow_keeps_sync_main_to_dev(tmp_path: Path) -> None:
+def test_gitflow_keeps_sync_main_to_dev() -> None:
     """gitflow retains sync-main-to-dev.yml (only trunk excludes it)."""
-    rendered = scaffold_tree(tmp_path, "gitflow")
+    rendered = cached_tree("gitflow")
     assert (rendered / ".github" / "workflows" / "sync-main-to-dev.yml").exists()
 
 
-def test_gitflow_vig_os_workflow_line_stays_empty(tmp_path: Path) -> None:
+def test_gitflow_vig_os_workflow_line_stays_empty() -> None:
     """Conditional writeback: a gitflow .vig-os keeps the bare DEVKIT_WORKFLOW=.
 
     Only trunk writes a value back, so a gitflow repo's manifest carries no
     new non-empty line — exactly one bare ``DEVKIT_WORKFLOW=`` line.
     """
-    rendered = scaffold_tree(tmp_path, "gitflow")
+    rendered = cached_tree("gitflow")
     lines = (rendered / ".vig-os").read_text(encoding="utf-8").splitlines()
     workflow_lines = [ln for ln in lines if ln.startswith("DEVKIT_WORKFLOW=")]
     assert workflow_lines == ["DEVKIT_WORKFLOW="]
@@ -112,21 +113,21 @@ def test_trunk_upgrade_prunes_leftover_sync_main_to_dev(tmp_path: Path) -> None:
     assert not (gitflow / ".github" / "workflows" / "sync-main-to-dev.yml").exists()
 
 
-def test_trunk_persists_workflow_in_manifest(tmp_path: Path) -> None:
+def test_trunk_persists_workflow_in_manifest() -> None:
     """trunk writes DEVKIT_WORKFLOW=trunk back to .vig-os (upgrade-persistent)."""
-    rendered = scaffold_tree(tmp_path, "trunk")
+    rendered = cached_tree("trunk")
     text = (rendered / ".vig-os").read_text(encoding="utf-8")
     assert "DEVKIT_WORKFLOW=trunk" in text
 
 
-def test_trunk_prepare_release_has_no_dev_cruft(tmp_path: Path) -> None:
+def test_trunk_prepare_release_has_no_dev_cruft() -> None:
     """No residual `dev` in prepare-release beyond /dev/null + the SHA var names.
 
     The maintainer decision (#1208) rewrites the inert dev step-names/comments to
     main so a trunk repo carries no dev cruft; only the device path and the
     dev_sha/DEV_SHA variable/output names (behavior-neutral) are preserved.
     """
-    text = _wf(scaffold_tree(tmp_path, "trunk"), "prepare-release.yml")
+    text = _wf(cached_tree("trunk"), "prepare-release.yml")
     # The branch base itself is retargeted: no heads/dev ref survives, the
     # release branch forks from refs/heads/main (the checkout-ref half lives in
     # test_workflow_prepare_extension.py::test_trunk_prepare_forks_release_branch_from_main).
@@ -146,7 +147,7 @@ def test_trunk_prepare_release_has_no_dev_cruft(tmp_path: Path) -> None:
     assert not stray, "stray dev tokens:\n" + "\n".join(stray)
 
 
-def test_trunk_promote_release_has_no_sync_main_to_dev_prose(tmp_path: Path) -> None:
+def test_trunk_promote_release_has_no_sync_main_to_dev_prose() -> None:
     """promote-release.yml carries no `sync-main-to-dev` prose in trunk (#1233).
 
     sync-main-to-dev.yml is copy-excluded in trunk, so the two parenthetical
@@ -154,13 +155,13 @@ def test_trunk_promote_release_has_no_sync_main_to_dev_prose(tmp_path: Path) -> 
     scrubbed — otherwise a trunk repo ships comments referencing a workflow it
     does not have. Follow-up to #1226 for a file the render did not touch.
     """
-    text = _wf(scaffold_tree(tmp_path, "trunk"), "promote-release.yml")
+    text = _wf(cached_tree("trunk"), "promote-release.yml")
     assert "sync-main-to-dev" not in text
 
 
-def test_trunk_ci_pr_filter_excludes_dev(tmp_path: Path) -> None:
+def test_trunk_ci_pr_filter_excludes_dev() -> None:
     """ci.yml drops `- dev` from the PR branch filter; commit-gate TRUNK=main."""
-    text = _wf(scaffold_tree(tmp_path, "trunk"), "ci.yml")
+    text = _wf(cached_tree("trunk"), "ci.yml")
     assert "\n      - dev\n" not in text
     assert 'TRUNK="main"' in text
     assert 'TRUNK="dev"' not in text
@@ -170,18 +171,18 @@ def test_trunk_ci_pr_filter_excludes_dev(tmp_path: Path) -> None:
     assert "origin/dev" not in text
 
 
-def test_trunk_codeql_pr_filter_excludes_dev(tmp_path: Path) -> None:
+def test_trunk_codeql_pr_filter_excludes_dev() -> None:
     """codeql.yml drops `- dev` from the PR filter; the main leg survives."""
-    text = _wf(scaffold_tree(tmp_path, "trunk"), "codeql.yml")
+    text = _wf(cached_tree("trunk"), "codeql.yml")
     assert "\n      - dev\n" not in text
     assert "\n      - main\n" in text
     # #1226: no lying `dev` prose survives the render (negative-only pin).
     assert "Pull requests to dev" not in text
 
 
-def test_trunk_skill_base_branch_main(tmp_path: Path) -> None:
+def test_trunk_skill_base_branch_main() -> None:
     """branch-naming SKILL base default dev -> main; example branch untouched."""
-    rendered = scaffold_tree(tmp_path, "trunk")
+    rendered = cached_tree("trunk")
     text = (rendered / ".claude" / "skills" / "branch-naming" / "SKILL.md").read_text(
         encoding="utf-8"
     )
@@ -192,15 +193,15 @@ def test_trunk_skill_base_branch_main(tmp_path: Path) -> None:
     assert "chore/sync-main-to-dev" in text
 
 
-def test_trunk_precommit_drops_dev_clause(tmp_path: Path) -> None:
+def test_trunk_precommit_drops_dev_clause() -> None:
     """.pre-commit-config drops the `(?!dev$)` protect-clause; main stays."""
-    rendered = scaffold_tree(tmp_path, "trunk")
+    rendered = cached_tree("trunk")
     text = (rendered / ".pre-commit-config.yaml").read_text(encoding="utf-8")
     assert "(?!dev$)" not in text
     assert "(?!main$)" in text
 
 
-def test_trunk_renovate_preset_targets_main(tmp_path: Path) -> None:
+def test_trunk_renovate_preset_targets_main() -> None:
     """renovate-default.json baseBranchPatterns dev -> main (#1336).
 
     Renovate restricted to a base-branch pattern that matches no existing
@@ -208,13 +209,13 @@ def test_trunk_renovate_preset_targets_main(tmp_path: Path) -> None:
     gitflow-shaped ``["dev"]`` runs no updates at all. The trunk render must
     retarget the shipped preset to main.
     """
-    rendered = scaffold_tree(tmp_path, "trunk")
+    rendered = cached_tree("trunk")
     text = (rendered / ".github" / "renovate-default.json").read_text(encoding="utf-8")
     assert '"baseBranchPatterns": ["main"]' in text
     assert '["dev"]' not in text
 
 
-def test_trunk_flake_forwards_workflow_to_hooks(tmp_path: Path) -> None:
+def test_trunk_flake_forwards_workflow_to_hooks() -> None:
     """The flake-hooks path follows the workflow model too (#1224).
 
     The scaffolded ``.pre-commit-config.yaml`` is workflow-model-aware, but a
@@ -227,7 +228,7 @@ def test_trunk_flake_forwards_workflow_to_hooks(tmp_path: Path) -> None:
     trunk; the flake-eval half (the generated guard actually loses the clause)
     is covered by ``tests/test_flake_hooks.py::TestWorkflowModelBranchGuard``.
     """
-    rendered = scaffold_tree(tmp_path, "trunk")
+    rendered = cached_tree("trunk")
     flake = (rendered / "flake.nix").read_text(encoding="utf-8")
     assert "DEVKIT_WORKFLOW=" in flake, "flake.nix does not read the workflow model"
     assert "inherit workflow;" in flake, "flake.nix does not forward `workflow`"
@@ -257,14 +258,14 @@ def test_template_flake_guards_workflow_forwarding() -> None:
     )
 
 
-def test_anchoring_preserves_dev_prefixed_and_device_tokens(tmp_path: Path) -> None:
+def test_anchoring_preserves_dev_prefixed_and_device_tokens() -> None:
     """Anchoring must not touch /dev/null, dev_sha, or development/devkit tokens.
 
     The render's word-boundary/end anchors exist precisely so these behaviorally
     or lexically dev-adjacent tokens survive. /dev/null in particular would be a
     catastrophic corruption if rewritten.
     """
-    text = _wf(scaffold_tree(tmp_path, "trunk"), "prepare-release.yml")
+    text = _wf(cached_tree("trunk"), "prepare-release.yml")
     assert "/dev/null" in text  # device path, not a branch ref
     assert "dev_sha:" in text  # workflow output variable name preserved
 

--- a/tests/test_workflow_prepare_extension.py
+++ b/tests/test_workflow_prepare_extension.py
@@ -29,6 +29,9 @@ from pathlib import Path
 import pytest
 
 from tests.workflow_scaffold import (
+    cached_tree,
+)
+from tests.workflow_scaffold import (
     jobs as _jobs,
 )
 from tests.workflow_scaffold import (
@@ -42,9 +45,6 @@ from tests.workflow_scaffold import (
 )
 from tests.workflow_scaffold import (
     run_text_of_job as _job_steps_text,
-)
-from tests.workflow_scaffold import (
-    scaffold_tree,
 )
 
 # Repository root (tests/ -> repo root) and the consumer scaffold tree.
@@ -183,14 +183,14 @@ def test_scaffold_prepare_forks_release_branch_from_dev() -> None:
     assert _branch_job_checkout_ref(_load(SCAFFOLD_PREPARE)) == "dev"
 
 
-def test_trunk_prepare_forks_release_branch_from_main(tmp_path: Path) -> None:
+def test_trunk_prepare_forks_release_branch_from_main() -> None:
     """Trunk: the release branch is cut from main, and the hook DAG survives.
 
     The trunk render retargets the branch base dev -> main; the extension hook
     (branch -> extension -> open-pr ordering) is model-independent and must
     still hold in the rendered trunk workflow.
     """
-    rendered = scaffold_tree(tmp_path, "trunk")
+    rendered = cached_tree("trunk")
     doc = _load(rendered / ".github" / "workflows" / "prepare-release.yml")
 
     assert _branch_job_checkout_ref(doc) == "main"

--- a/tests/test_workflow_sync_checkout.py
+++ b/tests/test_workflow_sync_checkout.py
@@ -30,8 +30,8 @@ import pytest
 from tests.workflow_scaffold import (
     REPO_ROOT,
     both_copies,
+    cached_tree,
     load_workflow,
-    scaffold_tree,
     steps_of_job,
 )
 
@@ -82,7 +82,7 @@ def test_sync_job_checkout_uses_default_ref(path: Path) -> None:
         )
 
 
-def test_trunk_scaffold_omits_sync_main_to_dev(tmp_path: Path) -> None:
+def test_trunk_scaffold_omits_sync_main_to_dev() -> None:
     """A trunk scaffold ships no sync-main-to-dev.yml (#1205).
 
     The whole point of this suite — the ``main -> dev`` sync bridge — has no
@@ -91,7 +91,7 @@ def test_trunk_scaffold_omits_sync_main_to_dev(tmp_path: Path) -> None:
     assert the absence (rather than skipping) so a regression that reships the
     gitflow bridge into a trunk repo is caught.
     """
-    rendered = scaffold_tree(tmp_path, "trunk")
+    rendered = cached_tree("trunk")
     assert not (rendered / ".github" / "workflows" / "sync-main-to-dev.yml").exists(), (
         "trunk scaffold must not ship the gitflow sync-main-to-dev bridge"
     )

--- a/tests/workflow_scaffold.py
+++ b/tests/workflow_scaffold.py
@@ -18,10 +18,13 @@ Refs: #1210, #1413
 
 from __future__ import annotations
 
+import atexit
+import functools
 import os
 import re
 import shutil
 import subprocess
+import tempfile
 from pathlib import Path
 
 import yaml
@@ -187,3 +190,17 @@ def scaffold_tree(tmp_path: Path, workflow: str | None = None, **kw: object) -> 
     proc = scaffold(tmp_path, workflow=workflow, name=name, **kw)  # type: ignore[arg-type]
     assert proc.returncode == 0, proc.stderr
     return tmp_path / name
+
+
+@functools.cache
+def cached_tree(workflow: str | None = None) -> Path:
+    """A scaffolded workspace shared across the whole pytest run (#1417).
+
+    Rendered once per workflow model into a private temp dir (removed at
+    interpreter exit) and handed to every caller. READ-ONLY by contract:
+    tests must never mutate the returned tree — upgrade/seed/guard cases keep
+    their own per-test ``scaffold``/``scaffold_tree`` runs.
+    """
+    base = Path(tempfile.mkdtemp(prefix=f"devkit-tree-{workflow or 'default'}-"))
+    atexit.register(shutil.rmtree, base, ignore_errors=True)
+    return scaffold_tree(base, workflow)


### PR DESCRIPTION
## Summary

Implements #1417 (WP5 of the #1413 audit): the suite's dominant wall-clock costs — repeated `init-workspace.sh` scaffold runs and per-test `nix develop`/`nix build` launches with identical inputs — now share cached fixtures. No assertion was removed or weakened; failure attribution is preserved in every merged sweep. TDD RED-first does not apply (test-infrastructure refactor, no production behavior change).

## Changes

- **`tests/workflow_scaffold.py`**: `cached_tree(workflow)` — one `functools.cache`d scaffold per workflow model (default/gitflow/trunk), rendered into a private temp dir removed at exit, documented read-only. Migrated all read-only shape assertions in `test_workflow_model.py` (13 sites), `test_sync_settings.py` (2), `test_workflow_devkit_upgrade.py` (3 via `_rendered`), `test_workflow_sync_checkout.py` (1), `test_workflow_prepare_extension.py` (1). Mutating cases (upgrades, seeds, hostile-input guards, enum/contradiction guards) keep per-test scaffolds. **Scaffold subprocess runs in the sweep: ~40 → 20.**
- **`tests/bats/init-workspace.bats`**: `setup_file` renders the four delivery-mode trees once per file; the read-only groups (#641 trio, #991 ci.yml identity, #994 composite ship, #991 resolve-image removal, #989 ships-in) read them via `_shared_tree`. **19 scaffold runs → 4**; upgrade/seed/preview tests untouched.
- **`tests/test_flake_devshell.py`**: `test_each_tool_runs_in_devshell` now runs ONE `nix develop` entry with a generated probe over all devTools (was one entry per tool, ~29), reporting each failing tool with rc + stderr; the python3 + vig-utils console-script probes merged into one `--ignore-environment` entry (`test_devshell_own_path_binaries`, #729/#993) with per-binary attribution. The stale `exposes_python3_and_precommit` name is gone; **the `-k` selection in `ci.yml` is updated in the same commit** (collects 10/16, verified).
- **`tests/test_setup_toolchain_env.py`**: one module-scoped run of the devshell step feeds the ~32 byte-identical default invocations (scalar/multiline forwards, 27 denylist params, uv-pin, store-PYTHONPATH, ambient filter); distinct-input tests keep their own runs.
- **`tests/test_flake_hooks.py`**: the three consumer-config fixtures (customized / gitleaks-enabled / trunk) build in ONE `nix build` via a named `linkFarm` (3 module-scoped builds → 1, cached per run).

## Timing (local, warm nix store — CI/cold benefits are larger)

| Suite | Before | After |
|---|---|---|
| Workflow-shape sweep (897 tests) | 27.0 s | **16–17.7 s** (~−35%) |
| `test_flake_devshell.py` full | 28.6 s (17+1) | **20.8 s** (15+1; 3 probes merged into 1) |
| `test_setup_toolchain_env.py` | ~32 step executions | 42 passed in **0.36 s** (1 shared + distinct-input runs) |
| `init-workspace.bats` (238 tests) | 125 s | 119 s (19 fewer scaffold runs; rsync is cheap locally, the win shows on slower I/O) |
| `test_flake_hooks.py` fixtures | 3 `nix build`s | 1 |

## Verification

- Workflow-shape sweep: **897 passed** (count unchanged from dev).
- `test_flake_devshell.py`: **15 passed, 1 skipped** (NixOS-gated skip, runs on CI ubuntu); ci.yml `-k` expression collects 10/16 with no stale names (`grep` clean).
- `test_flake_hooks.py` + `test_flake_services.py -k "not services_poc_boots"`: **39 passed**.
- `test_setup_toolchain_env.py`: **42 passed**.
- `bats tests/bats/init-workspace.bats`: **238/238 ok**.
- `prek run --all-files`: green.

Closes #1417
