### PR TITLE
fix(security): renew the glibc exception block to 2026-09-02

### DIFF
--- a/.vulnixignore
+++ b/.vulnixignore
@@ -79,20 +79,53 @@ CVE-2022-36883
 
 # glibc 2.42 — the base C library. Loaded by essentially every process in the
 #   closure, so unconditionally present; most glibc CVEs need a specific local
-#   vector (crafted input/locale/regex), mitigated by the single-user model but
-#   NOT individually verified here.
-Expiration: 2026-08-12
-# CVE-2025-15281 — glibc (base libc, loaded everywhere); specifics unverified offline.
+#   vector (crafted input/locale/regex), mitigated by the single-user model.
+#
+#   RE-VERIFIED 2026-08-13 (#1481) against the last green nightly scan on the
+#   current pin 531670d871c0 (run 31569093850, findings of 2026-08-12). All six
+#   entries are STILL live findings against glibc-2.42-67 — none became
+#   droppable the way the gawk block did after its rev advance (#1328) — so this
+#   is a renewed risk acceptance, not a date bump. The "advance the rev" lever
+#   has nowhere to land: the advisories scope the defects to "2.34 to 2.43" and
+#   "2.7 to 2.43", so 2.43 is itself affected and only backported patches can
+#   clear them. Renewed onto the shared 2026-09-02 grid date so the whole
+#   register is reviewed in one pass (#1337).
+#
+#   The same scan reports two further glibc CVEs deliberately absent from this
+#   register: CVE-2026-4438 (5.4) and CVE-2026-6238 (6.5) are below the gate's
+#   CVSS 7.0 threshold and need no exception.
+#
+#   The per-CVE notes below now carry the NVD CVSS and the advisory's own
+#   description of the required vector, which the 2026-06-23 HONESTY NOTE above
+#   could not (that triage had no CVE data offline). The reachability lines are
+#   an assessment of those vectors against this deployment model — they are NOT
+#   an audit of which closure members call the affected functions.
+Expiration: 2026-09-02
+# CVE-2025-15281 (7.5) — wordexp() with WRDE_REUSE|WRDE_APPEND returns
+#   uninitialized we_wordv, aborting on a later wordfree(). Needs a program using
+#   that flag pair; not a pattern in the image's own tooling.
 CVE-2025-15281
-# CVE-2026-4046 — glibc (base libc, loaded everywhere); specifics unverified offline.
+# CVE-2026-4046 (7.5) — iconv() assertion failure (crash/DoS) converting from the
+#   IBM1390/IBM1399 charsets. Reachable only where untrusted input is converted
+#   from those two charsets; the container's locales are UTF-8.
 CVE-2026-4046
-# CVE-2026-4437 — glibc (base libc, loaded everywhere); specifics unverified offline.
+# CVE-2026-4437 (7.5) — gethostbyaddr(_r) via the DNS backend can accept a
+#   non-answer section as a valid answer, given a crafted response. Needs a
+#   hostile or compromised resolver, and the legacy resolver API.
 CVE-2026-4437
-# CVE-2026-5435 — glibc (base libc, loaded everywhere); specifics unverified offline.
+# CVE-2026-5435 (7.3) — deprecated ns_printrrf/ns_printrr/fp_nquery ignore the
+#   caller's buffer length: out-of-bounds write when printing TSIG records. Needs
+#   a caller of those deprecated resolver-printing functions.
 CVE-2026-5435
-# CVE-2026-5450 — glibc (base libc, loaded everywhere); specifics unverified offline.
+# CVE-2026-5450 (9.8) — scanf-family %mc with an explicit field width > 1024
+#   overflows the heap by one byte. The highest-scored entry here; needs a
+#   program parsing attacker-controlled input with that specific %mc + width
+#   construct, which is a rare pattern.
 CVE-2026-5450
