### PR TITLE
feat(nix): Rust language pack — capability module + lib.mkRustProject

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,41 @@
 {
   "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1785782307,
+        "narHash": "sha256-MPaRdVkf6zZP5fCPxYCi8Dr4pZzgmXzg8T9nVEbp3Mw=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "2c71e194474d13de031d729b729c968ddbe3507f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1786432497,
+        "narHash": "sha256-iunnvo2ZqbFOwp/LXL3vtlbaG+45FuiHk+YKpbSoAec=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "45d045a58ed69993eb1d349a86def638fea93a9f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
     "flake-compat": {
       "flake": false,
       "locked": {
@@ -147,6 +183,8 @@
     },
     "root": {
       "inputs": {
+        "crane": "crane",
+        "fenix": "fenix",
         "flake-utils": "flake-utils",
         "git-hooks-nix": "git-hooks-nix",
         "home-manager": "home-manager",
@@ -155,6 +193,23 @@
         "process-compose-flake": "process-compose-flake",
         "services-flake": "services-flake",
         "treefmt-nix": "treefmt-nix"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1786396074,
+        "narHash": "sha256-tQAL2tJNNhPV6LBY/9pef+fq37RLYts/LknqJ6m9Y6Q=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "57bea800b866168ac4f310333e326b92ccba7aca",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
       }
     },
     "services-flake": {

--- a/flake.nix
+++ b/flake.nix
@@ -30,6 +30,24 @@
     # Refs #819.
     home-manager.url = "github:nix-community/home-manager/release-26.05";
     home-manager.inputs.nixpkgs.follows = "nixpkgs";
+    # ---- Rust language pack (#1400) -------------------------------------
+    # crane: the cargo build library behind lib.mkRustProject's checks and
+    # packages. Dependency-free (like process-compose-flake), so it adds one
+    # leaf lock entry and nothing transitive.
+    crane.url = "github:ipetkov/crane";
+    # fenix: resolves a toolchain from a repo's rust-toolchain.toml, so nix
+    # and rustup agree on the compiler. nixpkgs' Rust tracks the channel and
+    # cannot honour a pin, which is the one thing a language pack must do.
+    #
+    # These are inputs of devkit rather than arguments a Rust consumer passes
+    # in, and that is a deliberate tradeoff: every consumer — including the
+    # Python-only ones — pays for them in lock size and in fetch at eval. The
+    # alternative makes each Rust repo pin its own fenix, which is per-repo
+    # drift on precisely the axis devkit exists to hold still. If the eval
+    # cost turns out to bite, mkRustProject takes `crane`/`fenix` overrides
+    # and the inputs can move out without a consumer-visible change.
+    fenix.url = "github:nix-community/fenix";
+    fenix.inputs.nixpkgs.follows = "nixpkgs";
   };
 
   outputs =
@@ -43,6 +61,8 @@
       process-compose-flake,
       services-flake,
       home-manager,
+      crane,
+      fenix,
     }:
     let
       # ---------------------------------------------------------------------
@@ -208,6 +228,11 @@
       # the generated per-module `checks.<system>.module-<name>` below. See
       # docs/rfcs/ADR-capability-modules.md for the v1 contract.
       capabilityModules = import ./nix/modules/default.nix;
+
+      # How the generated `module-<name>` smoke check instantiates a module
+      # whose options are mandatory (nix/modules/check-entries.nix). Names
+      # absent here use the plain string form, unchanged.
+      capabilityModuleCheckEntries = import ./nix/modules/check-entries.nix;
 
       # One definition of the pre-commit hook set (#883): nix/hooks.nix
       # renders the sandbox-pure `checks.pre-commit` gate, the PATH-portable
@@ -672,6 +697,29 @@
       # mkProjectServices — reusable local dev-services builder (#795).
       #
       # Boots declared services (Postgres, SeaweedFS, Redis, …) as native processes via
+      # ---------------------------------------------------------------------
+      # mkRustProject — the Rust consumer's single entry point (#1400, #1427).
+      #
+      # Composes ABOVE mkProjectShell rather than inside the capability-module
+      # contract, because `checks` is not the shape that contract composes
+      # (the reasoning is in nix/mk-rust-project.nix's header, the decision
+      # in vig-os/devkit#1427). One call returns the dev shell, the checks and
+      # the packages together:
+      #
+      #   rust = inputs.devcontainer.lib.mkRustProject {
+      #     inherit pkgs;
+      #     src = ./.;
+      #     toolchainHash = "sha256-…";
+      #     crates = [ "my-cli" ];
+      #   };
+      #   devShells.default = rust.devShell;
+      #   checks = rust.checks;
+      #   packages = rust.packages;
+      # ---------------------------------------------------------------------
+      mkRustProject = import ./nix/mk-rust-project.nix {
+        inherit mkProjectShell crane fenix;
+      };
+
       # process-compose + services-flake — no Docker/Podman daemon — with the
       # service versions coming from the caller's `pkgs` (the pinned nixpkgs
       # lock, never out-of-lock image tags). services-flake is consumed through
@@ -1095,7 +1143,7 @@
           name: _:
           pkgs.lib.nameValuePair "module-${name}" (mkProjectShell {
             inherit pkgs;
-            modules = [ name ];
+            modules = [ (capabilityModuleCheckEntries.${name} or name) ];
           })
         ) capabilityModules
         # The ci homeConfigurations build as Tier-0 checks. x86_64-darwin is
