### PR TITLE
refactor(ci): drop the dead git identity plumbing from the scaffolded release workflows

### DIFF
--- a/.github/workflows/prepare-release-extension.yml
+++ b/.github/workflows/prepare-release-extension.yml
@@ -84,16 +84,6 @@ on:  # yamllint disable-line rule:truthy
         required: false
         default: false
         type: boolean
-      git_user_name:
-        description: "Git user name for commits"
-        required: false
-        default: "vigOS Release Bot"
-        type: string
-      git_user_email:
-        description: "Git user email for commits"
-        required: false
-        default: "release@vig-os.local"
-        type: string
 
 permissions:
   contents: read

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -30,16 +30,6 @@ on:  # yamllint disable-line rule:truthy
         required: false
         default: false
         type: boolean
-      git-user-name:
-        description: 'Git user name for commits'
-        required: false
-        default: 'vigOS Release Bot'
-        type: string
-      git-user-email:
-        description: 'Git user email for commits'
-        required: false
-        default: 'release@vig-os.local'
-        type: string
 
 permissions:
   contents: read          # safe default; prepare job escalates as needed
@@ -329,8 +319,6 @@ jobs:
       release_branch: ${{ needs.validate.outputs.release_branch }}
       branch_sha: ${{ needs.prepare.outputs.dev_sha }}
       dry_run: ${{ github.event.inputs.dry-run == 'true' }}
