### PR TITLE
docs(workspace): fix stale doctor comments on worktree hooksPath handling

### DIFF
--- a/assets/workspace/justfile
+++ b/assets/workspace/justfile
@@ -70,16 +70,23 @@ doctor:
         both)         hint="$hint; normally set by the devcontainer setup (reopen the container) or on dev-shell entry (direnv allow)" ;;
     esac
 
-    # A linked worktree is the one place where unset is the INTENDED state
-    # (#1454): `just worktree-start` unsets core.hooksPath there on purpose
-    # (prek refuses to install its shims while it is set) and installs the shims
-    # instead. `hooks` is one of git's shared paths, so they land in the common
-    # git dir and git runs them from inside the worktree — the gates are live,
-    # and the remediation above would undo the setup. Claim that only when a
-    # shim is really installed and executable: a worktree without one is inert
-    # exactly like any other unset case. `--git-path hooks/pre-commit` resolves
-    # to the file git itself would run (`.git` is a FILE in a linked worktree,
-    # so a literal `.git/hooks/...` test could never see it).
+    # A linked worktree may legitimately run with core.hooksPath unset and live
+    # shims in the shared git dir (#1454). Since #1463 `just worktree-start`
+    # leaves a configured hooks path untouched — the relative path resolves
+    # against each worktree's root and .githooks is tracked, so a post-fix
+    # worktree keeps the shared setting and hits the normal .githooks PASS
+    # branch — and prek-installs into the shared .git/hooks only as the
+    # fallback when no hooks path is configured at all. The shared-hooks PASS
+    # branch below covers that fallback plus worktrees created before #1463
+    # (worktree-start used to unset core.hooksPath — shared config, the #1463
+    # bug — and always install): `hooks` is one of git's shared paths, so the
+    # shims land in the common git dir and git runs them from inside the
+    # worktree — the gates are live, and the remediation above would undo the
+    # setup. Claim that only when a shim is really installed and executable: a
+    # worktree without one is inert exactly like any other unset case.
+    # `--git-path hooks/pre-commit` resolves to the file git itself would run
+    # (`.git` is a FILE in a linked worktree, so a literal `.git/hooks/...`
+    # test could never see it).
     hookspath="$(git config core.hooksPath || true)"
     gitdir="$(git rev-parse --absolute-git-dir 2>/dev/null || true)"
     commondir="$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)"

--- a/justfile
+++ b/justfile
@@ -81,16 +81,23 @@ doctor:
     # (or devcontainer / dev-shell entry) sets it. Until then every commit-side
     # gate is present, believed active, and inert. Refs #1430.
     #
-    # A linked worktree is the one place where unset is the INTENDED state
-    # (#1454): `just worktree-start` unsets core.hooksPath there on purpose
-    # (prek refuses to install its shims while it is set) and installs the shims
-    # instead. `hooks` is one of git's shared paths, so they land in the common
-    # git dir and git runs them from inside the worktree — the gates are live,
-    # and the fresh-clone remediation would undo the setup. Claim that only when
-    # a shim is really installed and executable: a worktree without one is inert
-    # exactly like any other unset case. `--git-path hooks/pre-commit` resolves
-    # to the file git itself would run (`.git` is a FILE in a linked worktree,
-    # so a literal `.git/hooks/...` test could never see it).
+    # A linked worktree may legitimately run with core.hooksPath unset and live
+    # shims in the shared git dir (#1454). Since #1463 `just worktree-start`
+    # leaves a configured hooks path untouched — the relative path resolves
+    # against each worktree's root and .githooks is tracked, so a post-fix
+    # worktree keeps the shared setting and hits the normal .githooks PASS
+    # branch — and prek-installs into the shared .git/hooks only as the
+    # fallback when no hooks path is configured at all. The shared-hooks PASS
+    # branch below covers that fallback plus worktrees created before #1463
+    # (worktree-start used to unset core.hooksPath — shared config, the #1463
+    # bug — and always install): `hooks` is one of git's shared paths, so the
+    # shims land in the common git dir and git runs them from inside the
+    # worktree — the gates are live, and the fresh-clone remediation would undo
+    # the setup. Claim that only when a shim is really installed and
+    # executable: a worktree without one is inert exactly like any other unset
+    # case. `--git-path hooks/pre-commit` resolves to the file git itself would
+    # run (`.git` is a FILE in a linked worktree, so a literal `.git/hooks/...`
+    # test could never see it).
     hookspath="$(git config core.hooksPath || true)"
     gitdir="$(git rev-parse --absolute-git-dir 2>/dev/null || true)"
     commondir="$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)"

--- a/tests/bats/consumer-doctor.bats
+++ b/tests/bats/consumer-doctor.bats
@@ -221,10 +221,13 @@ _run_doctor_at() {
     done
 }
 
