### PR TITLE
fix(workspace): ship the commit-msg hooks to flake-generated consumers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -150,6 +150,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Flake-generated hooks now carry the commit-message and agent-identity guards** ([#1434](https://github.com/vig-os/devkit/issues/1434))
+  - A direnv consumer on flake-generated hooks had **no local commit-message
+    or agent-identity enforcement at all**: `validate-commit-msg`,
+    `prepare-commit-msg-strip-trailers` and `check-agent-identity` carried no
+    consumer fragment, so the scaffolded `.githooks/commit-msg` shim ran an
+    empty stage and exited 0, and `git commit --author="Claude <…>"` passed
+    locally. All three now render into `mkProjectShell`'s generated config,
+    resolving the vig-utils console scripts from the pinned devkit rather
+    than the project venv
+  - `mkProjectShell` gains `commitTypes` and `refsPolicy` arguments so
+    `DEVKIT_COMMIT_TYPES` ([#1431](https://github.com/vig-os/devkit/issues/1431))
+    and `DEVKIT_REFS_POLICY` ([#1282](https://github.com/vig-os/devkit/issues/1282))
+    steer the generated hook exactly as they steer the scaffolded YAML and
+    CI — same defaults, same charset guard, same
+    `optional`-mirrors-the-resolved-types composition, same `required`
+    sentinel. The template `flake.nix` reads both keys from `.vig-os`;
+    consumers whose `flake.nix` predates this hand-port the reader
+    (`docs/MIGRATION.md`)
+  - Unset knobs keep the generated config byte-identical to the previous
+    render, and a consumer that never opts into hooks is untouched
 - **Scaffolded CI summary gate now fails on cancelled required checks** ([#1414](https://github.com/vig-os/devkit/issues/1414))
   - The consumer `ci.yml` summary treated a cancelled `lint`, `test`,
     `commit-checks`, `scaffold-drift`, or `dependency-review` job as green

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -150,6 +150,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Flake-generated hooks now carry the commit-message and agent-identity guards** ([#1434](https://github.com/vig-os/devkit/issues/1434))
+  - A direnv consumer on flake-generated hooks had **no local commit-message
+    or agent-identity enforcement at all**: `validate-commit-msg`,
+    `prepare-commit-msg-strip-trailers` and `check-agent-identity` carried no
+    consumer fragment, so the scaffolded `.githooks/commit-msg` shim ran an
+    empty stage and exited 0, and `git commit --author="Claude <…>"` passed
+    locally. All three now render into `mkProjectShell`'s generated config,
+    resolving the vig-utils console scripts from the pinned devkit rather
+    than the project venv
+  - `mkProjectShell` gains `commitTypes` and `refsPolicy` arguments so
+    `DEVKIT_COMMIT_TYPES` ([#1431](https://github.com/vig-os/devkit/issues/1431))
+    and `DEVKIT_REFS_POLICY` ([#1282](https://github.com/vig-os/devkit/issues/1282))
+    steer the generated hook exactly as they steer the scaffolded YAML and
+    CI — same defaults, same charset guard, same
+    `optional`-mirrors-the-resolved-types composition, same `required`
+    sentinel. The template `flake.nix` reads both keys from `.vig-os`;
+    consumers whose `flake.nix` predates this hand-port the reader
+    (`docs/MIGRATION.md`)
+  - Unset knobs keep the generated config byte-identical to the previous
+    render, and a consumer that never opts into hooks is untouched
 - **Scaffolded CI summary gate now fails on cancelled required checks** ([#1414](https://github.com/vig-os/devkit/issues/1414))
   - The consumer `ci.yml` summary treated a cancelled `lint`, `test`,
     `commit-checks`, `scaffold-drift`, or `dependency-review` job as green

--- a/assets/workspace/.vig-os
+++ b/assets/workspace/.vig-os
@@ -81,9 +81,10 @@ DEVKIT_SYNC_SCHEDULE=
 # flake — an unknown name aborts the scaffold loudly (#1284).
 DEVKIT_FEATURES_DISABLED=
 
-# Refs-line enforcement policy for the commit-message gate, driving BOTH the
-# validate-commit-msg pre-commit hook and CI's validate-commit-range from this
-# one key. Empty (default) resolves to `chore-optional` — every type but `chore`
+# Refs-line enforcement policy for the commit-message gate, driving the
+# validate-commit-msg pre-commit hook — scaffolded AND flake-generated (read by
+# flake.nix at eval time, #1434) — and CI's validate-commit-range from this one
+# key. Empty (default) resolves to `chore-optional` — every type but `chore`
 # requires a `Refs:` line — unchanged for devkit or existing consumers.
 # `optional` never requires Refs (any approved type may omit it); `required`
 # demands Refs on every type, `chore` included. Realized at scaffold time (an
@@ -92,9 +93,10 @@ DEVKIT_FEATURES_DISABLED=
 DEVKIT_REFS_POLICY=
 
 # Approved commit types for the commit-message gate — a comma-separated
-# (whitespace-tolerant) FULL REPLACEMENT list driving BOTH the
-# validate-commit-msg hook's `--types` arg and CI's validate-commit-range from
-# this one key. Empty (default) resolves to the stock 11 types
+# (whitespace-tolerant) FULL REPLACEMENT list driving the validate-commit-msg
+# hook's `--types` arg — scaffolded AND flake-generated (read by flake.nix at
+# eval time, #1434) — and CI's validate-commit-range from this one key.
+# Empty (default) resolves to the stock 11 types
 # (feat,fix,docs,chore,refactor,perf,test,ci,build,revert,style) — unchanged
 # for devkit or existing consumers. Lowercase alphanumerics only (guarded
 # loudly at scaffold time). Keep `chore` and `build` unless deliberate:

--- a/assets/workspace/flake.nix
+++ b/assets/workspace/flake.nix
@@ -50,10 +50,11 @@
           # add project tools here
         ];
 
-        # Devkit knobs read from .vig-os (#1224, #1432): the flake-generated
-        # pre-commit branch guard follows the workspace manifest, mirroring
-        # the scaffolded .pre-commit-config.yaml renders. Managed block;
-        # leave it.
+        # Devkit knobs read from .vig-os (#1224, #1432, #1431, #1282): the
+        # flake-generated pre-commit hooks — the branch guard and the
+        # commit-message validator — follow the workspace manifest, mirroring
+        # the scaffolded .pre-commit-config.yaml renders (#1434). Managed
+        # block; leave it.
         vigOsValue =
           key:
           let
@@ -67,23 +68,43 @@
           else
             nixpkgs.lib.removePrefix "${key}=" (builtins.head declared);
 
+        # A comma-separated manifest list -> a Nix list, or null when the key
+        # is absent/blank (= "keep the devkit default"). Whitespace around
+        # entries is trimmed and empty entries dropped, matching how
+        # init-workspace.sh resolves the same keys; validation (charset,
+        # non-empty) lives in mkProjectShell, which fails eval loudly on a bad
+        # value.
+        vigOsList =
+          key:
+          let
+            entries = builtins.filter (t: t != "") (
+              map (t: nixpkgs.lib.trim t) (nixpkgs.lib.splitString "," (vigOsValue key))
+            );
+          in
+          if entries == [ ] then null else entries;
+
         # Workflow model (#1224): a `trunk` workspace drops the dev-branch
         # clause. `gitflow` (the default) and an absent/blank value are inert.
         workflow = if vigOsValue "DEVKIT_WORKFLOW" == "trunk" then "trunk" else "gitflow";
 
-        # Branch-type set (#1432): DEVKIT_BRANCH_TYPES (comma-separated)
-        # replaces the issue-numbered alternation of the branch guard;
-        # absent/blank forwards null (= the stock set). Whitespace around
-        # entries is trimmed; validation (charset, non-empty) lives in
-        # mkProjectShell, which fails eval loudly on a bad value.
-        branchTypes =
+        # Branch-type set (#1432): DEVKIT_BRANCH_TYPES replaces the
+        # issue-numbered alternation of the branch guard.
+        branchTypes = vigOsList "DEVKIT_BRANCH_TYPES";
+
+        # Approved commit types (#1431): DEVKIT_COMMIT_TYPES replaces the
+        # validate-commit-msg `--types` list, so the local hook agrees with
+        # CI's validate-commit-range (#1434).
+        commitTypes = vigOsList "DEVKIT_COMMIT_TYPES";
+
+        # Refs policy (#1282): DEVKIT_REFS_POLICY steers whether a commit needs
+        # a `Refs: #N` line — chore-optional (default) | optional | required.
+        # Absent/blank forwards null (= the default); an unknown literal fails
+        # eval loudly in mkProjectShell (#1434).
+        refsPolicy =
           let
-            raw = vigOsValue "DEVKIT_BRANCH_TYPES";
-            entries = builtins.filter (t: t != "") (
-              map (t: nixpkgs.lib.trim t) (nixpkgs.lib.splitString "," raw)
-            );
+            raw = nixpkgs.lib.trim (vigOsValue "DEVKIT_REFS_POLICY");
           in
-          if entries == [ ] then null else entries;
+          if raw == "" then null else raw;
       in
       {
         # The dev shell = the shared vigOS toolchain + your extras.
@@ -128,6 +149,14 @@
           // nixpkgs.lib.optionalAttrs (builtins.functionArgs vigos.lib.mkProjectShell ? branchTypes) {
             # Branch guard follows the workspace branch-type set (#1432).
             inherit branchTypes;
+          }
+          // nixpkgs.lib.optionalAttrs (builtins.functionArgs vigos.lib.mkProjectShell ? commitTypes) {
+            # validate-commit-msg follows the workspace commit-type set (#1431).
+            inherit commitTypes;
+          }
+          // nixpkgs.lib.optionalAttrs (builtins.functionArgs vigos.lib.mkProjectShell ? refsPolicy) {
+            # validate-commit-msg follows the workspace Refs policy (#1282).
+            inherit refsPolicy;
           }
         );
 

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -390,9 +390,9 @@ unknown keys:
 | `DEVKIT_SYNC_TARGET` | Branch the scaffolded sync-issues job commits to; empty (default) => the workflow-model default (`dev`/`main`). A protected-`main` consumer sets an unprotected mirror branch, e.g. `sync/issue-mirror` (see [Point sync-issues at an unprotected mirror branch](#point-sync-issues-at-an-unprotected-mirror-branch-protected-main), [#1228](https://github.com/vig-os/devkit/issues/1228)) |
 | `DEVKIT_SYNC_SCHEDULE` | Cron override (5-field) for the sync-issues schedule trigger; empty (default) => the daily `0 2 * * *` ([#1228](https://github.com/vig-os/devkit/issues/1228)) |
 | `DEVKIT_FEATURES_DISABLED` | Comma-separated scaffold feature groups this repo opts OUT of; empty (default) => every group is scaffolded. A disabled group is never shipped and a prior scaffold's copy is pruned on upgrade (see [Scaffold feature opt-outs](#scaffold-feature-opt-outs), [#1284](https://github.com/vig-os/devkit/issues/1284)) |
-| `DEVKIT_REFS_POLICY` | Refs-line enforcement policy driving both the `validate-commit-msg` hook and CI's `validate-commit-range`: `chore-optional` (default/empty — only `chore` may omit `Refs:`) \| `optional` (never required) \| `required` (every type needs `Refs:`) ([#1282](https://github.com/vig-os/devkit/issues/1282)) |
-| `DEVKIT_COMMIT_TYPES` | Comma-separated FULL REPLACEMENT of the approved commit types, driving both the `validate-commit-msg` hook's `--types` and CI's `validate-commit-range`; empty (default) => the stock 11 types. Lowercase alphanumerics only; keep `chore`/`build` unless deliberate (bot commits — the scaffold prints a notice). `DEVKIT_REFS_POLICY=optional` mirrors this list ([#1431](https://github.com/vig-os/devkit/issues/1431)) |
-| `DEVKIT_BRANCH_TYPES` | Comma-separated FULL REPLACEMENT of the issue-numbered `<type>/<issue>-<summary>` branch-type set, driving the local `no-commit-to-branch` guard, the flake-generated consumer surface, and CI's branch-name gate; empty (default) => the stock set (`feature,bugfix,hotfix,release,docs,test,refactor`). The `chore/`, `renovate/`, `worktree/` clauses are never knob-driven. Pre-#1432 direnv consumers hand-port the flake reader (see [Custom branch types on the flake surface](#custom-branch-types-on-the-flake-surface-direnv-consumers), [#1432](https://github.com/vig-os/devkit/issues/1432)) |
+| `DEVKIT_REFS_POLICY` | Refs-line enforcement policy driving the `validate-commit-msg` hook — scaffolded **and** flake-generated ([#1434](https://github.com/vig-os/devkit/issues/1434)) — and CI's `validate-commit-range`: `chore-optional` (default/empty — only `chore` may omit `Refs:`) \| `optional` (never required) \| `required` (every type needs `Refs:`) ([#1282](https://github.com/vig-os/devkit/issues/1282)) |
+| `DEVKIT_COMMIT_TYPES` | Comma-separated FULL REPLACEMENT of the approved commit types, driving the `validate-commit-msg` hook's `--types` — scaffolded **and** flake-generated ([#1434](https://github.com/vig-os/devkit/issues/1434)) — and CI's `validate-commit-range`; empty (default) => the stock 11 types. Lowercase alphanumerics only; keep `chore`/`build` unless deliberate (bot commits — the scaffold prints a notice). `DEVKIT_REFS_POLICY=optional` mirrors this list ([#1431](https://github.com/vig-os/devkit/issues/1431)) |
+| `DEVKIT_BRANCH_TYPES` | Comma-separated FULL REPLACEMENT of the issue-numbered `<type>/<issue>-<summary>` branch-type set, driving the local `no-commit-to-branch` guard, the flake-generated consumer surface, and CI's branch-name gate; empty (default) => the stock set (`feature,bugfix,hotfix,release,docs,test,refactor`). The `chore/`, `renovate/`, `worktree/` clauses are never knob-driven. Pre-#1432 direnv consumers hand-port the flake reader (see [Commit and branch policy on the flake surface](#commit-and-branch-policy-on-the-flake-surface-direnv-consumers), [#1432](https://github.com/vig-os/devkit/issues/1432)) |
 | `DEVKIT_AUTO_UPGRADE` | Opt-out for the scaffolded `devkit-upgrade.yml` weekly schedule; empty (default) or any value but `false` keeps the auto-adoption poll on. `false` disables only the schedule — manual `workflow_dispatch` always runs ([#1296](https://github.com/vig-os/devkit/issues/1296)) |
 | `DEVKIT_UPGRADE_EXCLUDE` | Comma-separated (whitespace-tolerant) paths the `devkit-upgrade` workflow resets before the adoption commit, so generated-doc churn never rides along in the upgrade diff; empty (default) => no exclusions ([#1296](https://github.com/vig-os/devkit/issues/1296)) |
 
@@ -478,29 +478,36 @@ How it behaves:
   [`docs/SOLO_ADOPTION.md`](./SOLO_ADOPTION.md)
   ([#1285](https://github.com/vig-os/devkit/issues/1285)).
 
-### Custom branch types on the flake surface (direnv consumers)
+### Commit and branch policy on the flake surface (direnv consumers)
 
-`DEVKIT_BRANCH_TYPES` reaches the **scaffolded** `.pre-commit-config.yaml` and
-**CI's branch-name gate** automatically on re-scaffold/upgrade. The
-**flake-generated** consumer surface (direnv repos that opted into
-`mkProjectShell`'s `hooks`) reads the key at eval time through the project's
-own `flake.nix` — a **scaffold-once file the upgrade never overwrites**. New
-scaffolds ship the reader; a repo whose `flake.nix` predates #1432 ports it by
-hand (the same one-time port as the #1224 `workflow` forwarding):
+`DEVKIT_BRANCH_TYPES`, `DEVKIT_COMMIT_TYPES` and `DEVKIT_REFS_POLICY` reach the
+**scaffolded** `.pre-commit-config.yaml` and **CI** automatically on
+re-scaffold/upgrade. The **flake-generated** consumer surface (direnv repos
+that opted into `mkProjectShell`'s `hooks`) reads those keys at eval time
+through the project's own `flake.nix` — a **scaffold-once file the upgrade
+never overwrites**. New scaffolds ship the reader; a repo whose `flake.nix`
+predates #1432/#1434 ports it by hand (the same one-time port as the #1224
+`workflow` forwarding):
 
-1. Copy the managed `vigOsValue` / `workflow` / `branchTypes` `let`-block from
-   the current template
+1. Copy the managed `vigOsValue` / `vigOsList` / `workflow` / `branchTypes` /
+   `commitTypes` / `refsPolicy` `let`-block from the current template
    ([`assets/workspace/flake.nix`](https://github.com/vig-os/devkit/blob/main/assets/workspace/flake.nix))
    over your existing `workflow` reader.
-2. Copy the two `nixpkgs.lib.optionalAttrs (builtins.functionArgs … )`
-   forwarding blocks after the `mkProjectShell` argument set. The
-   `functionArgs` guard keeps older pinned devkits evaluating (they fall back
-   to the stock set instead of failing).
+2. Copy the `nixpkgs.lib.optionalAttrs (builtins.functionArgs … )` forwarding
+   blocks after the `mkProjectShell` argument set. The `functionArgs` guard
+   keeps older pinned devkits evaluating (they fall back to the stock values
+   instead of failing).
 
-Without the port the knob still works everywhere except the locally generated
-guard — which then keeps the stock set, and the loud signal comes from CI's
-gate instead. Validation is eval-time and loud: a bad entry (charset, empty
-list) fails `nix develop` with a `branchTypes` message.
+Without the port the knobs still work everywhere except the locally generated
+hooks — which then keep the stock values, and the loud signal comes from CI's
+gates instead. Validation is eval-time and loud: a bad value (branch/commit
+type charset, an empty list, an unknown Refs policy) fails `nix develop` with
+a `branchTypes` / `commitTypes` / `refsPolicy` message.
+
+Note that the flake-generated config only *carries* the commit-message hooks
+from devkit 1.8.0 on ([#1434](https://github.com/vig-os/devkit/issues/1434)) —
+before that a direnv consumer had no local `commit-msg` stage at all, so
+`DEVKIT_COMMIT_TYPES` / `DEVKIT_REFS_POLICY` were realized through CI only.
 
 ## What a consumer needs to know
 
@@ -757,6 +764,18 @@ The contract:
   the generated set includes it — `direnv`/`bare` consumers gain markdown lint
   from the shared toolchain like `shellcheck`/`typos`. Toggle it off with
   `pymarkdown.enable = false` if a repo has no markdown to lint.
+- **The commit-message and agent-identity guards are in the base set.** Since
+  [#1434](https://github.com/vig-os/devkit/issues/1434) the generated config
+  carries `validate-commit-msg` (`commit-msg` stage),
+  `prepare-commit-msg-strip-trailers` (`prepare-commit-msg` stage) and
+  `check-agent-identity`, resolving the `vig-utils` console scripts from the
+  pinned devkit — so `.githooks/commit-msg` actually rejects a malformed
+  message and `git commit --author="Claude <…>"` is refused locally, as in a
+  container-mode consumer. Before that release the `commit-msg` stage was
+  empty for flake-hooks consumers and only CI enforced the standard. The
+  `--types` / `--refs-optional-types` args follow `DEVKIT_COMMIT_TYPES` and
+  `DEVKIT_REFS_POLICY` (see [Commit and branch policy on the flake
+  surface](#commit-and-branch-policy-on-the-flake-surface-direnv-consumers)).
 - The planned declarative `.vig-os` manifest
   ([#885](https://github.com/vig-os/devkit/issues/885)) will carry an
   explicit raw-YAML opt-out flag so the choice is recorded per-repo rather

--- a/flake.nix
+++ b/flake.nix
@@ -92,23 +92,14 @@
 
       # vig-utils exposed on the overlay so `pkgs.vig-utils` resolves for the
       # toolchain SSoT (nix/devtools.nix) and for downstream consumers that
-      # apply `overlays.default`. A pure-Python hatchling package (single
-      # runtime dep `rich`) built from THIS flake's `packages/vig-utils`, so its
-      # console scripts (prepare-changelog, renovate-changelog-pr, …) reach the
-      # dev-shell, the image, and the home module from one list. The devkit pin
-      # in a consumer's `.vig-os` governs the version. Refs #993, #666.
+      # apply `overlays.default`, so its console scripts (prepare-changelog,
+      # renovate-changelog-pr, …) reach the dev-shell, the image, and the home
+      # module from one list. The devkit pin in a consumer's `.vig-os` governs
+      # the version. The package itself lives in nix/vig-utils.nix (like
+      # nix/pymarkdown.nix) so the consumer hook fragments can build it from a
+      # plain, un-overlaid `pkgs` too (#1434). Refs #993, #666.
       vigUtilsOverlay = final: _prev: {
-        vig-utils = final.python314.pkgs.buildPythonPackage {
-          pname = "vig-utils";
-          version = "0.1.0";
-          pyproject = true;
-          src = ./packages/vig-utils;
-          build-system = [ final.python314.pkgs.hatchling ];
-          dependencies = [ final.python314.pkgs.rich ];
-          pythonImportsCheck = [ "vig_utils" ];
-          # The package's own tests need pytest + the repo; CI covers them.
-          doCheck = false;
-        };
+        vig-utils = import ./nix/vig-utils.nix final;
       };
 
       # System-independent overlay for downstream consumers (overlays.default).
@@ -259,6 +250,23 @@
           # DEVKIT_BRANCH_TYPES and forwards it here. Validated below —
           # entries reach a regex alternation, so the charset is load-bearing.
           branchTypes ? null,
+          # Approved commit types (#1431): null (default) keeps the stock 11 in
+          # the flake-generated validate-commit-msg hook; a list of type
+          # strings replaces it, mirroring what render_commit_types does to the
+          # scaffolded config and what resolve-toolchain's `commit-types`
+          # output does to CI. The scaffold template reads this from the
+          # workspace `.vig-os` DEVKIT_COMMIT_TYPES and forwards it here.
+          # Validated below — entries reach a hook argv, so the charset guard
+          # mirrors the scaffold's. Refs #1434.
+          commitTypes ? null,
+          # Refs policy (#1282): null (default) == "chore-optional" — only
+          # `chore` may omit the `Refs:` line. "optional" mirrors the resolved
+          # commitTypes (never required), "required" admits no exemption. Same
+          # mapping as render_refs_policy and resolve-toolchain's
+          # `refs-optional-types` output — one key, three renderers in
+          # lockstep. Read from `.vig-os` DEVKIT_REFS_POLICY by the scaffold
+          # template. Refs #1434.
+          refsPolicy ? null,
           shellHook ? ''echo "devcontainer dev environment loaded (nix)"'',
           # Overridable CPython (#1038). Defaults to the pinned 3.14 so the
           # zero-argument shell is byte-identical to the pre-#1038 builder
@@ -357,7 +365,14 @@
           # tests/test_flake_devshell.py, tests/test_flake_hooks.py).
           # ------------------------------------------------------------------
           hooksEnabled = hooks != null || hooksExcludes != [ ];
-          consumerHooksBase = hooksModule.consumer pkgs workflow branchTypes;
+          consumerHooksBase = hooksModule.consumer pkgs {
+            inherit
+              workflow
+              branchTypes
+              commitTypes
+              refsPolicy
+              ;
+          };
           # Base values at priority 999: they beat git-hooks.nix's own
           # built-in hook defaults (mkDefault, 1000 — equal priorities would
           # conflict, e.g. the built-in nixfmt entry vs the base one) and
@@ -622,6 +637,29 @@
             )
           )
           "mkProjectShell: branchTypes must be null or a non-empty list of lowercase alphanumeric type names (e.g. [ \"feature\" \"record\" ]), got ${builtins.toJSON branchTypes}";
+        # commitTypes (#1431 on the flake surface, #1434): entries land in the
+        # validate-commit-msg argv, so mirror the scaffold's per-entry charset
+        # allowlist — loudly, at eval time, like init-workspace.sh's abort.
+        assert pkgs.lib.assertMsg
+          (
+            commitTypes == null
+            || (
+              builtins.isList commitTypes
+              && commitTypes != [ ]
+              && builtins.all (t: builtins.isString t && builtins.match "[a-z][a-z0-9]*" t != null) commitTypes
+            )
+          )
+          "mkProjectShell: commitTypes must be null or a non-empty list of lowercase alphanumeric type names (e.g. [ \"feat\" \"record\" ]), got ${builtins.toJSON commitTypes}";
+        # refsPolicy (#1282 on the flake surface, #1434): the same three-value
+        # enum init-workspace.sh guards, refused loudly on an unknown literal.
+        assert pkgs.lib.assertMsg
+          (builtins.elem refsPolicy [
+            null
+            "chore-optional"
+            "optional"
+            "required"
+          ])
+          "mkProjectShell: refsPolicy must be null, \"chore-optional\", \"optional\" or \"required\", got ${builtins.toJSON refsPolicy}";
         pkgs.mkShell (
           # Module env first: the builder's attrset below wins any collision,
           # so a capability module can never break the Python bootstrap pins

--- a/nix/hooks.nix
+++ b/nix/hooks.nix
@@ -17,7 +17,14 @@
 #                   shell installs the rendered config via git-hooks.nix's
 #                   installation script (`null` = not generatable, e.g. the
 #                   `uv run` generator/venv hooks like generate-docs or
-#                   sync-manifest, or the commit-msg-stage hooks).
+#                   sync-manifest, which need THIS repo's scripts and venv).
+#                   Stage-gated hooks ARE generatable (#1434): git-hooks.nix
+#                   carries `stages`, and a vig-utils console script resolves
+#                   as a store path via nix/vig-utils.nix — so the commit-msg
+#                   / prepare-commit-msg / agent-identity hooks ship here too.
+#                   Without them a direnv consumer's `.githooks/commit-msg`
+#                   shim runs an empty stage, exits 0, and the repo has no
+#                   local commit-message enforcement at all.
 #
 # `checkName`/`consumerName` map a committed hook id to the git-hooks.nix
 # attribute name where they differ (git-hooks.nix pluralises some
@@ -66,6 +73,52 @@ let
     "^(?!main$)${devClause}(?!^(chore)/[a-z0-9]+(-[a-z0-9]+)*$)(?!^(${typesAlternation})/[0-9]+-[a-z0-9]+(-[a-z0-9]+)*$)(?!^renovate/.+$)(?!^worktree/[0-9]+$).+$";
   # The gitflow default, used by the committed runner/scaffold YAML renders.
   branchNamePattern = branchNamePatternFor "gitflow" defaultBranchTypes;
+
+  # ── validate-commit-msg argv (knob-driven; #1431 + #1282) ──────────────
+  # The approved commit types (DEVKIT_COMMIT_TYPES, #1431) and the Refs
+  # enforcement policy (DEVKIT_REFS_POLICY, #1282) are ONE key each with two
+  # scaffold-path renderers already in lockstep — `render_commit_types` /
+  # `render_refs_policy` (assets/init-workspace.sh) for the scaffolded YAML,
+  # and resolve-toolchain's `commit-types` / `refs-optional-types` outputs for
+  # CI's validate-commit-range. `validateCommitMsgArgs` is the THIRD renderer,
+  # for the flake-generated consumer surface (#1434), and must resolve
+  # identically: same default list, same `optional` mirror of the RESOLVED
+  # types (never a hardcoded copy of the stock 11 — the #1431 composition
+  # fix), same `none` sentinel for `required` (an empty list reads as falsy to
+  # the CLI and reverts to its {chore} default). Charset validation lives at
+  # the write paths (init-workspace.sh; mkProjectShell's eval-time assert).
+  defaultCommitTypes = [
+    "feat"
+    "fix"
+    "docs"
+    "chore"
+    "refactor"
+    "perf"
+    "test"
+    "ci"
+    "build"
+    "revert"
+    "style"
+  ];
+  refsOptionalTypesFor =
+    refsPolicy: commitTypes:
+    if refsPolicy == "optional" then
+      lib.concatStringsSep "," commitTypes
+    else if refsPolicy == "required" then
+      "none"
+    else
+      "chore";
+  validateCommitMsgArgs = refsPolicy: commitTypes: [
+    "--types"
+    (lib.concatStringsSep "," commitTypes)
+    "--refs-optional-types"
+    (refsOptionalTypesFor refsPolicy commitTypes)
+    "--blocked-patterns"
+    ".github/agent-blocklist.toml"
+  ];
+  # The unset-knob default, used by the committed runner/scaffold YAML renders
+  # and as the parity baseline of the consumer render.
+  defaultValidateCommitMsgArgs = validateCommitMsgArgs null defaultCommitTypes;
 
   # Top-level exclude — one regex string in the committed YAML, a list for
   # git-hooks.nix (which joins with `|`). Same paths, two spellings.
@@ -719,7 +772,24 @@ let
     };
 
     # ── AI-agent identity + commit-message hooks (stage-gated / git-state
-    #    hooks: never run by `--all-files`, runner-only; Refs #163) ────────
+    #    hooks: `--all-files` never runs the two message hooks; Refs #163) ──
+    #
+    # All three carry a `consumer` fragment (#1434): a direnv consumer on
+    # flake-generated hooks (#1167) otherwise got NO commit-msg stage at all,
+    # so its `.githooks/commit-msg` shim exited 0 with nothing to run and
+    # `git commit --author="Claude <…>"` passed locally. The consumer entries
+    # resolve nix/vig-utils.nix store paths rather than the portable `uv run`
+    # form — a consumer's project venv does not carry vig-utils, whereas the
+    # flake ships it (nix/devtools.nix) — so the enforcement version follows
+    # the devkit pin the consumer bumps with `nix flake update vigos`. Same
+    # shape as every other tool-naming consumer fragment (nixfmt, statix,
+    # deadnix, just-fmt, gitleaks, pymarkdown), and like pymarkdown it builds
+    # from a plain `pkgs`, so the generation surface never depends on the
+    # consumer having applied `overlays.default`.
+    #
+    # No `check` fragments: the sandbox gate has no git repo and no commit to
+    # inspect, and `check-agent-identity` short-circuits under CI=true anyway.
+    #
     # Scaffolded: the consumer's `.githooks/prepare-commit-msg` already runs
     # `prek run --hook-stage prepare-commit-msg`, and this must reach consumers
     # together with validate-commit-msg — it strips agent trailers *before* the
@@ -730,6 +800,14 @@ let
       yaml = {
         name = "strip agent trailers from commit message";
         entry = "uv run prepare-commit-msg-strip-trailers";
+        language = "system";
+        stages = [ "prepare-commit-msg" ];
+        pass_filenames = true;
+      };
+      consumer = pkgs: {
+        enable = true;
+        name = "strip agent trailers from commit message";
+        entry = "${import ./vig-utils.nix pkgs}/bin/prepare-commit-msg-strip-trailers";
         language = "system";
         stages = [ "prepare-commit-msg" ];
         pass_filenames = true;
@@ -752,6 +830,13 @@ let
         language = "system";
         pass_filenames = false;
       };
+      consumer = pkgs: {
+        enable = true;
+        name = "check agent identity";
+        entry = "${import ./vig-utils.nix pkgs}/bin/check-agent-identity";
+        language = "system";
+        pass_filenames = false;
+      };
     };
     # No `--scopes` allowlist: a scope is free-form "alphanumeric and hyphens
     # only" per docs/COMMIT_MESSAGE_STANDARD.md, which the validator's subject
@@ -763,6 +848,12 @@ let
     # (`prek run --hook-stage commit-msg`) has no hooks to run, so every
     # scaffolded repo shipped a COMMIT_MESSAGE_STANDARD.md it could not
     # enforce. Refs #1019.
+    #
+    # The consumer fragment ships the DEFAULT argv; `consumer` below overrides
+    # it only when DEVKIT_COMMIT_TYPES / DEVKIT_REFS_POLICY resolve to
+    # something else, exactly like the branch guard — so an unset-knob
+    # consumer's generated config stays byte-identical to the pre-#1434
+    # render.
     validate-commit-msg = {
       scaffold = true;
       yaml = {
@@ -770,14 +861,15 @@ let
         entry = "uv run validate-commit-msg";
         language = "system";
         stages = [ "commit-msg" ];
-        args = [
-          "--types"
-          "feat,fix,docs,chore,refactor,perf,test,ci,build,revert,style"
-          "--refs-optional-types"
-          "chore"
-          "--blocked-patterns"
-          ".github/agent-blocklist.toml"
-        ];
+        args = defaultValidateCommitMsgArgs;
+      };
+      consumer = pkgs: {
+        enable = true;
+        name = "validate commit message";
+        entry = "${import ./vig-utils.nix pkgs}/bin/validate-commit-msg";
+        language = "system";
+        stages = [ "commit-msg" ];
+        args = defaultValidateCommitMsgArgs;
       };
     };
   };
@@ -842,23 +934,40 @@ in
   };
 
   # Base hook set for the consumer generation surface
-  # (`mkProjectShell { hooks = …; }`). ctx: pkgs; `workflow` (gitflow default |
-  # trunk) tunes the branch guard so a flake-hooks consumer's no-commit-to-branch
-  # pattern follows DEVKIT_WORKFLOW, mirroring the scaffold render (#1224). For
-  # gitflow the override is a no-op, so the generated config stays byte-identical
-  # to the pre-#1224 render (zero-hooks parity + consumer-surface tests).
+  # (`mkProjectShell { hooks = …; }`). ctx: pkgs, then the `.vig-os` knobs the
+  # scaffolded flake.nix forwards. Each knob tunes exactly one base hook so a
+  # flake-hooks consumer's local enforcement follows the same manifest keys as
+  # the scaffolded YAML renders:
+  #
+  #   workflow    — DEVKIT_WORKFLOW,     branch guard dev-clause      (#1224)
+  #   branchTypes — DEVKIT_BRANCH_TYPES, branch guard alternation     (#1432)
+  #   commitTypes — DEVKIT_COMMIT_TYPES, validate-commit-msg --types  (#1431)
+  #   refsPolicy  — DEVKIT_REFS_POLICY,  --refs-optional-types        (#1282)
+  #
+  # An attrset (not positional args): every knob is an optional nullable value
+  # and the list keeps growing. Each override is applied ONLY when the resolved
+  # value differs from the default, so an unset-knob consumer's generated
+  # config stays byte-identical to the pre-knob render (zero-hooks parity +
+  # consumer-surface tests).
   consumer =
-    pkgs: workflow: branchTypes:
+    pkgs:
+    {
+      workflow ? "gitflow",
+      branchTypes ? null,
+      commitTypes ? null,
+      refsPolicy ? null,
+    }:
     let
       base = collectFor "consumer" "consumerName" pkgs;
-      # Effective guard pattern for this consumer: workflow (#1224) and
-      # branch-types (#1432) both feed one computation. Override the base
-      # hook only when the result differs from the gitflow default, so a
-      # default consumer's generated config stays byte-identical to the
-      # pre-#1224/pre-#1432 render (zero-hooks parity + consumer-surface
-      # tests).
-      effectiveTypes = if branchTypes == null then defaultBranchTypes else branchTypes;
-      effectivePattern = branchNamePatternFor workflow effectiveTypes;
+      # Branch guard: workflow (#1224) and branch-types (#1432) feed one
+      # computation.
+      effectiveBranchTypes = if branchTypes == null then defaultBranchTypes else branchTypes;
+      effectivePattern = branchNamePatternFor workflow effectiveBranchTypes;
+      # validate-commit-msg argv: commit-types (#1431) and the Refs policy
+      # (#1282) feed one computation, because `optional` mirrors the resolved
+      # types list.
+      effectiveCommitTypes = if commitTypes == null then defaultCommitTypes else commitTypes;
+      effectiveValidateArgs = validateCommitMsgArgs refsPolicy effectiveCommitTypes;
     in
     {
       excludes = baseExcludes;
@@ -869,6 +978,11 @@ in
             settings = base.no-commit-to-branch.settings // {
               pattern = [ effectivePattern ];
             };
+          };
+        }
+        // lib.optionalAttrs (effectiveValidateArgs != defaultValidateCommitMsgArgs) {
+          validate-commit-msg = base.validate-commit-msg // {
+            args = effectiveValidateArgs;
           };
         };
     };

--- a/nix/vig-utils.nix
+++ b/nix/vig-utils.nix
@@ -1,0 +1,29 @@
+# vig-utils packaged from THIS flake's `packages/vig-utils` (#993, #666).
+#
+# A pure-Python hatchling package (single runtime dep `rich`) whose console
+# scripts (prepare-changelog, validate-commit-msg, check-agent-identity, …)
+# are the devkit's own automation surface.
+#
+# A function of `pkgs`, mirroring nix/pymarkdown.nix, so the definition works
+# with or without `overlays.default` applied. Two consumers:
+#
+#   - flake.nix's `vigUtilsOverlay`, which exposes it as `pkgs.vig-utils` for
+#     the toolchain SSoT (nix/devtools.nix -> dev-shell, image, home module);
+#   - the commit-message/agent-identity hook fragments in nix/hooks.nix, whose
+#     consumer surface must resolve the binaries from a plain `pkgs` — a
+#     consumer's `.pre-commit-config.yaml` is generated before their overlay
+#     is anyone's concern, and their project venv has no vig-utils (#1434).
+#
+# The devkit pin in a consumer's `flake.lock` governs the version.
+pkgs:
+pkgs.python314.pkgs.buildPythonPackage {
+  pname = "vig-utils";
+  version = "0.1.0";
+  pyproject = true;
+  src = ../packages/vig-utils;
+  build-system = [ pkgs.python314.pkgs.hatchling ];
+  dependencies = [ pkgs.python314.pkgs.rich ];
+  pythonImportsCheck = [ "vig_utils" ];
+  # The package's own tests need pytest + the repo; CI covers them.
+  doCheck = false;
+}

--- a/tests/test_flake_hooks.py
+++ b/tests/test_flake_hooks.py
@@ -320,20 +320,16 @@ def _consumer_config_set() -> dict[str, dict[str, Any]]:
     so the suite pays one build instead of one per shell. Cached for the whole
     pytest run.
 
-    ``pkgs`` carries ``overlays.default`` (as the scaffolded consumer flake
-    builds it): the vig-utils console scripts the commit-message hooks resolve
-    (#1434) come from that overlay, exactly like the ``devTools`` toolchain
-    every ``mkProjectShell`` consumer already gets.
+    ``pkgs`` is deliberately un-overlaid: the generated config must render from
+    a plain nixpkgs, so the commit-message hooks' vig-utils entries (#1434)
+    resolve through ``nix/vig-utils.nix`` rather than requiring the consumer to
+    have applied ``overlays.default`` first.
     """
     expr = f"""
     let
       flake = builtins.getFlake "path:{REPO_ROOT}";
       system = builtins.currentSystem;
-      pkgs = import flake.inputs.nixpkgs {{
-        inherit system;
-        overlays = [ flake.overlays.default ];
-        config.allowUnfree = true;
-      }};
+      pkgs = import flake.inputs.nixpkgs {{ inherit system; }};
       customized = flake.lib.mkProjectShell {{
         inherit pkgs;
         hooks = {{
@@ -886,7 +882,7 @@ class TestCommitPolicyKnobsOnTheFlakeSurface:
             ("DEVKIT_COMMIT_TYPES", "commitTypes"),
             ("DEVKIT_REFS_POLICY", "refsPolicy"),
         ):
-            assert f'vigOsValue "{key}"' in flake, f"flake.nix does not read {key}"
+            assert f'"{key}"' in flake, f"flake.nix does not read {key} from .vig-os"
             assert f"inherit {arg};" in flake, f"flake.nix does not forward `{arg}`"
             assert f"builtins.functionArgs vigos.lib.mkProjectShell ? {arg}" in flake, (
                 f"flake.nix forwards `{arg}` unconditionally — the floating vigos "

--- a/tests/test_flake_hooks.py
+++ b/tests/test_flake_hooks.py
@@ -17,9 +17,10 @@ and stages. Any hand edit to either YAML that is not mirrored in
 It also covers the consumer surface: ``mkProjectShell``'s ``hooks`` /
 ``hooksExcludes`` arguments (per-hook toggle/override, custom hooks, global
 excludes) and the zero-hooks-arg parity guarantee (no generation side effects
-unless a consumer opts in).
+unless a consumer opts in), including the stage-gated commit-message /
+agent-identity hooks and the commit-policy knobs that steer them (#1434).
 
-Refs: #883
+Refs: #883, #1434
 """
 
 from __future__ import annotations
@@ -311,18 +312,28 @@ class TestCommitMsgHookContract:
 
 @functools.cache
 def _consumer_config_set() -> dict[str, dict[str, Any]]:
-    """Build all three consumer hook configs in ONE nix build (#1417).
+    """Build every consumer hook config in ONE nix build (#1417).
 
-    The customized, gitleaks-enabled, and trunk-workflow consumer shells are
-    independent ``mkProjectShell`` calls whose ``hooksConfigFile`` outputs are
-    collected into a single ``linkFarm``, so the suite pays one build instead
-    of three module-scoped ones. Cached for the whole pytest run.
+    The customized, gitleaks-enabled, trunk-workflow, branch-types and
+    commit-policy consumer shells are independent ``mkProjectShell`` calls
+    whose ``hooksConfigFile`` outputs are collected into a single ``linkFarm``,
+    so the suite pays one build instead of one per shell. Cached for the whole
+    pytest run.
+
+    ``pkgs`` carries ``overlays.default`` (as the scaffolded consumer flake
+    builds it): the vig-utils console scripts the commit-message hooks resolve
+    (#1434) come from that overlay, exactly like the ``devTools`` toolchain
+    every ``mkProjectShell`` consumer already gets.
     """
     expr = f"""
     let
       flake = builtins.getFlake "path:{REPO_ROOT}";
       system = builtins.currentSystem;
-      pkgs = import flake.inputs.nixpkgs {{ inherit system; }};
+      pkgs = import flake.inputs.nixpkgs {{
+        inherit system;
+        overlays = [ flake.overlays.default ];
+        config.allowUnfree = true;
+      }};
       customized = flake.lib.mkProjectShell {{
         inherit pkgs;
         hooks = {{
@@ -360,6 +371,20 @@ def _consumer_config_set() -> dict[str, dict[str, Any]]:
         hooks = {{ }};
         branchTypes = [ "feature" "bugfix" "record" ];
       }};
+      commitpolicy = flake.lib.mkProjectShell {{
+        inherit pkgs;
+        hooks = {{ }};
+        commitTypes = [
+          "feat" "fix" "docs" "chore" "refactor" "perf" "test" "ci" "build"
+          "revert" "style" "record"
+        ];
+        refsPolicy = "optional";
+      }};
+      refsrequired = flake.lib.mkProjectShell {{
+        inherit pkgs;
+        hooks = {{ }};
+        refsPolicy = "required";
+      }};
     in
     pkgs.linkFarm "consumer-hook-configs" [
       {{ name = "customized"; path = customized.hooksConfigFile; }}
@@ -367,6 +392,8 @@ def _consumer_config_set() -> dict[str, dict[str, Any]]:
       {{ name = "trunk"; path = trunk.hooksConfigFile; }}
       {{ name = "branchtypes"; path = branchtypes.hooksConfigFile; }}
       {{ name = "branchtypes-trunk"; path = branchtypes-trunk.hooksConfigFile; }}
+      {{ name = "commitpolicy"; path = commitpolicy.hooksConfigFile; }}
+      {{ name = "refsrequired"; path = refsrequired.hooksConfigFile; }}
     ]
     """
     result = _run_nix(
@@ -387,6 +414,8 @@ def _consumer_config_set() -> dict[str, dict[str, Any]]:
             "trunk",
             "branchtypes",
             "branchtypes-trunk",
+            "commitpolicy",
+            "refsrequired",
         )
     }
 
@@ -642,6 +671,227 @@ class TestBranchTypesKnob:
         result = _run_nix(["eval", "--impure", "--raw", "--expr", expr])
         assert result.returncode != 0
         assert "branchTypes" in result.stderr
+
+
+STOCK_COMMIT_TYPES = "feat,fix,docs,chore,refactor,perf,test,ci,build,revert,style"
+# The argv the scaffolded .pre-commit-config.yaml ships with every knob unset —
+# the default the flake-generated surface must reproduce exactly (#1434).
+STOCK_VALIDATE_ARGS = [
+    "--types",
+    STOCK_COMMIT_TYPES,
+    "--refs-optional-types",
+    "chore",
+    "--blocked-patterns",
+    ".github/agent-blocklist.toml",
+]
+
+
+def _arg_value(hook: dict[str, Any], flag: str) -> str:
+    """The value following ``flag`` in a hook's rendered ``args`` list."""
+    args = hook["args"]
+    return args[args.index(flag) + 1]
+
+
+class TestCommitMsgHooksConsumerSurface:
+    """The #163/#1019/#1031 hooks reach flake-generated consumers (#1434).
+
+    A direnv consumer on flake-generated hooks (#1167 default) got a
+    ``.pre-commit-config.yaml`` with no ``commit-msg``/``prepare-commit-msg``
+    stage at all, so the scaffolded ``.githooks/commit-msg`` shim
+    (``prek run --hook-stage commit-msg``) exited 0 with nothing to run, and
+    ``check-agent-identity`` was absent too — ``git commit --author="Claude
+    <…>"`` passed locally. The three hooks must render on the consumer surface
+    with the same stages and argv the scaffolded YAML carries.
+    """
+
+    IDS = (
+        "validate-commit-msg",
+        "prepare-commit-msg-strip-trailers",
+        "check-agent-identity",
+    )
+
+    def test_all_three_hooks_reach_the_consumer_surface(
+        self, consumer_config: dict[str, Any]
+    ) -> None:
+        hooks = _normalize(consumer_config)["hooks"]
+        for hook_id in self.IDS:
+            assert hook_id in hooks, (
+                f"{hook_id} missing from the flake-generated consumer config — "
+                "local commit-message/agent-identity enforcement is a no-op (#1434)"
+            )
+
+    def test_validate_commit_msg_runs_at_the_commit_msg_stage(
+        self, consumer_config: dict[str, Any]
+    ) -> None:
+        """Without this stage the ``.githooks/commit-msg`` shim has nothing to run."""
+        hook = _normalize(consumer_config)["hooks"]["validate-commit-msg"]
+        assert hook["stages"] == ["commit-msg"]
+
+    def test_strip_trailers_runs_at_the_prepare_commit_msg_stage(
+        self, consumer_config: dict[str, Any]
+    ) -> None:
+        """Trailers are stripped BEFORE the validator's blocklist gate sees them."""
+        hook = _normalize(consumer_config)["hooks"]["prepare-commit-msg-strip-trailers"]
+        assert hook["stages"] == ["prepare-commit-msg"]
+        assert hook["pass_filenames"] is True
+
+    def test_check_agent_identity_stays_a_pre_commit_hook(
+        self, consumer_config: dict[str, Any]
+    ) -> None:
+        """It guards the author/committer, so it runs on the pre-commit stage."""
+        hook = _normalize(consumer_config)["hooks"]["check-agent-identity"]
+        assert hook["stages"] == ["pre-commit"]
+        assert hook["pass_filenames"] is False
+
+    def test_entries_resolve_the_pinned_vig_utils(
+        self, consumer_config: dict[str, Any]
+    ) -> None:
+        """Store-path entries, not ``uv run``: the consumer venv has no vig-utils.
+
+        Every other tool-naming consumer fragment (nixfmt, statix, deadnix,
+        just-fmt, gitleaks, pymarkdown) resolves a ``pkgs.<tool>`` store path,
+        so the hook follows the devkit pin the consumer bumps with
+        ``nix flake update vigos`` instead of whatever the project venv happens
+        to hold.
+        """
+        hooks = _normalize(consumer_config)["hooks"]
+        for hook_id in self.IDS:
+            entry = hooks[hook_id]["entry"]
+            assert entry.startswith("/nix/store/"), (
+                f"{hook_id} entry is not a store path: {entry!r}"
+            )
+            assert entry.endswith(f"/bin/{hook_id}"), entry
+            assert hooks[hook_id]["language"] == "system"
+
+    def test_default_args_match_the_scaffolded_render(
+        self, consumer_config: dict[str, Any], rendered_portable: dict[str, Any]
+    ) -> None:
+        """Default-render stability: both surfaces ship identical argv (#1434).
+
+        A docker-mode consumer (scaffolded YAML) and a direnv consumer
+        (flake-generated) must enforce the same rule with the knobs unset —
+        the hook/CI desync class #1074 and #1282 exist to prevent.
+        """
+        consumer = _normalize(consumer_config)["hooks"]["validate-commit-msg"]
+        scaffold = _normalize(rendered_portable["scaffold"])["hooks"][
+            "validate-commit-msg"
+        ]
+        assert consumer["args"] == scaffold["args"] == STOCK_VALIDATE_ARGS
+
+
+@pytest.fixture(scope="module")
+def commit_policy_config() -> dict[str, Any]:
+    """Generated config for custom ``commitTypes`` + ``refsPolicy = optional``."""
+    return _consumer_config_set()["commitpolicy"]
+
+
+@pytest.fixture(scope="module")
+def refs_required_config() -> dict[str, Any]:
+    """Generated config for ``refsPolicy = "required"`` (#1282)."""
+    return _consumer_config_set()["refsrequired"]
+
+
+class TestCommitPolicyKnobsOnTheFlakeSurface:
+    """``commitTypes`` / ``refsPolicy`` on mkProjectShell (#1434).
+
+    #1431 (``DEVKIT_COMMIT_TYPES``) and #1282 (``DEVKIT_REFS_POLICY``) render
+    into the scaffolded YAML and CI's ``validate-commit-range``; a direnv
+    consumer's local hook comes from ``mkProjectShell`` instead, so the same
+    two keys must reach it — threaded like ``workflow`` (#1224) and
+    ``branchTypes`` (#1432). The resolution semantics (defaults, charset,
+    the ``optional`` mirror of the resolved types list, the ``required``
+    ``none`` sentinel) must match ``render_commit_types`` /
+    ``render_refs_policy`` in ``assets/init-workspace.sh`` and
+    ``resolve-toolchain`` exactly — two renderers, one key.
+    """
+
+    def test_custom_commit_types_render_into_the_types_arg(
+        self, commit_policy_config: dict[str, Any]
+    ) -> None:
+        hook = _normalize(commit_policy_config)["hooks"]["validate-commit-msg"]
+        assert _arg_value(hook, "--types") == f"{STOCK_COMMIT_TYPES},record"
+
+    def test_refs_policy_optional_mirrors_the_resolved_commit_types(
+        self, commit_policy_config: dict[str, Any]
+    ) -> None:
+        """The #1431 composition fix, on the flake surface.
+
+        ``optional`` must mirror the RESOLVED types list, never a hardcoded
+        copy of the stock 11 — otherwise the hook requires ``Refs:`` for a
+        custom type it just accepted.
+        """
+        hook = _normalize(commit_policy_config)["hooks"]["validate-commit-msg"]
+        assert _arg_value(hook, "--refs-optional-types") == _arg_value(hook, "--types")
+
+    def test_refs_policy_required_uses_the_none_sentinel(
+        self, refs_required_config: dict[str, Any]
+    ) -> None:
+        """An empty list reads as falsy to the CLI, so ``required`` sends ``none``."""
+        hook = _normalize(refs_required_config)["hooks"]["validate-commit-msg"]
+        assert _arg_value(hook, "--refs-optional-types") == "none"
+        assert _arg_value(hook, "--types") == STOCK_COMMIT_TYPES
+
+    def test_unset_knobs_keep_the_stock_argv(
+        self, consumer_config: dict[str, Any]
+    ) -> None:
+        """Null/absent knobs resolve to today's behavior, byte for byte."""
+        hook = _normalize(consumer_config)["hooks"]["validate-commit-msg"]
+        assert hook["args"] == STOCK_VALIDATE_ARGS
+
+    @pytest.mark.parametrize(
+        ("arg", "value", "message"),
+        [
+            pytest.param(
+                "commitTypes",
+                '[ "feat" "Bad-Type" ]',
+                "commitTypes",
+                id="types-charset",
+            ),
+            pytest.param("commitTypes", "[ ]", "commitTypes", id="types-empty"),
+            pytest.param(
+                "refsPolicy", '"garbage"', "refsPolicy", id="refs-policy-enum"
+            ),
+        ],
+    )
+    def test_invalid_values_are_refused_at_eval_time(
+        self, arg: str, value: str, message: str
+    ) -> None:
+        """A bad value fails loudly, mirroring init-workspace.sh's loud abort."""
+        expr = f"""
+        let
+          flake = builtins.getFlake "path:{REPO_ROOT}";
+          system = builtins.currentSystem;
+          pkgs = import flake.inputs.nixpkgs {{ inherit system; }};
+        in
+        (flake.lib.mkProjectShell {{
+          inherit pkgs;
+          {arg} = {value};
+          hooks = {{ }};
+        }}).drvPath
+        """
+        result = _run_nix(["eval", "--impure", "--raw", "--expr", expr])
+        assert result.returncode != 0
+        assert message in result.stderr
+
+    def test_template_flake_reads_and_forwards_both_knobs(self) -> None:
+        """The scaffolded flake.nix wires ``.vig-os`` -> ``mkProjectShell``.
+
+        Same one-time port as #1224/#1432: the reader lives in the
+        scaffold-once ``flake.nix``, and the forwarding is gated behind a
+        ``builtins.functionArgs`` probe so a floating ``vigos`` input that
+        predates the argument still evaluates (#1249).
+        """
+        flake = (REPO_ROOT / "assets" / "workspace" / "flake.nix").read_text()
+        for key, arg in (
+            ("DEVKIT_COMMIT_TYPES", "commitTypes"),
+            ("DEVKIT_REFS_POLICY", "refsPolicy"),
+        ):
+            assert f'vigOsValue "{key}"' in flake, f"flake.nix does not read {key}"
+            assert f"inherit {arg};" in flake, f"flake.nix does not forward `{arg}`"
+            assert f"builtins.functionArgs vigos.lib.mkProjectShell ? {arg}" in flake, (
+                f"flake.nix forwards `{arg}` unconditionally — the floating vigos "
+                "input may resolve a devkit that predates the argument (#1249)"
+            )
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
## Description

Fixes #1434. A direnv consumer on flake-generated hooks (the #1167 default) had **no local commit-message or agent-identity enforcement at all**.

`validate-commit-msg`, `prepare-commit-msg-strip-trailers` and `check-agent-identity` were defined `scaffold = true` with no `consumer` fragment, so `mkProjectShell`'s generated config omitted all three. The scaffolded `.githooks/commit-msg` shim then ran `prek run --hook-stage commit-msg` against an empty stage and exited 0 — the exact false guarantee #1019 was filed to remove ("every scaffolded repo shipped a `COMMIT_MESSAGE_STANDARD.md` it could not enforce"), and `git commit --author="Claude <...>"` passed locally too.

Pre-existing since #883/#1167, not a regression; CI (`validate-commit-range`, `check-pr-agent-fingerprints`) was the only line of defense for these consumers.

## Type of Change

- [x] `fix` -- Bug fix
- [x] `test` -- Adding or updating tests
- [x] `docs` -- Documentation only

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

**Route chosen:** `consumer` fragments with Nix store-path entries, not "append the portable definition verbatim". The portable `yaml` entries are `uv run <tool>`, which resolves against the *consumer's* project venv — and a consumer venv has no `vig-utils` (many consumers have no `pyproject.toml` at all). Every other tool-naming consumer fragment (`nixfmt`, `statix`, `deadnix`, `just-fmt`, `gitleaks`, `pymarkdown`) already resolves `${pkgs.<tool>}/bin/…`, so the hook version follows the devkit pin the consumer bumps with `nix flake update vigos`. git-hooks.nix supports `commit-msg`/`prepare-commit-msg` in its `stages` set, so "stage-gated" was never the blocker — the header's "not generatable" claim was stale and is corrected.

- **`nix/vig-utils.nix`** (new) -- the vig-utils package lifted verbatim out of `flake.nix`'s overlay, so hook fragments build it from an un-overlaid `pkgs`. `pkgs.vig-utils` existed only via `overlays.default`, which would have made the generation surface fail eval on a plain `pkgs`. Follows the existing `nix/pymarkdown.nix` precedent — one definition, no new overlay requirement.
- **`nix/hooks.nix`** -- `consumer` fragments for the three hooks; `defaultCommitTypes` + `refsOptionalTypesFor` + `validateCommitMsgArgs` helpers, with the committed YAML render now deriving its argv from the same helper (one literal, not two); `consumer` render takes a knob attrset (`{ workflow, branchTypes, commitTypes, refsPolicy }`) instead of four positional nullables.
- **`flake.nix`** -- `mkProjectShell` gains `commitTypes ? null` / `refsPolicy ? null` with eval-time asserts mirroring the scaffold guards (per-entry `[a-z][a-z0-9]*`, non-empty list; three-value enum).
- **`assets/workspace/flake.nix`** -- reads `DEVKIT_COMMIT_TYPES` / `DEVKIT_REFS_POLICY` from `.vig-os`, each forwarded behind a `builtins.functionArgs vigos.lib.mkProjectShell ? <arg>` probe so a floating `vigos` input predating the argument still evaluates (#1249 pattern). New `vigOsList` helper now that the comma-list parse has two callers.
- **`docs/MIGRATION.md`**, **`assets/workspace/.vig-os`**, **`CHANGELOG.md`** (+ hook-synced mirror).

**Knob-resolution consistency (the issue's hard requirement).** The flake path resolves exactly as `render_commit_types` / `render_refs_policy` (`assets/init-workspace.sh`) and `resolve-toolchain` do: same default 11-type list, same trim/drop-empty parse, same charset allowlist, `optional` mirroring the **resolved** list (the #1431 composition, not a hardcoded stock copy), `required` using the `none` sentinel. Divergence is now structurally impossible on the Nix side, since `validateCommitMsgArgs` renders both the committed YAML and the consumer config.

## Changelog Entry

```
### Fixed

- **Flake-generated hooks now carry the commit-message and agent-identity guards** ([#1434](https://github.com/vig-os/devkit/issues/1434))
```

(Full entry with sub-bullets is in `CHANGELOG.md` under `## Unreleased` -> `### Fixed`.)

## Testing

- [x] Tests pass locally
- [x] Manual testing performed (describe below)

### Manual Testing Details

Live behavioral proof against a real generated config symlinked into a scratch repo, not just render assertions:

| check | before | after |
|---|---|---|
| `prek run --hook-stage commit-msg` on `totally-invalid message…` | exit 0, no hooks | **exit 1** -- `First line must match 'type(scope): short description'` |
| valid `fix(hooks): …` + `Refs:` | -- | exit 0 |
| `check-agent-identity` with `GIT_AUTHOR_NAME=Claude` | absent | **exit 1** -- `matches blocklisted AI agent identity: 'claude'` |
| `commitTypes=[feat,fix,chore,record] refsPolicy=optional` -> `record(registry): …` no Refs | -- | exit 0 |
| same config -> `perf(x): …` | -- | **exit 1** -- `Allowed types: chore, feat, fix, record` |

The "before" row is grounded: the pre-fix generated config's hook list contained none of the three.

- `uv run pytest tests/test_flake_hooks.py` -> 59 passed, exit 0 (baseline 45; RED run: 1 failed, 29 errors -- `function 'mkProjectShell' called with unexpected argument 'commitTypes'`).
- Targeted regression set (`test_flake_hooks`, `test_flake_devshell`, `test_workflow_model`, `test_vig_os_manifest`, `test_ci_runner`, `test_scaffold_drift`) -> 176 passed, 1 skipped, exit 0.
- `prek run --all-files` -> exit 0, fully green (re-run after merging `dev`).
- `nix flake check --accept-flake-config .` on a clean tree -> exit 0, `all checks passed!`.
- Custom-knob render verified directly: `--types feat,fix,chore,record --refs-optional-types feat,fix,chore,record`, i.e. `optional` mirrors the resolved list, matching `render_refs_policy`'s `RESOLVED_COMMIT_TYPES` branch.

Note: `tests/test_image.py::TestFileStructure::test_manifest_files` fails locally, and **fails identically on a clean `dev` without this branch** — it checksums the working-tree `CHANGELOG.md` against a locally cached devcontainer image. Stale-image noise, unrelated to this change; CI rebuilds the image.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

**Invariants held.** Drift gate: `.pre-commit-config.yaml` (both copies) is absent from the diff entirely — the argv refactor renders byte-identically. Zero-hooks parity: `TestZeroHooksParity` passes with an identical `drvPath`; the three hooks exist only on the `consumer` surface, inert without a `hooks`/`hooksExcludes` opt-in. Default-render stability: new `test_default_args_match_the_scaffolded_render` asserts consumer argv == scaffold argv == the stock six-element list.

**Adoption is a behavior change worth calling out in the release notes** — a consumer whose history contains non-conformant messages will start seeing local rejections on its next `nix flake update vigos`. Existing direnv consumers get nothing until they hand-port the `.vig-os` reader into their scaffold-once `flake.nix` (the same one-time port as #1224/#1432, now documented in `MIGRATION.md`); until then the hooks ship with stock defaults, still strictly better than no hooks.

**Deliberately not done.** No `check` (sandbox) fragments — the Nix sandbox has no git repo and no commit to inspect, and `check-agent-identity` short-circuits under `CI=true`; those would be dead weight. `check-agent-identity` does now run under a direnv consumer's `prek run --all-files` lint job, but returns 0 immediately when `CI`/`GITHUB_ACTIONS` is set, so consumer CI is unaffected (container-mode consumers have shipped it since #1031).

**Suggested follow-up:** `check-expirations`'s consumer fragment still uses `uv run check-expirations` — the exact venv-resolution weakness this issue is about, and now the odd one out among the vig-utils consumer fragments. Should move to the same store-path form.

Closes #1434

Refs: #1434
