### PR TITLE
feat(nix): Rust language pack — capability module + lib.mkRustProject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Rust language pack: `rust` capability module + `lib.mkRustProject`** ([#1400](https://github.com/vig-os/devkit/issues/1400), [#1427](https://github.com/vig-os/devkit/issues/1427))
+  - New `rust` capability module (`nix/modules/rust.nix`): a v1-contract
+    contribution that puts a Rust toolchain and the curated cargo tooling
+    (nextest, cargo-deny, cargo-auditable, cargo-audit, cargo-about,
+    cargo-shear by default; extensible via `tools`) on the dev-shell PATH,
+    with `mold` picked up on Linux. The `checks` option is MANDATORY and has
+    no default — a hand-written `modules = [ "rust" ]` fails at EVAL with a
+    message that names the fix (`mkRustProject`) and the deliberate opt-out
+    (`{ name = "rust"; checks = "none"; }`), because a v1 module cannot
+    contribute `checks.<system>.*` and a silently toolchain-only Rust shell
+    is exactly the failure the pack exists to prevent
+  - New `lib.mkRustProject` composed entry point (`nix/mk-rust-project.nix`):
+    ONE call returns `{ devShell, checks, packages, craneLib, cargoArtifacts,
+    commonArgs, toolchain, src }`, wiring the shell + the check suite (fmt,
+    clippy with `--deny warnings`, nextest, cargo-doc, cargo-deny when a
+    deny.toml exists) + per-crate builds together. Folds well-known root tool
+    configs (rustfmt.toml, clippy.toml, deny.toml, about.*, `.cargo/`,
+    rust-toolchain.toml) into the crane fileset unconditionally — their
+    absence from a build sandbox is silent and turns the checks into a rules-
+    nobody-wrote green
+  - New flake inputs `crane` and `fenix` (three leaf lock entries, including
+    fenix's `rust-analyzer-src`). Every consumer — including Python-only ones
+    — pays for them in lock size and in fetch-at-eval. The alternative — each
+    Rust repo pinning its own fenix — is per-repo drift on exactly the axis
+    devkit exists to hold still; `mkRustProject` takes `crane`/`fenix`
+    overrides so the inputs can move back out later without a consumer-
+    visible change
+  - New `nix/modules/check-entries.nix` (internal plumbing, not consumer
+    surface): a per-name override for how the generated `module-<name>` smoke
+    check instantiates a module whose options are mandatory. `rust` maps to
+    the toolchain-only opt-out form
+  - The ADR (`docs/rfcs/ADR-capability-modules.md`) records the #1427
+    decision: the v1 contract is NOT extended with a `checks` field, on the
+    reasoning that a field a contract can accept without touching what it
+    composes is not part of that contract. The bar for revisiting is a
+    SECOND, non-Rust capability module that independently needs to
+    contribute checks
+  - Zero-module invariant preserved: `devShells.<system>.default.drvPath` is
+    byte-identical to before the pack shipped, pinned by a new parity test
+
 - **`just doctor` host diagnostics + audit coverage gaps closed** ([#1418](https://github.com/vig-os/devkit/issues/1418))
   - New `just doctor` recipe reports host prerequisites (git identity, commit
     signing, ssh-agent, gh auth) as PASS/WARN diagnostics and always exits 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Rust performance tooling: `@perf` tool groups + a deterministic ratchet**
+  ([#1400](https://github.com/vig-os/devkit/issues/1400),
+  [#1440](https://github.com/vig-os/devkit/issues/1440))
+  - The `rust` module's `tools` list now accepts GROUPS: `@perf` (samply,
+    cargo-flamegraph, hyperfine, cargo-criterion, cargo-bloat,
+    cargo-llvm-lines, cargo-show-asm, plus heaptrack/valgrind/poop on Linux),
+    `@perf-async` (samply, tokio-console, hyperfine) and `@api`
+    (cargo-semver-checks, cargo-expand). A group skips members the current
+    platform lacks; an EXPLICITLY named tool still throws, because naming one
+    is a request that can only be met or refused
+  - New `checks.perf-ratchet` in `lib.mkRustProject`, auto-enabled when
+    `.repo/perf-baseline.toml` exists (same rule as `deny`). It measures only
+    things that are deterministic given a locked toolchain and lockfile —
+    shipped binary size per binary, and dependency-graph size from Cargo.lock
+    — and deliberately times NOTHING: wall-clock benchmarks on shared CI
+    runners are noise, and a gate that fires on noise teaches `--no-verify`.
+    Growth past the tolerance (default 5%) fails; a measured shrink is
+    reported so the win can be banked. Needs no benchmark to be authored,
+    which is what makes it a ratchet that is actually in place
+  - New `packages.perf-seal`, which emits the baseline file itself so sealing
+    is never hand-transcribed
+  - `fenix.inputs.rust-analyzer-src` now `follows` nixpkgs: it fed only
+    fenix's *nightly* rust-analyzer derivation, which the pack never builds
+    (`fromToolchainFile` takes components from the release-channel manifest).
+    Lock nodes 15 -> 14, fetched source ~33 MB -> ~5 MB, `rust-analyzer` still
+    present in the built toolchain
 - **Rust language pack: `rust` capability module + `lib.mkRustProject`** ([#1400](https://github.com/vig-os/devkit/issues/1400), [#1427](https://github.com/vig-os/devkit/issues/1427))
   - New `rust` capability module (`nix/modules/rust.nix`): a v1-contract
     contribution that puts a Rust toolchain and the curated cargo tooling

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     contribute checks
   - Zero-module invariant preserved: `devShells.<system>.default.drvPath` is
     byte-identical to before the pack shipped, pinned by a new parity test
+  - Consumer hardening from the second consumer, a single-crate feature-gated
+    library ([#1450](https://github.com/vig-os/devkit/issues/1450)):
+    `mkRustProject` now refuses a `pkgs` built without `overlays.default`
+    (previously `undefined variable 'vig-utils'` from inside `devtools.nix`,
+    and only on the dev shell — `checks` and `packages` evaluated fine, so a
+    repo could have a green `nix flake check` and a shell that had never
+    evaluated); a source tree with no `Cargo.lock` is named as such, on
+    `cleanSrc` so `fmt` fails with the rest instead of passing alone; new
+    `checks.doctest` runs `cargo test --doc`, which nextest cannot and
+    `cargoDoc` does not, so adopting the pack no longer silently drops a
+    consumer's doctests; and new `cargoExtraArgs` reaches every derivation so
+    the checks can build non-default features — composed with `-p <crate>`
+    rather than overwriting it, so a workspace's per-crate builds cannot end
+    up with a different feature set from the checks that ran against them
 
 - **`just doctor` host diagnostics + audit coverage gaps closed** ([#1418](https://github.com/vig-os/devkit/issues/1418))
   - New `just doctor` recipe reports host prerequisites (git identity, commit

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -9,6 +9,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Rust language pack: `rust` capability module + `lib.mkRustProject`** ([#1400](https://github.com/vig-os/devkit/issues/1400), [#1427](https://github.com/vig-os/devkit/issues/1427))
+  - New `rust` capability module (`nix/modules/rust.nix`): a v1-contract
+    contribution that puts a Rust toolchain and the curated cargo tooling
+    (nextest, cargo-deny, cargo-auditable, cargo-audit, cargo-about,
+    cargo-shear by default; extensible via `tools`) on the dev-shell PATH,
+    with `mold` picked up on Linux. The `checks` option is MANDATORY and has
+    no default — a hand-written `modules = [ "rust" ]` fails at EVAL with a
+    message that names the fix (`mkRustProject`) and the deliberate opt-out
+    (`{ name = "rust"; checks = "none"; }`), because a v1 module cannot
+    contribute `checks.<system>.*` and a silently toolchain-only Rust shell
+    is exactly the failure the pack exists to prevent
+  - New `lib.mkRustProject` composed entry point (`nix/mk-rust-project.nix`):
+    ONE call returns `{ devShell, checks, packages, craneLib, cargoArtifacts,
+    commonArgs, toolchain, src }`, wiring the shell + the check suite (fmt,
+    clippy with `--deny warnings`, nextest, cargo-doc, cargo-deny when a
+    deny.toml exists) + per-crate builds together. Folds well-known root tool
+    configs (rustfmt.toml, clippy.toml, deny.toml, about.*, `.cargo/`,
+    rust-toolchain.toml) into the crane fileset unconditionally — their
+    absence from a build sandbox is silent and turns the checks into a rules-
+    nobody-wrote green
+  - New flake inputs `crane` and `fenix` (three leaf lock entries, including
+    fenix's `rust-analyzer-src`). Every consumer — including Python-only ones
+    — pays for them in lock size and in fetch-at-eval. The alternative — each
+    Rust repo pinning its own fenix — is per-repo drift on exactly the axis
+    devkit exists to hold still; `mkRustProject` takes `crane`/`fenix`
+    overrides so the inputs can move back out later without a consumer-
+    visible change
+  - New `nix/modules/check-entries.nix` (internal plumbing, not consumer
+    surface): a per-name override for how the generated `module-<name>` smoke
+    check instantiates a module whose options are mandatory. `rust` maps to
+    the toolchain-only opt-out form
+  - The ADR (`docs/rfcs/ADR-capability-modules.md`) records the #1427
+    decision: the v1 contract is NOT extended with a `checks` field, on the
+    reasoning that a field a contract can accept without touching what it
+    composes is not part of that contract. The bar for revisiting is a
+    SECOND, non-Rust capability module that independently needs to
+    contribute checks
+  - Zero-module invariant preserved: `devShells.<system>.default.drvPath` is
+    byte-identical to before the pack shipped, pinned by a new parity test
+
 - **`just doctor` host diagnostics + audit coverage gaps closed** ([#1418](https://github.com/vig-os/devkit/issues/1418))
   - New `just doctor` recipe reports host prerequisites (git identity, commit
     signing, ssh-agent, gh auth) as PASS/WARN diagnostics and always exits 0

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -9,6 +9,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Rust performance tooling: `@perf` tool groups + a deterministic ratchet**
+  ([#1400](https://github.com/vig-os/devkit/issues/1400),
+  [#1440](https://github.com/vig-os/devkit/issues/1440))
+  - The `rust` module's `tools` list now accepts GROUPS: `@perf` (samply,
+    cargo-flamegraph, hyperfine, cargo-criterion, cargo-bloat,
+    cargo-llvm-lines, cargo-show-asm, plus heaptrack/valgrind/poop on Linux),
+    `@perf-async` (samply, tokio-console, hyperfine) and `@api`
+    (cargo-semver-checks, cargo-expand). A group skips members the current
+    platform lacks; an EXPLICITLY named tool still throws, because naming one
+    is a request that can only be met or refused
+  - New `checks.perf-ratchet` in `lib.mkRustProject`, auto-enabled when
+    `.repo/perf-baseline.toml` exists (same rule as `deny`). It measures only
+    things that are deterministic given a locked toolchain and lockfile —
+    shipped binary size per binary, and dependency-graph size from Cargo.lock
+    — and deliberately times NOTHING: wall-clock benchmarks on shared CI
+    runners are noise, and a gate that fires on noise teaches `--no-verify`.
+    Growth past the tolerance (default 5%) fails; a measured shrink is
+    reported so the win can be banked. Needs no benchmark to be authored,
+    which is what makes it a ratchet that is actually in place
+  - New `packages.perf-seal`, which emits the baseline file itself so sealing
+    is never hand-transcribed
+  - `fenix.inputs.rust-analyzer-src` now `follows` nixpkgs: it fed only
+    fenix's *nightly* rust-analyzer derivation, which the pack never builds
+    (`fromToolchainFile` takes components from the release-channel manifest).
+    Lock nodes 15 -> 14, fetched source ~33 MB -> ~5 MB, `rust-analyzer` still
+    present in the built toolchain
 - **Rust language pack: `rust` capability module + `lib.mkRustProject`** ([#1400](https://github.com/vig-os/devkit/issues/1400), [#1427](https://github.com/vig-os/devkit/issues/1427))
   - New `rust` capability module (`nix/modules/rust.nix`): a v1-contract
     contribution that puts a Rust toolchain and the curated cargo tooling

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -74,6 +74,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     contribute checks
   - Zero-module invariant preserved: `devShells.<system>.default.drvPath` is
     byte-identical to before the pack shipped, pinned by a new parity test
+  - Consumer hardening from the second consumer, a single-crate feature-gated
+    library ([#1450](https://github.com/vig-os/devkit/issues/1450)):
+    `mkRustProject` now refuses a `pkgs` built without `overlays.default`
+    (previously `undefined variable 'vig-utils'` from inside `devtools.nix`,
+    and only on the dev shell — `checks` and `packages` evaluated fine, so a
+    repo could have a green `nix flake check` and a shell that had never
+    evaluated); a source tree with no `Cargo.lock` is named as such, on
+    `cleanSrc` so `fmt` fails with the rest instead of passing alone; new
+    `checks.doctest` runs `cargo test --doc`, which nextest cannot and
+    `cargoDoc` does not, so adopting the pack no longer silently drops a
+    consumer's doctests; and new `cargoExtraArgs` reaches every derivation so
+    the checks can build non-default features — composed with `-p <crate>`
+    rather than overwriting it, so a workspace's per-crate builds cannot end
+    up with a different feature set from the checks that ran against them
 
 - **`just doctor` host diagnostics + audit coverage gaps closed** ([#1418](https://github.com/vig-os/devkit/issues/1418))
   - New `just doctor` recipe reports host prerequisites (git identity, commit

--- a/docs/rfcs/ADR-capability-modules.md
+++ b/docs/rfcs/ADR-capability-modules.md
@@ -78,10 +78,94 @@ Explicitly **not** in v1:
   #879's long-term answer: the image-side sysconfig sanitize (0.4.1) makes
   build backends do PATH discovery with generic names; this module provides
   the PATH (demonstrated need: hyrr/pycatima, #639).
+- **`rust` (ships now):** the Rust language pack — a toolchain and curated
+  cargo tooling on the dev-shell PATH, and a mandatory `checks` option that
+  makes the bare `modules = [ "rust" ]` form a loud eval-time refusal (see the
+  #1427 decision below). Shipped on gerchowl/filesender's ask (#1400). The
+  generated `checks.<system>.module-rust` cannot instantiate the module the
+  same way it does `native`/`node`/`docs` (the bare name throws by design), so
+  a per-name override in `nix/modules/check-entries.nix` supplies the
+  toolchain-only opt-out form (see the internal-plumbing subsection below).
+  The composed entry point for a Rust consumer is `lib.mkRustProject`.
 - **Ask-gated candidates (named, not shipped — YAGNI):** `geant4`
-  (fast-follow once an EXOMA/EXOPET repo asks), `rust`, `fortran`/`f2py`,
-  `root`. Each ships with its own devshell smoke check (e.g. `geant4-config`
-  resolves) the release it lands.
+  (fast-follow once an EXOMA/EXOPET repo asks), `fortran`/`f2py`, `root`.
+  Each ships with its own devshell smoke check (e.g. `geant4-config` resolves)
+  the release it lands.
+
+## Decision: `checks` stays out of the v1 contract (#1427)
+
+The Rust pack (#1400) forced the question the ADR punted: can a capability
+module contribute `checks.<system>.*`? The answer is no — the contract is not
+extended, and the Rust pack composes ABOVE it instead.
+
+**Why the v1 contract does not extend to `checks`.** `packages`, `env` and
+`shellHook` fold monoidally into one derivation — the dev shell — and that
+folding is exactly what `mkProjectShell` does. `checks` is not that shape: it
+is a namespaced map of independent peer derivations on a different lifecycle
+(`nix flake check`, not `nix develop`), and building them needs the consumer's
+source tree — project shape a module never sees. The decisive test: a `checks`
+field could be added to the shell-composition contract WITHOUT touching shell
+composition at all — the folding, the ordering, the reserved-env rules would
+be untouched. If a field can be added to a contract without touching what that
+contract composes, it is not part of that contract.
+
+**What ships instead.** `lib.mkRustProject` is a composed entry point ABOVE
+`mkProjectShell`. It wires the dev shell (via `mkProjectShell` with the `rust`
+module) AND the checks AND the packages from ONE call, returning them
+together. Crucially it is one call: there is no second function a consumer can
+forget to invoke, which was the whole objection to shipping the checks
+separately. The `rust` module itself keeps the v1 contract and gains a
+mandatory `checks` option with no default — a hand-written
+`modules = [ "rust" ]` fails at EVAL with a message that names the fix
+(`mkRustProject`) and the deliberate opt-out
+(`{ name = "rust"; checks = "none"; }`). Silence was the failure mode; that
+silence is what is removed.
+
+**Honest limitation.** Flake outputs are consumer-assigned by construction:
+`devShells.default = …`, `checks = …`, `packages = …` are the consumer's
+writes into their own flake, and NO contract change anywhere in devkit —
+including a hypothetical `checks` field on the module contract — could make
+wiring structurally impossible. What the chosen shape buys is real but
+bounded: one call instead of two, `checks` arriving visibly beside `devShell`
+so dropping it is a visible omission rather than an unknown-unknown, and a
+loud eval-time refusal on the remaining hand-edited path.
+
+**When to revisit.** Extend the contract when a SECOND capability module
+independently needs to contribute checks — demonstrated by a non-Rust
+consumer, not argued from one repo. One data point is a language pack; two is
+a pattern the contract should absorb.
+
+**Options considered and rejected.**
+
+- **(B) Extend the v1 contract with a `checks` field.** Rejected: the shape
+  is Rust-shaped, dead weight for `native`/`node`/`docs` which have no checks
+  to contribute, and a contract seam paid for by every module and every
+  consumer forever on the evidence of one repo. The decisive-test criterion
+  above formalises the rejection: a field a contract can accept without
+  touching what it composes is not part of it.
+- **(C) Template-only Rust starter (no module, no `mkRustProject`).**
+  Rejected: templates cover the greenfield path — one project bootstrap — and
+  nothing else. Hand-edits, copy-paste between repos, existing repos
+  retrofitted, agent-generated flakes: none of them go through
+  `nix flake init`, and the failure mode the pack exists to prevent lives in
+  precisely those cases.
+
+### Internal plumbing: `nix/modules/check-entries.nix`
+
+Not consumer surface. The flake generates `checks.<system>.module-<name>` for
+every entry in the registry (`nix/modules/default.nix`) so a module cannot
+ship without its check. The generator's default instantiation is the plain
+name string — the same thing a consumer writes for a module that needs no
+configuration. A module whose options are MANDATORY cannot be instantiated
+that way: the bare name throws by design. `nix/modules/check-entries.nix` is
+the generator's per-name override — a name → `modules` entry override,
+consulted only for the names present in it. Currently one entry: `rust` maps
+to `{ name = "rust"; checks = "none"; }`, the sanctioned toolchain-only form
+(the smoke check builds the devshell to prove the module evaluates and its
+packages resolve; deeper end-to-end coverage lives in
+`tests/test_flake_modules.py`). Keep the file small and keep each entry
+justified — an entry is a statement that the module's zero-option form is
+deliberately unusable, not that the check was inconvenient to write.
 
 ## Migration path to per-module options
 
@@ -109,8 +193,10 @@ first module needs it.
 
 ## References
 
-`flake.nix` (`mkProjectShell`, `nix/modules/`),
+`flake.nix` (`mkProjectShell`, `lib.mkRustProject`, `nix/modules/`,
+`nix/modules/check-entries.nix`, `nix/mk-rust-project.nix`),
 [MIGRATION.md — native-build contract](../MIGRATION.md#the-native-build-contract),
 [docs/NIX.md](../NIX.md), issues #884 (this), #882, #879, #854, #639, #883,
-#885; sibling ADRs [ADR-nix-devenv-strategy](ADR-nix-devenv-strategy.md),
+#885, #1400 (Rust pack ask), #1427 (checks-in-contract decision); sibling ADRs
+[ADR-nix-devenv-strategy](ADR-nix-devenv-strategy.md),
 [ADR-home-environment-modules](ADR-home-environment-modules.md).

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,41 @@
 {
   "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1785782307,
+        "narHash": "sha256-MPaRdVkf6zZP5fCPxYCi8Dr4pZzgmXzg8T9nVEbp3Mw=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "2c71e194474d13de031d729b729c968ddbe3507f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1786432497,
+        "narHash": "sha256-iunnvo2ZqbFOwp/LXL3vtlbaG+45FuiHk+YKpbSoAec=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "45d045a58ed69993eb1d349a86def638fea93a9f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
     "flake-compat": {
       "flake": false,
       "locked": {
@@ -147,6 +183,8 @@
     },
     "root": {
       "inputs": {
+        "crane": "crane",
+        "fenix": "fenix",
         "flake-utils": "flake-utils",
         "git-hooks-nix": "git-hooks-nix",
         "home-manager": "home-manager",
@@ -155,6 +193,23 @@
         "process-compose-flake": "process-compose-flake",
         "services-flake": "services-flake",
         "treefmt-nix": "treefmt-nix"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1786396074,
+        "narHash": "sha256-tQAL2tJNNhPV6LBY/9pef+fq37RLYts/LknqJ6m9Y6Q=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "57bea800b866168ac4f310333e326b92ccba7aca",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
       }
     },
     "services-flake": {

--- a/flake.lock
+++ b/flake.lock
@@ -20,7 +20,9 @@
         "nixpkgs": [
           "nixpkgs"
         ],
-        "rust-analyzer-src": "rust-analyzer-src"
+        "rust-analyzer-src": [
+          "nixpkgs"
+        ]
       },
       "locked": {
         "lastModified": 1786432497,
@@ -193,23 +195,6 @@
         "process-compose-flake": "process-compose-flake",
         "services-flake": "services-flake",
         "treefmt-nix": "treefmt-nix"
-      }
-    },
-    "rust-analyzer-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1786396074,
-        "narHash": "sha256-tQAL2tJNNhPV6LBY/9pef+fq37RLYts/LknqJ6m9Y6Q=",
-        "owner": "rust-lang",
-        "repo": "rust-analyzer",
-        "rev": "57bea800b866168ac4f310333e326b92ccba7aca",
-        "type": "github"
-      },
-      "original": {
-        "owner": "rust-lang",
-        "ref": "nightly",
-        "repo": "rust-analyzer",
-        "type": "github"
       }
     },
     "services-flake": {

--- a/flake.nix
+++ b/flake.nix
@@ -48,6 +48,22 @@
     # and the inputs can move out without a consumer-visible change.
     fenix.url = "github:nix-community/fenix";
     fenix.inputs.nixpkgs.follows = "nixpkgs";
+    # fenix pulls the rust-analyzer SOURCE TREE — 28 MB, and 85% of everything
+    # the two inputs above cost a downstream consumer. It feeds exactly one
+    # thing: fenix's *nightly* rust-analyzer derivation, which this pack never
+    # builds. `fromToolchainFile` takes its components from the release-channel
+    # manifest instead, so following this away costs nothing — verified by
+    # building filesender's toolchain (whose rust-toolchain.toml lists
+    # rust-analyzer as a component) with the follows in place and finding
+    # `rust-analyzer` present in the result.
+    #
+    # Pointed at nixpkgs because every consumer already has it, so the node
+    # disappears from downstream locks rather than being replaced. Lock nodes:
+    # 15 -> 14, fetched source ~33 MB -> ~5 MB.
+    #
+    # A consumer who genuinely wants fenix's nightly rust-analyzer must
+    # override this back; nothing in devkit does. Refs #1440.
+    fenix.inputs.rust-analyzer-src.follows = "nixpkgs";
   };
 
   outputs =

--- a/flake.nix
+++ b/flake.nix
@@ -706,7 +706,7 @@
       # in vig-os/devkit#1427). One call returns the dev shell, the checks and
       # the packages together:
       #
-      #   rust = inputs.devcontainer.lib.mkRustProject {
+      #   rust = inputs.devkit.lib.mkRustProject {
       #     inherit pkgs;
       #     src = ./.;
       #     toolchainHash = "sha256-…";

--- a/flake.nix
+++ b/flake.nix
@@ -30,6 +30,24 @@
     # Refs #819.
     home-manager.url = "github:nix-community/home-manager/release-26.05";
     home-manager.inputs.nixpkgs.follows = "nixpkgs";
+    # ---- Rust language pack (#1400) -------------------------------------
+    # crane: the cargo build library behind lib.mkRustProject's checks and
+    # packages. Dependency-free (like process-compose-flake), so it adds one
+    # leaf lock entry and nothing transitive.
+    crane.url = "github:ipetkov/crane";
+    # fenix: resolves a toolchain from a repo's rust-toolchain.toml, so nix
+    # and rustup agree on the compiler. nixpkgs' Rust tracks the channel and
+    # cannot honour a pin, which is the one thing a language pack must do.
+    #
+    # These are inputs of devkit rather than arguments a Rust consumer passes
+    # in, and that is a deliberate tradeoff: every consumer — including the
+    # Python-only ones — pays for them in lock size and in fetch at eval. The
+    # alternative makes each Rust repo pin its own fenix, which is per-repo
+    # drift on precisely the axis devkit exists to hold still. If the eval
+    # cost turns out to bite, mkRustProject takes `crane`/`fenix` overrides
+    # and the inputs can move out without a consumer-visible change.
+    fenix.url = "github:nix-community/fenix";
+    fenix.inputs.nixpkgs.follows = "nixpkgs";
   };
 
   outputs =
@@ -43,6 +61,8 @@
       process-compose-flake,
       services-flake,
       home-manager,
+      crane,
+      fenix,
     }:
     let
       # ---------------------------------------------------------------------
@@ -208,6 +228,11 @@
       # the generated per-module `checks.<system>.module-<name>` below. See
       # docs/rfcs/ADR-capability-modules.md for the v1 contract.
       capabilityModules = import ./nix/modules/default.nix;
+
+      # How the generated `module-<name>` smoke check instantiates a module
+      # whose options are mandatory (nix/modules/check-entries.nix). Names
+      # absent here use the plain string form, unchanged.
+      capabilityModuleCheckEntries = import ./nix/modules/check-entries.nix;
 
       # One definition of the pre-commit hook set (#883): nix/hooks.nix
       # renders the sandbox-pure `checks.pre-commit` gate, the PATH-portable
@@ -672,6 +697,29 @@
       # mkProjectServices — reusable local dev-services builder (#795).
       #
       # Boots declared services (Postgres, SeaweedFS, Redis, …) as native processes via
+      # ---------------------------------------------------------------------
+      # mkRustProject — the Rust consumer's single entry point (#1400, #1427).
+      #
+      # Composes ABOVE mkProjectShell rather than inside the capability-module
+      # contract, because `checks` is not the shape that contract composes
+      # (the reasoning is in nix/mk-rust-project.nix's header, the decision
+      # in vig-os/devkit#1427). One call returns the dev shell, the checks and
+      # the packages together:
+      #
+      #   rust = inputs.devcontainer.lib.mkRustProject {
+      #     inherit pkgs;
+      #     src = ./.;
+      #     toolchainHash = "sha256-…";
+      #     crates = [ "my-cli" ];
+      #   };
+      #   devShells.default = rust.devShell;
+      #   checks = rust.checks;
+      #   packages = rust.packages;
+      # ---------------------------------------------------------------------
+      mkRustProject = import ./nix/mk-rust-project.nix {
+        inherit mkProjectShell crane fenix;
+      };
+
       # process-compose + services-flake — no Docker/Podman daemon — with the
       # service versions coming from the caller's `pkgs` (the pinned nixpkgs
       # lock, never out-of-lock image tags). services-flake is consumed through
@@ -1095,7 +1143,7 @@
           name: _:
           pkgs.lib.nameValuePair "module-${name}" (mkProjectShell {
             inherit pkgs;
-            modules = [ name ];
+            modules = [ (capabilityModuleCheckEntries.${name} or name) ];
           })
         ) capabilityModules
         # The ci homeConfigurations build as Tier-0 checks. x86_64-darwin is
@@ -1556,6 +1604,7 @@
         inherit
           mkProjectShell
           mkProjectServices
+          mkRustProject
           devTools
           ;
         # PATH-portable renders of the one hook-set definition (#883):

--- a/flake.nix
+++ b/flake.nix
@@ -46,24 +46,29 @@
     # drift on precisely the axis devkit exists to hold still. If the eval
     # cost turns out to bite, mkRustProject takes `crane`/`fenix` overrides
     # and the inputs can move out without a consumer-visible change.
-    fenix.url = "github:nix-community/fenix";
-    fenix.inputs.nixpkgs.follows = "nixpkgs";
-    # fenix pulls the rust-analyzer SOURCE TREE — 28 MB, and 85% of everything
-    # the two inputs above cost a downstream consumer. It feeds exactly one
-    # thing: fenix's *nightly* rust-analyzer derivation, which this pack never
-    # builds. `fromToolchainFile` takes its components from the release-channel
-    # manifest instead, so following this away costs nothing — verified by
-    # building filesender's toolchain (whose rust-toolchain.toml lists
-    # rust-analyzer as a component) with the follows in place and finding
-    # `rust-analyzer` present in the result.
     #
-    # Pointed at nixpkgs because every consumer already has it, so the node
-    # disappears from downstream locks rather than being replaced. Lock nodes:
-    # 15 -> 14, fetched source ~33 MB -> ~5 MB.
-    #
-    # A consumer who genuinely wants fenix's nightly rust-analyzer must
-    # override this back; nothing in devkit does. Refs #1440.
-    fenix.inputs.rust-analyzer-src.follows = "nixpkgs";
+    # Written as one attrset rather than three dotted keys because statix
+    # flags the repetition (`checks.statix`, which is a required gate).
+    fenix = {
+      url = "github:nix-community/fenix";
+      inputs.nixpkgs.follows = "nixpkgs";
+      # fenix pulls the rust-analyzer SOURCE TREE — 28 MB, and 85% of
+      # everything these two inputs cost a downstream consumer. It feeds
+      # exactly one thing: fenix's *nightly* rust-analyzer derivation, which
+      # this pack never builds. `fromToolchainFile` takes its components from
+      # the release-channel manifest instead, so following this away costs
+      # nothing — verified by building filesender's toolchain (whose
+      # rust-toolchain.toml lists rust-analyzer as a component) with the
+      # follows in place and finding `rust-analyzer` in the result.
+      #
+      # Pointed at nixpkgs because every consumer already has it, so the node
+      # disappears from downstream locks rather than being replaced. Lock
+      # nodes 15 -> 14, fetched source ~33 MB -> ~5 MB.
+      #
+      # A consumer who genuinely wants fenix's nightly rust-analyzer must
+      # override this back; nothing in devkit does. Refs #1440.
+      inputs.rust-analyzer-src.follows = "nixpkgs";
+    };
   };
 
   outputs =

--- a/nix/mk-rust-project.nix
+++ b/nix/mk-rust-project.nix
@@ -107,6 +107,24 @@
   # Extra args for the clippy check. `--deny warnings` is already applied.
   clippyExtraArgs ? "--all-targets",
   fmt ? true,
+  # `cargo test --doc`. nextest cannot run doctests (its process-per-test model
+  # has nowhere to put them) and the `doc` check only lints rustdoc, so without
+  # this nothing executes them — and a consumer whose doctests ran under
+  # `cargo test` loses them on adoption, silently. #1400's stage table assigns
+  # both to pre-push for exactly that reason.
+  doctest ? true,
+
+  # ---- cargo invocation ----------------------------------------------------
+  # Appended to the cargo command line of EVERY derivation: the dependency
+  # build, the checks and the packages. This is where features live —
+  # `--all-features`, `--features a,b`, `--no-default-features`.
+  #
+  # It matters that this is one argument reaching all of them rather than a
+  # per-check knob. A default-features build means the gated code is never
+  # compiled, so clippy never sees it and its tests never run, and the suite
+  # reports success over the gap. `clippyExtraArgs` covers clippy alone and is
+  # deliberately left as-is: it carries lint flags, not feature selection.
+  cargoExtraArgs ? "",
 
   # ---- performance ratchet -------------------------------------------------
   # Defaults on when the baseline file exists, off otherwise — same rule as
@@ -137,6 +155,71 @@
 let
   inherit (pkgs) lib;
   system = pkgs.stdenv.hostPlatform.system;
+
+  # ---------------------------------------------------------------------------
+  # Consumer guards (#1450)
+  #
+  # Both replace a failure that was opaque, partial, or both. They follow the
+  # toolchainHash error's shape deliberately: say what happened, say why there
+  # is no default that could be right, and give the exact line to add.
+  # ---------------------------------------------------------------------------
+
+  # mkProjectShell pulls nix/devtools.nix, which references `vig-utils` — a
+  # package only devkit's overlay provides. Without it the shell died on
+  # `undefined variable 'vig-utils'`: an error inside devkit, naming something
+  # the consumer has never seen, from a file they did not open.
+  #
+  # Checked lazily, on the dev shell alone. `checks` and `packages` never touch
+  # mkProjectShell and are perfectly usable against a plain nixpkgs, so an
+  # eager throw would break a working configuration to improve a message.
+  overlayError = ''
+    mkRustProject: the `pkgs` you passed does not carry devkit's overlay.
+
+    The dev shell is built by mkProjectShell, whose toolchain list
+    (nix/devtools.nix) resolves `vig-utils` and the fast-movers from
+    `devkit.overlays.default`. Without the overlay this fails deep inside
+    devkit on a name that means nothing at your call site.
+
+    Build your pkgs with it:
+
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [ devkit.overlays.default ];
+        };
+
+    Note that `checks` and `packages` do NOT need the overlay — they never go
+    through mkProjectShell. That asymmetry is why this is a thrown error and
+    not a note in the docs: without it, a repo can have a green
+    `nix flake check` and a dev shell that has never once evaluated.
+  '';
+
+  hasOverlay = pkgs ? vig-utils;
+
+  # A flake's `src` is the git tree, so a repo that gitignores its lockfile
+  # hands crane a source without one. crane's own message is good, but it is
+  # only reachable from the derivations that vendor — `cargoFmt` takes `src`
+  # alone and passed regardless, which made a total failure look partial.
+  lockError = ''
+    mkRustProject: no Cargo.lock at
+
+        ${toString src}
+
+    Every check here builds from the FLAKE's source, which is your git tree —
+    so a lockfile that is untracked or gitignored does not exist as far as the
+    build is concerned, however plainly it sits in your working directory.
+
+    Library crates hit this most: not committing Cargo.lock was the convention
+    for years, and `cargo new --lib` wrote that .gitignore for you. Current
+    Cargo guidance is to commit it for libraries too, and a pinned build needs
+    it regardless, so the fix is:
+
+        git add Cargo.lock        # remove it from .gitignore first
+
+    Staging alone (`git add -N`) is enough for Nix to see it, but a lockfile
+    that is never committed makes the build reproducible only on your machine.
+  '';
+
+  hasLock = builtins.pathExists (src + "/Cargo.lock");
 
   # ---------------------------------------------------------------------------
   # Toolchain resolution
@@ -226,14 +309,21 @@ let
 
   toSrcPath = f: if builtins.isPath f then f else src + "/${f}";
 
-  cleanSrc = lib.fileset.toSource {
-    root = src;
-    fileset = lib.fileset.unions (
-      [ (craneLib.fileset.commonCargoSources src) ]
-      ++ map (f: lib.fileset.maybeMissing (src + "/${f}")) wellKnownConfigFiles
-      ++ map (f: lib.fileset.maybeMissing (toSrcPath f)) extraSrcFiles
-    );
-  };
+  # The lock guard sits here rather than on the derivations that vendor, so
+  # that `fmt` — which consumes only this — fails with the rest instead of
+  # passing alone (#1450).
+  cleanSrc =
+    if !hasLock then
+      throw lockError
+    else
+      lib.fileset.toSource {
+        root = src;
+        fileset = lib.fileset.unions (
+          [ (craneLib.fileset.commonCargoSources src) ]
+          ++ map (f: lib.fileset.maybeMissing (src + "/${f}")) wellKnownConfigFiles
+          ++ map (f: lib.fileset.maybeMissing (toSrcPath f)) extraSrcFiles
+        );
+      };
 
   denyEnabled = if deny != null then deny else builtins.pathExists (src + "/deny.toml");
 
@@ -254,6 +344,10 @@ let
     # Cargo.toml policy). Stripping twice is wasted work, not extra safety.
     dontStrip = true;
   }
+  // lib.optionalAttrs (cargoExtraArgs != "") { inherit cargoExtraArgs; }
+  # Still last, so an escape-hatch override beats everything above it. Note
+  # that it is a raw commonArgs merge, not an env-var attrset — the name is
+  # historical.
   // buildEnv;
 
   cargoArtifacts = craneLib.buildDepsOnly commonArgs;
@@ -273,7 +367,13 @@ let
       // {
         inherit cargoArtifacts;
         pname = name;
-        cargoExtraArgs = "-p ${name}";
+        # Composed, not assigned: `cargoExtraArgs` is also where a consumer's
+        # feature selection lives, and overwriting it here would silently give
+        # a workspace's per-crate builds a different feature set from every
+        # check that ran against them (#1450).
+        cargoExtraArgs = lib.concatStringsSep " " (
+          lib.optional (cargoExtraArgs != "") cargoExtraArgs ++ [ "-p ${name}" ]
+        );
       }
       // lib.optionalAttrs auditable {
         nativeBuildInputs = commonArgs.nativeBuildInputs ++ [ pkgs.cargo-auditable ];
@@ -351,6 +451,19 @@ let
           inherit cargoArtifacts;
           partitions = 1;
           partitionType = "count";
+        }
+      );
+    }
+    // lib.optionalAttrs doctest {
+      # nextest cannot run doctests — its process-per-test model has nowhere
+      # to put them — and `doc` below only lints rustdoc. Without this the
+      # suite looks complete while executing none of the examples in the
+      # public API docs, which for a library is often the only place a usage
+      # path is exercised end to end.
+      doctest = craneLib.cargoDocTest (
+        commonArgs
+        // {
+          inherit cargoArtifacts;
         }
       );
     }
@@ -541,19 +654,23 @@ let
     inherit tools linker;
   };
 
-  devShell = mkProjectShell (
-    {
-      inherit
-        pkgs
-        extraPackages
-        hooks
-        hooksExcludes
-        workflow
-        ;
-      modules = [ rustModuleEntry ] ++ modules;
-    }
-    // lib.optionalAttrs (shellHook != null) { inherit shellHook; }
-  );
+  devShell =
+    if !hasOverlay then
+      throw overlayError
+    else
+      mkProjectShell (
+        {
+          inherit
+            pkgs
+            extraPackages
+            hooks
+            hooksExcludes
+            workflow
+            ;
+          modules = [ rustModuleEntry ] ++ modules;
+        }
+        // lib.optionalAttrs (shellHook != null) { inherit shellHook; }
+      );
 
   # mkProjectShell owns the shell derivation, so extra env is applied here
   # rather than threaded through it — one override, no new argument on a

--- a/nix/mk-rust-project.nix
+++ b/nix/mk-rust-project.nix
@@ -87,7 +87,22 @@
   # ---- build inputs --------------------------------------------------------
   nativeBuildInputs ? [ ],
   buildInputs ? [ ],
-  # Merged into every crane derivation. For CMAKE_*, PKG_CONFIG_PATH, etc.
+  # Raw attrs merged, LAST, into every crane derivation — the unrestricted
+  # escape hatch for anything this function does not expose. Environment
+  # variables are the common case (CMAKE_*, PKG_CONFIG_PATH), but it is not
+  # limited to them: whatever you put here reaches mkDerivation, and because
+  # it merges last it beats every argument above.
+  #
+  # Named `craneArgs` since #1450. It was `buildEnv`, which was a lie of
+  # omission that cost a consumer real time: they needed feature selection,
+  # found this was the only seam that reached `buildDepsOnly`, and had to
+  # discover by reading the source that an argument documented as holding env
+  # vars would take `cargoExtraArgs`. Use `cargoExtraArgs` for that now; this
+  # is for the genuinely unanticipated.
+  craneArgs ? { },
+  # Deprecated alias, still honoured so the second consumer's flake keeps
+  # working. Merged after `craneArgs` on the reasoning that anyone still
+  # passing the old name is doing so deliberately.
   buildEnv ? { },
 
   # ---- behaviour -----------------------------------------------------------
@@ -147,7 +162,7 @@
   hooksExcludes ? [ ],
   workflow ? "gitflow",
   shellHook ? null,
-  # Extra dev-shell environment. Distinct from `buildEnv`, which goes to the
+  # Extra dev-shell environment. Distinct from `craneArgs`, which goes to the
   # build derivations.
   shellEnv ? { },
 }:
@@ -348,6 +363,7 @@ let
   # Still last, so an escape-hatch override beats everything above it. Note
   # that it is a raw commonArgs merge, not an env-var attrset — the name is
   # historical.
+  // craneArgs
   // buildEnv;
 
   cargoArtifacts = craneLib.buildDepsOnly commonArgs;
@@ -472,7 +488,7 @@ let
         commonArgs
         // {
           inherit cargoArtifacts;
-          # Top-level rather than under `env`, so a consumer's `buildEnv`
+          # Top-level rather than under `env`, so a consumer's `craneArgs`
           # cannot collide with it through two different mechanisms.
           RUSTDOCFLAGS = "--deny warnings";
         }

--- a/nix/mk-rust-project.nix
+++ b/nix/mk-rust-project.nix
@@ -1,0 +1,394 @@
+# mkRustProject — the composed entry point for a Rust consumer (#1400,
+# decision in #1427).
+#
+# ---------------------------------------------------------------------------
+# WHY THIS IS A LIB FUNCTION AND NOT PART OF THE MODULE CONTRACT
+# ---------------------------------------------------------------------------
+# A capability module contributes `packages` / `env` / `shellHook`: three
+# fields that fold monoidally into ONE derivation, the dev shell. `checks` is
+# not that shape. It is a namespaced map of independent peer derivations on a
+# different lifecycle (`nix flake check`, not `nix develop`), and building them
+# needs the consumer's source tree — project shape a module never sees.
+#
+# The test that settled it: a `checks` field could be added to the shell
+# composition contract WITHOUT touching shell composition at all. If a field
+# can be added to a contract without touching what that contract composes, it
+# is not part of that contract.
+#
+# So the module stays v1 and this function composes above it. Crucially it is
+# ONE call: it builds the dev shell (by calling mkProjectShell with the rust
+# module wired for us) AND the checks AND the packages, and hands all three
+# back together. There is no second function a consumer can forget to call,
+# which was the whole objection to shipping the checks separately.
+#
+# The consumer still has to assign the outputs — flake outputs are
+# consumer-assigned by construction, and no contract change anywhere in devkit
+# could alter that. What this shape buys is that `checks` arrives sitting
+# beside `devShell` in one attrset, so dropping it is a visible omission
+# rather than an unknown-unknown. The rust module's mandatory `checks` option
+# closes the remaining hand-edited path with an eval-time refusal.
+#
+# Usage:
+#
+#   perSystem = { system, pkgs, ... }:
+#     let
+#       rust = inputs.devkit.lib.mkRustProject {
+#         inherit pkgs;
+#         src = ./.;
+#         toolchainHash = "sha256-…";   # for ./rust-toolchain.toml
+#         crates = [ "my-cli" ];
+#       };
+#     in
+#     {
+#       devShells.default = rust.devShell;
+#       checks = rust.checks;
+#       packages = rust.packages;
+#     };
+{
+  mkProjectShell,
+  crane,
+  fenix,
+}:
+
+{
+  pkgs,
+  src,
+
+  # ---- what to build -------------------------------------------------------
+  # Cargo package names to build as both `packages.<name>` and
+  # `checks.<name>`. Null builds the workspace default as `packages.default`.
+  # Named crates are preferred for a workspace: each one is its own derivation,
+  # so a break is attributed rather than reported against "the workspace".
+  crates ? null,
+  # Which of `crates` becomes `packages.default`. Null uses the first.
+  defaultCrate ? null,
+  # Package name -> attrs merged into that crate's buildPackage call. The
+  # escape hatch for per-crate `doCheck`, features, or build commands.
+  crateOverrides ? { },
+
+  # ---- toolchain -----------------------------------------------------------
+  # A complete Rust toolchain derivation, if you are building one yourself.
+  toolchain ? null,
+  # Path to a rust-toolchain.toml. Defaults to `${src}/rust-toolchain.toml`
+  # when that file exists.
+  toolchainFile ? null,
+  # fenix requires a content hash for the resolved toolchain. There is no way
+  # around it and no sensible default — see the error below for how to get it.
+  toolchainHash ? null,
+
+  # ---- source --------------------------------------------------------------
+  # Extra files the build needs that crane's cargo-source filter drops:
+  # fixtures, .json goldens, templates. Paths relative to `src` (strings) or
+  # absolute paths. The well-known tool configs are picked up automatically —
+  # see wellKnownConfigFiles below, and read the comment there before assuming
+  # you do not need this.
+  extraSrcFiles ? [ ],
+
+  # ---- build inputs --------------------------------------------------------
+  nativeBuildInputs ? [ ],
+  buildInputs ? [ ],
+  # Merged into every crane derivation. For CMAKE_*, PKG_CONFIG_PATH, etc.
+  buildEnv ? { },
+
+  # ---- behaviour -----------------------------------------------------------
+  # Build shipped binaries with `cargo auditable`, embedding the dependency
+  # graph in the artifact so a consumer can audit what they actually hold
+  # rather than a source tree that has since moved on. Costs one extra tool in
+  # the build closure.
+  auditable ? true,
+  # `cargo deny check`. Defaults on when a deny.toml exists.
+  deny ? null,
+  # `cargo doc` with warnings denied — catches broken intra-doc links, which
+  # nothing else in the suite does.
+  doc ? true,
+  # `cargo nextest run`. Process-per-test, so an aborting test is reported.
+  nextest ? true,
+  clippy ? true,
+  # Extra args for the clippy check. `--deny warnings` is already applied.
+  clippyExtraArgs ? "--all-targets",
+  fmt ? true,
+
+  # ---- dev shell -----------------------------------------------------------
+  # Cargo tooling on the shell PATH (the rust module's curated map).
+  tools ? null,
+  linker ? true,
+  # Additional capability modules, composed alongside `rust`.
+  modules ? [ ],
+  extraPackages ? [ ],
+  hooks ? null,
+  hooksExcludes ? [ ],
+  workflow ? "gitflow",
+  shellHook ? null,
+  # Extra dev-shell environment. Distinct from `buildEnv`, which goes to the
+  # build derivations.
+  shellEnv ? { },
+}:
+
+let
+  inherit (pkgs) lib;
+  system = pkgs.stdenv.hostPlatform.system;
+
+  # ---------------------------------------------------------------------------
+  # Toolchain resolution
+  # ---------------------------------------------------------------------------
+  defaultToolchainFile = src + "/rust-toolchain.toml";
+  resolvedToolchainFile =
+    if toolchainFile != null then
+      toolchainFile
+    else if builtins.pathExists defaultToolchainFile then
+      defaultToolchainFile
+    else
+      null;
+
+  hashError = ''
+    mkRustProject: a rust-toolchain.toml was found at
+
+        ${toString resolvedToolchainFile}
+
+    but `toolchainHash` was not set. fenix resolves the toolchain from that
+    file as a fixed-output derivation, which needs its content hash; there is
+    no default that could be correct.
+
+    To get it, set the placeholder and build once:
+
+        toolchainHash = pkgs.lib.fakeHash;
+
+    Nix will fail with `specified: sha256-AAAA…` / `got: sha256-<real>`. Use
+    the `got` value. It changes when you change the pinned channel or the
+    component list in rust-toolchain.toml, and the same failure will tell you.
+
+    Not honouring the file is deliberately not an option here: a repo that
+    pins a toolchain and then builds with a different one is worse than a repo
+    that pins nothing. If you truly want the nixpkgs Rust, pass
+    `toolchainFile = null` explicitly.
+  '';
+
+  resolvedToolchain =
+    if toolchain != null then
+      toolchain
+    else if resolvedToolchainFile == null then
+      null
+    else if toolchainHash == null then
+      throw hashError
+    else
+      fenix.packages.${system}.fromToolchainFile {
+        file = resolvedToolchainFile;
+        sha256 = toolchainHash;
+      };
+
+  # `overrideToolchain` takes a FUNCTION, not a bare derivation. The function
+  # form is what lets crane splice correctly when cross-compiling; passing the
+  # derivation directly works until the day someone cross-compiles, and then
+  # fails somewhere far from here.
+  craneLib =
+    if resolvedToolchain == null then
+      crane.mkLib pkgs
+    else
+      (crane.mkLib pkgs).overrideToolchain (_: resolvedToolchain);
+
+  # ---------------------------------------------------------------------------
+  # Source
+  #
+  # crane's `commonCargoSources` walks the crate directories and allowlists
+  # Cargo.{toml,lock}, *.rs and *.toml. Root-level TOOL CONFIGS are outside
+  # that walk, and their absence is SILENT: rustfmt, clippy and cargo-deny
+  # each fall back to built-in defaults inside the sandbox, so the check
+  # passes while enforcing rules nobody wrote. The first consumer shipped that
+  # bug twice — a deny.toml banning openssl that banned nothing, and a
+  # clippy.toml that was never read by the clippy check meant to enforce it.
+  #
+  # Including these unconditionally is the fix. `maybeMissing` makes each one
+  # a no-op until the file exists, so there is nothing to remember and nothing
+  # to keep in sync.
+  # ---------------------------------------------------------------------------
+  wellKnownConfigFiles = [
+    "rustfmt.toml"
+    ".rustfmt.toml"
+    "clippy.toml"
+    ".clippy.toml"
+    "deny.toml"
+    "about.toml"
+    "about.hbs"
+    "rust-toolchain.toml"
+    "rust-toolchain"
+    ".cargo"
+  ];
+
+  toSrcPath = f: if builtins.isPath f then f else src + "/${f}";
+
+  cleanSrc = lib.fileset.toSource {
+    root = src;
+    fileset = lib.fileset.unions (
+      [ (craneLib.fileset.commonCargoSources src) ]
+      ++ map (f: lib.fileset.maybeMissing (src + "/${f}")) wellKnownConfigFiles
+      ++ map (f: lib.fileset.maybeMissing (toSrcPath f)) extraSrcFiles
+    );
+  };
+
+  denyEnabled = if deny != null then deny else builtins.pathExists (src + "/deny.toml");
+
+  # ---------------------------------------------------------------------------
+  # Build
+  # ---------------------------------------------------------------------------
+  useMold = linker && pkgs.stdenv.hostPlatform.isLinux;
+
+  commonArgs = {
+    src = cleanSrc;
+    # Keeps host and target dependencies from leaking into each other. On by
+    # default because the failure it prevents (a build that works only on the
+    # machine that has the library installed) is invisible until it isn't.
+    strictDeps = true;
+    nativeBuildInputs = nativeBuildInputs ++ lib.optional useMold pkgs.mold;
+    buildInputs = buildInputs ++ lib.optionals pkgs.stdenv.hostPlatform.isDarwin [ pkgs.libiconv ];
+    # cargo's release profile is expected to set `strip = true` (the pack's
+    # Cargo.toml policy). Stripping twice is wasted work, not extra safety.
+    dontStrip = true;
+  }
+  // buildEnv;
+
+  cargoArtifacts = craneLib.buildDepsOnly commonArgs;
+
+  buildCrate =
+    name:
+    craneLib.buildPackage (
+      commonArgs
+      // {
+        inherit cargoArtifacts;
+        pname = name;
+        cargoExtraArgs = "-p ${name}";
+      }
+      // lib.optionalAttrs auditable {
+        nativeBuildInputs = commonArgs.nativeBuildInputs ++ [ pkgs.cargo-auditable ];
+        cargoBuildCommand = "cargo auditable build --profile release";
+      }
+      // (crateOverrides.${name} or { })
+    );
+
+  workspacePackage = craneLib.buildPackage (
+    commonArgs
+    // {
+      inherit cargoArtifacts;
+    }
+    // lib.optionalAttrs auditable {
+      nativeBuildInputs = commonArgs.nativeBuildInputs ++ [ pkgs.cargo-auditable ];
+      cargoBuildCommand = "cargo auditable build --profile release";
+    }
+    // (crateOverrides.default or { })
+  );
+
+  cratePackages = lib.genAttrs (if crates == null then [ ] else crates) buildCrate;
+
+  resolvedDefault =
+    if crates == null then
+      workspacePackage
+    else if defaultCrate != null then
+      cratePackages.${defaultCrate} or (throw (
+        "mkRustProject: defaultCrate '${defaultCrate}' is not in `crates` "
+        + "(${lib.concatStringsSep ", " crates})"
+      ))
+    else if crates == [ ] then
+      throw "mkRustProject: `crates` is an empty list; pass null to build the workspace default, or name at least one crate"
+    else
+      cratePackages.${builtins.head crates};
+
+  packages = cratePackages // {
+    default = resolvedDefault;
+  };
+
+  # ---------------------------------------------------------------------------
+  # Checks
+  #
+  # The crate builds are checks too. A `nix flake check` that lints but never
+  # compiles the thing being shipped is the failure this pack exists to
+  # prevent, so the packages are folded in rather than left to `nix build`.
+  # ---------------------------------------------------------------------------
+  checks =
+    cratePackages
+    // lib.optionalAttrs (crates == null) { workspace = workspacePackage; }
+    // lib.optionalAttrs clippy {
+      clippy = craneLib.cargoClippy (
+        commonArgs
+        // {
+          inherit cargoArtifacts;
+          cargoClippyExtraArgs = "${clippyExtraArgs} -- --deny warnings";
+        }
+      );
+    }
+    // lib.optionalAttrs fmt {
+      # cargoFmt takes only `src` — it does not compile, so handing it
+      # cargoArtifacts would just pin an unrelated dependency build.
+      fmt = craneLib.cargoFmt { src = cleanSrc; };
+    }
+    // lib.optionalAttrs nextest {
+      nextest = craneLib.cargoNextest (
+        commonArgs
+        // {
+          inherit cargoArtifacts;
+          partitions = 1;
+          partitionType = "count";
+        }
+      );
+    }
+    // lib.optionalAttrs doc {
+      doc = craneLib.cargoDoc (
+        commonArgs
+        // {
+          inherit cargoArtifacts;
+          env = (commonArgs.env or { }) // {
+            RUSTDOCFLAGS = "--deny warnings";
+          };
+        }
+      );
+    }
+    // lib.optionalAttrs denyEnabled {
+      # No separate cargo-audit check: `cargo deny check advisories` already
+      # scans the RustSec database, so a second derivation would be a
+      # duplicate build for the same signal.
+      deny = craneLib.cargoDeny { src = cleanSrc; };
+    };
+
+  # ---------------------------------------------------------------------------
+  # Dev shell — the rust module, wired with the toolchain we just resolved so
+  # the shell and the builds cannot disagree about the compiler version.
+  # `checks = "mkRustProject"` is the module's acknowledgement token: it is
+  # true here, and it is exactly what a hand-wired consumer cannot honestly
+  # claim.
+  # ---------------------------------------------------------------------------
+  rustModuleEntry = {
+    name = "rust";
+    checks = "mkRustProject";
+    toolchain = resolvedToolchain;
+    inherit tools linker;
+  };
+
+  devShell = mkProjectShell (
+    {
+      inherit
+        pkgs
+        extraPackages
+        hooks
+        hooksExcludes
+        workflow
+        ;
+      modules = [ rustModuleEntry ] ++ modules;
+    }
+    // lib.optionalAttrs (shellHook != null) { inherit shellHook; }
+  );
+
+  # mkProjectShell owns the shell derivation, so extra env is applied here
+  # rather than threaded through it — one override, no new argument on a
+  # contract shared with every non-Rust consumer.
+  devShellWithEnv = if shellEnv == { } then devShell else devShell.overrideAttrs (_: shellEnv);
+in
+{
+  inherit packages checks;
+  devShell = devShellWithEnv;
+
+  # Escape hatches for consumers doing something the arguments above do not
+  # cover — an extra crane derivation, a second toolchain, a bespoke check.
+  # Exposed deliberately: without them the first unanticipated need forks the
+  # whole function.
+  inherit craneLib cargoArtifacts commonArgs;
+  toolchain = resolvedToolchain;
+  src = cleanSrc;
+}

--- a/nix/mk-rust-project.nix
+++ b/nix/mk-rust-project.nix
@@ -248,10 +248,18 @@ let
 
   cargoArtifacts = craneLib.buildDepsOnly commonArgs;
 
+  # crane's buildPackage runs `cargo test` as part of the build. With the
+  # nextest check enabled that is the same suite twice, on two derivations,
+  # for one signal — so the package builds compile only and the test run lives
+  # in `checks.nextest`, which is also what CI invokes. Without nextest the
+  # build keeps its tests, because otherwise nothing would run them.
+  packageDefaults = lib.optionalAttrs nextest { doCheck = false; };
+
   buildCrate =
     name:
     craneLib.buildPackage (
       commonArgs
+      // packageDefaults
       // {
         inherit cargoArtifacts;
         pname = name;
@@ -266,6 +274,7 @@ let
 
   workspacePackage = craneLib.buildPackage (
     commonArgs
+    // packageDefaults
     // {
       inherit cargoArtifacts;
     }

--- a/nix/mk-rust-project.nix
+++ b/nix/mk-rust-project.nix
@@ -343,9 +343,9 @@ let
         commonArgs
         // {
           inherit cargoArtifacts;
-          env = (commonArgs.env or { }) // {
-            RUSTDOCFLAGS = "--deny warnings";
-          };
+          # Top-level rather than under `env`, so a consumer's `buildEnv`
+          # cannot collide with it through two different mechanisms.
+          RUSTDOCFLAGS = "--deny warnings";
         }
       );
     }

