### PR TITLE
feat(workspace): ship a doctor host-preflight recipe on the consumer surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`just doctor` now ships on the consumer surface** ([#1448](https://github.com/vig-os/devkit/issues/1448))
+  - The host preflight added in
+    [#1418](https://github.com/vig-os/devkit/issues/1418) /
+    [#1430](https://github.com/vig-os/devkit/issues/1430) existed only in
+    devkit's own justfile, so a scaffolded repo had none. The managed root
+    `justfile` now carries the same diagnostic — git identity, commit signing,
+    `core.hooksPath`, ssh-agent, `gh` auth — reported as `PASS`/`WARN` lines,
+    always exiting 0
+  - The `core.hooksPath` remediation hint is delivery-mode aware, read from
+    `.vig-os` `DEVKIT_MODE`: the universal
+    `git config core.hooksPath .githooks` in every mode, plus the entry point
+    that normally wires it (reopen the devcontainer, or `direnv allow` for the
+    dev-shell hook from [#1112](https://github.com/vig-os/devkit/issues/1112)).
+    `bare` and ad-hoc checkouts, where nothing wires it, get the direct command
+    only — never devkit's own `./scripts/init.sh`, which no consumer has
+  - Lives in the managed root `justfile`, the only justfile layer present in
+    every delivery mode, so upgrades deliver it; `justfile.project` is
+    preserved on upgrade and would never reach an existing consumer
 - **`just doctor` reports whether the git hooks are actually wired** ([#1430](https://github.com/vig-os/devkit/issues/1430))
   - New `core.hooksPath` diagnostic: `PASS` when it points at `.githooks`,
     `WARN` otherwise, distinguishing "not set" (a fresh clone, where the

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -23,6 +23,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`just doctor` now ships on the consumer surface** ([#1448](https://github.com/vig-os/devkit/issues/1448))
+  - The host preflight added in
+    [#1418](https://github.com/vig-os/devkit/issues/1418) /
+    [#1430](https://github.com/vig-os/devkit/issues/1430) existed only in
+    devkit's own justfile, so a scaffolded repo had none. The managed root
+    `justfile` now carries the same diagnostic — git identity, commit signing,
+    `core.hooksPath`, ssh-agent, `gh` auth — reported as `PASS`/`WARN` lines,
+    always exiting 0
+  - The `core.hooksPath` remediation hint is delivery-mode aware, read from
+    `.vig-os` `DEVKIT_MODE`: the universal
+    `git config core.hooksPath .githooks` in every mode, plus the entry point
+    that normally wires it (reopen the devcontainer, or `direnv allow` for the
+    dev-shell hook from [#1112](https://github.com/vig-os/devkit/issues/1112)).
+    `bare` and ad-hoc checkouts, where nothing wires it, get the direct command
+    only — never devkit's own `./scripts/init.sh`, which no consumer has
+  - Lives in the managed root `justfile`, the only justfile layer present in
+    every delivery mode, so upgrades deliver it; `justfile.project` is
+    preserved on upgrade and would never reach an existing consumer
 - **`just doctor` reports whether the git hooks are actually wired** ([#1430](https://github.com/vig-os/devkit/issues/1430))
   - New `core.hooksPath` diagnostic: `PASS` when it points at `.githooks`,
     `WARN` otherwise, distinguishing "not set" (a fresh clone, where the

--- a/assets/workspace/justfile
+++ b/assets/workspace/justfile
@@ -16,6 +16,83 @@ set shell := ["bash", "-euo", "pipefail", "-c"]
 help:
     @just --list
 
+# Diagnostics only — always exits 0 (#1448). Lives here, not in
+# justfile.project: this is the only managed justfile layer present in EVERY
+# delivery mode (direnv/bare carry no .devcontainer/), and justfile.project is
+# preserved on upgrade, so a recipe placed there would never reach an existing
+# consumer.
+
+# Diagnose host prerequisites: git identity, signing, hooks path, ssh-agent, gh auth
+[group('info')]
+doctor:
+    #!/usr/bin/env bash
+    echo "vigOS devkit doctor"
+    echo "==================="
+
+    name="$(git config user.name || true)"
+    if [ -n "$name" ]; then
+        echo "PASS git user.name: $name"
+    else
+        echo "WARN git user.name: not set (git config --global user.name ...)"
+    fi
+
+    email="$(git config user.email || true)"
+    if [ -n "$email" ]; then
+        echo "PASS git user.email: $email"
+    else
+        echo "WARN git user.email: not set (git config --global user.email ...)"
+    fi
+
+    gpgsign="$(git config commit.gpgsign || true)"
+    format="$(git config gpg.format || true)"
+    signingkey="$(git config user.signingkey || true)"
+    if [ "$gpgsign" = "true" ] && [ -n "$signingkey" ] && \
+        { [ "$format" != "ssh" ] || [ -r "$signingkey" ] || \
+          [ "${signingkey#ssh-}" != "$signingkey" ]; }; then
+        echo "PASS commit signing: $format key $signingkey"
+    else
+        echo "WARN commit signing: incomplete (commit.gpgsign=$gpgsign, gpg.format=$format, user.signingkey=$signingkey)"
+    fi
+
+    # .githooks is tracked, so a fresh clone has the shims on disk — but git
+    # ignores them until core.hooksPath points there. It is LOCAL repo config,
+    # so it is never cloned: until something sets it, every commit-side gate is
+    # present, believed active, and inert (#1430). What sets it depends on the
+    # delivery mode recorded in .vig-os: the devcontainer setup
+    # (setup-git-conf.sh) or dev-shell entry (#1112). `bare` has neither, and
+    # neither does an ad-hoc checkout — so the direct git command is always the
+    # primary fix and the mode entry point is named on top of it. Refs #1448.
+    mode="$(sed -n 's/^DEVKIT_MODE=//p' "{{ justfile_directory() }}/.vig-os" 2>/dev/null | head -n1 | tr -d '[:space:]')"
+    hint="run: git config core.hooksPath .githooks"
+    case "$mode" in
+        devcontainer) hint="$hint (normally set by the devcontainer setup; reopen the container)" ;;
+        direnv)       hint="$hint (normally set on dev-shell entry; run: direnv allow)" ;;
+        both)         hint="$hint (normally set by the devcontainer setup, or on dev-shell entry: direnv allow)" ;;
+    esac
+
+    hookspath="$(git config core.hooksPath || true)"
+    if [ "$hookspath" = ".githooks" ]; then
+        echo "PASS git hooks: core.hooksPath -> .githooks"
+    elif [ -z "$hookspath" ]; then
+        echo "WARN git hooks: core.hooksPath not set, .githooks is tracked but inert ($hint)"
+    else
+        echo "WARN git hooks: core.hooksPath=$hookspath, expected .githooks ($hint)"
+    fi
+
+    if [ -n "${SSH_AUTH_SOCK:-}" ] && ssh-add -l >/dev/null 2>&1; then
+        echo "PASS ssh-agent: reachable with $(ssh-add -l | wc -l) key(s)"
+    else
+        echo "WARN ssh-agent: not reachable or no keys loaded"
+    fi
+
+    if gh auth status >/dev/null 2>&1; then
+        echo "PASS gh auth: logged in"
+    else
+        echo "WARN gh auth: not authenticated (run: gh auth login)"
+    fi
+
+    exit 0
+
 # Run a command with libstdc++ resolvable for uvx-run native wheels (#1181).
 # On a non-Python direnv-mode consumer the CI preamble keeps the Nix CPython on
 # PATH, whose loader does not search /usr/lib, so a uvx tool's manylinux native

--- a/assets/workspace/justfile
+++ b/assets/workspace/justfile
@@ -63,20 +63,20 @@ doctor:
     # neither does an ad-hoc checkout — so the direct git command is always the
     # primary fix and the mode entry point is named on top of it. Refs #1448.
     mode="$(sed -n 's/^DEVKIT_MODE=//p' "{{ justfile_directory() }}/.vig-os" 2>/dev/null | head -n1 | tr -d '[:space:]')"
-    hint="run: git config core.hooksPath .githooks"
+    hint="(run: git config core.hooksPath .githooks)"
     case "$mode" in
-        devcontainer) hint="$hint (normally set by the devcontainer setup; reopen the container)" ;;
-        direnv)       hint="$hint (normally set on dev-shell entry; run: direnv allow)" ;;
-        both)         hint="$hint (normally set by the devcontainer setup, or on dev-shell entry: direnv allow)" ;;
+        devcontainer) hint="$hint; normally set by the devcontainer setup: reopen the container" ;;
+        direnv)       hint="$hint; normally set on dev-shell entry: run direnv allow" ;;
+        both)         hint="$hint; normally set by the devcontainer setup (reopen the container) or on dev-shell entry (direnv allow)" ;;
     esac
 
     hookspath="$(git config core.hooksPath || true)"
     if [ "$hookspath" = ".githooks" ]; then
         echo "PASS git hooks: core.hooksPath -> .githooks"
     elif [ -z "$hookspath" ]; then
-        echo "WARN git hooks: core.hooksPath not set, .githooks is tracked but inert ($hint)"
+        echo "WARN git hooks: core.hooksPath not set, .githooks is tracked but inert $hint"
     else
-        echo "WARN git hooks: core.hooksPath=$hookspath, expected .githooks ($hint)"
+        echo "WARN git hooks: core.hooksPath=$hookspath, expected .githooks $hint"
     fi
 
     if [ -n "${SSH_AUTH_SOCK:-}" ] && ssh-add -l >/dev/null 2>&1; then

--- a/tests/bats/consumer-doctor.bats
+++ b/tests/bats/consumer-doctor.bats
@@ -1,0 +1,241 @@
+#!/usr/bin/env bats
+# BATS tests for the SCAFFOLDED `just doctor` host-diagnostics recipe (#1448).
+#
+# `doctor` shipped in devkit's own justfile only (#1418, extended in #1430), so
+# a consumer clone got no host preflight at all — the population where the
+# "configured, believed active, never executed" hooks failure hurts most. This
+# ships the same diagnostic on the consumer surface, in the MANAGED root
+# justfile (assets/workspace/justfile): it is the only managed justfile layer
+# present in every delivery mode (direnv/bare carry no .devcontainer/), and
+# justfile.project is preserved on upgrade so a recipe placed there would never
+# reach an existing consumer.
+#
+# The remediation hint is where the two implementations legitimately differ:
+# devkit's points at ./scripts/init.sh, which a consumer does not have. A
+# consumer's core.hooksPath is wired by the devcontainer setup
+# (setup-git-conf.sh) or on dev-shell entry (githooksPathHook, #1112), so the
+# hint names the mode's entry point from `.vig-os` DEVKIT_MODE, on top of a
+# universal `git config core.hooksPath .githooks` that works in every mode
+# (including `bare`, where nothing wires it automatically).
+#
+# Tests drive the REAL shipped justfile in a fixture workspace under a
+# controlled environment (GIT_CONFIG_GLOBAL/SYSTEM, SSH_AUTH_SOCK, stub `gh`)
+# so host state never leaks in — same harness idiom as doctor.bats.
+
+setup() {
+    load test_helper
+    WS="$BATS_TEST_TMPDIR/ws"
+    STUBS="$BATS_TEST_TMPDIR/stubs"
+    GIT_GLOBAL="$BATS_TEST_TMPDIR/gitconfig"
+    mkdir -p "$WS" "$STUBS"
+    : >"$GIT_GLOBAL"
+    # The managed root justfile, exactly as scaffolded into a consumer repo.
+    cp "$PROJECT_ROOT/assets/workspace/justfile" "$WS/justfile"
+    # Stub gh: GH_STUB_RC controls `gh auth status` (default: not logged in).
+    cat >"$STUBS/gh" <<'STUB'
+#!/usr/bin/env bash
+if [ "${GH_STUB_RC:-1}" -eq 0 ]; then
+    echo "Logged in to github.com"
+fi
+exit "${GH_STUB_RC:-1}"
+STUB
+    chmod +x "$STUBS/gh"
+}
+
+# Make the fixture a real repository so `git config core.hooksPath` resolves
+# against a known local config and can never walk up into the host's checkout
+# (the run also pins GIT_CONFIG_GLOBAL/SYSTEM, so global state cannot leak).
+# Shape of a scaffolded clone: tracked .githooks on disk, `.vig-os` manifest.
+# $1 (optional) is the DEVKIT_MODE value; omit it for a mode-less manifest.
+_scaffold_repo() {
+    git -c init.defaultBranch=main init -q "$WS"
+    mkdir -p "$WS/.githooks"
+    printf '#!/usr/bin/env bash\n' >"$WS/.githooks/pre-commit"
+    printf 'DEVKIT_VERSION=1.8.0\n' >"$WS/.vig-os"
+    if [ "$#" -gt 0 ]; then
+        printf 'DEVKIT_MODE=%s\n' "$1" >>"$WS/.vig-os"
+    fi
+}
+
+_run_doctor() {
+    run env -u SSH_AUTH_SOCK PATH="$STUBS:$PATH" \
+        GIT_CONFIG_GLOBAL="$GIT_GLOBAL" GIT_CONFIG_SYSTEM=/dev/null "$@" \
+        just --justfile "$WS/justfile" --working-directory "$WS" doctor
+}
+
+# ── layering: the recipe must ship in the MANAGED layer ───────────────────────
+
+@test "doctor ships in the managed root justfile, not the preserved justfile.project" {
+    run grep -qE '^doctor:' "$PROJECT_ROOT/assets/workspace/justfile"
+    assert_success
+    run grep -qE '^doctor:' "$PROJECT_ROOT/assets/workspace/justfile.project"
+    assert_failure
+}
+
+# ── diagnostics, never a gate ─────────────────────────────────────────────────
+
+@test "consumer doctor always exits 0 and warns on an unconfigured host" {
+    _scaffold_repo
+    _run_doctor
+    assert_success
+    assert_output --partial "devkit doctor"
+    assert_output --partial "WARN git user.name"
+    assert_output --partial "WARN git user.email"
+    assert_output --partial "WARN commit signing"
+    assert_output --partial "WARN git hooks"
+    assert_output --partial "WARN ssh-agent"
+    assert_output --partial "WARN gh auth"
+}
+
+@test "consumer doctor reports PASS for configured git identity and signing" {
+    _scaffold_repo
+    git config --file "$GIT_GLOBAL" user.name "Test User"
+    git config --file "$GIT_GLOBAL" user.email "test@example.com"
+    git config --file "$GIT_GLOBAL" gpg.format ssh
+    git config --file "$GIT_GLOBAL" commit.gpgsign true
+    git config --file "$GIT_GLOBAL" user.signingkey "$BATS_TEST_TMPDIR/key.pub"
+    printf 'ssh-ed25519 AAAA test\n' >"$BATS_TEST_TMPDIR/key.pub"
+    _run_doctor GH_STUB_RC=0
+    assert_success
+    assert_output --partial "PASS git user.name: Test User"
+    assert_output --partial "PASS git user.email: test@example.com"
+    assert_output --partial "PASS commit signing"
+    assert_output --partial "PASS gh auth"
+}
+
+@test "consumer doctor warns when the signing key path does not exist" {
+    _scaffold_repo
+    git config --file "$GIT_GLOBAL" commit.gpgsign true
+    git config --file "$GIT_GLOBAL" gpg.format ssh
+    git config --file "$GIT_GLOBAL" user.signingkey "$BATS_TEST_TMPDIR/missing.pub"
+    _run_doctor
+    assert_success
+    assert_output --partial "WARN commit signing"
+}
+
+# ── core.hooksPath verdict, per delivery mode ─────────────────────────────────
+# Devcontainer mode wires it in setup-git-conf.sh; direnv mode wires it on
+# dev-shell entry (githooksPathHook, #1112). Either way the wired state is the
+# same value, so the PASS verdict must hold in both.
+
+@test "consumer doctor reports PASS for core.hooksPath in devcontainer mode" {
+    _scaffold_repo devcontainer
+    git -C "$WS" config core.hooksPath .githooks
+    _run_doctor
+    assert_success
+    assert_output --partial "PASS git hooks"
+    refute_output --partial "WARN git hooks"
+}
+
+@test "consumer doctor reports PASS for core.hooksPath in direnv mode" {
+    _scaffold_repo direnv
+    git -C "$WS" config core.hooksPath .githooks
+    _run_doctor
+    assert_success
+    assert_output --partial "PASS git hooks"
+    refute_output --partial "WARN git hooks"
+}
+
+@test "consumer doctor warns and names the value when core.hooksPath points elsewhere" {
+    _scaffold_repo direnv
+    git -C "$WS" config core.hooksPath .git/hooks
+    _run_doctor
+    assert_success
+    assert_output --partial "WARN git hooks"
+    assert_output --partial "core.hooksPath=.git/hooks"
+    assert_output --partial "git config core.hooksPath .githooks"
+}
+
+# ── remediation hint: consumer entry points, never devkit's installer ─────────
+
+@test "consumer doctor gives the plain git command in an ad-hoc checkout" {
+    # No .vig-os at all: a clone outside both delivery modes. Nothing wires
+    # core.hooksPath there, so the only honest fix is the direct command.
+    git -c init.defaultBranch=main init -q "$WS"
+    _run_doctor
+    assert_success
+    assert_output --partial "WARN git hooks"
+    assert_output --partial "core.hooksPath not set"
+    assert_output --partial "run: git config core.hooksPath .githooks"
+}
+
+@test "consumer doctor names the devcontainer setup when hooks are inert in devcontainer mode" {
+    _scaffold_repo devcontainer
+    _run_doctor
+    assert_success
+    assert_output --partial "WARN git hooks"
+    assert_output --partial "run: git config core.hooksPath .githooks"
+    assert_output --partial "devcontainer"
+}
+
+@test "consumer doctor names the dev shell when hooks are inert in direnv mode" {
+    _scaffold_repo direnv
+    _run_doctor
+    assert_success
+    assert_output --partial "WARN git hooks"
+    assert_output --partial "run: git config core.hooksPath .githooks"
+    assert_output --partial "direnv allow"
+}
+
+@test "consumer doctor names both entry points in both mode" {
+    _scaffold_repo both
+    _run_doctor
+    assert_success
+    assert_output --partial "WARN git hooks"
+    assert_output --partial "devcontainer"
+    assert_output --partial "direnv allow"
+}
+
+@test "consumer doctor gives the plain git command in bare mode" {
+    # `bare` ships standards only — no container, no flake — so nothing wires
+    # core.hooksPath and no entry point can be named.
+    _scaffold_repo bare
+    _run_doctor
+    assert_success
+    assert_output --partial "run: git config core.hooksPath .githooks"
+    refute_output --partial "direnv allow"
+}
+
+@test "consumer doctor never points at devkit's own scripts/init.sh" {
+    # devkit's installer is not a consumer entry point; a consumer repo has no
+    # scripts/init.sh at all.
+    for mode in devcontainer direnv both bare; do
+        rm -rf "$WS"
+        mkdir -p "$WS"
+        cp "$PROJECT_ROOT/assets/workspace/justfile" "$WS/justfile"
+        _scaffold_repo "$mode"
+        _run_doctor
+        assert_success
+        refute_output --partial "scripts/init.sh"
+    done
+}
+
+# ── drift guard between the two doctor implementations ────────────────────────
+# The consumer recipe is a deliberate second implementation (different
+# remediation hints, different modes, no scripts/init.sh), so nothing but a
+# test keeps the two from drifting apart on WHAT they check. Pin the shared
+# expectation: identical check labels, identical PASS/WARN idiom, exit 0.
+
+# Emit the sorted check labels of a doctor recipe: $1 justfile, $2 working dir.
+_check_labels() {
+    env -u SSH_AUTH_SOCK PATH="$STUBS:$PATH" \
+        GIT_CONFIG_GLOBAL="$GIT_GLOBAL" GIT_CONFIG_SYSTEM=/dev/null \
+        just --justfile "$1" --working-directory "$2" doctor |
+        sed -n 's/^\(PASS\|WARN\) \([^:]*\):.*/\2/p' | sort
+}
+
+@test "consumer doctor checks exactly what devkit's doctor checks" {
+    _scaffold_repo direnv
+    local devkit_ws="$BATS_TEST_TMPDIR/devkit"
+    mkdir -p "$devkit_ws"
+    git -c init.defaultBranch=main init -q "$devkit_ws"
+
+    local consumer devkit
+    consumer="$(_check_labels "$WS/justfile" "$WS")"
+    devkit="$(_check_labels "$PROJECT_ROOT/justfile" "$devkit_ws")"
+
+    echo "consumer labels: $consumer"
+    echo "devkit labels:   $devkit"
+    [ -n "$consumer" ]
+    [ "$consumer" = "$devkit" ]
+}


### PR DESCRIPTION
## Description

Implements #1448. **Targets `release/1.8.0`** — the train is cut and `1.8.0-rc1` is tagged; this lands ahead of rc2.

`just doctor` (#1418, extended with a `core.hooksPath` diagnostic in #1430) existed only in devkit's own `justfile`. The scaffolded consumer surface shipped no equivalent, so a consumer clone got no host preflight at all — the same "configured, believed active, never executed" failure #1430 documents, in the population devkit actually ships to, where the person committing is least likely to know devkit's installer exists.

## Type of Change

- [x] `feat` -- New feature
- [x] `test` -- Adding or updating tests
- [x] `refactor` -- Code restructuring (no behavior change)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- `assets/workspace/justfile` -- new `[group('info')] doctor` recipe. Diagnostics only: `PASS`/`WARN` lines, always exits 0. Reports git identity, commit signing, `core.hooksPath`, ssh-agent and `gh` auth.
- `tests/bats/consumer-doctor.bats` -- 14 tests driving the real shipped justfile in a fixture workspace, using the `doctor.bats` harness idiom (`GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM` pinned, `SSH_AUTH_SOCK` stripped, stub `gh`) so host state never leaks in.
- `CHANGELOG.md` (+ hook-synced mirror) -- entry under the 1.8.0 `### Added`.

**Why the managed root justfile.** It is the only managed justfile layer present in *every* delivery mode — `direnv`/`bare` ship no `.devcontainer/` — and `justfile.project` is a `PRESERVE_FILES` entry, so a recipe placed there would never reach an existing consumer on upgrade. (Note: the `.devcontainer/justfile.base` layer named in the issue's context was retired in 0.4.0 and no longer exists.)

**Mode-aware remediation.** Devkit's hint is `./scripts/init.sh`, a file no consumer has. The consumer hint is driven by `DEVKIT_MODE` in `.vig-os`, with the universal command always first and the mode entry point named on top of it:

| mode | inert-hooks WARN tail |
|---|---|
| `direnv` | `(run: git config core.hooksPath .githooks); normally set on dev-shell entry: run direnv allow` |
| `devcontainer` | `(run: git config core.hooksPath .githooks); normally set by the devcontainer setup: reopen the container` |
| `both` | `(run: …); normally set by the devcontainer setup (reopen the container) or on dev-shell entry (direnv allow)` |
| `bare` / no `.vig-os` | `(run: git config core.hooksPath .githooks)` — nothing wires it, so no entry point is named |

`./scripts/init.sh` never appears in any mode, and that is test-enforced. The `.vig-os` read uses the same `sed -n 's/^KEY=//p' … | head -n1` form the scaffolded `devkit-upgrade.yml` already uses.

**Sharing vs. duplication — two implementations, drift pinned by a test.** Three sharing routes were evaluated and rejected: a synced shared script (needs a brand-new always-shipped managed root path — `.devcontainer/` is absent in direnv/bare and there is no scaffolded root `scripts/`); a manifest transform (`scripts/manifest.toml` transforms whole files, so splicing one recipe from file A into file B needs a new transform type bought for a single recipe); and importing devkit's justfile (never scaffolded, full of image/release recipes). The two also genuinely differ in behavior, not just wording — see the hint table.

Rather than force the abstraction, the shared *contract* is pinned: `consumer doctor checks exactly what devkit's doctor checks` runs both recipes under the same controlled environment, extracts the check labels from the `PASS|WARN <label>:` lines, and asserts the sets are non-empty and identical. Adding a check to one and not the other now fails CI.

**Manifest/sync wiring: none needed, and verified why.** `scripts/manifest.toml` governs only files copied from the repo root *into* `assets/workspace/`; `assets/workspace/justfile` is authored directly in the scaffold tree, picked up by `init-workspace.sh`'s rsync of `TEMPLATE_DIR`, and already in the never-migrate managed literal list (`assets/init-workspace.sh:1124`). The `.vig-os` manifest contract suite declares *keys*; this adds no knob, it only reads the existing `DEVKIT_MODE`.

## Changelog Entry

Placed in `## [1.8.0] - TBD` -> `### Added`, **not** `## Unreleased`: the changelog was frozen for 1.8.0 at `046ca547`, and the post-freeze fixes on this branch (#1443, #1444, #1447) all did the same. An Unreleased entry would be stranded out of these release notes.

```
### Added

- **`just doctor` now ships on the consumer surface** ([#1448](https://github.com/vig-os/devkit/issues/1448))
```

## Testing

- [x] Tests pass locally
- [x] Manual testing performed (describe below)

### Manual Testing Details

- Baseline on the pristine branch point `b60b306a`: `bats tests/bats/` -> 482 ok, exit 0; `uv run pytest tests/ -q` -> 1 failed, 776 passed, 20 skipped.
- RED: `bats tests/bats/consumer-doctor.bats` -> 14/14 `not ok`, all `error: justfile does not contain recipe 'doctor'` (the drift guard failing on an empty consumer label set while printing devkit's six).
- GREEN, post-merge of `release/1.8.0`: `bats tests/bats/` -> **496 ok, 0 failures, exit 0** (482 + 14 new).
- `uv run pytest tests/test_flake_hooks.py` -> 63 passed, exit 0 (confirms #1447's tests still hold after the merge).
- `prek run --all-files` -> exit 0, fully green.
- Full pytest: 776 passed, 20 skipped, 1 failed — the known `tests/test_image.py::TestFileStructure::test_manifest_files`. **Verified pre-existing**, and provably the stale image: the *destination* sha is byte-identical between the baseline and final runs (`0b4f7b0ff94c…`); only the source sha moved when `CHANGELOG.md` was edited. CI rebuilds the image.

Real output, from workspaces produced by the actual `assets/init-workspace.sh --no-prompts --mode <mode>`:

```
############ mode=direnv | hooksPath UNSET (fresh clone) ############
vigOS devkit doctor
===================
PASS git user.name: Carlos Vigo
PASS git user.email: …
WARN commit signing: incomplete (…)
WARN git hooks: core.hooksPath not set, .githooks is tracked but inert (run: git config core.hooksPath .githooks); normally set on dev-shell entry: run direnv allow
PASS ssh-agent: reachable with 9 key(s)
PASS gh auth: logged in
EXIT=0
############ mode=direnv | hooksPath WIRED ############
PASS git hooks: core.hooksPath -> .githooks
############ mode=direnv | hooksPath ELSEWHERE ############
WARN git hooks: core.hooksPath=.git/hooks, expected .githooks (run: …); normally set on dev-shell entry: run direnv allow
############ mode=devcontainer | hooksPath UNSET ############
WARN git hooks: … normally set by the devcontainer setup: reopen the container
############ ad-hoc checkout: no .vig-os ############
WARN git hooks: core.hooksPath not set, .githooks is tracked but inert (run: git config core.hooksPath .githooks)
EXIT=0
```

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`)
- [x] I have updated `CHANGELOG.md` (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

**Known limitation, worth a follow-up covering both doctors together.** Linked worktrees are not special-cased. `justfile.worktree` deliberately `--unset`s `core.hooksPath` and installs prek hooks into `.git/hooks`, and `githooksPathHook` guards itself to the main worktree — so `just doctor` inside a `just worktree-start` worktree reports `WARN git hooks … inert` when the hooks are in fact live. Devkit's own `doctor` has the identical behavior today, so this is not a regression, but a diagnostic that lies is exactly the failure class #1430 is about. Left alone here under YAGNI/minimal-diff given this is an rc; the fix (detect git-dir != common-dir, then PASS on an installed `.git/hooks/pre-commit`) should land in both recipes at once.

Not done deliberately: no consumer docs edit (the scaffolded `README.md` is a seeded stub enumerating no recipes), no `.vig-os` knob, no changes to devkit's own `justfile`.

Closes #1448

Refs: #1448
