### PR TITLE
feat(nix): guard the mkRustProject consumer path and close two gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     contribute checks
   - Zero-module invariant preserved: `devShells.<system>.default.drvPath` is
     byte-identical to before the pack shipped, pinned by a new parity test
+  - Consumer hardening from the second consumer, a single-crate feature-gated
+    library ([#1450](https://github.com/vig-os/devkit/issues/1450)):
+    `mkRustProject` now refuses a `pkgs` built without `overlays.default`
+    (previously `undefined variable 'vig-utils'` from inside `devtools.nix`,
+    and only on the dev shell — `checks` and `packages` evaluated fine, so a
+    repo could have a green `nix flake check` and a shell that had never
+    evaluated); a source tree with no `Cargo.lock` is named as such, on
+    `cleanSrc` so `fmt` fails with the rest instead of passing alone; new
+    `checks.doctest` runs `cargo test --doc`, which nextest cannot and
+    `cargoDoc` does not, so adopting the pack no longer silently drops a
+    consumer's doctests; and new `cargoExtraArgs` reaches every derivation so
+    the checks can build non-default features — composed with `-p <crate>`
+    rather than overwriting it, so a workspace's per-crate builds cannot end
+    up with a different feature set from the checks that ran against them
 
 - **`just doctor` host diagnostics + audit coverage gaps closed** ([#1418](https://github.com/vig-os/devkit/issues/1418))
   - New `just doctor` recipe reports host prerequisites (git identity, commit

--- a/nix/mk-rust-project.nix
+++ b/nix/mk-rust-project.nix
@@ -107,6 +107,24 @@
   # Extra args for the clippy check. `--deny warnings` is already applied.
   clippyExtraArgs ? "--all-targets",
   fmt ? true,
+  # `cargo test --doc`. nextest cannot run doctests (its process-per-test model
+  # has nowhere to put them) and the `doc` check only lints rustdoc, so without
+  # this nothing executes them — and a consumer whose doctests ran under
+  # `cargo test` loses them on adoption, silently. #1400's stage table assigns
+  # both to pre-push for exactly that reason.
+  doctest ? true,
+
+  # ---- cargo invocation ----------------------------------------------------
+  # Appended to the cargo command line of EVERY derivation: the dependency
+  # build, the checks and the packages. This is where features live —
+  # `--all-features`, `--features a,b`, `--no-default-features`.
+  #
+  # It matters that this is one argument reaching all of them rather than a
+  # per-check knob. A default-features build means the gated code is never
+  # compiled, so clippy never sees it and its tests never run, and the suite
+  # reports success over the gap. `clippyExtraArgs` covers clippy alone and is
+  # deliberately left as-is: it carries lint flags, not feature selection.
+  cargoExtraArgs ? "",
 
   # ---- performance ratchet -------------------------------------------------
   # Defaults on when the baseline file exists, off otherwise — same rule as
@@ -137,6 +155,71 @@
 let
   inherit (pkgs) lib;
   system = pkgs.stdenv.hostPlatform.system;
+
+  # ---------------------------------------------------------------------------
+  # Consumer guards (#1450)
+  #
+  # Both replace a failure that was opaque, partial, or both. They follow the
+  # toolchainHash error's shape deliberately: say what happened, say why there
+  # is no default that could be right, and give the exact line to add.
+  # ---------------------------------------------------------------------------
+
+  # mkProjectShell pulls nix/devtools.nix, which references `vig-utils` — a
+  # package only devkit's overlay provides. Without it the shell died on
+  # `undefined variable 'vig-utils'`: an error inside devkit, naming something
+  # the consumer has never seen, from a file they did not open.
+  #
+  # Checked lazily, on the dev shell alone. `checks` and `packages` never touch
+  # mkProjectShell and are perfectly usable against a plain nixpkgs, so an
+  # eager throw would break a working configuration to improve a message.
+  overlayError = ''
+    mkRustProject: the `pkgs` you passed does not carry devkit's overlay.
+
+    The dev shell is built by mkProjectShell, whose toolchain list
+    (nix/devtools.nix) resolves `vig-utils` and the fast-movers from
+    `devkit.overlays.default`. Without the overlay this fails deep inside
+    devkit on a name that means nothing at your call site.
+
+    Build your pkgs with it:
+
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [ devkit.overlays.default ];
+        };
+
+    Note that `checks` and `packages` do NOT need the overlay — they never go
+    through mkProjectShell. That asymmetry is why this is a thrown error and
+    not a note in the docs: without it, a repo can have a green
+    `nix flake check` and a dev shell that has never once evaluated.
+  '';
+
+  hasOverlay = pkgs ? vig-utils;
+
+  # A flake's `src` is the git tree, so a repo that gitignores its lockfile
+  # hands crane a source without one. crane's own message is good, but it is
+  # only reachable from the derivations that vendor — `cargoFmt` takes `src`
+  # alone and passed regardless, which made a total failure look partial.
+  lockError = ''
+    mkRustProject: no Cargo.lock at
+
+        ${toString src}
+
+    Every check here builds from the FLAKE's source, which is your git tree —
+    so a lockfile that is untracked or gitignored does not exist as far as the
+    build is concerned, however plainly it sits in your working directory.
+
+    Library crates hit this most: not committing Cargo.lock was the convention
+    for years, and `cargo new --lib` wrote that .gitignore for you. Current
+    Cargo guidance is to commit it for libraries too, and a pinned build needs
+    it regardless, so the fix is:
+
+        git add Cargo.lock        # remove it from .gitignore first
+
+    Staging alone (`git add -N`) is enough for Nix to see it, but a lockfile
+    that is never committed makes the build reproducible only on your machine.
+  '';
+
+  hasLock = builtins.pathExists (src + "/Cargo.lock");
 
   # ---------------------------------------------------------------------------
   # Toolchain resolution
@@ -226,14 +309,21 @@ let
 
   toSrcPath = f: if builtins.isPath f then f else src + "/${f}";
 
-  cleanSrc = lib.fileset.toSource {
-    root = src;
-    fileset = lib.fileset.unions (
-      [ (craneLib.fileset.commonCargoSources src) ]
-      ++ map (f: lib.fileset.maybeMissing (src + "/${f}")) wellKnownConfigFiles
-      ++ map (f: lib.fileset.maybeMissing (toSrcPath f)) extraSrcFiles
-    );
-  };
+  # The lock guard sits here rather than on the derivations that vendor, so
+  # that `fmt` — which consumes only this — fails with the rest instead of
+  # passing alone (#1450).
+  cleanSrc =
+    if !hasLock then
+      throw lockError
+    else
+      lib.fileset.toSource {
+        root = src;
+        fileset = lib.fileset.unions (
+          [ (craneLib.fileset.commonCargoSources src) ]
+          ++ map (f: lib.fileset.maybeMissing (src + "/${f}")) wellKnownConfigFiles
+          ++ map (f: lib.fileset.maybeMissing (toSrcPath f)) extraSrcFiles
+        );
+      };
 
   denyEnabled = if deny != null then deny else builtins.pathExists (src + "/deny.toml");
 
@@ -254,6 +344,10 @@ let
     # Cargo.toml policy). Stripping twice is wasted work, not extra safety.
     dontStrip = true;
   }
+  // lib.optionalAttrs (cargoExtraArgs != "") { inherit cargoExtraArgs; }
+  # Still last, so an escape-hatch override beats everything above it. Note
+  # that it is a raw commonArgs merge, not an env-var attrset — the name is
+  # historical.
   // buildEnv;
 
   cargoArtifacts = craneLib.buildDepsOnly commonArgs;
@@ -273,7 +367,13 @@ let
       // {
         inherit cargoArtifacts;
         pname = name;
-        cargoExtraArgs = "-p ${name}";
+        # Composed, not assigned: `cargoExtraArgs` is also where a consumer's
+        # feature selection lives, and overwriting it here would silently give
+        # a workspace's per-crate builds a different feature set from every
+        # check that ran against them (#1450).
+        cargoExtraArgs = lib.concatStringsSep " " (
+          lib.optional (cargoExtraArgs != "") cargoExtraArgs ++ [ "-p ${name}" ]
+        );
       }
       // lib.optionalAttrs auditable {
         nativeBuildInputs = commonArgs.nativeBuildInputs ++ [ pkgs.cargo-auditable ];
@@ -351,6 +451,19 @@ let
           inherit cargoArtifacts;
           partitions = 1;
           partitionType = "count";
+        }
+      );
+    }
+    // lib.optionalAttrs doctest {
+      # nextest cannot run doctests — its process-per-test model has nowhere
+      # to put them — and `doc` below only lints rustdoc. Without this the
+      # suite looks complete while executing none of the examples in the
+      # public API docs, which for a library is often the only place a usage
+      # path is exercised end to end.
+      doctest = craneLib.cargoDocTest (
+        commonArgs
+        // {
+          inherit cargoArtifacts;
         }
       );
     }