@@ -1556,6 +1604,7 @@
         inherit
           mkProjectShell
           mkProjectServices
+          mkRustProject
           devTools
           ;
         # PATH-portable renders of the one hook-set definition (#883):

--- a/nix/mk-rust-project.nix
+++ b/nix/mk-rust-project.nix
@@ -1,0 +1,394 @@
+# mkRustProject — the composed entry point for a Rust consumer (#1400,
+# decision in #1427).
+#
+# ---------------------------------------------------------------------------
+# WHY THIS IS A LIB FUNCTION AND NOT PART OF THE MODULE CONTRACT
+# ---------------------------------------------------------------------------
+# A capability module contributes `packages` / `env` / `shellHook`: three
+# fields that fold monoidally into ONE derivation, the dev shell. `checks` is
+# not that shape. It is a namespaced map of independent peer derivations on a
+# different lifecycle (`nix flake check`, not `nix develop`), and building them
+# needs the consumer's source tree — project shape a module never sees.
+#
+# The test that settled it: a `checks` field could be added to the shell
+# composition contract WITHOUT touching shell composition at all. If a field
+# can be added to a contract without touching what that contract composes, it
+# is not part of that contract.
+#
+# So the module stays v1 and this function composes above it. Crucially it is
+# ONE call: it builds the dev shell (by calling mkProjectShell with the rust
+# module wired for us) AND the checks AND the packages, and hands all three
+# back together. There is no second function a consumer can forget to call,
+# which was the whole objection to shipping the checks separately.
+#
+# The consumer still has to assign the outputs — flake outputs are
+# consumer-assigned by construction, and no contract change anywhere in devkit
+# could alter that. What this shape buys is that `checks` arrives sitting
+# beside `devShell` in one attrset, so dropping it is a visible omission
+# rather than an unknown-unknown. The rust module's mandatory `checks` option
+# closes the remaining hand-edited path with an eval-time refusal.
+#
+# Usage:
+#
+#   perSystem = { system, pkgs, ... }:
+#     let
+#       rust = inputs.devkit.lib.mkRustProject {
+#         inherit pkgs;
+#         src = ./.;
+#         toolchainHash = "sha256-…";   # for ./rust-toolchain.toml
+#         crates = [ "my-cli" ];
+#       };
+#     in
+#     {
+#       devShells.default = rust.devShell;
+#       checks = rust.checks;
+#       packages = rust.packages;
+#     };
+{
+  mkProjectShell,
+  crane,
+  fenix,
+}:
+
+{
+  pkgs,
+  src,
+
+  # ---- what to build -------------------------------------------------------
+  # Cargo package names to build as both `packages.<name>` and
+  # `checks.<name>`. Null builds the workspace default as `packages.default`.
+  # Named crates are preferred for a workspace: each one is its own derivation,
+  # so a break is attributed rather than reported against "the workspace".
+  crates ? null,
+  # Which of `crates` becomes `packages.default`. Null uses the first.
+  defaultCrate ? null,
+  # Package name -> attrs merged into that crate's buildPackage call. The
+  # escape hatch for per-crate `doCheck`, features, or build commands.
+  crateOverrides ? { },
+
+  # ---- toolchain -----------------------------------------------------------
+  # A complete Rust toolchain derivation, if you are building one yourself.
+  toolchain ? null,
+  # Path to a rust-toolchain.toml. Defaults to `${src}/rust-toolchain.toml`
+  # when that file exists.
+  toolchainFile ? null,
+  # fenix requires a content hash for the resolved toolchain. There is no way
+  # around it and no sensible default — see the error below for how to get it.
+  toolchainHash ? null,
+
+  # ---- source --------------------------------------------------------------
+  # Extra files the build needs that crane's cargo-source filter drops:
+  # fixtures, .json goldens, templates. Paths relative to `src` (strings) or
+  # absolute paths. The well-known tool configs are picked up automatically —
+  # see wellKnownConfigFiles below, and read the comment there before assuming
+  # you do not need this.
+  extraSrcFiles ? [ ],
+
+  # ---- build inputs --------------------------------------------------------
+  nativeBuildInputs ? [ ],
+  buildInputs ? [ ],
+  # Merged into every crane derivation. For CMAKE_*, PKG_CONFIG_PATH, etc.
+  buildEnv ? { },
+
+  # ---- behaviour -----------------------------------------------------------
+  # Build shipped binaries with `cargo auditable`, embedding the dependency
+  # graph in the artifact so a consumer can audit what they actually hold
+  # rather than a source tree that has since moved on. Costs one extra tool in
+  # the build closure.
+  auditable ? true,
+  # `cargo deny check`. Defaults on when a deny.toml exists.
+  deny ? null,
+  # `cargo doc` with warnings denied — catches broken intra-doc links, which
+  # nothing else in the suite does.
+  doc ? true,
+  # `cargo nextest run`. Process-per-test, so an aborting test is reported.
+  nextest ? true,
+  clippy ? true,
+  # Extra args for the clippy check. `--deny warnings` is already applied.
+  clippyExtraArgs ? "--all-targets",
+  fmt ? true,
+
+  # ---- dev shell -----------------------------------------------------------
+  # Cargo tooling on the shell PATH (the rust module's curated map).
+  tools ? null,
+  linker ? true,
+  # Additional capability modules, composed alongside `rust`.
+  modules ? [ ],
+  extraPackages ? [ ],
+  hooks ? null,
+  hooksExcludes ? [ ],
+  workflow ? "gitflow",
+  shellHook ? null,
+  # Extra dev-shell environment. Distinct from `buildEnv`, which goes to the
+  # build derivations.
+  shellEnv ? { },
+}:
+
+let
+  inherit (pkgs) lib;
+  system = pkgs.stdenv.hostPlatform.system;
+
+  # ---------------------------------------------------------------------------
+  # Toolchain resolution
+  # ---------------------------------------------------------------------------
+  defaultToolchainFile = src + "/rust-toolchain.toml";
+  resolvedToolchainFile =
+    if toolchainFile != null then
+      toolchainFile
+    else if builtins.pathExists defaultToolchainFile then
+      defaultToolchainFile
+    else
+      null;
+
+  hashError = ''
+    mkRustProject: a rust-toolchain.toml was found at
+
+        ${toString resolvedToolchainFile}
+
+    but `toolchainHash` was not set. fenix resolves the toolchain from that
+    file as a fixed-output derivation, which needs its content hash; there is
+    no default that could be correct.
+
+    To get it, set the placeholder and build once:
+
+        toolchainHash = pkgs.lib.fakeHash;
+
+    Nix will fail with `specified: sha256-AAAA…` / `got: sha256-<real>`. Use
+    the `got` value. It changes when you change the pinned channel or the
+    component list in rust-toolchain.toml, and the same failure will tell you.
+
+    Not honouring the file is deliberately not an option here: a repo that
+    pins a toolchain and then builds with a different one is worse than a repo
+    that pins nothing. If you truly want the nixpkgs Rust, pass
+    `toolchainFile = null` explicitly.
+  '';
+
+  resolvedToolchain =
+    if toolchain != null then
+      toolchain
+    else if resolvedToolchainFile == null then
+      null
+    else if toolchainHash == null then
+      throw hashError
+    else
+      fenix.packages.${system}.fromToolchainFile {
+        file = resolvedToolchainFile;
+        sha256 = toolchainHash;
+      };
+
+  # `overrideToolchain` takes a FUNCTION, not a bare derivation. The function
+  # form is what lets crane splice correctly when cross-compiling; passing the
+  # derivation directly works until the day someone cross-compiles, and then
+  # fails somewhere far from here.
+  craneLib =
+    if resolvedToolchain == null then
+      crane.mkLib pkgs
+    else
+      (crane.mkLib pkgs).overrideToolchain (_: resolvedToolchain);
+
+  # ---------------------------------------------------------------------------
+  # Source
+  #
+  # crane's `commonCargoSources` walks the crate directories and allowlists
+  # Cargo.{toml,lock}, *.rs and *.toml. Root-level TOOL CONFIGS are outside
+  # that walk, and their absence is SILENT: rustfmt, clippy and cargo-deny
+  # each fall back to built-in defaults inside the sandbox, so the check
+  # passes while enforcing rules nobody wrote. The first consumer shipped that
+  # bug twice — a deny.toml banning openssl that banned nothing, and a
+  # clippy.toml that was never read by the clippy check meant to enforce it.
+  #
+  # Including these unconditionally is the fix. `maybeMissing` makes each one
+  # a no-op until the file exists, so there is nothing to remember and nothing
+  # to keep in sync.
+  # ---------------------------------------------------------------------------
+  wellKnownConfigFiles = [
+    "rustfmt.toml"
+    ".rustfmt.toml"
+    "clippy.toml"
+    ".clippy.toml"
+    "deny.toml"
+    "about.toml"
+    "about.hbs"
+    "rust-toolchain.toml"
+    "rust-toolchain"
+    ".cargo"
+  ];
+
+  toSrcPath = f: if builtins.isPath f then f else src + "/${f}";
+
+  cleanSrc = lib.fileset.toSource {
+    root = src;
+    fileset = lib.fileset.unions (
+      [ (craneLib.fileset.commonCargoSources src) ]
+      ++ map (f: lib.fileset.maybeMissing (src + "/${f}")) wellKnownConfigFiles
+      ++ map (f: lib.fileset.maybeMissing (toSrcPath f)) extraSrcFiles
+    );
+  };
+
+  denyEnabled = if deny != null then deny else builtins.pathExists (src + "/deny.toml");
+
+  # ---------------------------------------------------------------------------
+  # Build
+  # ---------------------------------------------------------------------------
+  useMold = linker && pkgs.stdenv.hostPlatform.isLinux;
+
+  commonArgs = {
+    src = cleanSrc;
+    # Keeps host and target dependencies from leaking into each other. On by
+    # default because the failure it prevents (a build that works only on the
+    # machine that has the library installed) is invisible until it isn't.
+    strictDeps = true;
+    nativeBuildInputs = nativeBuildInputs ++ lib.optional useMold pkgs.mold;
+    buildInputs = buildInputs ++ lib.optionals pkgs.stdenv.hostPlatform.isDarwin [ pkgs.libiconv ];
+    # cargo's release profile is expected to set `strip = true` (the pack's
+    # Cargo.toml policy). Stripping twice is wasted work, not extra safety.
+    dontStrip = true;
+  }
+  // buildEnv;
+
+  cargoArtifacts = craneLib.buildDepsOnly commonArgs;
+
+  buildCrate =
+    name:
+    craneLib.buildPackage (
+      commonArgs
+      // {
+        inherit cargoArtifacts;
+        pname = name;
+        cargoExtraArgs = "-p ${name}";
+      }
+      // lib.optionalAttrs auditable {
+        nativeBuildInputs = commonArgs.nativeBuildInputs ++ [ pkgs.cargo-auditable ];
+        cargoBuildCommand = "cargo auditable build --profile release";
+      }
+      // (crateOverrides.${name} or { })
+    );
+
+  workspacePackage = craneLib.buildPackage (
+    commonArgs
+    // {
+      inherit cargoArtifacts;
+    }
+    // lib.optionalAttrs auditable {
+      nativeBuildInputs = commonArgs.nativeBuildInputs ++ [ pkgs.cargo-auditable ];
+      cargoBuildCommand = "cargo auditable build --profile release";
+    }
+    // (crateOverrides.default or { })
+  );
+
+  cratePackages = lib.genAttrs (if crates == null then [ ] else crates) buildCrate;
+
+  resolvedDefault =
+    if crates == null then
+      workspacePackage
+    else if defaultCrate != null then
+      cratePackages.${defaultCrate} or (throw (
+        "mkRustProject: defaultCrate '${defaultCrate}' is not in `crates` "
+        + "(${lib.concatStringsSep ", " crates})"
+      ))
+    else if crates == [ ] then
+      throw "mkRustProject: `crates` is an empty list; pass null to build the workspace default, or name at least one crate"
+    else
+      cratePackages.${builtins.head crates};
+
+  packages = cratePackages // {
+    default = resolvedDefault;
+  };
+
+  # ---------------------------------------------------------------------------
+  # Checks
+  #
+  # The crate builds are checks too. A `nix flake check` that lints but never
+  # compiles the thing being shipped is the failure this pack exists to
+  # prevent, so the packages are folded in rather than left to `nix build`.
+  # ---------------------------------------------------------------------------
+  checks =
+    cratePackages
+    // lib.optionalAttrs (crates == null) { workspace = workspacePackage; }
+    // lib.optionalAttrs clippy {
+      clippy = craneLib.cargoClippy (
+        commonArgs
+        // {
+          inherit cargoArtifacts;
+          cargoClippyExtraArgs = "${clippyExtraArgs} -- --deny warnings";
+        }
+      );
+    }
+    // lib.optionalAttrs fmt {
+      # cargoFmt takes only `src` — it does not compile, so handing it
+      # cargoArtifacts would just pin an unrelated dependency build.
+      fmt = craneLib.cargoFmt { src = cleanSrc; };
+    }
+    // lib.optionalAttrs nextest {
+      nextest = craneLib.cargoNextest (
+        commonArgs
+        // {
+          inherit cargoArtifacts;
+          partitions = 1;
+          partitionType = "count";
+        }
+      );
+    }
+    // lib.optionalAttrs doc {
+      doc = craneLib.cargoDoc (
+        commonArgs
+        // {
+          inherit cargoArtifacts;
+          env = (commonArgs.env or { }) // {
+            RUSTDOCFLAGS = "--deny warnings";
+          };
+        }
+      );
+    }
+    // lib.optionalAttrs denyEnabled {
+      # No separate cargo-audit check: `cargo deny check advisories` already
+      # scans the RustSec database, so a second derivation would be a
+      # duplicate build for the same signal.
+      deny = craneLib.cargoDeny { src = cleanSrc; };
+    };
+
+  # ---------------------------------------------------------------------------
+  # Dev shell — the rust module, wired with the toolchain we just resolved so
+  # the shell and the builds cannot disagree about the compiler version.
+  # `checks = "mkRustProject"` is the module's acknowledgement token: it is
+  # true here, and it is exactly what a hand-wired consumer cannot honestly
+  # claim.
+  # ---------------------------------------------------------------------------
+  rustModuleEntry = {
+    name = "rust";
+    checks = "mkRustProject";
+    toolchain = resolvedToolchain;
+    inherit tools linker;
+  };
+
+  devShell = mkProjectShell (
+    {
+      inherit
+        pkgs
+        extraPackages
+        hooks
+        hooksExcludes
+        workflow
+        ;
+      modules = [ rustModuleEntry ] ++ modules;
+    }
+    // lib.optionalAttrs (shellHook != null) { inherit shellHook; }
+  );
+
+  # mkProjectShell owns the shell derivation, so extra env is applied here
+  # rather than threaded through it — one override, no new argument on a
+  # contract shared with every non-Rust consumer.
+  devShellWithEnv = if shellEnv == { } then devShell else devShell.overrideAttrs (_: shellEnv);
+in
+{
+  inherit packages checks;
+  devShell = devShellWithEnv;
+
+  # Escape hatches for consumers doing something the arguments above do not
+  # cover — an extra crane derivation, a second toolchain, a bespoke check.
+  # Exposed deliberately: without them the first unanticipated need forks the
+  # whole function.
+  inherit craneLib cargoArtifacts commonArgs;
+  toolchain = resolvedToolchain;
+  src = cleanSrc;
+}

