### PR TITLE
fix(release): verify the release PR in promote validate, before publishing

### DIFF
--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -290,6 +290,132 @@ jobs:
           fi
           echo "✓ Downstream published final release verified for $VERSION"
 
+      # Repo-scoped App token: the cross-repo token above is scoped to
+      # devkit-smoke-test and cannot read this repository's PRs. Mirrors the
+      # merge job's token step, whose identity is proven on every promote.
+      - name: Generate token for the release-PR gate
+        id: release_pr_token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3
+        with:
+          client-id: ${{ secrets.RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
+      # #1487: this gate must run in validate, NOT only in merge. The sequence
+      # is validate → promote (moves :latest, undrafts the Release — both
+      # effectively irreversible: published releases are immutable org-wide) →
+      # merge. Checking the PR only in merge means an unapproved, draft or
+      # CI-red PR fails the promote from an already-published state, leaving
+      # the release public while main lacks the release commit.
+      #
+      # The trigger is the DEFAULT state, not an edge case: a final release.yml
+      # run's finalize job always pushes to the release branch, which always
+      # dismisses the approval under the org-wide stale-review dismissal
+      # (#1474). The merge copy of this check stays — PR state can change
+      # between the two jobs — so this is a duplication, not a move.
+      - name: Find and verify release PR
+        env:
+          VERSION: ${{ steps.vars.outputs.version }}
+          GH_TOKEN: ${{ steps.release_pr_token.outputs.token }}
+        run: |
+          set -euo pipefail
+          PR_JSON=$(retry --retries 3 --backoff 5 --max-backoff 30 -- gh pr list \
+            --head "release/$VERSION" \
+            --base main \
+            --json number,isDraft,reviewDecision,statusCheckRollup \
+            --limit 1)
+
+          PR_COUNT=$(echo "$PR_JSON" | jq 'length')
+          if [ "$PR_COUNT" != "1" ]; then
+            echo "ERROR: Expected exactly 1 PR from release/$VERSION to main, found $PR_COUNT"
+            exit 1
+          fi
+
+          PR_NUMBER=$(echo "$PR_JSON" | jq -r '.[0].number')
+          IS_DRAFT=$(echo "$PR_JSON" | jq -r '.[0].isDraft')
+          REVIEW_DECISION=$(echo "$PR_JSON" | jq -r '.[0].reviewDecision')
+
+          if [ "$IS_DRAFT" = "true" ]; then
+            echo "ERROR: PR #$PR_NUMBER is still in draft"
+            exit 1
+          fi
+          if [ "$REVIEW_DECISION" = "APPROVED" ]; then
+            echo "PR #$PR_NUMBER is approved"
+          elif [ "$REVIEW_DECISION" = "null" ] || [ -z "$REVIEW_DECISION" ]; then
+            APPROVED_COUNT=$(retry --retries 3 --backoff 5 --max-backoff 30 -- gh api \
+              --paginate --slurp \
+              "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/reviews" \
+              | jq 'add | map(select(.state == "APPROVED")) | length')
+            if [ "$APPROVED_COUNT" -eq 0 ]; then
+              echo "ERROR: PR #$PR_NUMBER is not approved (reviewDecision: $REVIEW_DECISION, approved reviews: 0)"
+              echo "A final release run dismisses the approval (#1474) — re-approve the release PR before promoting."
+              exit 1
+            fi
+            echo "reviewDecision='$REVIEW_DECISION' but $APPROVED_COUNT approved review(s) found"
+          else
+            echo "ERROR: PR #$PR_NUMBER is not approved (status: $REVIEW_DECISION)"
+            echo "A final release run dismisses the approval (#1474) — re-approve the release PR before promoting."
+            exit 1
+          fi
+
+          STATUS_ROLLUP=$(echo "$PR_JSON" | jq -r '.[0].statusCheckRollup // []')
+          CI_FAILED=$(echo "$STATUS_ROLLUP" | jq '[.[] | select(.conclusion == "FAILURE" or .conclusion == "ERROR")] | length')
+          if [ "$CI_FAILED" != "0" ]; then
+            echo "ERROR: PR #$PR_NUMBER has failed CI checks"
+            exit 1
+          fi
+
+          CI_PENDING=$(echo "$STATUS_ROLLUP" | jq '[.[] | select(.conclusion == null or .conclusion == "" or .conclusion == "PENDING" or .conclusion == "IN_PROGRESS" or .conclusion == "QUEUED")] | length')
+          if [ "$CI_PENDING" != "0" ]; then
+            echo "ERROR: PR #$PR_NUMBER has checks still in progress"
+            exit 1
+          fi
+
+          CI_SUCCESS=$(echo "$STATUS_ROLLUP" | jq '[.[] | select(.conclusion == "SUCCESS")] | length')
+          if [ "$CI_SUCCESS" = "0" ]; then
+            echo "ERROR: PR #$PR_NUMBER has no successful CI checks"
+            exit 1
+          fi
+
+          # Mergeability gate (#1132). Approved + CI-green is not the same as
+          # mergeable: a PR that is BEHIND main, BLOCKED or DIRTY would undraft
+          # the Release and only then fail to merge. GitHub computes
+          # mergeability asynchronously, so re-query while either field is
+          # UNKNOWN rather than trusting the first read.
+          MERGEABLE="UNKNOWN"
+          MERGE_STATE="UNKNOWN"
+          for attempt in 1 2 3 4 5; do
+            MERGE_JSON=$(retry --retries 3 --backoff 5 --max-backoff 30 -- \
+              gh pr view "$PR_NUMBER" --json mergeable,mergeStateStatus)
+            MERGEABLE=$(echo "$MERGE_JSON" | jq -r '.mergeable')
+            MERGE_STATE=$(echo "$MERGE_JSON" | jq -r '.mergeStateStatus')
+            if [ "$MERGEABLE" != "UNKNOWN" ] && [ "$MERGE_STATE" != "UNKNOWN" ]; then
+              break
+            fi
+            echo "Mergeability still computing (mergeable=$MERGEABLE, mergeStateStatus=$MERGE_STATE), retry $attempt/5..."
+            sleep $((attempt * 5))
+          done
+
+          if [ "$MERGEABLE" != "MERGEABLE" ]; then
+            echo "ERROR: PR #$PR_NUMBER is not mergeable (mergeable=$MERGEABLE, mergeStateStatus=$MERGE_STATE)"
+            echo "Refusing to promote: the publish step is irreversible and this merge would fail after it."
+            exit 1
+          fi
+          case "$MERGE_STATE" in
+            CLEAN | HAS_HOOKS | UNSTABLE)
+              echo "PR #$PR_NUMBER is mergeable (mergeStateStatus=$MERGE_STATE)"
+              ;;
+            BEHIND)
+              echo "ERROR: PR #$PR_NUMBER is BEHIND main — update release/$VERSION to base before promoting"
+              exit 1
+              ;;
+            *)
+              echo "ERROR: PR #$PR_NUMBER is not in a mergeable state (mergeStateStatus=$MERGE_STATE)"
+              exit 1
+              ;;
+          esac
+
+          echo "✓ PR #$PR_NUMBER verified for promote"
+
       - name: Summary
         env:
           VERSION: ${{ steps.vars.outputs.version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The promote gate checks the release PR before publishing, not after**
+  ([#1487](https://github.com/vig-os/devkit/issues/1487))
+  - Devkit's own `promote-release.yml` verified the release PR's draft status,
+    approvals and CI **only in the `merge` job** — which runs after `promote`
+    has already moved GHCR `:latest` and published the draft GitHub Release. An
+    unapproved PR therefore failed the promote *from an already-published
+    state*, leaving the release public while `main` lacked the release commit,
+    and published releases are immutable org-wide. The check now also runs in
+    `validate`, so the promote refuses before anything is published
+  - The trigger was the default state of every final release, not an edge case:
+    a final `release.yml` run's `finalize` job always pushes to the release
+    branch, which always dismisses the approval under the org-wide stale-review
+    dismissal ([#1474](https://github.com/vig-os/devkit/issues/1474)). Only
+    operator discipline had kept it latent
+  - The `validate` copy mirrors the scaffold template's, so it also brings the
+    mergeability gate ([#1132](https://github.com/vig-os/devkit/issues/1132)) —
+    BEHIND / BLOCKED / DIRTY — which the upstream workflow had never carried in
+    either job. The `merge` copy is kept: PR state can change between the jobs
 - **Trunk release preparation: the release PR is no longer empty, and the freeze
   never pushes to the trunk**
   ([#1479](https://github.com/vig-os/devkit/issues/1479))

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -137,6 +137,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The promote gate checks the release PR before publishing, not after**
+  ([#1487](https://github.com/vig-os/devkit/issues/1487))
+  - Devkit's own `promote-release.yml` verified the release PR's draft status,
+    approvals and CI **only in the `merge` job** — which runs after `promote`
+    has already moved GHCR `:latest` and published the draft GitHub Release. An
+    unapproved PR therefore failed the promote *from an already-published
+    state*, leaving the release public while `main` lacked the release commit,
+    and published releases are immutable org-wide. The check now also runs in
+    `validate`, so the promote refuses before anything is published
+  - The trigger was the default state of every final release, not an edge case:
+    a final `release.yml` run's `finalize` job always pushes to the release
+    branch, which always dismisses the approval under the org-wide stale-review
+    dismissal ([#1474](https://github.com/vig-os/devkit/issues/1474)). Only
+    operator discipline had kept it latent
+  - The `validate` copy mirrors the scaffold template's, so it also brings the
+    mergeability gate ([#1132](https://github.com/vig-os/devkit/issues/1132)) —
+    BEHIND / BLOCKED / DIRTY — which the upstream workflow had never carried in
+    either job. The `merge` copy is kept: PR state can change between the jobs
 - **Trunk release preparation: the release PR is no longer empty, and the freeze
   never pushes to the trunk**
   ([#1479](https://github.com/vig-os/devkit/issues/1479))

--- a/tests/test_promote_release.py
+++ b/tests/test_promote_release.py
@@ -19,16 +19,46 @@ Release was undrafted, and only then did the merge fail — leaving a
 half-promoted release. The validate job must query mergeability and reject a
 non-mergeable PR before the promote job undrafts the Release.
 
+Issue #1487: the same gate, the same reasoning — but the *upstream* copy had
+it only in ``merge``. Devkit's own ``promote-release.yml`` checked the release
+PR's draft status, approvals, CI and (not at all) mergeability after ``promote``
+had already moved GHCR ``:latest`` and published the Release, so an unapproved
+PR failed the promote from a published state. #1474 made the trigger condition
+the default: a final ``release.yml`` run always pushes to the release branch and
+so always dismisses the approval. Both copies now carry the gate in ``validate``
+*and* keep it in ``merge`` — state can change between the two jobs — so these
+suites are parametrized over both copies rather than pinning the scaffold alone.
+
 The tag-move and re-query choreography is bash and not unit-testable here.
 
-Refs: #1045, #1132
+Refs: #1045, #1132, #1487
 """
 
 from __future__ import annotations
 
-from tests.workflow_scaffold import WORKFLOWS, load_workflow
+from typing import TYPE_CHECKING
+
+import pytest
+
+from tests.workflow_scaffold import (
+    REPO_ROOT,
+    WORKFLOWS,
+    load_workflow,
+    step_by_name,
+    steps_of_job,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 PROMOTE = WORKFLOWS / "promote-release.yml"
+
+# copy id -> the promote-release.yml carrying the release-PR gate (#1487)
+PROMOTE_COPIES: dict[str, Path] = {
+    "devkit": REPO_ROOT / ".github" / "workflows" / "promote-release.yml",
+    "scaffold": WORKFLOWS / "promote-release.yml",
+}
+COPIES = list(PROMOTE_COPIES)
 
 
 # ── floating tags (#1045) ─────────────────────────────────────────────────────
@@ -118,30 +148,61 @@ def test_push_failure_emits_actionable_error() -> None:
     assert "first-release-floating-tags" in script
 
 
-# ── validate gates on PR mergeability (#1132) ─────────────────────────────────
+# ── validate gates on the release PR (#1132, #1487) ───────────────────────────
 
 
-def _validate_pr_step_run() -> str:
-    workflow = load_workflow(PROMOTE)
-    steps = workflow["jobs"]["validate"]["steps"]
-    step = next(s for s in steps if s.get("name") == "Find and verify release PR")
+def _pr_gate_run(copy: str, job: str) -> str:
+    """The bash body of the ``Find and verify release PR`` step of ``job``."""
+    workflow = load_workflow(PROMOTE_COPIES[copy])
+    step = step_by_name(steps_of_job(workflow, job), "Find and verify release PR")
     return step["run"]
 
 
-def test_validate_queries_pr_mergeability() -> None:
+def _validate_pr_step_run(copy: str = "scaffold") -> str:
+    return _pr_gate_run(copy, "validate")
+
+
+@pytest.mark.parametrize("copy", COPIES)
+def test_validate_gates_release_pr_before_promote(copy: str) -> None:
+    """Draft, approval and CI are all checked in validate — before the publish.
+
+    #1487: the upstream copy gated only in ``merge``, which runs *after*
+    ``promote`` moved ``:latest`` and undrafted the Release.
+    """
+    run = _validate_pr_step_run(copy)
+    assert "isDraft" in run
+    assert "still in draft" in run
+    assert "reviewDecision" in run
+    assert "not approved" in run
+    assert "statusCheckRollup" in run
+    assert "failed CI checks" in run
+
+
+@pytest.mark.parametrize("copy", COPIES)
+def test_merge_retains_release_pr_gate(copy: str) -> None:
+    """The merge copy of the gate stays: PR state can change between the jobs."""
+    run = _pr_gate_run(copy, "merge")
+    assert "isDraft" in run
+    assert "reviewDecision" in run
+
+
+@pytest.mark.parametrize("copy", COPIES)
+def test_validate_queries_pr_mergeability(copy: str) -> None:
     """The validate PR check fetches the PR's merge state."""
-    run = _validate_pr_step_run()
+    run = _validate_pr_step_run(copy)
     assert "mergeStateStatus" in run
     assert "mergeable" in run
 
 
-def test_validate_rejects_behind_pr() -> None:
+@pytest.mark.parametrize("copy", COPIES)
+def test_validate_rejects_behind_pr(copy: str) -> None:
     """A BEHIND (not-up-to-date) PR is rejected before the irreversible promote."""
-    run = _validate_pr_step_run()
+    run = _validate_pr_step_run(copy)
     assert "BEHIND" in run
 
 
-def test_validate_requeries_unknown_mergeability() -> None:
+@pytest.mark.parametrize("copy", COPIES)
+def test_validate_requeries_unknown_mergeability(copy: str) -> None:
     """GitHub computes mergeability async, so UNKNOWN is re-queried, not trusted."""
-    run = _validate_pr_step_run()
+    run = _validate_pr_step_run(copy)
     assert "UNKNOWN" in run


### PR DESCRIPTION
Closes #1487

## Problem

Devkit's own `promote-release.yml` checked the release PR's draft status,
approvals and CI **only in the `merge` job** — which runs *after* `promote` has
already moved GHCR `:latest` and published the draft GitHub Release. An
unapproved PR therefore failed the promote from an already-published state:
the release is public, `main` does not contain the release commit, and the
release PR is still open. Published releases are immutable org-wide, so that
state cannot be walked back — only fixed forward.

The scaffolded consumer template does not have this shape. It runs the same
`Find and verify release PR` check in `validate` (fail-fast) *and* repeats it
in `merge`. Only the upstream workflow was missing the early gate.

**Latent, not fired.** Every promote to date succeeded, because the maintainer
re-approves the release PR before dispatching. But #1474 established that a
final `release.yml` run's `finalize` job *always* pushes to the release branch
and so *always* dismisses the approval under the org-wide stale-review
dismissal. The trigger condition is the **default state of every final
release** — the only thing standing between it and a half-promoted release was
an undocumented habit, documented only last commit in #1486.

## Change

Mirror the consumer template rather than invent a third shape: the same
`Find and verify release PR` step now runs in `validate`, and the `merge` copy
**stays** — PR state can change between the two jobs, which is why the template
keeps both deliberately.

The check needs a repo-scoped App token: `validate`'s existing
`smoke-check-token` is scoped `repositories: devkit-smoke-test` and cannot read
this repository's PRs, and `github.token` there carries only
`contents: write, packages: read`. Rather than guess at a `GITHUB_TOKEN`
permission set that has never been exercised (a wrong guess fails closed and
breaks the next promote), the new step mints the App token exactly as the
`merge` job does — an identity proven on every promote run to date.

### One thing worth flagging

Mirroring the template's step wholesale also brings the **mergeability gate**
(#1132 — BEHIND / BLOCKED / DIRTY), which devkit's upstream workflow had never
carried in *either* job. This is slightly beyond the literal title of #1487,
and deliberate: it is the same defect class (approved + CI-green is not the
same as mergeable, and finding out during `merge` means finding out after the
publish), and carving those lines out of the step would produce exactly the
divergent third variant the issue asks to avoid. It is fail-*earlier*, not
fail-*more*: a BEHIND PR already failed the merge, just from a published state.

## Tests

`tests/test_promote_release.py` is parametrized over both copies (`devkit`,
`scaffold`) instead of pinning the scaffold alone — the divergence this issue
is about was invisible precisely because the shape suite only ever looked at
the template. RED before the fix on all four `[devkit]` cases:

```
FAILED test_validate_gates_release_pr_before_promote[devkit]
FAILED test_validate_queries_pr_mergeability[devkit]
FAILED test_validate_rejects_behind_pr[devkit]
FAILED test_validate_requeries_unknown_mergeability[devkit]
4 failed, 13 passed
```

Green after: `17 passed`. Full suite `1307 passed, 20 skipped`
(`tests/test_image.py` excluded — it checks a locally-pulled 1.8.0 image
against dev's CHANGELOG and fails identically on clean `dev`; CI builds the
image from the branch). `prek run --all-files` green.

## Verification owed

The gate cannot be live-proven without deliberately dispatching a promote
against an unapproved PR. The next 1.8.1 promote exercises the happy path —
`validate` passing the new step is the proof it does not false-positive.

Refs: #1487, #1474, #1132