@@ -541,19 +654,23 @@ let
     inherit tools linker;
   };
 
-  devShell = mkProjectShell (
-    {
-      inherit
-        pkgs
-        extraPackages
-        hooks
-        hooksExcludes
-        workflow
-        ;
-      modules = [ rustModuleEntry ] ++ modules;
-    }
-    // lib.optionalAttrs (shellHook != null) { inherit shellHook; }
-  );
+  devShell =
+    if !hasOverlay then
+      throw overlayError
+    else
+      mkProjectShell (
+        {
+          inherit
+            pkgs
+            extraPackages
+            hooks
+            hooksExcludes
+            workflow
+            ;
+          modules = [ rustModuleEntry ] ++ modules;
+        }
+        // lib.optionalAttrs (shellHook != null) { inherit shellHook; }
+      );
 
   # mkProjectShell owns the shell derivation, so extra env is applied here
   # rather than threaded through it — one override, no new argument on a

--- a/tests/test_flake_modules.py
+++ b/tests/test_flake_modules.py
@@ -730,3 +730,173 @@ def test_rust_module_rejects_unknown_tool_group() -> None:
     assert "unknown tool group" in result.stderr and "@perf" in result.stderr, (
         f"error must name the group and list the available ones; got: {result.stderr[-500:]}"
     )