-# ── linked worktrees: unset core.hooksPath is the INTENDED state (#1454) ──────
-# The scaffolded `just worktree-start` (.devcontainer/justfile.worktree)
-# deliberately unsets core.hooksPath in the worktree — prek refuses to install
-# its shims while it is set — and installs them instead. `hooks` is one of git's
+# ── linked worktrees: unset core.hooksPath can be a legitimate state (#1454) ──
+# Since #1463 the scaffolded `just worktree-start`
+# (.devcontainer/justfile.worktree) leaves a configured core.hooksPath
+# untouched — the tracked .githooks shims cover the worktree — and
+# prek-installs only as the fallback when no hooks path is set at all. That
+# fallback, plus worktrees created before #1463 (which always unset and
+# installed), is why unset can still be live here. `hooks` is one of git's
 # shared (common-dir) paths, so those shims land in the COMMON git dir and git
 # runs them from inside the linked worktree: the gates are LIVE. The fresh-clone
 # "tracked but inert" WARN is a lie there, and its remediation would undo the

--- a/tests/bats/doctor.bats
+++ b/tests/bats/doctor.bats
@@ -97,10 +97,13 @@ _init_clone() {
     assert_output --partial "scripts/init.sh"
 }
 
-# ── linked worktrees: unset core.hooksPath is the INTENDED state (#1454) ──────
-# `just worktree-start` deliberately unsets core.hooksPath in the worktree
-# (justfile.worktree) because prek refuses to install its shims while it is set,
-# then installs them. `hooks` is one of git's shared (common-dir) paths, so those
+# ── linked worktrees: unset core.hooksPath can be a legitimate state (#1454) ──
+# Since #1463 `just worktree-start` (justfile.worktree) leaves a configured
+# core.hooksPath untouched — the tracked .githooks shims cover the worktree —
+# and prek-installs only as the fallback when no hooks path is set at all. That
+# fallback, plus worktrees created before #1463 (which always unset and
+# installed), is why unset can still be live here.
+# `hooks` is one of git's shared (common-dir) paths, so those
 # shims land in the COMMON git dir and git runs them from inside the linked
 # worktree: the gates are LIVE. Reporting the fresh-clone "tracked but inert"
 # WARN there is a lie whose remediation would undo the worktree setup. A linked

--- a/tests/test_flake_hooks.py
+++ b/tests/test_flake_hooks.py
@@ -1213,8 +1213,8 @@ class TestGithooksPathWiring:
     so commit-time hooks (pre-commit / commit-msg via prek) were silently
     inactive until the consumer set it by hand. The base shellHook now mirrors
     the devcontainer, guarded so it only touches a scaffold-shaped repo and
-    never fights the worktree flow (justfile.worktree unsets core.hooksPath and
-    installs prek hooks directly in a linked worktree).
+    never fights the worktree flow (since #1463 justfile.worktree keeps a
+    configured core.hooksPath and prek-installs only when none is set).
     """
 
     def test_default_shellhook_sets_core_hookspath_to_githooks(


### PR DESCRIPTION
## Summary

After #1463 (PR #1464), `just worktree-start` no longer unsets `core.hooksPath` — a configured hooks path is left untouched (the tracked `.githooks` shims cover the new worktree) and the prek install into the shared `.git/hooks` survives only as the fallback when no hooks path is set. The #1454 doctor comments in both `justfile` copies still asserted the old behavior was "the INTENDED state ... on purpose", which would actively mislead the next hook-state investigation (the #1430 → #1454 → #1461 → #1463 chain shows how much debugging here leans on these comments).

## Changes

Comment-only, zero behavior delta:

- `justfile` + `assets/workspace/justfile`: the doctor linked-worktree comment now describes post-#1463 reality — the shared-hooks PASS branch covers the no-hooksPath fallback plus worktrees created before #1463; a post-fix worktree keeps the shared setting and hits the normal `.githooks` PASS branch. The `--git-path` rationale and the copies' one-phrase wording difference are preserved. (These are independent copies — `scripts/manifest.toml` mirrors only `justfile.gh`/`justfile.worktree` — so both needed the hand edit.)
- `tests/bats/doctor.bats`, `tests/bats/consumer-doctor.bats`, `tests/test_flake_hooks.py`: the same stale claim repeated in test comments, folded in per the scope note on the issue.

Doctor logic and echo strings untouched; no changelog entry (internal docs). TDD skipped: comment-only, non-testable.

## Verification

`bats tests/bats/doctor.bats tests/bats/consumer-doctor.bats` → 26/26 ok; full `prek run --all-files` → exit 0; clean tree.

Closes #1469