### PR TITLE
feat(workspace): add branch-types knob (DEVKIT_BRANCH_TYPES) and CI branch-name gate

### DIFF
--- a/.claude/skills/branch-naming/SKILL.md
+++ b/.claude/skills/branch-naming/SKILL.md
@@ -65,6 +65,13 @@ Example: `chore/sync-main-to-dev`, `chore/update-dependencies`
 | release  | Yes            | Release preparation, version bumps, release notes                       |
 | chore   | No             | Maintenance tasks, syncing branches, dependency updates, routine work   |
 
+The issue-numbered type set is per-repo configurable: `DEVKIT_BRANCH_TYPES` in
+`.vig-os` replaces it (e.g. adding a project-specific `record` type), steering
+the local branch guard AND CI's branch-name gate from one key — check that
+file before proposing a type outside the table. The stock issue-numbered set
+is `feature,bugfix,hotfix,release,docs,test,refactor`
+([#1432](https://github.com/vig-os/devkit/issues/1432)).
+
 ## One-off branch name only
 
 When the user only wants a branch name suggestion (no "create" or "start work"), propose the name in the format above and do not run the full workflow.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -291,6 +291,36 @@ jobs:
           cachix-cache: ${{ vars.CACHIX_CACHE }}
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
+      # Branch-name gate (#1432 / #1430): the local no-commit-to-branch guard
+      # depends on core.hooksPath, which a fresh clone does not have — this
+      # step is the enforcement point that survives an un-initialised clone
+      # (the repo that defines the standard enforces it on itself). Devkit is
+      # the producer (no .vig-os), so the stock type set is inline; it must
+      # match nix/hooks.nix defaultBranchTypes. The allowed set is a SUPERSET
+      # of the local guard's: automation branches (release trains, Renovate,
+      # the worktree pipeline) never run local hooks but do open PRs. The head
+      # ref is attacker-controlled text, so it reaches the check via env,
+      # never inline ${{ }}.
+      - name: Validate branch name
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+          BRANCH_TYPES: feature,bugfix,hotfix,release,docs,test,refactor
+        run: |
+          set -euo pipefail
+          TYPES_ALTERNATION="${BRANCH_TYPES//,/|}"
+          ALLOWED="^(main|dev)$"
+          ALLOWED+="|^chore/[a-z0-9]+(-[a-z0-9]+)*$"
+          ALLOWED+="|^(${TYPES_ALTERNATION})/[0-9]+-[a-z0-9]+(-[a-z0-9]+)*$"
+          ALLOWED+="|^worktree/[0-9]+$"
+          ALLOWED+="|^renovate/.+$"
+          ALLOWED+="|^release/[0-9]+\.[0-9]+\.[0-9]+$"
+          if printf '%s' "${HEAD_REF}" | grep -qE "${ALLOWED}"; then
+            echo "Branch name OK: ${HEAD_REF}"
+          else
+            echo "::error::Branch name '${HEAD_REF}' does not follow the convention <type>/<issue>-<summary> (types: ${BRANCH_TYPES}) or chore/<summary>. See docs/COMMIT_MESSAGE_STANDARD.md and the branch-naming skill."
+            exit 1
+          fi
+
       # The PR title is attacker-controlled text, so it reaches the validator as
       # an environment variable — never interpolated into the shell command.
       # The range starts at the merge-base with the *current* base branch, not

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Branch-types knob (`DEVKIT_BRANCH_TYPES`) + CI branch-name gate** ([#1432](https://github.com/vig-os/devkit/issues/1432))
+  - New `.vig-os` key: a comma-separated full replacement of the
+    issue-numbered `<type>/<issue>-<summary>` branch-type set, rendered into
+    the scaffolded `no-commit-to-branch` pattern, the flake-generated
+    consumer surface (new `mkProjectShell` `branchTypes` argument; the
+    template `flake.nix` reads the key at eval time), and CI — one key, every
+    gate; the `chore/`, `renovate/`, `worktree/` clauses stay fixed
+  - New CI branch-name gate ([#1430](https://github.com/vig-os/devkit/issues/1430)):
+    the commit-checks lane now validates the PR head ref against the resolved
+    type set plus automation allowances (`release/X.Y.Z`, `renovate/*`,
+    `worktree/<n>`, bot `chore/` branches, `main`/`dev`) — enforcement that
+    survives a fresh clone whose local hooks are not yet wired
+    (`core.hooksPath`), also added to devkit's own CI
+  - Empty key keeps every render byte-identical; the value round-trips across
+    `--force` upgrades; out-of-charset values fail the scaffold (and
+    `nix develop`) loudly while CI falls back to the stock set with a
+    warning; dropping `release` prints a notice
 - **Scaffold-time commit-types knob (`DEVKIT_COMMIT_TYPES`)** ([#1431](https://github.com/vig-os/devkit/issues/1431))
   - New `.vig-os` key: a comma-separated full replacement of the approved
     commit types, rendered into the `validate-commit-msg` hook's `--types`

--- a/assets/init-workspace.sh
+++ b/assets/init-workspace.sh
@@ -346,6 +346,7 @@ MANIFEST_FEATURES_DISABLED="$(read_manifest_value "$VIG_OS_MANIFEST" DEVKIT_FEAT
 
 MANIFEST_REFS_POLICY="$(read_manifest_value "$VIG_OS_MANIFEST" DEVKIT_REFS_POLICY || true)"
 MANIFEST_COMMIT_TYPES="$(read_manifest_value "$VIG_OS_MANIFEST" DEVKIT_COMMIT_TYPES || true)"
+MANIFEST_BRANCH_TYPES="$(read_manifest_value "$VIG_OS_MANIFEST" DEVKIT_BRANCH_TYPES || true)"
 
 # devkit-upgrade knobs (#1296): runtime-only keys consumed by the scaffolded
 # devkit-upgrade.yml at run time (not rendered here) — read them solely to write
@@ -543,6 +544,41 @@ if [[ -n "$MANIFEST_COMMIT_TYPES" ]]; then
 fi
 # An all-blank value (e.g. `DEVKIT_COMMIT_TYPES= ,`) falls back to the default.
 RESOLVED_COMMIT_TYPES="${RESOLVED_COMMIT_TYPES:-$DEFAULT_COMMIT_TYPES}"
+
+# Branch types (#1432): DEVKIT_BRANCH_TYPES is a comma-separated (whitespace-
+# tolerant) FULL REPLACEMENT of the issue-numbered branch-type set in the
+# no-commit-to-branch pattern, steering the local guard, the flake consumer
+# surface (via the template flake.nix reader), and CI's branch-name gate from
+# this one key. The chore/renovate/worktree clauses are never knob-driven. The
+# value lands in a sed replacement AND a regex alternation, so the same strict
+# per-entry charset allowlist as DEVKIT_COMMIT_TYPES is load-bearing. Resolves
+# into RESOLVED_BRANCH_TYPES (stock set when the key is empty) for
+# render_branch_types.
+DEFAULT_BRANCH_TYPES="feature,bugfix,hotfix,release,docs,test,refactor"
+RESOLVED_BRANCH_TYPES=""
+if [[ -n "$MANIFEST_BRANCH_TYPES" ]]; then
+    IFS=',' read -ra _raw_btypes <<< "$MANIFEST_BRANCH_TYPES"
+    for _btype in "${_raw_btypes[@]}"; do
+        # Trim surrounding whitespace (leading + trailing).
+        _btype="${_btype#"${_btype%%[![:space:]]*}"}"
+        _btype="${_btype%"${_btype##*[![:space:]]}"}"
+        [[ -z "$_btype" ]] && continue
+        if [[ ! "$_btype" =~ ^[a-z][a-z0-9]*$ ]]; then
+            echo "Error: Invalid DEVKIT_BRANCH_TYPES in $VIG_OS_MANIFEST: $_btype (expected a comma-separated list of lowercase alphanumeric branch types, e.g. 'feature,bugfix,record')" >&2
+            exit 1
+        fi
+        RESOLVED_BRANCH_TYPES+="${RESOLVED_BRANCH_TYPES:+,}$_btype"
+    done
+    # Release-type notice (never abort — a deliberate removal is allowed, but
+    # never silent, mirroring the #1431 bot-type notice): the release feature
+    # works on release/X.Y.Z branches, and maintainers commonly type topic
+    # branches into a release PR as release/<issue>-<slug>.
+    if [[ -n "$RESOLVED_BRANCH_TYPES" && ",$RESOLVED_BRANCH_TYPES," != *",release,"* ]]; then
+        echo "Notice: DEVKIT_BRANCH_TYPES omits 'release' — release-typed topic branches will be rejected by the branch guard (#1432)." >&2
+    fi
+fi
+# An all-blank value (e.g. `DEVKIT_BRANCH_TYPES= ,`) falls back to the default.
+RESOLVED_BRANCH_TYPES="${RESOLVED_BRANCH_TYPES:-$DEFAULT_BRANCH_TYPES}"
 
 # Scaffold-drift gate (#1295): pure runtime toggle for the ci.yml scaffold-drift
 # job (empty resolves to the enabled `true` default). No scaffold render — the CI
@@ -1804,6 +1840,29 @@ render_commit_types() {
     echo "Rendered commit types: ${RESOLVED_COMMIT_TYPES}"
 }
 
+# Render the branch-types knob (#1432): DEVKIT_BRANCH_TYPES replaces the
+# issue-numbered alternation of the no-commit-to-branch pattern in the
+# scaffolded .pre-commit-config.yaml (guarded + resolved above; the IDENTICAL
+# set drives the flake consumer surface via the template flake.nix reader and
+# CI's branch-name gate via resolve-toolchain's `branch-types` output — keep in
+# lockstep). Empty/absent is a pure no-op, so a default scaffold stays
+# byte-identical. Plain (basic-regex) sed with a `#` delimiter (the
+# replacement contains `|`, literal in basic syntax), anchored on the literal
+# stock alternation + its `/[0-9]` suffix — the
+# single occurrence in the file, distinct from the other renders' anchors, so
+# all four compose. The anchor is the STOCK list, so this must run before any
+# future render that could rewrite it (it is the only one that does).
+render_branch_types() {
+    [[ -z "$MANIFEST_BRANCH_TYPES" ]] && return 0
+
+    local pc="$WORKSPACE_DIR/.pre-commit-config.yaml"
+    [[ -f "$pc" ]] || return 0
+
+    local alternation="${RESOLVED_BRANCH_TYPES//,/|}"
+    sed -i "s#(feature|bugfix|hotfix|release|docs|test|refactor)/\[0-9\]#(${alternation})/[0-9]#" "$pc"
+    echo "Rendered branch types: ${RESOLVED_BRANCH_TYPES}"
+}
+
 # Warn if forcing (prompt user) - show which files would be overwritten
 if [[ "$FORCE" == "true" ]]; then
     echo ""
@@ -2466,6 +2525,10 @@ fi
 # anchors) so the renders compose.
 render_refs_policy
 render_commit_types
+# Branch types (#1432): swaps the issue-numbered alternation of the branch
+# guard pattern — a distinct anchor from the three renders above, so all
+# compose. No-op for the default.
+render_branch_types
 
 # Persist the resolved manifest (#885). The scaffolded .vig-os is a managed
 # file (template-overwritten on upgrade), so the resolved delivery mode and
@@ -2535,6 +2598,12 @@ if [[ -f "$VIG_OS_MANIFEST" ]]; then
     # round-trips (like DEVKIT_FEATURES_DISABLED).
     if [[ -n "$MANIFEST_COMMIT_TYPES" ]]; then
         write_manifest_value DEVKIT_COMMIT_TYPES "$MANIFEST_COMMIT_TYPES"
+    fi
+    # Branch types (#1432): bare in the template (DEVKIT_BRANCH_TYPES=), so a
+    # consumer's replacement set is written back — else an upgrade silently
+    # resets the branch guard (and the CI branch-name gate) to the stock set.
+    if [[ -n "$MANIFEST_BRANCH_TYPES" ]]; then
+        write_manifest_value DEVKIT_BRANCH_TYPES "$MANIFEST_BRANCH_TYPES"
     fi
     # devkit-upgrade knobs (#1296): bare in the template (DEVKIT_AUTO_UPGRADE= /
     # DEVKIT_UPGRADE_EXCLUDE=), so a consumer's opt-out / exclusion list is read

--- a/assets/workspace/.claude/skills/branch-naming/SKILL.md
+++ b/assets/workspace/.claude/skills/branch-naming/SKILL.md
@@ -67,6 +67,13 @@ Example: `chore/sync-main-to-dev`, `chore/update-dependencies`
 | release  | Yes            | Release preparation, version bumps, release notes                       |
 | chore   | No             | Maintenance tasks, syncing branches, dependency updates, routine work   |
 
+The issue-numbered type set is per-repo configurable: `DEVKIT_BRANCH_TYPES` in
+`.vig-os` replaces it (e.g. adding a project-specific `record` type), steering
+the local branch guard AND CI's branch-name gate from one key — check that
+file before proposing a type outside the table. The stock issue-numbered set
+is `feature,bugfix,hotfix,release,docs,test,refactor`
+([#1432](https://github.com/vig-os/devkit/issues/1432)).
+
 ## One-off branch name only
 
 When the user only wants a branch name suggestion (no "create" or "start work"), propose the name in the format above and do not run the full workflow.

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Branch-types knob (`DEVKIT_BRANCH_TYPES`) + CI branch-name gate** ([#1432](https://github.com/vig-os/devkit/issues/1432))
+  - New `.vig-os` key: a comma-separated full replacement of the
+    issue-numbered `<type>/<issue>-<summary>` branch-type set, rendered into
+    the scaffolded `no-commit-to-branch` pattern, the flake-generated
+    consumer surface (new `mkProjectShell` `branchTypes` argument; the
+    template `flake.nix` reads the key at eval time), and CI — one key, every
+    gate; the `chore/`, `renovate/`, `worktree/` clauses stay fixed
+  - New CI branch-name gate ([#1430](https://github.com/vig-os/devkit/issues/1430)):
+    the commit-checks lane now validates the PR head ref against the resolved
+    type set plus automation allowances (`release/X.Y.Z`, `renovate/*`,
+    `worktree/<n>`, bot `chore/` branches, `main`/`dev`) — enforcement that
+    survives a fresh clone whose local hooks are not yet wired
+    (`core.hooksPath`), also added to devkit's own CI
+  - Empty key keeps every render byte-identical; the value round-trips across
+    `--force` upgrades; out-of-charset values fail the scaffold (and
+    `nix develop`) loudly while CI falls back to the stock set with a
+    warning; dropping `release` prints a notice
 - **Scaffold-time commit-types knob (`DEVKIT_COMMIT_TYPES`)** ([#1431](https://github.com/vig-os/devkit/issues/1431))
   - New `.vig-os` key: a comma-separated full replacement of the approved
     commit types, rendered into the `validate-commit-msg` hook's `--types`

--- a/assets/workspace/.github/actions/resolve-toolchain/action.yml
+++ b/assets/workspace/.github/actions/resolve-toolchain/action.yml
@@ -85,6 +85,13 @@ outputs:
       is absent/empty (or carries an out-of-charset value — fail-safe, the
       loud guard lives at the scaffold write path).
     value: ${{ steps.resolve.outputs.commit-types }}
+  branch-types:
+    description: >-
+      Comma-separated issue-numbered branch types from DEVKIT_BRANCH_TYPES for
+      the commit-checks branch-name gate. The stock set when the key is
+      absent/empty (or carries an out-of-charset value — fail-safe, the loud
+      guard lives at the scaffold write path).
+    value: ${{ steps.resolve.outputs.branch-types }}
   drift-check:
     description: >-
       Scaffold-drift gate toggle from DEVKIT_DRIFT_CHECK: `true` (default/absent)
@@ -111,6 +118,7 @@ runs:
         CI_RUNNER=""
         REFS_POLICY=""
         COMMIT_TYPES=""
+        BRANCH_TYPES=""
         DRIFT_CHECK=""
 
         if [[ -f .vig-os ]]; then
@@ -123,7 +131,7 @@ runs:
             [[ "$line" =~ ^[[:space:]]*# ]] && continue
 
             case "$line" in
-              DEVKIT_MODE=*|DEVKIT_VERSION=*|DEVCONTAINER_VERSION=*|DEVKIT_TAG_PREFIX=*|DEVKIT_FLOATING_TAGS=*|DEVKIT_CI_RUNNER=*|DEVKIT_REFS_POLICY=*|DEVKIT_COMMIT_TYPES=*|DEVKIT_DRIFT_CHECK=*)
+              DEVKIT_MODE=*|DEVKIT_VERSION=*|DEVCONTAINER_VERSION=*|DEVKIT_TAG_PREFIX=*|DEVKIT_FLOATING_TAGS=*|DEVKIT_CI_RUNNER=*|DEVKIT_REFS_POLICY=*|DEVKIT_COMMIT_TYPES=*|DEVKIT_BRANCH_TYPES=*|DEVKIT_DRIFT_CHECK=*)
                 key="${line%%=*}"
                 value="${line#*=}"
                 value="${value#"${value%%[![:space:]]*}"}"
@@ -144,6 +152,7 @@ runs:
                   DEVKIT_CI_RUNNER) CI_RUNNER="$value" ;;
                   DEVKIT_REFS_POLICY) REFS_POLICY="$value" ;;
                   DEVKIT_COMMIT_TYPES) COMMIT_TYPES="$value" ;;
+                  DEVKIT_BRANCH_TYPES) BRANCH_TYPES="$value" ;;
                   DEVKIT_DRIFT_CHECK) DRIFT_CHECK="$value" ;;
                 esac
                 ;;
@@ -231,6 +240,38 @@ runs:
         # An all-blank value falls back to the default (like DEVKIT_CI_RUNNER).
         RESOLVED_COMMIT_TYPES="${RESOLVED_COMMIT_TYPES:-$DEFAULT_COMMIT_TYPES}"
         echo "commit-types=$RESOLVED_COMMIT_TYPES" >> "$GITHUB_OUTPUT"
+
+        # Branch types (#1432): resolve DEVKIT_BRANCH_TYPES into the
+        # issue-numbered type set the commit-checks branch-name gate consumes.
+        # Single mapping point for the CI surface; MIRRORS render_branch_types
+        # in assets/init-workspace.sh (two renderers, one key — keep in
+        # lockstep). Same guard philosophy as commit-types above: the loud
+        # charset guard lives at the write path, here an out-of-charset entry
+        # falls back to the stock set with a warning (fail-safe: a broken
+        # value must never break — or weaken — the gate).
+        DEFAULT_BRANCH_TYPES="feature,bugfix,hotfix,release,docs,test,refactor"
+        RESOLVED_BRANCH_TYPES=""
+        if [[ -n "$BRANCH_TYPES" ]]; then
+          branch_types_valid=1
+          IFS=',' read -ra btype_entries <<< "$BRANCH_TYPES"
+          for entry in "${btype_entries[@]}"; do
+            entry="${entry#"${entry%%[![:space:]]*}"}"
+            entry="${entry%"${entry##*[![:space:]]}"}"
+            [[ -z "$entry" ]] && continue
+            if [[ ! "$entry" =~ ^[a-z][a-z0-9]*$ ]]; then
+              branch_types_valid=0
+              break
+            fi
+            RESOLVED_BRANCH_TYPES+="${RESOLVED_BRANCH_TYPES:+,}$entry"
+          done
+          if [[ "$branch_types_valid" -ne 1 ]]; then
+            echo "::warning::Invalid DEVKIT_BRANCH_TYPES in .vig-os ('$BRANCH_TYPES'); falling back to the default branch types."
+            RESOLVED_BRANCH_TYPES=""
+          fi
+        fi
+        # An all-blank value falls back to the default (like DEVKIT_CI_RUNNER).
+        RESOLVED_BRANCH_TYPES="${RESOLVED_BRANCH_TYPES:-$DEFAULT_BRANCH_TYPES}"
+        echo "branch-types=$RESOLVED_BRANCH_TYPES" >> "$GITHUB_OUTPUT"
 
         # Refs policy (#1282): map DEVKIT_REFS_POLICY to the --refs-optional-types
         # list validate-commit-range consumes in the commit-checks job. This is

--- a/assets/workspace/.github/workflows/ci.yml
+++ b/assets/workspace/.github/workflows/ci.yml
@@ -87,6 +87,9 @@ jobs:
       # Commit types (#1431): re-export the resolved approved-types list so
       # commit-checks can consume it via needs.
       commit-types: ${{ steps.resolve.outputs.commit-types }}
+      # Branch types (#1432): re-export the resolved branch-type set so the
+      # commit-checks branch-name gate can consume it via needs.
+      branch-types: ${{ steps.resolve.outputs.branch-types }}
       # Scaffold-drift gate (#1295): re-export the DEVKIT_DRIFT_CHECK toggle so
       # the scaffold-drift job's `if:` can self-skip when a consumer opts out,
       # plus the all-modes image ref it `docker run`s (keeps the ghcr literal in
@@ -220,6 +223,50 @@ jobs:
           devkit-version: ${{ needs.resolve-toolchain.outputs.image-tag }}
           cachix-cache: ${{ vars.CACHIX_CACHE }}
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
+      # Branch-name gate (#1432 / #1430): validate the PR head ref against the
+      # same branch-type set the local no-commit-to-branch guard renders from.
+      # The local hook depends on local git config a fresh clone does not have
+      # (core.hooksPath), so this is the enforcement point that survives an
+      # un-initialised clone. The allowed set is a SUPERSET of the local
+      # guard's: automation branches never run local hooks but do open PRs.
+      # The head ref is attacker-controlled text, so it reaches the check via
+      # env, never inline ${{ }} (the zizmor template-injection gate / #1279
+      # env-routing pattern); the type set is mapped once from
+      # DEVKIT_BRANCH_TYPES by resolve-toolchain.
+      - name: Validate branch name
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+          BRANCH_TYPES: ${{ needs.resolve-toolchain.outputs.branch-types }}
+        run: |
+          set -euo pipefail
+          TYPES_ALTERNATION="${BRANCH_TYPES//,/|}"
+          # Every alternative is individually ^...$-anchored:
+          #   main|dev                 long-lived branches (committing on them
+          #                            is allowed locally; a deliberate PR
+          #                            from one stays possible)
+          #   chore/<slug>             issue-less maintenance branches — also
+          #                            covers the sync-main-to-dev and
+          #                            devkit-upgrade bot branches
+          #   <type>/<issue>-<slug>    issue-numbered topic branches
+          #                            (DEVKIT_BRANCH_TYPES)
+          #   worktree/<n>             autonomous worktree pipeline
+          #   renovate/*               Renovate's namespace (#1433); free-form
+          #                            names (dots, parentheses)
+          #   release/X.Y.Z            release-train branches (prepare-release
+          #                            creates release/$VERSION, bare semver)
+          ALLOWED="^(main|dev)$"
+          ALLOWED+="|^chore/[a-z0-9]+(-[a-z0-9]+)*$"
+          ALLOWED+="|^(${TYPES_ALTERNATION})/[0-9]+-[a-z0-9]+(-[a-z0-9]+)*$"
+          ALLOWED+="|^worktree/[0-9]+$"
+          ALLOWED+="|^renovate/.+$"
+          ALLOWED+="|^release/[0-9]+\.[0-9]+\.[0-9]+$"
+          if printf '%s' "${HEAD_REF}" | grep -qE "${ALLOWED}"; then
+            echo "Branch name OK: ${HEAD_REF}"
+          else
+            echo "::error::Branch name '${HEAD_REF}' does not follow the convention <type>/<issue>-<summary> (types: ${BRANCH_TYPES}) or chore/<summary>. See docs/COMMIT_MESSAGE_STANDARD.md and the branch-naming skill."
+            exit 1
+          fi
 
       # The PR title is attacker-controlled text, so it reaches the validator as
       # an environment variable — never interpolated into the shell command.

--- a/assets/workspace/.vig-os
+++ b/assets/workspace/.vig-os
@@ -105,6 +105,20 @@ DEVKIT_REFS_POLICY=
 # output); written back only for a non-empty value (#1431).
 DEVKIT_COMMIT_TYPES=
 
+# Issue-numbered branch types for the branch guard — a comma-separated
+# (whitespace-tolerant) FULL REPLACEMENT of the `<type>/<issue>-<summary>` set,
+# driving the local no-commit-to-branch hook, the flake-generated consumer
+# surface (read by flake.nix at eval time), and CI's branch-name gate from this
+# one key. Empty (default) resolves to the stock set
+# (feature,bugfix,hotfix,release,docs,test,refactor) — unchanged for devkit or
+# existing consumers. The `chore/<summary>`, `renovate/*`, and
+# `worktree/<issue>` clauses are never knob-driven. Lowercase alphanumerics
+# only (guarded loudly at scaffold time; the scaffold prints a notice when
+# `release` is dropped). Realized at scaffold time (an anchored render of the
+# hook pattern + resolve-toolchain's `branch-types` output); written back only
+# for a non-empty value (#1432).
+DEVKIT_BRANCH_TYPES=
+
 # Auto-upgrade opt-out for the scaffolded devkit-upgrade.yml workflow. Empty
 # (default) or any value other than `false` keeps the WEEKLY schedule path
 # enabled — it polls devkit's latest release and, when this repo's DEVKIT_VERSION

--- a/assets/workspace/flake.nix
+++ b/assets/workspace/flake.nix
@@ -50,24 +50,40 @@
           # add project tools here
         ];
 
-        # Workflow model (#1224): read DEVKIT_WORKFLOW from .vig-os and forward
-        # it to mkProjectShell so the flake-generated pre-commit branch guard
-        # follows the model — a `trunk` workspace drops the dev-branch clause,
-        # mirroring the scaffolded .pre-commit-config.yaml. `gitflow` (the
-        # default) and an absent/blank value are inert. Managed line; leave it.
-        workflow =
+        # Devkit knobs read from .vig-os (#1224, #1432): the flake-generated
+        # pre-commit branch guard follows the workspace manifest, mirroring
+        # the scaffolded .pre-commit-config.yaml renders. Managed block;
+        # leave it.
+        vigOsValue =
+          key:
           let
             vigOsPath = self + "/.vig-os";
-            declared = builtins.filter (l: nixpkgs.lib.hasPrefix "DEVKIT_WORKFLOW=" l) (
+            declared = builtins.filter (l: nixpkgs.lib.hasPrefix "${key}=" l) (
               nixpkgs.lib.splitString "\n" (builtins.readFile vigOsPath)
             );
-            value =
-              if declared == [ ] then
-                ""
-              else
-                nixpkgs.lib.removePrefix "DEVKIT_WORKFLOW=" (builtins.head declared);
           in
-          if builtins.pathExists vigOsPath && value == "trunk" then "trunk" else "gitflow";
+          if !builtins.pathExists vigOsPath || declared == [ ] then
+            ""
+          else
+            nixpkgs.lib.removePrefix "${key}=" (builtins.head declared);
+
+        # Workflow model (#1224): a `trunk` workspace drops the dev-branch
+        # clause. `gitflow` (the default) and an absent/blank value are inert.
+        workflow = if vigOsValue "DEVKIT_WORKFLOW" == "trunk" then "trunk" else "gitflow";
+
+        # Branch-type set (#1432): DEVKIT_BRANCH_TYPES (comma-separated)
+        # replaces the issue-numbered alternation of the branch guard;
+        # absent/blank forwards null (= the stock set). Whitespace around
+        # entries is trimmed; validation (charset, non-empty) lives in
+        # mkProjectShell, which fails eval loudly on a bad value.
+        branchTypes =
+          let
+            raw = vigOsValue "DEVKIT_BRANCH_TYPES";
+            entries = builtins.filter (t: t != "") (
+              map (t: nixpkgs.lib.trim t) (nixpkgs.lib.splitString "," raw)
+            );
+          in
+          if entries == [ ] then null else entries;
       in
       {
         # The dev shell = the shared vigOS toolchain + your extras.
@@ -108,6 +124,10 @@
           // nixpkgs.lib.optionalAttrs (builtins.functionArgs vigos.lib.mkProjectShell ? workflow) {
             # Branch guard follows the workspace workflow model (#1224).
             inherit workflow;
+          }
+          // nixpkgs.lib.optionalAttrs (builtins.functionArgs vigos.lib.mkProjectShell ? branchTypes) {
+            # Branch guard follows the workspace branch-type set (#1432).
+            inherit branchTypes;
           }
         );
 

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -392,6 +392,7 @@ unknown keys:
 | `DEVKIT_FEATURES_DISABLED` | Comma-separated scaffold feature groups this repo opts OUT of; empty (default) => every group is scaffolded. A disabled group is never shipped and a prior scaffold's copy is pruned on upgrade (see [Scaffold feature opt-outs](#scaffold-feature-opt-outs), [#1284](https://github.com/vig-os/devkit/issues/1284)) |
 | `DEVKIT_REFS_POLICY` | Refs-line enforcement policy driving both the `validate-commit-msg` hook and CI's `validate-commit-range`: `chore-optional` (default/empty — only `chore` may omit `Refs:`) \| `optional` (never required) \| `required` (every type needs `Refs:`) ([#1282](https://github.com/vig-os/devkit/issues/1282)) |
 | `DEVKIT_COMMIT_TYPES` | Comma-separated FULL REPLACEMENT of the approved commit types, driving both the `validate-commit-msg` hook's `--types` and CI's `validate-commit-range`; empty (default) => the stock 11 types. Lowercase alphanumerics only; keep `chore`/`build` unless deliberate (bot commits — the scaffold prints a notice). `DEVKIT_REFS_POLICY=optional` mirrors this list ([#1431](https://github.com/vig-os/devkit/issues/1431)) |
+| `DEVKIT_BRANCH_TYPES` | Comma-separated FULL REPLACEMENT of the issue-numbered `<type>/<issue>-<summary>` branch-type set, driving the local `no-commit-to-branch` guard, the flake-generated consumer surface, and CI's branch-name gate; empty (default) => the stock set (`feature,bugfix,hotfix,release,docs,test,refactor`). The `chore/`, `renovate/`, `worktree/` clauses are never knob-driven. Pre-#1432 direnv consumers hand-port the flake reader (see [Custom branch types on the flake surface](#custom-branch-types-on-the-flake-surface-direnv-consumers), [#1432](https://github.com/vig-os/devkit/issues/1432)) |
 | `DEVKIT_AUTO_UPGRADE` | Opt-out for the scaffolded `devkit-upgrade.yml` weekly schedule; empty (default) or any value but `false` keeps the auto-adoption poll on. `false` disables only the schedule — manual `workflow_dispatch` always runs ([#1296](https://github.com/vig-os/devkit/issues/1296)) |
 | `DEVKIT_UPGRADE_EXCLUDE` | Comma-separated (whitespace-tolerant) paths the `devkit-upgrade` workflow resets before the adoption commit, so generated-doc churn never rides along in the upgrade diff; empty (default) => no exclusions ([#1296](https://github.com/vig-os/devkit/issues/1296)) |
 
@@ -476,6 +477,30 @@ How it behaves:
   the hook stack and upgrade path but drops the team/traceability layer. See
   [`docs/SOLO_ADOPTION.md`](./SOLO_ADOPTION.md)
   ([#1285](https://github.com/vig-os/devkit/issues/1285)).
+
+### Custom branch types on the flake surface (direnv consumers)
+
+`DEVKIT_BRANCH_TYPES` reaches the **scaffolded** `.pre-commit-config.yaml` and
+**CI's branch-name gate** automatically on re-scaffold/upgrade. The
+**flake-generated** consumer surface (direnv repos that opted into
+`mkProjectShell`'s `hooks`) reads the key at eval time through the project's
+own `flake.nix` — a **scaffold-once file the upgrade never overwrites**. New
+scaffolds ship the reader; a repo whose `flake.nix` predates #1432 ports it by
+hand (the same one-time port as the #1224 `workflow` forwarding):
+
+1. Copy the managed `vigOsValue` / `workflow` / `branchTypes` `let`-block from
+   the current template
+   ([`assets/workspace/flake.nix`](https://github.com/vig-os/devkit/blob/main/assets/workspace/flake.nix))
+   over your existing `workflow` reader.
+2. Copy the two `nixpkgs.lib.optionalAttrs (builtins.functionArgs … )`
+   forwarding blocks after the `mkProjectShell` argument set. The
+   `functionArgs` guard keeps older pinned devkits evaluating (they fall back
+   to the stock set instead of failing).
+
+Without the port the knob still works everywhere except the locally generated
+guard — which then keeps the stock set, and the loud signal comes from CI's
+gate instead. Validation is eval-time and loud: a bad entry (charset, empty
+list) fails `nix develop` with a `branchTypes` message.
 
 ## What a consumer needs to know
 

--- a/flake.nix
+++ b/flake.nix
@@ -251,6 +251,14 @@
           # scaffold template reads this from the workspace `.vig-os`
           # DEVKIT_WORKFLOW and forwards it here. Inert for gitflow.
           workflow ? "gitflow",
+          # Branch-type set (#1432): null (default) keeps the stock
+          # issue-numbered alternation in the flake-generated branch guard; a
+          # list of type strings replaces it, mirroring what
+          # render_branch_types does to the scaffolded config. The scaffold
+          # template reads this from the workspace `.vig-os`
+          # DEVKIT_BRANCH_TYPES and forwards it here. Validated below —
+          # entries reach a regex alternation, so the charset is load-bearing.
+          branchTypes ? null,
           shellHook ? ''echo "devcontainer dev environment loaded (nix)"'',
           # Overridable CPython (#1038). Defaults to the pinned 3.14 so the
           # zero-argument shell is byte-identical to the pre-#1038 builder
@@ -349,7 +357,7 @@
           # tests/test_flake_devshell.py, tests/test_flake_hooks.py).
           # ------------------------------------------------------------------
           hooksEnabled = hooks != null || hooksExcludes != [ ];
-          consumerHooksBase = hooksModule.consumer pkgs workflow;
+          consumerHooksBase = hooksModule.consumer pkgs workflow branchTypes;
           # Base values at priority 999: they beat git-hooks.nix's own
           # built-in hook defaults (mkDefault, 1000 — equal priorities would
           # conflict, e.g. the built-in nixfmt entry vs the base one) and
@@ -601,6 +609,19 @@
           "gitflow"
           "trunk"
         ]) "mkProjectShell: workflow must be \"gitflow\" or \"trunk\", got \"${workflow}\"";
+        # branchTypes (#1432): entries land inside the branch guard's regex
+        # alternation, so refuse anything but a non-empty list of lowercase
+        # alphanumeric type names — loudly, at eval time.
+        assert pkgs.lib.assertMsg
+          (
+            branchTypes == null
+            || (
+              builtins.isList branchTypes
+              && branchTypes != [ ]
+              && builtins.all (t: builtins.isString t && builtins.match "[a-z][a-z0-9]*" t != null) branchTypes
+            )
+          )
+          "mkProjectShell: branchTypes must be null or a non-empty list of lowercase alphanumeric type names (e.g. [ \"feature\" \"record\" ]), got ${builtins.toJSON branchTypes}";
         pkgs.mkShell (
           # Module env first: the builder's attrset below wins any collision,
           # so a capability module can never break the Python bootstrap pins

--- a/nix/hooks.nix
+++ b/nix/hooks.nix
@@ -42,14 +42,30 @@ let
   # dist/ rebuilds) are a legitimate local flow. Permissive `.+` after the
   # prefix — Renovate composes names from dep names/version ranges (dots,
   # parentheses), so a charset pin would re-break on the next scheme.
+  # Issue-numbered branch-type set (#1432): the ONLY knob-driven clause of the
+  # pattern — DEVKIT_BRANCH_TYPES replaces this list (scaffold path:
+  # render_branch_types in assets/init-workspace.sh; flake path:
+  # mkProjectShell's `branchTypes`). The chore/renovate/worktree clauses stay
+  # fixed. The default must render the pattern byte-identically to the
+  # pre-#1432 literal (drift gate + zero-hooks parity).
+  defaultBranchTypes = [
+    "feature"
+    "bugfix"
+    "hotfix"
+    "release"
+    "docs"
+    "test"
+    "refactor"
+  ];
   branchNamePatternFor =
-    workflow:
+    workflow: branchTypes:
     let
       devClause = lib.optionalString (workflow != "trunk") "(?!dev$)";
+      typesAlternation = lib.concatStringsSep "|" branchTypes;
     in
-    "^(?!main$)${devClause}(?!^(chore)/[a-z0-9]+(-[a-z0-9]+)*$)(?!^(feature|bugfix|hotfix|release|docs|test|refactor)/[0-9]+-[a-z0-9]+(-[a-z0-9]+)*$)(?!^renovate/.+$)(?!^worktree/[0-9]+$).+$";
+    "^(?!main$)${devClause}(?!^(chore)/[a-z0-9]+(-[a-z0-9]+)*$)(?!^(${typesAlternation})/[0-9]+-[a-z0-9]+(-[a-z0-9]+)*$)(?!^renovate/.+$)(?!^worktree/[0-9]+$).+$";
   # The gitflow default, used by the committed runner/scaffold YAML renders.
-  branchNamePattern = branchNamePatternFor "gitflow";
+  branchNamePattern = branchNamePatternFor "gitflow" defaultBranchTypes;
 
   # Top-level exclude — one regex string in the committed YAML, a list for
   # git-hooks.nix (which joins with `|`). Same paths, two spellings.
@@ -832,18 +848,26 @@ in
   # gitflow the override is a no-op, so the generated config stays byte-identical
   # to the pre-#1224 render (zero-hooks parity + consumer-surface tests).
   consumer =
-    pkgs: workflow:
+    pkgs: workflow: branchTypes:
     let
       base = collectFor "consumer" "consumerName" pkgs;
+      # Effective guard pattern for this consumer: workflow (#1224) and
+      # branch-types (#1432) both feed one computation. Override the base
+      # hook only when the result differs from the gitflow default, so a
+      # default consumer's generated config stays byte-identical to the
+      # pre-#1224/pre-#1432 render (zero-hooks parity + consumer-surface
+      # tests).
+      effectiveTypes = if branchTypes == null then defaultBranchTypes else branchTypes;
+      effectivePattern = branchNamePatternFor workflow effectiveTypes;
     in
     {
       excludes = baseExcludes;
       hooks =
         base
-        // lib.optionalAttrs (workflow == "trunk") {
+        // lib.optionalAttrs (effectivePattern != branchNamePattern) {
           no-commit-to-branch = base.no-commit-to-branch // {
             settings = base.no-commit-to-branch.settings // {
-              pattern = [ (branchNamePatternFor "trunk") ];
+              pattern = [ effectivePattern ];
             };
           };
         };

--- a/tests/bats/init-workspace.bats
+++ b/tests/bats/init-workspace.bats
@@ -2302,10 +2302,10 @@ _upgrade_no_flags() {
     done
 }
 
-@test "template .vig-os ships every optional knob key empty (#1173, #1228, #1282, #1295, #1284, #1431)" {
+@test "template .vig-os ships every optional knob key empty (#1173, #1228, #1282, #1295, #1284, #1431, #1432)" {
     local keys=(DEVKIT_CI_RUNNER DEVKIT_SYNC_TARGET DEVKIT_SYNC_SCHEDULE
         DEVKIT_REFS_POLICY DEVKIT_DRIFT_CHECK DEVKIT_FEATURES_DISABLED
-        DEVKIT_COMMIT_TYPES)
+        DEVKIT_COMMIT_TYPES DEVKIT_BRANCH_TYPES)
     for key in "${keys[@]}"; do
         echo "key: $key"
         run grep -x "${key}=" "$TEMPLATE_DIR/.vig-os"
@@ -2383,7 +2383,7 @@ _upgrade_no_flags() {
     assert_failure
 }
 
-@test "invalid or hostile .vig-os knob values fail the scaffold loudly (#1228, #1282, #1295, #1284, #1431)" {
+@test "invalid or hostile .vig-os knob values fail the scaffold loudly (#1228, #1282, #1295, #1284, #1431, #1432)" {
     # KEY|VALUE table of rejected values, each asserted against the clean
     # "Invalid <KEY>" message. The hostile SYNC_TARGET row: git
     # check-ref-format alone accepts quotes/$/backticks/;/|/# — values that
@@ -2408,6 +2408,10 @@ _upgrade_no_flags() {
         # case/punctuation, not just hostile shell (#1431).
         'DEVKIT_COMMIT_TYPES|feat,Bad-Type'
         'DEVKIT_COMMIT_TYPES|feat;rm -rf /'
+        # Branch-type values additionally land inside a regex alternation, so
+        # the same allowlist guards render_branch_types (#1432).
+        'DEVKIT_BRANCH_TYPES|feature,Bad-Type'
+        'DEVKIT_BRANCH_TYPES|feature|record'
     )
     local i=0
     for row in "${rows[@]}"; do
@@ -2662,6 +2666,76 @@ _upgrade_no_flags() {
     run _upgrade_no_flags "$ws"
     assert_success
     assert_output --partial "Notice: DEVKIT_COMMIT_TYPES omits"
+}
+
+# ── Branch types knob (#1432) ─────────────────────────────────────────────────
+# DEVKIT_BRANCH_TYPES replaces the issue-numbered branch-type set in the
+# no-commit-to-branch pattern at scaffold time (the CI branch-name gate is
+# driven from the same key via resolve-toolchain, covered in
+# tests/test_ci_runner.py; the flake consumer surface in
+# tests/test_flake_hooks.py). Empty (default) keeps the stock alternation
+# byte-identical; the chore/renovate/worktree clauses are never knob-driven.
+# Persisted like DEVKIT_COMMIT_TYPES; invalid values fail loudly (knob loop
+# above).
+
+STOCK_BRANCH_ALTERNATION='(feature|bugfix|hotfix|release|docs|test|refactor)'
+
+@test "default scaffold keeps the stock branch-type alternation (#1432)" {
+    ws="$BATS_TEST_TMPDIR/e2e-1432-default"
+    mkdir -p "$ws"
+    run _scaffold both "$ws"
+    assert_success
+    run grep -qF "${STOCK_BRANCH_ALTERNATION}/[0-9]" "$ws/.pre-commit-config.yaml"
+    assert_success
+}
+
+@test "DEVKIT_BRANCH_TYPES renders the custom alternation + writes back (#1432)" {
+    ws="$BATS_TEST_TMPDIR/e2e-1432-custom"
+    mkdir -p "$ws"
+    run _scaffold both "$ws"
+    assert_success
+    sed -i 's/^DEVKIT_BRANCH_TYPES=.*/DEVKIT_BRANCH_TYPES=feature,bugfix,hotfix,release,docs,test,refactor,record/' "$ws/.vig-os"
+    run _upgrade_no_flags "$ws"
+    assert_success
+    run grep -qF '(feature|bugfix|hotfix|release|docs|test|refactor|record)/[0-9]' "$ws/.pre-commit-config.yaml"
+    assert_success
+    # The stock alternation is gone (replaced, not duplicated).
+    run grep -qF "${STOCK_BRANCH_ALTERNATION}/[0-9]" "$ws/.pre-commit-config.yaml"
+    assert_failure
+    run grep -x 'DEVKIT_BRANCH_TYPES=feature,bugfix,hotfix,release,docs,test,refactor,record' "$ws/.vig-os"
+    assert_success
+}
+
+@test "DEVKIT_BRANCH_TYPES composes with the trunk workflow render (#1432)" {
+    # render_workflow_model deletes the `(?!dev$)` clause; render_branch_types
+    # swaps the alternation — distinct anchors on the same pattern line, both
+    # must apply.
+    ws="$BATS_TEST_TMPDIR/e2e-1432-trunk"
+    mkdir -p "$ws"
+    run _scaffold both "$ws"
+    assert_success
+    sed -i 's/^DEVKIT_WORKFLOW=.*/DEVKIT_WORKFLOW=trunk/' "$ws/.vig-os"
+    sed -i 's/^DEVKIT_BRANCH_TYPES=.*/DEVKIT_BRANCH_TYPES=feature,bugfix,record/' "$ws/.vig-os"
+    run _upgrade_no_flags "$ws"
+    assert_success
+    run grep -qF '(feature|bugfix|record)/[0-9]' "$ws/.pre-commit-config.yaml"
+    assert_success
+    run grep -qF '(?!dev$)' "$ws/.pre-commit-config.yaml"
+    assert_failure
+}
+
+@test "dropping the release branch type prints a notice, never aborts (#1432)" {
+    # The release train forks release/X.Y.Z branches; a maintainer using
+    # release-typed topic branches loses them from the local guard. Deliberate
+    # is allowed — but never silent (mirrors the #1431 bot-type notice).
+    ws="$BATS_TEST_TMPDIR/e2e-1432-release-notice"
+    mkdir -p "$ws"
+    run _scaffold both "$ws"
+    assert_success
+    sed -i 's/^DEVKIT_BRANCH_TYPES=.*/DEVKIT_BRANCH_TYPES=feature,bugfix,record/' "$ws/.vig-os"
+    run _upgrade_no_flags "$ws"
+    assert_success
+    assert_output --partial "Notice: DEVKIT_BRANCH_TYPES omits"
 }
 
 # ── scaffold-drift opt-out knob (#1295) ───────────────────────────────────────

--- a/tests/test_ci_runner.py
+++ b/tests/test_ci_runner.py
@@ -16,6 +16,8 @@ Refs: #1173
 from __future__ import annotations
 
 import json
+import os
+import subprocess
 from typing import TYPE_CHECKING
 
 import pytest
@@ -265,3 +267,153 @@ def test_commit_checks_step_passes_types_flag() -> None:
     workflow = _load(WORKFLOWS / "ci.yml")
     step = _commit_checks_step(workflow)
     assert '--types "${COMMIT_TYPES}"' in step["run"]
+
+
+# ── Branch types knob + CI branch-name gate (#1432 / #1430) ───────────────────
+# DEVKIT_BRANCH_TYPES replaces the issue-numbered branch-type set that the
+# local no-commit-to-branch guard renders from, and — because the local hook
+# depends on local git config that a fresh clone does not have (#1430) — the
+# same resolved set drives a CI branch-name gate: a commit-checks step
+# validating the PR head ref. The list->output mapping lives once in
+# resolve-toolchain and mirrors render_branch_types in init-workspace.sh; the
+# step consumes the head ref and the list via env, never inline (zizmor /
+# #1279). The CI allowance set is a SUPERSET of the local hook's: automation
+# branches (release/X.Y.Z, renovate/*, chore/<slug> bot branches, worktree/<n>)
+# never run local hooks but do open PRs.
+
+# The default issue-numbered branch types emitted when the key is absent.
+DEFAULT_BRANCH_TYPES = "feature,bugfix,hotfix,release,docs,test,refactor"
+
+# The commit-checks step that validates the PR head ref.
+BRANCH_NAME_STEP = "Validate branch name"
+
+
+@pytest.mark.parametrize(
+    ("types_value", "expected"),
+    [
+        pytest.param(None, DEFAULT_BRANCH_TYPES, id="key-absent-defaults"),
+        pytest.param(
+            "feature,bugfix,record", "feature,bugfix,record", id="custom-list"
+        ),
+        pytest.param(
+            "feature, bugfix, record",
+            "feature,bugfix,record",
+            id="whitespace-trimmed",
+        ),
+        # The loud guard lives at the write path (init-workspace.sh); by the
+        # time CI reads .vig-os the value was validated at scaffold, so a
+        # defensive fallback keeps CI from breaking (or weakening the gate) on
+        # an unexpected literal.
+        pytest.param("feature,Bad-Type", DEFAULT_BRANCH_TYPES, id="invalid-falls-back"),
+        pytest.param(" ,", DEFAULT_BRANCH_TYPES, id="all-blank-falls-back"),
+    ],
+)
+def test_branch_types_mapping(
+    tmp_path: Path, types_value: str | None, expected: str
+) -> None:
+    """DEVKIT_BRANCH_TYPES maps to the resolved branch-types list."""
+    manifest = "DEVKIT_MODE=direnv\n"
+    if types_value is not None:
+        manifest += f"DEVKIT_BRANCH_TYPES={types_value}\n"
+    outputs = _run_resolve(tmp_path, manifest)
+    assert outputs["branch-types"] == expected
+
+
+def test_resolve_toolchain_job_reexports_branch_types() -> None:
+    """ci.yml's resolve-toolchain job maps the action output to a job output."""
+    workflow = _load(WORKFLOWS / "ci.yml")
+    outputs = workflow["jobs"]["resolve-toolchain"]["outputs"]
+    assert outputs.get("branch-types") == "${{ steps.resolve.outputs.branch-types }}"
+
+
+def _branch_name_step(workflow: dict) -> dict:
+    for step in workflow["jobs"]["commit-checks"]["steps"]:
+        if step.get("name") == BRANCH_NAME_STEP:
+            return step
+    raise AssertionError(f"commit-checks step {BRANCH_NAME_STEP!r} not found")
+
+
+def test_branch_name_step_routes_inputs_through_env() -> None:
+    """The gate reads the head ref and the resolved types via env, not inline.
+
+    The head ref is attacker-controlled text; inline ``${{ }}`` in the run
+    block is the template-injection shape the zizmor gate exists to refuse.
+    """
+    workflow = _load(WORKFLOWS / "ci.yml")
+    step = _branch_name_step(workflow)
+    env_values = step["env"].values()
+    assert "${{ github.head_ref }}" in env_values
+    assert "${{ needs.resolve-toolchain.outputs.branch-types }}" in env_values
+    assert "${{" not in step["run"]
+
+
+def test_branch_name_step_precedes_commit_validation() -> None:
+    """The cheap head-ref check fails fast, before the range walk."""
+    workflow = _load(WORKFLOWS / "ci.yml")
+    names = [step.get("name") for step in workflow["jobs"]["commit-checks"]["steps"]]
+    assert names.index(BRANCH_NAME_STEP) < names.index(COMMIT_CHECKS_STEP)
+
+
+def _run_branch_gate(head_ref: str, branch_types: str) -> int:
+    """Execute the gate step's real bash against a head ref; return exit code."""
+    workflow = _load(WORKFLOWS / "ci.yml")
+    step = _branch_name_step(workflow)
+    result = subprocess.run(
+        ["bash", "-c", step["run"]],
+        env={
+            **os.environ,
+            "HEAD_REF": head_ref,
+            "BRANCH_TYPES": branch_types,
+        },
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    return result.returncode
+
+
+@pytest.mark.parametrize(
+    "head_ref",
+    [
+        # Human topic branches (the local hook's own shapes).
+        pytest.param("feature/12-x", id="feature"),
+        pytest.param("chore/foo-bar", id="chore-slug"),
+        pytest.param("worktree/9", id="worktree"),
+        # Long-lived branches: the local hook allows committing on them, so a
+        # deliberate PR from one stays possible.
+        pytest.param("dev", id="dev"),
+        pytest.param("main", id="main"),
+        # Automation branches that never run local hooks but do open PRs.
+        pytest.param("release/1.7.1", id="release-train"),
+        pytest.param("renovate/lock-file-maintenance", id="renovate"),
+        pytest.param("renovate/github-actions-(minor-and-patch)", id="renovate-parens"),
+        pytest.param("chore/sync-main-to-dev-123-1", id="sync-bot"),
+        pytest.param("chore/devkit-1-7-1", id="upgrade-bot"),
+    ],
+)
+def test_branch_gate_allows(head_ref: str) -> None:
+    """The default gate admits every conforming and automation head ref."""
+    assert _run_branch_gate(head_ref, DEFAULT_BRANCH_TYPES) == 0
+
+
+@pytest.mark.parametrize(
+    "head_ref",
+    [
+        # The #1430 incident literal: `feat` is a commit type, not a branch type.
+        pytest.param("feat/rust-language-pack", id="feat-prefix"),
+        pytest.param("random-branch", id="no-convention"),
+        pytest.param("record/54-x", id="record-not-in-defaults"),
+        pytest.param("release/1.7", id="release-partial-version"),
+        pytest.param("renovated/x", id="renovate-prefix-confusion"),
+    ],
+)
+def test_branch_gate_rejects(head_ref: str) -> None:
+    """The default gate refuses non-conforming head refs."""
+    assert _run_branch_gate(head_ref, DEFAULT_BRANCH_TYPES) == 1
+
+
+def test_branch_gate_follows_custom_types() -> None:
+    """A custom DEVKIT_BRANCH_TYPES steers the gate like the local guard."""
+    custom = DEFAULT_BRANCH_TYPES + ",record"
+    assert _run_branch_gate("record/54-x", custom) == 0
+    assert _run_branch_gate("record/no-issue", custom) == 1

--- a/tests/test_flake_hooks.py
+++ b/tests/test_flake_hooks.py
@@ -381,7 +381,13 @@ def _consumer_config_set() -> dict[str, dict[str, Any]]:
     # a JSON superset that treats them as comments, so parse with yaml.
     return {
         name: yaml.safe_load((root / name).read_text())
-        for name in ("customized", "gitleaks", "trunk")
+        for name in (
+            "customized",
+            "gitleaks",
+            "trunk",
+            "branchtypes",
+            "branchtypes-trunk",
+        )
     }
 
 

--- a/tests/test_flake_hooks.py
+++ b/tests/test_flake_hooks.py
@@ -349,11 +349,24 @@ def _consumer_config_set() -> dict[str, dict[str, Any]]:
         workflow = "trunk";
         hooks = {{ }};
       }};
+      branchtypes = flake.lib.mkProjectShell {{
+        inherit pkgs;
+        hooks = {{ }};
+        branchTypes = [ "feature" "bugfix" "hotfix" "release" "docs" "test" "refactor" "record" ];
+      }};
+      branchtypes-trunk = flake.lib.mkProjectShell {{
+        inherit pkgs;
+        workflow = "trunk";
+        hooks = {{ }};
+        branchTypes = [ "feature" "bugfix" "record" ];
+      }};
     in
     pkgs.linkFarm "consumer-hook-configs" [
       {{ name = "customized"; path = customized.hooksConfigFile; }}
       {{ name = "gitleaks"; path = gitleaks.hooksConfigFile; }}
       {{ name = "trunk"; path = trunk.hooksConfigFile; }}
+      {{ name = "branchtypes"; path = branchtypes.hooksConfigFile; }}
+      {{ name = "branchtypes-trunk"; path = branchtypes-trunk.hooksConfigFile; }}
     ]
     """
     result = _run_nix(
@@ -541,6 +554,88 @@ class TestRenovateBranchAllowance:
     ) -> None:
         """The trunk variant drops only the dev clause, never this one."""
         assert "(?!^renovate/.+$)" in _branch_guard(trunk_consumer_config)
+
+
+@pytest.fixture(scope="module")
+def branch_types_config() -> dict[str, Any]:
+    """Generated config for a consumer passing a custom ``branchTypes`` (#1432)."""
+    return _consumer_config_set()["branchtypes"]
+
+
+@pytest.fixture(scope="module")
+def branch_types_trunk_config() -> dict[str, Any]:
+    """Custom ``branchTypes`` composed with ``workflow = "trunk"`` (#1432)."""
+    return _consumer_config_set()["branchtypes-trunk"]
+
+
+class TestBranchTypesKnob:
+    """mkProjectShell's ``branchTypes`` argument (#1432).
+
+    ``DEVKIT_BRANCH_TYPES`` steers the issue-numbered alternation of the
+    branch guard. The scaffolded YAML render is covered in bats; here the
+    flake-generated consumer surface must follow the same set — the template
+    flake.nix reads the key from ``.vig-os`` and forwards it, mirroring the
+    #1224 ``workflow`` threading. Null (the default) keeps the stock
+    alternation byte-identical, so the drift gate and the zero-hooks parity
+    stay green.
+    """
+
+    STOCK_ALTERNATION = "(feature|bugfix|hotfix|release|docs|test|refactor)"
+
+    def test_custom_types_extend_alternation(
+        self, branch_types_config: dict[str, Any]
+    ) -> None:
+        """The custom set renders into the issue-numbered alternation."""
+        entry = _branch_guard(branch_types_config)
+        assert "(feature|bugfix|hotfix|release|docs|test|refactor|record)" in entry
+
+    def test_custom_types_regex_semantics(
+        self, branch_types_config: dict[str, Any]
+    ) -> None:
+        """``record/<issue>-<slug>`` commits pass; issue-less record stays blocked."""
+        pattern = _branch_guard(branch_types_config).split("--pattern ")[1]
+        assert re.match(pattern, "record/54-supplier-x") is None
+        assert re.match(pattern, "record/no-issue") is not None
+
+    def test_null_default_keeps_stock_alternation(
+        self, consumer_config: dict[str, Any]
+    ) -> None:
+        """A consumer not passing ``branchTypes`` keeps the stock pattern."""
+        assert self.STOCK_ALTERNATION in _branch_guard(consumer_config)
+
+    def test_composes_with_trunk_workflow(
+        self, branch_types_trunk_config: dict[str, Any]
+    ) -> None:
+        """Custom types and the trunk dev-clause drop apply together."""
+        entry = _branch_guard(branch_types_trunk_config)
+        assert "(feature|bugfix|record)" in entry
+        assert "(?!dev$)" not in entry
+        assert "(?!main$)" in entry
+
+    @pytest.mark.parametrize(
+        "bad_types",
+        [
+            pytest.param('[ "feature" "Bad-Type" ]', id="bad-charset"),
+            pytest.param("[ ]", id="empty-list"),
+        ],
+    )
+    def test_invalid_branch_types_rejected(self, bad_types: str) -> None:
+        """A malformed ``branchTypes`` list is refused loudly at eval time."""
+        expr = f"""
+        let
+          flake = builtins.getFlake "path:{REPO_ROOT}";
+          system = builtins.currentSystem;
+          pkgs = import flake.inputs.nixpkgs {{ inherit system; }};
+        in
+        (flake.lib.mkProjectShell {{
+          inherit pkgs;
+          branchTypes = {bad_types};
+          hooks = {{ }};
+        }}).drvPath
+        """
+        result = _run_nix(["eval", "--impure", "--raw", "--expr", expr])
+        assert result.returncode != 0
+        assert "branchTypes" in result.stderr
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_vig_os_manifest.py
+++ b/tests/test_vig_os_manifest.py
@@ -28,6 +28,7 @@ MANIFEST_KEYS = [
     ("DEVKIT_FEATURES_DISABLED", "#1284"),
     ("DEVKIT_REFS_POLICY", "#1282"),
     ("DEVKIT_COMMIT_TYPES", "#1431"),
+    ("DEVKIT_BRANCH_TYPES", "#1432"),
     ("DEVKIT_AUTO_UPGRADE", "#1296"),
     ("DEVKIT_UPGRADE_EXCLUDE", "#1296"),
     ("DEVKIT_DRIFT_CHECK", "#1295"),
@@ -41,6 +42,7 @@ RESOLVE_OUTPUTS = [
     ("runner-json", "#1173"),
     ("refs-optional-types", "#1282"),
     ("commit-types", "#1431"),
+    ("branch-types", "#1432"),
     ("drift-check", "#1295"),
     ("drift-image", "#1295"),
 ]

--- a/tests/test_workflow_model.py
+++ b/tests/test_workflow_model.py
@@ -230,7 +230,10 @@ def test_trunk_flake_forwards_workflow_to_hooks() -> None:
     """
     rendered = cached_tree("trunk")
     flake = (rendered / "flake.nix").read_text(encoding="utf-8")
-    assert "DEVKIT_WORKFLOW=" in flake, "flake.nix does not read the workflow model"
+    # The key is read through the shared vigOsValue helper since #1432.
+    assert 'vigOsValue "DEVKIT_WORKFLOW"' in flake, (
+        "flake.nix does not read the workflow model"
+    )
     assert "inherit workflow;" in flake, "flake.nix does not forward `workflow`"
     manifest = (rendered / ".vig-os").read_text(encoding="utf-8")
     assert "DEVKIT_WORKFLOW=trunk" in manifest


### PR DESCRIPTION
## Summary

Two halves, one SSoT (#1432, folding in #1430's enforcement gap per https://github.com/vig-os/devkit/issues/1430#issuecomment-5263090624):

1. **`DEVKIT_BRANCH_TYPES` knob** — comma-separated full replacement of the issue-numbered branch-type set (`<type>/<issue>-<slug>`) in the `no-commit-to-branch` guard; the `chore/`, `renovate/` (#1433), and `worktree/` clauses stay fixed. Rendered into all three surfaces from one key: the scaffolded YAML (anchored BRE sed), the flake consumer surface (`branchNamePatternFor` gains a types parameter; `mkProjectShell` gains `branchTypes ? null` with a loud eval-time charset assert; the template flake.nix reads the key from `.vig-os` and forwards it under a `functionArgs` guard — pre-#1432 consumer flakes hand-port the block, documented in MIGRATION.md), and CI (below). Defaults are byte-identical everywhere (drift gate + zero-hooks parity).
2. **CI branch-name gate** (#1430) — a commit-checks step validating the env-routed PR head ref against the same resolved type set (new `branch-types` resolve-toolchain output, fail-safe to stock on bad values). The allowed set is a commented superset of the local guard's: `main|dev`, `chore/<slug>` (also covers sync-main-to-dev + devkit-upgrade bot branches), `<type>/<issue>-<slug>`, `worktree/<n>`, `renovate/*`, `release/X.Y.Z`. The same step lands in devkit's own bespoke ci.yml with the stock set inline — the repo that defines the standard now enforces it on itself (the #1430 incident: `feat/rust-language-pack` from an un-initialised clone is now caught at PR time).

The trunk workflow special-case in the consumer render generalizes to one `effectivePattern != branchNamePattern` comparison — workflow (#1224) and branch types feed a single computation.

## Companion (cross-repo, pre-train prerequisite)

The allowance inventory surfaced that devkit-smoke-test's deploy PRs ride `chore/deploy-<tag>` with **dotted** tags (`chore/deploy-1.7.1-rc1`), which the gate rejects. Fixed at the source per the established dot-free lane-branch convention: vig-os/devkit-smoke-test PR (linked in a comment below) must merge to smoke-test **main** (the dispatch listener runs from the default branch) before the 1.7.1 train's smoke stage.

## Test evidence

- TDD RED: 24 test_ci_runner.py failures (`KeyError: 'branch-types'`, missing step), flake fixture `unexpected argument 'branchTypes'`, 4 bats failures — all for the right reasons before the implementation commit
- GREEN: test_ci_runner.py 50 passed; test_flake_hooks.py 45 passed (incl. drift gate + default-parity + eval-rejection tests); bats 6/6; **full pytest: 1290 passed** (2 failures proven pre-existing on clean dev: stale local image + container gh-auth); `just precommit` fully green
- Gate acceptance pinned in tests: `release/1.7.1`, `renovate/lock-file-maintenance`, `chore/foo-bar`, `feature/12-x`, `worktree/9`, `record/54-x` (custom types) accepted; `feat/rust-language-pack` (the #1430 literal) and `random-branch` rejected

Refs: #1432