+
+
+# ---------------------------------------------------------------------------
+# mkRustProject consumer guards (#1450) — found by adopting the pack on a
+# second consumer (gerchowl/squelch: single-crate, no binaries, heavily
+# feature-gated). The two guards below turn failures that were opaque or
+# partial into ones that name the fix; the two coverage tests pin behaviour
+# the pack promised in #1400 but did not ship.
+#
+# These need project shape, which is why the older mkRustProject coverage
+# stops at a schema smoke test. A dependency-free crate keeps the lockfile a
+# literal, so the whole set runs at EVAL time — no vendoring, no network, no
+# compile.
+# ---------------------------------------------------------------------------
+
+
+def _minimal_crate(root: Path, *, with_lock: bool = True) -> Path:
+    """Write the smallest crate crane will accept, and return its path."""
+    (root / "src").mkdir(parents=True, exist_ok=True)
+    (root / "Cargo.toml").write_text(
+        '[package]\nname = "fixture"\nversion = "0.0.0"\nedition = "2021"\n'
+    )
+    (root / "src" / "lib.rs").write_text("pub fn answer() -> u8 { 42 }\n")
+    if with_lock:
+        (root / "Cargo.lock").write_text(
+            'version = 3\n\n[[package]]\nname = "fixture"\nversion = "0.0.0"\n'
+        )
+    return root
+
+
+def _mk_rust_project_expr(
+    src: Path, attr: str, *, overlay: bool = True, extra: str = ""
+) -> str:
+    """An expression selecting ``attr`` off a ``mkRustProject`` call on ``src``."""
+    overlays = "[ flake.overlays.default ]" if overlay else "[ ]"
+    return f"""
+    let
+      flake = builtins.getFlake "path:{REPO_ROOT}";
+      system = builtins.currentSystem;
+      pkgs = import flake.inputs.nixpkgs {{
+        inherit system;
+        overlays = {overlays};
+        config.allowUnfree = true;
+      }};
+      rust = flake.lib.mkRustProject {{
+        inherit pkgs;
+        src = {src};
+        {extra}
+      }};
+    in {attr}
+    """
+
+
+def test_mk_rust_project_refuses_pkgs_without_the_devkit_overlay(
+    tmp_path: Path,
+) -> None:
+    """A ``pkgs`` lacking ``overlays.default`` is named as such, not as ``vig-utils``.
+
+    ``mkProjectShell`` pulls ``nix/devtools.nix``, which references
+    ``vig-utils`` — a package only the overlay provides. Without the overlay
+    the dev shell died with ``undefined variable 'vig-utils'``, pointing inside
+    devkit at a name the consumer has never seen.
+
+    The reason this is a guard rather than a docs fix: ``checks`` and
+    ``packages`` never touch ``mkProjectShell``, so they evaluate fine without
+    the overlay. The unguarded result is a repo whose ``nix flake check`` is
+    green and whose ``nix develop`` is broken — the silent split the pack
+    exists to close, one layer up.
+    """
+    src = _minimal_crate(tmp_path)
+    result = _nix_eval_expr(
+        _mk_rust_project_expr(src, "rust.devShell.drvPath", overlay=False)
+    )
+    assert result.returncode != 0, (
+        "a pkgs without devkit's overlay must fail eval, not produce a shell"
+    )
+    assert "overlays.default" in result.stderr, (
+        "the error must name the overlay the consumer has to add; "
+        f"got: {result.stderr[-800:]}"
+    )
+    assert "undefined variable" not in result.stderr, (
+        "the raw nixpkgs error must be replaced, not merely preceded; "
+        f"got: {result.stderr[-800:]}"
+    )
+
+
+def test_mk_rust_project_names_a_missing_cargo_lock(tmp_path: Path) -> None:
+    """A source tree with no ``Cargo.lock`` fails with the library case spelled out.
+
+    A flake's ``src`` is the git tree, so a repo that gitignores its lockfile —
+    the long-standing library convention — hands crane a source without one.
+    crane's own message is good but reachable only from the derivations that
+    vendor: ``fmt`` takes ``src`` alone and passed regardless, so a consumer
+    who built one check first saw green.
+
+    Asserted through ``fmt`` for exactly that reason.
+    """
+    src = _minimal_crate(tmp_path, with_lock=False)
+    result = _nix_eval_expr(_mk_rust_project_expr(src, "rust.checks.fmt.drvPath"))
+    assert result.returncode != 0, (
+        "fmt must not evaluate against a lockless tree — it passing is what "
+        "made the missing lockfile look like a partial success"
+    )
+    assert "Cargo.lock" in result.stderr, (
+        f"the error must name Cargo.lock; got: {result.stderr[-800:]}"
+    )
+
+
+def test_mk_rust_project_ships_a_doctest_check(tmp_path: Path) -> None:
+    """``checks.doctest`` exists (#1400's stage table, unshipped in #1429).
+
+    #1400 assigns pre-push ``nextest`` **and** ``cargo test --doc``. nextest
+    cannot run doctests by design, and ``cargoDoc`` only lints rustdoc, so a
+    consumer whose doctests ran under ``cargo test`` lost them on adoption
+    without being told.
+    """
+    src = _minimal_crate(tmp_path)
+    result = subprocess.run(
+        [
+            "nix",
+            "eval",
+            "--impure",
+            "--json",
+            "--expr",
+            _mk_rust_project_expr(src, "builtins.attrNames rust.checks"),
+        ],
+        capture_output=True,
+        text=True,
+        env=_nix_env(),
+        timeout=300,
+    )
+    assert result.returncode == 0, result.stderr[-1500:]
+    names = json.loads(result.stdout)
+    assert "doctest" in names, (
+        f"the default check suite must run doctests; got {names!r}"
+    )
+
+
+def test_mk_rust_project_threads_cargo_extra_args(tmp_path: Path) -> None:
+    """``cargoExtraArgs`` reaches every derivation through ``commonArgs``.
+
+    The checks built default features only, and nothing reached
+    ``buildDepsOnly`` / ``nextest`` / ``doc`` / the package builds —
+    ``clippyExtraArgs`` covers clippy alone. A feature-gated crate therefore
+    got less linting from the pack than from a bare ``cargo clippy
+    --all-features``, because the gated code was never compiled.
+    """
+    src = _minimal_crate(tmp_path)
+    result = subprocess.run(
+        [
+            "nix",
+            "eval",
+            "--impure",
+            "--raw",
+            "--expr",
+            _mk_rust_project_expr(
+                src,
+                "rust.commonArgs.cargoExtraArgs",
+                extra='cargoExtraArgs = "--all-features";',
+            ),
+        ],
+        capture_output=True,
+        text=True,
+        env=_nix_env(),
+        timeout=300,
+    )
+    assert result.returncode == 0, result.stderr[-1500:]
+    assert "--all-features" in result.stdout, (
+        f"cargoExtraArgs must land in commonArgs; got {result.stdout!r}"
+    )


