### PR TITLE
feat(doctor): report whether core.hooksPath wires the tracked git hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`just doctor` reports whether the git hooks are actually wired** ([#1430](https://github.com/vig-os/devkit/issues/1430))
+  - New `core.hooksPath` diagnostic: `PASS` when it points at `.githooks`,
+    `WARN` otherwise, distinguishing "not set" (a fresh clone, where the
+    tracked `.githooks/` shims are on disk but inert) from "set to something
+    else", both with a `./scripts/init.sh` remediation hint
+  - Closes the last gap in #1430: an un-initialised clone now has a local
+    signal it can read before its first commit lands, complementing the CI
+    branch-name and `Refs:` gates that hold regardless of local git config
+  - `doctor` remains diagnostics-only and still always exits 0
 - **Branch-types knob (`DEVKIT_BRANCH_TYPES`) + CI branch-name gate** ([#1432](https://github.com/vig-os/devkit/issues/1432))
   - New `.vig-os` key: a comma-separated full replacement of the
     issue-numbered `<type>/<issue>-<summary>` branch-type set, rendered into

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -169,7 +169,7 @@ Available recipes:
     [info]
     default                                    # Show available commands (default)
     docs                                       # Generate documentation from templates
-    doctor                                     # Diagnose host prerequisites: git identity, commit signing, ssh-agent, gh auth
+    doctor                                     # Diagnose host prerequisites: git identity, signing, hooks path, ssh-agent, gh auth
     help                                       # Show available commands
     info                                       # Show image information
     init *args                                 # Gate Nix prerequisites and bootstrap the project (venv, git hooks, pre-commit)

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ Available recipes:
     [info]
     default                                    # Show available commands (default)
     docs                                       # Generate documentation from templates
-    doctor                                     # Diagnose host prerequisites: git identity, commit signing, ssh-agent, gh auth
+    doctor                                     # Diagnose host prerequisites: git identity, signing, hooks path, ssh-agent, gh auth
     help                                       # Show available commands
     info                                       # Show image information
     init *args                                 # Gate Nix prerequisites and bootstrap the project (venv, git hooks, pre-commit)

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`just doctor` reports whether the git hooks are actually wired** ([#1430](https://github.com/vig-os/devkit/issues/1430))
+  - New `core.hooksPath` diagnostic: `PASS` when it points at `.githooks`,
+    `WARN` otherwise, distinguishing "not set" (a fresh clone, where the
+    tracked `.githooks/` shims are on disk but inert) from "set to something
+    else", both with a `./scripts/init.sh` remediation hint
+  - Closes the last gap in #1430: an un-initialised clone now has a local
+    signal it can read before its first commit lands, complementing the CI
+    branch-name and `Refs:` gates that hold regardless of local git config
+  - `doctor` remains diagnostics-only and still always exits 0
 - **Branch-types knob (`DEVKIT_BRANCH_TYPES`) + CI branch-name gate** ([#1432](https://github.com/vig-os/devkit/issues/1432))
   - New `.vig-os` key: a comma-separated full replacement of the
     issue-numbered `<type>/<issue>-<summary>` branch-type set, rendered into

--- a/justfile
+++ b/justfile
@@ -44,7 +44,7 @@ precommit:
 
 # Diagnostics only — always exits 0 (#1418; replaces the deleted
 # TestHostGitSignatureSetup skip-on-failure tests).
-# Diagnose host prerequisites: git identity, commit signing, ssh-agent, gh auth
+# Diagnose host prerequisites: git identity, signing, hooks path, ssh-agent, gh auth
 [group('info')]
 doctor:
     #!/usr/bin/env bash
@@ -74,6 +74,19 @@ doctor:
         echo "PASS commit signing: $format key $signingkey"
     else
         echo "WARN commit signing: incomplete (commit.gpgsign=$gpgsign, gpg.format=$format, user.signingkey=$signingkey)"
+    fi
+
+    # .githooks is tracked, so a fresh clone has the shims on disk — but git
+    # ignores them until core.hooksPath points there, and only scripts/init.sh
+    # (or devcontainer / dev-shell entry) sets it. Until then every commit-side
+    # gate is present, believed active, and inert. Refs #1430.
+    hookspath="$(git config core.hooksPath || true)"
+    if [ "$hookspath" = ".githooks" ]; then
+        echo "PASS git hooks: core.hooksPath -> .githooks"
+    elif [ -z "$hookspath" ]; then
+        echo "WARN git hooks: core.hooksPath not set, .githooks is tracked but inert (run: ./scripts/init.sh)"
+    else
+        echo "WARN git hooks: core.hooksPath=$hookspath, expected .githooks (run: ./scripts/init.sh)"
     fi
 
     if [ -n "${SSH_AUTH_SOCK:-}" ] && ssh-add -l >/dev/null 2>&1; then

--- a/tests/bats/doctor.bats
+++ b/tests/bats/doctor.bats
@@ -60,6 +60,43 @@ _run_doctor() {
     assert_output --partial "PASS gh auth"
 }
 
+# Make DOCTOR_WORK a real repository so `git config core.hooksPath` resolves
+# against a known local config and can never walk up into the host's checkout
+# (the run already pins GIT_CONFIG_GLOBAL/SYSTEM, so global state cannot leak
+# either). This is the shape of the case #1430 reports: a fresh clone that has
+# .githooks on disk but no core.hooksPath pointing at it.
+_init_clone() {
+    git -c init.defaultBranch=main init -q "$DOCTOR_WORK"
+}
+
+@test "doctor warns when core.hooksPath is unset in a fresh clone" {
+    _init_clone
+    _run_doctor
+    assert_success
+    assert_output --partial "WARN git hooks"
+    assert_output --partial "core.hooksPath not set"
+    assert_output --partial "scripts/init.sh"
+}
+
+@test "doctor reports PASS when core.hooksPath points at .githooks" {
+    _init_clone
+    git -C "$DOCTOR_WORK" config core.hooksPath .githooks
+    _run_doctor
+    assert_success
+    assert_output --partial "PASS git hooks"
+    refute_output --partial "WARN git hooks"
+}
+
+@test "doctor warns and names the value when core.hooksPath points elsewhere" {
+    _init_clone
+    git -C "$DOCTOR_WORK" config core.hooksPath .git/hooks
+    _run_doctor
+    assert_success
+    assert_output --partial "WARN git hooks"
+    assert_output --partial "core.hooksPath=.git/hooks"
+    assert_output --partial "scripts/init.sh"
+}
+
 @test "doctor warns when the signing key path does not exist" {
     git config --file "$GIT_GLOBAL" commit.gpgsign true
     git config --file "$GIT_GLOBAL" gpg.format ssh


### PR DESCRIPTION
## Description

Closes the last open gap in #1430: an un-initialised clone now gets a local signal that the tracked `.githooks/` shims are inert.

`.githooks/` is tracked, so a fresh clone has the hook shims on disk — but git ignores them until `core.hooksPath` points there, and only `scripts/init.sh:203` (or devcontainer / dev-shell entry) sets it. `core.hooksPath` is local repo config, so it cannot be cloned. Between `git clone` and `scripts/init.sh`, devkit's entire commit-side gate stack is present, believed active, and inert — and the failure is silent in the dangerous direction.

Two of #1430's three acceptance boxes were already satisfied on `dev` and were re-verified rather than reimplemented:

- **Enforcement independent of local git config** — the `commit-checks` job validates the PR head ref (`.github/workflows/ci.yml:304`, the gate that folded into #1432 and explicitly credits #1430) and runs `validate-commit-range` over `merge-base..head` plus the PR title (`.github/workflows/ci.yml:330`). Both run on GitHub-side clones. The originally reported `feat/rust-language-pack` + `Refs #1400` pair fails both.
- **Docs state that tracked ≠ active** — `docs/COMMIT_MESSAGE_STANDARD.md:95`, mirrored to consumers at `assets/workspace/docs/COMMIT_MESSAGE_STANDARD.md:98`.

So this PR implements only the third box.

## Type of Change

- [x] `feat` -- New feature
- [x] `test` -- Adding or updating tests

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- `justfile` -- new `core.hooksPath` block in the `doctor` recipe (#1418), placed after the signing check. Distinguishes the two failure modes:

  ```
  PASS git hooks: core.hooksPath -> .githooks
  WARN git hooks: core.hooksPath not set, .githooks is tracked but inert (run: ./scripts/init.sh)
  WARN git hooks: core.hooksPath=<value>, expected .githooks (run: ./scripts/init.sh)
  ```

  `doctor` stays diagnostics-only and still always exits 0.
- `tests/bats/doctor.bats` -- three tests plus an `_init_clone` helper that makes the working directory a real repo, so `core.hooksPath` resolves against a known local config and can never walk up into the host checkout (the harness already pins `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM`).
- `README.md`, `CONTRIBUTING.md`, `assets/workspace/.devcontainer/CHANGELOG.md` -- hook-generated only (`generate-docs` re-rendered the recipe list, `sync-manifest` mirrored the changelog). Not hand-edited.

Scope held deliberately tight: devkit's own `justfile` only (`just doctor` has no scaffolded consumer equivalent), no hard gate added to `default`/`help`, `scripts/init.sh` untouched.

## Changelog Entry

```
### Added

- **`just doctor` reports whether the git hooks are actually wired** ([#1430](https://github.com/vig-os/devkit/issues/1430))
  - New `core.hooksPath` diagnostic: `PASS` when it points at `.githooks`,
    `WARN` otherwise, distinguishing "not set" (a fresh clone, where the
    tracked `.githooks/` shims are on disk but inert) from "set to something
    else", both with a `./scripts/init.sh` remediation hint
  - Closes the last gap in #1430: an un-initialised clone now has a local
    signal it can read before its first commit lands, complementing the CI
    branch-name and `Refs:` gates that hold regardless of local git config
  - `doctor` remains diagnostics-only and still always exits 0
```

## Testing

- [x] Tests pass locally
- [x] Manual testing performed (describe below)

### Manual Testing Details

- `bats tests/bats/doctor.bats tests/bats/just.bats` -> exit 0, 55/55 pass (6/6 in `doctor.bats`).
- RED confirmed before implementation: the three new tests failed on the missing `PASS`/`WARN git hooks` line.
- The PASS test uses `refute_output --partial "WARN git hooks"`, so it cannot pass spuriously.
- `prek run --all-files` -> exit 0, full suite green in both hook roots.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

The signal is pull-based — a contributor who reads nothing still gets nothing locally. That is acceptable because the CI gates above are the enforcement that actually holds for that population; `doctor` serves the person who is looking.

Follow-ups worth filing separately (not implemented here):

1. The scaffolded consumer surface ships no `doctor` equivalent at all, so a consumer clone gets no host preflight. That is a new consumer-facing recipe needing its own manifest/sync and bats coverage, not a #1430 fix.
2. `PASS` is an exact match on `.githooks`; an equivalent absolute path would `WARN`. Correct today since `scripts/init.sh:203` only ever writes the literal relative value.

Closes #1430

Refs: #1430
