### PR TITLE
fix(scaffold): gate CI on the project languages a repo declares in .vig-os

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **CI fails when a declared language's project file disappears**
+  ([#1478](https://github.com/vig-os/devkit/issues/1478))
+  - New `.vig-os` key `DEVKIT_LANGUAGES` — a comma-separated subset of
+    `python,node,rust,nix` recording the languages a repo DECLARES. It is a
+    declaration, not a detection cache: the scaffold seeds it from the marker
+    files it detects, ADDS a newly detected language on a later upgrade, and
+    never removes one. Dropping a language is a deliberate hand-edit; the
+    scaffold prints a loud notice when a declared language's marker is absent,
+    and an unknown name fails the scaffold. The key ships empty, so a
+    language-neutral repo and every consumer adopting from an older devkit are
+    unaffected (the value is seeded on the adoption scaffold)
+  - New early gate in the scaffolded `ci.yml`: `resolve-toolchain` emits the
+    declared list as a `languages` output and one step fails the run when a
+    declared language's marker file (`pyproject.toml` / `package.json` /
+    `Cargo.toml`) is missing. It runs in the job every toolchain job already
+    `needs:`, so lint/test never start on a repo whose project is gone —
+    closing the blind spot that let a deleted Python suite report a green
+    `Tests` check ([#1466](https://github.com/vig-os/devkit/issues/1466)).
+    `nix` is declared but not gated (no single marker file)
+  - The scaffolded `justfile.project` recipes now REPORT the skip
+    (`no pyproject.toml — skipping`) instead of no-oping in silence, and
+    `test` / `test-cov` only swallow pytest's exit 5 ("no tests collected")
+    while the repo has no `tests/` directory — once one exists, zero collected
+    propagates as a failure
+
 ### Deprecated
 
 ### Removed

--- a/assets/init-workspace.sh
+++ b/assets/init-workspace.sh
@@ -355,6 +355,11 @@ MANIFEST_AUTO_UPGRADE="$(read_manifest_value "$VIG_OS_MANIFEST" DEVKIT_AUTO_UPGR
 MANIFEST_UPGRADE_EXCLUDE="$(read_manifest_value "$VIG_OS_MANIFEST" DEVKIT_UPGRADE_EXCLUDE || true)"
 MANIFEST_DRIFT_CHECK="$(read_manifest_value "$VIG_OS_MANIFEST" DEVKIT_DRIFT_CHECK || true)"
 
+# Declared project languages (#1478): read before the template overwrite, both to
+# seed the sticky declaration further down and to write it back — the template
+# ships the key empty, so without the read an upgrade would erase the declaration.
+MANIFEST_LANGUAGES="$(read_manifest_value "$VIG_OS_MANIFEST" DEVKIT_LANGUAGES || true)"
+
 # The pin this workspace carried BEFORE this run rewrites it (#1348). Read here,
 # far ahead of the #852 rewrite further down, because it is the only evidence of
 # which devkit generation produced the tree we are upgrading — and the
@@ -591,6 +596,44 @@ case "$MANIFEST_DRIFT_CHECK" in
         exit 1
         ;;
 esac
+
+# Declared project languages (#1478): the repo's own statement of which language
+# projects it is expected to carry. Parsed here (the same charset/enum guard shape
+# as DEVKIT_FEATURES_DISABLED — an unknown name aborts rather than silently
+# declaring nothing); SEEDED from detection and only ever GROWN further down,
+# where DETECTED_LANGUAGES is computed. Pure `.vig-os` key, no CLI flag.
+VALID_LANGUAGES=(python node rust nix)
+DECLARED_LANGUAGES=()
+
+# True when language $1 is already in DECLARED_LANGUAGES.
+language_declared() {
+    local name="$1" l
+    for l in ${DECLARED_LANGUAGES[@]+"${DECLARED_LANGUAGES[@]}"}; do
+        [[ "$l" == "$name" ]] && return 0
+    done
+    return 1
+}
+
+if [[ -n "$MANIFEST_LANGUAGES" ]]; then
+    IFS=',' read -ra _raw_langs <<< "$MANIFEST_LANGUAGES"
+    for _lang in "${_raw_langs[@]}"; do
+        # Trim surrounding whitespace (leading + trailing).
+        _lang="${_lang#"${_lang%%[![:space:]]*}"}"
+        _lang="${_lang%"${_lang##*[![:space:]]}"}"
+        [[ -z "$_lang" ]] && continue
+        _valid_lang=false
+        for _v in "${VALID_LANGUAGES[@]}"; do
+            [[ "$_lang" == "$_v" ]] && { _valid_lang=true; break; }
+        done
+        if [[ "$_valid_lang" != "true" ]]; then
+            echo "Error: Invalid DEVKIT_LANGUAGES in $VIG_OS_MANIFEST: $_lang (expected a comma-separated subset of: python, node, rust, nix)" >&2
+            exit 1
+        fi
+        # De-duplicate: the value is rewritten on every scaffold, so a repeated
+        # entry must not multiply across upgrades.
+        language_declared "$_lang" || DECLARED_LANGUAGES+=("$_lang")
+    done
+fi
 
 # Get SHORT_NAME - from env var, manifest, or prompt (#885)
 if [[ -z "${SHORT_NAME:-}" && -n "$MANIFEST_PROJECT" ]]; then
@@ -942,6 +985,54 @@ if find "$WORKSPACE_DIR" \
     | grep -q .; then
     DETECTED_LANGUAGES+=("nix")
 fi
+
+# ── declared languages: seed from detection, never narrow (#1478) ─────────────
+# DETECTED_LANGUAGES above is live truth and keeps driving every scaffold render
+# (.gitignore fragments, codeql.yml's language matrix, the Node justfile.project
+# seed). DECLARED_LANGUAGES is the repo's persisted DECLARATION, written back to
+# .vig-os, and it is deliberately NOT a detection cache: the scaffold seeds it
+# from detection, ADDS a language that appeared since the last run, and never
+# removes one. A cache would not have caught #1466 — the deploy that deleted
+# pyproject.toml re-ran the scaffold in the same commit, so the cache would have
+# been rewritten to empty and CI would still have been green. Divergence between
+# declared and detected is exactly the signal the CI gate exists to surface, so
+# it is reported loudly here and reconciled by nobody but the consumer.
+for lang in ${DETECTED_LANGUAGES[@]+"${DETECTED_LANGUAGES[@]}"}; do
+    language_declared "$lang" || DECLARED_LANGUAGES+=("$lang")
+done
+
+# Canonicalize to the VALID_LANGUAGES order so the written-back value is
+# deterministic (a hand-written `node,python` normalizes once, then is stable —
+# an unstable order would read as scaffold drift on every upgrade).
+_ordered_languages=()
+for _v in "${VALID_LANGUAGES[@]}"; do
+    language_declared "$_v" && _ordered_languages+=("$_v")
+done
+DECLARED_LANGUAGES=(${_ordered_languages[@]+"${_ordered_languages[@]}"})
+
+# Loud notice per declared-but-undetected language: the scaffold keeps the
+# declaration (sticky), it does not reconcile it. `nix` is called out separately
+# because CI cannot gate it — it has no single marker file.
+for lang in ${DECLARED_LANGUAGES[@]+"${DECLARED_LANGUAGES[@]}"}; do
+    _still_detected=false
+    for _d in ${DETECTED_LANGUAGES[@]+"${DETECTED_LANGUAGES[@]}"}; do
+        [[ "$_d" == "$lang" ]] && { _still_detected=true; break; }
+    done
+    [[ "$_still_detected" == "true" ]] && continue
+    case "$lang" in
+        python) _marker="pyproject.toml" ;;
+        node) _marker="package.json" ;;
+        rust) _marker="Cargo.toml" ;;
+        nix) _marker="*.nix files beyond flake.nix" ;;
+        *) _marker="its marker file" ;;
+    esac
+    echo "Notice: DEVKIT_LANGUAGES declares '$lang' but $_marker is absent." >&2
+    if [[ "$lang" == "nix" ]]; then
+        echo "Notice: the declaration is STICKY — the scaffold keeps '$lang' (CI does not gate nix: it has no single marker file). Drop it from DEVKIT_LANGUAGES in .vig-os if this repo is deliberately no longer a nix project (#1478)." >&2
+    else
+        echo "Notice: the declaration is STICKY — the scaffold keeps '$lang', and CI's declared-language gate will FAIL until $_marker is restored. Drop '$lang' from DEVKIT_LANGUAGES in .vig-os if this repo is deliberately no longer a $lang project (#1478)." >&2
+    fi
+done
 
 # Seed npm-mapped justfile.project recipes on the FIRST scaffold of a Node
 # consumer (#1027). justfile.project is a PRESERVE_FILE: the stock template
