### PR TITLE
feat: fold the sync mirror archive at release and reset it at promote

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Mirror-mode consumers integrate the issue archive via the release train** ([#1424](https://github.com/vig-os/devkit/issues/1424))
+  - With `DEVKIT_SYNC_TARGET` set, the scaffolded `release-core.yml` final leg
+    now dispatches sync-issues onto the **mirror** (the only branch that may
+    advance the shared incremental-sync cutoff) and then folds the mirror's
+    `docs/issues/` + `docs/pull-requests/` into the release branch, so the
+    full archive reaches `main` through the human-approved release PR —
+    previously the mirror diverged forever and `main` never carried the
+    archive
+  - The scaffolded `promote-release.yml` gains a rendered `reset-sync-mirror`
+    job that force-resets the mirror onto `main` after the release PR merges,
+    bounding its divergence to post-release snapshot commits
+  - Unset knob renders byte-identical templates; no change for non-mirror
+    consumers
 - **Bot changelog entries are synthesized at release time** ([#1423](https://github.com/vig-os/devkit/issues/1423))
   - New `synthesize-bot-changelog` (vig-utils) enumerates merged bot PRs
     (Renovate, devkit adoptions) since the last stable tag and regenerates a

--- a/assets/init-workspace.sh
+++ b/assets/init-workspace.sh
@@ -1551,6 +1551,162 @@ render_sync_settings() {
 YAML
         sed -i "/^          private-key: /r $block" "$si"
         rm -f "$block"
+
+        # Mirror mode makes the release train the mirror's integration point
+        # (#1424). release-core's final-leg sync dispatch retargets to the
+        # MIRROR — the only branch allowed to advance the shared
+        # incremental-state cutoff (sync-issues-state-<repo> is repo-wide; a
+        # release-branch run would leave the mirror permanently missing the
+        # inter-sync window, and unlike gitflow there is no sync-main-to-dev
+        # backflow to heal it) — then fold steps land the mirror's snapshot
+        # archive on the release branch so it reaches main via the
+        # human-approved release PR. Absent when the release feature is
+        # disabled — the -f guard skips it then.
+        local rc="$WORKSPACE_DIR/.github/workflows/release-core.yml"
+        if [[ -f "$rc" ]]; then
+            sed -i "s#target-branch=release/\$VERSION#target-branch=${tgt_esc}#" "$rc"
+
+            local fold_block
+            fold_block="$(mktemp)"
+            cat > "$fold_block" <<YAML
+
+      # Rendered by init-workspace.sh (#1424): DEVKIT_SYNC_TARGET mirror mode.
+      # The sync dispatch above targeted the mirror, so the release branch has
+      # no archive yet; fold the mirror's snapshot dirs in, then re-pull so
+      # the finalize SHA (the tag target) includes the fold commit. A missing
+      # mirror or an already-identical archive is a clean no-op. commit-action
+      # only adds/updates files — a path deleted on the mirror survives on the
+      # release branch until it is removed by hand (archives only grow, so
+      # this stays theoretical).
+      - name: Stage sync mirror archive for fold
+        if: \${{ inputs.release_kind == 'final' }}
+        id: mirror_fold
+        run: |
+          set -euo pipefail
+          MIRROR_REF="\$(retry --retries 3 --backoff 3 --max-backoff 20 -- git ls-remote origin "refs/heads/${MANIFEST_SYNC_TARGET}")"
+          if [ -z "\$MIRROR_REF" ]; then
+            echo "eligible=false" >> "\$GITHUB_OUTPUT"
+            echo "Mirror branch '${MANIFEST_SYNC_TARGET}' not found; skipping fold."
+            exit 0
+          fi
+          retry --retries 3 --backoff 3 --max-backoff 20 -- git fetch origin "${MANIFEST_SYNC_TARGET}"
+          staged=false
+          for dir in docs/issues docs/pull-requests; do
+            if git rev-parse -q --verify "FETCH_HEAD:\${dir}" >/dev/null; then
+              git checkout FETCH_HEAD -- "\${dir}"
+              staged=true
+            fi
+          done
+          if [ "\$staged" != "true" ]; then
+            echo "eligible=false" >> "\$GITHUB_OUTPUT"
+            echo "Mirror carries no snapshot dirs; skipping fold."
+            exit 0
+          fi
+          CHANGED="\$(git status --porcelain -- docs/issues docs/pull-requests | awk '{print \$2}')"
+          if [ -z "\$CHANGED" ]; then
+            echo "eligible=false" >> "\$GITHUB_OUTPUT"
+            echo "Release branch already matches the mirror archive; nothing to fold."
+            exit 0
+          fi
+          {
+            echo "file_paths<<PATHS_EOF"
+            printf '%s\n' "\$CHANGED"
+            echo "PATHS_EOF"
+          } >> "\$GITHUB_OUTPUT"
+          echo "eligible=true" >> "\$GITHUB_OUTPUT"
+          echo "Folding \$(printf '%s\n' "\$CHANGED" | wc -l) mirror archive path(s) into the release branch."
+
+      - name: Commit folded archive to the release branch
+        if: \${{ steps.mirror_fold.outputs.eligible == 'true' }}
+        uses: vig-os/commit-action@0361e9aa65b64711a18286ac5dfdcba7cc7a2ac7  # v0.3.2
+        env:
+          GH_TOKEN: \${{ steps.commit_app_token.outputs.token }}
+          GITHUB_REPOSITORY: \${{ github.repository }}
+          TARGET_BRANCH: refs/heads/release/\${{ needs.validate.outputs.version }}
+          MAX_ATTEMPTS: "3"
+          COMMIT_MESSAGE: "chore: fold sync mirror archive into release \${{ needs.validate.outputs.version }}"
+          FILE_PATHS: \${{ steps.mirror_fold.outputs.file_paths }}
+
+      - name: Re-pull release branch after fold
+        if: \${{ steps.mirror_fold.outputs.eligible == 'true' }}
+        env:
+          VERSION: \${{ needs.validate.outputs.version }}
+        run: |
+          set -euo pipefail
+          retry --retries 3 --backoff 3 --max-backoff 20 -- git fetch origin "release/\$VERSION"
+          git reset --hard "origin/release/\$VERSION"
+YAML
+            # shellcheck disable=SC2016  # literal $VERSION: the anchor is the rendered YAML's shell line, not an expansion
+            sed -i '/^          git reset --hard "origin\/release\/\$VERSION"$/r '"$fold_block" "$rc"
+            rm -f "$fold_block"
+        fi
+
+        # After the release PR merges, main carries exactly the archive the
+        # release folded in, so promote re-bases the mirror onto main and its
+        # divergence stays bounded to post-release snapshot commits (#1424).
+        # Ref mutation goes via git push, never the REST refs API (#1157,
+        # #1377); the mirror is unprotected by design and its history is
+        # regenerated state, so a force reset loses nothing. A concurrent
+        # nightly sync run is benign — the next nightly regenerates any
+        # clobbered delta.
+        local prom="$WORKSPACE_DIR/.github/workflows/promote-release.yml"
+        if [[ -f "$prom" ]]; then
+            cat >> "$prom" <<YAML
+
+  # Rendered by init-workspace.sh (#1424): DEVKIT_SYNC_TARGET mirror mode.
+  reset-sync-mirror:
+    name: Reset sync mirror onto main
+    needs: [resolve-toolchain, merge]
+    runs-on: ubuntu-24.04
+    container:
+      image: \${{ needs.resolve-toolchain.outputs.image }}
+      credentials:
+        username: \${{ github.actor }}
+        password: \${{ secrets.GHCR_PULL_TOKEN || github.token }}
+    timeout-minutes: 5
+    if: \${{ needs.merge.result == 'success' }}
+    permissions:
+      contents: read
+      packages: read
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+      - name: Set up devkit toolchain
+        uses: ./.github/actions/setup-devkit-toolchain
+        with:
+          mode: \${{ needs.resolve-toolchain.outputs.mode }}
+          devkit-version: \${{ needs.resolve-toolchain.outputs.image-tag }}
+
+      - name: Generate commit app token
+        id: commit_app_token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3
+        with:
+          client-id: \${{ secrets.COMMIT_APP_CLIENT_ID }}
+          private-key: \${{ secrets.COMMIT_APP_PRIVATE_KEY }}
+
+      - name: Force-reset mirror to main
+        env:
+          APP_TOKEN: \${{ steps.commit_app_token.outputs.token }}
+          GITHUB_REPOSITORY: \${{ github.repository }}
+        run: |
+          set -euo pipefail
+          # After the merged release PR, main carries the folded archive; the
+          # mirror re-bases onto it so divergence stays bounded (#1424). Push,
+          # never the REST refs API (#1157, #1377). The mirror is unprotected
+          # and its history is regenerated state — a force reset loses
+          # nothing; a racing nightly sync self-heals at its next run.
+          retry --retries 3 --backoff 3 --max-backoff 20 -- git fetch origin main
+          MAIN_SHA="\$(git rev-parse origin/main)"
+          REMOTE_URL="https://x-access-token:\${APP_TOKEN}@github.com/\${GITHUB_REPOSITORY}.git"
+          retry --retries 3 --backoff 5 --max-backoff 30 -- git push --force "\$REMOTE_URL" "\${MAIN_SHA}:refs/heads/${MANIFEST_SYNC_TARGET}"
+          echo "Mirror '${MANIFEST_SYNC_TARGET}' reset to main @ \${MAIN_SHA}"
+YAML
+        fi
     fi
 
     echo "Rendered sync-issues settings (target=${MANIFEST_SYNC_TARGET:-default}, schedule=${MANIFEST_SYNC_SCHEDULE:-default})"

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -32,6 +32,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Mirror-mode consumers integrate the issue archive via the release train** ([#1424](https://github.com/vig-os/devkit/issues/1424))
+  - With `DEVKIT_SYNC_TARGET` set, the scaffolded `release-core.yml` final leg
+    now dispatches sync-issues onto the **mirror** (the only branch that may
+    advance the shared incremental-sync cutoff) and then folds the mirror's
+    `docs/issues/` + `docs/pull-requests/` into the release branch, so the
+    full archive reaches `main` through the human-approved release PR —
+    previously the mirror diverged forever and `main` never carried the
+    archive
+  - The scaffolded `promote-release.yml` gains a rendered `reset-sync-mirror`
+    job that force-resets the mirror onto `main` after the release PR merges,
+    bounding its divergence to post-release snapshot commits
+  - Unset knob renders byte-identical templates; no change for non-mirror
+    consumers
 - **Bot changelog entries are synthesized at release time** ([#1423](https://github.com/vig-os/devkit/issues/1423))
   - New `synthesize-bot-changelog` (vig-utils) enumerates merged bot PRs
     (Renovate, devkit adoptions) since the last stable tag and regenerates a

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -322,11 +322,25 @@ DEVKIT_SYNC_TARGET=sync/issue-mirror
 
 The scaffolded job then **bootstraps** that branch from the default branch head
 if it is absent (so its first run creates it) and pushes the archive there,
-outside the `main` ruleset. The mirror branch **diverges permanently and is never
-merged back** — every sync run regenerates the full issue/PR state from the
-GitHub API, so the branch is a standalone, self-healing archive, not integration
-work. Absent => the workflow-model default (`dev`/`main`), unchanged for every
-existing consumer.
+outside the `main` ruleset. Every sync run regenerates the issue/PR state from
+the GitHub API, so the branch is a standalone, self-healing archive, not
+integration work. Absent => the workflow-model default (`dev`/`main`),
+unchanged for every existing consumer.
+
+The mirror **never merges directly into `main`** — the release train is its
+integration point ([#1424](https://github.com/vig-os/devkit/issues/1424)).
+The rendered `release-core.yml` retargets the final-leg sync dispatch to the
+mirror (the mirror stays the *only* branch that advances the shared
+incremental-sync cutoff; a release-branch run would strand every update
+between the last nightly and the release, since mirror mode has no
+sync-main-to-dev backflow to heal it), then folds the mirror's
+`docs/issues/` + `docs/pull-requests/` into the release branch, so the full
+archive reaches `main` through the human-approved release PR. After that PR
+merges, the rendered `promote-release.yml` force-resets the mirror onto
+`main` (via `git push`, never the REST refs API — #1157/#1377), so its
+divergence stays bounded to post-release snapshot commits. Between releases
+the mirror remains the live archive; `main` holds the archive as of the last
+release.
 
 A second optional key, `DEVKIT_SYNC_SCHEDULE`, overrides the schedule trigger's
 cron (validated as a 5-field cron at scaffold time; a protected-main mirror is

--- a/tests/bats/init-workspace.bats
+++ b/tests/bats/init-workspace.bats
@@ -2417,6 +2417,108 @@ _upgrade_no_flags() {
     done
 }
 
+# ── sync-mirror release fold (#1424) ──────────────────────────────────────────
+# In mirror mode (DEVKIT_SYNC_TARGET set) the release train is the mirror's
+# integration point: release-core's final-leg sync dispatch targets the MIRROR
+# (never the release branch — a release-branch run advances the shared
+# incremental-state cutoff and the mirror permanently misses the inter-sync
+# window), a fold lands the mirror's snapshot archive on the release branch,
+# and promote force-resets the mirror onto main so divergence stays bounded.
+
+@test "DEVKIT_SYNC_TARGET retargets the release-time sync dispatch to the mirror (#1424)" {
+    ws="$BATS_TEST_TMPDIR/e2e-1424-retarget"
+    mkdir -p "$ws"
+    run _scaffold both "$ws"
+    assert_success
+    sed -i 's#^DEVKIT_SYNC_TARGET=.*#DEVKIT_SYNC_TARGET=sync/issue-mirror#' "$ws/.vig-os"
+    run _upgrade_no_flags "$ws"
+    assert_success
+    rc="$ws/.github/workflows/release-core.yml"
+    run grep -qF -- '-f "target-branch=sync/issue-mirror"' "$rc"
+    assert_success
+    # No release-branch-targeted dispatch survives in mirror mode.
+    # shellcheck disable=SC2016  # literal shell variable in rendered YAML
+    run grep -qF -- '-f "target-branch=release/$VERSION"' "$rc"
+    assert_failure
+}
+
+@test "DEVKIT_SYNC_TARGET renders the fold steps between pull and finalize SHA (#1424)" {
+    ws="$BATS_TEST_TMPDIR/e2e-1424-fold"
+    mkdir -p "$ws"
+    run _scaffold both "$ws"
+    assert_success
+    sed -i 's#^DEVKIT_SYNC_TARGET=.*#DEVKIT_SYNC_TARGET=sync/issue-mirror#' "$ws/.vig-os"
+    run _upgrade_no_flags "$ws"
+    assert_success
+    rc="$ws/.github/workflows/release-core.yml"
+    run grep -qF 'name: Stage sync mirror archive for fold' "$rc"
+    assert_success
+    run grep -qF 'name: Commit folded archive to the release branch' "$rc"
+    assert_success
+    run grep -qF 'name: Re-pull release branch after fold' "$rc"
+    assert_success
+    # Ordering: Pull < fold staging < finalize SHA, so the fold commit is on
+    # origin before the local reset that feeds `git rev-parse HEAD` (the tag
+    # target) — a fold after the SHA capture would ship an untagged commit.
+    pull_ln=$(grep -n 'name: Pull sync-issues changes' "$rc" | cut -d: -f1)
+    fold_ln=$(grep -n 'name: Stage sync mirror archive for fold' "$rc" | cut -d: -f1)
+    sha_ln=$(grep -n 'name: Output finalize SHA' "$rc" | cut -d: -f1)
+    echo "pull=$pull_ln fold=$fold_ln sha=$sha_ln"
+    [ "$pull_ln" -lt "$fold_ln" ]
+    [ "$fold_ln" -lt "$sha_ln" ]
+}
+
+@test "DEVKIT_SYNC_TARGET renders the promote-time mirror reset job (#1424)" {
+    ws="$BATS_TEST_TMPDIR/e2e-1424-reset"
+    mkdir -p "$ws"
+    run _scaffold both "$ws"
+    assert_success
+    sed -i 's#^DEVKIT_SYNC_TARGET=.*#DEVKIT_SYNC_TARGET=sync/issue-mirror#' "$ws/.vig-os"
+    run _upgrade_no_flags "$ws"
+    assert_success
+    prom="$ws/.github/workflows/promote-release.yml"
+    run grep -qF 'reset-sync-mirror:' "$prom"
+    assert_success
+    # Ref mutation goes via git push, never the REST refs API (#1157, #1377).
+    run grep -qF 'git push --force' "$prom"
+    assert_success
+    run grep -qF ':refs/heads/sync/issue-mirror' "$prom"
+    assert_success
+}
+
+@test "unset DEVKIT_SYNC_TARGET leaves release-core + promote-release byte-identical (#1424)" {
+    ws="$BATS_TEST_TMPDIR/e2e-1424-noop"
+    mkdir -p "$ws"
+    run _scaffold both "$ws"
+    assert_success
+    run _upgrade_no_flags "$ws"
+    assert_success
+    run cmp "$ws/.github/workflows/release-core.yml" \
+        "$TEMPLATE_DIR/.github/workflows/release-core.yml"
+    assert_success
+    run cmp "$ws/.github/workflows/promote-release.yml" \
+        "$TEMPLATE_DIR/.github/workflows/promote-release.yml"
+    assert_success
+}
+
+@test "actionlint passes over the mirror-rendered workflows (#1424, #995)" {
+    # The fold steps and reset job only exist in a mirror-mode render, so the
+    # default-render actionlint fixtures (#995) never see them; lint the
+    # knob-set render explicitly.
+    ws="$BATS_TEST_TMPDIR/al-1424-mirror"
+    mkdir -p "$ws"
+    run _scaffold both "$ws"
+    assert_success
+    sed -i 's#^DEVKIT_SYNC_TARGET=.*#DEVKIT_SYNC_TARGET=sync/issue-mirror#' "$ws/.vig-os"
+    run _upgrade_no_flags "$ws"
+    assert_success
+    (
+        cd "$ws" &&
+            git init -q &&
+            actionlint
+    )
+}
+
 # ── Refs policy knob (#1282) ──────────────────────────────────────────────────
 # DEVKIT_REFS_POLICY steers the validate-commit-msg hook's --refs-optional-types
 # arg at scaffold time (the CI validate-commit-range surface is driven from the


### PR DESCRIPTION
## Description

Makes the release train the integration point for mirror-mode sync-issues
consumers (`DEVKIT_SYNC_TARGET` set, #1227/#1228). Today the mirror "diverges
permanently and is never merged back", so a protected-`main` consumer never
carries the issue/PR archive on `main` (live evidence: org-config has no
`docs/issues/` despite two releases), and the existing release-time sync leg
cannot fix it — it is an incremental top-up sharing the repo-wide
`sync-issues-state-<repo>` cutoff cache, so a release-branch run would both
produce a partial archive *and* permanently starve the mirror of the
inter-sync window (mirror mode has no sync-main-to-dev backflow).

Closes #1424

## Type of Change

- [x] `feat` -- New feature

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- `render_sync_settings` (init-workspace.sh), only when `DEVKIT_SYNC_TARGET`
  is set:
  - `release-core.yml` final leg: the sync dispatch retargets to the
    **mirror** (`--ref` stays on the release branch so the release's own
    workflow definition runs and the wait step's `--branch` filter is
    untouched), and three fold steps land after the release-branch pull —
    stage `docs/issues/` + `docs/pull-requests/` from the mirror
    (`git checkout FETCH_HEAD -- <dirs>`, no branch merge, so mirror
    divergence is irrelevant), commit via commit-action with the existing
    `commit_app_token`, then re-pull so `Output finalize SHA` (the tag
    target) includes the fold commit. Missing mirror, missing snapshot dirs,
    or an already-identical archive are clean no-ops.
  - `promote-release.yml`: appended `reset-sync-mirror` job
    (`needs: [resolve-toolchain, merge]`, gated on merge success) that
    force-resets the mirror ref onto `main` via `git push` — never the REST
    refs API (#1157/#1377) — using the commit App (git/ref-ops identity).
    The mirror is unprotected by design and its history is regenerated
    state, so the reset loses nothing; a racing nightly sync self-heals.
- Unset knob ⇒ byte-identical `release-core.yml`/`promote-release.yml`
  (pinned by test), so every existing non-mirror consumer is untouched.
- MIGRATION.md mirror doctrine amended: never merges *directly* into `main`;
  folded via the release PR at finalize, re-based onto `main` at promote.

Known limitation (noted in the rendered comment): commit-action v0.3.2 only
adds/updates files, so a path deleted on the mirror survives on the release
branch — theoretical for an include-closed archive that only grows; revisit
with commit-action deletion support.

## Changelog Entry

### Changed

- **Mirror-mode consumers integrate the issue archive via the release train** ([#1424](https://github.com/vig-os/devkit/issues/1424))
  - With `DEVKIT_SYNC_TARGET` set, the scaffolded `release-core.yml` final leg
    now dispatches sync-issues onto the **mirror** (the only branch that may
    advance the shared incremental-sync cutoff) and then folds the mirror's
    `docs/issues/` + `docs/pull-requests/` into the release branch, so the
    full archive reaches `main` through the human-approved release PR —
    previously the mirror diverged forever and `main` never carried the
    archive
  - The scaffolded `promote-release.yml` gains a rendered `reset-sync-mirror`
    job that force-resets the mirror onto `main` after the release PR merges,
    bounding its divergence to post-release snapshot commits
  - Unset knob renders byte-identical templates; no change for non-mirror
    consumers

## Testing

TDD: contract pinned first (e5644084, 3 of 5 new bats tests red), then the
render (19a24a96, all green):

- `DEVKIT_SYNC_TARGET retargets the release-time sync dispatch to the mirror` —
  mirror-targeted `-f target-branch=`, no release-branch dispatch survives
- `renders the fold steps between pull and finalize SHA` — presence + strict
  ordering (Pull < fold < finalize SHA), so the tag target includes the fold
- `renders the promote-time mirror reset job` — job present, push-based ref
  mutation, mirror ref literal
- `unset DEVKIT_SYNC_TARGET leaves release-core + promote-release
  byte-identical` — `cmp` against the templates
- `actionlint passes over the mirror-rendered workflows` — the #995 fixtures
  only lint default renders and would never see the injected steps/job; this
  lints the knob-set render (expressions, needs wiring, shellcheck on run
  blocks)

Local: `bats --filter "#1424|#1228|#995|#1279"` 12/12 green;
`just precommit` (full `--all-files` suite) green.
