### PR TITLE
fix(smoke-test): publish installer deletions to the deploy branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -171,7 +171,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Flake-generated hooks now carry the commit-message and agent-identity guards** ([#1434](https://github.com/vig-os/devkit/issues/1434))
+- **Smoke deploy now publishes installer deletions to the deploy branch** ([#1443](https://github.com/vig-os/devkit/issues/1443))
+  - The smoke-test dispatch deploy committed via `commit-action`, which builds
+    its tree additively from working-tree contents and cannot express file
+    deletions — so paths the installer removed (retired scaffold paths, #1348)
+    silently survived on the deploy branch and the scaffold-drift gate rejected
+    the deploy PR (its second live catch, after
+    [#1344](https://github.com/vig-os/devkit/issues/1344)); caught on the
+    1.8.0-rc1 dispatch, where the per-PR renovate-changelog workflows retired
+    by [#1423](https://github.com/vig-os/devkit/issues/1423) rode along
+  - The deploy job now publishes `git ls-files --deleted` as a follow-up
+    verified API commit of null-sha tree entries — the same tree-API pattern
+    the scaffolded `devkit-upgrade.yml` already uses for adoption PRs (which
+    were never affected)
   - A direnv consumer on flake-generated hooks had **no local commit-message
     or agent-identity enforcement at all**: `validate-commit-msg`,
     `prepare-commit-msg-strip-trailers` and `check-agent-identity` carried no

--- a/assets/smoke-test/.github/workflows/repository-dispatch.yml
+++ b/assets/smoke-test/.github/workflows/repository-dispatch.yml
@@ -357,6 +357,50 @@ jobs:
             chore: deploy ${{ needs.validate.outputs.tag }}
           FILE_PATHS: .
 
+      # commit-action builds its tree additively from working-tree contents, so
+      # paths the installer DELETED — retired scaffold paths (#1348), or anything
+      # the smoke-mode rsync --delete render no longer ships — never reach the
+      # deploy branch, and the scaffold-drift gate rejects the PR
+      # (vig-os/devkit#1443). Publish those deletions as an explicit follow-up
+      # commit: a null-sha tree entry removes a path. Same tree-API pattern as
+      # the scaffolded devkit-upgrade.yml, and an App-token API commit is
+      # GitHub-verified just like the commit-action one.
+      - name: Publish installer deletions via verified API commit
+        env:
+          GH_TOKEN: ${{ steps.generate_commit_token.outputs.token }}
+          BRANCH: ${{ steps.prepare_branch.outputs.branch_name }}
+          TAG: ${{ needs.validate.outputs.tag }}
+        run: |
+          set -euo pipefail
+          mapfile -t DELETED < <(git ls-files --deleted)
+          if [ "${#DELETED[@]}" -eq 0 ]; then
+            echo "No installer deletions to publish."
+            exit 0
+          fi
+
+          REPO="${GITHUB_REPOSITORY}"
+          HEAD_SHA="$(gh api "repos/${REPO}/git/ref/heads/${BRANCH}" --jq '.object.sha')"
+          BASE_TREE="$(gh api "repos/${REPO}/git/commits/${HEAD_SHA}" --jq .tree.sha)"
+
+          entries='[]'
+          for path in "${DELETED[@]}"; do
+            echo "  deleting ${path}"
+            entries="$(jq --arg p "$path" \
+              '. + [{path: $p, mode: "100644", type: "blob", sha: null}]' \
+              <<<"$entries")"
+          done
+
+          TREE="$(jq -n --argjson t "$entries" --arg b "$BASE_TREE" \
+            '{base_tree: $b, tree: $t}' \
+            | gh api -X POST "repos/${REPO}/git/trees" --input - --jq .sha)"
+          MESSAGE="$(printf 'chore: remove paths the %s render no longer ships' "$TAG")"
+          COMMIT="$(jq -n --arg m "$MESSAGE" --arg t "$TREE" --arg p "$HEAD_SHA" \
+            '{message: $m, tree: $t, parents: [$p]}' \
+            | gh api -X POST "repos/${REPO}/git/commits" --input - --jq .sha)"
+          gh api -X PATCH "repos/${REPO}/git/refs/heads/${BRANCH}" \
+            -f sha="$COMMIT" -F force=true >/dev/null
+          echo "Published ${#DELETED[@]} deletion(s) as ${COMMIT}."
+
       - name: Create deploy PR
         id: create_pr
         env:

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -171,7 +171,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Flake-generated hooks now carry the commit-message and agent-identity guards** ([#1434](https://github.com/vig-os/devkit/issues/1434))
+- **Smoke deploy now publishes installer deletions to the deploy branch** ([#1443](https://github.com/vig-os/devkit/issues/1443))
+  - The smoke-test dispatch deploy committed via `commit-action`, which builds
+    its tree additively from working-tree contents and cannot express file
+    deletions — so paths the installer removed (retired scaffold paths, #1348)
+    silently survived on the deploy branch and the scaffold-drift gate rejected
+    the deploy PR (its second live catch, after
+    [#1344](https://github.com/vig-os/devkit/issues/1344)); caught on the
+    1.8.0-rc1 dispatch, where the per-PR renovate-changelog workflows retired
+    by [#1423](https://github.com/vig-os/devkit/issues/1423) rode along
+  - The deploy job now publishes `git ls-files --deleted` as a follow-up
+    verified API commit of null-sha tree entries — the same tree-API pattern
+    the scaffolded `devkit-upgrade.yml` already uses for adoption PRs (which
+    were never affected)
   - A direnv consumer on flake-generated hooks had **no local commit-message
     or agent-identity enforcement at all**: `validate-commit-msg`,
     `prepare-commit-msg-strip-trailers` and `check-agent-identity` carried no

--- a/tests/bats/just.bats
+++ b/tests/bats/just.bats
@@ -210,6 +210,16 @@ EOF
     assert_success
 }
 
+@test "smoke-test dispatch publishes installer deletions to the deploy branch (#1443)" {
+    # commit-action builds its tree additively from working-tree contents, so
+    # paths the installer deleted (retired scaffold paths, #1348) never reach
+    # the deploy branch and the scaffold-drift gate rejects the PR. The deploy
+    # job must publish those deletions explicitly (null-sha tree entries, the
+    # same tree-API pattern as the scaffolded devkit-upgrade.yml).
+    run bash -lc 'grep -Fq -- "Publish installer deletions via verified API commit" assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- "git ls-files --deleted" assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- "{path: \$p, mode: \"100644\", type: \"blob\", sha: null}" assets/smoke-test/.github/workflows/repository-dispatch.yml'
+    assert_success
+}
+
 @test "smoke-test dispatch preflight validates required workflow contract" {
     run bash -lc "grep -Fq -- 'Preflight check required release workflows on dispatch ref' assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- 'REQUIRED_WORKFLOWS=(prepare-release.yml release.yml promote-release.yml)' assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- 'for workflow_file in \"\${REQUIRED_WORKFLOWS[@]}\"; do' assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- 'WORKFLOW_CHECK_OUTPUT=\"\$(gh workflow view \"\${workflow_file}\" --ref \"\${WORKFLOW_REF}\" --yaml 2>&1 >/dev/null)\"' assets/smoke-test/.github/workflows/repository-dispatch.yml"
     assert_success


### PR DESCRIPTION
## Summary

The 1.8.0-rc1 smoke dispatch failed at the deploy-merge wait: the deploy PR (devkit-smoke-test#356) was rejected by its Scaffold Drift gate because the two workflows retired by #1423 (\`renovate-changelog-build.yml\`, \`renovate-changelog-commit.yml\`) survived on the deploy branch. The installer deleted them correctly in the working tree (retired-paths manifest, #1348), but the deploy publishes via \`commit-action\` (\`FILE_PATHS: .\`), which builds its tree additively and cannot express deletions.

## Fix

New deploy step \`Publish installer deletions via verified API commit\`: collects \`git ls-files --deleted\` (in smoke mode the working tree after install is exactly the fresh render + smoke overlay, so this set is precisely what the new scaffold no longer ships) and publishes one follow-up commit of null-sha tree entries via the git tree API — the same pattern the scaffolded \`devkit-upgrade.yml\` already uses for adoption PRs (which were never affected). App-token API commits are GitHub-verified, matching the commit-action commit.

TDD: bats contract test pinned first (\`smoke-test dispatch publishes installer deletions to the deploy branch (#1443)\`), then the step; \`bats tests/bats/just.bats\` 51/51 green, \`prek run --all-files\` green, \`actionlint\` clean on the template.

## Operational note

The listener executes from devkit-smoke-test's **default branch (main)** — the fixed template must be manually redeployed there before dispatching rc2 (tracked in #1443).

Closes #1443

Refs: #1443