### PR TITLE
fix(release): cut the release branch before the changelog freeze

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Trunk release preparation: the release PR is no longer empty, and the freeze
+  never pushes to the trunk**
+  ([#1479](https://github.com/vig-os/devkit/issues/1479))
+  - `prepare-release.yml` now creates `release/X.Y.Z` **before** the changelog
+    freeze and fast-forwards it onto the freeze commit afterwards. Under
+    `DEVKIT_WORKFLOW=trunk` the freeze targets the release branch instead of
+    `main`, so the draft release PR carries exactly one commit — it previously
+    froze onto `main` and cut the branch from that same post-freeze SHA, and
+    `gh pr create` failed with *"No commits between main and release/X.Y.Z"*
+  - A trunk consumer's Commit App therefore needs **no bypass on the `main`
+    ruleset**: the prepare phase only ever writes to `release/*`. `main` gets
+    the frozen changelog when the release PR merges at promote time
+  - New same-SHA guard in `open-pr`: head and base are resolved and compared
+    before the PR is created, so a collapsed topology fails with a named cause
+    instead of an opaque GitHub refusal
+  - The `gitflow` leg is behaviour-identical: the freeze still lands on `dev`
+    and the release branch still ends up at the freeze commit
+
 ### Security
 
 - **Renew the glibc exception block in the vulnix register**

--- a/assets/init-workspace.sh
+++ b/assets/init-workspace.sh
@@ -1447,8 +1447,13 @@ done
 #
 # Anchoring is load-bearing: `heads/dev\b` (word boundary) never touches
 # `development`/`devkit`/`devcontainer`; `ref: dev$` / ` from dev$` are
-# end-anchored. /dev/null device paths and the dev_sha/DEV_SHA variable names
-# are deliberately preserved (behavior is unaffected by their spelling).
+# end-anchored. /dev/null device paths are deliberately preserved (behavior is
+# unaffected by their spelling).
+#
+# One retarget is NOT a plain dev->main rename: the CHANGELOG freeze targets the
+# release branch under trunk (#1479). That is still an anchored substitution
+# rather than a structural rewrite, because the shipped asset already creates
+# release/X.Y.Z before it freezes.
 render_workflow_model() {
     local model="$1"
     [[ "$model" == "trunk" ]] || return 0
@@ -1456,10 +1461,22 @@ render_workflow_model() {
     local wf="$WORKSPACE_DIR/.github/workflows"
 
     # prepare-release.yml — retarget the release base dev -> main (#590/#617
-    # logic is base-agnostic) and scrub the inert dev step-names/comments so a
-    # trunk repo carries no `dev` cruft (variable names + /dev/null stay intact).
+    # logic is base-agnostic), point the CHANGELOG freeze at the release branch
+    # instead of the trunk (#1479), and scrub the inert dev step-names/comments
+    # so a trunk repo carries no `dev` cruft (/dev/null stays intact).
     local pr="$wf/prepare-release.yml"
     if [[ -f "$pr" ]]; then
+        # Freeze target (#1479). Under trunk the base branch IS the PR base, so
+        # freezing onto it would leave the release PR's head and base at the same
+        # commit (GitHub then refuses to open it) and would push straight to a
+        # trunk a require-PR ruleset protects. The asset creates release/X.Y.Z
+        # BEFORE the freeze precisely so this stays a literal substitution: the
+        # freeze commit (and the rollback's restore commit) target the release
+        # branch, and the ref reads that watch the freeze — the #617 wait and the
+        # rollback's post-delete guard — follow via FREEZE_REF. Both run BEFORE
+        # the blanket heads/dev retarget below, which must not claim these lines.
+        sed -i -E 's|^([[:space:]]*TARGET_BRANCH:) refs/heads/dev$|\1 refs/heads/${{ needs.validate.outputs.release_branch }}|' "$pr"
+        sed -i -E 's|^([[:space:]]*FREEZE_REF:) heads/dev$|\1 heads/${{ needs.validate.outputs.release_branch }}|' "$pr"
         # Behavioral branch literals: checkout refs + REST ref reads + targets.
         sed -i -E 's|^([[:space:]]*ref:) dev$|\1 main|' "$pr"
         sed -i -E 's|heads/dev\b|heads/main|g' "$pr"
@@ -1468,12 +1485,8 @@ render_workflow_model() {
         # above are what drive the retarget).
         sed -i 's|Checkout dev branch|Checkout main branch|' "$pr"
         sed -i 's|Capture pre-prepare dev SHA|Capture pre-prepare main SHA|' "$pr"
-        sed -i 's| to dev via API| to main via API|g' "$pr"
-        sed -i 's|Wait for dev to advance|Wait for main to advance|' "$pr"
-        sed -i 's|freeze commit-action updates dev|freeze commit-action updates main|' "$pr"
-        sed -i 's|dev still at pre-freeze SHA|main still at pre-freeze SHA|' "$pr"
-        sed -i 's|ERROR: dev did not advance|ERROR: main did not advance|' "$pr"
-        sed -i 's|CHANGELOG.md on dev|CHANGELOG.md on main|g' "$pr"
+        sed -i 's| to dev via API| to the release branch via API|g' "$pr"
+        sed -i 's|CHANGELOG.md on dev|CHANGELOG.md on the release branch|g' "$pr"
         # The #590 rationale comment describes the gitflow main/dev sync merge,
         # which does not exist in trunk — reword it (full-line anchored swaps).
         sed -i 's|dated release, matching$|dated release, so the|' "$pr"

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -97,6 +97,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Trunk release preparation: the release PR is no longer empty, and the freeze
+  never pushes to the trunk**
+  ([#1479](https://github.com/vig-os/devkit/issues/1479))
+  - `prepare-release.yml` now creates `release/X.Y.Z` **before** the changelog
+    freeze and fast-forwards it onto the freeze commit afterwards. Under
+    `DEVKIT_WORKFLOW=trunk` the freeze targets the release branch instead of
+    `main`, so the draft release PR carries exactly one commit — it previously
+    froze onto `main` and cut the branch from that same post-freeze SHA, and
+    `gh pr create` failed with *"No commits between main and release/X.Y.Z"*
+  - A trunk consumer's Commit App therefore needs **no bypass on the `main`
+    ruleset**: the prepare phase only ever writes to `release/*`. `main` gets
+    the frozen changelog when the release PR merges at promote time
+  - New same-SHA guard in `open-pr`: head and base are resolved and compared
+    before the PR is created, so a collapsed topology fails with a named cause
+    instead of an opaque GitHub refusal
+  - The `gitflow` leg is behaviour-identical: the freeze still lands on `dev`
+    and the release branch still ends up at the freeze commit
+
 ### Security
 
 - **Renew the glibc exception block in the vulnix register**

--- a/assets/workspace/.github/workflows/prepare-release.yml
+++ b/assets/workspace/.github/workflows/prepare-release.yml
@@ -150,7 +150,7 @@ jobs:
     outputs:
       changelog: ${{ steps.changelog.outputs.changelog }}
       prepare_start_sha: ${{ steps.pre_state.outputs.prepare_start_sha }}
-      dev_sha: ${{ steps.create_branch.outputs.dev_sha }}
+      freeze_sha: ${{ steps.freeze_wait.outputs.freeze_sha }}
 
     steps:
       - name: Generate Commit App Token
@@ -181,6 +181,49 @@ jobs:
           PREPARE_START_SHA=$(retry --retries 3 --backoff 5 --max-backoff 60 -- \
             gh api "repos/${{ github.repository }}/git/ref/heads/dev" --jq '.object.sha')
           echo "prepare_start_sha=$PREPARE_START_SHA" >> "$GITHUB_OUTPUT"
+
+      # The release branch is cut from the base BEFORE the changelog freeze, so
+      # that the freeze target is free to be either branch (#1479). That keeps
+      # this file model-agnostic: the trunk render is a literal substitution of
+      # the freeze target (release/X.Y.Z there, so the freeze never pushes to
+      # the protected trunk and the release PR carries a real commit), with no
+      # step reordering. The branch starts at the PRE-freeze base SHA and is
+      # fast-forwarded onto the freeze commit further down.
+      - name: Create release branch from dev
+        id: create_branch
+        env:
+          GH_TOKEN: ${{ steps.commit_app_token.outputs.token }}
+          RELEASE_BRANCH: ${{ needs.validate.outputs.release_branch }}
+          PREPARE_START_SHA: ${{ steps.pre_state.outputs.prepare_start_sha }}
+        run: |
+          set -euo pipefail
+          BRANCH_CREATED=true
+          retry --retries 3 --backoff 5 --max-backoff 60 -- \
+            gh api "repos/${{ github.repository }}/git/refs" \
+            -f ref="refs/heads/$RELEASE_BRANCH" \
+            -f sha="$PREPARE_START_SHA" || {
+              if retry --retries 2 --backoff 5 --max-backoff 20 -- \
+                gh api "repos/${{ github.repository }}/git/ref/heads/$RELEASE_BRANCH" >/dev/null 2>&1; then
+                echo "Release branch already exists: $RELEASE_BRANCH"
+                BRANCH_CREATED=false
+              else
+                exit 1
+              fi
+            }
+          echo "branch_created=$BRANCH_CREATED" >> "$GITHUB_OUTPUT"
+
+      # Absorbs GitHub's ref read-after-write lag before anything else touches
+      # the branch — under a trunk render the very next writer is the changelog
+      # freeze itself, which targets this branch.
+      - name: Verify release branch is resolvable
+        env:
+          GH_TOKEN: ${{ steps.commit_app_token.outputs.token }}
+          RELEASE_BRANCH: ${{ needs.validate.outputs.release_branch }}
+        run: |
+          set -euo pipefail
+          retry --retries 10 --backoff 2 --max-backoff 30 -- \
+            gh api "repos/${{ github.repository }}/git/ref/heads/$RELEASE_BRANCH" --jq '.object.sha'
+          echo "✓ Release branch ref verified as resolvable"
 
       # Bot-PR entries (Renovate, devkit adoptions) are synthesized into
       # Unreleased right before the freeze so they ride the freeze commit; the
@@ -245,56 +288,67 @@ jobs:
             and create fresh empty Unreleased section for continued development.
           FILE_PATHS: CHANGELOG.md
 
-      - name: Create release branch from dev
-        id: create_branch
+      - name: Wait for the freeze commit to become visible
+        id: freeze_wait
         env:
           GH_TOKEN: ${{ steps.commit_app_token.outputs.token }}
-          RELEASE_BRANCH: ${{ needs.validate.outputs.release_branch }}
+          FREEZE_REF: heads/dev
           PREPARE_START_SHA: ${{ steps.pre_state.outputs.prepare_start_sha }}
         run: |
           set -euo pipefail
-          # Wait for dev to advance past the pre-freeze SHA before branching (#617).
-          # The freeze commit-action updates dev's ref, but a REST ref read can
-          # briefly return the stale pre-freeze SHA (read-after-write lag); branching
-          # then would create release/X.Y.Z without the freeze. `retry` only retries
-          # on failure, so a stale-but-successful read slips through -- assert the SHA
-          # actually changed instead of trusting the first read.
-          DEV_SHA=""
+          # Wait for the freeze target to advance past the pre-freeze SHA (#617).
+          # The freeze commit-action updates that ref, but a REST ref read can
+          # briefly return the stale pre-freeze SHA (read-after-write lag); acting
+          # on it would fast-forward release/X.Y.Z to a commit without the freeze.
+          # `retry` only retries on failure, so a stale-but-successful read slips
+          # through -- assert the SHA actually changed instead of trusting the
+          # first read.
+          FREEZE_SHA=""
           for attempt in $(seq 1 8); do
-            DEV_SHA=$(retry --retries 3 --backoff 5 --max-backoff 60 -- \
-              gh api "repos/${{ github.repository }}/git/ref/heads/dev" --jq '.object.sha')
-            if [ "$DEV_SHA" != "$PREPARE_START_SHA" ]; then
+            FREEZE_SHA=$(retry --retries 3 --backoff 5 --max-backoff 60 -- \
+              gh api "repos/${{ github.repository }}/git/ref/$FREEZE_REF" --jq '.object.sha')
+            if [ "$FREEZE_SHA" != "$PREPARE_START_SHA" ]; then
               break
             fi
-            echo "dev still at pre-freeze SHA $DEV_SHA (attempt $attempt/8); waiting for freeze to propagate..."
+            echo "$FREEZE_REF still at pre-freeze SHA $FREEZE_SHA (attempt $attempt/8); waiting for the freeze to propagate..."
             sleep 5
           done
-          if [ "$DEV_SHA" = "$PREPARE_START_SHA" ]; then
-            echo "ERROR: dev did not advance past pre-freeze SHA $PREPARE_START_SHA; freeze commit not visible"
+          if [ "$FREEZE_SHA" = "$PREPARE_START_SHA" ]; then
+            echo "ERROR: $FREEZE_REF did not advance past pre-freeze SHA $PREPARE_START_SHA; freeze commit not visible"
             exit 1
           fi
-          retry --retries 3 --backoff 5 --max-backoff 60 -- \
-            gh api "repos/${{ github.repository }}/git/refs" \
-            -f ref="refs/heads/$RELEASE_BRANCH" \
-            -f sha="$DEV_SHA" || {
-              if retry --retries 2 --backoff 5 --max-backoff 20 -- \
-                gh api "repos/${{ github.repository }}/git/ref/heads/$RELEASE_BRANCH" >/dev/null 2>&1; then
-                echo "Release branch already exists: $RELEASE_BRANCH"
-              else
-                exit 1
-              fi
-            }
-          echo "dev_sha=$DEV_SHA" >> "$GITHUB_OUTPUT"
+          echo "freeze_sha=$FREEZE_SHA" >> "$GITHUB_OUTPUT"
 
-      - name: Verify release branch is resolvable
+      # Fast-forward release/X.Y.Z onto the freeze commit, so the branch (and
+      # every downstream consumer of `freeze_sha`) carries the frozen CHANGELOG.
+      # The update is NON-force: under gitflow the branch sits exactly one commit
+      # behind the freeze, a genuine fast-forward; under trunk the freeze already
+      # landed ON this branch, so the SHAs match and the step short-circuits.
+      #
+      # Gated on this run having created the branch: a pre-existing release/X.Y.Z
+      # (a re-prepare race -- `validate` normally refuses it) may carry commits
+      # that are NOT ancestors of the freeze commit, where the update is not a
+      # fast-forward at all and force=false would rightly refuse it. Skipping
+      # keeps the tolerant behaviour that branch creation has always had. (#1479)
+      - name: Fast-forward release branch to the freeze commit
+        if: ${{ steps.create_branch.outputs.branch_created == 'true' }}
         env:
           GH_TOKEN: ${{ steps.commit_app_token.outputs.token }}
           RELEASE_BRANCH: ${{ needs.validate.outputs.release_branch }}
+          FREEZE_SHA: ${{ steps.freeze_wait.outputs.freeze_sha }}
         run: |
           set -euo pipefail
-          retry --retries 10 --backoff 2 --max-backoff 30 -- \
-            gh api "repos/${{ github.repository }}/git/ref/heads/$RELEASE_BRANCH" --jq '.object.sha'
-          echo "✓ Release branch ref verified as resolvable"
+          BRANCH_SHA=$(retry --retries 3 --backoff 5 --max-backoff 60 -- \
+            gh api "repos/${{ github.repository }}/git/ref/heads/$RELEASE_BRANCH" --jq '.object.sha')
+          if [ "$BRANCH_SHA" = "$FREEZE_SHA" ]; then
+            echo "✓ $RELEASE_BRANCH already carries the freeze commit"
+          else
+            retry --retries 3 --backoff 5 --max-backoff 60 -- \
+              gh api -X PATCH "repos/${{ github.repository }}/git/refs/heads/$RELEASE_BRANCH" \
+              -f sha="$FREEZE_SHA" \
+              -F force=false
+            echo "✓ Fast-forwarded $RELEASE_BRANCH to the freeze commit $FREEZE_SHA"
+          fi
 
       # The release branch keeps the empty ## Unreleased section (no stripping).
       # main therefore retains ## Unreleased above the dated release, matching
@@ -316,7 +370,7 @@ jobs:
     with:
       version: ${{ needs.validate.outputs.version }}
       release_branch: ${{ needs.validate.outputs.release_branch }}
-      branch_sha: ${{ needs.prepare.outputs.dev_sha }}
+      branch_sha: ${{ needs.prepare.outputs.freeze_sha }}
       dry_run: ${{ inputs.dry-run }}
     secrets: inherit
 
@@ -392,6 +446,21 @@ jobs:
           if [ -n "$EXISTING_PR_URL" ]; then
             PR_URL="$EXISTING_PR_URL"
           else
+            # Same-SHA guard (#1479): GitHub refuses to open a pull request whose
+            # head and base resolve to the same commit ("No commits between main
+            # and release/X.Y.Z"). That is precisely what a release branch cut
+            # from a post-freeze base produces, and a local-git simulation cannot
+            # express the server-side refusal (why #1206 could not catch it), so
+            # the topology is asserted here where the diagnosis is unambiguous.
+            BASE_SHA=$(retry --retries 3 --backoff 5 --max-backoff 60 -- \
+              gh api "repos/${{ github.repository }}/git/ref/heads/main" --jq '.object.sha')
+            HEAD_SHA=$(retry --retries 3 --backoff 5 --max-backoff 60 -- \
+              gh api "repos/${{ github.repository }}/git/ref/heads/$RELEASE_BRANCH" --jq '.object.sha')
+            if [ "$BASE_SHA" = "$HEAD_SHA" ]; then
+              echo "ERROR: $RELEASE_BRANCH and main are the same commit ($HEAD_SHA)"
+              echo "The release PR would carry zero commits; the changelog freeze did not reach $RELEASE_BRANCH."
+              exit 1
+            fi
             PR_URL=$(retry --retries 3 --backoff 5 --max-backoff 60 -- \
               gh pr create \
                 --base main \
@@ -467,22 +536,28 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.commit_app_token.outputs.token }}
           RELEASE_BRANCH: ${{ needs.validate.outputs.release_branch }}
+          FREEZE_REF: heads/dev
           PREPARE_START_SHA: ${{ needs.prepare.outputs.prepare_start_sha }}
-          POST_FREEZE_DEV_SHA: ${{ needs.prepare.outputs.dev_sha }}
+          POST_FREEZE_SHA: ${{ needs.prepare.outputs.freeze_sha }}
         run: |
           set -euo pipefail
           CHANGELOG_ROLLBACK_NEEDED=false
           retry --retries 3 --backoff 5 --max-backoff 60 -- \
             gh api -X DELETE "repos/${{ github.repository }}/git/refs/heads/$RELEASE_BRANCH" || true
 
-          if [ -z "${PREPARE_START_SHA:-}" ] || [ -z "${POST_FREEZE_DEV_SHA:-}" ]; then
+          if [ -z "${PREPARE_START_SHA:-}" ] || [ -z "${POST_FREEZE_SHA:-}" ]; then
             echo "changelog_rollback_needed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          CURRENT_DEV_SHA=$(retry --retries 3 --backoff 5 --max-backoff 60 -- \
-            gh api "repos/${{ github.repository }}/git/ref/heads/dev" --jq '.object.sha')
-          if [ "$CURRENT_DEV_SHA" != "$POST_FREEZE_DEV_SHA" ]; then
+          # Read the freeze target AFTER the delete above, and tolerate a missing
+          # ref: under a trunk render the freeze lives on the release branch that
+          # was just deleted, so an unresolvable ref is the correct "the freeze is
+          # already gone, nothing to restore" answer -- and the restore commit
+          # below can then never touch the trunk (#1479).
+          CURRENT_FREEZE_SHA=$(retry --retries 3 --backoff 5 --max-backoff 60 -- \
+            gh api "repos/${{ github.repository }}/git/ref/$FREEZE_REF" --jq '.object.sha' || echo "")
+          if [ "$CURRENT_FREEZE_SHA" != "$POST_FREEZE_SHA" ]; then
             echo "changelog_rollback_needed=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -490,7 +565,7 @@ jobs:
           retry --retries 3 --backoff 5 --max-backoff 60 -- \
             gh api "repos/${{ github.repository }}/contents/CHANGELOG.md?ref=$PREPARE_START_SHA" --jq '.content' | tr -d '\n' | base64 -d > /tmp/changelog.pre.md
           retry --retries 3 --backoff 5 --max-backoff 60 -- \
-            gh api "repos/${{ github.repository }}/contents/CHANGELOG.md?ref=$CURRENT_DEV_SHA" --jq '.content' | tr -d '\n' | base64 -d > /tmp/changelog.current.md
+            gh api "repos/${{ github.repository }}/contents/CHANGELOG.md?ref=$CURRENT_FREEZE_SHA" --jq '.content' | tr -d '\n' | base64 -d > /tmp/changelog.current.md
           if ! cmp -s /tmp/changelog.pre.md /tmp/changelog.current.md; then
             cp /tmp/changelog.pre.md CHANGELOG.md
             CHANGELOG_ROLLBACK_NEEDED=true

--- a/assets/workspace/docs/DOWNSTREAM_RELEASE.md
+++ b/assets/workspace/docs/DOWNSTREAM_RELEASE.md
@@ -72,8 +72,19 @@ is still cut, driven through the RC train, finalized, and merged. The models
 differ only in the base the release branch forks from and merges back to, which
 is settled entirely at scaffold time (an anchored `dev -> main` render — see
 [`docs/rfcs/ADR-workflow-model.md`](https://github.com/vig-os/devkit/blob/main/docs/rfcs/ADR-workflow-model.md)).
-One release step is model-dependent:
+Two release steps are model-dependent:
 
+- **The changelog freeze targets `dev` under `gitflow` and `release/X.Y.Z` under
+  `trunk`** ([#1479](https://github.com/vig-os/devkit/issues/1479)).
+  `prepare-release.yml` cuts `release/X.Y.Z` from the base *before* it freezes,
+  then commits the freeze to the model's freeze target and fast-forwards the
+  release branch onto it (a no-op under `trunk`, where the freeze already landed
+  there). Under `trunk` the base branch is also the release PR's base, so
+  freezing onto it would leave head and base at the same commit — GitHub then
+  refuses to open the PR — and would push straight to the trunk. Consequence for
+  a trunk consumer: **the Commit App needs no bypass on the `main` ruleset**; it
+  only ever writes to `release/*`. `main` receives the frozen changelog when the
+  release PR merges at promote time.
 - **`sync-main-to-dev.yml` runs only under `gitflow`.** The gitflow model keeps a
   long-lived `dev` integration branch, so a push to `main` (including a release
   merge) opens a PR syncing `main` back into `dev`. The `trunk` model has no
@@ -195,7 +206,7 @@ Contract inputs:
 
 - `version` — the release version being prepared (`X.Y.Z`)
 - `release_branch` — the release branch just created (`release/X.Y.Z`)
-- `branch_sha` — the post-freeze head SHA the release branch was created from
+- `branch_sha` — the post-freeze head SHA of the release branch (the changelog-freeze commit)
 - `dry_run` — validate without making changes (extensions must honor it)
 
 `prepare-release.yml` calls the hook with `secrets: inherit`, so an extension can mint the `COMMIT_APP` token to push to the write-protected release branch — the same bypass and identity the changelog-freeze commit already uses.

--- a/docs/DOWNSTREAM_RELEASE.md
+++ b/docs/DOWNSTREAM_RELEASE.md
@@ -69,8 +69,19 @@ is still cut, driven through the RC train, finalized, and merged. The models
 differ only in the base the release branch forks from and merges back to, which
 is settled entirely at scaffold time (an anchored `dev -> main` render — see
 [`docs/rfcs/ADR-workflow-model.md`](https://github.com/vig-os/devkit/blob/main/docs/rfcs/ADR-workflow-model.md)).
-One release step is model-dependent:
+Two release steps are model-dependent:
 
+- **The changelog freeze targets `dev` under `gitflow` and `release/X.Y.Z` under
+  `trunk`** ([#1479](https://github.com/vig-os/devkit/issues/1479)).
+  `prepare-release.yml` cuts `release/X.Y.Z` from the base *before* it freezes,
+  then commits the freeze to the model's freeze target and fast-forwards the
+  release branch onto it (a no-op under `trunk`, where the freeze already landed
+  there). Under `trunk` the base branch is also the release PR's base, so
+  freezing onto it would leave head and base at the same commit — GitHub then
+  refuses to open the PR — and would push straight to the trunk. Consequence for
+  a trunk consumer: **the Commit App needs no bypass on the `main` ruleset**; it
+  only ever writes to `release/*`. `main` receives the frozen changelog when the
+  release PR merges at promote time.
 - **`sync-main-to-dev.yml` runs only under `gitflow`.** The gitflow model keeps a
   long-lived `dev` integration branch, so a push to `main` (including a release
   merge) opens a PR syncing `main` back into `dev`. The `trunk` model has no
@@ -192,7 +203,7 @@ Contract inputs:
 
 - `version` — the release version being prepared (`X.Y.Z`)
 - `release_branch` — the release branch just created (`release/X.Y.Z`)
-- `branch_sha` — the post-freeze head SHA the release branch was created from
+- `branch_sha` — the post-freeze head SHA of the release branch (the changelog-freeze commit)
 - `dry_run` — validate without making changes (extensions must honor it)
 
 `prepare-release.yml` calls the hook with `secrets: inherit`, so an extension can mint the `COMMIT_APP` token to push to the write-protected release branch — the same bypass and identity the changelog-freeze commit already uses.

--- a/tests/bats/init-workspace.bats
+++ b/tests/bats/init-workspace.bats
@@ -3171,6 +3171,21 @@ _referenced_secrets() {
     assert_success
 }
 
+@test "actionlint passes over the trunk-rendered workflows (#1479)" {
+    # The per-mode fixtures above all render the gitflow default. The trunk
+    # render substitutes a ${{ }} expression into workflow env values (the
+    # CHANGELOG freeze target and the ref the #617 wait watches it on, #1479),
+    # a render class only actionlint can validate — a malformed expression, or
+    # one landing in a job without `needs: validate`, would otherwise reach a
+    # consumer's release train unlinted.
+    local ws="$BATS_TEST_TMPDIR/al-trunk"
+    mkdir -p "$ws"
+    run _scaffold_ex both "$ws" --workflow trunk
+    assert_success
+    run bash -c "cd '$ws' && git init -q && actionlint"
+    assert_success
+}
+
 @test "actionlint passes over the smoke-test workflow templates (#995)" {
     # The smoke-test overlay ships standalone workflows (no reusable siblings),
     # so they are linted in-place by explicit path from the repo root. The repo

--- a/tests/test_workflow_model.py
+++ b/tests/test_workflow_model.py
@@ -22,10 +22,14 @@ from __future__ import annotations
 import subprocess
 from pathlib import Path
 
+import pytest
+
 from tests.workflow_scaffold import (
     INIT_WORKSPACE,
     WORKSPACE,
     cached_tree,
+    jobs,
+    load_workflow,
     scaffold,
     scaffold_tree,
 )
@@ -124,16 +128,19 @@ def test_trunk_prepare_release_has_no_dev_cruft() -> None:
     """No residual `dev` in prepare-release beyond /dev/null + the SHA var names.
 
     The maintainer decision (#1208) rewrites the inert dev step-names/comments to
-    main so a trunk repo carries no dev cruft; only the device path and the
-    dev_sha/DEV_SHA variable/output names (behavior-neutral) are preserved.
+    main so a trunk repo carries no dev cruft; only the device path is preserved
+    (the dev_sha/DEV_SHA names the render used to carry are gone since #1479
+    renamed them to the model-neutral freeze_sha/FREEZE_SHA).
     """
     text = _wf(cached_tree("trunk"), "prepare-release.yml")
     # The branch base itself is retargeted: no heads/dev ref survives, the
-    # release branch forks from refs/heads/main (the checkout-ref half lives in
+    # release branch forks from heads/main (the checkout-ref half lives in
     # test_workflow_prepare_extension.py::test_trunk_prepare_forks_release_branch_from_main).
+    # `refs/heads/main` is deliberately NOT asserted: since #1479 nothing in a
+    # trunk render writes to the trunk, so main appears only as a ref *read*.
     assert "heads/dev" not in text
-    assert "refs/heads/main" in text
-    allowed = ("/dev/null", "dev_sha", "DEV_SHA")
+    assert "heads/main" in text
+    allowed = ("/dev/null",)
     stray = [
         line
         for line in text.splitlines()
@@ -262,15 +269,194 @@ def test_template_flake_guards_workflow_forwarding() -> None:
 
 
 def test_anchoring_preserves_dev_prefixed_and_device_tokens() -> None:
-    """Anchoring must not touch /dev/null, dev_sha, or development/devkit tokens.
+    """Anchoring must not touch /dev/null or development/devkit tokens.
 
     The render's word-boundary/end anchors exist precisely so these behaviorally
     or lexically dev-adjacent tokens survive. /dev/null in particular would be a
-    catastrophic corruption if rewritten.
+    catastrophic corruption if rewritten. (The ``dev_sha`` output this also used
+    to pin is gone — #1479 renamed it ``freeze_sha`` — so the devkit-prefixed
+    composite name carries the word-boundary half of the assertion now.)
     """
     text = _wf(cached_tree("trunk"), "prepare-release.yml")
     assert "/dev/null" in text  # device path, not a branch ref
-    assert "dev_sha:" in text  # workflow output variable name preserved
+    assert "setup-devkit-toolchain" in text  # dev-prefixed token preserved
+
+
+# ── release topology: branch before freeze, freeze off the trunk (#1479) ─────
+#
+# The trunk render is a literal ``dev -> main`` substitution, so the SHIPPED
+# (gitflow) asset has to carry an ordering that is already model-agnostic:
+#
+#   1. capture the base head (BASE_SHA),
+#   2. create ``release/X.Y.Z`` AT that SHA,
+#   3. freeze the changelog onto the freeze target — the base branch under
+#      gitflow, the release branch under trunk,
+#   4. wait for the freeze target to advance past BASE_SHA (#617),
+#   5. fast-forward ``release/X.Y.Z`` onto the freeze commit (a real FF under
+#      gitflow, a no-op under trunk — the freeze already landed there).
+#
+# Freezing onto the base first (the pre-#1479 order) collapses the two-branch
+# topology under trunk: head and base resolve to the SAME commit, so
+# ``gh pr create`` fails with "No commits between main and release/X.Y.Z", and
+# the freeze is a direct push to a trunk that a require-PR ruleset protects.
+
+SCAFFOLD_PREPARE = WORKSPACE / ".github" / "workflows" / "prepare-release.yml"
+
+# The freeze target the trunk render substitutes for gitflow's refs/heads/dev.
+TRUNK_FREEZE_TARGET = "refs/heads/${{ needs.validate.outputs.release_branch }}"
+TRUNK_FREEZE_REF = "heads/${{ needs.validate.outputs.release_branch }}"
+
+
+def _prepare_doc(model: str) -> dict:
+    """The parsed prepare-release.yml for a workflow model.
+
+    gitflow reads the shipped asset directly (the render is a no-op for it);
+    trunk reads the rendered scaffold tree.
+    """
+    if model == "gitflow":
+        return load_workflow(SCAFFOLD_PREPARE)
+    path = cached_tree(model) / ".github" / "workflows" / "prepare-release.yml"
+    return load_workflow(path)
+
+
+def _steps(doc: dict, job: str) -> list[dict]:
+    return [s for s in (jobs(doc)[job].get("steps") or []) if isinstance(s, dict)]
+
+
+def _is_commit_action(step: dict) -> bool:
+    return "vig-os/commit-action" in str(step.get("uses", ""))
+
+
+def _is_branch_create(step: dict) -> bool:
+    run = str(step.get("run", ""))
+    return "git/refs" in run and '-f ref="refs/heads/$RELEASE_BRANCH"' in run
+
+
+def _index_where(steps: list[dict], pred, what: str) -> int:
+    for i, step in enumerate(steps):
+        if pred(step):
+            return i
+    raise AssertionError(f"no step {what}")
+
+
+@pytest.mark.parametrize("model", ["gitflow", "trunk"])
+def test_release_branch_is_created_before_the_changelog_freeze(model: str) -> None:
+    """Ordering invariant that makes the trunk render a literal substitution."""
+    steps = _steps(_prepare_doc(model), "prepare")
+    create = _index_where(steps, _is_branch_create, "creating release/X.Y.Z")
+    freeze = _index_where(steps, _is_commit_action, "committing the changelog freeze")
+    assert create < freeze, (
+        "release/X.Y.Z must be created BEFORE the changelog freeze, so the "
+        "freeze target can be the release branch under trunk (#1479)"
+    )
+
+
+def test_gitflow_freeze_still_targets_dev() -> None:
+    """The gitflow leg is unchanged: the freeze commit still lands on dev."""
+    steps = _steps(_prepare_doc("gitflow"), "prepare")
+    freeze = steps[_index_where(steps, _is_commit_action, "committing the freeze")]
+    assert (freeze.get("env") or {}).get("TARGET_BRANCH") == "refs/heads/dev"
+
+
+def test_trunk_freeze_targets_the_release_branch() -> None:
+    """Trunk: the freeze lands on release/X.Y.Z, never on the trunk (#1479)."""
+    steps = _steps(_prepare_doc("trunk"), "prepare")
+    freeze = steps[_index_where(steps, _is_commit_action, "committing the freeze")]
+    assert (freeze.get("env") or {}).get("TARGET_BRANCH") == TRUNK_FREEZE_TARGET
+
+
+def test_trunk_never_commits_to_the_trunk_branch() -> None:
+    """No commit-action anywhere in a trunk render writes to ``main``.
+
+    Both the prepare freeze and the rollback's changelog restore must target
+    the release branch: a direct push to the trunk is refused by a require-PR
+    ruleset unless the Commit App is a bypass actor — the collision class
+    #1227 resolved by not pushing to ``main`` at all.
+    """
+    doc = _prepare_doc("trunk")
+    targets = [
+        (step.get("env") or {}).get("TARGET_BRANCH")
+        for job in jobs(doc).values()
+        if isinstance(job, dict)
+        for step in (job.get("steps") or [])
+        if isinstance(step, dict) and _is_commit_action(step)
+    ]
+    assert targets, "expected at least one commit-action step"
+    assert set(targets) == {TRUNK_FREEZE_TARGET}, targets
+
+
+@pytest.mark.parametrize("job", ["prepare", "rollback"])
+def test_gitflow_freeze_ref_reads_dev(job: str) -> None:
+    """The freeze-target ref read (#617 wait, rollback guard) follows dev."""
+    refs = [
+        (step.get("env") or {}).get("FREEZE_REF")
+        for step in _steps(_prepare_doc("gitflow"), job)
+        if (step.get("env") or {}).get("FREEZE_REF")
+    ]
+    assert refs == ["heads/dev"], refs
+
+
+@pytest.mark.parametrize("job", ["prepare", "rollback"])
+def test_trunk_freeze_ref_reads_the_release_branch(job: str) -> None:
+    """Under trunk the freeze lives on the release branch, so its ref reads do too.
+
+    The rollback deletes ``release/X.Y.Z`` first, so its post-delete read of
+    this ref cannot resolve — which is exactly the "nothing to restore" answer
+    the trunk leg needs, and never a read of (or a write to) ``main``.
+    """
+    refs = [
+        (step.get("env") or {}).get("FREEZE_REF")
+        for step in _steps(_prepare_doc("trunk"), job)
+        if (step.get("env") or {}).get("FREEZE_REF")
+    ]
+    assert refs == [TRUNK_FREEZE_REF], refs
+
+
+@pytest.mark.parametrize("model", ["gitflow", "trunk"])
+def test_release_branch_fast_forward_is_gated_and_non_forcing(model: str) -> None:
+    """Step 5 is a NON-force FF, taken only on a branch this run created.
+
+    A pre-existing ``release/X.Y.Z`` (re-prepare race; ``validate`` normally
+    rejects it) may already carry commits that are not ancestors of the freeze
+    commit, where the update is not a fast-forward at all — so the tolerant
+    pre-#1479 behaviour is kept by skipping it.
+    """
+    steps = _steps(_prepare_doc(model), "prepare")
+    ff = [s for s in steps if "-X PATCH" in str(s.get("run", ""))]
+    assert len(ff) == 1, "expected exactly one release-branch fast-forward step"
+    assert "-F force=false" in str(ff[0]["run"]), (
+        "the release-branch fast-forward must pin force=false"
+    )
+    assert "branch_created == 'true'" in str(ff[0].get("if", "")), (
+        "the fast-forward must be gated on this run having created the branch"
+    )
+
+
+@pytest.mark.parametrize("model", ["gitflow", "trunk"])
+def test_open_pr_refuses_a_zero_commit_release_pr(model: str) -> None:
+    """The same-SHA guard: head == base is caught in-workflow, before the PR call.
+
+    GitHub refuses to open a PR whose head and base resolve to the same commit
+    ("No commits between main and release/X.Y.Z") — the exact trunk failure of
+    #1479. A local-git simulation cannot express that server-side refusal (why
+    the #1206 spike could not catch it), so the workflow asserts it itself.
+    """
+    steps = _steps(_prepare_doc(model), "open-pr")
+    step = steps[
+        _index_where(
+            steps,
+            lambda s: "gh pr create" in str(s.get("run", "")),
+            "opening the draft PR",
+        )
+    ]
+    run = str(step["run"])
+    guard = run.find('"$BASE_SHA" = "$HEAD_SHA"')
+    assert guard != -1, (
+        "the PR-opening step must compare the resolved base and head SHAs"
+    )
+    assert guard < run.find("gh pr create"), (
+        "the same-SHA guard must run before the PR is created"
+    )
 
 
 # ── guards (enum + contradiction) ────────────────────────────────────────────


### PR DESCRIPTION
## Description

Fixes the trunk release train. Under `DEVKIT_WORKFLOW=trunk`,
`render_workflow_model()` was a pure literal `dev` -> `main` rewrite, so
`prepare-release.yml` froze the CHANGELOG onto `main` and then cut
`release/X.Y.Z` from that **same post-freeze SHA**, while the draft PR was still
opened `--base main --head release/X.Y.Z`. Head and base resolved to one commit
and `gh pr create` failed with *"No commits between main and release/X.Y.Z"*.
The same freeze was also a direct push to the protected trunk.

`vig-os/org-config` is blocked on exactly this; its `v1.0.0`/`v1.0.1` were
hand-cut, so the train has never executed there and the defect stayed latent.

## Type of Change

- [x] `fix` -- Bug fix

## Changes Made

The shipped (gitflow) asset is restructured into a **model-agnostic ordering**,
so the trunk render stays a literal substitution with no step reordering in sed:

1. capture `prepare_start_sha` = base head (`dev`; trunk: `main`)
2. **create `release/X.Y.Z` at that pre-freeze SHA** — moved ahead of the freeze
3. freeze -> `TARGET_BRANCH` = `refs/heads/dev` (trunk: the release branch)
4. `freeze_wait` — the #617 read-after-write loop, now watching `FREEZE_REF`
5. fast-forward `release/X.Y.Z` onto the freeze commit (`force=false`); under
   trunk the SHAs already match and the step short-circuits

`open-pr` gained an explicit **same-SHA guard** before `gh pr create` — the
regression assert the issue asks for, since a local-git simulation cannot express
GitHub's server-side refusal (which is why the #1206 spike could not catch this).

Verified on the actual trunk render: base reads resolve to `heads/main`, the
freeze `TARGET_BRANCH` and `FREEZE_REF` resolve to the release branch, the
rollback's restore target likewise, and there are **zero residual bare `dev`
tokens**. The freeze therefore never touches the trunk, so **no Commit App bypass
on `main` is required** — consistent with how #1227 was resolved.

**gitflow is behaviourally unchanged**: the freeze still lands on `dev` and the
release branch still ends at the freeze commit (now by fast-forward instead of by
late creation). `test_gitflow_scaffold_matches_default_path` and
`test_gitflow_render_files_are_byte_identical_to_template` still pass.

Incidental improvement: a failure *between* the freeze and branch creation used
to leave `dev_sha` empty, silently skipping the rollback's changelog restore;
`freeze_sha` is now emitted immediately after the freeze.

## Changelog Entry

```
### Fixed

- **Trunk release: cut the release branch before the changelog freeze**
  ([#1479](https://github.com/vig-os/devkit/issues/1479))
```
(full entry with sub-bullets is in `CHANGELOG.md`)

## Testing

- [x] `uv run pytest tests/test_workflow_model.py` -> 12 failed before the fix, **32 passed** after
- [x] `uv run pytest tests/test_workflow_model.py tests/test_workflow_prepare_extension.py tests/test_release_core.py tests/test_release_rollback_guard.py tests/test_scaffold_lint.py tests/test_scaffold_drift.py` -> 136 passed
- [x] full suite `uv run pytest -m "not integration"` -> 1355 passed, 20 skipped
- [x] `just test-bats` -> 506 ok, 0 not ok — including a **new** case running actionlint over the *trunk*-rendered workflows (previously only gitflow renders were linted)
- [x] `prek run --all-files` -> only `check-expirations` fails; `.vulnixignore` is byte-identical to `dev` on this branch. **Fixed by #1482 — merge that first.**

### Manual Testing Details

Rendered a trunk scaffold and read the resulting `prepare-release.yml` directly to
confirm the branch/freeze/PR topology and the absence of `dev` residue.

**No live CI proof exists in this repo** — `devkit-smoke-test` is gitflow, so every
automated leg here exercises only the unchanged gitflow path. Live proof will be
`vig-os/org-config`'s next release train.

Closes #1479

Refs: #1479