--- a/nix/mk-rust-project.nix
+++ b/nix/mk-rust-project.nix
@@ -108,6 +108,16 @@
   clippyExtraArgs ? "--all-targets",
   fmt ? true,
 
+  # ---- performance ratchet -------------------------------------------------
+  # Defaults on when the baseline file exists, off otherwise — same rule as
+  # `deny`, so adopting it is `just perf-seal` and adopting nothing is doing
+  # nothing. See the long comment at the ratchet itself for what it measures
+  # and, more importantly, what it refuses to measure.
+  perfRatchet ? null,
+  perfBaselineFile ? null,
+  # Growth beyond this fails. Overridable per repo in the baseline file.
+  perfTolerancePct ? 5,
+
   # ---- dev shell -----------------------------------------------------------
   # Cargo tooling on the shell PATH (the rust module's curated map).
   tools ? null,
@@ -304,6 +314,12 @@ let
     default = resolvedDefault;
   };
 
+  # Exposed unconditionally, including before a baseline exists — sealing the
+  # first one is how you adopt the ratchet, so it must work when it is off.
+  perfPackages = {
+    perf-seal = perfSeal;
+  };
+
   # ---------------------------------------------------------------------------
   # Checks
   #
@@ -354,7 +370,162 @@ let
       # scans the RustSec database, so a second derivation would be a
       # duplicate build for the same signal.
       deny = craneLib.cargoDeny { src = cleanSrc; };
