### PR TITLE
fix(ci): revert only the run's own finalize commits in release rollback

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -488,6 +488,10 @@ jobs:
     outputs:
       finalize_sha: ${{ steps.finalize.outputs.finalize_sha }}
       tag_already_exists: ${{ steps.tag_state.outputs.tag_already_exists }}
+      # Exact commit this job pushed + last tip it observed: the rollback job
+      # refuses to touch the branch unless its tip matches them (#1462).
+      finalize_commit_sha: ${{ steps.finalize_commit.outputs.commit-sha }}
+      post_sync_sha: ${{ steps.post_sync.outputs.post_sync_sha }}
 
     steps:
       - name: Generate GitHub App Token
@@ -597,6 +601,7 @@ jobs:
 
       - name: Commit finalization changes via API
         if: needs.validate.outputs.release_kind == 'final'
+        id: finalize_commit
         uses: vig-os/commit-action@0361e9aa65b64711a18286ac5dfdcba7cc7a2ac7  # v0.3.2
         env:
           GH_TOKEN: ${{ steps.commit-app-token.outputs.token }}
@@ -784,6 +789,22 @@ jobs:
             echo "⚠ Timed out waiting for sync-issues workflow"
             echo "The release may continue, but PR documentation may not be synced"
           fi
+
+      # The sync-issues run above may push its own commit onto the release
+      # branch; record the tip after it so the rollback job can recognize that
+      # commit as this run's own write (#1462).
+      - name: Record post-sync branch tip
+        id: post_sync
+        if: needs.validate.outputs.release_kind == 'final'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs.validate.outputs.version }}
+        run: |
+          set -euo pipefail
+          POST_SYNC_SHA=$(retry --retries 3 --backoff 5 --max-backoff 30 -- \
+            gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/release/$VERSION" --jq '.object.sha')
+          echo "post_sync_sha=$POST_SYNC_SHA" >> "$GITHUB_OUTPUT"
+          echo "Post-sync branch tip: $POST_SYNC_SHA"
 
   build-and-test:
     name: Build and Test (${{ matrix.arch }})
@@ -1533,7 +1554,9 @@ jobs:
 
       - name: Generate Release App Token
         id: release-app-token
-        if: ${{ needs.validate.outputs.release_kind == 'final' && needs.validate.outputs.pr_number != '' }}
+        # Restore-only token: minted only when the PR-body restore below runs,
+        # i.e. never when finalize was skipped and left the body untouched (#1462).
+        if: ${{ needs.validate.outputs.release_kind == 'final' && needs.validate.outputs.pr_number != '' && needs.finalize.result != 'skipped' }}
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3
         with:
           client-id: ${{ secrets.RELEASE_APP_CLIENT_ID }}
@@ -1555,14 +1578,29 @@ jobs:
           GH_TOKEN: ${{ steps.commit-app-token.outputs.token }}
           VERSION: ${{ needs.validate.outputs.version }}
           PRE_SHA: ${{ needs.validate.outputs.pre_finalize_sha }}
+          RELEASE_KIND: ${{ needs.validate.outputs.release_kind }}
+          FINALIZE_RESULT: ${{ needs.finalize.result }}
+          FINALIZE_COMMIT_SHA: ${{ needs.finalize.outputs.finalize_commit_sha }}
+          FINAL_TIP_SHA: ${{ needs.finalize.outputs.post_sync_sha || needs.finalize.outputs.finalize_sha }}
         run: |
           set -euo pipefail
-          echo "Rolling back release branch to pre-finalization state..."
           REPO="${{ github.repository }}"
           BRANCH_REF="heads/release/$VERSION"
 
-          TREE_SHA=$(retry --retries 3 --backoff 5 --max-backoff 30 -- \
-            gh api "repos/$REPO/git/commits/$PRE_SHA" --jq '.tree.sha')
+          # Guard (#1462): if finalize never ran, this run wrote nothing to
+          # the branch — leave it alone no matter where the tip is.
+          if [ "$FINALIZE_RESULT" = "skipped" ] || [ -z "$FINALIZE_RESULT" ]; then
+            echo "Finalize never ran (result: '${FINALIZE_RESULT:-none}'); nothing to roll back"
+            exit 0
+          fi
+
+          # Guard (#1462): candidates are branch-neutral — finalize commits
+          # only on final releases, so there is nothing to roll back either.
+          if [ "$RELEASE_KIND" != "final" ]; then
+            echo "Release kind '$RELEASE_KIND' writes no finalize commit; nothing to roll back"
+            exit 0
+          fi
+
           CURRENT_SHA=$(retry --retries 3 --backoff 5 --max-backoff 30 -- \
             gh api "repos/$REPO/git/refs/$BRANCH_REF" --jq '.object.sha')
 
@@ -1570,6 +1608,39 @@ jobs:
             echo "Branch already at pre-finalization SHA, no rollback needed"
             exit 0
           fi
+
+          # Sole parent of a commit; empty for merge commits (never this run's).
+          parent_of() {
+            retry --retries 3 --backoff 5 --max-backoff 30 -- \
+              gh api "repos/$REPO/git/commits/$1" \
+                --jq 'if (.parents | length) == 1 then .parents[0].sha else "" end'
+          }
+
+          # Guard (#1462): revert only what THIS run wrote. The tip must be
+          # exactly the finalize commit — optionally with the sync-issues
+          # commit on top — parented on the pre-finalization snapshot.
+          # Anything else means the branch moved during the run: refuse
+          # loudly instead of clobbering foreign commits (#1459/#1460).
+          SAFE=false
+          if [ -n "$FINALIZE_COMMIT_SHA" ] && [ "$(parent_of "$FINALIZE_COMMIT_SHA")" = "$PRE_SHA" ]; then
+            if [ "$CURRENT_SHA" = "$FINALIZE_COMMIT_SHA" ]; then
+              SAFE=true
+            elif [ -n "$FINAL_TIP_SHA" ] && [ "$CURRENT_SHA" = "$FINAL_TIP_SHA" ] \
+              && [ "$(parent_of "$FINAL_TIP_SHA")" = "$FINALIZE_COMMIT_SHA" ]; then
+              SAFE=true
+            fi
+          fi
+
+          if [ "$SAFE" != "true" ]; then
+            echo "::error::Refusing to roll back release/$VERSION: branch tip $CURRENT_SHA is not the commit(s) this run wrote (finalize commit: '${FINALIZE_COMMIT_SHA:-none}', post-finalize tip: '${FINAL_TIP_SHA:-none}', pre-finalize: $PRE_SHA). The branch moved during the run; leave it as is and revert the finalize commit manually if needed."
+            exit 1
+          fi
+
+          # Safe: the tip holds only this run's commits, so resetting the tree
+          # to the pre-finalization snapshot is exactly a revert of them.
+          echo "Rolling back release branch to pre-finalization state..."
+          TREE_SHA=$(retry --retries 3 --backoff 5 --max-backoff 30 -- \
+            gh api "repos/$REPO/git/commits/$PRE_SHA" --jq '.tree.sha')
 
           REVERT_SHA=$(retry --retries 3 --backoff 5 --max-backoff 30 -- \
             gh api -X POST "repos/$REPO/git/commits" \
@@ -1586,7 +1657,10 @@ jobs:
 
       - name: Restore release PR body from pre-finalization CHANGELOG
         id: restore-pr-body
-        if: ${{ needs.validate.outputs.release_kind == 'final' && needs.validate.outputs.pr_number != '' }}
+        # Only finalize's refresh step rewrites the PR body; when finalize was
+        # skipped the body is untouched and must not be overwritten from a
+        # possibly-stale PRE_SHA changelog (#1462).
+        if: ${{ needs.validate.outputs.release_kind == 'final' && needs.validate.outputs.pr_number != '' && needs.finalize.result != 'skipped' }}
         continue-on-error: true
         env:
           GH_TOKEN: ${{ steps.release-app-token.outputs.token }}
@@ -1676,7 +1750,7 @@ jobs:
             - If the tag was pushed before the failure, it remains on the remote; use a new release candidate to validate fixes, then re-run the final release when ready.
 
             **Actions Taken:**
-            - Release branch reset to pre-finalization state (best-effort)
+            - Release branch: this run's finalize commit(s) reverted, but only when the branch tip matched exactly what the run wrote — otherwise the branch is left untouched and the rollback result above is \`failure\` (#1462)
             - Release PR body restored to TBD / prepare-release format when applicable (best-effort)
             - This issue created for investigation
 
@@ -1708,7 +1782,7 @@ jobs:
           echo "✗ Release workflow failed"
           echo ""
           echo "Automatic rollback completed:"
-          echo "  - Release branch reset to pre-finalization state (best-effort)"
+          echo "  - Release branch rollback: ${{ steps.rollback-branch.outcome }} (reverts only this run's finalize commit(s); refuses if the branch moved, #1462)"
           echo "  - Release PR body restoration: ${{ steps.restore-pr-body.outcome }} (skipped if not a final release or no PR number)"
           echo "  - Tags were not deleted (forward-fix policy)"
           echo "  - GitHub issue created for investigation"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1582,6 +1582,9 @@ jobs:
           FINALIZE_RESULT: ${{ needs.finalize.result }}
           FINALIZE_COMMIT_SHA: ${{ needs.finalize.outputs.finalize_commit_sha }}
           FINAL_TIP_SHA: ${{ needs.finalize.outputs.post_sync_sha || needs.finalize.outputs.finalize_sha }}
+          # The org commit App's author name, pinned so a foreign commit cannot
+          # pass as the sync commit (#1462); live-verified on daeb5c54.
+          SYNC_COMMIT_AUTHOR: "commit-action-bot[bot]"
         run: |
           set -euo pipefail
           REPO="${{ github.repository }}"
@@ -1625,9 +1628,21 @@ jobs:
           if [ -n "$FINALIZE_COMMIT_SHA" ] && [ "$(parent_of "$FINALIZE_COMMIT_SHA")" = "$PRE_SHA" ]; then
             if [ "$CURRENT_SHA" = "$FINALIZE_COMMIT_SHA" ]; then
               SAFE=true
-            elif [ -n "$FINAL_TIP_SHA" ] && [ "$CURRENT_SHA" = "$FINAL_TIP_SHA" ] \
-              && [ "$(parent_of "$FINAL_TIP_SHA")" = "$FINALIZE_COMMIT_SHA" ]; then
-              SAFE=true
+            elif [ -n "$FINAL_TIP_SHA" ] && [ "$CURRENT_SHA" = "$FINAL_TIP_SHA" ]; then
+              # The only legitimate commit on top of finalize's is the
+              # sync-issues one — and a foreign PR squash-merged mid-run is
+              # single-parent too, so parentage alone cannot tell them apart
+              # (#1462). Gate on the sync commit's fixed message and, where
+              # the org's commit bot name is a known constant, its author.
+              TIP_FACTS=$(retry --retries 3 --backoff 5 --max-backoff 30 -- \
+                gh api "repos/$REPO/git/commits/$FINAL_TIP_SHA" \
+                  --jq '[(if (.parents | length) == 1 then .parents[0].sha else "" end), .author.name, (.message | split("\n")[0])] | join("\t")')
+              IFS=$'\t' read -r TIP_PARENT TIP_AUTHOR TIP_TITLE <<< "$TIP_FACTS"
+              if [ "$TIP_PARENT" = "$FINALIZE_COMMIT_SHA" ] \
+                && [ "$TIP_TITLE" = "chore: sync issues and PRs" ] \
+                && { [ -z "${SYNC_COMMIT_AUTHOR:-}" ] || [ "$TIP_AUTHOR" = "$SYNC_COMMIT_AUTHOR" ]; }; then
+                SAFE=true
+              fi
             fi
           fi
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,6 +189,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Release rollback no longer resets the branch to a stale run-start snapshot** ([#1462](https://github.com/vig-os/devkit/issues/1462))
+  - The `release.yml` rollback job rebuilt the branch tree at `PRE_SHA`
+    (captured when `validate` started) whenever a failed run's tip had moved,
+    silently destroying commits merged mid-run — twice on `release/1.8.0`
+    ([#1459](https://github.com/vig-os/devkit/issues/1459) /
+    [#1460](https://github.com/vig-os/devkit/issues/1460)), both times with
+    `finalize` skipped and nothing to roll back
+  - The rollback now no-ops when `finalize` never ran (and on candidates,
+    which are branch-neutral), and otherwise refuses loudly unless the tip is
+    exactly the commit(s) this run wrote — the finalize commit, optionally
+    with the sync-issues commit on top, parented on the snapshot — which
+    `finalize` now exports as job outputs; only then is the tree revert
+    performed, making it equivalent to reverting the run's own commits
+  - The scaffolded consumer `release.yml` rollback carried the same exposure
+    as a `git reset --hard` + force push; it now runs the identical guarded
+    Git Data API revert (no history rewrite, no release-branch checkout), and
+    `release-core.yml` exposes `finalize_result` / `finalize_commit_sha` to
+    the caller. The devkit PR-body restore step likewise skips when
+    `finalize` never rewrote the PR body
 - **`just doctor` no longer calls the git hooks inert inside a linked worktree** ([#1454](https://github.com/vig-os/devkit/issues/1454))
   - `just worktree-start` unsets `core.hooksPath` in the worktree on purpose —
     prek refuses to install its shims while it is set — and installs those

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -189,6 +189,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Release rollback no longer resets the branch to a stale run-start snapshot** ([#1462](https://github.com/vig-os/devkit/issues/1462))
+  - The `release.yml` rollback job rebuilt the branch tree at `PRE_SHA`
+    (captured when `validate` started) whenever a failed run's tip had moved,
+    silently destroying commits merged mid-run — twice on `release/1.8.0`
+    ([#1459](https://github.com/vig-os/devkit/issues/1459) /
+    [#1460](https://github.com/vig-os/devkit/issues/1460)), both times with
+    `finalize` skipped and nothing to roll back
+  - The rollback now no-ops when `finalize` never ran (and on candidates,
+    which are branch-neutral), and otherwise refuses loudly unless the tip is
+    exactly the commit(s) this run wrote — the finalize commit, optionally
+    with the sync-issues commit on top, parented on the snapshot — which
+    `finalize` now exports as job outputs; only then is the tree revert
+    performed, making it equivalent to reverting the run's own commits
+  - The scaffolded consumer `release.yml` rollback carried the same exposure
+    as a `git reset --hard` + force push; it now runs the identical guarded
+    Git Data API revert (no history rewrite, no release-branch checkout), and
+    `release-core.yml` exposes `finalize_result` / `finalize_commit_sha` to
+    the caller. The devkit PR-body restore step likewise skips when
+    `finalize` never rewrote the PR body
 - **`just doctor` no longer calls the git hooks inert inside a linked worktree** ([#1454](https://github.com/vig-os/devkit/issues/1454))
   - `just worktree-start` unsets `core.hooksPath` in the worktree on purpose —
     prek refuses to install its shims while it is set — and installs those

--- a/assets/workspace/.github/workflows/release-core.yml
+++ b/assets/workspace/.github/workflows/release-core.yml
@@ -96,6 +96,15 @@ on:  # yamllint disable-line rule:truthy
       finalize_sha:
         description: "Release branch SHA after finalization"
         value: ${{ jobs.finalize.outputs.finalize_sha }}
+      finalize_result:
+        # jobs.finalize.result would be the natural source, but actionlint's
+        # jobs-context type for workflow_call outputs only carries `outputs`,
+        # so the ran/skipped signal is derived from a first-step marker.
+        description: "'ran' when the finalize job started, 'skipped' when it never ran (#1462)"
+        value: ${{ jobs.finalize.outputs.finalize_ran == 'true' && 'ran' || 'skipped' }}
+      finalize_commit_sha:
+        description: "Exact commit SHA the finalize job pushed (empty when none) (#1462)"
+        value: ${{ jobs.finalize.outputs.finalize_commit_sha }}
       tag_already_exists:
         description: "Remote publish tag already exists at finalize SHA (retry path)"
         value: ${{ jobs.finalize.outputs.tag_already_exists }}
@@ -392,8 +401,19 @@ jobs:
     outputs:
       finalize_sha: ${{ steps.finalize.outputs.finalize_sha }}
       tag_already_exists: ${{ steps.tag_state.outputs.tag_already_exists }}
+      # Exact commit this job pushed: the caller's rollback job refuses to
+      # touch the branch unless its tip matches what this run wrote (#1462).
+      finalize_commit_sha: ${{ steps.finalize_commit.outputs.commit-sha }}
+      # Set by the first step, so a skipped job yields an empty string: the
+      # rollback job must not touch the branch when finalize never ran (#1462).
+      finalize_ran: ${{ steps.started.outputs.value }}
 
     steps:
+      # Ran/skipped marker for the finalize_result workflow output (#1462).
+      - name: Mark finalize as started
+        id: started
+        run: echo "value=true" >> "$GITHUB_OUTPUT"
+
       - name: Generate commit app token
         id: commit_app_token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3
@@ -510,6 +530,7 @@ jobs:
 
       - name: Commit and push finalization changes via API
         if: ${{ inputs.release_kind == 'final' }}
+        id: finalize_commit
         uses: vig-os/commit-action@0361e9aa65b64711a18286ac5dfdcba7cc7a2ac7  # v0.3.2
         env:
           GH_TOKEN: ${{ steps.commit_app_token.outputs.token }}

--- a/assets/workspace/.github/workflows/release.yml
+++ b/assets/workspace/.github/workflows/release.yml
@@ -262,9 +262,21 @@ jobs:
           if [ -n "$FINALIZE_COMMIT_SHA" ] && [ "$(parent_of "$FINALIZE_COMMIT_SHA")" = "$PRE_SHA" ]; then
             if [ "$CURRENT_SHA" = "$FINALIZE_COMMIT_SHA" ]; then
               SAFE=true
-            elif [ -n "$FINAL_TIP_SHA" ] && [ "$CURRENT_SHA" = "$FINAL_TIP_SHA" ] \
-              && [ "$(parent_of "$FINAL_TIP_SHA")" = "$FINALIZE_COMMIT_SHA" ]; then
-              SAFE=true
+            elif [ -n "$FINAL_TIP_SHA" ] && [ "$CURRENT_SHA" = "$FINAL_TIP_SHA" ]; then
+              # The only legitimate commit on top of finalize's is the
+              # sync-issues one — and a foreign PR squash-merged mid-run is
+              # single-parent too, so parentage alone cannot tell them apart
+              # (#1462). Gate on the sync commit's fixed message and, where
+              # the org's commit bot name is a known constant, its author.
+              TIP_FACTS=$(retry --retries 3 --backoff 5 --max-backoff 30 -- \
+                gh api "repos/$REPO/git/commits/$FINAL_TIP_SHA" \
+                  --jq '[(if (.parents | length) == 1 then .parents[0].sha else "" end), .author.name, (.message | split("\n")[0])] | join("\t")')
+              IFS=$'\t' read -r TIP_PARENT TIP_AUTHOR TIP_TITLE <<< "$TIP_FACTS"
+              if [ "$TIP_PARENT" = "$FINALIZE_COMMIT_SHA" ] \
+                && [ "$TIP_TITLE" = "chore: sync issues and PRs" ] \
+                && { [ -z "${SYNC_COMMIT_AUTHOR:-}" ] || [ "$TIP_AUTHOR" = "$SYNC_COMMIT_AUTHOR" ]; }; then
+                SAFE=true
+              fi
             fi
           fi
 

--- a/assets/workspace/.github/workflows/release.yml
+++ b/assets/workspace/.github/workflows/release.yml
@@ -179,11 +179,10 @@ jobs:
     steps:
       # Provision the toolchain unconditionally: the failure-issue and
       # branch-rollback steps below run independently (on different guards) and
-      # both need `retry`/`gh`/`git` — in the host modes those come from the
-      # composite, so it must run even when the guarded release-branch checkout
-      # is skipped. Checkout the workflow ref first so the local composite (and,
-      # in direnv mode, the repo flake) resolves; the guarded checkout below
-      # re-checks out the release branch with the commit token when needed.
+      # both need `retry`/`gh` — in the host modes those come from the
+      # composite. Checkout the workflow ref first so the local composite (and,
+      # in direnv mode, the repo flake) resolves; the rollback itself works
+      # through the Git Data API and needs no release-branch checkout (#1462).
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 
@@ -209,37 +208,89 @@ jobs:
           client-id: ${{ secrets.COMMIT_APP_CLIENT_ID }}
           private-key: ${{ secrets.COMMIT_APP_PRIVATE_KEY }}
 
-      - name: Checkout release branch
-        if: ${{ needs.core.outputs.pre_finalize_sha != '' }}
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
-        with:
-          fetch-depth: 0
-          token: ${{ steps.commit_app_token.outputs.token }}
-
-      - name: Configure git
-        if: ${{ needs.core.outputs.pre_finalize_sha != '' }}
-        env:
-          GIT_USER_NAME: ${{ inputs.git-user-name }}
-          GIT_USER_EMAIL: ${{ inputs.git-user-email }}
-        run: |
-          git config user.name "$GIT_USER_NAME"
-          git config user.email "$GIT_USER_EMAIL"
-
       - name: Rollback release branch
         if: ${{ needs.core.outputs.pre_finalize_sha != '' }}
         continue-on-error: true
         env:
+          GH_TOKEN: ${{ steps.commit_app_token.outputs.token }}
           VERSION: ${{ needs.core.outputs.version }}
           PRE_SHA: ${{ needs.core.outputs.pre_finalize_sha }}
+          RELEASE_KIND: ${{ needs.core.outputs.release_kind }}
+          FINALIZE_RESULT: ${{ needs.core.outputs.finalize_result }}
+          FINALIZE_COMMIT_SHA: ${{ needs.core.outputs.finalize_commit_sha }}
+          FINAL_TIP_SHA: ${{ needs.core.outputs.finalize_sha }}
         run: |
           set -euo pipefail
-          retry --retries 3 --backoff 3 --max-backoff 20 -- git fetch origin "release/$VERSION"
-          git checkout "release/$VERSION"
-          if git reset --hard "$PRE_SHA" 2>/dev/null; then
-            if retry --retries 3 --backoff 5 --max-backoff 30 -- git push --force-with-lease origin "release/$VERSION"; then
-              echo "Release branch rolled back"
+          REPO="${{ github.repository }}"
+          BRANCH_REF="heads/release/$VERSION"
+
+          # Guard (#1462): if finalize never ran, this run wrote nothing to
+          # the branch — leave it alone no matter where the tip is.
+          if [ "$FINALIZE_RESULT" = "skipped" ] || [ -z "$FINALIZE_RESULT" ]; then
+            echo "Finalize never ran (result: '${FINALIZE_RESULT:-none}'); nothing to roll back"
+            exit 0
+          fi
+
+          # Guard (#1462): candidates are branch-neutral — finalize commits
+          # only on final releases, so there is nothing to roll back either.
+          if [ "$RELEASE_KIND" != "final" ]; then
+            echo "Release kind '$RELEASE_KIND' writes no finalize commit; nothing to roll back"
+            exit 0
+          fi
+
+          CURRENT_SHA=$(retry --retries 3 --backoff 5 --max-backoff 30 -- \
+            gh api "repos/$REPO/git/refs/$BRANCH_REF" --jq '.object.sha')
+
+          if [ "$CURRENT_SHA" = "$PRE_SHA" ]; then
+            echo "Branch already at pre-finalization SHA, no rollback needed"
+            exit 0
+          fi
+
+          # Sole parent of a commit; empty for merge commits (never this run's).
+          parent_of() {
+            retry --retries 3 --backoff 5 --max-backoff 30 -- \
+              gh api "repos/$REPO/git/commits/$1" \
+                --jq 'if (.parents | length) == 1 then .parents[0].sha else "" end'
+          }
+
+          # Guard (#1462): revert only what THIS run wrote. The tip must be
+          # exactly the finalize commit — optionally with the sync-issues
+          # commit on top — parented on the pre-finalization snapshot.
+          # Anything else means the branch moved during the run: refuse
+          # loudly instead of clobbering foreign commits.
+          SAFE=false
+          if [ -n "$FINALIZE_COMMIT_SHA" ] && [ "$(parent_of "$FINALIZE_COMMIT_SHA")" = "$PRE_SHA" ]; then
+            if [ "$CURRENT_SHA" = "$FINALIZE_COMMIT_SHA" ]; then
+              SAFE=true
+            elif [ -n "$FINAL_TIP_SHA" ] && [ "$CURRENT_SHA" = "$FINAL_TIP_SHA" ] \
+              && [ "$(parent_of "$FINAL_TIP_SHA")" = "$FINALIZE_COMMIT_SHA" ]; then
+              SAFE=true
             fi
           fi
+
+          if [ "$SAFE" != "true" ]; then
+            echo "::error::Refusing to roll back release/$VERSION: branch tip $CURRENT_SHA is not the commit(s) this run wrote (finalize commit: '${FINALIZE_COMMIT_SHA:-none}', post-finalize tip: '${FINAL_TIP_SHA:-none}', pre-finalize: $PRE_SHA). The branch moved during the run; leave it as is and revert the finalize commit manually if needed."
+            exit 1
+          fi
+
+          # Safe: the tip holds only this run's commits, so resetting the tree
+          # to the pre-finalization snapshot is exactly a revert of them.
+          echo "Rolling back release branch to pre-finalization state..."
+          TREE_SHA=$(retry --retries 3 --backoff 5 --max-backoff 30 -- \
+            gh api "repos/$REPO/git/commits/$PRE_SHA" --jq '.tree.sha')
+
+          REVERT_SHA=$(retry --retries 3 --backoff 5 --max-backoff 30 -- \
+            gh api -X POST "repos/$REPO/git/commits" \
+              -f message="revert: undo finalize release $VERSION (workflow rollback)" \
+              -f tree="$TREE_SHA" \
+              -f "parents[]=$CURRENT_SHA" \
+              --jq '.sha')
+
+          retry --retries 3 --backoff 5 --max-backoff 30 -- \
+            gh api "repos/$REPO/git/refs/$BRANCH_REF" \
+              -X PATCH \
+              -f sha="$REVERT_SHA"
+          echo "✓ Release branch rolled back via revert commit $REVERT_SHA (tree at $PRE_SHA)"
 
       - name: Create failure issue
         if: ${{ needs.core.outputs.version != '' }}
@@ -260,7 +311,7 @@ jobs:
           **Release PR:** #$PR_NUMBER
 
           **Automatic rollback attempted:**
-          - Release branch reset to pre-finalization state (best-effort)
+          - Release branch: this run's finalize commit(s) reverted, but only when the branch tip matched exactly what the run wrote — otherwise the branch is left untouched and the rollback step fails loudly instead (vig-os/devkit#1462)
 
           **Tag status (forward-fix policy):**
           - Release tags are not deleted by automation (workflow choice; GitHub immutable-release lock-in applies only after a release is **published** when that setting is enabled). If a tag was pushed before the failure, it remains on the remote.

--- a/assets/workspace/docs/DOWNSTREAM_RELEASE.md
+++ b/assets/workspace/docs/DOWNSTREAM_RELEASE.md
@@ -18,7 +18,7 @@ The downstream template uses a split release architecture:
 
 All files are deployed from `assets/workspace/` by `init-workspace.sh`.
 
-On failure, the orchestrator runs a single consolidated rollback that resets the release branch (best-effort), does **not** delete tags (forward-fix policy), and opens a failure issue with forward-fix guidance.
+On failure, the orchestrator runs a single consolidated rollback that reverts only the finalize commit(s) this run wrote — it no-ops when finalize never ran and refuses to touch a branch that moved during the run ([#1462](https://github.com/vig-os/devkit/issues/1462)) — does **not** delete tags (forward-fix policy), and opens a failure issue with forward-fix guidance.
 
 ## Release Modes
 
@@ -48,7 +48,7 @@ changelog-neutral. Preview the pending block anytime with
 
 - **Candidate (`X.Y.Z-rcN`)**: By default only the git tag is created. With **`create-release: true`**, `release-publish.yml` creates a **draft** GitHub **pre-release** (`gh release create --draft --prerelease`). Promote-time validation uses `gh api .../releases/tags/<tag>` and inspects `.draft` to ensure the expected draft pre-release exists; see [Cross-repo gate](https://github.com/vig-os/devkit/blob/main/docs/CROSS_REPO_RELEASE_GATE.md) for upstream enforcement status. With **immutable releases** enabled, **publishing** a pre-release locks the **linked** tag and assets (see [upstream policy](https://github.com/vig-os/devkit/blob/main/docs/RELEASE_CYCLE.md#immutable-releases-tag-rulesets-and-forward-fix-policy)); iterate with a **new** RC tag.
 - **Final (`X.Y.Z`)**: Automation creates a **draft** GitHub Release; **publishing** it (UI or `promote-release.yml`) applies immutable-release lock-in for the linked tag and assets when that setting is enabled. Enable **immutable releases** and **tag rulesets** on each consumer repository (and org policy) as needed; see [Preventing changes to your releases](https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/preventing-changes-to-your-releases).
-- **Rollback**: The orchestrator resets the release branch and does **not** delete tags (forward-fix policy); recover with a new RC or a careful final retry per workflow logs.
+- **Rollback**: The orchestrator reverts only the finalize commit(s) the failed run wrote (never a wholesale branch reset; it refuses when the branch moved mid-run, [#1462](https://github.com/vig-os/devkit/issues/1462)) and does **not** delete tags (forward-fix policy); recover with a new RC or a careful final retry per workflow logs.
 
 ## Promote release (final)
 

--- a/docs/DOWNSTREAM_RELEASE.md
+++ b/docs/DOWNSTREAM_RELEASE.md
@@ -15,7 +15,7 @@ The downstream template uses a split release architecture:
 
 All files are deployed from `assets/workspace/` by `init-workspace.sh`.
 
-On failure, the orchestrator runs a single consolidated rollback that resets the release branch (best-effort), does **not** delete tags (forward-fix policy), and opens a failure issue with forward-fix guidance.
+On failure, the orchestrator runs a single consolidated rollback that reverts only the finalize commit(s) this run wrote — it no-ops when finalize never ran and refuses to touch a branch that moved during the run ([#1462](https://github.com/vig-os/devkit/issues/1462)) — does **not** delete tags (forward-fix policy), and opens a failure issue with forward-fix guidance.
 
 ## Release Modes
 
@@ -45,7 +45,7 @@ changelog-neutral. Preview the pending block anytime with
 
 - **Candidate (`X.Y.Z-rcN`)**: By default only the git tag is created. With **`create-release: true`**, `release-publish.yml` creates a **draft** GitHub **pre-release** (`gh release create --draft --prerelease`). Promote-time validation uses `gh api .../releases/tags/<tag>` and inspects `.draft` to ensure the expected draft pre-release exists; see [Cross-repo gate](https://github.com/vig-os/devkit/blob/main/docs/CROSS_REPO_RELEASE_GATE.md) for upstream enforcement status. With **immutable releases** enabled, **publishing** a pre-release locks the **linked** tag and assets (see [upstream policy](https://github.com/vig-os/devkit/blob/main/docs/RELEASE_CYCLE.md#immutable-releases-tag-rulesets-and-forward-fix-policy)); iterate with a **new** RC tag.
 - **Final (`X.Y.Z`)**: Automation creates a **draft** GitHub Release; **publishing** it (UI or `promote-release.yml`) applies immutable-release lock-in for the linked tag and assets when that setting is enabled. Enable **immutable releases** and **tag rulesets** on each consumer repository (and org policy) as needed; see [Preventing changes to your releases](https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/preventing-changes-to-your-releases).
-- **Rollback**: The orchestrator resets the release branch and does **not** delete tags (forward-fix policy); recover with a new RC or a careful final retry per workflow logs.
+- **Rollback**: The orchestrator reverts only the finalize commit(s) the failed run wrote (never a wholesale branch reset; it refuses when the branch moved mid-run, [#1462](https://github.com/vig-os/devkit/issues/1462)) and does **not** delete tags (forward-fix policy); recover with a new RC or a careful final retry per workflow logs.
 
 ## Promote release (final)
 

--- a/docs/RELEASE_CYCLE.md
+++ b/docs/RELEASE_CYCLE.md
@@ -479,7 +479,7 @@ Release Summary:
 
 - **Earlier validation**: All checks happen at the start in CI
 - **Safer workflow**: Tag is created AFTER successful build/test, not before
-- **Automatic rollback**: Failed releases roll back the release branch; tags are not deleted (forward-fix policy, independent of whether GitHub immutability applies)—recover with a new RC or a careful final retry per docs above
+- **Automatic rollback**: Failed releases revert only the finalize commit(s) the run wrote (refusing when the branch moved mid-run, #1462); tags are not deleted (forward-fix policy, independent of whether GitHub immutability applies)—recover with a new RC or a careful final retry per docs above
 - **Audit trail**: All steps are recorded in GitHub Actions logs with actor information
 - **Reproducible**: Uses consistent CI environment, not dependent on local tooling
 
@@ -774,7 +774,7 @@ gh workflow run release.yml \
 **Key characteristics:**
 - Tag created AFTER successful build/test (safer than before)
 - Final GitHub Release is a **draft** until a human publishes it from the UI
-- Automatic rollback resets the release branch only; tags are not deleted (forward-fix policy)
+- Automatic rollback reverts only the run's own finalize commit(s) on the release branch (no-op when finalize never ran; refuses if the branch moved mid-run, #1462); tags are not deleted (forward-fix policy)
 - All in one workflow for atomic operation
 - Audit trail in GitHub Actions logs
 - Dispatch is pinned to `release/X.Y.Z` so candidate/final runs use the release branch workflow definition
@@ -1039,7 +1039,8 @@ gh issue list --label release
 
 # 3. Examine what was rolled back (issue will document this)
 # The workflow automatically:
-#   - Reset release branch to pre-finalization state (best-effort)
+#   - Reverted this run's finalize commit(s) only — no-op when finalize never
+#     ran; refuses (loud step failure) if the branch moved during the run (#1462)
 #   - Left any pushed tags in place (forward-fix policy)
 #   - Created this issue for investigation
 

--- a/tests/test_release_rollback_guard.py
+++ b/tests/test_release_rollback_guard.py
@@ -155,6 +155,24 @@ def test_scaffold_rollback_needs_no_release_branch_checkout() -> None:
     assert "Configure git" not in names
 
 
+@pytest.mark.parametrize("copy", ROLLBACK_COPIES)
+def test_rollback_gates_the_sync_tip_on_the_fixed_message(copy: str) -> None:
+    """Both copies pin the sync commit's message; devkit also pins the author.
+
+    The message constant is shared: the scaffolded sync-issues.yml ships the
+    same 'chore: sync issues and PRs' default and the release-core dispatch
+    does not override it. The author is only a constant inside the vig-os
+    org (commit-action-bot[bot], live-verified on daeb5c54), so the scaffold
+    omits the SYNC_COMMIT_AUTHOR knob.
+    """
+    step = _rollback_step(copy)
+    assert "chore: sync issues and PRs" in step["run"]
+    if copy == "devkit":
+        assert step["env"].get("SYNC_COMMIT_AUTHOR") == "commit-action-bot[bot]"
+    else:
+        assert "SYNC_COMMIT_AUTHOR" not in step["env"]
+
+
 def test_devkit_pr_body_restore_skips_when_finalize_never_ran() -> None:
     """The PR-body restore (and its token mint) no-op when finalize skipped."""
     workflow = load_workflow(ROLLBACK_COPIES["devkit"])
@@ -172,6 +190,7 @@ _GH_STUB = """\
 # Git Data API simulator for the rollback step.
 #  - ref read  -> $FAKE_CURRENT_SHA
 #  - commit read (--jq .tree.sha)  -> tree-<sha>
+#  - commit read (facts query, jq join) -> $PARENT_<sha> TAB $AUTHOR_<sha> TAB $TITLE_<sha>
 #  - commit read (parents query)   -> $PARENT_<sha> (empty when unset)
 #  - POST git/commits -> $FAKE_REVERT_SHA ; PATCH ref -> recorded only
 args="$*"
@@ -190,6 +209,9 @@ case "$args" in
     sha="${sha%% *}"
     if [[ "$args" == *".tree.sha"* ]]; then
       echo "tree-$sha"
+    elif [[ "$args" == *"join"* ]]; then
+      p="PARENT_$sha"; a="AUTHOR_$sha"; t="TITLE_$sha"
+      printf '%s\\t%s\\t%s\\n' "${!p:-}" "${!a:-}" "${!t:-}"
     else
       var="PARENT_$sha"
       echo "${!var:-}"
@@ -240,6 +262,12 @@ def _run_rollback_script(
         "FAKE_CURRENT_SHA": "presha",
         **env_overrides,
     }
+    # Mirror literal (non-expression) step env the workflow copy defines, e.g.
+    # devkit's SYNC_COMMIT_AUTHOR knob; the scaffold omits it on purpose.
+    step_env = _rollback_step(copy).get("env", {})
+    for key, value in step_env.items():
+        if key not in env and "${{" not in str(value):
+            env[key] = str(value)
     proc = subprocess.run(
         ["bash", "-c", script], env=env, capture_output=True, text=True
     )
@@ -308,7 +336,7 @@ def test_reverts_when_tip_is_the_finalize_commit(copy: str, tmp_path: Path) -> N
 
 @pytest.mark.parametrize("copy", ROLLBACK_COPIES)
 def test_reverts_when_tip_is_sync_commit_on_finalize(copy: str, tmp_path: Path) -> None:
-    """Tip == sync commit whose chain is sync -> finalize -> snapshot."""
+    """Tip == genuine sync commit whose chain is sync -> finalize -> snapshot."""
     proc, calls = _run_rollback_script(
         copy,
         tmp_path,
@@ -317,11 +345,65 @@ def test_reverts_when_tip_is_sync_commit_on_finalize(copy: str, tmp_path: Path) 
             "FINAL_TIP_SHA": "ssha",
             "FAKE_CURRENT_SHA": "ssha",
             "PARENT_ssha": "fsha",
+            "AUTHOR_ssha": "commit-action-bot[bot]",
+            "TITLE_ssha": "chore: sync issues and PRs",
             "PARENT_fsha": "presha",
         },
     )
     assert proc.returncode == 0, proc.stderr
     assert any("-X PATCH" in c and "sha=revertsha" in c for c in _writes(calls))
+
+
+@pytest.mark.parametrize("copy", ROLLBACK_COPIES)
+def test_refuses_foreign_squash_commit_atop_finalize(copy: str, tmp_path: Path) -> None:
+    """A squash merge is single-parent too: parentage alone cannot tell a
+    foreign PR squash-merged between the finalize commit and the post-sync
+    record from the sync commit. The message gate must refuse it."""
+    proc, calls = _run_rollback_script(
+        copy,
+        tmp_path,
+        {
+            "FINALIZE_COMMIT_SHA": "fsha",
+            "FINAL_TIP_SHA": "xsha",
+            "FAKE_CURRENT_SHA": "xsha",
+            "PARENT_xsha": "fsha",
+            "AUTHOR_xsha": "Some Human",
+            "TITLE_xsha": "fix(scope): foreign change squash-merged mid-run",
+            "PARENT_fsha": "presha",
+        },
+    )
+    assert proc.returncode != 0, "foreign squash commit must fail the rollback step"
+    assert not _writes(calls), f"foreign squash commit clobbered: {calls}"
+    assert "Refusing" in proc.stdout + proc.stderr
+
+
+@pytest.mark.parametrize("copy", ROLLBACK_COPIES)
+def test_sync_author_gate_applies_where_the_bot_name_is_constant(
+    copy: str, tmp_path: Path
+) -> None:
+    """Right message but wrong author: devkit pins its org's commit bot via the
+    SYNC_COMMIT_AUTHOR knob and refuses; the scaffold ships without the knob
+    (consumer App bot names are not a devkit-known constant) and relies on the
+    message gate, so it reverts."""
+    proc, calls = _run_rollback_script(
+        copy,
+        tmp_path,
+        {
+            "FINALIZE_COMMIT_SHA": "fsha",
+            "FINAL_TIP_SHA": "xsha",
+            "FAKE_CURRENT_SHA": "xsha",
+            "PARENT_xsha": "fsha",
+            "AUTHOR_xsha": "Some Human",
+            "TITLE_xsha": "chore: sync issues and PRs",
+            "PARENT_fsha": "presha",
+        },
+    )
+    if copy == "devkit":
+        assert proc.returncode != 0, "devkit must also pin the sync commit author"
+        assert not _writes(calls)
+    else:
+        assert proc.returncode == 0, proc.stderr
+        assert any("-X PATCH" in c for c in _writes(calls))
 
 
 @pytest.mark.parametrize("copy", ROLLBACK_COPIES)

--- a/tests/test_release_rollback_guard.py
+++ b/tests/test_release_rollback_guard.py
@@ -1,0 +1,363 @@
+"""Rollback guard tests: ``release.yml`` must never clobber foreign commits.
+
+Issue #1462: the ``rollback`` job's "Rollback release branch" step built a
+commit whose **tree was reset to ``PRE_SHA``** — the branch tip captured when
+``validate`` started — whenever the run failed and the tip had moved at all.
+Both live incidents (#1459/#1460) had ``finalize`` SKIPPED: nothing had been
+written, yet the reset destroyed the merged content of #1447 and #1448 on
+``release/1.8.0``.
+
+The guarded design pinned here (both devkit's own ``release.yml`` and the
+scaffolded consumer ``release.yml``/``release-core.yml``):
+
+1. **No-op when finalize never ran** (``FINALIZE_RESULT`` skipped/empty) and
+   for candidates (finalize is branch-neutral unless ``release_kind`` is
+   ``final``).
+2. **Refuse instead of clobber**: finalize exports the exact commit SHA it
+   wrote (commit-action's ``commit-sha`` output) and the last branch tip it
+   observed; rollback only proceeds when the current tip is exactly that
+   chain — the finalize commit, optionally with the sync-issues commit on
+   top, parented on the pre-finalization snapshot. Anything else fails the
+   step loudly and leaves the branch alone.
+3. The tree-level revert commit is kept, but only after the chain proof makes
+   it equivalent to reverting the run's own commit(s). The existing
+   ``CURRENT_SHA == PRE_SHA`` no-op is retained.
+
+The decision matrix is executed for real: the step's bash runs against ``gh``
+and ``retry`` stubs that simulate the Git Data API, mirroring the executed-bash
+harness precedent in ``workflow_scaffold.run_resolve_toolchain``.
+
+Refs: #1462
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from tests.workflow_scaffold import (
+    WORKFLOWS,
+    load_workflow,
+    step_by_name,
+    steps_of_job,
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# copy id -> release.yml path carrying the rollback job
+ROLLBACK_COPIES: dict[str, Path] = {
+    "devkit": REPO_ROOT / ".github" / "workflows" / "release.yml",
+    "scaffold": WORKFLOWS / "release.yml",
+}
+
+
+def _rollback_step(copy: str) -> dict:
+    workflow = load_workflow(ROLLBACK_COPIES[copy])
+    steps = steps_of_job(workflow, "rollback")
+    return step_by_name(steps, "Rollback release branch")
+
+
+# ── finalize exports the SHA(s) it wrote ──────────────────────────────────────
+
+
+def test_devkit_finalize_exports_commit_and_post_sync_shas() -> None:
+    """Devkit finalize exposes the commit-action SHA and the post-sync tip."""
+    workflow = load_workflow(ROLLBACK_COPIES["devkit"])
+    finalize = workflow["jobs"]["finalize"]
+    outputs = finalize["outputs"]
+    assert "finalize_commit_sha" in outputs
+    assert "commit-sha" in outputs["finalize_commit_sha"]
+    assert "post_sync_sha" in outputs
+
+    # The commit-action step carries the id the output references.
+    commit_step = step_by_name(finalize["steps"], "Commit finalization")
+    assert commit_step.get("id"), "commit-action step needs an id for its output"
+    assert commit_step["id"] in outputs["finalize_commit_sha"]
+
+    # The post-sync tip is recorded after the sync-issues wait so the rollback
+    # job can recognize the sync commit as this run's own write.
+    names = [str(s.get("name", "")) for s in finalize["steps"]]
+    sync_idx = next(i for i, n in enumerate(names) if "Trigger sync-issues" in n)
+    post_idx = next(i for i, n in enumerate(names) if "post-sync" in n.lower())
+    assert post_idx > sync_idx
+
+
+def test_scaffold_core_exports_finalize_result_and_commit_sha() -> None:
+    """release-core.yml re-exposes finalize's result and exact commit SHA."""
+    core = load_workflow(WORKFLOWS / "release-core.yml")
+    call_outputs = core[True]["workflow_call"]["outputs"]
+
+    assert "finalize_result" in call_outputs
+    assert "jobs.finalize.result" in call_outputs["finalize_result"]["value"]
+
+    assert "finalize_commit_sha" in call_outputs
+    finalize = core["jobs"]["finalize"]
+    assert "finalize_commit_sha" in finalize["outputs"]
+    assert "commit-sha" in finalize["outputs"]["finalize_commit_sha"]
+    commit_step = step_by_name(finalize["steps"], "Commit and push finalization")
+    assert commit_step.get("id"), "commit-action step needs an id for its output"
+    assert commit_step["id"] in finalize["outputs"]["finalize_commit_sha"]
+
+
+# ── rollback step wiring ──────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("copy", ROLLBACK_COPIES)
+def test_rollback_step_threads_the_guard_inputs(copy: str) -> None:
+    """The step receives finalize result/kind and the run-written SHAs."""
+    env = _rollback_step(copy)["env"]
+    for key in (
+        "PRE_SHA",
+        "FINALIZE_RESULT",
+        "RELEASE_KIND",
+        "FINALIZE_COMMIT_SHA",
+        "FINAL_TIP_SHA",
+    ):
+        assert key in env, f"{copy}: rollback step env is missing {key}"
+    if copy == "devkit":
+        assert "needs.finalize.result" in env["FINALIZE_RESULT"]
+    else:
+        assert "needs.core.outputs.finalize_result" in env["FINALIZE_RESULT"]
+
+
+def test_scaffold_rollback_never_rewrites_history() -> None:
+    """The consumer rollback drops ``reset --hard`` + force-push for a revert."""
+    run = _rollback_step("scaffold")["run"]
+    assert "reset --hard" not in run
+    assert "--force-with-lease" not in run
+    assert "git push" not in run
+
+
+def test_scaffold_rollback_needs_no_release_branch_checkout() -> None:
+    """The API-based revert needs no working-tree checkout of the branch."""
+    workflow = load_workflow(ROLLBACK_COPIES["scaffold"])
+    names = [str(s.get("name", "")) for s in steps_of_job(workflow, "rollback")]
+    assert "Checkout release branch" not in names
+    assert "Configure git" not in names
+
+
+def test_devkit_pr_body_restore_skips_when_finalize_never_ran() -> None:
+    """The PR-body restore (and its token mint) no-op when finalize skipped."""
+    workflow = load_workflow(ROLLBACK_COPIES["devkit"])
+    steps = steps_of_job(workflow, "rollback")
+    restore = step_by_name(steps, "Restore release PR body")
+    token = step_by_name(steps, "Generate Release App Token")
+    for step in (restore, token):
+        assert "needs.finalize.result != 'skipped'" in str(step["if"])
+
+
+# ── executed decision matrix ──────────────────────────────────────────────────
+
+_GH_STUB = """\
+#!/usr/bin/env bash
+# Git Data API simulator for the rollback step.
+#  - ref read  -> $FAKE_CURRENT_SHA
+#  - commit read (--jq .tree.sha)  -> tree-<sha>
+#  - commit read (parents query)   -> $PARENT_<sha> (empty when unset)
+#  - POST git/commits -> $FAKE_REVERT_SHA ; PATCH ref -> recorded only
+args="$*"
+echo "$args" >> "$GH_LOG"
+case "$args" in
+  *"-X POST"*)
+    echo "$FAKE_REVERT_SHA"
+    ;;
+  *"-X PATCH"*)
+    ;;
+  *git/refs/heads/*|*git/ref/heads/*)
+    echo "$FAKE_CURRENT_SHA"
+    ;;
+  *git/commits/*)
+    sha="${args##*git/commits/}"
+    sha="${sha%% *}"
+    if [[ "$args" == *".tree.sha"* ]]; then
+      echo "tree-$sha"
+    else
+      var="PARENT_$sha"
+      echo "${!var:-}"
+    fi
+    ;;
+esac
+"""
+
+_RETRY_STUB = """\
+#!/usr/bin/env bash
+while [ "$#" -gt 0 ] && [ "$1" != "--" ]; do shift; done
+shift
+exec "$@"
+"""
+
+
+def _run_rollback_script(
+    copy: str, tmp_path: Path, env_overrides: dict[str, str]
+) -> tuple[subprocess.CompletedProcess[str], list[str]]:
+    """Execute the rollback step's bash against the gh/retry stubs."""
+    script = _rollback_step(copy)["run"]
+    script = script.replace("${{ github.repository }}", "o/r")
+    assert "${{" not in script, f"{copy}: unreplaced expression in run script"
+
+    stub_bin = tmp_path / "bin"
+    stub_bin.mkdir(exist_ok=True)
+    for name, body in (("gh", _GH_STUB), ("retry", _RETRY_STUB)):
+        stub = stub_bin / name
+        stub.write_text(body, encoding="utf-8")
+        stub.chmod(stub.stat().st_mode | stat.S_IEXEC)
+
+    gh_log = tmp_path / "gh.log"
+    gh_log.touch()
+
+    env = {
+        **os.environ,
+        "PATH": f"{stub_bin}{os.pathsep}{os.environ['PATH']}",
+        "GH_LOG": str(gh_log),
+        "GH_TOKEN": "test-token",
+        "VERSION": "9.9.9",
+        "PRE_SHA": "presha",
+        "FAKE_REVERT_SHA": "revertsha",
+        # defaults; individual cases override
+        "FINALIZE_RESULT": "success",
+        "RELEASE_KIND": "final",
+        "FINALIZE_COMMIT_SHA": "",
+        "FINAL_TIP_SHA": "",
+        "FAKE_CURRENT_SHA": "presha",
+        **env_overrides,
+    }
+    proc = subprocess.run(
+        ["bash", "-c", script], env=env, capture_output=True, text=True
+    )
+    calls = gh_log.read_text(encoding="utf-8").splitlines()
+    return proc, calls
+
+
+def _writes(calls: list[str]) -> list[str]:
+    return [c for c in calls if "-X POST" in c or "-X PATCH" in c]
+
+
+@pytest.mark.parametrize("copy", ROLLBACK_COPIES)
+def test_noop_when_finalize_skipped(copy: str, tmp_path: Path) -> None:
+    """THE incident shape: validate failed, finalize skipped, branch moved."""
+    proc, calls = _run_rollback_script(
+        copy,
+        tmp_path,
+        {"FINALIZE_RESULT": "skipped", "FAKE_CURRENT_SHA": "foreignsha"},
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert not _writes(calls), f"branch written despite skipped finalize: {calls}"
+
+
+@pytest.mark.parametrize("copy", ROLLBACK_COPIES)
+def test_noop_for_candidates(copy: str, tmp_path: Path) -> None:
+    """Candidates never write a finalize commit; the branch is left alone."""
+    proc, calls = _run_rollback_script(
+        copy,
+        tmp_path,
+        {"RELEASE_KIND": "candidate", "FAKE_CURRENT_SHA": "foreignsha"},
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert not _writes(calls), f"branch written on a candidate run: {calls}"
+
+
+@pytest.mark.parametrize("copy", ROLLBACK_COPIES)
+def test_noop_when_branch_already_at_pre_sha(copy: str, tmp_path: Path) -> None:
+    """The existing exact-match no-op survives the redesign."""
+    proc, calls = _run_rollback_script(copy, tmp_path, {})
+    assert proc.returncode == 0, proc.stderr
+    assert not _writes(calls)
+
+
+@pytest.mark.parametrize("copy", ROLLBACK_COPIES)
+def test_reverts_when_tip_is_the_finalize_commit(copy: str, tmp_path: Path) -> None:
+    """Tip == finalize commit parented on the snapshot: revert proceeds."""
+    proc, calls = _run_rollback_script(
+        copy,
+        tmp_path,
+        {
+            "FINALIZE_COMMIT_SHA": "fsha",
+            "FINAL_TIP_SHA": "fsha",
+            "FAKE_CURRENT_SHA": "fsha",
+            "PARENT_fsha": "presha",
+        },
+    )
+    assert proc.returncode == 0, proc.stderr
+    writes = _writes(calls)
+    assert any("-X POST" in c and "tree=tree-presha" in c for c in writes), (
+        f"expected a revert commit with the pre-finalization tree: {calls}"
+    )
+    assert any("-X PATCH" in c and "sha=revertsha" in c for c in writes), (
+        f"expected the branch ref moved to the revert commit: {calls}"
+    )
+
+
+@pytest.mark.parametrize("copy", ROLLBACK_COPIES)
+def test_reverts_when_tip_is_sync_commit_on_finalize(copy: str, tmp_path: Path) -> None:
+    """Tip == sync commit whose chain is sync -> finalize -> snapshot."""
+    proc, calls = _run_rollback_script(
+        copy,
+        tmp_path,
+        {
+            "FINALIZE_COMMIT_SHA": "fsha",
+            "FINAL_TIP_SHA": "ssha",
+            "FAKE_CURRENT_SHA": "ssha",
+            "PARENT_ssha": "fsha",
+            "PARENT_fsha": "presha",
+        },
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert any("-X PATCH" in c and "sha=revertsha" in c for c in _writes(calls))
+
+
+@pytest.mark.parametrize("copy", ROLLBACK_COPIES)
+def test_refuses_when_tip_is_a_foreign_commit(copy: str, tmp_path: Path) -> None:
+    """A tip this run did not write fails loudly and leaves the branch alone."""
+    proc, calls = _run_rollback_script(
+        copy,
+        tmp_path,
+        {
+            "FINALIZE_COMMIT_SHA": "fsha",
+            "FINAL_TIP_SHA": "fsha",
+            "FAKE_CURRENT_SHA": "foreignsha",
+            "PARENT_fsha": "presha",
+        },
+    )
+    assert proc.returncode != 0, "foreign tip must fail the rollback step"
+    assert not _writes(calls), f"foreign tip clobbered: {calls}"
+    assert "Refusing" in proc.stdout + proc.stderr
+
+
+@pytest.mark.parametrize("copy", ROLLBACK_COPIES)
+def test_refuses_when_finalize_commit_sits_on_a_foreign_parent(
+    copy: str, tmp_path: Path
+) -> None:
+    """A mid-run merge beneath the finalize commit blocks the tree reset."""
+    proc, calls = _run_rollback_script(
+        copy,
+        tmp_path,
+        {
+            "FINALIZE_COMMIT_SHA": "fsha",
+            "FINAL_TIP_SHA": "fsha",
+            "FAKE_CURRENT_SHA": "fsha",
+            "PARENT_fsha": "mergesha",
+        },
+    )
+    assert proc.returncode != 0, "foreign parent must fail the rollback step"
+    assert not _writes(calls), f"foreign parent clobbered: {calls}"
+
+
+@pytest.mark.parametrize("copy", ROLLBACK_COPIES)
+def test_refuses_when_no_finalize_commit_sha_and_branch_moved(
+    copy: str, tmp_path: Path
+) -> None:
+    """Finalize failed without exporting its SHA and the tip moved: refuse."""
+    proc, calls = _run_rollback_script(
+        copy,
+        tmp_path,
+        {
+            "FINALIZE_RESULT": "failure",
+            "FAKE_CURRENT_SHA": "somesha",
+        },
+    )
+    assert proc.returncode != 0
+    assert not _writes(calls)

--- a/tests/test_release_rollback_guard.py
+++ b/tests/test_release_rollback_guard.py
@@ -87,15 +87,30 @@ def test_devkit_finalize_exports_commit_and_post_sync_shas() -> None:
 
 
 def test_scaffold_core_exports_finalize_result_and_commit_sha() -> None:
-    """release-core.yml re-exposes finalize's result and exact commit SHA."""
+    """release-core.yml re-exposes finalize's ran/skipped state and commit SHA.
+
+    ``jobs.finalize.result`` would be the natural source, but actionlint's
+    jobs-context type for ``workflow_call`` outputs only carries ``outputs``,
+    so the signal is a first-step marker output: empty (-> 'skipped') when the
+    job never started, 'ran' otherwise.
+    """
     core = load_workflow(WORKFLOWS / "release-core.yml")
     call_outputs = core[True]["workflow_call"]["outputs"]
 
     assert "finalize_result" in call_outputs
-    assert "jobs.finalize.result" in call_outputs["finalize_result"]["value"]
+    result_value = call_outputs["finalize_result"]["value"]
+    assert "jobs.finalize.outputs.finalize_ran" in result_value
+    assert "'skipped'" in result_value
+
+    finalize = core["jobs"]["finalize"]
+    assert "finalize_ran" in finalize["outputs"]
+    first_step = finalize["steps"][0]
+    assert first_step.get("id") == "started", (
+        "the ran/skipped marker must be the first step so any finalize "
+        "execution — even one that fails immediately after — records it"
+    )
 
     assert "finalize_commit_sha" in call_outputs
-    finalize = core["jobs"]["finalize"]
     assert "finalize_commit_sha" in finalize["outputs"]
     assert "commit-sha" in finalize["outputs"]["finalize_commit_sha"]
     commit_step = step_by_name(finalize["steps"], "Commit and push finalization")

--- a/tests/test_workflow_release_publish.py
+++ b/tests/test_workflow_release_publish.py
@@ -163,18 +163,29 @@ def test_scaffold_drops_the_dead_git_identity_inputs() -> None:
         )
 
 
-def test_scaffold_orchestrator_keeps_the_rollback_identity() -> None:
-    """The dispatch identity inputs survive: the rollback job still commits."""
+def test_scaffold_orchestrator_keeps_the_dispatch_identity_inputs() -> None:
+    """The dispatch identity inputs survive while release-core declares them.
+
+    #1378 kept them for the git-CLI rollback; #1462 replaced that rollback
+    with Git Data API commits (App identity, no configured git user), so the
+    rollback job must mint the commit App token instead of configuring a
+    local identity.
+    """
     workflow = load_workflow(SCAFFOLD_ORCHESTRATOR)
     dispatch_inputs = on_block(workflow)["workflow_dispatch"]["inputs"]
     for kept in ("git-user-name", "git-user-email"):
         assert kept in dispatch_inputs, (
-            f"release.yml must keep the {kept!r} dispatch input: the rollback "
-            "job checks out the release branch and writes with that identity"
+            f"release.yml must keep the {kept!r} dispatch input while the "
+            "release-core call still declares it"
         )
     rollback_steps = workflow["jobs"]["rollback"]["steps"]
-    configure = next(s for s in rollback_steps if s.get("name") == "Configure git")
-    assert configure["env"]["GIT_USER_NAME"] == "${{ inputs.git-user-name }}"
+    assert not any(s.get("name") == "Configure git" for s in rollback_steps), (
+        "the API-based rollback must not configure a git-CLI identity (#1462)"
+    )
+    rollback = next(
+        s for s in rollback_steps if s.get("name") == "Rollback release branch"
+    )
+    assert rollback["env"]["GH_TOKEN"] == "${{ steps.commit_app_token.outputs.token }}"
 
 
 def test_scaffold_publish_accepts_a_lost_race_only_at_the_release_commit() -> None:


### PR DESCRIPTION
## Summary

`release.yml`'s **Rollback on Failure** built a commit whose tree was reset to `pre_finalize_sha` — a run-start snapshot — whenever the run failed and the branch tip had moved at all. Any commit merged to the release branch while a run was in flight was silently destroyed on that run's failure (#1459: the merged content of #1447 and #1448 wiped off `release/1.8.0` twice, both times with `finalize` *skipped*).

## Fix

The rollback branch step now proves the branch holds only this run's own writes before touching anything, and refuses loudly otherwise:

1. **No-op when `finalize` never ran** (`needs.finalize.result == 'skipped'`/empty) — this alone prevents both incidents.
2. **No-op for candidates** — finalize is branch-neutral unless `release_kind == final` (second independent shield; both incidents were candidates).
3. Retained `CURRENT_SHA == PRE_SHA` no-op.
4. **Chain proof before any write**: `finalize` now exports the exact commit SHA it pushed (commit-action's `commit-sha` output) plus the post-sync tip. The tip must be exactly the finalize commit parented on `PRE_SHA`, or the sync commit directly on top of it — and since this org squash-merges PRs (single-parent, indistinguishable by parentage alone), the sync-tip path additionally gates on the sync commit's fixed message `chore: sync issues and PRs` (devkit also pins the author `commit-action-bot[bot]`; live-verified against the real 1.7.0 finalize/sync pair on `main`). Anything else ⇒ `::error` + step failure, branch untouched; the failure issue and job summary report the outcome.

Only when the proof passes does the existing tree-at-`PRE_SHA` revert commit run — at that point it is exactly a revert of the run's own commits.

The PR-body restore step (and its Release-App token mint) now also skip when finalize was skipped — finalize is the only PR-body writer.

**All three copies fixed consistently**: devkit's `release.yml`, scaffolded `release-core.yml` (new `finalize_commit_sha` / `finalize_result` workflow_call outputs), and the scaffolded orchestrator `release.yml` — whose old rollback was a `git reset --hard $PRE_SHA` + force-push with zero guards, now replaced by the identical guarded API revert. Scaffold copies gate on the sync message only (the commit-bot name is per-consumer, the shipped `sync-issues.yml` message is a constant); script bodies are byte-identical between copies.

No concurrency group (issue proposal 4) — deliberately out of scope.

## Tests

TDD: `test(ci)` commit landed RED first (18 failed / 5 passed — the 5 were retained behaviors). New `tests/test_release_rollback_guard.py` executes the actual workflow scripts against stubbed `gh`/`retry` simulating the Git Data API, parametrized over both copies: both incident shapes no-op, foreign-tip and foreign-parent refuse, foreign squash commit atop finalize refuses (the row that fails against the unhardened script), genuine sync commit reverts. Existing #1378 rollback-identity test rewritten to pin the App-token API rollback.

Verification (direct exit codes): `pytest tests/test_release_rollback_guard.py tests/test_workflow_release_publish.py` → 43 passed; broad `pytest tests/` (excl. image/integration/flake) → 524 passed; `actionlint .github/workflows/release.yml` clean; rendered-tree actionlint bats 6/6 (covers the scaffold copies in all modes); full `prek run --all-files` → exit 0.

Also included: `chore` merge of `release/1.8.0` (brings in the #1463 fix from #1464; changelog union resolved manually, mirror byte-identical), and stale "branch reset to pre-finalization state" wording updated in `docs/RELEASE_CYCLE.md` / `DOWNSTREAM_RELEASE.md` and the failure-issue texts.

## Notes

- Failed-job output propagation for `finalize_commit_sha` follows the pattern the job already relied on for `pre_finalize_sha`.
- The dead `git_user_name`/`git_user_email` plumbing in `release-core.yml` (now unused after dropping the git-CLI rollback) is left in place — removal ripples across three workflows; separate-issue material.
- The interim operating rule from the issue (don't merge into a release branch mid-run) becomes a courtesy rather than a data-integrity requirement, but remains good practice.

Closes #1462