### PR DESCRIPTION
Targets `feature/1400-rust-language-pack`, not `dev` — these are fixes to the pack before it ships, so a reader of the released notes never sees the behaviour being corrected.

Everything here came out of adopting #1429 on a second consumer, `gerchowl/squelch`: a **single-crate library, no binaries, heavily feature-gated** (`browser`/`logs` default; `gh-cli`, `endpoint`, `serde` optional), wired from scratch rather than migrated. Full adoption report is the comment on #1429. Closes #1450.

## Two guards

Both replace a failure that was opaque, partial, or both. Both follow the `toolchainHash` error's shape, which is the best error in the pack: say what happened, say why no default could be right, give the exact line to add.

**`pkgs` without `overlays.default`.** `mkProjectShell` pulls `nix/devtools.nix`, which resolves `vig-utils` from devkit's overlay. Without it the shell died on `undefined variable 'vig-utils'` — an error inside devkit, naming something the consumer has never seen, from a file they did not open.

The reason this is a guard and not a docs fix: **`checks` and `packages` never touch `mkProjectShell`**, so they evaluate fine without the overlay. Unguarded, that is a repo with a green `nix flake check` and a dev shell that has never once evaluated. Checked lazily, on the dev shell alone — an eager throw would break a configuration that legitimately uses only the checks.