-      git_user_name: ${{ github.event.inputs.git-user-name }}
-      git_user_email: ${{ github.event.inputs.git-user-email }}
     secrets: inherit
 
   open-pr:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -179,6 +179,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- **Dead `git_user_name` / `git_user_email` plumbing dropped from the scaffolded release workflows** ([#1470](https://github.com/vig-os/devkit/issues/1470))
+  - The Git Data API rollback ([#1462](https://github.com/vig-os/devkit/issues/1462))
+    removed the last consumer of the git identity threaded through the release
+    train, so the `release.yml` dispatch inputs (`git-user-name` /
+    `git-user-email`), the `release-core.yml` `workflow_call` declarations, and
+    the `prepare-release.yml` dispatch inputs plus their forwarding into the
+    `prepare-release-extension.yml` hook contract are all gone
+  - Orchestrator and core ship together via the scaffold, so caller and callee
+    change in lockstep — no consumer action is needed beyond the normal
+    upgrade. Preserved consumer copies of `prepare-release-extension.yml` that
+    still declare the optional pair remain valid and simply fall back to their
+    own declared defaults
+
 - **`devc-upgrade` recipe removed from the scaffold** ([#1421](https://github.com/vig-os/devkit/issues/1421))
   - Upgrades are driven by the `devkit-upgrade` workflow's adoption PRs; the
     local recipe wrapped `install.sh --force` and steered users around the

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -179,6 +179,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- **Dead `git_user_name` / `git_user_email` plumbing dropped from the scaffolded release workflows** ([#1470](https://github.com/vig-os/devkit/issues/1470))
+  - The Git Data API rollback ([#1462](https://github.com/vig-os/devkit/issues/1462))
+    removed the last consumer of the git identity threaded through the release
+    train, so the `release.yml` dispatch inputs (`git-user-name` /
+    `git-user-email`), the `release-core.yml` `workflow_call` declarations, and
+    the `prepare-release.yml` dispatch inputs plus their forwarding into the
+    `prepare-release-extension.yml` hook contract are all gone
+  - Orchestrator and core ship together via the scaffold, so caller and callee
+    change in lockstep — no consumer action is needed beyond the normal
+    upgrade. Preserved consumer copies of `prepare-release-extension.yml` that
+    still declare the optional pair remain valid and simply fall back to their
+    own declared defaults
+
 - **`devc-upgrade` recipe removed from the scaffold** ([#1421](https://github.com/vig-os/devkit/issues/1421))
   - Upgrades are driven by the `devkit-upgrade` workflow's adoption PRs; the
     local recipe wrapped `install.sh --force` and steered users around the

--- a/assets/workspace/.github/workflows/prepare-release-extension.yml
+++ b/assets/workspace/.github/workflows/prepare-release-extension.yml
@@ -23,16 +23,6 @@ on:  # yamllint disable-line rule:truthy
         required: false
         default: false
         type: boolean
-      git_user_name:
-        description: "Git user name for commits"
-        required: false
-        default: "github-actions[bot]"
-        type: string
-      git_user_email:
-        description: "Git user email for commits"
-        required: false
-        default: "41898282+github-actions[bot]@users.noreply.github.com"
-        type: string
 
 # The orchestrator calls this workflow with `secrets: inherit`, so a real
 # extension can mint the COMMIT_APP token to push to the write-protected release

--- a/assets/workspace/.github/workflows/prepare-release.yml
+++ b/assets/workspace/.github/workflows/prepare-release.yml
@@ -15,16 +15,6 @@ on:  # yamllint disable-line rule:truthy
         required: false
         default: false
         type: boolean
-      git-user-name:
-        description: "Git user name for commits"
-        required: false
-        default: "github-actions[bot]"
-        type: string
-      git-user-email:
-        description: "Git user email for commits"
-        required: false
-        default: "41898282+github-actions[bot]@users.noreply.github.com"
-        type: string
 
 permissions:
   contents: read
@@ -328,8 +318,6 @@ jobs:
       release_branch: ${{ needs.validate.outputs.release_branch }}
       branch_sha: ${{ needs.prepare.outputs.dev_sha }}
       dry_run: ${{ inputs.dry-run }}
-      git_user_name: ${{ inputs.git-user-name }}
-      git_user_email: ${{ inputs.git-user-email }}
     secrets: inherit
 
   open-pr:

--- a/assets/workspace/.github/workflows/release-core.yml
+++ b/assets/workspace/.github/workflows/release-core.yml
@@ -20,16 +20,6 @@ on:  # yamllint disable-line rule:truthy
         required: false
         default: false
         type: boolean
-      git_user_name:
-        description: "Git user name for release commits"
-        required: false
-        default: "github-actions[bot]"
-        type: string
-      git_user_email:
-        description: "Git user email for release commits"
-        required: false
-        default: "41898282+github-actions[bot]@users.noreply.github.com"
-        type: string
       rc_number:
         description: "Candidate RC index (e.g. 21 for X.Y.Z-rc21). Omit to auto-increment from existing tags."
         required: false

--- a/assets/workspace/.github/workflows/release.yml
+++ b/assets/workspace/.github/workflows/release.yml
@@ -20,16 +20,6 @@ on:  # yamllint disable-line rule:truthy
         required: false
         default: false
         type: boolean
-      git-user-name:
-        description: "Git user name for release commits"
-        required: false
-        default: "github-actions[bot]"
-        type: string
-      git-user-email:
-        description: "Git user email for release commits"
-        required: false
-        default: "41898282+github-actions[bot]@users.noreply.github.com"
-        type: string
       rc-number:
         description: "Candidate RC index (e.g. 21 for X.Y.Z-rc21). Omit to auto-increment from existing tags."
         required: false
@@ -91,8 +81,6 @@ jobs:
       version: ${{ inputs.version }}
       release_kind: ${{ inputs.release-kind }}
       dry_run: ${{ inputs.dry-run }}
-      git_user_name: ${{ inputs.git-user-name }}
-      git_user_email: ${{ inputs.git-user-email }}
       rc_number: ${{ inputs.rc-number || '' }}
       toolchain_mode: ${{ needs.resolve-toolchain.outputs.mode }}
       toolchain_image: ${{ needs.resolve-toolchain.outputs.image }}

--- a/assets/workspace/docs/DOWNSTREAM_RELEASE.md
+++ b/assets/workspace/docs/DOWNSTREAM_RELEASE.md
@@ -153,7 +153,7 @@ Template behavior relies on explicit app-token generation for release operations
 
 ## Input Naming Convention
 
-All `workflow_call` inputs use underscores (e.g. `release_kind`, `dry_run`, `git_user_name`). The orchestrator `release.yml` translates its own `workflow_dispatch` hyphenated inputs at each call site.
+All `workflow_call` inputs use underscores (e.g. `release_kind`, `dry_run`, `tag_prefix`). The orchestrator `release.yml` translates its own `workflow_dispatch` hyphenated inputs at each call site.
 
 ## Extension Hook
 
@@ -197,7 +197,6 @@ Contract inputs:
 - `release_branch` — the release branch just created (`release/X.Y.Z`)
 - `branch_sha` — the post-freeze head SHA the release branch was created from
 - `dry_run` — validate without making changes (extensions must honor it)
-- `git_user_name`, `git_user_email` — the git identity `prepare-release.yml` carries
 
 `prepare-release.yml` calls the hook with `secrets: inherit`, so an extension can mint the `COMMIT_APP` token to push to the write-protected release branch — the same bypass and identity the changelog-freeze commit already uses.
 
@@ -230,12 +229,6 @@ on:
         required: false
         default: false
         type: boolean
-      git_user_name:
-        required: false
-        type: string
-      git_user_email:
-        required: false
-        type: string
 
 permissions:
   contents: read

--- a/docs/DOWNSTREAM_RELEASE.md
+++ b/docs/DOWNSTREAM_RELEASE.md
@@ -150,7 +150,7 @@ Template behavior relies on explicit app-token generation for release operations
 
 ## Input Naming Convention
 
-All `workflow_call` inputs use underscores (e.g. `release_kind`, `dry_run`, `git_user_name`). The orchestrator `release.yml` translates its own `workflow_dispatch` hyphenated inputs at each call site.
+All `workflow_call` inputs use underscores (e.g. `release_kind`, `dry_run`, `tag_prefix`). The orchestrator `release.yml` translates its own `workflow_dispatch` hyphenated inputs at each call site.
 
 ## Extension Hook
 
@@ -194,7 +194,6 @@ Contract inputs:
 - `release_branch` — the release branch just created (`release/X.Y.Z`)
 - `branch_sha` — the post-freeze head SHA the release branch was created from
 - `dry_run` — validate without making changes (extensions must honor it)
-- `git_user_name`, `git_user_email` — the git identity `prepare-release.yml` carries
 
 `prepare-release.yml` calls the hook with `secrets: inherit`, so an extension can mint the `COMMIT_APP` token to push to the write-protected release branch — the same bypass and identity the changelog-freeze commit already uses.
 
@@ -227,12 +226,6 @@ on:
         required: false
         default: false
         type: boolean
-      git_user_name:
-        required: false
-        type: string
-      git_user_email:
-        required: false
-        type: string
 
 permissions:
   contents: read

--- a/tests/test_workflow_prepare_extension.py
+++ b/tests/test_workflow_prepare_extension.py
@@ -62,15 +62,18 @@ DEVKIT_EXTENSION = REPO_ROOT / ".github" / "workflows" / "prepare-release-extens
 CALLER_WORKFLOWS = [SCAFFOLD_PREPARE, DEVKIT_PREPARE]
 
 # Inputs the hook contract carries (issue #1059). Underscore convention, per
-# DOWNSTREAM_RELEASE.md's "Input Naming Convention".
+# DOWNSTREAM_RELEASE.md's "Input Naming Convention". The git identity pair the
+# contract once carried is dead plumbing since the Git Data API rewrite and is
+# removed end to end (#1470).
 REQUIRED_INPUTS = {
     "version",
     "release_branch",
     "branch_sha",
     "dry_run",
-    "git_user_name",
-    "git_user_email",
 }
+
+DEAD_IDENTITY_CALL_INPUTS = ("git_user_name", "git_user_email")
+DEAD_IDENTITY_DISPATCH_INPUTS = ("git-user-name", "git-user-email")
 
 
 def _extension_job(doc: dict) -> tuple[str, dict] | tuple[None, None]:
@@ -134,6 +137,26 @@ def test_prepare_extension_default_is_noop_readonly() -> None:
     assert "vig-os/commit-action" not in SCAFFOLD_EXTENSION.read_text(
         encoding="utf-8"
     ), "the default no-op hook must not commit anything"
+
+
+@pytest.mark.parametrize(
+    "path",
+    [SCAFFOLD_EXTENSION, DEVKIT_EXTENSION],
+    ids=lambda p: str(p.relative_to(REPO_ROOT)),
+)
+def test_prepare_extension_drops_the_dead_git_identity_inputs(path: Path) -> None:
+    """The hook contract carries no git identity (#1470).
+
+    All extension writes go through the COMMIT_APP token (App identity, Git
+    Data API), so the ``git_user_name`` / ``git_user_email`` pair the contract
+    once carried is dead and must not be declared.
+    """
+    inputs = _on(_load(path))["workflow_call"].get("inputs") or {}
+    for dead in DEAD_IDENTITY_CALL_INPUTS:
+        assert dead not in inputs, (
+            f"{path.relative_to(REPO_ROOT)} must not declare the dead input "
+            f"{dead!r} (#1470)"
+        )
 
 
 # --------------------------------------------------------------------------- #
@@ -216,6 +239,27 @@ def test_prepare_release_forwards_dry_run_to_extension(path: Path) -> None:
     _, ext_job = _extension_job(_load(path))
     passed = ext_job.get("with") or {}
     assert "dry_run" in passed, "the extension call must forward dry_run"
+
+
+@pytest.mark.parametrize(
+    "path", CALLER_WORKFLOWS, ids=lambda p: str(p.relative_to(REPO_ROOT))
+)
+def test_prepare_release_drops_the_dead_git_identity_plumbing(path: Path) -> None:
+    """Neither caller declares nor forwards the dead identity pair (#1470)."""
+    doc = _load(path)
+    dispatch_inputs = _on(doc)["workflow_dispatch"].get("inputs") or {}
+    for dead in DEAD_IDENTITY_DISPATCH_INPUTS:
+        assert dead not in dispatch_inputs, (
+            f"{path.relative_to(REPO_ROOT)} must not declare the dead dispatch "
+            f"input {dead!r} (#1470)"
+        )
+    _, ext_job = _extension_job(doc)
+    passed = ext_job.get("with") or {}
+    for dead in DEAD_IDENTITY_CALL_INPUTS:
+        assert dead not in passed, (
+            f"{path.relative_to(REPO_ROOT)} must not forward the dead input "
+            f"{dead!r} to the extension (#1470)"
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_workflow_release_publish.py
+++ b/tests/test_workflow_release_publish.py
@@ -31,6 +31,7 @@ from tests.workflow_scaffold import REPO_ROOT, WORKFLOWS, load_workflow, on_bloc
 DEVKIT_RELEASE = REPO_ROOT / ".github" / "workflows" / "release.yml"
 SCAFFOLD_PUBLISH = WORKFLOWS / "release-publish.yml"
 SCAFFOLD_ORCHESTRATOR = WORKFLOWS / "release.yml"
+SCAFFOLD_CORE = WORKFLOWS / "release-core.yml"
 
 
 def _publish_steps(surface: str) -> list[dict]:
@@ -163,20 +164,31 @@ def test_scaffold_drops_the_dead_git_identity_inputs() -> None:
         )
 
 
-def test_scaffold_orchestrator_keeps_the_dispatch_identity_inputs() -> None:
-    """The dispatch identity inputs survive while release-core declares them.
+def test_scaffold_orchestrator_drops_the_dispatch_identity_inputs() -> None:
+    """The rollback identity plumbing is gone end to end (#1470).
 
-    #1378 kept them for the git-CLI rollback; #1462 replaced that rollback
-    with Git Data API commits (App identity, no configured git user), so the
-    rollback job must mint the commit App token instead of configuring a
-    local identity.
+    #1378 kept the dispatch inputs for the git-CLI rollback; #1462 replaced
+    that rollback with Git Data API commits (App identity, no configured git
+    user), leaving the plumbing dead: release.yml must not declare the
+    dispatch inputs nor thread them into the release-core call, and
+    release-core.yml must not declare the workflow_call inputs. The rollback
+    job must still mint the commit App token instead of configuring a local
+    identity.
     """
     workflow = load_workflow(SCAFFOLD_ORCHESTRATOR)
     dispatch_inputs = on_block(workflow)["workflow_dispatch"]["inputs"]
-    for kept in ("git-user-name", "git-user-email"):
-        assert kept in dispatch_inputs, (
-            f"release.yml must keep the {kept!r} dispatch input while the "
-            "release-core call still declares it"
+    for dead in ("git-user-name", "git-user-email"):
+        assert dead not in dispatch_inputs, (
+            f"release.yml must not declare the dead dispatch input {dead!r} (#1470)"
+        )
+    core_with = workflow["jobs"]["core"]["with"]
+    core_inputs = on_block(load_workflow(SCAFFOLD_CORE))["workflow_call"]["inputs"]
+    for dead in ("git_user_name", "git_user_email"):
+        assert dead not in core_with, (
+            f"release.yml must not pass the dead input {dead!r} to release-core"
+        )
+        assert dead not in core_inputs, (
+            f"release-core.yml must not declare the dead input {dead!r} (#1470)"
         )
     rollback_steps = workflow["jobs"]["rollback"]["steps"]
     assert not any(s.get("name") == "Configure git" for s in rollback_steps), (


### PR DESCRIPTION
## Summary

#1467 replaced the scaffolded orchestrator's rollback (`git reset --hard` + force-push under a configured git identity) with the guarded Git Data API revert — the last consumer of the `git_user_name` / `git_user_email` values threaded through the release workflows. This removes the dead plumbing everywhere, caller and callee in lockstep.

The set turned out larger than #1467's "three workflows" note: **four workflows × two copies**:

- scaffold `release.yml`: `workflow_dispatch` inputs + the forward into the `release-core` call
- scaffold `release-core.yml`: `workflow_call` declarations (zero use sites in the file)
- `prepare-release.yml` (devkit's own + scaffold): dispatch inputs + the forward into the extension call
- `prepare-release-extension.yml` (devkit's own + scaffold): seam template declarations (the default no-op never reads them)

Plus the contract docs (`docs/DOWNSTREAM_RELEASE.md` + scaffold copy). Devkit's own `release.yml` was already clean (bespoke, zero hits) and is untouched. Historical archives and released changelog entries deliberately kept.

## Consumer safety

This is a `workflow_call`/seam interface change, hence the `semver:minor` label and the `### Removed` changelog entry under 1.8.0. Orchestrator and core ship together via the scaffold, so caller and callee change in lockstep — no consumer action beyond the normal upgrade. All six reachable consumers' **preserved** `prepare-release-extension.yml` copies (commit-action, sync-issues-action, org-config, devkit-smoke-test, vault, exo-fleet) were checked: they declare the pair but have zero use sites, and since the inputs are optional with declared defaults, a stale preserved copy stays valid against the upgraded caller. The one genuine surface change: the (never-exercised) dispatch knob for a custom release-commit identity is gone — all release writes are App-identity API commits.

## Tests

TDD: `test(ci)` commit landed RED first (5 failed / 32 passed — exactly the new absence assertions). `test_scaffold_orchestrator_keeps_the_dispatch_identity_inputs` rewritten to `..._drops_...` (also pins the release-core declarations and the core-call `with:`, keeps the App-token rollback assertions); the pair dropped from `REQUIRED_INPUTS` in `test_workflow_prepare_extension.py` plus two absence tests parametrized over both extension copies.

Verification (direct exit codes): workflow suites 66 passed; broad `pytest tests/` (excl. image/integration/flake) 534 passed; `actionlint` on the two touched devkit workflows clean; rendered-tree actionlint bats 6/6; after merging in the updated `release/1.8.0` (#1468 landed mid-flight; clean auto-merge, changelog union verified, mirror byte-identical): full `init-workspace.bats` 252/252 ok and full `prek run --all-files` exit 0.

Closes #1470