### PR TITLE
fix(workspace): keep shared core.hooksPath intact across worktree-start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,6 +189,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`just worktree-start` no longer unsets `core.hooksPath` repo-wide** ([#1463](https://github.com/vig-os/devkit/issues/1463))
+  - `core.hooksPath` is shared repo config, so unsetting it from inside the
+    new linked worktree silently disarmed the main checkout's tracked
+    `.githooks` shims — the
+    [#1430](https://github.com/vig-os/devkit/issues/1430) failure mode,
+    self-inflicted by a primary devkit workflow
+  - A relative `core.hooksPath` resolves against each worktree's root and
+    `.githooks` is tracked, so when it is set the tracked shims already cover
+    every hook stage in the new worktree: `worktree-start` now leaves the
+    config untouched and skips the `prek install`, falling back to the old
+    install-into-shared-`.git/hooks` path only when no hooks path is
+    configured at all
+  - Fixed in both copies (devkit's `justfile.worktree` and the scaffolded
+    `.devcontainer/justfile.worktree`), pinned by bats tests driving the real
+    recipe in a sandbox repo
 - **`just doctor` no longer calls the git hooks inert inside a linked worktree** ([#1454](https://github.com/vig-os/devkit/issues/1454))
   - `just worktree-start` unsets `core.hooksPath` in the worktree on purpose —
     prek refuses to install its shims while it is set — and installs those

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -189,6 +189,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`just worktree-start` no longer unsets `core.hooksPath` repo-wide** ([#1463](https://github.com/vig-os/devkit/issues/1463))
+  - `core.hooksPath` is shared repo config, so unsetting it from inside the
+    new linked worktree silently disarmed the main checkout's tracked
+    `.githooks` shims — the
+    [#1430](https://github.com/vig-os/devkit/issues/1430) failure mode,
+    self-inflicted by a primary devkit workflow
+  - A relative `core.hooksPath` resolves against each worktree's root and
+    `.githooks` is tracked, so when it is set the tracked shims already cover
+    every hook stage in the new worktree: `worktree-start` now leaves the
+    config untouched and skips the `prek install`, falling back to the old
+    install-into-shared-`.git/hooks` path only when no hooks path is
+    configured at all
+  - Fixed in both copies (devkit's `justfile.worktree` and the scaffolded
+    `.devcontainer/justfile.worktree`), pinned by bats tests driving the real
+    recipe in a sandbox repo
 - **`just doctor` no longer calls the git hooks inert inside a linked worktree** ([#1454](https://github.com/vig-os/devkit/issues/1454))
   - `just worktree-start` unsets `core.hooksPath` in the worktree on purpose —
     prek refuses to install its shims while it is set — and installs those

--- a/assets/workspace/.devcontainer/justfile.worktree
+++ b/assets/workspace/.devcontainer/justfile.worktree
@@ -202,10 +202,21 @@ worktree-start issue prompt="" reviewer="":
     echo "Setting up worktree environment..."
     pushd "$WT_DIR" >/dev/null
     uv sync
-    git config --unset-all core.hooksPath 2>/dev/null || true
-    # Install every hook stage the repo uses: bare `prek install` only wires the
-    # pre-commit shim, dropping the commit-msg / prepare-commit-msg hooks (#778).
-    prek install -t pre-commit -t commit-msg -t prepare-commit-msg
+    # core.hooksPath is SHARED repo config, not per-worktree: unsetting it from
+    # here would disarm the main checkout's tracked .githooks shims repo-wide
+    # (#1463). A relative hooksPath resolves against each worktree's root and
+    # .githooks is tracked (present in every worktree), so when it is set the
+    # tracked shims already cover every hook stage here — leave the config
+    # alone and skip the prek install.
+    if HOOKS_PATH=$(git config --get core.hooksPath 2>/dev/null); then
+        echo "[OK] core.hooksPath is set ($HOOKS_PATH); tracked hooks cover this worktree"
+    else
+        # No hooksPath configured: prek's shims land in the shared .git/hooks,
+        # the active hooks dir in that state. Install every hook stage the
+        # repo uses: bare `prek install` only wires the pre-commit shim,
+        # dropping the commit-msg / prepare-commit-msg hooks (#778).
+        prek install -t pre-commit -t commit-msg -t prepare-commit-msg
+    fi
     git config commit.template .gitmessage
     if [ -f "$(git worktree list --porcelain | head -1 | cut -d' ' -f2-)/.env" ]; then
         cp "$(git worktree list --porcelain | head -1 | cut -d' ' -f2-)/.env" .env

--- a/justfile.worktree
+++ b/justfile.worktree
@@ -199,10 +199,21 @@ worktree-start issue prompt="" reviewer="":
     echo "Setting up worktree environment..."
     pushd "$WT_DIR" >/dev/null
     uv sync
-    git config --unset-all core.hooksPath 2>/dev/null || true
-    # Install every hook stage the repo uses: bare `prek install` only wires the
-    # pre-commit shim, dropping the commit-msg / prepare-commit-msg hooks (#778).
-    prek install -t pre-commit -t commit-msg -t prepare-commit-msg
+    # core.hooksPath is SHARED repo config, not per-worktree: unsetting it from
+    # here would disarm the main checkout's tracked .githooks shims repo-wide
+    # (#1463). A relative hooksPath resolves against each worktree's root and
+    # .githooks is tracked (present in every worktree), so when it is set the
+    # tracked shims already cover every hook stage here — leave the config
+    # alone and skip the prek install.
+    if HOOKS_PATH=$(git config --get core.hooksPath 2>/dev/null); then
+        echo "[OK] core.hooksPath is set ($HOOKS_PATH); tracked hooks cover this worktree"
+    else
+        # No hooksPath configured: prek's shims land in the shared .git/hooks,
+        # the active hooks dir in that state. Install every hook stage the
+        # repo uses: bare `prek install` only wires the pre-commit shim,
+        # dropping the commit-msg / prepare-commit-msg hooks (#778).
+        prek install -t pre-commit -t commit-msg -t prepare-commit-msg
+    fi
     git config commit.template .gitmessage
     if [ -f "$(git worktree list --porcelain | head -1 | cut -d' ' -f2-)/.env" ]; then
         cp "$(git worktree list --porcelain | head -1 | cut -d' ' -f2-)/.env" .env

--- a/tests/bats/worktree.bats
+++ b/tests/bats/worktree.bats
@@ -6,6 +6,8 @@
 
 setup() {
     load test_helper
+    WT_MAIN="${PROJECT_ROOT}/justfile.worktree"
+    WT_TEMPLATE="${PROJECT_ROOT}/assets/workspace/.devcontainer/justfile.worktree"
 }
 
 # ── worktree-attach restart logic (#132) ───────────────────────────────────────
@@ -189,4 +191,161 @@ setup() {
     assert_success
     refute_output --partial "not a git repository"
     refute_output --partial "fatal:"
+}
+
+# ── worktree-start leaves shared core.hooksPath alone (#1463) ─────────────────
+# `core.hooksPath` is SHARED repo config, not per-worktree: unsetting it from
+# inside the new linked worktree disarmed the MAIN checkout's tracked .githooks
+# shims repo-wide. A relative hooksPath resolves against each worktree's root
+# and .githooks is tracked (present in every worktree), so when it is set the
+# tracked shims already cover every hook stage in the new worktree —
+# worktree-start must leave the config untouched and skip the prek install.
+# Only a repo with no hooksPath configured at all still gets prek's shims
+# (they land in the shared .git/hooks, the active hooks dir in that state).
+#
+# Tests drive the REAL worktree-start recipe (both the root copy and the
+# scaffolded template) in a sandbox repo — with a bare origin so `git fetch`
+# succeeds — under stubbed tools (tmux/claude/gh/prek/uv and the helper CLIs)
+# and pinned git config, the same harness idiom as consumer-doctor.bats.
+
+WT_BRANCH="bugfix/4242-wt-hookspath"
+
+# Write the tool stubs worktree-start shells out to. `uv run <tool>` delegates
+# to the stubbed helper CLIs on PATH, so one stub set serves both the root copy
+# (`uv run resolve-branch`) and the template copy (bare `resolve-branch`).
+_wt_stubs() {
+    STUBS="$BATS_TEST_TMPDIR/stubs"
+    STUB_LOG="$BATS_TEST_TMPDIR/stub.log"
+    mkdir -p "$STUBS"
+    : >"$STUB_LOG"
+    cat >"$STUBS/gh" <<STUB
+#!/usr/bin/env bash
+case "\${1:-} \${2:-}" in
+    "repo set-default") echo "stub/default" ;;
+    "api user")         echo "tester" ;;
+    "issue develop")    printf '%s\thttps://example.invalid\n' "$WT_BRANCH" ;;
+esac
+exit 0
+STUB
+    cat >"$STUBS/claude" <<'STUB'
+#!/usr/bin/env bash
+echo "logged in"
+exit 0
+STUB
+    cat >"$STUBS/tmux" <<'STUB'
+#!/usr/bin/env bash
+echo "tmux $*" >>"$STUB_LOG"
+exit 0
+STUB
+    cat >"$STUBS/prek" <<'STUB'
+#!/usr/bin/env bash
+echo "prek $*" >>"$STUB_LOG"
+exit 0
+STUB
+    cat >"$STUBS/uv" <<'STUB'
+#!/usr/bin/env bash
+cmd="${1:-}"
+shift || true
+case "$cmd" in
+    run) exec "$@" ;;
+esac
+exit 0
+STUB
+    cat >"$STUBS/resolve-branch" <<'STUB'
+#!/usr/bin/env bash
+[ "${1:-}" = "--help" ] && exit 0
+awk 'NR==1 { print $1 }'
+STUB
+    cat >"$STUBS/derive-branch-summary" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+    chmod +x "$STUBS"/*
+}
+
+# Pin git config sources so host global/system state never leaks into the
+# sandbox (or the assertions).
+_wt_git() {
+    GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null git "$@"
+}
+
+# Build a sandbox: main/ checkout with tracked .githooks shims covering all
+# three stages, plus a bare origin.git carrying the issue branch so the
+# recipe's `git fetch origin <branch>` succeeds.
+_wt_sandbox() {
+    local root="$1" main="$1/main" hook
+    mkdir -p "$main/.githooks"
+    _wt_git -c init.defaultBranch=main init -q "$main"
+    for hook in pre-commit commit-msg prepare-commit-msg; do
+        printf '#!/usr/bin/env bash\nexit 0\n' >"$main/.githooks/$hook"
+        chmod +x "$main/.githooks/$hook"
+    done
+    : >"$main/.gitmessage"
+    _wt_git -C "$main" add -A
+    _wt_git -C "$main" -c user.name=t -c user.email=t@example.com \
+        -c commit.gpgsign=false commit -qm init
+    _wt_git -C "$main" branch "$WT_BRANCH"
+    _wt_git init -q --bare "$root/origin.git"
+    _wt_git -C "$main" remote add origin "$root/origin.git"
+    _wt_git -C "$main" push -q origin main "$WT_BRANCH"
+}
+
+_run_wt_start() {
+    local file="$1" main="$2"
+    run env PATH="$STUBS:$PATH" STUB_LOG="$STUB_LOG" \
+        GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null \
+        just --justfile "$file" --working-directory "$main" worktree-start 4242
+}
+
+@test "worktree-start keeps the main checkout's core.hooksPath and skips prek (#1463)" {
+    command -v just >/dev/null 2>&1 || skip "just not installed"
+
+    local i=0 f box hook
+    for f in "$WT_MAIN" "$WT_TEMPLATE"; do
+        echo "file: $f"
+        i=$((i + 1))
+        box="$BATS_TEST_TMPDIR/set$i"
+        _wt_stubs
+        _wt_sandbox "$box"
+        _wt_git -C "$box/main" config core.hooksPath .githooks
+
+        _run_wt_start "$f" "$box/main"
+        assert_success
+
+        # Shared config survives: the main checkout keeps its tracked shims.
+        run _wt_git -C "$box/main" config core.hooksPath
+        assert_success
+        assert_output ".githooks"
+
+        # The linked worktree runs the same tracked shims — the relative
+        # hooksPath resolves against the worktree root, all three stages.
+        for hook in pre-commit commit-msg prepare-commit-msg; do
+            assert_file_executable "$box/main-worktrees/4242/.githooks/$hook"
+        done
+
+        # No prek install: the tracked shims already cover the worktree.
+        run grep "prek install" "$STUB_LOG"
+        assert_failure
+    done
+}
+
+@test "worktree-start still installs prek shims when no core.hooksPath is set (#1463)" {
+    command -v just >/dev/null 2>&1 || skip "just not installed"
+
+    local i=0 f box
+    for f in "$WT_MAIN" "$WT_TEMPLATE"; do
+        echo "file: $f"
+        i=$((i + 1))
+        box="$BATS_TEST_TMPDIR/unset$i"
+        _wt_stubs
+        _wt_sandbox "$box"
+
+        _run_wt_start "$f" "$box/main"
+        assert_success
+
+        # Fallback: no hooksPath configured, so prek wires every hook stage
+        # the repo uses into the shared .git/hooks (#778).
+        run grep -- "prek install -t pre-commit -t commit-msg -t prepare-commit-msg" "$STUB_LOG"
+        assert_success
+    done
 }


### PR DESCRIPTION
## Summary

`just worktree-start` ran `git config --unset-all core.hooksPath` from inside the new linked worktree. `core.hooksPath` is **shared** repo config, so the unset disarmed the main checkout's tracked `.githooks` shims repo-wide — the #1430 failure mode, self-inflicted by a primary devkit workflow.

## Fix

Skip-when-set: a relative `core.hooksPath` resolves against each worktree's root, and `.githooks` is tracked (present in every worktree), so when the setting exists the tracked shims already cover all three hook stages in the new worktree. `worktree-start` now leaves the config untouched and skips `prek install` in that state. The old `prek install` path survives only as the fallback when no hooks path is configured at all (the unset line is gone — it was a no-op there anyway).

Rejected alternatives:
- `git config --worktree --unset-all`: needs `extensions.worktreeConfig` repo-wide, and a worktree-scoped *unset* cannot mask a shared value — it would actually require a worktree-scoped SET plus the extension flip. More moving parts for no gain given the shims are already present.
- Restore-after-install / restore-on-stop: still mutates shared state, leaving a disarm window (or a disarmed main checkout for the worktree's whole lifetime).

Both copies fixed identically: `justfile.worktree` and the scaffolded `assets/workspace/.devcontainer/justfile.worktree`.

## Tests

TDD: `test(workspace)` commit landed RED first. Two new bats tests in `tests/bats/worktree.bats` drive the **real** recipe (both copies) in a sandbox repo with a bare origin and stubbed tools:
- main checkout's `core.hooksPath` survives `worktree-start`, all three tracked shims are executable in the new worktree, and `prek install` is never invoked;
- the no-hooksPath fallback still installs all three prek stages (#778 pin).

`bats tests/bats/worktree.bats tests/bats/githooks.bats` → 14/14 ok; full `prek run --all-files` green.

## Notes

- The #1454 doctor comments in `justfile` / `assets/workspace/justfile` still describe the pre-fix behavior ("worktree-start unsets core.hooksPath on purpose"); the doctor logic itself remains correct for both pre-fix worktrees and the fallback path, so those comments were left alone (minimal diff) — cheap follow-up if wanted.
- `git config commit.template .gitmessage` in the same recipe also writes shared config from the worktree, but idempotently (same value as main); out of scope here.

Closes #1463