### PR TITLE
feat(hooks): allow renovate branches in the no-commit-to-branch guard

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,7 @@ repos:
       # - chore/<short_summary> (no issue required)
       # - <type>/<issue_number>-<short_summary> (for feature, bugfix, etc.)
       # - worktree/<issue_number> (autonomous worktree branches)
+      # - renovate/* (Renovate's branch namespace; maintainer fix-up commits)
       # Allows main, dev, and branches matching the convention.
       - id: no-commit-to-branch
         name: branch-name (enforce <type>/<issue>-<summary>)
@@ -24,7 +25,7 @@ repos:
           - --branch
           - __none__  # override default so main/dev are not protected
           - --pattern
-          - "^(?!main$)(?!dev$)(?!^(chore)/[a-z0-9]+(-[a-z0-9]+)*$)(?!^(feature|bugfix|hotfix|release|docs|test|refactor)/[0-9]+-[a-z0-9]+(-[a-z0-9]+)*$)(?!^worktree/[0-9]+$).+$"
+          - "^(?!main$)(?!dev$)(?!^(chore)/[a-z0-9]+(-[a-z0-9]+)*$)(?!^(feature|bugfix|hotfix|release|docs|test|refactor)/[0-9]+-[a-z0-9]+(-[a-z0-9]+)*$)(?!^renovate/.+$)(?!^worktree/[0-9]+$).+$"
       - id: check-added-large-files
       - id: check-case-conflict
       - id: check-json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Allow `renovate/*` branches in the branch guard** ([#1433](https://github.com/vig-os/devkit/issues/1433))
+  - The `no-commit-to-branch` pattern (committed hook config, scaffold
+    template, and flake-generated consumer surface) now admits Renovate's
+    tool-owned branch namespace, so maintainer fix-up commits on Renovate PRs
+    (changelog conflict merges, `dist/` rebuilds) no longer need the
+    commit-on-a-compliant-branch-then-`git push HEAD:renovate/…` workaround
 - **Mirror-mode consumers integrate the issue archive via the release train** ([#1424](https://github.com/vig-os/devkit/issues/1424))
   - With `DEVKIT_SYNC_TARGET` set, the scaffolded `release-core.yml` final leg
     now dispatches sync-issues onto the **mirror** (the only branch that may

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -32,6 +32,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Allow `renovate/*` branches in the branch guard** ([#1433](https://github.com/vig-os/devkit/issues/1433))
+  - The `no-commit-to-branch` pattern (committed hook config, scaffold
+    template, and flake-generated consumer surface) now admits Renovate's
+    tool-owned branch namespace, so maintainer fix-up commits on Renovate PRs
+    (changelog conflict merges, `dist/` rebuilds) no longer need the
+    commit-on-a-compliant-branch-then-`git push HEAD:renovate/…` workaround
 - **Mirror-mode consumers integrate the issue archive via the release train** ([#1424](https://github.com/vig-os/devkit/issues/1424))
   - With `DEVKIT_SYNC_TARGET` set, the scaffolded `release-core.yml` final leg
     now dispatches sync-issues onto the **mirror** (the only branch that may

--- a/assets/workspace/.pre-commit-config.yaml
+++ b/assets/workspace/.pre-commit-config.yaml
@@ -17,6 +17,7 @@ repos:
       # - chore/<short_summary> (no issue required)
       # - <type>/<issue_number>-<short_summary> (for feature, bugfix, etc.)
       # - worktree/<issue_number> (autonomous worktree branches)
+      # - renovate/* (Renovate's branch namespace; maintainer fix-up commits)
       # Allows main, dev, and branches matching the convention.
       - id: no-commit-to-branch
         name: branch-name (enforce <type>/<issue>-<summary>)
@@ -24,7 +25,7 @@ repos:
           - --branch
           - __none__  # override default so main/dev are not protected
           - --pattern
-          - "^(?!main$)(?!dev$)(?!^(chore)/[a-z0-9]+(-[a-z0-9]+)*$)(?!^(feature|bugfix|hotfix|release|docs|test|refactor)/[0-9]+-[a-z0-9]+(-[a-z0-9]+)*$)(?!^worktree/[0-9]+$).+$"
+          - "^(?!main$)(?!dev$)(?!^(chore)/[a-z0-9]+(-[a-z0-9]+)*$)(?!^(feature|bugfix|hotfix|release|docs|test|refactor)/[0-9]+-[a-z0-9]+(-[a-z0-9]+)*$)(?!^renovate/.+$)(?!^worktree/[0-9]+$).+$"
       - id: check-added-large-files
       - id: check-case-conflict
       - id: check-json

--- a/nix/hooks.nix
+++ b/nix/hooks.nix
@@ -25,8 +25,8 @@
 { lib }:
 let
   # Topic-branch naming convention enforced by no-commit-to-branch:
-  # chore/<summary>, <type>/<issue>-<summary>, worktree/<issue>; main and dev
-  # are allowed (pushing there is blocked server-side, not here).
+  # chore/<summary>, <type>/<issue>-<summary>, worktree/<issue>, renovate/*;
+  # main and dev are allowed (pushing there is blocked server-side, not here).
   #
   # Workflow-model aware (#1224): the `(?!dev$)` clause protects the long-lived
   # gitflow `dev` branch, which a trunk workspace does not have — so the trunk
@@ -35,12 +35,19 @@ let
   # `.pre-commit-config.yaml`. The committed runner/scaffold YAML stays gitflow
   # (its trunk render is the scaffold path's job); only the flake-generated
   # consumer surface follows `workflow`.
+  #
+  # The `renovate/` clause (#1433) admits the Renovate app's tool-owned branch
+  # namespace (like `worktree/<n>`): the bot commits server-side, but
+  # maintainer fix-up commits on its branches (changelog conflict merges,
+  # dist/ rebuilds) are a legitimate local flow. Permissive `.+` after the
+  # prefix — Renovate composes names from dep names/version ranges (dots,
+  # parentheses), so a charset pin would re-break on the next scheme.
   branchNamePatternFor =
     workflow:
     let
       devClause = lib.optionalString (workflow != "trunk") "(?!dev$)";
     in
-    "^(?!main$)${devClause}(?!^(chore)/[a-z0-9]+(-[a-z0-9]+)*$)(?!^(feature|bugfix|hotfix|release|docs|test|refactor)/[0-9]+-[a-z0-9]+(-[a-z0-9]+)*$)(?!^worktree/[0-9]+$).+$";
+    "^(?!main$)${devClause}(?!^(chore)/[a-z0-9]+(-[a-z0-9]+)*$)(?!^(feature|bugfix|hotfix|release|docs|test|refactor)/[0-9]+-[a-z0-9]+(-[a-z0-9]+)*$)(?!^renovate/.+$)(?!^worktree/[0-9]+$).+$";
   # The gitflow default, used by the committed runner/scaffold YAML renders.
   branchNamePattern = branchNamePatternFor "gitflow";
 

--- a/tests/test_flake_hooks.py
+++ b/tests/test_flake_hooks.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import functools
 import json
+import re
 import shlex
 import shutil
 import subprocess
@@ -100,6 +101,17 @@ def _branch_guard(config: dict[str, Any]) -> str:
     the generated config's no-commit-to-branch entry.
     """
     return _normalize(config)["hooks"]["no-commit-to-branch"]["entry"]
+
+
+def _pattern_arg(hook: dict[str, Any]) -> str:
+    """The ``--pattern`` regex from a portable no-commit-to-branch args list.
+
+    The committed YAML artifacts carry the regex as the value following
+    ``--pattern`` in ``args`` (unlike the consumer surface, where git-hooks.nix
+    bakes it into ``entry`` — see ``_branch_guard``).
+    """
+    args = hook["args"]
+    return args[args.index("--pattern") + 1]
 
 
 def _diff_hooks(rendered: dict[str, Any], committed: dict[str, Any]) -> str:
@@ -477,6 +489,58 @@ class TestWorkflowModelBranchGuard:
         result = _run_nix(["eval", "--impure", "--raw", "--expr", expr])
         assert result.returncode != 0
         assert "workflow" in result.stderr
+
+
+class TestRenovateBranchAllowance:
+    """The default branch guard admits Renovate's tool-owned namespace (#1433).
+
+    The Renovate app commits server-side, where local hooks never run — but
+    maintainer fix-up commits on ``renovate/*`` branches (changelog conflict
+    merges, ``dist/`` rebuilds) are a real flow the guard used to block,
+    forcing a commit-on-a-compliant-branch-then-push-to-ref workaround.
+    Renovate branch names carry no issue number and use a charset outside the
+    slug rule (live example: ``renovate/github-actions-(minor-and-patch)``),
+    so the namespace gets its own lookahead clause next to ``worktree/<n>``
+    rather than a ``DEVKIT_BRANCH_TYPES`` value.
+
+    ``no-commit-to-branch`` BLOCKS a branch whose name matches ``--pattern``,
+    so "allowed" asserts the regex does NOT match.
+    """
+
+    ALLOWED = (
+        "renovate/lock-file-maintenance",
+        "renovate/github-actions-(minor-and-patch)",
+    )
+    BLOCKED = (
+        # Prefix confusion is not the Renovate namespace.
+        "renovated/x",
+        # The guard still bites outside every allowance clause.
+        "random-branch",
+    )
+
+    def test_runner_render_allows_renovate_branches(
+        self, rendered_portable: dict[str, Any]
+    ) -> None:
+        """The committed runner/scaffold pattern admits renovate/* only."""
+        pattern = _pattern_arg(
+            _normalize(rendered_portable["runner"])["hooks"]["no-commit-to-branch"]
+        )
+        for branch in self.ALLOWED:
+            assert re.match(pattern, branch) is None, f"{branch} must be allowed"
+        for branch in self.BLOCKED:
+            assert re.match(pattern, branch) is not None, f"{branch} must be blocked"
+
+    def test_consumer_surface_carries_renovate_allowance(
+        self, consumer_config: dict[str, Any]
+    ) -> None:
+        """The flake-generated (gitflow) guard carries the same clause."""
+        assert "(?!^renovate/.+$)" in _branch_guard(consumer_config)
+
+    def test_trunk_consumer_keeps_renovate_allowance(
+        self, trunk_consumer_config: dict[str, Any]
+    ) -> None:
+        """The trunk variant drops only the dev clause, never this one."""
+        assert "(?!^renovate/.+$)" in _branch_guard(trunk_consumer_config)
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
## Summary

Adds a `(?!^renovate/.+$)` allowance clause to the default `no-commit-to-branch` pattern in `branchNamePatternFor` (nix/hooks.nix — the one definition), regenerating both committed YAML artifacts in lockstep. The Renovate app commits server-side where hooks never run, but maintainer fix-up commits on `renovate/*` branches (changelog conflict merges, `dist/` rebuilds during batch weeks) were blocked, forcing the commit-on-a-compliant-branch-then-`git push HEAD:renovate/…` workaround. Renovate names carry no issue number and use a charset outside the slug rule (live: `renovate/github-actions-(minor-and-patch)`), so this is a dedicated namespace clause next to `worktree/<n>`, not a #1432 knob value.

## Changes

- `nix/hooks.nix`: clause in the base pattern string (gitflow AND trunk variants), header comment extended with the rationale
- `.pre-commit-config.yaml` + `assets/workspace/.pre-commit-config.yaml`: pattern + convention comment regenerated (drift-gated)
- `tests/test_flake_hooks.py`: `TestRenovateBranchAllowance` — regex semantics on the portable render (allowed: real Renovate names; blocked: `renovated/x` prefix confusion, non-compliant names) + clause presence on the gitflow and trunk consumer surfaces
- `CHANGELOG.md` (+ hook-synced mirror): Unreleased/Changed entry

## Test evidence

- TDD: new test class failed against the old pattern (`renovate/lock-file-maintenance must be allowed`), passes after the change
- `tests/test_flake_hooks.py`: 39 passed (incl. the portable-render drift gate over both YAMLs)
- `just precommit` fully green (sync-manifest changelog-mirror rewrite staged and converged)

Refs: #1433