### PR TITLE
fix(smoke-test): make the template deploy branch name dot-free

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -184,6 +184,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     verified API commit of null-sha tree entries — the same tree-API pattern
     the scaffolded `devkit-upgrade.yml` already uses for adoption PRs (which
     were never affected)
+- **Smoke dispatch template deploy branch is now dot-free** ([#1444](https://github.com/vig-os/devkit/issues/1444))
+  - The template still generated `chore/deploy-<tag>` with dots, which the
+    scaffolded CI branch-name gate
+    ([#1432](https://github.com/vig-os/devkit/issues/1432)) rejects
+    (`^chore/[a-z0-9]+(-[a-z0-9]+)*$`). The live listener was hand-fixed
+    (devkit-smoke-test#354) but every deploy overlays the template back over
+    it, re-arming the regression for the next train. Dots now map to dashes
+    in the template SSoT, matching the live listener
   - A direnv consumer on flake-generated hooks had **no local commit-message
     or agent-identity enforcement at all**: `validate-commit-msg`,
     `prepare-commit-msg-strip-trailers` and `check-agent-identity` carried no

--- a/assets/smoke-test/.github/workflows/repository-dispatch.yml
+++ b/assets/smoke-test/.github/workflows/repository-dispatch.yml
@@ -3,7 +3,9 @@ name: Repository Dispatch Listener
 # Purpose:
 # - Handle cross-repo `repository_dispatch` events from vig-os/devkit.
 # - Deploy the requested tag into the smoke-test repo.
-# - Always create a `chore/deploy-<tag>` branch and PR to `dev`.
+# - Always create a `chore/deploy-<tag-with-dashes>` branch (dots mapped to
+#   dashes: the scaffolded CI branch-name gate, vig-os/devkit#1432, and the
+#   local guard both reject dots in chore slugs) and PR to `dev`.
 # - Create signed deploy commits via `vig-os/commit-action`.
 # - CI (`ci.yml`) triggers on the deploy PR.
 #
@@ -330,7 +332,7 @@ jobs:
           GH_TOKEN: ${{ steps.generate_release_token.outputs.token }}
           TAG: ${{ needs.validate.outputs.tag }}
         run: |
-          BRANCH_NAME="chore/deploy-${TAG}"
+          BRANCH_NAME="chore/deploy-${TAG//./-}"
           echo "branch_name=${BRANCH_NAME}" >> "${GITHUB_OUTPUT}"
 
           DEV_SHA="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/dev" --jq '.object.sha')"

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -184,6 +184,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     verified API commit of null-sha tree entries — the same tree-API pattern
     the scaffolded `devkit-upgrade.yml` already uses for adoption PRs (which
     were never affected)
+- **Smoke dispatch template deploy branch is now dot-free** ([#1444](https://github.com/vig-os/devkit/issues/1444))
+  - The template still generated `chore/deploy-<tag>` with dots, which the
+    scaffolded CI branch-name gate
+    ([#1432](https://github.com/vig-os/devkit/issues/1432)) rejects
+    (`^chore/[a-z0-9]+(-[a-z0-9]+)*$`). The live listener was hand-fixed
+    (devkit-smoke-test#354) but every deploy overlays the template back over
+    it, re-arming the regression for the next train. Dots now map to dashes
+    in the template SSoT, matching the live listener
   - A direnv consumer on flake-generated hooks had **no local commit-message
     or agent-identity enforcement at all**: `validate-commit-msg`,
     `prepare-commit-msg-strip-trailers` and `check-agent-identity` carried no

--- a/tests/bats/just.bats
+++ b/tests/bats/just.bats
@@ -220,6 +220,15 @@ EOF
     assert_success
 }
 
+@test "smoke-test dispatch deploy branch name is dot-free (#1444)" {
+    # The scaffolded CI branch-name gate (#1432) allows chore branches only as
+    # ^chore/[a-z0-9]+(-[a-z0-9]+)*$ — dots rejected. The live listener was
+    # hand-fixed (devkit-smoke-test#354) but the template SSoT must match, or
+    # every deploy reverts the fix and the next train's deploy PR fails CI.
+    run bash -lc 'grep -Fq -- "BRANCH_NAME=\"chore/deploy-\${TAG//./-}\"" assets/smoke-test/.github/workflows/repository-dispatch.yml && ! grep -Fq -- "BRANCH_NAME=\"chore/deploy-\${TAG}\"" assets/smoke-test/.github/workflows/repository-dispatch.yml'
+    assert_success
+}
+
 @test "smoke-test dispatch preflight validates required workflow contract" {
     run bash -lc "grep -Fq -- 'Preflight check required release workflows on dispatch ref' assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- 'REQUIRED_WORKFLOWS=(prepare-release.yml release.yml promote-release.yml)' assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- 'for workflow_file in \"\${REQUIRED_WORKFLOWS[@]}\"; do' assets/smoke-test/.github/workflows/repository-dispatch.yml && grep -Fq -- 'WORKFLOW_CHECK_OUTPUT=\"\$(gh workflow view \"\${workflow_file}\" --ref \"\${WORKFLOW_REF}\" --yaml 2>&1 >/dev/null)\"' assets/smoke-test/.github/workflows/repository-dispatch.yml"
     assert_success


### PR DESCRIPTION
## Summary

The smoke dispatch template still computes \`BRANCH_NAME="chore/deploy-${TAG}"\` (dotted). The scaffolded CI branch-name gate (#1432) allows chore branches only as \`^chore/[a-z0-9]+(-[a-z0-9]+)*$\` — dots rejected. The live listener on devkit-smoke-test \`main\` was hand-fixed as a 1.8.0 train prerequisite (devkit-smoke-test#354), but every deploy overlays the template listener over the live one, so the 1.8.0 deploy would revert the fix and the **next** train's deploy PR would fail its own branch gate.

## Fix

Port smoke#354 into the template SSoT: dots map to dashes (\`${TAG//./-}\`), and the header comment documents why. Found while diagnosing #1443 on the rc1 dispatch failure (fixed in #1445).

TDD: bats contract test pinned first; \`bats tests/bats/just.bats\` 51/51 green, \`actionlint\` clean, \`prek run --all-files\` green.

Closes #1444

Refs: #1444