-# CVE-2026-5928 — glibc (base libc, loaded everywhere); specifics unverified offline.
+# CVE-2026-5928 (7.5) — ungetwc() operates on the byte read pointer instead of
+#   the wide one, allowing a read before the buffer (heap disclosure or crash).
+#   The advisory states the spurious-match case "is not possible in the standard
+#   Unicode character sets"; this image runs UTF-8 locales throughout.
 CVE-2026-5928
 
 # Remaining lower-reachability components (provenance per note). Specifics

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **Renew the glibc exception block in the vulnix register**
+  ([#1481](https://github.com/vig-os/devkit/issues/1481))
+  - The block expired 2026-08-12, failing `check-expirations` on every branch
+    (the hook runs inside the flake's `pre-commit` check) and on the nightly
+    security scan
+  - Re-verified against the current pin before renewing: all six CVEs are still
+    live findings against `glibc-2.42-67`, so none could be dropped the way the
+    gawk block was after its rev advance; the advisories cover glibc through
+    2.43, so advancing the pin cannot clear them either
+  - Renewed onto the shared `2026-09-02` grid date, and each entry now records
+    its CVSS and the advisory's required vector in place of the previous
+    "specifics unverified offline" placeholder
+
+
 ## [1.8.0](https://github.com/vig-os/devkit/releases/tag/1.8.0) - 2026-08-12
 
 ### Added

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -99,6 +99,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **Renew the glibc exception block in the vulnix register**
+  ([#1481](https://github.com/vig-os/devkit/issues/1481))
+  - The block expired 2026-08-12, failing `check-expirations` on every branch
+    (the hook runs inside the flake's `pre-commit` check) and on the nightly
+    security scan
+  - Re-verified against the current pin before renewing: all six CVEs are still
+    live findings against `glibc-2.42-67`, so none could be dropped the way the
+    gawk block was after its rev advance; the advisories cover glibc through
+    2.43, so advancing the pin cannot clear them either
+  - Renewed onto the shared `2026-09-02` grid date, and each entry now records
+    its CVSS and the advisory's required vector in place of the previous
+    "specifics unverified offline" placeholder
+
+
 ## [1.8.0](https://github.com/vig-os/devkit/releases/tag/1.8.0) - 2026-08-12
 
 ### Added


### PR DESCRIPTION
## Description

The glibc exception block in `.vulnixignore` expired **2026-08-12**, so
`check-expirations` fails on every branch — the hook is `enable = true` in the
flake hook set (`nix/hooks.nix:749`), so Tier 0 `nix-fast-build` runs it inside
the `pre-commit` derivation — and the nightly `Scheduled Security Scan` has been
red on both `dev` and `main` since 2026-08-13 06:14Z.

**Merge this first.** It is the reason CI is red on the other four 1.8.1 PRs
(#1479, #1478, #1477, #1474); none of them touch `.vulnixignore`.

## Type of Change

- [x] `fix` -- Bug fix

## Changes Made

Renewed rather than date-bumped. Re-verified against the last green nightly scan
on the current pin `531670d871c0` ([run 31569093850](https://github.com/vig-os/devkit/actions/runs/31569093850),
findings of 2026-08-12): **all six CVEs are still live findings** against
`glibc-2.42-67`, so none became droppable the way the gawk block did after its
rev advance (#1328).

| CVE | CVSS | Vector requires |
|-----|------|-----------------|
| CVE-2026-5450 | 9.8 | `scanf` `%mc` with an explicit width > 1024 on attacker-controlled input |
| CVE-2025-15281 | 7.5 | `wordexp()` with `WRDE_REUSE｜WRDE_APPEND` |
| CVE-2026-4437 | 7.5 | hostile/compromised resolver + the legacy `gethostbyaddr` API |
| CVE-2026-4046 | 7.5 | converting untrusted input **from** IBM1390/IBM1399 |
| CVE-2026-5928 | 7.5 | a non-Unicode charset with single/multi-byte overlaps |
| CVE-2026-5435 | 7.3 | a caller of the deprecated `ns_printrr*` / `fp_nquery` |

Advancing the pin cannot clear them either: the advisories scope the defects to
*"2.34 to 2.43"* and *"2.7 to 2.43"*, so glibc 2.43 is itself affected and only
backported patches help.

- Expiry renewed to **2026-09-02**, the Wednesday grid date the register's five
  other blocks already share (#1337), so the whole register is reviewed in one pass.
- Each entry now records its NVD CVSS and the advisory's required vector, replacing
  the `specifics unverified offline` placeholder the 2026-06-23 triage had to use.
  The reachability lines assess those vectors against the single-user container
  model; they are explicitly **not** an audit of which closure members call the
  affected functions.
- `CVE-2026-4438` (5.4) and `CVE-2026-6238` (6.5) are reported against the same
  derivation and stay out of the register — both are below the gate's 7.0 threshold.

## Changelog Entry

```
### Security

- **Renew the glibc exception block in the vulnix register**
  ([#1481](https://github.com/vig-os/devkit/issues/1481))
  - The block expired 2026-08-12, failing `check-expirations` on every branch
    (the hook runs inside the flake's `pre-commit` check) and on the nightly
    security scan
  - Re-verified against the current pin before renewing: all six CVEs are still
    live findings against `glibc-2.42-67`, so none could be dropped the way the
    gawk block was after its rev advance; the advisories cover glibc through
    2.43, so advancing the pin cannot clear them either
  - Renewed onto the shared `2026-09-02` grid date, and each entry now records
    its CVSS and the advisory's required vector in place of the previous
    "specifics unverified offline" placeholder
```

## Testing

- [x] `uv run check-expirations .trivyignore .vulnixignore` -> `Validated 32 exception(s) across 2 file(s)`, exit 0
- [x] `prek run --all-files` -> fully green, exit 0

Closes #1481

Refs: #1481