-    };
+    }
+    // lib.optionalAttrs perfEnabled { perf-ratchet = perfRatchetCheck; };
+
+  # ---------------------------------------------------------------------------
+  # Performance ratchet
+  #
+  # WHAT THIS DELIBERATELY DOES NOT DO: time anything. Wall-clock benchmarks
+  # on shared CI runners are noise — neighbours, thermal state and scheduler
+  # luck move them more than most real regressions do — and a gate that fires
+  # on noise is a gate people learn to re-run until it passes. The pack ADR
+  # already says coverage is reported and never gated; the same reasoning
+  # applies harder here, because a flaky perf gate teaches `--no-verify`.
+  #
+  # What it measures instead is deterministic given a locked toolchain and a
+  # locked dependency graph, so a change means a change:
+  #
+  #   * SHIPPED BINARY SIZE, per binary. Catches the dependency that quietly
+  #     added two megabytes, the accidental monomorphization blowup, the
+  #     debug info that stopped being stripped.
+  #   * DEPENDENCY GRAPH SIZE, from Cargo.lock. Catches supply-chain creep,
+  #     which is a build-time, audit-surface and compile-time cost at once.
+  #
+  # Neither needs anyone to have written a benchmark, which is the point: a
+  # ratchet nobody has to author is a ratchet that is actually in place. Repos
+  # doing real performance work should add criterion/divan benches and run
+  # them OFF the CI critical path — `tools = [ "@perf" ]` puts the kit on
+  # PATH for that.
+  #
+  # It is a RATCHET, not a limit: growth past the tolerance fails, and a
+  # measured shrink is reported so the win can be banked by re-sealing. The
+  # baseline is committed, so the diff shows who spent the budget and when.
+  # ---------------------------------------------------------------------------
+  resolvedBaselineFile =
+    if perfBaselineFile != null then perfBaselineFile else src + "/.repo/perf-baseline.toml";
+  baselineExists = builtins.pathExists resolvedBaselineFile;
+  perfEnabled = if perfRatchet != null then perfRatchet else baselineExists;
+
+  baseline =
+    if baselineExists then builtins.fromTOML (builtins.readFile resolvedBaselineFile) else { };
+  tolerance = baseline.tolerance_pct or perfTolerancePct;
+
+  # Cargo.lock is TOML, so the graph size is an eval-time read — no build, no
+  # network, no cargo invocation.
+  cargoLockFile = src + "/Cargo.lock";
+  lockCrateCount =
+    if builtins.pathExists cargoLockFile then
+      builtins.length ((builtins.fromTOML (builtins.readFile cargoLockFile)).package or [ ])
+    else
+      null;
+
+  baselineBinaries = baseline.binaries or { };
+  baselineLines = lib.concatStringsSep "\n" (
+    lib.mapAttrsToList (n: v: "${n} ${toString v.bytes}") baselineBinaries
+  );
+
+  measuredPackages = if crates == null then { workspace = workspacePackage; } else cratePackages;
+
+  perfRatchetCheck = pkgs.runCommand "rust-perf-ratchet" { } ''
+    set -euo pipefail
+    printf '%s\n' ${lib.escapeShellArg baselineLines} > baseline.txt
+    tolerance=${toString tolerance}
+    status=0
+    echo "perf ratchet — tolerance ${toString tolerance}%"
+    echo
+
+    check_metric() {
+      name="$1"; actual="$2"; expected="$3"; unit="$4"
+      if [ -z "$expected" ]; then
+        echo "  NEW      $name = $actual $unit (no baseline entry)"
+        echo "$name = $actual" >> new-entries.txt
+        return
+      fi
+      # Integer percent-delta; avoids depending on bc/awk floats.
+      delta=$(( (actual - expected) * 100 / (expected > 0 ? expected : 1) ))
+      if [ "$delta" -gt "$tolerance" ]; then
+        echo "  REGRESS  $name = $actual $unit (baseline $expected, +''${delta}%)"
+        status=1
+      elif [ "$delta" -lt "-$tolerance" ]; then
+        echo "  IMPROVED $name = $actual $unit (baseline $expected, ''${delta}%) — re-seal to bank it"
+      else
+        echo "  ok       $name = $actual $unit (baseline $expected, ''${delta}%)"
+      fi
+    }
+
+    ${lib.concatStringsSep "\n" (
+      lib.mapAttrsToList (_: drv: ''
+        if [ -d ${drv}/bin ]; then
+          for f in ${drv}/bin/*; do
+            [ -f "$f" ] || continue
+            bin=$(basename "$f")
+            actual=$(wc -c < "$f" | tr -d ' ')
+            expected=$(awk -v k="$bin" '$1 == k { print $2 }' baseline.txt)
+            check_metric "binary/$bin" "$actual" "$expected" bytes
+          done
+        fi
+      '') measuredPackages
+    )}
+
+    ${lib.optionalString (lockCrateCount != null) ''
+      check_metric "graph/crates" ${toString lockCrateCount} \
+        ${toString (baseline.graph.crates or "")} crates
+    ''}
+
+    echo
+    if [ "$status" -ne 0 ]; then
+      cat <<'MSG'
+    A measured budget was exceeded.
+
+    This is deterministic, not a flaky timing check: same toolchain, same
+    Cargo.lock, same bytes. Something in this change actually made the
+    artifact bigger or the graph wider.
+
+      cargo bloat --release --crates     # which dependency took the bytes
+      cargo llvm-lines --release         # which generic exploded
+      cargo tree --duplicates            # two versions of the same crate
+
+    If the growth is intended — a real feature, a dependency you chose —
+    re-seal the baseline in the same commit, so the diff records who spent
+    the budget and why:
+
+      just perf-seal
+    MSG
+    fi
+    ${lib.optionalString (!baselineExists) ''
+      echo "No baseline at ${toString resolvedBaselineFile} — reporting only."
+      echo "Seal one with \`just perf-seal\` to start ratcheting."
+      status=0
+    ''}
+    [ "$status" -eq 0 ] || exit 1
+    touch $out
+  '';
+
+  # `nix run .#perf-seal > .repo/perf-baseline.toml` — emits the current
+  # measurements as the file itself, so sealing is never hand-transcribed.
+  perfSeal = pkgs.writeShellScriptBin "perf-seal" ''
+    set -euo pipefail
+    echo "schema = 1"
+    echo "tolerance_pct = ${toString tolerance}"
+    echo
+    ${lib.optionalString (lockCrateCount != null) ''
+      echo "[graph]"
+      echo "crates = ${toString lockCrateCount}"
+      echo
+    ''}
+    echo "[binaries]"
+    ${lib.concatStringsSep "\n" (
+      lib.mapAttrsToList (_: drv: ''
+        if [ -d ${drv}/bin ]; then
+          for f in ${drv}/bin/*; do
+            [ -f "$f" ] || continue
+            printf '%s = { bytes = %s }\n' "$(basename "$f")" "$(wc -c < "$f" | tr -d ' ')"
+          done
+        fi
+      '') measuredPackages
+    )}
+  '';
 
   # ---------------------------------------------------------------------------
   # Dev shell — the rust module, wired with the toolchain we just resolved so
@@ -390,7 +561,8 @@ let
   devShellWithEnv = if shellEnv == { } then devShell else devShell.overrideAttrs (_: shellEnv);
 in
 {
-  inherit packages checks;
+  inherit checks;
+  packages = packages // perfPackages;
   devShell = devShellWithEnv;
 
   # Escape hatches for consumers doing something the arguments above do not

--- a/nix/modules/check-entries.nix
+++ b/nix/modules/check-entries.nix
@@ -1,0 +1,26 @@
+# How the generated per-module smoke check instantiates each capability module.
+#
+# flake.nix builds `checks.<system>.module-<name>` for every entry in the
+# registry (nix/modules/default.nix) so a module cannot ship without its check.
+# The generator's default instantiation is the plain name string — the same
+# thing a consumer writes for a module that needs no configuration.
+#
+# A module whose options are MANDATORY cannot be instantiated that way: the
+# bare name throws by design. This file is the generator's answer — a name ->
+# `modules` entry override, consulted only for the names present here.
+#
+# Keep this small and keep it justified. An entry here is a statement that the
+# module's zero-option form is deliberately unusable, not that the check was
+# inconvenient to write.
+{
+  # `rust` refuses the bare form so nobody wires a toolchain without the check
+  # suite (#1427; the reasoning is in the module header). The smoke check is
+  # exactly the sanctioned toolchain-only case: it builds the devshell to prove
+  # the module evaluates and its packages resolve, and owns no source tree to
+  # run checks against. The deeper end-to-end coverage lives in
+  # tests/test_flake_modules.py.
+  rust = {
+    name = "rust";
+    checks = "none";
+  };
+}

--- a/nix/modules/default.nix
+++ b/nix/modules/default.nix
@@ -7,12 +7,16 @@
 # passes via `{ name = "<name>"; … }` minus `name` (empty `{}` for the plain
 # string form). mkProjectShell resolves names against this attrset and the
 # flake generates a per-system `checks.<system>.module-<name>` devshell
-# build for every entry, so a module cannot ship without its check.
+# build for every entry, so a module cannot ship without its check. A module
+# whose options are mandatory overrides how that check instantiates it — see
+# ./check-entries.nix.
 #
-# Candidate modules — geant4, rust, fortran/f2py, root — are deliberately
-# NOT defined until a concrete consumer asks (YAGNI; see the ADR).
+# Candidate modules — geant4, fortran/f2py, root — are deliberately NOT
+# defined until a concrete consumer asks (YAGNI; see the ADR). `rust` was such
+# a candidate and shipped on gerchowl/filesender's ask (#1400).
 {
   native = import ./native.nix;
   node = import ./node.nix;
   docs = import ./docs.nix;
+  rust = import ./rust.nix;
 }

--- a/nix/modules/rust.nix
+++ b/nix/modules/rust.nix
@@ -1,0 +1,220 @@
+# `rust` capability module (#1400, decision in #1427): the Rust dev-shell
+# capability. One of the ADR's ask-gated candidates; `gerchowl/filesender` is
+# the ask.
+#
+# v1 contract (`pkgs -> options -> { packages, env, shellHook }`, per
+# docs/rfcs/ADR-capability-modules.md) — this module contributes packages and
+# env only. It deliberately does NOT provide the cargo justfile recipes, the
+# .gitignore fragment, the pre-commit hooks or the CodeQL language: those are
+# scaffold concerns, not shell contributions, exactly as for `node`.
+#
+# ---------------------------------------------------------------------------
+# WHY THIS MODULE REFUSES TO LOAD BARE
+# ---------------------------------------------------------------------------
+# A Rust toolchain on PATH is the *easy* half of the capability. The half that
+# earns its keep is the check suite — fmt, clippy, nextest, cargo-deny, the
+# per-crate builds — and a v1 capability module cannot contribute
+# `checks.<system>.*`. Checks need the project's source tree, which is
+# consumer-owned project shape, neither ambient here nor derivable from
+# options.
+#
+# So a consumer who writes `modules = [ "rust" ]` and stops would get a
+# toolchain, a green `nix flake check` that builds nothing, and CI that
+# compiles nothing — the precise silent-green failure the Rust pack exists to
+# prevent, delivered by the pack itself. #1427 settled that the fix is
+# `lib.mkRustProject` (which wires shell AND checks from one call) plus this
+# eval-time refusal for anyone who hand-edits their way around it. Detection
+# is not enough here: the record on the first consumer is five separate
+# things configured, believed active, and never executed.
+#
+# Hence the mandatory `checks` option. It has no default on purpose.
+pkgs:
+{
+  checks ? null,
+  toolchain ? null,
+  tools ? null,
+  linker ? true,
+  ...
+}@options:
+let
+  inherit (pkgs) lib;
+
+  knownOptions = [
+    "checks"
+    "toolchain"
+    "tools"
+    "linker"
+  ];
+  unknownOptions = builtins.filter (k: !builtins.elem k knownOptions) (builtins.attrNames options);
+
+  # -------------------------------------------------------------------------
+  # Curated cargo tooling. A name -> package map rather than free-form
+  # derivations so `tools` stays a reviewable list in a consumer's flake and a
+  # typo is an eval error, not a silently missing binary.
+  # -------------------------------------------------------------------------
+  toolMap = {
+    # Test runner. Not a nicety: nextest is process-per-test, so a panicking
+    # or aborting test is reported rather than taking the runner with it.
+    nextest = pkgs.cargo-nextest or null;
+    # Supply chain: advisories, licence policy, source bans (deny.toml).
+    deny = pkgs.cargo-deny or null;
+    # Embeds the dependency graph in the SHIPPED binary, so `cargo audit bin`
+    # audits the artifact rather than a source tree that may have moved on.
+    auditable = pkgs.cargo-auditable or null;
+    audit = pkgs.cargo-audit or null;
+    # Third-party attribution text. deny.toml says which licences are allowed;
+    # this produces the notice the permissive ones oblige us to distribute.
+    about = pkgs.cargo-about or null;
+    # Unused dependency detection — the one cargo itself will not tell you.
+    shear = pkgs.cargo-shear or null;
+    # Coverage. Reported, never gated (see the pack ADR).
+    llvm-cov = pkgs.cargo-llvm-cov or null;
+    watch = pkgs.cargo-watch or null;
+    expand = pkgs.cargo-expand or null;
+    machete = pkgs.cargo-machete or null;
+    outdated = pkgs.cargo-outdated or null;
+    insta = pkgs.cargo-insta or null;
+    flamegraph = pkgs.cargo-flamegraph or null;
+    criterion = pkgs.cargo-criterion or null;
+    mutants = pkgs.cargo-mutants or null;
+    semver-checks = pkgs.cargo-semver-checks or null;
+    hakari = pkgs.cargo-hakari or null;
+    dist = pkgs.cargo-dist or null;
+  };
+
+  # The default set is what every tier in the pack ADR needs: run the tests,
+  # police the supply chain, produce the attribution file, notice dead deps.
+  # Anything tier-specific (semver-checks for `lib`, mutants for `runner`) is
+  # opt-in via `tools`, because each one costs build time for every consumer.
+  defaultTools = [
+    "nextest"
+    "deny"
+    "auditable"
+    "audit"
+    "about"
+    "shear"
+  ];
+
+  requestedTools = if tools == null then defaultTools else tools;
+
+  unknownTools = builtins.filter (t: !(toolMap ? ${t}) || toolMap.${t} == null) requestedTools;
+
+  toolPackages = map (t: toolMap.${t}) requestedTools;
+
+  # -------------------------------------------------------------------------
+  # Toolchain. `toolchain` is a complete Rust toolchain derivation — in
+  # practice fenix's `fromToolchainFile`, which is what lib.mkRustProject
+  # passes so `rust-toolchain.toml` is the single source of truth for the
+  # version. Omitted, we fall back to the pinned nixpkgs Rust: a real
+  # toolchain, but one that tracks the channel rather than the repo's pin.
+  # -------------------------------------------------------------------------
+  toolchainPackages =
+    if toolchain != null then
+      [ toolchain ]
+    else
+      [
+        pkgs.rustc
+        pkgs.cargo
+        pkgs.clippy
+        pkgs.rustfmt
+        pkgs.rust-analyzer
+      ];
+
+  # mold cuts link time on large debug builds by an order of magnitude, and
+  # link time is what a Rust edit-compile loop is actually made of. Linux
+  # only: on Darwin the system linker is already the fast path and mold's
+  # Mach-O support is not the supported configuration.
+  useMold = linker && pkgs.stdenv.hostPlatform.isLinux;
+
+  # `checks` is mandatory and has no default — see the header. The message is
+  # the whole point of the guard, so it states the fix, the escape hatch, and
+  # why the escape hatch is not the default.
+  checksError = ''
+    rust module: the `checks` option is required.
+
+    `modules = [ "rust" ]` puts a Rust toolchain on the dev-shell PATH and
+    NOTHING ELSE. It cannot add `checks.<system>.*` — a v1 capability module
+    contributes packages/env/shellHook only, and checks need your source tree,
+    which the module never sees. A repo wired this way compiles nothing in CI
+    and reports success. Refs vig-os/devkit#1427.
+
+    Use the composed entry point instead, which wires the shell AND the checks
+    from one call:
+
+        rust = inputs.devkit.lib.mkRustProject {
+          inherit pkgs;
+          src = ./.;
+        };
+      in {
+        devShells.default = rust.devShell;
+        checks.''${system}  = rust.checks;
+        packages.''${system} = rust.packages;
+      }
+
+    If you genuinely want the toolchain WITHOUT the check suite — a scratch
+    shell, a repo whose Rust is incidental, a consumer that already owns its
+    own checks — say so explicitly:
+
+        modules = [ { name = "rust"; checks = "none"; } ];
+
+    It is spelled out rather than defaulted because the default would be the
+    failure mode: silence is exactly how the unwired case reaches CI.
+  '';
+
+  validChecks = [
+    "mkRustProject"
+    "none"
+  ];
+in
+if unknownOptions != [ ] then
+  throw (
+    "rust module: unknown option(s): "
+    + lib.concatStringsSep ", " unknownOptions
+    + "; recognized options are "
+    + lib.concatStringsSep ", " knownOptions
+  )
+else if checks == null then
+  throw checksError
+else if !builtins.elem checks validChecks then
+  throw (
+    "rust module: invalid `checks` value "
+    + builtins.toJSON checks
+    + "; expected \"mkRustProject\" (set for you by lib.mkRustProject) or "
+    + "\"none\" (deliberate opt-out — toolchain only, no check suite)"
+  )
+else if unknownTools != [ ] then
+  throw (
+    "rust module: unknown or unavailable tool(s): "
+    + lib.concatStringsSep ", " unknownTools
+    + "; available: "
+    + lib.concatStringsSep ", " (builtins.filter (n: toolMap.${n} != null) (builtins.attrNames toolMap))
+  )
+else
+  {
+    packages = toolchainPackages ++ toolPackages ++ lib.optional useMold pkgs.mold;
+
+    env = {
+      # Point rust-analyzer and friends at the toolchain's own sources. Without
+      # it, "go to definition" on a std symbol lands nowhere in a Nix shell,
+      # because there is no rustup to infer the sysroot from.
+      RUST_SRC_PATH =
+        if toolchain != null then
+          "${toolchain}/lib/rustlib/src/rust/library"
+        else
+          "${pkgs.rustPlatform.rustLibSrc}";
+      # Full backtraces by default in a dev shell. This is the environment
+      # where you are debugging; the cost of the flag is zero unless you panic.
+      RUST_BACKTRACE = "1";
+    };
+
+    # The toolchain SSoT (nix/devtools.nix) does not ship Rust, so unlike the
+    # node module there is nothing to shadow — the package contribution above
+    # already wins PATH. This fragment exists only for mold, which cannot be
+    # selected by PATH order: it has to be requested through rustflags.
+    #
+    # Deliberately additive to RUSTFLAGS rather than assigning it, so a repo's
+    # own .cargo/config.toml or a caller's export is not silently discarded.
+    shellHook = lib.optionalString useMold ''
+      export RUSTFLAGS="''${RUSTFLAGS:+$RUSTFLAGS }-C link-arg=-fuse-ld=mold"
+    '';
+  }

--- a/nix/modules/rust.nix
+++ b/nix/modules/rust.nix
@@ -74,12 +74,85 @@ let
     machete = pkgs.cargo-machete or null;
     outdated = pkgs.cargo-outdated or null;
     insta = pkgs.cargo-insta or null;
-    flamegraph = pkgs.cargo-flamegraph or null;
-    criterion = pkgs.cargo-criterion or null;
     mutants = pkgs.cargo-mutants or null;
     semver-checks = pkgs.cargo-semver-checks or null;
     hakari = pkgs.cargo-hakari or null;
     dist = pkgs.cargo-dist or null;
+
+    # ---- performance ------------------------------------------------------
+    # None of these are in `defaultTools`: they are large, and a repo that is
+    # not doing performance work should not pay to have them on PATH. Ask for
+    # the platform's set with `tools = [ … "@perf" ]`.
+    #
+    # samply first because it is the one to reach for by default in 2026:
+    # sampling profiler, no root, no kernel perf_events, works on both Linux
+    # and macOS, and opens the result in the Firefox Profiler UI. flamegraph
+    # is kept for the SVG workflow and for CI artifacts.
+    samply = pkgs.samply or null;
+    flamegraph = pkgs.cargo-flamegraph or null;
+    # Statistical A/B timing of whole commands — the honest tool for "is the
+    # CLI faster", where a criterion microbenchmark would answer a different
+    # question convincingly and wrongly.
+    hyperfine = pkgs.hyperfine or null;
+    criterion = pkgs.cargo-criterion or null;
+    # Where the binary's bytes went, by crate. Pairs with the size ratchet in
+    # mkRustProject: the ratchet tells you a regression happened, bloat tells
+    # you which dependency did it.
+    bloat = pkgs.cargo-bloat or null;
+    # Monomorphization volume. The usual cause of a binary that grew without
+    # anyone adding a feature is a generic instantiated over more types.
+    llvm-lines = pkgs.cargo-llvm-lines or null;
+    # Emitted assembly / LLVM IR for one function. The last resort, and the
+    # only way to confirm a bounds check or an allocation actually went away.
+    asm = pkgs.cargo-show-asm or null;
+    # Async runtime observability: task-level stalls and busy time. Belongs to
+    # the `service` and `mcp` tiers, where the interesting stalls are awaits
+    # rather than CPU.
+    tokio-console = pkgs.tokio-console or null;
+
+    # Linux-only. heaptrack and valgrind's Darwin support is either absent or
+    # unusable on Apple Silicon, and `poop` is built on perf_events. Listed
+    # here so `@perf` can pick them up where they work and skip them where
+    # they do not, rather than every consumer hand-writing that condition.
+    heaptrack = if pkgs.stdenv.hostPlatform.isLinux then (pkgs.heaptrack or null) else null;
+    valgrind = if pkgs.stdenv.hostPlatform.isLinux then (pkgs.valgrind or null) else null;
+    poop = if pkgs.stdenv.hostPlatform.isLinux then (pkgs.poop or null) else null;
+  };
+
+  # -------------------------------------------------------------------------
+  # Tool groups. A `tools` entry beginning with `@` expands to a curated set.
+  #
+  # Groups and explicit names differ deliberately in how they treat a tool
+  # that is unavailable on this platform: naming `valgrind` on Darwin is a
+  # request that cannot be met, so it throws; asking for `@perf` is asking for
+  # *this platform's* profiling kit, so unavailable members are dropped. That
+  # asymmetry is the whole reason groups exist — otherwise every consumer
+  # writes the same `optionals isLinux` by hand and gets it subtly wrong.
+  # -------------------------------------------------------------------------
+  toolGroups = {
+    perf = [
+      "samply"
+      "flamegraph"
+      "hyperfine"
+      "criterion"
+      "bloat"
+      "llvm-lines"
+      "asm"
+      "heaptrack"
+      "valgrind"
+      "poop"
+    ];
+    # Async services: profiling plus the runtime's own instrumentation.
+    perf-async = [
+      "samply"
+      "tokio-console"
+      "hyperfine"
+    ];
+    # Everything a `lib` tier owes its downstreams beyond the base set.
+    api = [
+      "semver-checks"
+      "expand"
+    ];
   };
 
   # The default set is what every tier in the pack ADR needs: run the tests,
@@ -97,9 +170,27 @@ let
 
   requestedTools = if tools == null then defaultTools else tools;
 
-  unknownTools = builtins.filter (t: !(toolMap ? ${t}) || toolMap.${t} == null) requestedTools;
+  isGroup = t: lib.hasPrefix "@" t;
+  groupName = t: lib.removePrefix "@" t;
 
-  toolPackages = map (t: toolMap.${t}) requestedTools;
+  unknownGroups = builtins.filter (t: isGroup t && !(toolGroups ? ${groupName t})) requestedTools;
+
+  # Group members that this platform does not have are dropped (see the
+  # toolGroups comment); explicitly named tools are not.
+  expandedGroupTools = lib.concatMap (
+    t: builtins.filter (m: (toolMap.${m} or null) != null) toolGroups.${groupName t}
+  ) (builtins.filter isGroup requestedTools);
+
+  explicitTools = builtins.filter (t: !isGroup t) requestedTools;
+
+  unknownTools = builtins.filter (t: (toolMap.${t} or null) == null) explicitTools;
+
+  # A tool named both explicitly and via a group must not appear twice — a
+  # duplicated derivation in `packages` is harmless to nix and confusing to
+  # read in a `nix develop` diff.
+  resolvedTools = lib.unique (explicitTools ++ expandedGroupTools);
+
+  toolPackages = map (t: toolMap.${t}) resolvedTools;
 
   # -------------------------------------------------------------------------
   # Toolchain. `toolchain` is a complete Rust toolchain derivation — in
@@ -182,12 +273,22 @@ else if !builtins.elem checks validChecks then
     + "; expected \"mkRustProject\" (set for you by lib.mkRustProject) or "
     + "\"none\" (deliberate opt-out — toolchain only, no check suite)"
   )
+else if unknownGroups != [ ] then
+  throw (
+    "rust module: unknown tool group(s): "
+    + lib.concatStringsSep ", " unknownGroups
+    + "; available groups: "
+    + lib.concatStringsSep ", " (map (g: "@${g}") (builtins.attrNames toolGroups))
+  )
 else if unknownTools != [ ] then
   throw (
-    "rust module: unknown or unavailable tool(s): "
+    "rust module: unknown or unavailable-on-${pkgs.stdenv.hostPlatform.system} tool(s): "
     + lib.concatStringsSep ", " unknownTools
-    + "; available: "
+    + "; available here: "
     + lib.concatStringsSep ", " (builtins.filter (n: toolMap.${n} != null) (builtins.attrNames toolMap))
+    + ". Tool groups (@name) skip members this platform lacks; an explicitly "
+    + "named tool does not, because naming one is a request that either can "
+    + "or cannot be met."
   )
 else
   {

--- a/tests/test_flake_modules.py
+++ b/tests/test_flake_modules.py
@@ -667,3 +667,66 @@ def test_zero_module_shell_unaffected_by_rust_module(current_system: str) -> Non
         "adding the rust module must not perturb the zero-module default "
         f"dev-shell drv; got {paths!r}"
     )
+
+
+def test_rust_tool_group_expands_and_skips_unavailable_members() -> None:
+    """``tools = [ "@perf" ]`` expands, dropping members this platform lacks (#1400).
+
+    A group is a request for *this platform's* kit, so members that are not
+    packaged here (heaptrack, valgrind and poop are Linux-only) are skipped
+    rather than failing eval. Without this, every consumer writes the same
+    ``optionals stdenv.isLinux`` by hand and some of them get it wrong.
+    """
+    with_group = _nix_eval_expr(
+        _rust_module_expr('{ name = "rust"; checks = "none"; tools = [ "@perf" ]; }')
+    )
+    assert with_group.returncode == 0, (
+        f"@perf group must evaluate on this platform; got: {with_group.stderr[-500:]}"
+    )
+
+    # The shell derivation must actually differ from a no-tools one. Asserting
+    # only that it evaluates would pass even if the group silently expanded to
+    # nothing -- which is exactly the "configured, contributes nothing" failure
+    # this suite exists to catch.
+    without = _nix_eval_expr(
+        _rust_module_expr('{ name = "rust"; checks = "none"; tools = [ ]; }')
+    )
+    assert without.returncode == 0, (
+        f"empty tools must evaluate; got: {without.stderr[-500:]}"
+    )
+    assert with_group.stdout != without.stdout, (
+        "@perf expanded to no packages -- the group contributed nothing"
+    )
+
+
+def test_rust_explicit_unavailable_tool_still_throws() -> None:
+    """A tool named EXPLICITLY is not silently skipped (#1400).
+
+    The asymmetry against groups is deliberate and is the reason groups exist:
+    asking for ``@perf`` is asking for whatever this platform has, but naming
+    ``heaptrack`` is a request that can only be met or refused. Silently
+    dropping it would hand someone a shell missing the one tool they asked
+    for -- configured, believed present, never there.
+    """
+    result = _nix_eval_expr(
+        _rust_module_expr(
+            '{ name = "rust"; checks = "none"; tools = [ "heaptrack" ]; }'
+        )
+    )
+    if result.returncode == 0:
+        # Linux: heaptrack IS available, so there is nothing to refuse.
+        return
+    assert "heaptrack" in result.stderr and "unavailable-on" in result.stderr, (
+        f"error must name the tool and the platform; got: {result.stderr[-500:]}"
+    )
+
+
+def test_rust_module_rejects_unknown_tool_group() -> None:
+    """A mistyped group name fails eval and lists the real groups (#1400)."""
+    result = _nix_eval_expr(
+        _rust_module_expr('{ name = "rust"; checks = "none"; tools = [ "@perff" ]; }')
+    )
+    assert result.returncode != 0, "unknown tool group must fail eval, not pass"
+    assert "unknown tool group" in result.stderr and "@perf" in result.stderr, (
+        f"error must name the group and list the available ones; got: {result.stderr[-500:]}"
+    )

--- a/tests/test_flake_modules.py
+++ b/tests/test_flake_modules.py
@@ -900,3 +900,54 @@ def test_mk_rust_project_threads_cargo_extra_args(tmp_path: Path) -> None:
     assert "--all-features" in result.stdout, (
         f"cargoExtraArgs must land in commonArgs; got {result.stdout!r}"
     )
+
+
+def test_mk_rust_project_dev_shell_evaluates_with_the_overlay(tmp_path: Path) -> None:
+    """The overlay guard's POSITIVE direction (#1450).
+
+    ``hasOverlay`` is a proxy: it infers "the overlay was applied" from the
+    presence of one package, ``vig-utils``. Proxies drift. If devkit's overlay
+    ever renames or drops that package, the guard starts throwing
+    "you did not apply the overlay" at consumers who did — and the negative
+    test above would still pass, because it asserts a throw.
+
+    The rule this branch is built on is that a gate needs a fixture for
+    known-bad input AND known-good input; the guard shipped with only the
+    first. This is the second, and it is the one that fails when the sentinel
+    stops tracking what it stands for.
+    """
+    src = _minimal_crate(tmp_path)
+    result = _nix_eval_expr(_mk_rust_project_expr(src, "rust.devShell.drvPath"))
+    assert result.returncode == 0, (
+        "the dev shell must evaluate when devkit's overlay IS applied — if this "
+        "fails, the `pkgs ? vig-utils` sentinel has stopped tracking the "
+        f"overlay and the guard now rejects correct configurations; got: {result.stderr[-800:]}"
+    )
+    assert ".drv" in result.stdout, (
+        f"expected a derivation path; got: {result.stdout[-200:]}"
+    )
+
+
+def test_mk_rust_project_accepts_crane_args_and_the_deprecated_alias(
+    tmp_path: Path,
+) -> None:
+    """``craneArgs`` is honoured, and the old ``buildEnv`` name still works (#1450).
+
+    ``buildEnv`` was documented as holding environment variables while in fact
+    being a raw merge into every crane derivation — which cost the second
+    consumer real time, since it was the only seam reaching ``buildDepsOnly``
+    and nothing said so. It is renamed to ``craneArgs``; the old name stays
+    accepted so an existing consumer flake keeps evaluating.
+    """
+    src = _minimal_crate(tmp_path)
+    for arg in ("craneArgs", "buildEnv"):
+        result = _nix_eval_expr(
+            _mk_rust_project_expr(
+                src,
+                "rust.checks.fmt.drvPath",
+                extra=f'{arg} = {{ CARGO_PROFILE_RELEASE_DEBUG = "0"; }};',
+            )
+        )
+        assert result.returncode == 0, (
+            f"`{arg}` must be accepted by mkRustProject; got: {result.stderr[-500:]}"
+        )

--- a/tests/test_flake_modules.py
+++ b/tests/test_flake_modules.py
@@ -730,3 +730,173 @@ def test_rust_module_rejects_unknown_tool_group() -> None:
     assert "unknown tool group" in result.stderr and "@perf" in result.stderr, (
         f"error must name the group and list the available ones; got: {result.stderr[-500:]}"
     )
+
+
+# ---------------------------------------------------------------------------
+# mkRustProject consumer guards (#1450) — found by adopting the pack on a
+# second consumer (gerchowl/squelch: single-crate, no binaries, heavily
+# feature-gated). The two guards below turn failures that were opaque or
+# partial into ones that name the fix; the two coverage tests pin behaviour
+# the pack promised in #1400 but did not ship.
+#
+# These need project shape, which is why the older mkRustProject coverage
+# stops at a schema smoke test. A dependency-free crate keeps the lockfile a
+# literal, so the whole set runs at EVAL time — no vendoring, no network, no
+# compile.
+# ---------------------------------------------------------------------------
+
+
+def _minimal_crate(root: Path, *, with_lock: bool = True) -> Path:
+    """Write the smallest crate crane will accept, and return its path."""
+    (root / "src").mkdir(parents=True, exist_ok=True)
+    (root / "Cargo.toml").write_text(
+        '[package]\nname = "fixture"\nversion = "0.0.0"\nedition = "2021"\n'
+    )
+    (root / "src" / "lib.rs").write_text("pub fn answer() -> u8 { 42 }\n")
+    if with_lock:
+        (root / "Cargo.lock").write_text(
+            'version = 3\n\n[[package]]\nname = "fixture"\nversion = "0.0.0"\n'
+        )
+    return root
+
+
+def _mk_rust_project_expr(
+    src: Path, attr: str, *, overlay: bool = True, extra: str = ""
+) -> str:
+    """An expression selecting ``attr`` off a ``mkRustProject`` call on ``src``."""
+    overlays = "[ flake.overlays.default ]" if overlay else "[ ]"
+    return f"""
+    let
+      flake = builtins.getFlake "path:{REPO_ROOT}";
+      system = builtins.currentSystem;
+      pkgs = import flake.inputs.nixpkgs {{
+        inherit system;
+        overlays = {overlays};
+        config.allowUnfree = true;
+      }};
+      rust = flake.lib.mkRustProject {{
+        inherit pkgs;
+        src = {src};
+        {extra}
+      }};
+    in {attr}
+    """
+
+
+def test_mk_rust_project_refuses_pkgs_without_the_devkit_overlay(
+    tmp_path: Path,
+) -> None:
+    """A ``pkgs`` lacking ``overlays.default`` is named as such, not as ``vig-utils``.
+
+    ``mkProjectShell`` pulls ``nix/devtools.nix``, which references
+    ``vig-utils`` — a package only the overlay provides. Without the overlay
+    the dev shell died with ``undefined variable 'vig-utils'``, pointing inside
+    devkit at a name the consumer has never seen.
+
+    The reason this is a guard rather than a docs fix: ``checks`` and
+    ``packages`` never touch ``mkProjectShell``, so they evaluate fine without
+    the overlay. The unguarded result is a repo whose ``nix flake check`` is
+    green and whose ``nix develop`` is broken — the silent split the pack
+    exists to close, one layer up.
+    """
+    src = _minimal_crate(tmp_path)
+    result = _nix_eval_expr(
+        _mk_rust_project_expr(src, "rust.devShell.drvPath", overlay=False)
+    )
+    assert result.returncode != 0, (
+        "a pkgs without devkit's overlay must fail eval, not produce a shell"
+    )
+    assert "overlays.default" in result.stderr, (
+        "the error must name the overlay the consumer has to add; "
+        f"got: {result.stderr[-800:]}"
+    )
+    assert "undefined variable" not in result.stderr, (
+        "the raw nixpkgs error must be replaced, not merely preceded; "
+        f"got: {result.stderr[-800:]}"
+    )
+
+
+def test_mk_rust_project_names_a_missing_cargo_lock(tmp_path: Path) -> None:
+    """A source tree with no ``Cargo.lock`` fails with the library case spelled out.
+
+    A flake's ``src`` is the git tree, so a repo that gitignores its lockfile —
+    the long-standing library convention — hands crane a source without one.
+    crane's own message is good but reachable only from the derivations that
+    vendor: ``fmt`` takes ``src`` alone and passed regardless, so a consumer
+    who built one check first saw green.
+
+    Asserted through ``fmt`` for exactly that reason.
+    """
+    src = _minimal_crate(tmp_path, with_lock=False)
+    result = _nix_eval_expr(_mk_rust_project_expr(src, "rust.checks.fmt.drvPath"))
+    assert result.returncode != 0, (
+        "fmt must not evaluate against a lockless tree — it passing is what "
+        "made the missing lockfile look like a partial success"
+    )
+    assert "Cargo.lock" in result.stderr, (
+        f"the error must name Cargo.lock; got: {result.stderr[-800:]}"
+    )
+
+
+def test_mk_rust_project_ships_a_doctest_check(tmp_path: Path) -> None:
+    """``checks.doctest`` exists (#1400's stage table, unshipped in #1429).
+
+    #1400 assigns pre-push ``nextest`` **and** ``cargo test --doc``. nextest
+    cannot run doctests by design, and ``cargoDoc`` only lints rustdoc, so a
+    consumer whose doctests ran under ``cargo test`` lost them on adoption
+    without being told.
+    """
+    src = _minimal_crate(tmp_path)
+    result = subprocess.run(
+        [
+            "nix",
+            "eval",
+            "--impure",
+            "--json",
+            "--expr",
+            _mk_rust_project_expr(src, "builtins.attrNames rust.checks"),
+        ],
+        capture_output=True,
+        text=True,
+        env=_nix_env(),
+        timeout=300,
+    )
+    assert result.returncode == 0, result.stderr[-1500:]
+    names = json.loads(result.stdout)
+    assert "doctest" in names, (
+        f"the default check suite must run doctests; got {names!r}"
+    )
+
+
+def test_mk_rust_project_threads_cargo_extra_args(tmp_path: Path) -> None:
+    """``cargoExtraArgs`` reaches every derivation through ``commonArgs``.
+
+    The checks built default features only, and nothing reached
+    ``buildDepsOnly`` / ``nextest`` / ``doc`` / the package builds —
+    ``clippyExtraArgs`` covers clippy alone. A feature-gated crate therefore
+    got less linting from the pack than from a bare ``cargo clippy
+    --all-features``, because the gated code was never compiled.
+    """
+    src = _minimal_crate(tmp_path)
+    result = subprocess.run(
+        [
+            "nix",
+            "eval",
+            "--impure",
+            "--raw",
+            "--expr",
+            _mk_rust_project_expr(
+                src,
+                "rust.commonArgs.cargoExtraArgs",
+                extra='cargoExtraArgs = "--all-features";',
+            ),
+        ],
+        capture_output=True,
+        text=True,
+        env=_nix_env(),
+        timeout=300,
+    )
+    assert result.returncode == 0, result.stderr[-1500:]
+    assert "--all-features" in result.stdout, (
+        f"cargoExtraArgs must land in commonArgs; got {result.stdout!r}"
+    )

--- a/tests/test_flake_modules.py
+++ b/tests/test_flake_modules.py
@@ -10,6 +10,11 @@ are exported, and a trivial setuptools C-extension sdist builds and installs
 with ``uv`` (the pycatima-class scenario from #639/#879). For ``node`` (#1027):
 ``node`` + bundled ``npm`` resolve, and the ``{ name = "node"; version = …; }``
 per-module-options form pins the Node major (the mechanism the ADR deferred).
+For ``rust`` (#1400, decision in #1427): the bare-form guard (which is the
+single most important test — the whole design rests on it) fires at eval, the
+explicit ``{ name = "rust"; checks = "none"; }`` opt-out evaluates, the
+module's per-option validation throws with a targeted message, and
+``lib.mkRustProject`` composes above the module as a callable entry point.
 
 The zero-module parity guarantee (the default dev-shell is byte-identical to
 the pre-module builder) is covered by ``tests/test_flake_devshell.py`` staying
@@ -23,6 +28,7 @@ Refs: #884
 
 from __future__ import annotations
 
+import json
 import shutil
 import subprocess
 from typing import TYPE_CHECKING
@@ -384,4 +390,280 @@ def test_node_module_rejects_non_int_version(
         "invalid Node version" in result.stderr and "integer major" in result.stderr
     ), (
         f"error must be the module-scoped invalid-version throw; got: {result.stderr[-500:]}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# rust module (#1400, decision in #1427) — the Rust dev-shell capability. v1
+# contract (packages + env + shellHook) with a MANDATORY ``checks`` option and
+# no default: the whole point of the module is to refuse the bare
+# ``modules = [ "rust" ]`` form loudly, because a v1 module cannot contribute
+# ``checks.<system>.*`` and a hand-wired Rust repo with a green ``nix flake
+# check`` that compiles nothing is exactly the failure the language pack
+# exists to prevent. ``lib.mkRustProject`` composes above ``mkProjectShell``
+# and wires shell + checks + packages from one call; the check-entries
+# registry (nix/modules/check-entries.nix) is how the generated per-module
+# smoke check instantiates a module whose options are mandatory. See
+# docs/rfcs/ADR-capability-modules.md and nix/mk-rust-project.nix.
+# ---------------------------------------------------------------------------
+
+
+def _rust_module_expr(entry: str) -> str:
+    """A ``mkProjectShell`` expression whose sole module entry is ``entry``.
+
+    Shared by the guard/opt-out/option-validation tests — each one only differs
+    in the attrset (or bare string) it hands to ``modules``. ``.drvPath`` forces
+    evaluation to the derivation, which is the only stage where the module's
+    guards fire (the shell body never runs, so throws surface as eval errors).
+    """
+    return f"""
+    let
+      flake = builtins.getFlake "path:{REPO_ROOT}";
+      system = builtins.currentSystem;
+      pkgs = import flake.inputs.nixpkgs {{
+        inherit system;
+        overlays = [ flake.overlays.default ];
+        config.allowUnfree = true;
+      }};
+    in (flake.lib.mkProjectShell {{
+      inherit pkgs;
+      modules = [ {entry} ];
+    }}).drvPath
+    """
+
+
+def _nix_eval_expr(
+    expr: str, *, timeout: int = 300
+) -> subprocess.CompletedProcess[str]:
+    """Run ``nix eval --impure --expr`` and return the completed process.
+
+    Used by the guard/option-validation tests, which assert on the error
+    surfaced in ``stderr`` — a non-zero exit is the expected shape.
+    """
+    return subprocess.run(
+        ["nix", "eval", "--impure", "--expr", expr],
+        capture_output=True,
+        text=True,
+        env=_nix_env(),
+        timeout=timeout,
+    )
+
+
+def test_rust_is_in_capability_module_registry() -> None:
+    """``rust`` is one of the shipped capability modules (#1400).
+
+    Reads the registry names via the same generated per-module check
+    ``checks.<system>.module-<name>`` the other modules are asserted through —
+    a check whose existence is proof the flake resolved the ``rust`` entry in
+    ``nix/modules/default.nix``. Kept parallel to how ``native``/``node``/
+    ``docs`` are exercised so a new entry cannot ship without extending the
+    per-family assertions below.
+    """
+    system = nix_helpers.current_system()
+    names = set(
+        nix_helpers.nix_eval_json(
+            f"{REPO_ROOT}#checks.{system}", apply="builtins.attrNames"
+        )
+    )
+    assert "module-rust" in names, (
+        "the flake must expose checks.<system>.module-rust from the "
+        f"nix/modules/ registry; got: {sorted(n for n in names if n.startswith('module-'))}"
+    )
+
+
+def test_rust_module_check_evaluates(current_system: str) -> None:
+    """``checks.<system>.module-rust`` evaluates to a real derivation (#1400).
+
+    The generated smoke check MUST reach a drvPath — the registry entry, the
+    ``rust`` module import and the ``check-entries.nix`` override for the
+    mandatory-options form all have to resolve before this returns a store
+    path. Only asks for ``.drvPath`` (cheap eval) rather than building the
+    devshell, which would pull the Rust toolchain into the cache; the deeper
+    end-to-end tests own that cost when they need it.
+    """
+    drv = nix_helpers.nix_eval_raw(
+        f"{REPO_ROOT}#checks.{current_system}.module-rust.drvPath"
+    )
+    assert drv.startswith("/nix/store/") and drv.endswith(".drv"), (
+        f"module-rust must evaluate to a .drv path; got {drv!r}"
+    )
+
+
+def test_rust_module_bare_form_throws_with_mkrustproject_guidance() -> None:
+    """``modules = [ "rust" ]`` fails at eval with the ``mkRustProject`` fix (#1427).
+
+    THIS is the single most important test — the whole design rests on it. The
+    ``rust`` module's ``checks`` option is mandatory with no default so a
+    hand-written bare entry never silently produces a toolchain-only shell
+    (the failure mode: five things believed active, none of them run, CI green
+    compiling nothing). The eval error must name the composed entry point
+    (``mkRustProject``) and the option (``checks``) so the message itself
+    routes the reader to the fix and to the deliberate opt-out spelled out in
+    the module header.
+    """
+    result = _nix_eval_expr(_rust_module_expr('"rust"'))
+    assert result.returncode != 0, (
+        'bare `modules = [ "rust" ]` MUST fail eval — this is the guard the '
+        "language pack rests on; got a successful eval instead"
+    )
+    stderr = result.stderr
+    assert "mkRustProject" in stderr, (
+        f"guard message must name mkRustProject (the fix); got: {stderr[-800:]}"
+    )
+    assert "checks" in stderr, (
+        "guard message must name the `checks` option (the mandatory knob); "
+        f"got: {stderr[-800:]}"
+    )
+
+
+def test_rust_module_explicit_opt_out_evaluates() -> None:
+    """``{ name = "rust"; checks = "none"; }`` is the sanctioned toolchain-only form.
+
+    The deliberate opt-out from the guard above (#1427): a scratch shell, a
+    repo whose Rust is incidental, a consumer that already owns its own
+    checks. It is spelled out because a default would BE the failure mode.
+    Evaluate to a drvPath to confirm the module returns a valid contribution
+    (packages/env/shellHook) instead of throwing.
+    """
+    result = _nix_eval_expr(_rust_module_expr('{ name = "rust"; checks = "none"; }'))
+    assert result.returncode == 0, (
+        'explicit opt-out `{ name = "rust"; checks = "none"; }` must '
+        f"evaluate; got: {result.stderr[-500:]}"
+    )
+    assert result.stdout.strip().startswith('"/nix/store/'), (
+        f"opt-out form must return a store drvPath; got: {result.stdout!r}"
+    )
+
+
+def test_rust_module_rejects_unknown_option() -> None:
+    """An unrecognized ``rust`` option fails eval and names the option (#1400).
+
+    Every rust option is enumerated in ``knownOptions``; anything else throws
+    before the module returns a contribution, so a typo (or an unsupported
+    knob) is a hard eval error rather than a silently-ignored no-op — the same
+    strictness the ``node`` module applies (see
+    ``test_node_module_rejects_unknown_option``).
+    """
+    result = _nix_eval_expr(
+        _rust_module_expr('{ name = "rust"; checks = "none"; frobnicate = 1; }')
+    )
+    assert result.returncode != 0, "unknown rust option must fail eval, not pass"
+    assert "frobnicate" in result.stderr and "rust module" in result.stderr, (
+        "error must name the offending option and the module; "
+        f"got: {result.stderr[-500:]}"
+    )
+
+
+def test_rust_module_rejects_invalid_checks_value() -> None:
+    """A ``checks`` value outside ``{"mkRustProject","none"}`` fails eval (#1427).
+
+    The ``checks`` option is the module's acknowledgement token: the
+    mkRustProject-set value or the deliberate opt-out are the only honest
+    answers. Any other string (e.g. ``"yes"``) is a hand-edited fake and must
+    throw with a message naming both valid values.
+    """
+    result = _nix_eval_expr(_rust_module_expr('{ name = "rust"; checks = "yes"; }'))
+    assert result.returncode != 0, "invalid `checks` value must fail eval, not pass"
+    stderr = result.stderr
+    assert "rust module" in stderr and "checks" in stderr, (
+        f"error must name the module and the option; got: {stderr[-500:]}"
+    )
+    # Both sanctioned values are surfaced in the message so the reader learns
+    # what the correct answers are, not just that theirs is wrong.
+    assert "mkRustProject" in stderr and "none" in stderr, (
+        "error must enumerate the two valid `checks` values (mkRustProject, "
+        f"none); got: {stderr[-500:]}"
+    )
+
+
+def test_rust_module_rejects_unknown_tool() -> None:
+    """An unknown ``tools`` name fails eval and names it (#1400).
+
+    The curated ``toolMap`` in the module is a name -> package map, chosen so a
+    consumer's ``tools`` list stays reviewable and a typo becomes an eval
+    error rather than a silently-missing cargo helper on the shell PATH. The
+    error must name the offending tool so the reader can fix or drop it.
+    """
+    result = _nix_eval_expr(
+        _rust_module_expr(
+            '{ name = "rust"; checks = "none"; tools = [ "not-a-cargo-tool" ]; }'
+        )
+    )
+    assert result.returncode != 0, "unknown rust tool name must fail eval, not pass"
+    stderr = result.stderr
+    assert "not-a-cargo-tool" in stderr and "rust module" in stderr, (
+        f"error must name the offending tool and the module; got: {stderr[-500:]}"
+    )
+
+
+def test_mk_rust_project_is_exposed_as_a_function() -> None:
+    """``lib.mkRustProject`` is a callable function (#1400).
+
+    The composed entry point sits above ``mkProjectShell`` and returns
+    ``{ devShell, checks, packages, craneLib, cargoArtifacts, commonArgs,
+    toolchain, src }`` from a single call. Kept as a cheap schema smoke test:
+    calling it needs a Rust source tree (project shape a devkit test cannot
+    ambiently supply), so the deep end-to-end coverage of the shape lives in
+    the first consumer (gerchowl/filesender). ``--apply`` reduces the raw
+    function to a discriminator string — ``nix eval --raw`` on a bare function
+    is a type error, hence the direct subprocess call.
+    """
+    result = subprocess.run(
+        [
+            "nix",
+            "eval",
+            "--raw",
+            f"{REPO_ROOT}#lib.mkRustProject",
+            "--apply",
+            'f: if builtins.isFunction f then "ok" else "not-a-function"',
+        ],
+        capture_output=True,
+        text=True,
+        env=_nix_env(),
+        timeout=120,
+    )
+    assert result.returncode == 0 and result.stdout.strip() == "ok", (
+        "lib.mkRustProject must be a function; "
+        f"rc={result.returncode} stdout={result.stdout!r} "
+        f"stderr={result.stderr[-500:]}"
+    )
+
+
+def test_zero_module_shell_unaffected_by_rust_module(current_system: str) -> None:
+    """The default dev-shell's drvPath is byte-identical to the no-modules build (#884, #1400).
+
+    The ADR's zero-module invariant, re-asserted after the Rust pack shipped:
+    adding a module to the registry must not perturb the shell a consumer who
+    never asks for it gets. This is the same shape as ``TestZeroHooksParity``
+    (tests/test_flake_hooks.py) — compare the flake's own
+    ``devShells.<system>.default.drvPath`` to a freshly-built
+    ``mkProjectShell { inherit pkgs; }`` and require equality — but pinned
+    here so a future module cannot silently leak into the default path.
+    """
+    expr = f"""
+    let
+      flake = builtins.getFlake "path:{REPO_ROOT}";
+      system = "{current_system}";
+      pkgs = import flake.inputs.nixpkgs {{
+        inherit system;
+        overlays = [ flake.overlays.default ];
+        config.allowUnfree = true;
+      }};
+    in {{
+      default = flake.devShells.${{system}}.default.drvPath;
+      zeroModules = (flake.lib.mkProjectShell {{ inherit pkgs; }}).drvPath;
+    }}
+    """
+    result = subprocess.run(
+        ["nix", "eval", "--impure", "--json", "--expr", expr],
+        capture_output=True,
+        text=True,
+        env=_nix_env(),
+        timeout=300,
+    )
+    assert result.returncode == 0, result.stderr
+    paths = json.loads(result.stdout)
+    assert paths["default"] == paths["zeroModules"], (
+        "adding the rust module must not perturb the zero-module default "
+        f"dev-shell drv; got {paths!r}"
     )


### PR DESCRIPTION
Ships the Rust language pack as **two pieces**, and the split between them is the design. Implements the `A + D + assert` resolution recorded in #1427.

Closes #1400. Refs #1427.

## How to test it

```nix
# flake.nix
inputs.devkit.url = "github:vig-os/devkit/feature/1400-rust-language-pack";

# perSystem
rust = devkit.lib.mkRustProject {
  inherit pkgs;
  src = ./.;
  toolchainHash = "sha256-…";       # for your rust-toolchain.toml
  crates = [ "my-cli" ];
};
devShells.default = rust.devShell;
checks             = rust.checks;
packages           = rust.packages;
```

Set `toolchainHash = pkgs.lib.fakeHash` first; the build failure prints the real one.

Toolchain-only, no check suite — deliberate and explicit:

```nix
modules = [ { name = "rust"; checks = "none"; } ];
```

And the thing that should NOT work:

```nix
modules = [ "rust" ];   # eval error, by design — see below
```

## What's here

| File | |
|---|---|
| `nix/modules/rust.nix` | v1 capability module: toolchain + curated cargo tooling + mold on Linux |
| `nix/mk-rust-project.nix` | `lib.mkRustProject` — dev shell, checks and packages from one call |
| `nix/modules/check-entries.nix` | internal: how the generated `module-<name>` check instantiates a module whose options are mandatory |

Checks produced: the per-crate builds, plus `clippy`, `fmt`, `nextest`, `doc` (rustdoc warnings denied) and `deny` (auto-enabled when a `deny.toml` exists).

## Why checks are a lib function and not a contract field

`packages` / `env` / `shellHook` fold monoidally into **one** derivation — the shell. `checks` is a namespaced map of **independent peer derivations** on a different lifecycle (`nix flake check`, not `nix develop`), built from the consumer's source tree, which is project shape a module never sees.

The test that settled it: a `checks` field could be added to the shell-composition contract **without touching shell composition at all**. If a field can be added to a contract without touching what that contract composes, it isn't part of that contract.

So `mkRustProject` composes *above* `mkProjectShell` and returns all three together. One call — there is no second function to forget.

## Why the module refuses to load bare

`modules = [ "rust" ]` would hand you a toolchain, a green `nix flake check` that builds nothing, and CI that compiles nothing: the exact silent-green failure the pack exists to prevent, delivered by the pack. So the module's `checks` option is **mandatory with no default**, and the bare form throws at eval with a message naming the fix and the opt-out.

Being straight about the limit: **flake outputs are consumer-assigned by construction.** No option here — including extending the contract — could have made correct wiring structurally impossible. What this shape buys is one call instead of two, `checks` arriving visibly beside `devShell`, and a loud eval-time failure on the one remaining path. Silence was the failure mode; silence is what's removed.

## Costs, stated plainly

- **`crane` + `fenix` become devkit inputs — 3 leaf lock entries that every consumer pays for**, Python-only ones included, in lock size and fetch-at-eval. The alternative is each Rust repo pinning its own fenix, which is per-repo drift on exactly the axis devkit exists to hold still. `mkRustProject` takes `crane`/`fenix` overrides, so the inputs can move back out later without a consumer-visible change. **Flag it if you disagree — this is the most reversible-but-annoying-later decision in the PR.**
- `nix/lib/` turned out to be **gitignored** (`.gitignore:17` has a bare `lib/` from the Python layout, which swallows any `lib` directory at any depth). The file lives at `nix/mk-rust-project.nix` instead, matching `nix/hooks.nix` / `nix/devtools.nix`. Worth fixing that pattern separately — it will bite someone else.

## Verified, not assumed

- `checks.<system>.module-rust` evaluates ✅
- Bare `modules = [ "rust" ]` throws the guidance error ✅
- **Zero-module invariant holds**: `devShells.<system>.default.drvPath` is byte-identical to `dev` ✅
- End-to-end on the first consumer (`gerchowl/filesender`, a cli + mcp + lib workspace): its ~120 lines of hand-rolled crane/fenix wiring were deleted and replaced by one `mkRustProject` call; all 9 checks evaluate and build.

## Two bugs this shape prevents by construction

Both were shipped by the first consumer, and both were invisible to inspection:

1. `deny.toml` outside the crane fileset — an `openssl` ban that banned nothing.
2. `clippy.toml` outside the fileset — the sandboxed clippy check ran against defaults, enforcing rules nobody wrote.

`mkRustProject` folds the well-known root tool configs (`rustfmt.toml`, `clippy.toml`, `deny.toml`, `about.*`, `.cargo/`) into the fileset unconditionally via `maybeMissing`, so there is nothing to remember and nothing to keep in sync.

## Found by devkit's own gates, on devkit

Worth recording because it is the same failure class this PR is about. My first branch was `feat/rust-language-pack` and the first two commits said `Refs #1400` without the colon. Both were **wrong by devkit's own rules** — the taxonomy is `feature`, not `feat`, and `Refs:` is a mandatory trailer — and both went through, because a fresh `git clone` has no hooks installed until something installs them. They were caught only when the hooks happened to be present for the third commit.

That is exactly the shape of the five bugs in the first consumer's history: configured, believed active, never executed. Branch renamed, trailers normalized, commits signed. But **a fresh clone of devkit does not enforce devkit's rules until someone runs the installer**, and nothing tells you that. Probably worth its own issue.

## Review asks

1. The **`crane`/`fenix` as devkit inputs** tradeoff above.
2. `check-entries.nix` — is a per-name generator override the right answer for mandatory-option modules, or should the generated smoke check learn about them some other way?
3. Whether the eval-time refusal is too aggressive for a scratch-shell user (the opt-out is one attrset, but it *is* friction).
