### PR TITLE
fix(workspace): stop the smoke deploy from deleting consumer-owned files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,6 +189,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Smoke deploys no longer delete consumer-owned files** ([#1466](https://github.com/vig-os/devkit/issues/1466))
+  - The smoke-mode scaffold copy ran `rsync --delete`, removing every tracked
+    path the template does not ship — the smoke repo's own `pyproject.toml`,
+    `uv.lock`, `src/` and `tests/` among them. Harmless while the deploy
+    commit was built additively; once
+    [#1443](https://github.com/vig-os/devkit/issues/1443) started publishing
+    the installer's deletions, the deploy committed them and the repo lost its
+    Python project, which in turn made the scaffold-drift gate re-render
+    CodeQL and `.gitignore` language-neutral and aborted the release gate
+  - Retiring a path is the
+    [#1348](https://github.com/vig-os/devkit/issues/1348) manifest's job, and
+    the drift gate re-scaffolds in normal mode, which never deletes — so smoke
+    mode now copies without `--delete` and the two modes agree by construction
 - **`just worktree-start` no longer unsets `core.hooksPath` repo-wide** ([#1463](https://github.com/vig-os/devkit/issues/1463))
   - `core.hooksPath` is shared repo config, so unsetting it from inside the
     new linked worktree silently disarmed the main checkout's tracked

--- a/assets/init-workspace.sh
+++ b/assets/init-workspace.sh
@@ -2129,13 +2129,25 @@ echo "Copying files from $TEMPLATE_DIR to $WORKSPACE_DIR..."
 # silently skips it. Content comparison is the only sound check here; the
 # template is small, so the cost is negligible.
 if [[ "$SMOKE_TEST" == "true" ]]; then
-    # Smoke mode: clean deploy (--delete removes stale files), then overlay
-    # smoke-test assets. /CHANGELOG.md is root-anchored (#953 semantics): the
-    # consumer's ROOT changelog is consumer state — its own frozen release
-    # history (## [X.Y.Z] - TBD) must survive re-deploys (#1403). The anchor
-    # keeps .devcontainer/CHANGELOG.md (devkit's manifest mirror) syncing, and
-    # the exclude also shields the root file from --delete.
-    rsync -avL --checksum --delete --exclude='.git' --exclude='.venv' --exclude='/CHANGELOG.md' --exclude='docs/issues/' --exclude='docs/pull-requests/' "$TEMPLATE_DIR/" "$WORKSPACE_DIR/"
+    # Smoke mode: overwrite the managed scaffold (no preserve excludes — every
+    # deploy is a fresh render), then overlay smoke-test assets.
+    #
+    # No --delete (#1466). It removed every tracked path the template does not
+    # ship, which is the consumer's own payload: the smoke repo's pyproject.toml,
+    # uv.lock, src/ and tests/. That was invisible while commit-action built the
+    # deploy tree additively; once #1443 began publishing `git ls-files --deleted`
+    # the 1.8.0-rc3 deploy committed those deletions and the smoke repo lost its
+    # Python project. Retirement is expressed by the #1348 manifest (pruned below,
+    # in this mode as in any other), not by a blanket delete — and the drift gate
+    # re-scaffolds in NORMAL mode, which never deletes, so gate and deploy now
+    # agree by construction. The docs/issues/ + docs/pull-requests/ excludes went
+    # with it: they existed only to shield sync-issues output from --delete.
+    #
+    # /CHANGELOG.md is root-anchored (#953 semantics): the consumer's ROOT
+    # changelog is consumer state — its own frozen release history
+    # (## [X.Y.Z] - TBD) must survive re-deploys (#1403). The anchor keeps
+    # .devcontainer/CHANGELOG.md (devkit's manifest mirror) syncing.
+    rsync -avL --checksum --exclude='.git' --exclude='.venv' --exclude='/CHANGELOG.md' "$TEMPLATE_DIR/" "$WORKSPACE_DIR/"
 
     SMOKE_TEST_DIR="$SCRIPT_DIR/smoke-test"
     if [[ -d "$SMOKE_TEST_DIR" ]]; then

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -189,6 +189,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Smoke deploys no longer delete consumer-owned files** ([#1466](https://github.com/vig-os/devkit/issues/1466))
+  - The smoke-mode scaffold copy ran `rsync --delete`, removing every tracked
+    path the template does not ship — the smoke repo's own `pyproject.toml`,
+    `uv.lock`, `src/` and `tests/` among them. Harmless while the deploy
+    commit was built additively; once
+    [#1443](https://github.com/vig-os/devkit/issues/1443) started publishing
+    the installer's deletions, the deploy committed them and the repo lost its
+    Python project, which in turn made the scaffold-drift gate re-render
+    CodeQL and `.gitignore` language-neutral and aborted the release gate
+  - Retiring a path is the
+    [#1348](https://github.com/vig-os/devkit/issues/1348) manifest's job, and
+    the drift gate re-scaffolds in normal mode, which never deletes — so smoke
+    mode now copies without `--delete` and the two modes agree by construction
 - **`just worktree-start` no longer unsets `core.hooksPath` repo-wide** ([#1463](https://github.com/vig-os/devkit/issues/1463))
   - `core.hooksPath` is shared repo config, so unsetting it from inside the
     new linked worktree silently disarmed the main checkout's tracked

--- a/tests/bats/init-workspace.bats
+++ b/tests/bats/init-workspace.bats
@@ -904,6 +904,58 @@ EOF
     assert_failure
 }
 
+# ── Smoke deploys keep the consumer's own payload (#1466) ─────────────────────
+# The smoke rsync used to carry --delete, which removes every tracked path the
+# template does not ship — including the smoke repo's own Python project. That
+# was invisible while commit-action built the deploy tree additively; once
+# #1443 started publishing `git ls-files --deleted`, the 1.8.0-rc3 deploy
+# committed the deletion of pyproject.toml, uv.lock, src/ and tests/.
+#
+# Retirement is expressed by the #1348 manifest, not by --delete, and the
+# scaffold-drift gate re-scaffolds in NORMAL mode (which never deletes). Smoke
+# mode now matches that path, so gate and deploy agree by construction.
+
+@test "smoke deploy preserves the consumer's own project payload (#1466)" {
+    ws="$BATS_TEST_TMPDIR/e2e-1466-payload"
+    mkdir -p "$ws/src/demo_pkg" "$ws/tests"
+    printf '[project]\nname = "demo"\n' >"$ws/pyproject.toml"
+    printf 'version = 1\n' >"$ws/uv.lock"
+    printf '# SENTINEL-1466 package\n' >"$ws/src/demo_pkg/__init__.py"
+    printf '# SENTINEL-1466 test\n' >"$ws/tests/test_demo.py"
+
+    run _smoke_deploy "$ws"
+    assert_success
+
+    # The template ships none of these; a smoke deploy must not remove them.
+    run test -f "$ws/pyproject.toml"
+    assert_success
+    run test -f "$ws/uv.lock"
+    assert_success
+    run grep -q 'SENTINEL-1466 package' "$ws/src/demo_pkg/__init__.py"
+    assert_success
+    run grep -q 'SENTINEL-1466 test' "$ws/tests/test_demo.py"
+    assert_success
+}
+
+@test "smoke deploy still prunes retired scaffold paths (#1466/#1348)" {
+    ws="$BATS_TEST_TMPDIR/e2e-1466-retired"
+    mkdir -p "$ws/.github/workflows"
+    # Pin predates the 1.8.0 retirement, so the prune is in scope.
+    printf 'DEVKIT_VERSION=1.7.0\n' >"$ws/.vig-os"
+    printf 'name: retired\n' >"$ws/.github/workflows/renovate-changelog-build.yml"
+    printf 'name: retired\n' >"$ws/.github/workflows/renovate-changelog-commit.yml"
+
+    run _smoke_deploy "$ws"
+    assert_success
+
+    # Dropping --delete must not cost the #1443 retirement behaviour: the
+    # #1348 prune is what removes these, in smoke mode as in normal mode.
+    run test -e "$ws/.github/workflows/renovate-changelog-build.yml"
+    assert_failure
+    run test -e "$ws/.github/workflows/renovate-changelog-commit.yml"
+    assert_failure
+}
+
 # ── Nix-image scaffold: real, writable files (#664) ───────────────────────────
 # The Nix image bakes the template as read-only /nix/store symlinks. The scaffold
 # rsync must --copy-links (-L) so a new workspace gets real files (not dangling

--- a/tests/bats/init-workspace.bats
+++ b/tests/bats/init-workspace.bats
@@ -823,16 +823,11 @@ _preview_symlinked_template_venv() {
     assert_output --partial 'FORCE=true'
 }
 
-@test "init-workspace.sh smoke mode uses rsync --delete for clean deploy" {
-    run grep 'rsync -avL --checksum --delete' "$INIT_WORKSPACE_SH"
-    assert_success
-}
-
-@test "init-workspace.sh smoke mode excludes synced docs directories from delete" {
-    run grep -A1 'rsync -avL --checksum --delete' "$INIT_WORKSPACE_SH"
-    assert_success
-    assert_output --partial "--exclude='docs/issues/'"
-    assert_output --partial "--exclude='docs/pull-requests/'"
+@test "init-workspace.sh never deletes on a smoke deploy (#1466)" {
+    # --delete removed the consumer's own payload, not just stale scaffold.
+    # Retirement is the #1348 manifest's job; see the smoke-deploy tests below.
+    run grep -E '^[[:space:]]*rsync .*--delete' "$INIT_WORKSPACE_SH"
+    assert_failure
 }
 
 # ── Smoke deploys preserve the consumer's root CHANGELOG (#1403) ───────────────


### PR DESCRIPTION
## Summary

The 1.8.0-rc3 smoke deploy committed the deletion of devkit-smoke-test's own Python project (`pyproject.toml`, `uv.lock`, `src/`, `tests/`), which failed the scaffold-drift gate and aborted the release gate. This drops `--delete` from the smoke-mode scaffold copy.

`assets/init-workspace.sh` smoke mode was the only copy branch carrying `rsync --delete`, so it removed every tracked path the template does not ship — consumer payload included. That was invisible while `commit-action` built the deploy tree additively; #1443 then started publishing `git ls-files --deleted`, and the deletions reached the branch.

The drift gate re-scaffolds in **normal** mode, which never deletes and prunes retirement via the #1348 manifest. Smoke mode now does the same, so gate and deploy agree by construction. The `docs/issues/` and `docs/pull-requests/` excludes go with `--delete` — they existed only to shield sync-issues output from it. The `/CHANGELOG.md` exclude stays: it is overwrite protection (#1403), not delete protection.

Second-order effect this clears: with `pyproject.toml` gone from the branch, the gate's re-scaffold no longer detected a Python repo, so it rendered `language: ['actions']` for CodeQL and stripped the 166-line Python block from `.gitignore`.

## Changes

- `assets/init-workspace.sh` — smoke-mode rsync drops `--delete` and the two docs excludes
- `tests/bats/init-workspace.bats` — two new end-to-end regression tests (consumer payload survives; retired paths are still pruned); the two tests that asserted the `--delete` behaviour replaced by one that pins its absence
- `CHANGELOG.md` — Fixed entry under 1.8.0

## Verification

| Suite | Result |
|---|---|
| `bats tests/bats/init-workspace.bats` | 252/252 pass |
| `bats tests/bats/install.bats tests/bats/just.bats` | 140 pass, exit 0 |
| `pytest tests/` (excluding container suites) | 608 passed, 1 skipped |
| `prek run --all-files` | exit 0 |

Both new tests were confirmed RED before the fix: the payload test failed on the deleted `pyproject.toml`/`uv.lock`, the retirement test passed throughout (pinning that the #1348 prune, not `--delete`, is what removes retired paths).

## Notes

No change to `assets/smoke-test/.github/workflows/repository-dispatch.yml`, so the listener already deployed to devkit-smoke-test `main` needs **no** redeploy — its `git ls-files --deleted` step now sees only genuine retirements.

Live proof is the next candidate's smoke chain.

Closes #1466
