### PR TITLE
docs(changelog): restore the #1434 entry title bullet in 1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -205,6 +205,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     (devkit-smoke-test#354) but every deploy overlays the template back over
     it, re-arming the regression for the next train. Dots now map to dashes
     in the template SSoT, matching the live listener
+- **Flake-generated hooks now carry the commit-message and agent-identity guards** ([#1434](https://github.com/vig-os/devkit/issues/1434))
   - A direnv consumer on flake-generated hooks had **no local commit-message
     or agent-identity enforcement at all**: `validate-commit-msg`,
     `prepare-commit-msg-strip-trailers` and `check-agent-identity` carried no

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -205,6 +205,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     (devkit-smoke-test#354) but every deploy overlays the template back over
     it, re-arming the regression for the next train. Dots now map to dashes
     in the template SSoT, matching the live listener
+- **Flake-generated hooks now carry the commit-message and agent-identity guards** ([#1434](https://github.com/vig-os/devkit/issues/1434))
   - A direnv consumer on flake-generated hooks had **no local commit-message
     or agent-identity enforcement at all**: `validate-commit-msg`,
     `prepare-commit-msg-strip-trailers` and `check-agent-identity` carried no


### PR DESCRIPTION
## Description

Fixes #1453. **Targets `release/1.8.0`** — the train is cut and `1.8.0-rc1` is tagged; this must land before the notes are finalized, after which the `[1.8.0]` section is released and immutable.

The #1434 entry had lost its bold title bullet, so its three sub-bullets hung off the #1444 entry. As it stood, the 1.8.0 release notes would have presented a user-visible fix to local commit-message and agent-identity enforcement as part of an unrelated smoke-dispatch branch-naming fix, and #1434 would have had no entry at all.

## Type of Change

- [x] `docs` -- Documentation only

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

A **single added line**. No re-indentation was needed — the orphaned sub-bullets were already at the correct 2-space depth:

```diff
     (devkit-smoke-test#354) but every deploy overlays the template back over
     it, re-arming the regression for the next train. Dots now map to dashes
     in the template SSoT, matching the live listener
+- **Flake-generated hooks now carry the commit-message and agent-identity guards** ([#1434](https://github.com/vig-os/devkit/issues/1434))
   - A direnv consumer on flake-generated hooks had **no local commit-message
     or agent-identity enforcement at all**: `validate-commit-msg`,
```

`### Fixed` now reads #1447, #1443, #1444, #1434, #1414, #1403, #1396, and #1444 keeps only its own sub-bullet.

**The title is recovered, not invented.** `git show 20e5660c:CHANGELOG.md` (the PR #1439 merge) carries this exact line, and #1439's body proposes it verbatim under "Changelog Entry". The restored 20-line region diffs byte-identical against the original, and the entry lands back in its original slot ahead of #1414.

**Root cause — this corrects the guess in the issue.** It was *not* the changelog freeze. `046ca547` only moved headings (14 insertions / 4 deletions). The culprit is **`c427dee8`** (#1443), whose diff shows `-- **Flake-generated hooks…**`: it *replaced* the #1434 title line instead of inserting above it. `d0f276cd` (#1444) then inserted below that, inheriting the orphans.

## Changelog Entry

No changelog entry needed — this **is** a changelog repair. Adding a "fixed the changelog" bullet to the section it repairs would be noise in the released notes.

## Testing

- [x] Tests pass locally
- [x] Manual testing performed (describe below)

### Manual Testing Details

- `prek run --all-files` -> exit 0, fully green, including `pymarkdown` on both the root file and the synced mirror — which is the real risk here, since it validates list nesting. Re-run clean after `sync-manifest` mirrored the file.
- `uv run pytest tests/ -q` -> 780 passed, 20 skipped, 1 failed. The single failure is the known `tests/test_image.py::TestFileStructure::test_manifest_files`, **proved** pre-existing rather than assumed: stashing to a fully pristine tree reproduces it, and the stale image's *destination* hash is identical across both runs (`0b4f7b0ff94c…`) while only the source hash moves. CI rebuilds the image.
- Re-verified after merging `release/1.8.0` in: `prek run --all-files` exit 0, the restored entry intact, #1448's entry present.
- The mirror `assets/workspace/.devcontainer/CHANGELOG.md` was written by the hook, never hand-edited; its diff is the same single line.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] I have updated `CHANGELOG.md` (this PR *is* the changelog change)
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works -- see below
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

**No test was added, deliberately.** The defect is not an orphaned sub-bullet — the three sub-bullets had a perfectly valid parent (#1444). A "every sub-bullet has a titled parent entry" assertion passes identically before and after this fix, so it cannot express the bug. The only detecting heuristic would be "a sub-bullet cites an issue other than its parent's", which this changelog violates constantly by design (#1447's sub-bullet cites #1434; #1443's cites #1344/#1348/#1423). It would be almost entirely false positives. This is a semantic authorship error, not a structural one — which is also why `pymarkdown` passes it. TDD does not apply; the commit body says so explicitly rather than skipping it silently.

Nothing below `## [1.8.0]` was touched. Every top-level bullet in the 1.8.0 section was checked against the canonical shape post-fix; all 19 conform. One suspected second instance was chased and cleared: the #1403 entry's sub-bullets about smoke deploys preserving `CHANGELOG.md` look misparented, but `git show 64b524ac` proves all three were authored together as facets of the same sync-conflict fix.

Two cosmetic inconsistencies remain, both pre-existing and deliberately out of scope: stray blank lines between three entries in `### Changed` (#1411, #1409, #1405) where every other section is contiguous, and trailing periods on four sub-bullets (#1403's three, #1396's one) where the rest of the section is period-free.

**Worth flagging for the train:** this defect class — a hand-inserted entry silently consuming the line beneath it — survived a PR review and the freeze, and surfaced only by eye during #1447 review. Since the section becomes immutable at cut, one last read of the rendered notes before finalize is cheap insurance.

Closes #1453

Refs: #1453
