### PR TITLE
fix(workspace): report git hooks as live in a linked worktree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,6 +189,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`just doctor` no longer calls the git hooks inert inside a linked worktree** ([#1454](https://github.com/vig-os/devkit/issues/1454))
+  - `just worktree-start` unsets `core.hooksPath` in the worktree on purpose —
+    prek refuses to install its shims while it is set — and installs those
+    shims instead; `hooks` is one of git's shared paths, so they land in the
+    common git dir and git runs them from inside the worktree. Both `doctor`
+    recipes read that intended state as the fresh-clone failure and reported
+    `WARN git hooks: … tracked but inert`, whose remediation would have undone
+    the worktree setup
+  - A linked worktree with an installed, executable `hooks/pre-commit` now
+    reports `PASS git hooks: linked worktree, installed at <path>`. A linked
+    worktree with no installed shim is genuinely inert and still warns, as do
+    all the other unset and set-elsewhere cases
+  - Fixed in devkit's own `justfile` and the scaffolded
+    `assets/workspace/justfile` in the same change, keeping the two recipes in
+    step for the [#1448](https://github.com/vig-os/devkit/issues/1448) drift
+    guard
 - **Smoke deploy now publishes installer deletions to the deploy branch** ([#1443](https://github.com/vig-os/devkit/issues/1443))
   - The smoke-test dispatch deploy committed via `commit-action`, which builds
     its tree additively from working-tree contents and cannot express file

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -189,6 +189,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`just doctor` no longer calls the git hooks inert inside a linked worktree** ([#1454](https://github.com/vig-os/devkit/issues/1454))
+  - `just worktree-start` unsets `core.hooksPath` in the worktree on purpose —
+    prek refuses to install its shims while it is set — and installs those
+    shims instead; `hooks` is one of git's shared paths, so they land in the
+    common git dir and git runs them from inside the worktree. Both `doctor`
+    recipes read that intended state as the fresh-clone failure and reported
+    `WARN git hooks: … tracked but inert`, whose remediation would have undone
+    the worktree setup
+  - A linked worktree with an installed, executable `hooks/pre-commit` now
+    reports `PASS git hooks: linked worktree, installed at <path>`. A linked
+    worktree with no installed shim is genuinely inert and still warns, as do
+    all the other unset and set-elsewhere cases
+  - Fixed in devkit's own `justfile` and the scaffolded
+    `assets/workspace/justfile` in the same change, keeping the two recipes in
+    step for the [#1448](https://github.com/vig-os/devkit/issues/1448) drift
+    guard
 - **Smoke deploy now publishes installer deletions to the deploy branch** ([#1443](https://github.com/vig-os/devkit/issues/1443))
   - The smoke-test dispatch deploy committed via `commit-action`, which builds
     its tree additively from working-tree contents and cannot express file

--- a/assets/workspace/justfile
+++ b/assets/workspace/justfile
@@ -70,9 +70,24 @@ doctor:
         both)         hint="$hint; normally set by the devcontainer setup (reopen the container) or on dev-shell entry (direnv allow)" ;;
     esac
 
+    # A linked worktree is the one place where unset is the INTENDED state
+    # (#1454): `just worktree-start` unsets core.hooksPath there on purpose
+    # (prek refuses to install its shims while it is set) and installs the shims
+    # instead. `hooks` is one of git's shared paths, so they land in the common
+    # git dir and git runs them from inside the worktree — the gates are live,
+    # and the remediation above would undo the setup. Claim that only when a
+    # shim is really installed and executable: a worktree without one is inert
+    # exactly like any other unset case. `--git-path hooks/pre-commit` resolves
+    # to the file git itself would run (`.git` is a FILE in a linked worktree,
+    # so a literal `.git/hooks/...` test could never see it).
     hookspath="$(git config core.hooksPath || true)"
+    gitdir="$(git rev-parse --absolute-git-dir 2>/dev/null || true)"
+    commondir="$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)"
+    installed="$(git rev-parse --git-path hooks/pre-commit 2>/dev/null || true)"
     if [ "$hookspath" = ".githooks" ]; then
         echo "PASS git hooks: core.hooksPath -> .githooks"
+    elif [ -z "$hookspath" ] && [ -n "$gitdir" ] && [ "$gitdir" != "$commondir" ] && [ -x "$installed" ]; then
+        echo "PASS git hooks: linked worktree, installed at $installed (core.hooksPath unset by design)"
     elif [ -z "$hookspath" ]; then
         echo "WARN git hooks: core.hooksPath not set, .githooks is tracked but inert $hint"
     else

--- a/justfile
+++ b/justfile
@@ -80,9 +80,25 @@ doctor:
     # ignores them until core.hooksPath points there, and only scripts/init.sh
     # (or devcontainer / dev-shell entry) sets it. Until then every commit-side
     # gate is present, believed active, and inert. Refs #1430.
+    #
+    # A linked worktree is the one place where unset is the INTENDED state
+    # (#1454): `just worktree-start` unsets core.hooksPath there on purpose
+    # (prek refuses to install its shims while it is set) and installs the shims
+    # instead. `hooks` is one of git's shared paths, so they land in the common
+    # git dir and git runs them from inside the worktree — the gates are live,
+    # and the fresh-clone remediation would undo the setup. Claim that only when
+    # a shim is really installed and executable: a worktree without one is inert
+    # exactly like any other unset case. `--git-path hooks/pre-commit` resolves
+    # to the file git itself would run (`.git` is a FILE in a linked worktree,
+    # so a literal `.git/hooks/...` test could never see it).
     hookspath="$(git config core.hooksPath || true)"
+    gitdir="$(git rev-parse --absolute-git-dir 2>/dev/null || true)"
+    commondir="$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)"
+    installed="$(git rev-parse --git-path hooks/pre-commit 2>/dev/null || true)"
     if [ "$hookspath" = ".githooks" ]; then
         echo "PASS git hooks: core.hooksPath -> .githooks"
+    elif [ -z "$hookspath" ] && [ -n "$gitdir" ] && [ "$gitdir" != "$commondir" ] && [ -x "$installed" ]; then
+        echo "PASS git hooks: linked worktree, installed at $installed (core.hooksPath unset by design)"
     elif [ -z "$hookspath" ]; then
         echo "WARN git hooks: core.hooksPath not set, .githooks is tracked but inert (run: ./scripts/init.sh)"
     else

--- a/tests/bats/consumer-doctor.bats
+++ b/tests/bats/consumer-doctor.bats
@@ -63,6 +63,17 @@ _run_doctor() {
         just --justfile "$WS/justfile" --working-directory "$WS" doctor
 }
 
+# Same, but from another checkout of the same repo ($1) — the shipped justfile
+# is tracked, so a linked worktree carries its own copy exactly as a consumer
+# would run it there.
+_run_doctor_at() {
+    local wd="$1"
+    shift
+    run env -u SSH_AUTH_SOCK PATH="$STUBS:$PATH" \
+        GIT_CONFIG_GLOBAL="$GIT_GLOBAL" GIT_CONFIG_SYSTEM=/dev/null "$@" \
+        just --justfile "$wd/justfile" --working-directory "$wd" doctor
+}
+
 # ── layering: the recipe must ship in the MANAGED layer ───────────────────────
 
 @test "doctor ships in the managed root justfile, not the preserved justfile.project" {
@@ -208,6 +219,73 @@ _run_doctor() {
         assert_success
         refute_output --partial "scripts/init.sh"
     done
+}
+
+# ── linked worktrees: unset core.hooksPath is the INTENDED state (#1454) ──────
+# The scaffolded `just worktree-start` (.devcontainer/justfile.worktree)
+# deliberately unsets core.hooksPath in the worktree — prek refuses to install
+# its shims while it is set — and installs them instead. `hooks` is one of git's
+# shared (common-dir) paths, so those shims land in the COMMON git dir and git
+# runs them from inside the linked worktree: the gates are LIVE. The fresh-clone
+# "tracked but inert" WARN is a lie there, and its remediation would undo the
+# worktree setup. A linked worktree with NO installed shim is genuinely inert
+# and must stay a WARN.
+
+# Fixture git with a pinned identity and no signing, so host global/system
+# config can never make the fixture commit fail.
+_git_fixture() {
+    env GIT_CONFIG_GLOBAL="$GIT_GLOBAL" GIT_CONFIG_SYSTEM=/dev/null \
+        git -c user.name=Fixture -c user.email=fixture@example.com \
+            -c commit.gpgsign=false "$@"
+}
+
+# Scaffold the fixture in mode $1, commit it (so the linked checkout carries the
+# justfile, .githooks and .vig-os a consumer really has there), and add a linked
+# worktree. $2 = "hooks" installs an executable pre-commit shim where git looks
+# with core.hooksPath unset — the common git dir, where `prek install` lands
+# from inside a linked worktree. Echoes the worktree path.
+_scaffold_linked_worktree() {
+    _scaffold_repo "$1"
+    _git_fixture -C "$WS" add -A
+    _git_fixture -C "$WS" commit -q -m "fixture"
+    if [ "${2:-}" = "hooks" ]; then
+        printf '#!/usr/bin/env bash\nexit 0\n' >"$WS/.git/hooks/pre-commit"
+        chmod +x "$WS/.git/hooks/pre-commit"
+    fi
+    _git_fixture -C "$WS" worktree add -q "$BATS_TEST_TMPDIR/linked" -b fixture/wt
+    echo "$BATS_TEST_TMPDIR/linked"
+}
+
+@test "consumer doctor reports PASS in a linked worktree with hooks installed" {
+    local linked
+    linked="$(_scaffold_linked_worktree direnv hooks)"
+    _run_doctor_at "$linked"
+    assert_success
+    assert_output --partial "PASS git hooks"
+    assert_output --partial "linked worktree"
+    refute_output --partial "WARN git hooks"
+    refute_output --partial "scripts/init.sh"
+}
+
+@test "consumer doctor warns in a linked worktree with no hooks installed" {
+    local linked
+    linked="$(_scaffold_linked_worktree direnv)"
+    _run_doctor_at "$linked"
+    assert_success
+    assert_output --partial "WARN git hooks"
+    assert_output --partial "core.hooksPath not set"
+    assert_output --partial "run: git config core.hooksPath .githooks"
+    refute_output --partial "scripts/init.sh"
+}
+
+@test "consumer doctor reports PASS in a linked worktree that still has core.hooksPath" {
+    local linked
+    linked="$(_scaffold_linked_worktree direnv)"
+    git -C "$linked" config core.hooksPath .githooks
+    _run_doctor_at "$linked"
+    assert_success
+    assert_output --partial "PASS git hooks"
+    refute_output --partial "WARN git hooks"
 }
 
 # ── drift guard between the two doctor implementations ────────────────────────

--- a/tests/bats/doctor.bats
+++ b/tests/bats/doctor.bats
@@ -97,6 +97,66 @@ _init_clone() {
     assert_output --partial "scripts/init.sh"
 }
 
+# ── linked worktrees: unset core.hooksPath is the INTENDED state (#1454) ──────
+# `just worktree-start` deliberately unsets core.hooksPath in the worktree
+# (justfile.worktree) because prek refuses to install its shims while it is set,
+# then installs them. `hooks` is one of git's shared (common-dir) paths, so those
+# shims land in the COMMON git dir and git runs them from inside the linked
+# worktree: the gates are LIVE. Reporting the fresh-clone "tracked but inert"
+# WARN there is a lie whose remediation would undo the worktree setup. A linked
+# worktree with NO installed shim is genuinely inert and must stay a WARN.
+
+# Run git for fixture setup with a pinned identity and no signing, so host
+# global/system config can never make the fixture commit fail.
+_git_fixture() {
+    env GIT_CONFIG_GLOBAL="$GIT_GLOBAL" GIT_CONFIG_SYSTEM=/dev/null \
+        git -c user.name=Fixture -c user.email=fixture@example.com \
+            -c commit.gpgsign=false "$@"
+}
+
+# Build a real main clone + linked worktree under BATS_TEST_TMPDIR and point the
+# run at the worktree. $1 = "hooks" to install an executable pre-commit shim
+# where git looks with core.hooksPath unset (the common git dir — exactly where
+# `prek install` lands from inside a linked worktree).
+_init_linked_worktree() {
+    _init_clone
+    local main="$DOCTOR_WORK"
+    _git_fixture -C "$main" commit -q --allow-empty -m "fixture"
+    if [ "${1:-}" = "hooks" ]; then
+        printf '#!/usr/bin/env bash\nexit 0\n' >"$main/.git/hooks/pre-commit"
+        chmod +x "$main/.git/hooks/pre-commit"
+    fi
+    _git_fixture -C "$main" worktree add -q "$BATS_TEST_TMPDIR/linked" -b fixture/wt
+    DOCTOR_WORK="$BATS_TEST_TMPDIR/linked"
+}
+
+@test "doctor reports PASS in a linked worktree with hooks installed" {
+    _init_linked_worktree hooks
+    _run_doctor
+    assert_success
+    assert_output --partial "PASS git hooks"
+    assert_output --partial "linked worktree"
+    refute_output --partial "WARN git hooks"
+}
+
+@test "doctor warns in a linked worktree with no hooks installed" {
+    _init_linked_worktree
+    _run_doctor
+    assert_success
+    assert_output --partial "WARN git hooks"
+    assert_output --partial "core.hooksPath not set"
+    assert_output --partial "scripts/init.sh"
+}
+
+@test "doctor reports PASS in a linked worktree that still has core.hooksPath" {
+    _init_linked_worktree
+    git -C "$DOCTOR_WORK" config core.hooksPath .githooks
+    _run_doctor
+    assert_success
+    assert_output --partial "PASS git hooks"
+    refute_output --partial "WARN git hooks"
+}
+
 @test "doctor warns when the signing key path does not exist" {
     git config --file "$GIT_GLOBAL" commit.gpgsign true
     git config --file "$GIT_GLOBAL" gpg.format ssh


### PR DESCRIPTION
## Description

Fixes #1454. **Targets `release/1.8.0`** (post-recovery base `9cce85ed`).

`just doctor` reported `WARN git hooks: … tracked but inert` inside a linked worktree **where the hooks are live**, and the remediation it offered would have undone the worktree setup. A diagnostic that lies is the exact failure class #1430 exists to close.

`just worktree-start` unsets `core.hooksPath` on purpose — prek refuses to install its shims while it is set — and installs the shims instead. `hooks` is one of git's **shared** paths, so they land in the common git dir and git runs them from inside the worktree. Both `doctor` recipes read that intended state as the fresh-clone failure.

## Type of Change

- [x] `fix` -- Bug fix
- [x] `test` -- Adding or updating tests

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

- `justfile` -- devkit's `doctor`: linked-worktree PASS branch ahead of the fresh-clone WARN.
- `assets/workspace/justfile` -- the scaffolded `doctor`: identical branch, inserted after the mode-aware `hint` construction so #1448's hints are untouched.
- `tests/bats/doctor.bats` -- 3 tests + hermetic `_git_fixture` / `_init_linked_worktree` helpers (real `git worktree add` under `BATS_TEST_TMPDIR`, pinned identity, signing off).
- `tests/bats/consumer-doctor.bats` -- 3 tests + `_run_doctor_at` / `_scaffold_linked_worktree` (commits the fixture so the linked checkout really carries `justfile`, `.githooks`, `.vig-os`).
- `CHANGELOG.md` (+ hook-synced mirror) -- entry under the 1.8.0 `### Fixed`.

**Two mechanics the obvious implementation gets wrong**, both established empirically rather than assumed:

- `.git` is a **file** in a linked worktree, so a literal `.git/hooks/pre-commit` test can never see the shim. This uses `git rev-parse --git-path hooks/pre-commit` — the file git itself would run.
- `git rev-parse --absolute-git-dir` vs `--path-format=absolute --git-common-dir` is the safe comparison. A plain `--git-dir` / `--git-common-dir` compare falsely reports "linked" from a *subdirectory* of the main worktree (`/abs/.git` vs `../.git`). This is also the idiom `flake.nix`'s `githooksPathHook` already uses.

The PASS additionally requires the shim to be **executable** (`-x`), since git ignores a non-executable hook.

## Verdict matrix

| worktree | `core.hooksPath` | installed `hooks/pre-commit` | verdict |
|---|---|---|---|
| main | `.githooks` | any | PASS `core.hooksPath -> .githooks` |
| main | unset | none | WARN fresh-clone |
| main | unset | present | WARN fresh-clone (unchanged — see notes) |
| main | other | any | WARN naming the value |
| linked | `.githooks` | any | PASS (still live; pinned by a new test) |
| linked | unset | **present** | **PASS `linked worktree, installed at <path> (core.hooksPath unset by design)`** |
| linked | unset | none | WARN fresh-clone — genuinely inert |
| linked | other | any | WARN naming the value |
| not a repo | — | — | WARN (the `-n "$gitdir"` guard keeps it out of the PASS branch) |

## Changelog Entry

```
### Fixed

- **`just doctor` no longer calls the git hooks inert inside a linked worktree** ([#1454](https://github.com/vig-os/devkit/issues/1454))
```

Placed in `## [1.8.0] - TBD`, matching every post-freeze entry on this branch.

## Testing

- [x] Tests pass locally
- [x] Manual testing performed (describe below)

### Manual Testing Details

Real clone + `git worktree add` + the exact `worktree-start` setup (`unset-all core.hooksPath`, `prek install`):

BEFORE:
```
WARN git hooks: core.hooksPath not set, .githooks is tracked but inert (run: ./scripts/init.sh)
```
AFTER:
```
PASS git hooks: linked worktree, installed at /…/demo/.git/hooks/pre-commit (core.hooksPath unset by design)
```
AFTER, same worktree with the shims deleted (must-stay-WARN case):
```
WARN git hooks: core.hooksPath not set, .githooks is tracked but inert (run: ./scripts/init.sh)
```

The verdicts are grounded in behavior, not inference: in the live worktree `git commit -m "bad message"` was **rejected** by `validate-commit-msg`; after deleting the shims the same commit **landed unblocked**, confirming the WARN is true in that state.

- RED: `bats tests/bats/doctor.bats tests/bats/consumer-doctor.bats` -> exit 1, exactly 2 failures (`not ok 6`, `not ok 23`), both showing the lying WARN. The other 4 new tests passed as intended — they pin cells that must not move.
- GREEN: same command -> 26/26 ok, exit 0.
- Full bats after merging the recovered `release/1.8.0`: **502 ok, 0 not ok, exit 0**.
- `prek run --all-files` -> exit 0, tree clean.
- Full pytest -> 776 passed, 20 skipped, 1 failed — the known stale-image `test_manifest_files`, verified pre-existing two ways (branch-point changelog sha already differs from the image's baked copy; re-ran with the pristine changelog checked out and it still failed).

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] I have updated `CHANGELOG.md` (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

**Drift guard intact.** #1448's `consumer doctor checks exactly what devkit's doctor checks` passes — the new PASS keeps the `git hooks` label, so both label sets stay identical. All mode-aware hint tests pass, and `refute_output --partial "scripts/init.sh"` was added to both new consumer tests.

**Deliberately unchanged:** main worktree + unset `core.hooksPath` + a prek shim in `.git/hooks` still WARNs. The gates are live there too, so the WARN is under-informative — but it is literally true (`.githooks` *is* inert) and its remediation is harmless. #1454 explicitly says to keep the fresh-clone WARN for every other unset case, so that cell was left alone and not pinned either way. Worth a follow-up if `doctor` should key purely off "what will git execute".

**Separate bug found, not fixed here:** `git config --unset-all core.hooksPath` inside a linked worktree writes to the **shared** config, so `just worktree-start` silently unsets `core.hooksPath` for the **main** checkout too, leaving its `.githooks` inert until something re-sets it. Reproduced. Deserves its own issue — and `doctor` will now correctly WARN about it.

The base merge resolved one additive `CHANGELOG.md` conflict by keeping both this entry and the restored #1447 entry (#1459 recovery); the 1.8.0 section was re-audited afterwards and all entries carry their title bullets.

Closes #1454

Refs: #1454
