### PR TITLE
revert: restore the #1447 and #1448 content dropped by failed-run rollbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`just doctor` now ships on the consumer surface** ([#1448](https://github.com/vig-os/devkit/issues/1448))
+  - The host preflight added in
+    [#1418](https://github.com/vig-os/devkit/issues/1418) /
+    [#1430](https://github.com/vig-os/devkit/issues/1430) existed only in
+    devkit's own justfile, so a scaffolded repo had none. The managed root
+    `justfile` now carries the same diagnostic — git identity, commit signing,
+    `core.hooksPath`, ssh-agent, `gh` auth — reported as `PASS`/`WARN` lines,
+    always exiting 0
+  - The `core.hooksPath` remediation hint is delivery-mode aware, read from
+    `.vig-os` `DEVKIT_MODE`: the universal
+    `git config core.hooksPath .githooks` in every mode, plus the entry point
+    that normally wires it (reopen the devcontainer, or `direnv allow` for the
+    dev-shell hook from [#1112](https://github.com/vig-os/devkit/issues/1112)).
+    `bare` and ad-hoc checkouts, where nothing wires it, get the direct command
+    only — never devkit's own `./scripts/init.sh`, which no consumer has
+  - Lives in the managed root `justfile`, the only justfile layer present in
+    every delivery mode, so upgrades deliver it; `justfile.project` is
+    preserved on upgrade and would never reach an existing consumer
 - **`just doctor` reports whether the git hooks are actually wired** ([#1430](https://github.com/vig-os/devkit/issues/1430))
   - New `core.hooksPath` diagnostic: `PASS` when it points at `.githooks`,
     `WARN` otherwise, distinguishing "not set" (a fresh clone, where the
@@ -171,6 +189,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`check-expirations` resolves from the devkit pin in generated consumer hooks** ([#1447](https://github.com/vig-os/devkit/issues/1447))
+  - It was the last vig-utils hook whose flake-generated consumer fragment
+    shelled out to `uv run`, i.e. to the *consumer's* project venv — which
+    carries no `vig-utils`, and which many consumers do not have at all (no
+    `pyproject.toml`). The entry now resolves a `nix/vig-utils.nix` store
+    path, like the three hooks fixed in
+    [#1434](https://github.com/vig-os/devkit/issues/1434) and every other
+    tool-naming consumer fragment, so the hook follows the devkit pin the
+    consumer bumps with `nix flake update vigos`
+  - The committed `.pre-commit-config.yaml` renders are unchanged: only the
+    consumer surface moves off `uv run`, and a new class-wide test rejects any
+    future consumer fragment that names a vig-utils console script without a
+    store path
 - **Smoke deploy now publishes installer deletions to the deploy branch** ([#1443](https://github.com/vig-os/devkit/issues/1443))
   - The smoke-test dispatch deploy committed via `commit-action`, which builds
     its tree additively from working-tree contents and cannot express file

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -23,6 +23,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`just doctor` now ships on the consumer surface** ([#1448](https://github.com/vig-os/devkit/issues/1448))
+  - The host preflight added in
+    [#1418](https://github.com/vig-os/devkit/issues/1418) /
+    [#1430](https://github.com/vig-os/devkit/issues/1430) existed only in
+    devkit's own justfile, so a scaffolded repo had none. The managed root
+    `justfile` now carries the same diagnostic — git identity, commit signing,
+    `core.hooksPath`, ssh-agent, `gh` auth — reported as `PASS`/`WARN` lines,
+    always exiting 0
+  - The `core.hooksPath` remediation hint is delivery-mode aware, read from
+    `.vig-os` `DEVKIT_MODE`: the universal
+    `git config core.hooksPath .githooks` in every mode, plus the entry point
+    that normally wires it (reopen the devcontainer, or `direnv allow` for the
+    dev-shell hook from [#1112](https://github.com/vig-os/devkit/issues/1112)).
+    `bare` and ad-hoc checkouts, where nothing wires it, get the direct command
+    only — never devkit's own `./scripts/init.sh`, which no consumer has
+  - Lives in the managed root `justfile`, the only justfile layer present in
+    every delivery mode, so upgrades deliver it; `justfile.project` is
+    preserved on upgrade and would never reach an existing consumer
 - **`just doctor` reports whether the git hooks are actually wired** ([#1430](https://github.com/vig-os/devkit/issues/1430))
   - New `core.hooksPath` diagnostic: `PASS` when it points at `.githooks`,
     `WARN` otherwise, distinguishing "not set" (a fresh clone, where the
@@ -171,6 +189,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`check-expirations` resolves from the devkit pin in generated consumer hooks** ([#1447](https://github.com/vig-os/devkit/issues/1447))
+  - It was the last vig-utils hook whose flake-generated consumer fragment
+    shelled out to `uv run`, i.e. to the *consumer's* project venv — which
+    carries no `vig-utils`, and which many consumers do not have at all (no
+    `pyproject.toml`). The entry now resolves a `nix/vig-utils.nix` store
+    path, like the three hooks fixed in
+    [#1434](https://github.com/vig-os/devkit/issues/1434) and every other
+    tool-naming consumer fragment, so the hook follows the devkit pin the
+    consumer bumps with `nix flake update vigos`
+  - The committed `.pre-commit-config.yaml` renders are unchanged: only the
+    consumer surface moves off `uv run`, and a new class-wide test rejects any
+    future consumer fragment that names a vig-utils console script without a
+    store path
 - **Smoke deploy now publishes installer deletions to the deploy branch** ([#1443](https://github.com/vig-os/devkit/issues/1443))
   - The smoke-test dispatch deploy committed via `commit-action`, which builds
     its tree additively from working-tree contents and cannot express file

--- a/assets/workspace/justfile
+++ b/assets/workspace/justfile
@@ -16,6 +16,83 @@ set shell := ["bash", "-euo", "pipefail", "-c"]
 help:
     @just --list
 
+# Diagnostics only — always exits 0 (#1448). Lives here, not in
+# justfile.project: this is the only managed justfile layer present in EVERY
+# delivery mode (direnv/bare carry no .devcontainer/), and justfile.project is
+# preserved on upgrade, so a recipe placed there would never reach an existing
+# consumer.
+
+# Diagnose host prerequisites: git identity, signing, hooks path, ssh-agent, gh auth
+[group('info')]
+doctor:
+    #!/usr/bin/env bash
+    echo "vigOS devkit doctor"
+    echo "==================="
+
+    name="$(git config user.name || true)"
+    if [ -n "$name" ]; then
+        echo "PASS git user.name: $name"
+    else
+        echo "WARN git user.name: not set (git config --global user.name ...)"
+    fi
+
+    email="$(git config user.email || true)"
+    if [ -n "$email" ]; then
+        echo "PASS git user.email: $email"
+    else
+        echo "WARN git user.email: not set (git config --global user.email ...)"
+    fi
+
+    gpgsign="$(git config commit.gpgsign || true)"
+    format="$(git config gpg.format || true)"
+    signingkey="$(git config user.signingkey || true)"
+    if [ "$gpgsign" = "true" ] && [ -n "$signingkey" ] && \
+        { [ "$format" != "ssh" ] || [ -r "$signingkey" ] || \
+          [ "${signingkey#ssh-}" != "$signingkey" ]; }; then
+        echo "PASS commit signing: $format key $signingkey"
+    else
+        echo "WARN commit signing: incomplete (commit.gpgsign=$gpgsign, gpg.format=$format, user.signingkey=$signingkey)"
+    fi
+
+    # .githooks is tracked, so a fresh clone has the shims on disk — but git
+    # ignores them until core.hooksPath points there. It is LOCAL repo config,
+    # so it is never cloned: until something sets it, every commit-side gate is
+    # present, believed active, and inert (#1430). What sets it depends on the
+    # delivery mode recorded in .vig-os: the devcontainer setup
+    # (setup-git-conf.sh) or dev-shell entry (#1112). `bare` has neither, and
+    # neither does an ad-hoc checkout — so the direct git command is always the
+    # primary fix and the mode entry point is named on top of it. Refs #1448.
+    mode="$(sed -n 's/^DEVKIT_MODE=//p' "{{ justfile_directory() }}/.vig-os" 2>/dev/null | head -n1 | tr -d '[:space:]')"
+    hint="(run: git config core.hooksPath .githooks)"
+    case "$mode" in
+        devcontainer) hint="$hint; normally set by the devcontainer setup: reopen the container" ;;
+        direnv)       hint="$hint; normally set on dev-shell entry: run direnv allow" ;;
+        both)         hint="$hint; normally set by the devcontainer setup (reopen the container) or on dev-shell entry (direnv allow)" ;;
+    esac
+
+    hookspath="$(git config core.hooksPath || true)"
+    if [ "$hookspath" = ".githooks" ]; then
+        echo "PASS git hooks: core.hooksPath -> .githooks"
+    elif [ -z "$hookspath" ]; then
+        echo "WARN git hooks: core.hooksPath not set, .githooks is tracked but inert $hint"
+    else
+        echo "WARN git hooks: core.hooksPath=$hookspath, expected .githooks $hint"
+    fi
+
+    if [ -n "${SSH_AUTH_SOCK:-}" ] && ssh-add -l >/dev/null 2>&1; then
+        echo "PASS ssh-agent: reachable with $(ssh-add -l | wc -l) key(s)"
+    else
+        echo "WARN ssh-agent: not reachable or no keys loaded"
+    fi
+
+    if gh auth status >/dev/null 2>&1; then
+        echo "PASS gh auth: logged in"
+    else
+        echo "WARN gh auth: not authenticated (run: gh auth login)"
+    fi
+
+    exit 0
+
 # Run a command with libstdc++ resolvable for uvx-run native wheels (#1181).
 # On a non-Python direnv-mode consumer the CI preamble keeps the Nix CPython on
 # PATH, whose loader does not search /usr/lib, so a uvx tool's manylinux native

--- a/nix/hooks.nix
+++ b/nix/hooks.nix
@@ -740,8 +740,12 @@ let
         };
     };
     # Security exception expiry enforcement (#566). Ships to the scaffold
-    # (consumer repos carry .trivyignore/.vulnixignore too), so the
-    # consumer render keeps the PATH-portable `uv run` entry.
+    # (consumer repos carry .trivyignore/.vulnixignore too), so the committed
+    # YAML renders keep the PATH-portable `uv run` entry, while the consumer
+    # fragment resolves a nix/vig-utils.nix store path like every other
+    # tool-naming consumer fragment (#1447, same defect as #1434): `uv run`
+    # resolves against the *consumer's* project venv, which carries no
+    # vig-utils and which many consumers do not have at all.
     check-expirations = {
       scaffold = true;
       yaml = {
@@ -761,10 +765,10 @@ let
           files = expirationsFiles;
           pass_filenames = false;
         };
-      consumer = _: {
+      consumer = pkgs: {
         enable = true;
         name = "check-expirations";
-        entry = "uv run check-expirations .trivyignore .vulnixignore";
+        entry = "${import ./vig-utils.nix pkgs}/bin/check-expirations .trivyignore .vulnixignore";
         language = "system";
         files = expirationsFiles;
         pass_filenames = false;

--- a/tests/bats/consumer-doctor.bats
+++ b/tests/bats/consumer-doctor.bats
@@ -1,0 +1,241 @@
+#!/usr/bin/env bats
+# BATS tests for the SCAFFOLDED `just doctor` host-diagnostics recipe (#1448).
+#
+# `doctor` shipped in devkit's own justfile only (#1418, extended in #1430), so
+# a consumer clone got no host preflight at all — the population where the
+# "configured, believed active, never executed" hooks failure hurts most. This
+# ships the same diagnostic on the consumer surface, in the MANAGED root
+# justfile (assets/workspace/justfile): it is the only managed justfile layer
+# present in every delivery mode (direnv/bare carry no .devcontainer/), and
+# justfile.project is preserved on upgrade so a recipe placed there would never
+# reach an existing consumer.
+#
+# The remediation hint is where the two implementations legitimately differ:
+# devkit's points at ./scripts/init.sh, which a consumer does not have. A
+# consumer's core.hooksPath is wired by the devcontainer setup
+# (setup-git-conf.sh) or on dev-shell entry (githooksPathHook, #1112), so the
+# hint names the mode's entry point from `.vig-os` DEVKIT_MODE, on top of a
+# universal `git config core.hooksPath .githooks` that works in every mode
+# (including `bare`, where nothing wires it automatically).
+#
+# Tests drive the REAL shipped justfile in a fixture workspace under a
+# controlled environment (GIT_CONFIG_GLOBAL/SYSTEM, SSH_AUTH_SOCK, stub `gh`)
+# so host state never leaks in — same harness idiom as doctor.bats.
+
+setup() {
+    load test_helper
+    WS="$BATS_TEST_TMPDIR/ws"
+    STUBS="$BATS_TEST_TMPDIR/stubs"
+    GIT_GLOBAL="$BATS_TEST_TMPDIR/gitconfig"
+    mkdir -p "$WS" "$STUBS"
+    : >"$GIT_GLOBAL"
+    # The managed root justfile, exactly as scaffolded into a consumer repo.
+    cp "$PROJECT_ROOT/assets/workspace/justfile" "$WS/justfile"
+    # Stub gh: GH_STUB_RC controls `gh auth status` (default: not logged in).
+    cat >"$STUBS/gh" <<'STUB'
+#!/usr/bin/env bash
+if [ "${GH_STUB_RC:-1}" -eq 0 ]; then
+    echo "Logged in to github.com"
+fi
+exit "${GH_STUB_RC:-1}"
+STUB
+    chmod +x "$STUBS/gh"
+}
+
+# Make the fixture a real repository so `git config core.hooksPath` resolves
+# against a known local config and can never walk up into the host's checkout
+# (the run also pins GIT_CONFIG_GLOBAL/SYSTEM, so global state cannot leak).
+# Shape of a scaffolded clone: tracked .githooks on disk, `.vig-os` manifest.
+# $1 (optional) is the DEVKIT_MODE value; omit it for a mode-less manifest.
+_scaffold_repo() {
+    git -c init.defaultBranch=main init -q "$WS"
+    mkdir -p "$WS/.githooks"
+    printf '#!/usr/bin/env bash\n' >"$WS/.githooks/pre-commit"
+    printf 'DEVKIT_VERSION=1.8.0\n' >"$WS/.vig-os"
+    if [ "$#" -gt 0 ]; then
+        printf 'DEVKIT_MODE=%s\n' "$1" >>"$WS/.vig-os"
+    fi
+}
+
+_run_doctor() {
+    run env -u SSH_AUTH_SOCK PATH="$STUBS:$PATH" \
+        GIT_CONFIG_GLOBAL="$GIT_GLOBAL" GIT_CONFIG_SYSTEM=/dev/null "$@" \
+        just --justfile "$WS/justfile" --working-directory "$WS" doctor
+}
+
+# ── layering: the recipe must ship in the MANAGED layer ───────────────────────
+
+@test "doctor ships in the managed root justfile, not the preserved justfile.project" {
+    run grep -qE '^doctor:' "$PROJECT_ROOT/assets/workspace/justfile"
+    assert_success
+    run grep -qE '^doctor:' "$PROJECT_ROOT/assets/workspace/justfile.project"
+    assert_failure
+}
+
+# ── diagnostics, never a gate ─────────────────────────────────────────────────
+
+@test "consumer doctor always exits 0 and warns on an unconfigured host" {
+    _scaffold_repo
+    _run_doctor
+    assert_success
+    assert_output --partial "devkit doctor"
+    assert_output --partial "WARN git user.name"
+    assert_output --partial "WARN git user.email"
+    assert_output --partial "WARN commit signing"
+    assert_output --partial "WARN git hooks"
+    assert_output --partial "WARN ssh-agent"
+    assert_output --partial "WARN gh auth"
+}
+
+@test "consumer doctor reports PASS for configured git identity and signing" {
+    _scaffold_repo
+    git config --file "$GIT_GLOBAL" user.name "Test User"
+    git config --file "$GIT_GLOBAL" user.email "test@example.com"
+    git config --file "$GIT_GLOBAL" gpg.format ssh
+    git config --file "$GIT_GLOBAL" commit.gpgsign true
+    git config --file "$GIT_GLOBAL" user.signingkey "$BATS_TEST_TMPDIR/key.pub"
+    printf 'ssh-ed25519 AAAA test\n' >"$BATS_TEST_TMPDIR/key.pub"
+    _run_doctor GH_STUB_RC=0
+    assert_success
+    assert_output --partial "PASS git user.name: Test User"
+    assert_output --partial "PASS git user.email: test@example.com"
+    assert_output --partial "PASS commit signing"
+    assert_output --partial "PASS gh auth"
+}
+
+@test "consumer doctor warns when the signing key path does not exist" {
+    _scaffold_repo
+    git config --file "$GIT_GLOBAL" commit.gpgsign true
+    git config --file "$GIT_GLOBAL" gpg.format ssh
+    git config --file "$GIT_GLOBAL" user.signingkey "$BATS_TEST_TMPDIR/missing.pub"
+    _run_doctor
+    assert_success
+    assert_output --partial "WARN commit signing"
+}
+
+# ── core.hooksPath verdict, per delivery mode ─────────────────────────────────
+# Devcontainer mode wires it in setup-git-conf.sh; direnv mode wires it on
+# dev-shell entry (githooksPathHook, #1112). Either way the wired state is the
+# same value, so the PASS verdict must hold in both.
+
+@test "consumer doctor reports PASS for core.hooksPath in devcontainer mode" {
+    _scaffold_repo devcontainer
+    git -C "$WS" config core.hooksPath .githooks
+    _run_doctor
+    assert_success
+    assert_output --partial "PASS git hooks"
+    refute_output --partial "WARN git hooks"
+}
+
+@test "consumer doctor reports PASS for core.hooksPath in direnv mode" {
+    _scaffold_repo direnv
+    git -C "$WS" config core.hooksPath .githooks
+    _run_doctor
+    assert_success
+    assert_output --partial "PASS git hooks"
+    refute_output --partial "WARN git hooks"
+}
+
+@test "consumer doctor warns and names the value when core.hooksPath points elsewhere" {
+    _scaffold_repo direnv
+    git -C "$WS" config core.hooksPath .git/hooks
+    _run_doctor
+    assert_success
+    assert_output --partial "WARN git hooks"
+    assert_output --partial "core.hooksPath=.git/hooks"
+    assert_output --partial "git config core.hooksPath .githooks"
+}
+
+# ── remediation hint: consumer entry points, never devkit's installer ─────────
+
+@test "consumer doctor gives the plain git command in an ad-hoc checkout" {
+    # No .vig-os at all: a clone outside both delivery modes. Nothing wires
+    # core.hooksPath there, so the only honest fix is the direct command.
+    git -c init.defaultBranch=main init -q "$WS"
+    _run_doctor
+    assert_success
+    assert_output --partial "WARN git hooks"
+    assert_output --partial "core.hooksPath not set"
+    assert_output --partial "run: git config core.hooksPath .githooks"
+}
+
+@test "consumer doctor names the devcontainer setup when hooks are inert in devcontainer mode" {
+    _scaffold_repo devcontainer
+    _run_doctor
+    assert_success
+    assert_output --partial "WARN git hooks"
+    assert_output --partial "run: git config core.hooksPath .githooks"
+    assert_output --partial "devcontainer"
+}
+
+@test "consumer doctor names the dev shell when hooks are inert in direnv mode" {
+    _scaffold_repo direnv
+    _run_doctor
+    assert_success
+    assert_output --partial "WARN git hooks"
+    assert_output --partial "run: git config core.hooksPath .githooks"
+    assert_output --partial "direnv allow"
+}
+
+@test "consumer doctor names both entry points in both mode" {
+    _scaffold_repo both
+    _run_doctor
+    assert_success
+    assert_output --partial "WARN git hooks"
+    assert_output --partial "devcontainer"
+    assert_output --partial "direnv allow"
+}
+
+@test "consumer doctor gives the plain git command in bare mode" {
+    # `bare` ships standards only — no container, no flake — so nothing wires
+    # core.hooksPath and no entry point can be named.
+    _scaffold_repo bare
+    _run_doctor
+    assert_success
+    assert_output --partial "run: git config core.hooksPath .githooks"
+    refute_output --partial "direnv allow"
+}
+
+@test "consumer doctor never points at devkit's own scripts/init.sh" {
+    # devkit's installer is not a consumer entry point; a consumer repo has no
+    # scripts/init.sh at all.
+    for mode in devcontainer direnv both bare; do
+        rm -rf "$WS"
+        mkdir -p "$WS"
+        cp "$PROJECT_ROOT/assets/workspace/justfile" "$WS/justfile"
+        _scaffold_repo "$mode"
+        _run_doctor
+        assert_success
+        refute_output --partial "scripts/init.sh"
+    done
+}
+
+# ── drift guard between the two doctor implementations ────────────────────────
+# The consumer recipe is a deliberate second implementation (different
+# remediation hints, different modes, no scripts/init.sh), so nothing but a
+# test keeps the two from drifting apart on WHAT they check. Pin the shared
+# expectation: identical check labels, identical PASS/WARN idiom, exit 0.
+
+# Emit the sorted check labels of a doctor recipe: $1 justfile, $2 working dir.
+_check_labels() {
+    env -u SSH_AUTH_SOCK PATH="$STUBS:$PATH" \
+        GIT_CONFIG_GLOBAL="$GIT_GLOBAL" GIT_CONFIG_SYSTEM=/dev/null \
+        just --justfile "$1" --working-directory "$2" doctor |
+        sed -n 's/^\(PASS\|WARN\) \([^:]*\):.*/\2/p' | sort
+}
+
+@test "consumer doctor checks exactly what devkit's doctor checks" {
+    _scaffold_repo direnv
+    local devkit_ws="$BATS_TEST_TMPDIR/devkit"
+    mkdir -p "$devkit_ws"
+    git -c init.defaultBranch=main init -q "$devkit_ws"
+
+    local consumer devkit
+    consumer="$(_check_labels "$WS/justfile" "$WS")"
+    devkit="$(_check_labels "$PROJECT_ROOT/justfile" "$devkit_ws")"
+
+    echo "consumer labels: $consumer"
+    echo "devkit labels:   $devkit"
+    [ -n "$consumer" ]
+    [ "$consumer" = "$devkit" ]
+}

--- a/tests/test_flake_hooks.py
+++ b/tests/test_flake_hooks.py
@@ -31,6 +31,7 @@ import re
 import shlex
 import shutil
 import subprocess
+import tomllib
 from pathlib import Path
 from typing import Any
 
@@ -773,6 +774,107 @@ class TestCommitMsgHooksConsumerSurface:
             "validate-commit-msg"
         ]
         assert consumer["args"] == scaffold["args"] == STOCK_VALIDATE_ARGS
+
+
+@functools.cache
+def _vig_utils_console_scripts() -> frozenset[str]:
+    """Console scripts vig-utils installs.
+
+    Read from ``packages/vig-utils/pyproject.toml`` rather than hardcoded, so
+    the class-wide guard below covers every current *and* future script
+    without a second list to keep in sync.
+    """
+    data = tomllib.loads(
+        (REPO_ROOT / "packages" / "vig-utils" / "pyproject.toml").read_text()
+    )
+    return frozenset(data["project"]["scripts"])
+
+
+class TestCheckExpirationsConsumerSurface:
+    """``check-expirations`` resolves the pinned vig-utils too (#1447).
+
+    It was the last vig-utils hook whose consumer fragment shelled out to
+    ``uv run``, i.e. to the *consumer's* project venv — which carries no
+    vig-utils, and which many consumers do not have at all (no
+    ``pyproject.toml``). Same defect and same fix as the three hooks of #1434.
+    """
+
+    def test_entry_resolves_the_pinned_vig_utils(
+        self, consumer_config: dict[str, Any]
+    ) -> None:
+        """Store-path entry, so the hook follows the consumer's devkit pin."""
+        entry = _normalize(consumer_config)["hooks"]["check-expirations"]["entry"]
+        argv = shlex.split(entry)
+        assert argv[0].startswith("/nix/store/"), (
+            f"check-expirations entry is not a store path: {entry!r}"
+        )
+        assert argv[0].endswith("/bin/check-expirations"), entry
+
+    def test_scope_and_argv_match_the_scaffolded_render(
+        self, consumer_config: dict[str, Any], rendered_portable: dict[str, Any]
+    ) -> None:
+        """Only the resolution changes: the hook still guards the same files.
+
+        A docker-mode consumer (scaffolded YAML) and a direnv consumer
+        (flake-generated) must enforce the same expiries over the same paths.
+        """
+        consumer = _normalize(consumer_config)["hooks"]["check-expirations"]
+        scaffold = _normalize(rendered_portable["scaffold"])["hooks"][
+            "check-expirations"
+        ]
+        scaffold_argv = shlex.split(scaffold["entry"])
+        assert scaffold_argv[:3] == ["uv", "run", "check-expirations"]
+        assert shlex.split(consumer["entry"])[1:] == [".trivyignore", ".vulnixignore"]
+        assert scaffold_argv[3:] == shlex.split(consumer["entry"])[1:]
+        assert consumer["files"] == scaffold["files"]
+        assert consumer["language"] == "system"
+        assert consumer["pass_filenames"] is False
+
+    def test_portable_render_keeps_the_uv_run_entry(
+        self, rendered_portable: dict[str, Any]
+    ) -> None:
+        """The committed YAMLs stay PATH-portable — no store-path churn.
+
+        Only the *consumer* (flake-generated) fragment resolves a store path;
+        the runner and scaffold renders are committed artifacts pinned by the
+        drift gate, so they keep the ``uv run`` form (docs/NIX.md).
+        """
+        for render in ("runner", "scaffold"):
+            entry = _normalize(rendered_portable[render])["hooks"]["check-expirations"][
+                "entry"
+            ]
+            assert entry.startswith("uv run check-expirations "), (render, entry)
+
+
+class TestNoConsumerHookResolvesVigUtilsThroughTheVenv:
+    """Class-wide guard for the #1434/#1447 defect, on every consumer shell.
+
+    A ``uv run <vig-utils script>`` entry on the consumer surface resolves
+    against the *consumer's* project venv, which devkit neither controls nor
+    can assume exists. Every consumer fragment that names a vig-utils console
+    script must resolve a ``nix/vig-utils.nix`` store path instead. Pinning
+    the class — rather than one hook at a time — is what keeps the next hook
+    added to ``nix/hooks.nix`` from reintroducing it.
+    """
+
+    def test_every_vig_utils_entry_is_a_store_path(self) -> None:
+        scripts = _vig_utils_console_scripts()
+        offenders: list[str] = []
+        for shell, config in _consumer_config_set().items():
+            for hook_id, hook in _normalize(config)["hooks"].items():
+                argv = shlex.split(hook.get("entry") or "")
+                if not argv:
+                    continue
+                names = {Path(argv[0]).name, *(argv[1:3] if argv[0] == "uv" else [])}
+                if not names & scripts:
+                    continue
+                if not argv[0].startswith("/nix/store/"):
+                    offenders.append(f"{shell}:{hook_id}: {hook['entry']!r}")
+        assert not offenders, (
+            "consumer hook entries resolve vig-utils through the project venv "
+            "instead of the pinned store path (#1434, #1447):\n  "
+            + "\n  ".join(offenders)
+        )
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
## Description

Fixes #1459. **Targets `release/1.8.0`.** Restores the #1447 and #1448 content that two failed `release.yml` dispatches stripped off the release branch.

Both PRs (#1449, #1451) merged green and both issues are closed, but the content is absent from the branch tip. Without this, 1.8.0 would ship claiming two fixes it does not contain, and the changelog would omit both.

| Rollback commit | Time | Triggering run | Destroyed |
|---|---|---|---|
| `71cd72fb` | 09:49Z | `31583273344` (failed: `Candidate tag '1.8.0-rc2' already exists on origin`) | **#1447** — `nix/hooks.nix` fix, 102 lines of tests, changelog entry |
| `c1cc5d82` | 09:59Z | `31584765199` (failed: validate's PR gate — #1441 is a draft with `REVIEW_REQUIRED`) | **#1448** — 77-line `doctor` recipe, 241-line `consumer-doctor.bats`, changelog entry |

## Type of Change

- [x] `revert` -- Reverts a previous commit

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

`git revert --no-commit c1cc5d82 71cd72fb`, squashed into one commit. No hand edits, no conflicts:

```
CHANGELOG.md                                |  31 ++
assets/workspace/.devcontainer/CHANGELOG.md |  31 ++
assets/workspace/justfile                   |  77 ++
nix/hooks.nix                               |  12 +-
tests/bats/consumer-doctor.bats             | 241 ++
tests/test_flake_hooks.py                   | 102 ++
6 files changed, 490 insertions(+), 4 deletions(-)
```

## Root cause (tracked separately — not fixed here)

`release.yml`'s **Rollback on Failure** job (`.github/workflows/release.yml:1551`) builds a commit whose **tree is `PRE_SHA`** — the branch tip captured when `validate` started — parented onto the current tip. A tree-level reset expressed as a commit.

Two properties make it destructive:

1. It runs when **`validate`** fails. `Finalize Release` was **skipped** in both runs — nothing needed rolling back — yet the tree was reset anyway.
2. `PRE_SHA` is a run-start snapshot, so **anything merged to the release branch while a release run is in flight is destroyed if that run fails**, related to the release or not.

The trigger was merging into the release branch while a run was live. The defect is that a rollback for a step that never executed discards unrelated merged commits. Filed separately; this PR only restores content.

**Interim operating rule:** never merge into a release branch while a `release.yml` run is in flight.

## Changelog Entry

No new entry. This restores the #1447 and #1448 entries that the rollbacks deleted from the `## [1.8.0] - TBD` section; adding a "restored the changelog" bullet would be noise in the released notes.

## Testing

- [x] Tests pass locally
- [x] Manual testing performed (describe below)

### Manual Testing Details

Content restoration verified item by item on the branch:

| item | present |
|---|---|
| `check-expirations` store-path entry (`nix/hooks.nix`) | yes |
| `TestNoConsumerHookResolvesVigUtilsThroughTheVenv` | yes |
| consumer `doctor` recipe (`assets/workspace/justfile`) | yes |
| `tests/bats/consumer-doctor.bats` | yes |
| changelog entries #1447 / #1448 | yes / yes |
| #1434 title bullet (from #1453) | exactly 1, not duplicated |

- `bats tests/bats/` -> **496 ok, 0 not ok, exit 0** — exactly the pre-loss baseline, confirming #1448's 14 tests are back and passing.
- `uv run pytest tests/test_flake_hooks.py` -> 63 passed, exit 0 — #1447's tests restored and green.
- `uv run pytest tests/ -q` -> 780 passed, 20 skipped, 1 failed. The single failure is the known `tests/test_image.py::TestFileStructure::test_manifest_files`, which checksums the working-tree `CHANGELOG.md` against a stale locally cached devcontainer image; it reproduces on a clean `dev` without this branch, and CI rebuilds the image.
- `prek run --all-files` -> exit 0, fully green.
- `git status` clean; no stray or untracked files in the revert.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] I have updated `CHANGELOG.md` (restores the deleted entries)
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works (restores the deleted tests)
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

**Merge only while no `release.yml` run is in flight** — otherwise this PR is subject to the very defect it repairs. I will re-check immediately before merging.

**`1.8.0-rc2` is stale.** It is tagged at `b60b306a`, which predates #1447, #1448, #1453 and #1454. After this lands (and #1454 after it) the branch matches no existing RC, so a fresh candidate is warranted before finalize rather than finalizing content no RC validated. Published tags are immutable, so it must be rc3 — re-dispatching rc2 is what failed at 09:31.

#1454 is complete and pushed but not yet PR'd: its `consumer-doctor.bats` additions conflict until this restores the base file.

Closes #1459

Refs: #1459