@@ -2632,6 +2723,16 @@ if [[ -f "$VIG_OS_MANIFEST" ]]; then
     # silently re-enables the drift gate the consumer disabled.
     if [[ -n "$MANIFEST_DRIFT_CHECK" ]]; then
         write_manifest_value DEVKIT_DRIFT_CHECK "$MANIFEST_DRIFT_CHECK"
+    fi
+    # Declared languages (#1478): bare in the template (DEVKIT_LANGUAGES=), so
+    # the declaration is written back — else an upgrade would erase it and the
+    # CI gate would go silent exactly when it is needed. Unlike the other
+    # round-tripped keys this one is not merely preserved: it is the union of
+    # the previous declaration and this run's detection, so a first scaffold
+    # SEEDS it and a later one GROWS it. A language-neutral repo has an empty
+    # union and keeps the bare template line.
+    if [[ ${#DECLARED_LANGUAGES[@]} -gt 0 ]]; then
+        write_manifest_value DEVKIT_LANGUAGES "$(IFS=','; echo "${DECLARED_LANGUAGES[*]}")"
     fi
 fi
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -91,6 +91,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **CI fails when a declared language's project file disappears**
+  ([#1478](https://github.com/vig-os/devkit/issues/1478))
+  - New `.vig-os` key `DEVKIT_LANGUAGES` — a comma-separated subset of
+    `python,node,rust,nix` recording the languages a repo DECLARES. It is a
+    declaration, not a detection cache: the scaffold seeds it from the marker
+    files it detects, ADDS a newly detected language on a later upgrade, and
+    never removes one. Dropping a language is a deliberate hand-edit; the
+    scaffold prints a loud notice when a declared language's marker is absent,
+    and an unknown name fails the scaffold. The key ships empty, so a
+    language-neutral repo and every consumer adopting from an older devkit are
+    unaffected (the value is seeded on the adoption scaffold)
+  - New early gate in the scaffolded `ci.yml`: `resolve-toolchain` emits the
+    declared list as a `languages` output and one step fails the run when a
+    declared language's marker file (`pyproject.toml` / `package.json` /
+    `Cargo.toml`) is missing. It runs in the job every toolchain job already
+    `needs:`, so lint/test never start on a repo whose project is gone —
+    closing the blind spot that let a deleted Python suite report a green
+    `Tests` check ([#1466](https://github.com/vig-os/devkit/issues/1466)).
+    `nix` is declared but not gated (no single marker file)
+  - The scaffolded `justfile.project` recipes now REPORT the skip
+    (`no pyproject.toml — skipping`) instead of no-oping in silence, and
+    `test` / `test-cov` only swallow pytest's exit 5 ("no tests collected")
+    while the repo has no `tests/` directory — once one exists, zero collected
+    propagates as a failure
+
 ### Deprecated
 
 ### Removed

--- a/assets/workspace/.github/actions/resolve-toolchain/action.yml
+++ b/assets/workspace/.github/actions/resolve-toolchain/action.yml
@@ -98,6 +98,13 @@ outputs:
       keeps ci.yml's scaffold-drift job enabled, `false` self-skips it. Emitted
       for every mode so the job's `if:` can gate on it with no re-scaffold.
     value: ${{ steps.resolve.outputs.drift-check }}
+  languages:
+    description: >-
+      Comma-separated project languages DECLARED in DEVKIT_LANGUAGES, for the
+      ci.yml gate that fails when a declared language's marker file is gone. An
+      EXPLICIT EMPTY STRING when the key is absent/empty (nothing declared), so
+      a language-neutral repo — and any consumer predating the key — stays green.
+    value: ${{ steps.resolve.outputs.languages }}
 
 runs:
   using: composite
@@ -120,6 +127,7 @@ runs:
         COMMIT_TYPES=""
         BRANCH_TYPES=""
         DRIFT_CHECK=""
+        LANGUAGES=""
 
         if [[ -f .vig-os ]]; then
           # Tolerant KEY=VALUE parsing shared with resolve-image (#781): capture
@@ -131,7 +139,7 @@ runs:
             [[ "$line" =~ ^[[:space:]]*# ]] && continue
 
             case "$line" in
-              DEVKIT_MODE=*|DEVKIT_VERSION=*|DEVCONTAINER_VERSION=*|DEVKIT_TAG_PREFIX=*|DEVKIT_FLOATING_TAGS=*|DEVKIT_CI_RUNNER=*|DEVKIT_REFS_POLICY=*|DEVKIT_COMMIT_TYPES=*|DEVKIT_BRANCH_TYPES=*|DEVKIT_DRIFT_CHECK=*)
+              DEVKIT_MODE=*|DEVKIT_VERSION=*|DEVCONTAINER_VERSION=*|DEVKIT_TAG_PREFIX=*|DEVKIT_FLOATING_TAGS=*|DEVKIT_CI_RUNNER=*|DEVKIT_REFS_POLICY=*|DEVKIT_COMMIT_TYPES=*|DEVKIT_BRANCH_TYPES=*|DEVKIT_DRIFT_CHECK=*|DEVKIT_LANGUAGES=*)
                 key="${line%%=*}"
                 value="${line#*=}"
                 value="${value#"${value%%[![:space:]]*}"}"
@@ -154,6 +162,7 @@ runs:
                   DEVKIT_COMMIT_TYPES) COMMIT_TYPES="$value" ;;
                   DEVKIT_BRANCH_TYPES) BRANCH_TYPES="$value" ;;
                   DEVKIT_DRIFT_CHECK) DRIFT_CHECK="$value" ;;
+                  DEVKIT_LANGUAGES) LANGUAGES="$value" ;;
                 esac
                 ;;
             esac
@@ -302,6 +311,26 @@ runs:
         DRIFT_CHECK="${DRIFT_CHECK:-true}"
         [[ "$DRIFT_CHECK" == "false" ]] || DRIFT_CHECK="true"
         echo "drift-check=$DRIFT_CHECK" >> "$GITHUB_OUTPUT"
+
+        # Declared languages (#1478): DEVKIT_LANGUAGES is the repo's own
+        # statement of which language projects it carries — a DECLARATION the
+        # scaffold seeds and only ever grows, never a detection cache. Normalize
+        # only (trim each entry, drop empties); the enum guard lives at the write
+        # path (init-workspace.sh) and the ci.yml gate skips a name it cannot map
+        # to a marker, so a surprise literal warns instead of breaking CI.
+        # Emitted for every mode, ALWAYS (an explicit empty string when nothing
+        # is declared) so the gate can treat empty as "nothing to assert".
+        RESOLVED_LANGUAGES=""
+        if [[ -n "$LANGUAGES" ]]; then
+          IFS=',' read -ra language_entries <<< "$LANGUAGES"
+          for entry in "${language_entries[@]}"; do
+            entry="${entry#"${entry%%[![:space:]]*}"}"
+            entry="${entry%"${entry##*[![:space:]]}"}"
+            [[ -z "$entry" ]] && continue
+            RESOLVED_LANGUAGES+="${RESOLVED_LANGUAGES:+,}$entry"
+          done
+        fi
+        echo "languages=$RESOLVED_LANGUAGES" >> "$GITHUB_OUTPUT"
 
         # Resolve the version tag: explicit override wins, else DEVKIT_VERSION,
         # else the legacy DEVCONTAINER_VERSION.

--- a/assets/workspace/.github/workflows/ci.yml
+++ b/assets/workspace/.github/workflows/ci.yml
@@ -105,6 +105,9 @@ jobs:
           sparse-checkout: |
             .vig-os
             .github/actions/resolve-toolchain
+            pyproject.toml
+            package.json
+            Cargo.toml
           sparse-checkout-cone-mode: false
 
       - name: Resolve toolchain
@@ -114,6 +117,65 @@ jobs:
           registry-token: ${{ secrets.GHCR_PULL_TOKEN || github.token }}
           registry-username: ${{ github.actor }}
           image-tag: ${{ inputs.image-tag }}
+
+      # Declared-language gate (#1478). `just test` / `just lint` are guarded on
+      # `[ -f pyproject.toml ]` and exit 0 when it is absent, so a repo whose
+      # entire Python project was deleted still reported a green `Tests` check
+      # (#1466) — CI could not tell "no suite by design" from "the suite
+      # vanished". The `.vig-os` declaration is the missing evidence; this step
+      # asserts it.
+      #
+      # ONE gate for the whole workflow, run as a step of resolve-toolchain
+      # rather than as its own job: every toolchain job already `needs:` this
+      # one, so a failure here stops lint/test/commit-checks before they start
+      # (which covers the identical lint/format blind spot at the same time), it
+      # reuses the checkout this job already performs, and it costs no extra
+      # runner, container pull or `needs:` edge in the summary gate. The marker
+      # files are added to the sparse checkout above for exactly this step.
+      #
+      # A language-neutral repo declares nothing and stays green. `nix` is
+      # declared but never gated: it has no single marker file (flake.nix ships
+      # with every direnv scaffold), so its absence is not decidable from a path.
+      # The declared list reaches the shell via env, never inline `${{ }}` (the
+      # zizmor template-injection gate / #1279 env-routing pattern).
+      - name: Check declared languages
+        env:
+          LANGUAGES: ${{ steps.resolve.outputs.languages }}
+        run: |
+          set -euo pipefail
+          if [[ -z "$LANGUAGES" ]]; then
+            echo "No languages declared in .vig-os (DEVKIT_LANGUAGES) — nothing to check."
+            exit 0
+          fi
+
+          MISSING=()
+          IFS=',' read -ra declared <<< "$LANGUAGES"
+          for lang in "${declared[@]}"; do
+            case "$lang" in
+              python) marker="pyproject.toml" ;;
+              node) marker="package.json" ;;
+              rust) marker="Cargo.toml" ;;
+              nix)
+                echo "Declared language 'nix': no single marker file — not gated."
+                continue
+                ;;
+              *)
+                echo "::warning::Unknown language '$lang' in DEVKIT_LANGUAGES — not gated. Expected a subset of: python, node, rust, nix."
+                continue
+                ;;
+            esac
+            if [[ -f "$marker" ]]; then
+              echo "Declared language '$lang': $marker present."
+            else
+              echo "::error::Declared language '$lang' but $marker is missing from the repository root."
+              MISSING+=("$lang ($marker)")
+            fi
+          done
+
+          if [[ ${#MISSING[@]} -gt 0 ]]; then
+            echo "::error::.vig-os declares language(s) whose project file is gone: ${MISSING[*]}. The lint/test recipes skip a language whose marker file is absent, so nothing else in this workflow would notice. Restore the missing file(s), or — if the language was dropped deliberately — remove it from DEVKIT_LANGUAGES in .vig-os."
+            exit 1
+          fi
 
   lint:
     name: Lint & Format

--- a/assets/workspace/.vig-os
+++ b/assets/workspace/.vig-os
@@ -147,3 +147,21 @@ DEVKIT_UPGRADE_EXCLUDE=
 # it via resolve-toolchain's `drift-check` output, so flipping it takes effect
 # with no re-scaffold; the value round-trips across `--force` upgrades (#1295).
 DEVKIT_DRIFT_CHECK=
+
+# Project languages this repo DECLARES — a comma-separated (whitespace-tolerant)
+# subset of: python, node, rust, nix. A DECLARATION, not a detection cache. The
+# scaffold SEEDS it from the marker files it detects (pyproject.toml /
+# package.json / Cargo.toml / *.nix beyond flake.nix) and ADDS a newly detected
+# language on a later upgrade, but NEVER removes one — dropping a language is a
+# deliberate hand-edit of this line, and the scaffold prints a loud notice when a
+# declared language's marker is absent. Stickiness is the whole point: a deploy
+# that deleted a repo's entire Python project also re-ran the scaffold in the
+# same commit, so a cache would have been rewritten to empty and the `Tests`
+# check stayed green (#1466). Empty (default) => nothing declared, so a
+# language-neutral repo (and every consumer upgrading from an older devkit,
+# whose key is seeded from detection on the adoption scaffold) is unaffected.
+# Pure runtime gate — CI reads it via resolve-toolchain's `languages` output and
+# fails ONE early ci.yml step when a declared language's marker file is missing;
+# `nix` is declared but never gated (no single marker file). Written back only
+# for a non-empty value (#1478).
+DEVKIT_LANGUAGES=

--- a/assets/workspace/justfile.project
+++ b/assets/workspace/justfile.project
@@ -24,15 +24,21 @@ info:
 # CODE QUALITY
 # -------------------------------------------------------------------------------
 
+# The uv-backed recipes below are guarded on pyproject.toml so they stay safe in
+# a non-Python repo — but they REPORT the skip instead of no-oping in silence: a
+# repo that lost its pyproject.toml used to run nothing, print nothing and exit 0
+# (#1478). Whether the skip is legitimate is asserted once in CI, against the
+# languages this repo declares in .vig-os (DEVKIT_LANGUAGES).
+
 # Run all linters
 [group('quality')]
 lint:
-    @if [ -f pyproject.toml ]; then uv run ruff check .; fi
+    @if [ -f pyproject.toml ]; then uv run ruff check .; else echo "just lint: no pyproject.toml — skipping"; fi
 
 # Format code
 [group('quality')]
 format:
-    @if [ -f pyproject.toml ]; then uv run ruff format .; fi
+    @if [ -f pyproject.toml ]; then uv run ruff format .; else echo "just format: no pyproject.toml — skipping"; fi
 
 # Run pre-commit hooks on all files
 [group('quality')]
@@ -43,15 +49,18 @@ precommit:
 # TESTING
 # -------------------------------------------------------------------------------
 
-# Run tests with pytest (exit 5 = "no tests collected" is a no-op, not a failure)
+# Run tests with pytest. Exit 5 ("no tests collected") is a no-op ONLY while the
+# repo has no tests/ directory — a fresh scaffold. Once a test directory exists,
+# zero collected is a signal, not a no-op, so it propagates (#1281 narrowed by
+# #1478).
 [group('test')]
 test *args:
-    @if [ -f pyproject.toml ]; then uv run pytest {{ args }} || { rc=$?; [ "$rc" -eq 5 ] || exit "$rc"; }; fi
+    @if [ ! -f pyproject.toml ]; then echo "just test: no pyproject.toml — skipping"; elif uv run pytest {{ args }}; then :; else rc=$?; if [ "$rc" -eq 5 ] && [ ! -d tests ]; then echo "just test: no tests collected and no tests/ directory — skipping"; else exit "$rc"; fi; fi
 
-# Run tests with coverage (exit 5 = "no tests collected" is a no-op, not a failure)
+# Run tests with coverage (same exit-5 rule as `test` above)
 [group('test')]
 test-cov *args:
-    @if [ -f pyproject.toml ]; then uv run pytest --cov --cov-report=term-missing {{ args }} || { rc=$?; [ "$rc" -eq 5 ] || exit "$rc"; }; fi
+    @if [ ! -f pyproject.toml ]; then echo "just test-cov: no pyproject.toml — skipping"; elif uv run pytest --cov --cov-report=term-missing {{ args }}; then :; else rc=$?; if [ "$rc" -eq 5 ] && [ ! -d tests ]; then echo "just test-cov: no tests collected and no tests/ directory — skipping"; else exit "$rc"; fi; fi
 
 # -------------------------------------------------------------------------------
 # DEPENDENCIES
@@ -60,7 +69,7 @@ test-cov *args:
 # Sync dependencies (all groups; extras are opt-in, e.g. `just sync --all-extras`)
 [group('deps')]
 sync *args="--all-groups":
-    @if [ -f pyproject.toml ]; then uv sync {{ args }}; fi
+    @if [ -f pyproject.toml ]; then uv sync {{ args }}; else echo "just sync: no pyproject.toml — skipping"; fi
 
 # Update all dependencies
 [group('deps')]

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -395,6 +395,39 @@ unknown keys:
 | `DEVKIT_BRANCH_TYPES` | Comma-separated FULL REPLACEMENT of the issue-numbered `<type>/<issue>-<summary>` branch-type set, driving the local `no-commit-to-branch` guard, the flake-generated consumer surface, and CI's branch-name gate; empty (default) => the stock set (`feature,bugfix,hotfix,release,docs,test,refactor`). The `chore/`, `renovate/`, `worktree/` clauses are never knob-driven. Pre-#1432 direnv consumers hand-port the flake reader (see [Commit and branch policy on the flake surface](#commit-and-branch-policy-on-the-flake-surface-direnv-consumers), [#1432](https://github.com/vig-os/devkit/issues/1432)) |
 | `DEVKIT_AUTO_UPGRADE` | Opt-out for the scaffolded `devkit-upgrade.yml` weekly schedule; empty (default) or any value but `false` keeps the auto-adoption poll on. `false` disables only the schedule — manual `workflow_dispatch` always runs ([#1296](https://github.com/vig-os/devkit/issues/1296)) |
 | `DEVKIT_UPGRADE_EXCLUDE` | Comma-separated (whitespace-tolerant) paths the `devkit-upgrade` workflow resets before the adoption commit, so generated-doc churn never rides along in the upgrade diff; empty (default) => no exclusions ([#1296](https://github.com/vig-os/devkit/issues/1296)) |
+| `DEVKIT_LANGUAGES` | Comma-separated (whitespace-tolerant) subset of `python,node,rust,nix` the repo DECLARES. A declaration, not a detection cache: the scaffold seeds it from detection, ADDS a newly detected language, and never removes one (see [Declared project languages](#declared-project-languages), [#1478](https://github.com/vig-os/devkit/issues/1478)) |
+
+### Declared project languages
+
+`DEVKIT_LANGUAGES` records which language projects a repo is *expected* to
+carry, so CI can tell "this repo has no Python suite by design" from "this
+repo's Python suite vanished". The scaffolded `just test` / `just lint` recipes
+are guarded on `[ -f pyproject.toml ]` and exit 0 when it is absent, so before
+this key a repo that lost its whole Python project still reported a green
+`Tests` check ([#1466](https://github.com/vig-os/devkit/issues/1466)).
+
+- **Seeded, then sticky.** The scaffold seeds the key from the marker files it
+  detects (`pyproject.toml` -> `python`, `package.json` -> `node`,
+  `Cargo.toml` -> `rust`, `*.nix` beyond `flake.nix` -> `nix`) and ADDS a
+  language that appeared since the last run. It NEVER removes one. Stickiness is
+  the point: a detection cache would be rewritten to empty by the same scaffold
+  run that observed the deletion.
+- **Removing a language is a hand-edit** of the `.vig-os` line. When a declared
+  language's marker is absent, the scaffold keeps the declaration and prints a
+  loud notice; an unknown language name fails the scaffold.
+- **The CI gate.** `resolve-toolchain` emits the declared list as its
+  `languages` output and one early `ci.yml` step fails when a declared
+  language's marker file is missing. It runs in the job every toolchain job
+  already `needs:`, so lint/test never start against a repo whose project is
+  gone. `nix` is declared but never gated — it has no single marker file, since
+  `flake.nix` ships with every direnv scaffold.
+- **Adoption is a no-op.** The key ships empty; a consumer upgrading from an
+  older devkit has it seeded from detection on the adoption scaffold, and a
+  language-neutral repo declares nothing and stays green.
+- The declaration drives the gate ONLY. `.gitignore` fragments, the `codeql.yml`
+  language matrix and the Node `justfile.project` seed keep rendering from live
+  detection — divergence between declared and detected is exactly the signal the
+  gate exists to surface.
 
 ### Scaffold feature opt-outs
 

--- a/tests/bats/just.bats
+++ b/tests/bats/just.bats
@@ -395,3 +395,81 @@ STUB
     assert_line "LD_LIBRARY_PATH=/pre/existing"
     refute_output --partial "LD_LIBRARY_PATH=:"
 }
+
+# ── recipe skip/exit-5 semantics (#1478) ──────────────────────────────────────
+# The scaffolded recipes are guarded on `[ -f pyproject.toml ]`, so a repo whose
+# Python project was deleted ran NOTHING and exited 0 — silently (#1466). Two
+# mitigations: the guard now reports the skip instead of no-oping in silence,
+# and pytest's exit 5 ("no tests collected") is swallowed ONLY while the repo has
+# no `tests/` directory. Once a test directory exists, zero collected is a
+# signal, not a no-op (#1281 narrowed, not reverted).
+
+_recipe_fixture() {
+    RC_DIR="$BATS_TEST_TMPDIR/recipes"
+    mkdir -p "$RC_DIR/bin"
+    cp "$PROJECT_ROOT/assets/workspace/justfile" "$RC_DIR/justfile"
+    cp "$PROJECT_ROOT/assets/workspace/justfile.project" "$RC_DIR/justfile.project"
+    # `just` substitutes {{SHORT_NAME}} at scaffold time; do the same here.
+    sed -i 's/{{SHORT_NAME}}/testproj/' "$RC_DIR/justfile.project"
+}
+
+# A `uv` stub whose `run pytest` exits with $1 (5 = no tests collected).
+_uv_stub() {
+    cat > "$RC_DIR/bin/uv" <<STUB
+#!/usr/bin/env bash
+echo "uv \$*"
+exit $1
+STUB
+    chmod +x "$RC_DIR/bin/uv"
+}
+
+@test "just test reports the skip when pyproject.toml is absent (#1478)" {
+    _recipe_fixture
+    run just -f "$RC_DIR/justfile" -d "$RC_DIR" test
+    assert_success
+    assert_output --partial "pyproject.toml"
+    assert_output --partial "skipping"
+}
+
+@test "just lint/format/sync report the skip when pyproject.toml is absent (#1478)" {
+    _recipe_fixture
+    for recipe in lint format sync; do
+        run just -f "$RC_DIR/justfile" -d "$RC_DIR" "$recipe"
+        assert_success
+        assert_output --partial "skipping"
+    done
+}
+
+@test "just test swallows pytest exit 5 when there is no tests/ directory (#1281)" {
+    _recipe_fixture
+    _uv_stub 5
+    touch "$RC_DIR/pyproject.toml"
+    run env PATH="$RC_DIR/bin:$PATH" just -f "$RC_DIR/justfile" -d "$RC_DIR" test
+    assert_success
+}
+
+@test "just test propagates pytest exit 5 once a tests/ directory exists (#1478)" {
+    _recipe_fixture
+    _uv_stub 5
+    touch "$RC_DIR/pyproject.toml"
+    mkdir -p "$RC_DIR/tests"
+    run env PATH="$RC_DIR/bin:$PATH" just -f "$RC_DIR/justfile" -d "$RC_DIR" test
+    assert_failure
+}
+
+@test "just test-cov propagates pytest exit 5 once a tests/ directory exists (#1478)" {
+    _recipe_fixture
+    _uv_stub 5
+    touch "$RC_DIR/pyproject.toml"
+    mkdir -p "$RC_DIR/tests"
+    run env PATH="$RC_DIR/bin:$PATH" just -f "$RC_DIR/justfile" -d "$RC_DIR" test-cov
+    assert_failure
+}
+
+@test "just test still propagates a real pytest failure (#1478)" {
+    _recipe_fixture
+    _uv_stub 1
+    touch "$RC_DIR/pyproject.toml"
+    run env PATH="$RC_DIR/bin:$PATH" just -f "$RC_DIR/justfile" -d "$RC_DIR" test
+    assert_failure
+}

--- a/tests/test_declared_languages.py
+++ b/tests/test_declared_languages.py
@@ -1,0 +1,294 @@
+"""Scaffold + workflow tests: the declared-language manifest key and CI gate.
+
+Issue #1478: ``just test`` / ``just lint`` are guarded on ``[ -f pyproject.toml ]``
+and exit 0 when the marker is absent, so a repo whose whole Python project was
+deleted still reported a green ``Tests`` check (live instance: the 1.8.0-rc3
+smoke deploy, #1466). Detection alone cannot close that hole — the deploy that
+deleted ``pyproject.toml`` also re-ran the scaffold, so a detection *cache* would
+have been rewritten to empty in the same commit.
+
+The fix is a STICKY declaration: ``DEVKIT_LANGUAGES`` in ``.vig-os`` is seeded
+from detection on scaffold, grows when a new language appears, and is NEVER
+narrowed by the scaffold — removing a language is a deliberate hand-edit.
+``resolve-toolchain`` re-emits it as the ``languages`` output and ``ci.yml``
+fails early when a declared language's marker file is gone.
+
+Refs: #1478, #1466, #1281
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from typing import TYPE_CHECKING
+
+import pytest
+
+from tests.workflow_scaffold import (
+    WORKFLOWS,
+    load_workflow,
+    run_resolve_toolchain,
+    scaffold,
+    step_by_name,
+    steps_of_job,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+# The manifest key and the resolve-toolchain output that re-exports it.
+LANGUAGES_KEY = "DEVKIT_LANGUAGES"
+LANGUAGES_OUTPUT = "languages"
+
+# The ci.yml step that gates declared languages on their marker files.
+GATE_STEP = "Check declared languages"
+
+# Marker file per gated language (nix is declared but deliberately not gated —
+# flake.nix ships with every direnv scaffold, so absence is not decidable).
+MARKERS = {"python": "pyproject.toml", "node": "package.json", "rust": "Cargo.toml"}
+
+
+def _seed(tmp_path: Path, name: str, files: dict[str, str]) -> Path:
+    """Build a seed workspace tree with the given relative files."""
+    root = tmp_path / name
+    root.mkdir(parents=True)
+    for rel, content in files.items():
+        path = root / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+    return root
+
+
+def _read_key(manifest: Path, key: str) -> str:
+    """The value of ``key`` in a scaffolded ``.vig-os`` (empty when bare)."""
+    lines = manifest.read_text(encoding="utf-8").splitlines()
+    declarations = [ln for ln in lines if ln.startswith(f"{key}=")]
+    assert len(declarations) == 1, f"expected one {key}= line, found {declarations!r}"
+    return declarations[0].split("=", 1)[1]
+
+
+def _manifest(**keys: str) -> str:
+    """A minimal consumer .vig-os carrying the given keys."""
+    body = "DEVKIT_VERSION=1.2.3\nDEVKIT_MODE=both\n"
+    for key, value in keys.items():
+        body += f"{key}={value}\n"
+    return body
+
+
+def _scaffolded_languages(tmp_path: Path, seed: Path, name: str) -> str:
+    """Scaffold over ``seed`` and return the resulting DEVKIT_LANGUAGES value."""
+    proc = scaffold(tmp_path, seed=seed, name=name)
+    assert proc.returncode == 0, proc.stderr
+    return _read_key(tmp_path / name / ".vig-os", LANGUAGES_KEY)
+
+
+# ── Scaffold: seeding, stickiness, growth ────────────────────────────────────
+
+
+def test_languages_seeded_from_detection_on_python_repo(tmp_path: Path) -> None:
+    """A fresh scaffold of a Python repo declares `python`."""
+    seed = _seed(tmp_path, "seed", {"pyproject.toml": "[project]\nname='x'\n"})
+    assert _scaffolded_languages(tmp_path, seed, "py") == "python"
+
+
+def test_languages_stay_empty_for_language_neutral_repo(tmp_path: Path) -> None:
+    """A repo with no language marker declares nothing — and stays green."""
+    seed = _seed(tmp_path, "seed-neutral", {"README.md": "# neutral\n"})
+    assert _scaffolded_languages(tmp_path, seed, "neutral") == ""
+
+
+def test_languages_are_sticky_when_marker_disappears(tmp_path: Path) -> None:
+    """A re-scaffold NEVER removes a declared language (#1466).
+
+    This is the load-bearing property: the deploy that deleted pyproject.toml
+    re-ran the scaffold in the same commit, so a detection cache would have been
+    rewritten to empty and CI would still have been green.
+    """
+    seed = _seed(
+        tmp_path,
+        "seed-sticky",
+        {".vig-os": _manifest(**{LANGUAGES_KEY: "python"}), "README.md": "# x\n"},
+    )
+    proc = scaffold(tmp_path, seed=seed, name="sticky")
+    assert proc.returncode == 0, proc.stderr
+    assert _read_key(tmp_path / "sticky" / ".vig-os", LANGUAGES_KEY) == "python"
+
+
+def test_missing_marker_prints_a_loud_notice(tmp_path: Path) -> None:
+    """The scaffold names the declared language and its missing marker."""
+    seed = _seed(
+        tmp_path,
+        "seed-notice",
+        {".vig-os": _manifest(**{LANGUAGES_KEY: "python"}), "README.md": "# x\n"},
+    )
+    proc = scaffold(tmp_path, seed=seed, name="notice")
+    assert proc.returncode == 0, proc.stderr
+    combined = proc.stdout + proc.stderr
+    assert "python" in combined
+    assert "pyproject.toml" in combined
+    assert LANGUAGES_KEY in combined
+
+
+def test_newly_detected_language_is_added(tmp_path: Path) -> None:
+    """A language that appears since the last scaffold joins the declaration."""
+    seed = _seed(
+        tmp_path,
+        "seed-grow",
+        {
+            ".vig-os": _manifest(**{LANGUAGES_KEY: "python"}),
+            "pyproject.toml": "[project]\nname='x'\n",
+            "package.json": '{"name": "x"}\n',
+        },
+    )
+    assert _scaffolded_languages(tmp_path, seed, "grow") == "python,node"
+
+
+def test_languages_round_trip_across_force_upgrade(tmp_path: Path) -> None:
+    """A hand-declared value survives a `--force` upgrade unchanged."""
+    seed = _seed(
+        tmp_path,
+        "seed-rt",
+        {
+            ".vig-os": _manifest(**{LANGUAGES_KEY: "python,rust"}),
+            "pyproject.toml": "[project]\nname='x'\n",
+            "Cargo.toml": "[package]\nname='x'\n",
+        },
+    )
+    assert _scaffolded_languages(tmp_path, seed, "rt") == "python,rust"
+
+
+def test_invalid_language_aborts_the_scaffold(tmp_path: Path) -> None:
+    """An unknown language name fails loudly at the write path."""
+    seed = _seed(
+        tmp_path,
+        "seed-bad",
+        {".vig-os": _manifest(**{LANGUAGES_KEY: "klingon"})},
+    )
+    proc = scaffold(tmp_path, seed=seed, name="bad", check=False)
+    assert proc.returncode != 0
+    assert LANGUAGES_KEY in proc.stderr
+
+
+# ── resolve-toolchain: the `languages` output ────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        pytest.param(None, "", id="key-absent-empty"),
+        pytest.param("", "", id="key-empty"),
+        pytest.param("python", "python", id="single"),
+        pytest.param("python, node ,rust", "python,node,rust", id="whitespace-trimmed"),
+        pytest.param(" ,", "", id="all-blank-empty"),
+    ],
+)
+def test_languages_output_emission(
+    tmp_path: Path, value: str | None, expected: str
+) -> None:
+    """DEVKIT_LANGUAGES is normalized onto the `languages` output."""
+    manifest = "DEVKIT_MODE=direnv\nDEVKIT_VERSION=1.2.3\n"
+    if value is not None:
+        manifest += f"{LANGUAGES_KEY}={value}\n"
+    outputs = run_resolve_toolchain(tmp_path, manifest)
+    assert outputs[LANGUAGES_OUTPUT] == expected
+
+
+def test_languages_output_emitted_without_manifest(tmp_path: Path) -> None:
+    """No .vig-os at all still emits an explicit empty `languages`."""
+    outputs = run_resolve_toolchain(tmp_path, None, check=False)
+    assert outputs[LANGUAGES_OUTPUT] == ""
+
+
+# ── ci.yml: the gate's wiring ────────────────────────────────────────────────
+
+
+def test_gate_runs_in_resolve_toolchain_job() -> None:
+    """One early gate, in the job every toolchain job already `needs:`."""
+    workflow = load_workflow(WORKFLOWS / "ci.yml")
+    step = step_by_name(steps_of_job(workflow, "resolve-toolchain"), GATE_STEP)
+    assert step["run"], "the gate must carry a run block"
+
+
+def test_gate_routes_languages_through_env() -> None:
+    """The declared list reaches the shell via env, never inline (zizmor)."""
+    workflow = load_workflow(WORKFLOWS / "ci.yml")
+    step = step_by_name(steps_of_job(workflow, "resolve-toolchain"), GATE_STEP)
+    assert (
+        f"${{{{ steps.resolve.outputs.{LANGUAGES_OUTPUT} }}}}" in step["env"].values()
+    )
+    assert "${{" not in step["run"]
+
+
+@pytest.mark.parametrize("marker", sorted(MARKERS.values()))
+def test_resolve_toolchain_checkout_includes_markers(marker: str) -> None:
+    """The sparse checkout must fetch the marker files the gate tests for."""
+    workflow = load_workflow(WORKFLOWS / "ci.yml")
+    checkout = step_by_name(steps_of_job(workflow, "resolve-toolchain"), "Checkout")
+    patterns = checkout["with"]["sparse-checkout"].split()
+    assert marker in patterns
+
+
+# ── ci.yml: the gate's behavior (executed bash) ──────────────────────────────
+
+
+def _run_gate(tmp_path: Path, languages: str, markers: list[str]) -> tuple[int, str]:
+    """Execute the gate step's real bash against a tree carrying ``markers``."""
+    workflow = load_workflow(WORKFLOWS / "ci.yml")
+    step = step_by_name(steps_of_job(workflow, "resolve-toolchain"), GATE_STEP)
+    for marker in markers:
+        (tmp_path / marker).write_text("", encoding="utf-8")
+    proc = subprocess.run(
+        ["bash", "-c", step["run"]],
+        cwd=tmp_path,
+        env={**os.environ, "LANGUAGES": languages},
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return proc.returncode, proc.stdout + proc.stderr
+
+
+def test_gate_passes_for_language_neutral_repo(tmp_path: Path) -> None:
+    """No declaration => nothing to assert; a neutral repo stays green."""
+    rc, _ = _run_gate(tmp_path, "", [])
+    assert rc == 0
+
+
+@pytest.mark.parametrize(("language", "marker"), sorted(MARKERS.items()))
+def test_gate_passes_when_marker_present(
+    tmp_path: Path, language: str, marker: str
+) -> None:
+    rc, _ = _run_gate(tmp_path, language, [marker])
+    assert rc == 0
+
+
+@pytest.mark.parametrize(("language", "marker"), sorted(MARKERS.items()))
+def test_gate_fails_when_marker_absent(
+    tmp_path: Path, language: str, marker: str
+) -> None:
+    """The failure names the language, the marker, and the way out."""
+    rc, output = _run_gate(tmp_path, language, [])
+    assert rc == 1
+    assert language in output
+    assert marker in output
+    assert ".vig-os" in output
+
+
+def test_gate_fails_when_one_of_several_markers_is_absent(tmp_path: Path) -> None:
+    rc, output = _run_gate(tmp_path, "python,node", ["package.json"])
+    assert rc == 1
+    assert "pyproject.toml" in output
+
+
+def test_gate_skips_nix(tmp_path: Path) -> None:
+    """nix has no single marker file, so it is declared but never gated."""
+    rc, output = _run_gate(tmp_path, "nix", [])
+    assert rc == 0
+    assert "nix" in output
+
+
+def test_gate_warns_on_unknown_language(tmp_path: Path) -> None:
+    """An unmapped name warns; the loud guard lives at the scaffold write path."""
+    rc, output = _run_gate(tmp_path, "klingon", [])
+    assert rc == 0
+    assert "::warning::" in output

--- a/tests/test_vig_os_manifest.py
+++ b/tests/test_vig_os_manifest.py
@@ -8,7 +8,8 @@ the near-identical ``test_vig_os_declares_X_key`` /
 ``test_resolve_toolchain_emits_X_output`` tests that had accreted one per
 feature file (#1413).
 
-Refs: #1044, #1045, #1173, #1207, #1228, #1282, #1284, #1295, #1296, #1431
+Refs: #1044, #1045, #1173, #1207, #1228, #1282, #1284, #1295, #1296, #1431,
+#1478
 """
 
 from __future__ import annotations
@@ -32,6 +33,7 @@ MANIFEST_KEYS = [
     ("DEVKIT_AUTO_UPGRADE", "#1296"),
     ("DEVKIT_UPGRADE_EXCLUDE", "#1296"),
     ("DEVKIT_DRIFT_CHECK", "#1295"),
+    ("DEVKIT_LANGUAGES", "#1478"),
 ]
 
 # (output, issue) — outputs the resolve-toolchain composite action must declare
@@ -45,6 +47,7 @@ RESOLVE_OUTPUTS = [
     ("branch-types", "#1432"),
     ("drift-check", "#1295"),
     ("drift-image", "#1295"),
+    ("languages", "#1478"),
 ]
 
 


### PR DESCRIPTION
## Description

CI reported a green `Tests` check for a repo whose entire Python project had been
deleted. Two individually-correct leniencies composed into one blind spot: no
`pyproject.toml` -> the recipe body is skipped and exits 0; `pyproject.toml`
present but nothing collected -> pytest's exit 5 is swallowed (#1281). Together,
CI could not distinguish *"no Python suite by design"* from *"the Python suite
vanished"* — and reported success for both. That is why #1466's damage travelled
as far as it did.

## Type of Change

- [x] `fix` -- Bug fix

### Modifiers

- [ ] Breaking change

> **SemVer note:** this is arguably **minor**, not patch — it adds a consumer-facing
> `.vig-os` key and a new `resolve-toolchain` output, and it can turn a previously-green
> repo red (by design). Milestone `1.8.1` may need the same rename `1.7.1` -> `1.8.0` got.

## Changes Made

**The key is a sticky DECLARATION, not a detection cache.** A cache would not have
caught #1466: the deploy that deleted `pyproject.toml` re-ran the scaffold in the
same commit, so a cache would have been rewritten to empty and CI would still have
been green. So `DEVKIT_LANGUAGES` is seeded from detection, **grows** when a
language appears, and is **never** narrowed by the scaffold — removal is a
deliberate `.vig-os` hand-edit. A declared-but-undetected language prints a loud
scaffold notice rather than being silently reconciled.

- **`.vig-os`** — new `DEVKIT_LANGUAGES=` key, shipped empty, documented in house style.
- **`init-workspace.sh`** — read before the template overwrite (else an upgrade would
  erase the declaration); enum guard (unknown name aborts, `DEVKIT_FEATURES_DISABLED`
  shape); union with `DETECTED_LANGUAGES`; canonical ordering so the written-back
  value is deterministic and does not read as drift each upgrade.
- **`resolve-toolchain`** — new `languages` output, always emitted (explicit empty
  string when nothing is declared), following the `drift-check` precedent.
- **`ci.yml`** — one `Check declared languages` gate as a step of `resolve-toolchain`.
  Every toolchain job already `needs:` that job, so a failure stops lint/test/
  commit-checks before they start — which closes the identical `lint`/`format` blind
  spot (the issue's option 4) at the same time — and it costs no extra runner,
  container pull or `needs:` edge. **The gate lives in managed `ci.yml` on purpose:**
  `justfile.project` is a preserved file, so a recipe-only fix would never reach an
  existing consumer.
- **`justfile.project`** — recipes now report the skip instead of no-oping silently,
  and exit 5 is swallowed only while there is no `tests/` directory (the issue's
  options 2 and 3). The scaffold ships no `tests/` directory, so a fresh scaffold
  stays green.

`nix` is declared and notified but never gated in CI: it has no single marker file
(`flake.nix` ships with every direnv scaffold), so its absence is not decidable from
a path. Stated in the manifest comment, the action output, `ci.yml` and `MIGRATION.md`.

A language-neutral repo stays green at all three levels — bare template line, explicit
empty output, gate prints "nothing to check" and exits 0. A consumer whose `.vig-os`
predates the key resolves to the seeded-from-detection default; no hard failure is
reachable from an absent key.

## Changelog Entry

```
### Changed

- **Gate CI on the project languages a repo declares in .vig-os**
  ([#1478](https://github.com/vig-os/devkit/issues/1478))
```
(full entry with sub-bullets is in `CHANGELOG.md`)

## Testing

- [x] RED first: `uv run pytest tests/test_declared_languages.py` -> **28 failed**; `bats` filter -> 4 not ok
- [x] `uv run pytest tests/test_declared_languages.py tests/test_vig_os_manifest.py` -> **51 passed**
- [x] `uv run pytest` (+ `test_ci_runner`, `test_scaffold_drift`, `test_scaffold_lint`, `test_install_script`, `test_integration`) -> 223 passed, 19 skipped
- [x] full suite -> 1372 passed, 20 skipped
- [x] `just test-bats` -> 511 ok, 0 not ok
- [x] `prek run --all-files` -> only `check-expirations` fails; `.vulnixignore` is byte-identical to `dev` on this branch. **Fixed by #1482 — merge that first.**

### Manual Testing Details

Reproduced #1466's shape end to end: scaffolded a Python repo, deleted
`pyproject.toml`, re-scaffolded — the declaration **survived** and the notices
printed; the real `resolve-toolchain` script then emitted `languages=python` and
the real `ci.yml` gate step exited 1 with the diagnosable error.

Closes #1478

Refs: #1478
