### PR TITLE
refactor(hooks): pin the remaining unfiltered local hooks to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -167,6 +167,7 @@ repos:
         entry: uv run python scripts/sync_manifest.py sync assets/workspace/
         language: system
         pass_filenames: false
+        stages: [pre-commit]
 
   # Typo Linting (typos sourced from the flake dev-shell)
   - repo: local
@@ -245,6 +246,7 @@ repos:
         entry: uv run check-agent-identity
         language: system
         pass_filenames: false
+        stages: [pre-commit]
 
   # Commit message validation (commit-msg stage)
   - repo: local

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`sync-manifest` and `check-agent-identity` run once per commit, at
+  `pre-commit`** ([#1491](https://github.com/vig-os/devkit/issues/1491))
+  - Both hooks carried neither `stages:` nor a file filter, so each ran at
+    *every* hook stage — three `uv run` invocations per commit for one useful
+    result. Neither was broken by it (unlike `typos`,
+    [#1489](https://github.com/vig-os/devkit/issues/1489), which received a
+    filename and rejected rebases); this is the waste that trap left behind
+  - For `check-agent-identity` the pin also settles a real disagreement between
+    surfaces: flake-generated (direnv) consumers have always run it at
+    `pre-commit` only, because git-hooks.nix defaults it there, while the
+    committed configs ran it at all three. **Consumers are affected**: the hook
+    is scaffolded, so adopting this release aligns a scaffolded repo with what
+    its direnv counterpart already did
+  - The message stages were not wanted: git exports the same
+    `GIT_AUTHOR_NAME`/`GIT_AUTHOR_EMAIL` to all three stages of an ordinary
+    commit, including under `git commit --author=…` — the case this hook exists
+    to catch — so the `commit-msg` round only re-read what `pre-commit` had
+    already rejected on. The one path where the message stages fire alone is
+    `git merge`, where git exports no author at all and the hook fell back to
+    `git config user.*`, the persistent identity that fails the committer's very
+    next ordinary commit
+  - No coverage is lost elsewhere: `prek run --all-files` and the CI lint lane
+    both run the `pre-commit` stage
 - **CI fails when a declared language's project file disappears**
   ([#1478](https://github.com/vig-os/devkit/issues/1478))
   - New `.vig-os` key `DEVKIT_LANGUAGES` — a comma-separated subset of

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -91,6 +91,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`sync-manifest` and `check-agent-identity` run once per commit, at
+  `pre-commit`** ([#1491](https://github.com/vig-os/devkit/issues/1491))
+  - Both hooks carried neither `stages:` nor a file filter, so each ran at
+    *every* hook stage — three `uv run` invocations per commit for one useful
+    result. Neither was broken by it (unlike `typos`,
+    [#1489](https://github.com/vig-os/devkit/issues/1489), which received a
+    filename and rejected rebases); this is the waste that trap left behind
+  - For `check-agent-identity` the pin also settles a real disagreement between
+    surfaces: flake-generated (direnv) consumers have always run it at
+    `pre-commit` only, because git-hooks.nix defaults it there, while the
+    committed configs ran it at all three. **Consumers are affected**: the hook
+    is scaffolded, so adopting this release aligns a scaffolded repo with what
+    its direnv counterpart already did
+  - The message stages were not wanted: git exports the same
+    `GIT_AUTHOR_NAME`/`GIT_AUTHOR_EMAIL` to all three stages of an ordinary
+    commit, including under `git commit --author=…` — the case this hook exists
+    to catch — so the `commit-msg` round only re-read what `pre-commit` had
+    already rejected on. The one path where the message stages fire alone is
+    `git merge`, where git exports no author at all and the hook fell back to
+    `git config user.*`, the persistent identity that fails the committer's very
+    next ordinary commit
+  - No coverage is lost elsewhere: `prek run --all-files` and the CI lint lane
+    both run the `pre-commit` stage
 - **CI fails when a declared language's project file disappears**
   ([#1478](https://github.com/vig-os/devkit/issues/1478))
   - New `.vig-os` key `DEVKIT_LANGUAGES` — a comma-separated subset of

--- a/assets/workspace/.pre-commit-config.yaml
+++ b/assets/workspace/.pre-commit-config.yaml
@@ -157,6 +157,7 @@ repos:
         entry: uv run check-agent-identity
         language: system
         pass_filenames: false
+        stages: [pre-commit]
 
   # Commit message validation (commit-msg stage). Scope is free-form
   # ("alphanumeric and hyphens only" per docs/COMMIT_MESSAGE_STANDARD.md);

--- a/nix/hooks.nix
+++ b/nix/hooks.nix
@@ -674,12 +674,19 @@ let
         pass_filenames = false;
       };
     };
+    # Runner-only (no consumer fragment): the generator needs THIS repo's
+    # scripts and venv. `stages` is the same fix as #1489 without the bug —
+    # with none, the manifest generator reran at prepare-commit-msg and
+    # commit-msg too, three `uv run` invocations per commit for one useful
+    # result. It only ever has anything to say about staged files, so
+    # pre-commit is the one stage it belongs at. Refs #1491.
     sync-manifest = {
       yaml = {
         name = "sync-manifest";
         entry = "uv run python scripts/sync_manifest.py sync assets/workspace/";
         language = "system";
         pass_filenames = false;
+        stages = [ "pre-commit" ];
       };
     };
     pip-licenses = {
@@ -839,6 +846,20 @@ let
     # pre-commit-stage, so `prek run --all-files` also enforces it in the
     # scaffold's lint job. The blocklist it reads (.github/agent-blocklist.toml)
     # is already manifest-synced into the scaffold. Refs #1031.
+    #
+    # "pre-commit-stage" above was only ever true of the consumer fragment,
+    # which git-hooks.nix defaults there; the yaml fragment carried no `stages`
+    # and so ran at all three, and the two surfaces disagreed about when this
+    # hook fires. Pinning reconciles them, and the message stages are the ones
+    # to drop: git exports GIT_AUTHOR_NAME/GIT_AUTHOR_EMAIL to every stage of
+    # an ordinary commit with identical values — including under an `--author=`
+    # override, the case this hook exists for — so the commit-msg round re-reads
+    # what pre-commit already rejected on. The lone path where the message
+    # stages fire and pre-commit does not is `git merge`, and git exports no
+    # author there at all: the hook falls back to `git config user.*`, the
+    # persistent identity that fails the committer's very next ordinary commit.
+    # That leaves a merge as the one commit this no longer guards locally, in
+    # exchange for dropping two of three runs per commit. Refs #1491.
     check-agent-identity = {
       scaffold = true;
       yaml = {
@@ -846,6 +867,7 @@ let
         entry = "uv run check-agent-identity";
         language = "system";
         pass_filenames = false;
+        stages = [ "pre-commit" ];
       };
       consumer = pkgs: {
         enable = true;

--- a/tests/test_flake_hooks.py
+++ b/tests/test_flake_hooks.py
@@ -256,6 +256,59 @@ class TestTyposRunsOnlyAtPreCommit:
             assert hooks["typos"].get("stages") == ["pre-commit"], name
 
 
+class TestUnfilteredLocalHooksPinTheirStage:
+    """The remaining stage-less local hooks run once, at pre-commit (#1491).
+
+    Split out of #1489, which fixed the one hook of this group that actually
+    broke a commit. ``sync-manifest`` and ``check-agent-identity`` carry neither
+    ``stages:`` nor a file filter, so each commit pays for three invocations of
+    a ``uv run`` entry point where one is meant.
+
+    For ``check-agent-identity`` the pin also reconciles a real disagreement
+    between surfaces: the consumer fragment has always run at pre-commit only
+    (git-hooks.nix defaults it there), while the yaml fragment behind both
+    committed configs ran at every stage. The message stages are genuinely not
+    wanted — git exports ``GIT_AUTHOR_NAME``/``GIT_AUTHOR_EMAIL`` to all three
+    stages of an ordinary commit with identical values, including under an
+    ``--author=`` override, so the hook sees the same identity at pre-commit
+    that it saw at commit-msg. The one path where only the message stages fire
+    is ``git merge``, and there git exports no author at all: the hook falls
+    back to ``git config user.*``, the persistent identity that already fails
+    the next ordinary commit at pre-commit.
+    """
+
+    def test_runner_render_pins_the_stage(
+        self, rendered_portable: dict[str, Any]
+    ) -> None:
+        """sync-manifest is runner-only — a repo generator for this repo."""
+        hook = _normalize(rendered_portable["runner"])["hooks"]["sync-manifest"]
+        assert hook.get("stages") == ["pre-commit"], (
+            "sync-manifest runs at every stage, so each commit re-runs the "
+            "manifest generator three times (#1491)"
+        )
+
+    def test_portable_renders_pin_the_agent_identity_stage(
+        self, rendered_portable: dict[str, Any]
+    ) -> None:
+        for profile in ("runner", "scaffold"):
+            hook = _normalize(rendered_portable[profile])["hooks"][
+                "check-agent-identity"
+            ]
+            assert hook.get("stages") == ["pre-commit"], (
+                f"{profile}: check-agent-identity guards the author, not the "
+                "message, and its consumer fragment runs at pre-commit only "
+                "(#1491)"
+            )
+
+    def test_consumer_surface_pins_the_agent_identity_stage(self) -> None:
+        """The surface the yaml fragments are being reconciled against."""
+        for name, config in _consumer_config_set().items():
+            hooks = _normalize(config)["hooks"]
+            if "check-agent-identity" not in hooks:
+                continue  # the customized shell disables it on purpose
+            assert hooks["check-agent-identity"].get("stages") == ["pre-commit"], name
+
+
 class TestCheckJsonExcludesJsoncBanners:
     """check-json skips the `//`-bannered JSONC scaffold files (#1053).
 


### PR DESCRIPTION
Closes #1491

## Summary

`sync-manifest` and `check-agent-identity` carried neither `stages:` nor a file
filter, so both ran at **every** hook stage. Split out of #1489, which fixed the
one hook of this group (`typos`) that actually broke a commit — only `typos`
received a filename, so the other two were pure waste rather than a second bug.

Both are now pinned to `pre-commit` in the `yaml` fragment of `nix/hooks.nix`,
which renders both committed configs.

## The `check-agent-identity` decision

The issue asked for a deliberate decision here rather than a reflex pin, because
this hook guards the *author/committer* and its consumer fragment already ran at
`pre-commit` only (git-hooks.nix defaults it there) while the `yaml` fragment ran
at all three — the runner and the flake-generated surfaces disagreed about when
it fires. Probed against real git rather than assumed:

| Path | `pre-commit` | message stages | `GIT_AUTHOR_NAME` / `EMAIL` seen |
|---|---|---|---|
| `git commit` | fires | fire | identical at all three stages |
| `git commit --author="Claude <…>"` | fires | fire | `Claude` at all three stages |
| `git merge` | — | fire | **empty** → falls back to `git config user.*` |
| `git rebase` replay | — | — (no `commit-msg` per pick) | — |

So the message stages saw nothing `pre-commit` did not, including under the
`--author=` override this hook exists to catch. The only real coverage delta is a
**merge commit**, where git exports no author and the hook merely re-read
`git config user.*` — the persistent identity that fails the committer's very
next ordinary commit at `pre-commit`. That is the trade recorded in the code
comment and the changelog: one locally-unguarded merge, in exchange for dropping
two of three invocations per commit.

## Verification

- `tests/test_flake_hooks.py::TestUnfilteredLocalHooksPinTheirStage` — RED on
  both portable renders before the fix, with the consumer surface already
  passing (the disagreement being reconciled). Full module green after: 68 passed
- Drift gate green — `nix/hooks.nix` and both committed configs stay in step
- Live-proven on this branch's own commits: before, one commit ran the two hooks
  9 times across the three rounds and both surfaces; after, they appear only in
  the `pre-commit` round — 3 invocations
- `just precommit` (`prek run --all-files`) green, exit 0, with both hooks still
  running — no lint coverage lost, which was the acceptance criterion
- `pytest tests/test_flake_hooks.py tests/test_transforms.py
  tests/test_workflow_model.py tests/test_workflow_prepare_extension.py` — 159 passed

## Consumer impact

`check-agent-identity` is scaffolded, so scaffolded repos adopt the alignment
with this release; direnv consumers were already at `pre-commit` and see no
change. `sync-manifest` is runner-only.