### PR TITLE
docs(release): document the release-PR re-approval before promote

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     `test` / `test-cov` only swallow pytest's exit 5 ("no tests collected")
     while the repo has no `tests/` directory — once one exists, zero collected
     propagates as a failure
+- **Release docs: the release PR must be re-approved before promote**
+  ([#1474](https://github.com/vig-os/devkit/issues/1474))
+  - A final `release.yml` run's `finalize` job pushes to `release/X.Y.Z` (the
+    CHANGELOG date stamp and the `sync-issues` commit), which dismisses the PR
+    approval that same run required wherever stale-review dismissal is enabled.
+    `promote-release.yml` re-checks approvals before merging, so re-approving is
+    a mandatory step between the final and the promote dispatch
+  - `docs/RELEASE_CYCLE.md` now says so in Phase 2 step 7, the Phase 3
+    prerequisites, the release lifecycle diagram, and the `release.yml`
+    reference, and carries the re-approval commands as an explicit Phase 5 step
+    before the promote dispatch; `docs/DOWNSTREAM_RELEASE.md` mirrors the
+    operator step for consumers
+  - Documentation only — no workflow or behaviour change. Both approval gates
+    are kept: each guards a different irreversible act (burning the immutable
+    `X.Y.Z` tag; moving `:latest` and merging to `main`)
 
 ### Deprecated
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -115,6 +115,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     `test` / `test-cov` only swallow pytest's exit 5 ("no tests collected")
     while the repo has no `tests/` directory — once one exists, zero collected
     propagates as a failure
+- **Release docs: the release PR must be re-approved before promote**
+  ([#1474](https://github.com/vig-os/devkit/issues/1474))
+  - A final `release.yml` run's `finalize` job pushes to `release/X.Y.Z` (the
+    CHANGELOG date stamp and the `sync-issues` commit), which dismisses the PR
+    approval that same run required wherever stale-review dismissal is enabled.
+    `promote-release.yml` re-checks approvals before merging, so re-approving is
+    a mandatory step between the final and the promote dispatch
+  - `docs/RELEASE_CYCLE.md` now says so in Phase 2 step 7, the Phase 3
+    prerequisites, the release lifecycle diagram, and the `release.yml`
+    reference, and carries the re-approval commands as an explicit Phase 5 step
+    before the promote dispatch; `docs/DOWNSTREAM_RELEASE.md` mirrors the
+    operator step for consumers
+  - Documentation only — no workflow or behaviour change. Both approval gates
+    are kept: each guards a different irreversible act (burning the immutable
+    `X.Y.Z` tag; moving `:latest` and merging to `main`)
 
 ### Deprecated
 

--- a/assets/workspace/docs/DOWNSTREAM_RELEASE.md
+++ b/assets/workspace/docs/DOWNSTREAM_RELEASE.md
@@ -59,6 +59,18 @@ After final `release.yml` has pushed tag `X.Y.Z` and created a **draft** GitHub 
 3. **Merge** — merge `release/X.Y.Z` → `main` (triggers `sync-main-to-dev` under the gitflow model — see [Workflow models](#workflow-models))
 4. **Cleanup** (best-effort, does not fail the workflow) — delete remote git tags matching `${VERSION}-rc*` that have **no** GitHub Release
 
+**Re-approve the release PR before dispatching promote** ([#1474](https://github.com/vig-os/devkit/issues/1474)). The final `release.yml` run's `finalize` job pushes to `release/X.Y.Z` (CHANGELOG date stamp plus the `sync-issues` commit), so on any repository with stale-review dismissal enabled the approval that authorised the final dispatch is already dismissed when promote validates it in step 1 above — and any later push to the release branch dismisses it again:
+
+```bash
+# Current state (REVIEW_REQUIRED after finalize)
+gh pr view <PR_NUMBER> --json reviewDecision
+
+# Re-approve (must be a human account other than the PR author)
+gh -R <owner>/<repo> pr review <PR_NUMBER> --approve
+```
+
+Full reasoning and the upstream runbook: [`docs/RELEASE_CYCLE.md`](https://github.com/vig-os/devkit/blob/main/docs/RELEASE_CYCLE.md#phase-5-post-release-cleanup).
+
 **Upstream (`vig-os/devcontainer`) only:** Root `promote-release.yml` also prunes GHCR RC package versions via the org Packages API using **`GITHUB_TOKEN`** with **repo Admin** on the `devcontainer` package (one-time **Manage Actions access** grant). See [GitHub App Configuration](https://github.com/vig-os/devkit/blob/main/docs/RELEASE_CYCLE.md#github-app-configuration) and [Registry and cleanup tokens](https://github.com/vig-os/devkit/blob/main/docs/RELEASE_CYCLE.md#registry-and-cleanup-tokens-upstream) in `docs/RELEASE_CYCLE.md`.
 
 This template does **not** implement upstream-only steps (GHCR `:latest`, cosign, cross-repo smoke-test gate). Projects that need registry or deploy promotion after merge should run separate automation or extend their `release-extension.yml` / own workflows; see [Extension Hook](#extension-hook).

--- a/docs/DOWNSTREAM_RELEASE.md
+++ b/docs/DOWNSTREAM_RELEASE.md
@@ -56,6 +56,18 @@ After final `release.yml` has pushed tag `X.Y.Z` and created a **draft** GitHub 
 3. **Merge** — merge `release/X.Y.Z` → `main` (triggers `sync-main-to-dev` under the gitflow model — see [Workflow models](#workflow-models))
 4. **Cleanup** (best-effort, does not fail the workflow) — delete remote git tags matching `${VERSION}-rc*` that have **no** GitHub Release
 
+**Re-approve the release PR before dispatching promote** ([#1474](https://github.com/vig-os/devkit/issues/1474)). The final `release.yml` run's `finalize` job pushes to `release/X.Y.Z` (CHANGELOG date stamp plus the `sync-issues` commit), so on any repository with stale-review dismissal enabled the approval that authorised the final dispatch is already dismissed when promote validates it in step 1 above — and any later push to the release branch dismisses it again:
+
+```bash
+# Current state (REVIEW_REQUIRED after finalize)
+gh pr view <PR_NUMBER> --json reviewDecision
+
+# Re-approve (must be a human account other than the PR author)
+gh -R <owner>/<repo> pr review <PR_NUMBER> --approve
+```
+
+Full reasoning and the upstream runbook: [`docs/RELEASE_CYCLE.md`](https://github.com/vig-os/devkit/blob/main/docs/RELEASE_CYCLE.md#phase-5-post-release-cleanup).
+
 **Upstream (`vig-os/devcontainer`) only:** Root `promote-release.yml` also prunes GHCR RC package versions via the org Packages API using **`GITHUB_TOKEN`** with **repo Admin** on the `devcontainer` package (one-time **Manage Actions access** grant). See [GitHub App Configuration](https://github.com/vig-os/devkit/blob/main/docs/RELEASE_CYCLE.md#github-app-configuration) and [Registry and cleanup tokens](https://github.com/vig-os/devkit/blob/main/docs/RELEASE_CYCLE.md#registry-and-cleanup-tokens-upstream) in `docs/RELEASE_CYCLE.md`.
 
 This template does **not** implement upstream-only steps (GHCR `:latest`, cosign, cross-repo smoke-test gate). Projects that need registry or deploy promotion after merge should run separate automation or extend their `release-extension.yml` / own workflows; see [Extension Hook](#extension-hook).

--- a/docs/RELEASE_CYCLE.md
+++ b/docs/RELEASE_CYCLE.md
@@ -158,20 +158,21 @@ graph TB
     L --> M["Publish X.Y.Z-rcN"]
     M --> U{External gate pass?}
     U -->|No| I
-    U -->|Yes| J["Mark PR ready<br/>Get approval"]
+    U -->|Yes| J["Mark PR ready<br/>Approve (authorises the final dispatch)"]
     J --> N["just finalize-release X.Y.Z"]
     N --> O["Workflow: set release date<br/>build & test"]
     O --> P{Tests pass?}
     P -->|No| Q["Automatic rollback<br/>+ issue creation"]
     P -->|Yes| R["Workflow: create tag<br/>publish images<br/>draft GitHub Release (final only)"]
-    R --> S["Merge PR to main"]
+    R --> R2["Re-approve PR<br/>(finalize dismissed the approval)"]
+    R2 --> S["Merge PR to main"]
     S --> T["Workflow: sync-main-to-dev<br/>PR-based sync"]
 ```
 
 ### Release Phases
 
 1. **Preparation** (`prepare-release`): Freeze CHANGELOG on dev, create release branch, reset Unreleased on dev, open draft PR
-2. **Review & Testing**: CI validation, fix issues, publish candidates to verify; mark PR ready and get approvals last (this is the final-release gate, not the candidate gate)
+2. **Review & Testing**: CI validation, fix issues, publish candidates to verify; mark PR ready and get approvals last (this is the final-release gate, not the candidate gate — the approval authorises the final dispatch and does not survive it, see [Phase 5](#phase-5-post-release-cleanup))
 3. **Candidate Publish** (`publish-candidate`): Build/test/publish `X.Y.Z-rcN` and dispatch cross-repo validation workflow
 4. **Cross-Repo Validation**: Smoke-test runs asynchronously after candidate and final publish; see `docs/CROSS_REPO_RELEASE_GATE.md`. Before promotion, **`promote-release.yml`** requires a published **final** (non-draft, non-prerelease) GitHub Release for the version tag on `devkit-smoke-test` so human acceptance downstream is reflected before `:latest` and the draft release are published.
 5. **Finalization & Post-Release**: Publish final image/tag, open a **draft** GitHub Release for human review, then merge PR to `main` and let sync automation update `dev`
@@ -389,8 +390,19 @@ This is the main quality gate. The release branch and draft PR serve as the coor
    gh pr ready <PR_NUMBER>
    ```
 
-   Because this happens last, the approval lands on the exact diff that ships,
-   not an intermediate one.
+   Because this happens last, the approval lands on the release content as it
+   will ship, not an intermediate one — everything after it is the mechanical
+   finalization that automation writes on top (CHANGELOG date stamp,
+   regenerated docs, `sync-issues`).
+
+   **This approval authorises the final *dispatch*; it does not survive it.**
+   Those finalization commits are pushed to `release/X.Y.Z`, and a push
+   dismisses existing approvals wherever stale-review dismissal is enabled
+   (org-wide in `vig-os`), so the PR is back to `REVIEW_REQUIRED` the moment
+   the final run finishes. `promote-release.yml` re-checks approvals
+   independently, so the PR must be **re-approved before the promote dispatch**
+   — see [Phase 5](#phase-5-post-release-cleanup)
+   ([#1474](https://github.com/vig-os/devkit/issues/1474)).
 
 **Iteration:** Repeat steps 3-6 until the candidate is verified and reviewers
 approve, then do step 7 once before finalizing.
@@ -401,8 +413,17 @@ approve, then do step 7 once before finalizing.
 Phase 2 require just the first bullet):
 - All CI checks passed on `release/X.Y.Z`
 - PR marked as ready for review (not draft)
-- PR has required approvals
+- PR has required approvals (**consumed by this run** — see below)
 - No uncommitted changes
+
+**The final run destroys the approval it requires.** Its `finalize` job pushes
+to `release/X.Y.Z` (CHANGELOG date stamp, regenerated docs, plus the
+`sync-issues` commit on top), and any push dismisses existing approvals wherever
+stale-review dismissal is enabled — org-wide in `vig-os`, and in every consumer
+repository with that setting. The release PR is therefore `REVIEW_REQUIRED`
+again as soon as this workflow finishes and must be re-approved before the
+promote dispatch ([Phase 5](#phase-5-post-release-cleanup),
+[#1474](https://github.com/vig-os/devkit/issues/1474)).
 
 **Execute:**
 
@@ -507,7 +528,17 @@ Automated with one exception: on the **final** dispatch the smoke-test listener 
 
    If the gate already timed out, approve the PR and **re-run the failed jobs** of that listener run to resume the final release. Full gate contract and failure modes: [`docs/CROSS_REPO_RELEASE_GATE.md`](CROSS_REPO_RELEASE_GATE.md).
 3. **Migrate RC-pinned consumers to the final tag** ([#880](https://github.com/vig-os/devkit/issues/880)): consumers pin the devcontainer image via their `.vig-os` file (`DEVCONTAINER_VERSION=X.Y.Z-rcN`). The **`cleanup`** job ("Cleanup RC artifacts") in `promote-release.yml` deletes all `X.Y.Z-rc*` git tags and GHCR image versions, so any consumer still pinned to an RC (e.g. field-validation repos) can no longer pull its image. Bump those pins to `DEVCONTAINER_VERSION=X.Y.Z` before running promote (preferred), or immediately after — the RC images and tags are gone once the cleanup job has run.
-4. After smoke-test has published its **final** GitHub Release for `X.Y.Z`, run **`promote-release.yml`** (e.g. `just promote-release X.Y.Z`), which updates GHCR `:latest`, publishes the draft release, merges the release PR, and runs best-effort RC cleanup. See [Release Phases](#release-phases) step 6 and [`docs/CROSS_REPO_RELEASE_GATE.md`](CROSS_REPO_RELEASE_GATE.md).
+4. **Re-approve the release PR** ([#1474](https://github.com/vig-os/devkit/issues/1474)): the final `release.yml` run pushed the date stamp and the `sync-issues` commit to `release/X.Y.Z`, which dismissed the approval collected in [Phase 2](#phase-2-review--testing) step 7. `promote-release.yml` re-checks approvals in its **`merge`** job, which runs *after* `promote` has already published the draft release and moved `:latest` — so a stale-dismissed approval leaves the release half-promoted. Approve immediately before dispatching promote, and again after **any** later push to the release branch:
+
+   ```bash
+   # Current state (REVIEW_REQUIRED after finalize)
+   gh pr view <PR_NUMBER> --json reviewDecision
+
+   # Re-approve (must be a human account other than the PR author)
+   gh -R vig-os/devkit pr review <PR_NUMBER> --approve
+   ```
+
+5. After smoke-test has published its **final** GitHub Release for `X.Y.Z`, run **`promote-release.yml`** (e.g. `just promote-release X.Y.Z`), which updates GHCR `:latest`, publishes the draft release, merges the release PR, and runs best-effort RC cleanup. See [Release Phases](#release-phases) step 6 and [`docs/CROSS_REPO_RELEASE_GATE.md`](CROSS_REPO_RELEASE_GATE.md).
 
 **Consumer projects** using templates from `assets/workspace/` follow [Downstream release workflows](DOWNSTREAM_RELEASE.md): final `release.yml` leaves a **draft** GitHub Release; run **`promote-release.yml`** (or `just promote-release X.Y.Z`) to publish the release and merge to `main` (no upstream GHCR/smoke-test gate in that template).
 
@@ -774,6 +805,7 @@ gh workflow run release.yml \
 **Key characteristics:**
 - Tag created AFTER successful build/test (safer than before)
 - Final GitHub Release is a **draft** until a human publishes it from the UI
+- The final run's `finalize` pushes dismiss the release PR approval its own `validate` job required (stale-review dismissal); re-approve before `promote-release.yml` ([#1474](https://github.com/vig-os/devkit/issues/1474))
 - Automatic rollback reverts only the run's own finalize commit(s) on the release branch (no-op when finalize never ran; refuses if the branch moved mid-run, #1462); tags are not deleted (forward-fix policy)
 - All in one workflow for atomic operation
 - Audit trail in GitHub Actions logs


### PR DESCRIPTION
## Description

`vig-os` dismisses PR approvals when new commits are pushed. The `finalize` job of
a **final** `release.yml` run always pushes to the release branch (the CHANGELOG
date stamp, plus the sync-issues commit), so **the approval that authorises the
final release is destroyed by that very run** — every time, in every repo consuming
the scaffolded release workflow. `promote-release.yml` then re-checks approvals
independently, making re-approval a mandatory, undocumented step between the final
and the promote dispatch.

Observed live on the 1.8.0 train: #1441 was `APPROVED` when `validate` passed, and
`DISMISSED` / `REVIEW_REQUIRED` immediately after `finalize` pushed `15abe1b3` +
`7a07142d`.

## Type of Change

- [x] `docs` -- Documentation only

**Both approval gates are kept.** Each guards a genuinely different irreversible act
— burning the immutable `X.Y.Z` tag, and moving `:latest` + merging to `main`. No
workflow or code file is touched by this PR.

## Changes Made

`docs/RELEASE_CYCLE.md`:
- lifecycle diagram — approval node relabelled as authorising the final dispatch; new
  `Re-approve PR` node between publish and merge
- Release Phases item 2, Phase 2 step 7 — the approval authorises the *dispatch* and
  does not survive it
- Phase 3 prerequisites — "PR has required approvals (**consumed by this run**)",
  plus a paragraph naming the pushes that dismiss it
- Phase 5 — new step 4 "Re-approve the release PR" with the concrete commands, before
  the promote dispatch
- `release.yml` reference — one bullet in Key characteristics

`docs/DOWNSTREAM_RELEASE.md` — mirrors the **operator step** only, linking to
`RELEASE_CYCLE.md` for the reasoning (SSoT: no duplicated explanation).

Three pre-existing sentences had to be reconciled rather than left contradicting the
new text. Notably, Phase 2 step 7's *"the approval lands on the exact diff that
ships"* now says the approval lands on the release content **as it will ship**, with
the mechanical finalization written on top. The issue's phrasing that "the approved
SHA is what gets tagged" was deliberately **not** reused — the tag points at
`finalize_sha`, i.e. the approved content *plus* the finalize commit, so that
sentence would have been false.

## Changelog Entry

```
### Changed

- **Release docs: the release PR must be re-approved before promote**
  ([#1474](https://github.com/vig-os/devkit/issues/1474))
```
(full entry with sub-bullets is in `CHANGELOG.md`)

## Testing

- [x] `prek run --all-files` (incl. `pymarkdown` on every changed file) -> only
      `check-expirations` fails; `.vulnixignore` is byte-identical to `dev` on this
      branch. **Fixed by #1482 — merge that first.**

TDD does not apply: documentation only, nothing testable, as the repo's TDD rule allows.

### Manual Testing Details

Verified the load-bearing claim against the code rather than the issue text: devkit's
own `promote-release.yml` checks approval **only** in the `merge` job (`:435`), which
runs *after* `promote` has published the draft release and moved `:latest` — so a
dismissed approval leaves the release half-promoted. The consumer template checks in
**both** `validate` (fails fast) and `merge`. The two documents say the right thing
for their own audience.

Closes #1474

Refs: #1474
