### PR TITLE
fix(hooks): run typos at the pre-commit stage only

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -175,6 +175,7 @@ repos:
         name: typos (source typo checker)
         entry: typos --force-exclude
         language: system
+        stages: [pre-commit]
 
   # License Compliance Check (runs only when dependencies change)
   - repo: local

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,6 +155,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     mergeability gate ([#1132](https://github.com/vig-os/devkit/issues/1132)) —
     BEHIND / BLOCKED / DIRTY — which the upstream workflow had never carried in
     either job. The `merge` copy is kept: PR state can change between the jobs
+- **`typos` no longer lints the commit-message buffer, so a rebase can commit**
+  ([#1489](https://github.com/vig-os/devkit/issues/1489))
+  - The hook carried no `stages:`, so it ran at *every* hook stage — and since
+    it passes filenames, the `commit-msg` round handed it `COMMIT_EDITMSG`.
+    `typos` reads short letter runs inside abbreviated git SHAs as misspelled
+    words, and `git rebase --continue` writes the rebase todo into that buffer
+    as comment lines, so a legitimate rebase was refused over a *comment* that
+    never enters the commit message. It now runs at `pre-commit` only, which is
+    what a source typo checker is for
+  - **Consumers are affected too**: the hook is scaffolded, so every scaffolded
+    repo shipped the same trap. Adopting this release fixes it. Flake-generated
+    (direnv) consumers were never affected — git-hooks.nix already defaults the
+    hook to the `pre-commit` stage
+  - No coverage is lost: `prek run --all-files` and the CI lint lane both run
+    the `pre-commit` stage
 - **Trunk release preparation: the release PR is no longer empty, and the freeze
   never pushes to the trunk**
   ([#1479](https://github.com/vig-os/devkit/issues/1479))

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -155,6 +155,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     mergeability gate ([#1132](https://github.com/vig-os/devkit/issues/1132)) —
     BEHIND / BLOCKED / DIRTY — which the upstream workflow had never carried in
     either job. The `merge` copy is kept: PR state can change between the jobs
+- **`typos` no longer lints the commit-message buffer, so a rebase can commit**
+  ([#1489](https://github.com/vig-os/devkit/issues/1489))
+  - The hook carried no `stages:`, so it ran at *every* hook stage — and since
+    it passes filenames, the `commit-msg` round handed it `COMMIT_EDITMSG`.
+    `typos` reads short letter runs inside abbreviated git SHAs as misspelled
+    words, and `git rebase --continue` writes the rebase todo into that buffer
+    as comment lines, so a legitimate rebase was refused over a *comment* that
+    never enters the commit message. It now runs at `pre-commit` only, which is
+    what a source typo checker is for
+  - **Consumers are affected too**: the hook is scaffolded, so every scaffolded
+    repo shipped the same trap. Adopting this release fixes it. Flake-generated
+    (direnv) consumers were never affected — git-hooks.nix already defaults the
+    hook to the `pre-commit` stage
+  - No coverage is lost: `prek run --all-files` and the CI lint lane both run
+    the `pre-commit` stage
 - **Trunk release preparation: the release PR is no longer empty, and the freeze
   never pushes to the trunk**
   ([#1479](https://github.com/vig-os/devkit/issues/1479))

--- a/assets/workspace/.pre-commit-config.yaml
+++ b/assets/workspace/.pre-commit-config.yaml
@@ -127,6 +127,7 @@ repos:
         name: typos (source typo checker)
         entry: typos --force-exclude
         language: system
+        stages: [pre-commit]
 
   # Security exception expiry enforcement (Refs: #566)
   - repo: local

--- a/nix/hooks.nix
+++ b/nix/hooks.nix
@@ -635,12 +635,25 @@ let
         files = "\\.nix$";
       };
     };
+    # `stages` is mandatory here (#1489): a hook with none runs at EVERY stage,
+    # and typos passes filenames — so the commit-msg round hands it
+    # COMMIT_EDITMSG. typos reads short letter runs inside abbreviated git
+    # SHAs as misspelled words, and `git rebase --continue` writes the rebase
+    # todo into that buffer as comment lines ("# pick <sha> # <subject>"), so
+    # the commit is refused over a comment that never enters the message —
+    # and the natural workarounds are editing git's own todo or --no-verify,
+    # which this repo forbids. Pinning the pre-commit stage costs no coverage:
+    # `prek run --all-files` and the CI lane both run it. The git-hooks.nix
+    # surfaces (check/consumer) already default to pre-commit, so only the
+    # portable YAML render needs the pin — all three are held by
+    # tests/test_flake_hooks.py::TestTyposRunsOnlyAtPreCommit.
     typos = {
       scaffold = true;
       yaml = {
         name = "typos (source typo checker)";
         entry = "typos --force-exclude";
         language = "system";
+        stages = [ "pre-commit" ];
       };
       check = _: {
         enable = true;

--- a/tests/test_flake_hooks.py
+++ b/tests/test_flake_hooks.py
@@ -217,6 +217,45 @@ class TestPortableRenderFidelity:
             assert "rev" not in hook, profile
 
 
+class TestTyposRunsOnlyAtPreCommit:
+    """typos lints source, never the commit-message buffer (#1489).
+
+    With no ``stages:`` a pre-commit hook runs at EVERY stage, and typos has
+    ``pass_filenames: true``, so the commit-msg round hands it
+    ``COMMIT_EDITMSG``. typos reads short letter runs inside abbreviated git
+    SHAs as misspelled words, and ``git rebase --continue`` writes the rebase
+    todo into that buffer as comment lines::
+
+        #    pick <sha> # docs(release): document the re-approval
+
+    so the commit is refused over a *comment* that never enters the message.
+    The natural workarounds are editing git's own todo or ``--no-verify``,
+    which this repo forbids.
+
+    Pinning ``pre-commit`` costs no coverage — ``prek run --all-files`` and the
+    CI lane both run that stage — and it must hold on every surface: the trap
+    shipped to every scaffolded consumer too (``scaffold = true``).
+    """
+
+    def test_portable_renders_pin_the_pre_commit_stage(
+        self, rendered_portable: dict[str, Any]
+    ) -> None:
+        for profile in ("runner", "scaffold"):
+            hook = _normalize(rendered_portable[profile])["hooks"]["typos"]
+            assert hook.get("stages") == ["pre-commit"], (
+                f"{profile}: typos runs at every stage, so the commit-msg round "
+                "lints COMMIT_EDITMSG (#1489)"
+            )
+
+    def test_consumer_surface_pins_the_pre_commit_stage(self) -> None:
+        """Direnv consumers install real git hooks from this render."""
+        for name, config in _consumer_config_set().items():
+            hooks = _normalize(config)["hooks"]
+            if "typos" not in hooks:
+                continue  # the customized shell disables it on purpose
+            assert hooks["typos"].get("stages") == ["pre-commit"], name
+
+
 class TestCheckJsonExcludesJsoncBanners:
     """check-json skips the `//`-bannered JSONC scaffold files (#1053).
 


### PR DESCRIPTION
Closes #1489

## Problem

The `typos` hook carried no `stages:`, so it ran at **every** hook stage — and
because it has `pass_filenames: true`, the `commit-msg` round handed it
`COMMIT_EDITMSG`. `typos` reads short letter runs inside abbreviated git SHAs as
misspelled words, and `git rebase --continue` writes the rebase todo into that
buffer as comment lines, so a legitimate rebase was refused over a **comment
that never enters the commit message**. The content being committed is
irrelevant.

The workarounds it invites are editing git's own todo comment or `--no-verify`,
which this repo forbids.

## Change

`stages: [pre-commit]` on the `yaml` fragment in `nix/hooks.nix`, which renders
both committed configs. That is what a *source* typo checker is for, and it
costs no coverage: `prek run --all-files` and the CI lint lane both run the
`pre-commit` stage.

### One correction to the issue's diagnosis

#1489 proposed changing the `yaml`, `check` **and** `consumer` fragments. Only
`yaml` needs it. I checked the rendered consumer surface directly:

```
trunk -> {... 'pass_filenames': True, 'stages': ['pre-commit'], ...}
```

git-hooks.nix **already** defaults the hook to `pre-commit`, in all six consumer
variants that enable it — so flake-generated (direnv) consumers were never
affected, and an explicit pin there would be redundant. The test still asserts
that surface, so the guard does not depend on the default staying put.

Scaffolded consumers **were** affected (`scaffold = true` ships the identical
unfiltered definition) and are fixed by adopting this release.

## Verification

Live repro on this branch's worktree, before the fix — the `pre-commit` round
passes and the *message* round fails:

```console
$ git commit -F msg.txt        # msg.txt has a "# pick <sha> # …" comment line
typos (source typo checker).....................Passed
typos (source typo checker).....................Failed
- hook id: typos
- exit code: 2
  error: `afe` should be `safe`
    ╭▸ .git/worktrees/1489/COMMIT_EDITMSG:3:11
```

The identical commit after the fix: **both rounds pass, exit 0.**

Tests: `TestTyposRunsOnlyAtPreCommit` covers all three surfaces (runner render,
scaffold render, consumer surface). RED on both portable renders before the fix
(`assert None == ['pre-commit']`); the consumer case passed already, and I
confirmed that is not vacuous. The existing drift gate covers the two committed
YAMLs. Full suite `1302 passed, 20 skipped`; `prek run --all-files` green.

## Note on the diff

The explanatory comments deliberately do **not** spell out the offending
trigrams or a real example SHA — writing them out makes `typos` fail on this
very PR's source files. typos 1.46.3 does not honour inline
`spellchecker:disable-line` directives (verified), and widening `.typos.toml`
would weaken the linter repo-wide, so the comments describe the mechanism
instead of exhibiting it.

## Follow-up filed

#1491 — the other two unfiltered `local` hooks (`sync-manifest`,
`check-agent-identity`) run 3x per commit for no benefit. Not bundled here:
neither receives a filename, so neither is broken, and `check-agent-identity`
needs a deliberate decision (its `consumer` fragment is pinned to `pre-commit`
while its `yaml` fragment is unpinned — the two surfaces disagree).

Refs: #1489