--- a/nix/mk-rust-project.nix
+++ b/nix/mk-rust-project.nix
@@ -248,10 +248,18 @@ let
 
   cargoArtifacts = craneLib.buildDepsOnly commonArgs;
 
+  # crane's buildPackage runs `cargo test` as part of the build. With the
+  # nextest check enabled that is the same suite twice, on two derivations,
+  # for one signal — so the package builds compile only and the test run lives
+  # in `checks.nextest`, which is also what CI invokes. Without nextest the
+  # build keeps its tests, because otherwise nothing would run them.
+  packageDefaults = lib.optionalAttrs nextest { doCheck = false; };
+
   buildCrate =
     name:
     craneLib.buildPackage (
       commonArgs
+      // packageDefaults
       // {
         inherit cargoArtifacts;
         pname = name;
@@ -266,6 +274,7 @@ let
 
   workspacePackage = craneLib.buildPackage (
     commonArgs
+    // packageDefaults
     // {
       inherit cargoArtifacts;
     }

--- a/nix/modules/check-entries.nix
+++ b/nix/modules/check-entries.nix
@@ -1,0 +1,26 @@
+# How the generated per-module smoke check instantiates each capability module.
+#
+# flake.nix builds `checks.<system>.module-<name>` for every entry in the
+# registry (nix/modules/default.nix) so a module cannot ship without its check.
+# The generator's default instantiation is the plain name string — the same
+# thing a consumer writes for a module that needs no configuration.
+#
+# A module whose options are MANDATORY cannot be instantiated that way: the
+# bare name throws by design. This file is the generator's answer — a name ->
+# `modules` entry override, consulted only for the names present here.
+#
+# Keep this small and keep it justified. An entry here is a statement that the
+# module's zero-option form is deliberately unusable, not that the check was
+# inconvenient to write.
+{
+  # `rust` refuses the bare form so nobody wires a toolchain without the check
+  # suite (#1427; the reasoning is in the module header). The smoke check is
+  # exactly the sanctioned toolchain-only case: it builds the devshell to prove
+  # the module evaluates and its packages resolve, and owns no source tree to
+  # run checks against. The deeper end-to-end coverage lives in
+  # tests/test_flake_modules.py.
+  rust = {
+    name = "rust";
+    checks = "none";
+  };
+}

--- a/nix/modules/default.nix
+++ b/nix/modules/default.nix
@@ -7,12 +7,16 @@
 # passes via `{ name = "<name>"; … }` minus `name` (empty `{}` for the plain
 # string form). mkProjectShell resolves names against this attrset and the
 # flake generates a per-system `checks.<system>.module-<name>` devshell
-# build for every entry, so a module cannot ship without its check.
+# build for every entry, so a module cannot ship without its check. A module
+# whose options are mandatory overrides how that check instantiates it — see
+# ./check-entries.nix.
 #
-# Candidate modules — geant4, rust, fortran/f2py, root — are deliberately
-# NOT defined until a concrete consumer asks (YAGNI; see the ADR).
+# Candidate modules — geant4, fortran/f2py, root — are deliberately NOT
+# defined until a concrete consumer asks (YAGNI; see the ADR). `rust` was such
+# a candidate and shipped on gerchowl/filesender's ask (#1400).
 {
   native = import ./native.nix;
   node = import ./node.nix;
   docs = import ./docs.nix;
+  rust = import ./rust.nix;
 }

--- a/nix/modules/rust.nix
+++ b/nix/modules/rust.nix
@@ -1,0 +1,220 @@
+# `rust` capability module (#1400, decision in #1427): the Rust dev-shell
+# capability. One of the ADR's ask-gated candidates; `gerchowl/filesender` is
+# the ask.
+#
+# v1 contract (`pkgs -> options -> { packages, env, shellHook }`, per
+# docs/rfcs/ADR-capability-modules.md) — this module contributes packages and
+# env only. It deliberately does NOT provide the cargo justfile recipes, the
+# .gitignore fragment, the pre-commit hooks or the CodeQL language: those are
+# scaffold concerns, not shell contributions, exactly as for `node`.
+#
+# ---------------------------------------------------------------------------
+# WHY THIS MODULE REFUSES TO LOAD BARE
+# ---------------------------------------------------------------------------
+# A Rust toolchain on PATH is the *easy* half of the capability. The half that
+# earns its keep is the check suite — fmt, clippy, nextest, cargo-deny, the
+# per-crate builds — and a v1 capability module cannot contribute
+# `checks.<system>.*`. Checks need the project's source tree, which is
+# consumer-owned project shape, neither ambient here nor derivable from
+# options.
+#
+# So a consumer who writes `modules = [ "rust" ]` and stops would get a
+# toolchain, a green `nix flake check` that builds nothing, and CI that
+# compiles nothing — the precise silent-green failure the Rust pack exists to
+# prevent, delivered by the pack itself. #1427 settled that the fix is
+# `lib.mkRustProject` (which wires shell AND checks from one call) plus this
+# eval-time refusal for anyone who hand-edits their way around it. Detection
+# is not enough here: the record on the first consumer is five separate
+# things configured, believed active, and never executed.
+#
+# Hence the mandatory `checks` option. It has no default on purpose.
+pkgs:
+{
+  checks ? null,
+  toolchain ? null,
+  tools ? null,
+  linker ? true,
+  ...
+}@options:
+let
+  inherit (pkgs) lib;
+
+  knownOptions = [
+    "checks"
+    "toolchain"
+    "tools"
+    "linker"
+  ];
+  unknownOptions = builtins.filter (k: !builtins.elem k knownOptions) (builtins.attrNames options);
+
+  # -------------------------------------------------------------------------
+  # Curated cargo tooling. A name -> package map rather than free-form
+  # derivations so `tools` stays a reviewable list in a consumer's flake and a
+  # typo is an eval error, not a silently missing binary.
+  # -------------------------------------------------------------------------
+  toolMap = {
+    # Test runner. Not a nicety: nextest is process-per-test, so a panicking
+    # or aborting test is reported rather than taking the runner with it.
+    nextest = pkgs.cargo-nextest or null;
+    # Supply chain: advisories, licence policy, source bans (deny.toml).
+    deny = pkgs.cargo-deny or null;
+    # Embeds the dependency graph in the SHIPPED binary, so `cargo audit bin`
+    # audits the artifact rather than a source tree that may have moved on.
+    auditable = pkgs.cargo-auditable or null;
+    audit = pkgs.cargo-audit or null;
+    # Third-party attribution text. deny.toml says which licences are allowed;
+    # this produces the notice the permissive ones oblige us to distribute.
+    about = pkgs.cargo-about or null;
+    # Unused dependency detection — the one cargo itself will not tell you.
+    shear = pkgs.cargo-shear or null;
+    # Coverage. Reported, never gated (see the pack ADR).
+    llvm-cov = pkgs.cargo-llvm-cov or null;
+    watch = pkgs.cargo-watch or null;
+    expand = pkgs.cargo-expand or null;
+    machete = pkgs.cargo-machete or null;
+    outdated = pkgs.cargo-outdated or null;
+    insta = pkgs.cargo-insta or null;
+    flamegraph = pkgs.cargo-flamegraph or null;
+    criterion = pkgs.cargo-criterion or null;
+    mutants = pkgs.cargo-mutants or null;
+    semver-checks = pkgs.cargo-semver-checks or null;
+    hakari = pkgs.cargo-hakari or null;
+    dist = pkgs.cargo-dist or null;
+  };
+
+  # The default set is what every tier in the pack ADR needs: run the tests,
+  # police the supply chain, produce the attribution file, notice dead deps.
+  # Anything tier-specific (semver-checks for `lib`, mutants for `runner`) is
+  # opt-in via `tools`, because each one costs build time for every consumer.
+  defaultTools = [
+    "nextest"
+    "deny"
+    "auditable"
+    "audit"
+    "about"
+    "shear"
+  ];
+
+  requestedTools = if tools == null then defaultTools else tools;
+
+  unknownTools = builtins.filter (t: !(toolMap ? ${t}) || toolMap.${t} == null) requestedTools;
+
+  toolPackages = map (t: toolMap.${t}) requestedTools;
+
+  # -------------------------------------------------------------------------
+  # Toolchain. `toolchain` is a complete Rust toolchain derivation — in
+  # practice fenix's `fromToolchainFile`, which is what lib.mkRustProject
+  # passes so `rust-toolchain.toml` is the single source of truth for the
+  # version. Omitted, we fall back to the pinned nixpkgs Rust: a real
+  # toolchain, but one that tracks the channel rather than the repo's pin.
+  # -------------------------------------------------------------------------
+  toolchainPackages =
+    if toolchain != null then
+      [ toolchain ]
+    else
+      [
+        pkgs.rustc
+        pkgs.cargo
+        pkgs.clippy
+        pkgs.rustfmt
+        pkgs.rust-analyzer
+      ];
+
+  # mold cuts link time on large debug builds by an order of magnitude, and
+  # link time is what a Rust edit-compile loop is actually made of. Linux
+  # only: on Darwin the system linker is already the fast path and mold's
+  # Mach-O support is not the supported configuration.
+  useMold = linker && pkgs.stdenv.hostPlatform.isLinux;
+
+  # `checks` is mandatory and has no default — see the header. The message is
+  # the whole point of the guard, so it states the fix, the escape hatch, and
+  # why the escape hatch is not the default.
+  checksError = ''
+    rust module: the `checks` option is required.
+
+    `modules = [ "rust" ]` puts a Rust toolchain on the dev-shell PATH and
+    NOTHING ELSE. It cannot add `checks.<system>.*` — a v1 capability module
+    contributes packages/env/shellHook only, and checks need your source tree,
+    which the module never sees. A repo wired this way compiles nothing in CI
+    and reports success. Refs vig-os/devkit#1427.
+
+    Use the composed entry point instead, which wires the shell AND the checks
+    from one call:
+
+        rust = inputs.devkit.lib.mkRustProject {
+          inherit pkgs;
+          src = ./.;
+        };
+      in {
+        devShells.default = rust.devShell;
+        checks.''${system}  = rust.checks;
+        packages.''${system} = rust.packages;
+      }
+
+    If you genuinely want the toolchain WITHOUT the check suite — a scratch
+    shell, a repo whose Rust is incidental, a consumer that already owns its
+    own checks — say so explicitly:
+
+        modules = [ { name = "rust"; checks = "none"; } ];
+
+    It is spelled out rather than defaulted because the default would be the
+    failure mode: silence is exactly how the unwired case reaches CI.
+  '';
+
+  validChecks = [
+    "mkRustProject"
+    "none"
+  ];
+in
+if unknownOptions != [ ] then
+  throw (
+    "rust module: unknown option(s): "
+    + lib.concatStringsSep ", " unknownOptions
+    + "; recognized options are "
+    + lib.concatStringsSep ", " knownOptions
+  )
+else if checks == null then
+  throw checksError
+else if !builtins.elem checks validChecks then
+  throw (
+    "rust module: invalid `checks` value "
+    + builtins.toJSON checks
+    + "; expected \"mkRustProject\" (set for you by lib.mkRustProject) or "
+    + "\"none\" (deliberate opt-out — toolchain only, no check suite)"
+  )
+else if unknownTools != [ ] then
+  throw (
+    "rust module: unknown or unavailable tool(s): "
+    + lib.concatStringsSep ", " unknownTools
+    + "; available: "
+    + lib.concatStringsSep ", " (builtins.filter (n: toolMap.${n} != null) (builtins.attrNames toolMap))
+  )
+else
+  {
+    packages = toolchainPackages ++ toolPackages ++ lib.optional useMold pkgs.mold;
+
+    env = {
+      # Point rust-analyzer and friends at the toolchain's own sources. Without
+      # it, "go to definition" on a std symbol lands nowhere in a Nix shell,
+      # because there is no rustup to infer the sysroot from.
+      RUST_SRC_PATH =
+        if toolchain != null then
+          "${toolchain}/lib/rustlib/src/rust/library"
+        else
+          "${pkgs.rustPlatform.rustLibSrc}";
+      # Full backtraces by default in a dev shell. This is the environment
+      # where you are debugging; the cost of the flag is zero unless you panic.
+      RUST_BACKTRACE = "1";
+    };
+
+    # The toolchain SSoT (nix/devtools.nix) does not ship Rust, so unlike the
+    # node module there is nothing to shadow — the package contribution above
+    # already wins PATH. This fragment exists only for mold, which cannot be
+    # selected by PATH order: it has to be requested through rustflags.
+    #
+    # Deliberately additive to RUSTFLAGS rather than assigning it, so a repo's
+    # own .cargo/config.toml or a caller's export is not silently discarded.
+    shellHook = lib.optionalString useMold ''
+      export RUSTFLAGS="''${RUSTFLAGS:+$RUSTFLAGS }-C link-arg=-fuse-ld=mold"
+    '';
+  }


### PR DESCRIPTION
Ships the Rust language pack as **two pieces**, and the split between them is the design. Implements the `A + D + assert` resolution recorded in #1427.

Closes #1400. Refs #1427.

## How to test it

```nix
# flake.nix
inputs.devkit.url = "github:vig-os/devkit/feat/rust-language-pack";

# perSystem
rust = devkit.lib.mkRustProject {
  inherit pkgs;
  src = ./.;
  toolchainHash = "sha256-…";       # for your rust-toolchain.toml
  crates = [ "my-cli" ];
};
devShells.default = rust.devShell;
checks             = rust.checks;
packages           = rust.packages;
```

Set `toolchainHash = pkgs.lib.fakeHash` first; the build failure prints the real one.

Toolchain-only, no check suite — deliberate and explicit:

```nix
modules = [ { name = "rust"; checks = "none"; } ];
```

And the thing that should NOT work:

```nix
modules = [ "rust" ];   # eval error, by design — see below
```

## What's here

| File | |
|---|---|
| `nix/modules/rust.nix` | v1 capability module: toolchain + curated cargo tooling + mold on Linux |
| `nix/mk-rust-project.nix` | `lib.mkRustProject` — dev shell, checks and packages from one call |
| `nix/modules/check-entries.nix` | internal: how the generated `module-<name>` check instantiates a module whose options are mandatory |

Checks produced: the per-crate builds, plus `clippy`, `fmt`, `nextest`, `doc` (rustdoc warnings denied) and `deny` (auto-enabled when a `deny.toml` exists).

## Why checks are a lib function and not a contract field

`packages` / `env` / `shellHook` fold monoidally into **one** derivation — the shell. `checks` is a namespaced map of **independent peer derivations** on a different lifecycle (`nix flake check`, not `nix develop`), built from the consumer's source tree, which is project shape a module never sees.

The test that settled it: a `checks` field could be added to the shell-composition contract **without touching shell composition at all**. If a field can be added to a contract without touching what that contract composes, it isn't part of that contract.

So `mkRustProject` composes *above* `mkProjectShell` and returns all three together. One call — there is no second function to forget.

## Why the module refuses to load bare

`modules = [ "rust" ]` would hand you a toolchain, a green `nix flake check` that builds nothing, and CI that compiles nothing: the exact silent-green failure the pack exists to prevent, delivered by the pack. So the module's `checks` option is **mandatory with no default**, and the bare form throws at eval with a message naming the fix and the opt-out.

Being straight about the limit: **flake outputs are consumer-assigned by construction.** No option here — including extending the contract — could have made correct wiring structurally impossible. What this shape buys is one call instead of two, `checks` arriving visibly beside `devShell`, and a loud eval-time failure on the one remaining path. Silence was the failure mode; silence is what's removed.

## Costs, stated plainly

- **`crane` + `fenix` become devkit inputs — 3 leaf lock entries that every consumer pays for**, Python-only ones included, in lock size and fetch-at-eval. The alternative is each Rust repo pinning its own fenix, which is per-repo drift on exactly the axis devkit exists to hold still. `mkRustProject` takes `crane`/`fenix` overrides, so the inputs can move back out later without a consumer-visible change. **Flag it if you disagree — this is the most reversible-but-annoying-later decision in the PR.**
- `nix/lib/` turned out to be **gitignored** (`.gitignore:17` has a bare `lib/` from the Python layout, which swallows any `lib` directory at any depth). The file lives at `nix/mk-rust-project.nix` instead, matching `nix/hooks.nix` / `nix/devtools.nix`. Worth fixing that pattern separately — it will bite someone else.

## Verified, not assumed

- `checks.<system>.module-rust` evaluates ✅
- Bare `modules = [ "rust" ]` throws the guidance error ✅
- **Zero-module invariant holds**: `devShells.<system>.default.drvPath` is byte-identical to `dev` ✅
- End-to-end on the first consumer (`gerchowl/filesender`, a cli + mcp + lib workspace): its ~120 lines of hand-rolled crane/fenix wiring were deleted and replaced by one `mkRustProject` call; all 9 checks evaluate and build.

## Two bugs this shape prevents by construction

Both were shipped by the first consumer, and both were invisible to inspection:

1. `deny.toml` outside the crane fileset — an `openssl` ban that banned nothing.
2. `clippy.toml` outside the fileset — the sandboxed clippy check ran against defaults, enforcing rules nobody wrote.

`mkRustProject` folds the well-known root tool configs (`rustfmt.toml`, `clippy.toml`, `deny.toml`, `about.*`, `.cargo/`) into the fileset unconditionally via `maybeMissing`, so there is nothing to remember and nothing to keep in sync.

## Review asks

1. The **`crane`/`fenix` as devkit inputs** tradeoff above.
2. `check-entries.nix` — is a per-name generator override the right answer for mandatory-option modules, or should the generated smoke check learn about them some other way?
3. Whether the eval-time refusal is too aggressive for a scratch-shell user (the opt-out is one attrset, but it *is* friction).
