### PR TITLE
fix(workspace): resolve the check-expirations consumer entry from the devkit pin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -171,6 +171,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`check-expirations` resolves from the devkit pin in generated consumer hooks** ([#1447](https://github.com/vig-os/devkit/issues/1447))
+  - It was the last vig-utils hook whose flake-generated consumer fragment
+    shelled out to `uv run`, i.e. to the *consumer's* project venv — which
+    carries no `vig-utils`, and which many consumers do not have at all (no
+    `pyproject.toml`). The entry now resolves a `nix/vig-utils.nix` store
+    path, like the three hooks fixed in
+    [#1434](https://github.com/vig-os/devkit/issues/1434) and every other
+    tool-naming consumer fragment, so the hook follows the devkit pin the
+    consumer bumps with `nix flake update vigos`
+  - The committed `.pre-commit-config.yaml` renders are unchanged: only the
+    consumer surface moves off `uv run`, and a new class-wide test rejects any
+    future consumer fragment that names a vig-utils console script without a
+    store path
 - **Smoke deploy now publishes installer deletions to the deploy branch** ([#1443](https://github.com/vig-os/devkit/issues/1443))
   - The smoke-test dispatch deploy committed via `commit-action`, which builds
     its tree additively from working-tree contents and cannot express file

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -171,6 +171,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`check-expirations` resolves from the devkit pin in generated consumer hooks** ([#1447](https://github.com/vig-os/devkit/issues/1447))
+  - It was the last vig-utils hook whose flake-generated consumer fragment
+    shelled out to `uv run`, i.e. to the *consumer's* project venv — which
+    carries no `vig-utils`, and which many consumers do not have at all (no
+    `pyproject.toml`). The entry now resolves a `nix/vig-utils.nix` store
+    path, like the three hooks fixed in
+    [#1434](https://github.com/vig-os/devkit/issues/1434) and every other
+    tool-naming consumer fragment, so the hook follows the devkit pin the
+    consumer bumps with `nix flake update vigos`
+  - The committed `.pre-commit-config.yaml` renders are unchanged: only the
+    consumer surface moves off `uv run`, and a new class-wide test rejects any
+    future consumer fragment that names a vig-utils console script without a
+    store path
 - **Smoke deploy now publishes installer deletions to the deploy branch** ([#1443](https://github.com/vig-os/devkit/issues/1443))
   - The smoke-test dispatch deploy committed via `commit-action`, which builds
     its tree additively from working-tree contents and cannot express file

--- a/nix/hooks.nix
+++ b/nix/hooks.nix
@@ -740,8 +740,12 @@ let
         };
     };
     # Security exception expiry enforcement (#566). Ships to the scaffold
-    # (consumer repos carry .trivyignore/.vulnixignore too), so the
-    # consumer render keeps the PATH-portable `uv run` entry.
+    # (consumer repos carry .trivyignore/.vulnixignore too), so the committed
+    # YAML renders keep the PATH-portable `uv run` entry, while the consumer
+    # fragment resolves a nix/vig-utils.nix store path like every other
+    # tool-naming consumer fragment (#1447, same defect as #1434): `uv run`
+    # resolves against the *consumer's* project venv, which carries no
+    # vig-utils and which many consumers do not have at all.
     check-expirations = {
       scaffold = true;
       yaml = {
@@ -761,10 +765,10 @@ let
           files = expirationsFiles;
           pass_filenames = false;
         };
-      consumer = _: {
+      consumer = pkgs: {
         enable = true;
         name = "check-expirations";
-        entry = "uv run check-expirations .trivyignore .vulnixignore";
+        entry = "${import ./vig-utils.nix pkgs}/bin/check-expirations .trivyignore .vulnixignore";
         language = "system";
         files = expirationsFiles;
         pass_filenames = false;

--- a/tests/test_flake_hooks.py
+++ b/tests/test_flake_hooks.py
@@ -31,6 +31,7 @@ import re
 import shlex
 import shutil
 import subprocess
+import tomllib
 from pathlib import Path
 from typing import Any
 
@@ -773,6 +774,107 @@ class TestCommitMsgHooksConsumerSurface:
             "validate-commit-msg"
         ]
         assert consumer["args"] == scaffold["args"] == STOCK_VALIDATE_ARGS
+
+
+@functools.cache
+def _vig_utils_console_scripts() -> frozenset[str]:
+    """Console scripts vig-utils installs.
+
+    Read from ``packages/vig-utils/pyproject.toml`` rather than hardcoded, so
+    the class-wide guard below covers every current *and* future script
+    without a second list to keep in sync.
+    """
+    data = tomllib.loads(
+        (REPO_ROOT / "packages" / "vig-utils" / "pyproject.toml").read_text()
+    )
+    return frozenset(data["project"]["scripts"])
+
+
+class TestCheckExpirationsConsumerSurface:
+    """``check-expirations`` resolves the pinned vig-utils too (#1447).
+
+    It was the last vig-utils hook whose consumer fragment shelled out to
+    ``uv run``, i.e. to the *consumer's* project venv — which carries no
+    vig-utils, and which many consumers do not have at all (no
+    ``pyproject.toml``). Same defect and same fix as the three hooks of #1434.
+    """
+
+    def test_entry_resolves_the_pinned_vig_utils(
+        self, consumer_config: dict[str, Any]
+    ) -> None:
+        """Store-path entry, so the hook follows the consumer's devkit pin."""
+        entry = _normalize(consumer_config)["hooks"]["check-expirations"]["entry"]
+        argv = shlex.split(entry)
+        assert argv[0].startswith("/nix/store/"), (
+            f"check-expirations entry is not a store path: {entry!r}"
+        )
+        assert argv[0].endswith("/bin/check-expirations"), entry
+
+    def test_scope_and_argv_match_the_scaffolded_render(
+        self, consumer_config: dict[str, Any], rendered_portable: dict[str, Any]
+    ) -> None:
+        """Only the resolution changes: the hook still guards the same files.
+
+        A docker-mode consumer (scaffolded YAML) and a direnv consumer
+        (flake-generated) must enforce the same expiries over the same paths.
+        """
+        consumer = _normalize(consumer_config)["hooks"]["check-expirations"]
+        scaffold = _normalize(rendered_portable["scaffold"])["hooks"][
+            "check-expirations"
+        ]
+        scaffold_argv = shlex.split(scaffold["entry"])
+        assert scaffold_argv[:3] == ["uv", "run", "check-expirations"]
+        assert shlex.split(consumer["entry"])[1:] == [".trivyignore", ".vulnixignore"]
+        assert scaffold_argv[3:] == shlex.split(consumer["entry"])[1:]
+        assert consumer["files"] == scaffold["files"]
+        assert consumer["language"] == "system"
+        assert consumer["pass_filenames"] is False
+
+    def test_portable_render_keeps_the_uv_run_entry(
+        self, rendered_portable: dict[str, Any]
+    ) -> None:
+        """The committed YAMLs stay PATH-portable — no store-path churn.
+
+        Only the *consumer* (flake-generated) fragment resolves a store path;
+        the runner and scaffold renders are committed artifacts pinned by the
+        drift gate, so they keep the ``uv run`` form (docs/NIX.md).
+        """
+        for render in ("runner", "scaffold"):
+            entry = _normalize(rendered_portable[render])["hooks"]["check-expirations"][
+                "entry"
+            ]
+            assert entry.startswith("uv run check-expirations "), (render, entry)
+
+
+class TestNoConsumerHookResolvesVigUtilsThroughTheVenv:
+    """Class-wide guard for the #1434/#1447 defect, on every consumer shell.
+
+    A ``uv run <vig-utils script>`` entry on the consumer surface resolves
+    against the *consumer's* project venv, which devkit neither controls nor
+    can assume exists. Every consumer fragment that names a vig-utils console
+    script must resolve a ``nix/vig-utils.nix`` store path instead. Pinning
+    the class — rather than one hook at a time — is what keeps the next hook
+    added to ``nix/hooks.nix`` from reintroducing it.
+    """
+
+    def test_every_vig_utils_entry_is_a_store_path(self) -> None:
+        scripts = _vig_utils_console_scripts()
+        offenders: list[str] = []
+        for shell, config in _consumer_config_set().items():
+            for hook_id, hook in _normalize(config)["hooks"].items():
+                argv = shlex.split(hook.get("entry") or "")
+                if not argv:
+                    continue
+                names = {Path(argv[0]).name, *(argv[1:3] if argv[0] == "uv" else [])}
+                if not names & scripts:
+                    continue
+                if not argv[0].startswith("/nix/store/"):
+                    offenders.append(f"{shell}:{hook_id}: {hook['entry']!r}")
+        assert not offenders, (
+            "consumer hook entries resolve vig-utils through the project venv "
+            "instead of the pinned store path (#1434, #1447):\n  "
+            + "\n  ".join(offenders)
+        )
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
## Description

Fixes #1447. **Targets `release/1.8.0`** — the train is cut and `1.8.0-rc1` is tagged; this lands ahead of rc2 alongside #1443/#1444.

`check-expirations` was the last vig-utils hook whose **consumer** fragment resolved its entry through the consumer's project venv (`uv run check-expirations …`). A consumer venv carries no `vig-utils`, and many consumers have no `pyproject.toml` at all — the exact defect #1434 fixed for the three commit-message/agent-identity hooks. After #1434, this one was the odd one out among the tool-naming consumer fragments.

## Type of Change

- [x] `fix` -- Bug fix
- [x] `test` -- Adding or updating tests

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- `nix/hooks.nix` -- `check-expirations`'s `consumer` fragment now takes `pkgs` and resolves `${import ./vig-utils.nix pkgs}/bin/check-expirations .trivyignore .vulnixignore`, matching the #1434 fragments. Leading comment updated to explain the split.
- `tests/test_flake_hooks.py` -- `_vig_utils_console_scripts()` helper, `TestCheckExpirationsConsumerSurface` (3 tests), `TestNoConsumerHookResolvesVigUtilsThroughTheVenv` (1 test).
- `CHANGELOG.md` (+ hook-synced mirror) -- entry under the 1.8.0 `### Fixed`.

The `yaml` (portable, committed-runner) representation deliberately stays `uv run`; the `check` (hermetic) fragment already used `${vigUtils}/bin/…` and is untouched.

**Test strategy — specific and general, deliberately.** The specific tests pin the exact contract (store path, argv preserved, `files`/`language`/`pass_filenames` matching the scaffold render, and that the runner + scaffold renders still start with `uv run`). The general test is what the issue actually argues for: it reads the console-script list from `packages/vig-utils/pyproject.toml` (SSoT, no second list to maintain), walks all seven generated consumer configs, and fails any hook naming a vig-utils script that does not resolve `/nix/store/...`. That closes the defect *class* — a future hook added to `hookDefs` cannot reintroduce it. The specific tests still earn their place: the general one would also pass if the hook vanished from the consumer surface entirely.

## Changelog Entry

Placed in `## [1.8.0] - TBD` -> `### Fixed`, **not** `## Unreleased`: the changelog was frozen for 1.8.0 at `046ca547`, and both post-freeze fixes already on this branch (#1443 `c427dee8`, #1444 `d0f276cd`) did the same. An `## Unreleased` entry would be missing from the 1.8.0 release notes and would resurface in the next release.

```
### Fixed

- **`check-expirations` resolves from the pinned devkit on the consumer surface** ([#1447](https://github.com/vig-os/devkit/issues/1447))
```

## Testing

- [x] Tests pass locally
- [x] Manual testing performed (describe below)

### Manual Testing Details

- RED on pristine `nix/hooks.nix`: `-k "CheckExpirations or NoConsumerHook"` -> 3 failed, 1 passed, exit 1. All three failed with `check-expirations entry is not a store path: 'uv run check-expirations .trivyignore .vulnixignore'` (the general test enumerated all 7 shells). The 1 pass was `test_portable_render_keeps_the_uv_run_entry`, an invariant pin correctly green from the start.
- GREEN: `uv run pytest tests/test_flake_hooks.py` -> 63 passed, exit 0.
- Full suite: `uv run pytest tests/ -q` -> 780 passed, 20 skipped, 1 failed. The single failure is `tests/test_image.py::TestFileStructure::test_manifest_files`, **verified pre-existing** by stashing `CHANGELOG.md` back to `b60b306a` and re-running: still fails. It checksums the working-tree `CHANGELOG.md` against a locally cached devcontainer image; stale-image noise, and CI rebuilds the image.
- `prek run --all-files` -> exit 0, fully green.

**Behavioral proof, not just render-level.** Built a plain consumer config from an un-overlaid `pkgs`; the `check-expirations` entry is now:

```
/nix/store/v1r12zx3zcgnb4hiqvi7a8spsc4b0wy3-python3.14-vig-utils-0.1.0/bin/check-expirations .trivyignore .vulnixignore
```

Executing that store binary directly with `VIRTUAL_ENV` unset: `Validated 32 exception(s) across 2 file(s)`, exit 0 — it resolves and runs with no project venv involved.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

**Invariants.** Drift gate: neither `.pre-commit-config.yaml` appears in the diff (`git diff --stat b60b306a HEAD` touches only `CHANGELOG.md`, its mirror, `nix/hooks.nix`, `tests/test_flake_hooks.py`), and both `TestPortableRenderFidelity` tests pass. Zero-hooks parity: all four `TestZeroHooksParity` tests pass, including the identical-`drvPath` check.

**Unrelated defect spotted, deliberately not fixed here** (no out-of-scope drive-bys): in the 1.8.0 `### Fixed` section, the #1434 entry has lost its bold title bullet, so its three sub-bullets now hang off the #1444 entry (`CHANGELOG.md:187-213` on `b60b306a`). As it stands the 1.8.0 release notes will present the commit-msg-hooks fix as part of the smoke-dispatch branch-name fix, and #1434 will have no visible entry. Worth repairing before the notes are cut.

Closes #1447

Refs: #1447