**Missing `Cargo.lock`.** A flake's `src` is the git tree, so a repo that gitignores its lockfile — the long-standing library convention, and what `cargo new --lib` wrote for years — hands crane a source without one. crane's own message is good, but only reachable from the derivations that vendor: `cargoFmt` takes `src` alone and **passed**, which made a total failure look partial. The guard sits on `cleanSrc` so `fmt` fails with the rest.

## Two gaps the suite did not admit to

**`checks.doctest`.** #1400's stage table assigns pre-push `nextest` **and** `cargo test --doc`. nextest cannot run doctests (process-per-test has nowhere to put them) and `cargoDoc` only lints rustdoc, so nothing executed them — a consumer whose doctests ran under `cargo test` lost them on adoption, silently. `crane` already ships `cargoDocTest`; this is one `optionalAttrs` block.

**`cargoExtraArgs`.** The checks built default features only, and nothing reached `buildDepsOnly` / `nextest` / `doc` / the package builds — `clippyExtraArgs` covers clippy alone, and carries lint flags rather than feature selection. On squelch that was 55 of 59 tests, with the gated code never compiled and therefore never linted. The suite reported success over the gap.

Composed with `-p <crate>` in `buildCrate` rather than overwriting it, so a workspace's per-crate builds cannot end up with a different feature set from the checks that ran against them.

The seam that worked before this was `buildEnv = { cargoExtraArgs = …; }`, since `buildEnv` is a raw `commonArgs` merge wearing an env-var name. Left in place, now commented as what it actually is.

## Verified

- `uv run pytest tests/test_flake_modules.py -k "rust or mk_rust"` — **13 passed**, including the zero-module parity invariant.
- The four new tests were committed failing first, and each fails for its own reason before the implementation commit.
- **End-to-end on the consumer**, with `--override-input devkit` pointed at this branch: `nix flake check` green on **6** checks, `doctest` executing squelch's 3 doctests, and `cargoExtraArgs = "--all-features"` replacing the `buildEnv` workaround.

## Note on scope

The fixture crate is written to `tmp_path` at test time rather than committed under `tests/fixtures/`, deliberately: a `Cargo.toml` inside devkit would make devkit look like a Rust consumer to its own language detection.

Refs: #1450
