### PR TITLE
feat(nix): guardrails capability module — the org's semantic gates

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -98,7 +98,7 @@ repos:
         # .envrc files (root + the scaffolded template stub) are direnv stdlib
         # scripts with no shebang; exclude them from SC2148 at any path.
         args: ["-x"]
-        exclude: (^|/)\.envrc$
+        exclude: (^|/)\.envrc$|^assets/guardrails/
 
   # GitHub Actions workflow linting (actionlint from the flake dev-shell). Lints
   # THIS repo's own .github/workflows/ via auto-discovery; actionlint's bundled

--- a/.typos.toml
+++ b/.typos.toml
@@ -10,3 +10,11 @@ unexcepted = "unexcepted"
 Nd = "Nd"
 # podman rootless-networking helper package name (#1106), not a misspelling
 passt = "passt"
+# Vendored guardrails gates (#1488). All three are false positives in shell:
+# `tatus` is the tail of the regex class `[Ss]tatus:`, `fnd` is a shell
+# function name in the test harness, and `mis-attributes` is a real word.
+# Added as words rather than excluding assets/guardrails/ wholesale, so the
+# prose in those files stays spell-checked.
+tatus = "tatus"
+fnd = "fnd"
+mis = "mis"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`guardrails` capability module — the org's semantic gates, now devkit-owned**
+  ([#1488](https://github.com/vig-os/devkit/issues/1488),
+  [#1492](https://github.com/vig-os/devkit/issues/1492))
+  - devkit shipped 26 hooks to consumers and every one was syntactic. These 15
+    gates are the semantic half: no fake implementations, no hardcoded magic
+    values, no commented-out code, generated docs matching their source
+    command, no debug prints, trunk protection, ADR/feature-matrix coherence
+  - Vendored from `gerchowl/guardrails` under Apache-2.0 (the same licence and
+    holder as devkit, so the copies need no separate attribution). devkit is
+    now the source of truth; the upstream personal repo is being retired, so
+    the org's semantic enforcement no longer depends on one person's account
+  - **The module contributes `packages` only — no contract change.** Hook
+    ENTRIES are a scaffold concern, not a shell one: `.pre-commit-config.yaml`
+    is read by the runner from a bare git tree, by CI containers that never
+    enter `nix develop`, and by humans reading a diff. #1492 records why this
+    resolves the opposite way to `checks` (#1427) despite looking similar
+  - New `checks.guardrails-canary`: every gate is fed a known-bad fixture and
+    must reject it, and a known-good one and must stay quiet. This is the
+    assurance half — "protected" means *the gate rejected a known-bad input*,
+    not *the entry is in the config*, because four of this org's eight
+    recorded gate failures were "listed, did not run"
+  - New `checks.guardrails-shellcheck` at error+warning over the vendored
+    shell; the repo-wide hook (which runs at `style`) skips that tree rather
+    than force a rewrite of 3,000 lines of working, fixture-covered script
+
 - **Rust performance tooling: `@perf` tool groups + a deterministic ratchet**
   ([#1400](https://github.com/vig-os/devkit/issues/1400),
   [#1440](https://github.com/vig-os/devkit/issues/1440))

--- a/assets/guardrails/LICENSE
+++ b/assets/guardrails/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 vigOS
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/assets/guardrails/README.md
+++ b/assets/guardrails/README.md
@@ -1,0 +1,45 @@
+# Vendored guardrails gates
+
+Semantic code gates, vendored from [`gerchowl/guardrails`](https://github.com/gerchowl/guardrails)
+@ `61538e2` under Apache-2.0 (see `LICENSE`) — the same licence and holder as
+devkit, so these copies need no separate attribution block.
+
+**devkit is the source of truth for these files.** The upstream repo is being
+retired (vig-os/devkit#1488): an org toolchain whose semantic enforcement lives
+in a personal repository is a bus-factor question, and two separately-versioned
+copies of the same 3,000 lines drift. Edit them here.
+
+## Layout
+
+| path | what |
+|---|---|
+| `gates/` | the 15 gates, each a standalone POSIX shell script exiting non-zero on a finding |
+| `tools/` | `guardrails` (the CLI), `trace` (the per-hook JSONL wrapper every entry wraps), `trace-report` |
+| `gates/test-*.sh` | upstream's own fires-on-bad / quiet-on-good fixtures. They live BESIDE the gates because they resolve siblings via `dirname "$0"` — vendoring keeps upstream's layout so the scripts run unmodified |
+
+## Why shell
+
+Deliberate, and re-decided rather than inherited (vig-os/devkit#1488). The
+scripts are shellcheck-clean at `-S warning` (1 warning across all 15), every
+gate has a fixture, and the absent `set -e` is correct rather than sloppy —
+these gates `grep`, and grep exits 1 on no-match, so `-e` would abort on the
+*quiet* path.
+
+New gates should be written in Python (`vig-utils`), so the shell surface stops
+growing and the test/lint story converges. Port an existing gate only where
+shell is genuinely the wrong tool — the stateful ones (`perf-budget`,
+`perf-record`) and the nudge ledger, not the scanners.
+
+## Deliberately not vendored
+
+`templates/` — upstream's starter template for a repo adopting guardrails
+(a `flake.nix`, `ci.yml`, `deny.toml`, and two config stubs). devkit IS the
+scaffolding system, so carrying a second, unreferenced one would be dead
+surface that drifts from `assets/workspace/`. Nothing in `gates/` or `tools/`
+reads it. If a consumer needs those stubs, they belong in the scaffold proper.
+
+`crates/` — `guardrails-tunables` is Rust-only and belongs with the Rust
+language pack, not an org-wide gate module; `guardrails-trace` (the crate) is
+a tracing-subscriber wrapper for consumer *applications*, unrelated to the
+`guardrails-trace` hook wrapper in `tools/`, which is shell. Both are tracked
+on vig-os/devkit#1488.

--- a/assets/guardrails/gates/adr-matrix.sh
+++ b/assets/guardrails/gates/adr-matrix.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# guardrails: every **Accepted** ADR is reflected in the project's feature/status matrix. An ADR
+# records a decision; a hand-maintained FEATURE-MATRIX (or status doc) silently drifts the moment an
+# ADR is accepted without a matching row — and `derived-docs` can't catch a doc that has no generator.
+# This gate keys on ADR **status** (Accepted), NOT on edits, so Proposed ADRs (roadmap) and typo fixes
+# never trip it; only *decided* designs are required to appear.
+#
+# SOURCE OF TRUTH — the ADR FILES, not the index. Each `<adr-dir>/NNNN-slug.md` carries its own
+# `- Status: Accepted|Proposed|Superseded by NNNN` header, and that header IS the decision. This
+# gate used to read the *index* (docs/adr/README.md) instead — a hand-maintained restatement of
+# exactly that — so an Accepted ADR never added to the index was invisible to the gate built to
+# catch unreflected decisions. Two ADRs shipped that way in a consumer repo, sharing one id, with
+# the matrix citing that id for both documents. A gate that trusts a restatement has the very
+# defect it exists to prevent.
+#
+# Three checks, all keyed on the files:
+#   1. ids are unique     — two files claiming NNNN make every `ADR-NNNN` citation ambiguous
+#   2. Accepted → matrix  — the original purpose, now on real input
+#   3. Accepted → index   — the index is a DERIVED listing; if it exists it must be complete and
+#                           must agree that the ADR is Accepted
+#
+# Legacy fallback: a repo with an index but no parseable ADR files keeps the old index-derived
+# behaviour, so consumers that store ADRs elsewhere don't break.
+#
+# Convention: an ADR *index* (default docs/adr/README.md) has rows like
+#   | [0024](0024-....md) | description | **Accepted** |
+#
+# Usage: guardrails-adr-matrix [<adr-index>] [<matrix>]
+#   defaults: adr-index = docs/adr/README.md (else first **/adr/README.md)
+#             matrix    = first **/FEATURE-MATRIX.md
+# Exempt (recorded decisions that aren't feature rows): ADR numbers in guardrails-adr-exempt.txt
+#   (one per line, '#' comments allowed) and/or the $ADR_MATRIX_EXEMPT env (space-separated).
+set -uo pipefail
+
+case "${1:-}" in -h | --help) sed -n '2,/^set /p' "$0" | sed 's/^# \{0,1\}//; /^set /d'; exit 0 ;; esac
+
+index="${1:-}"
+matrix="${2:-}"
+[ -n "$index" ] || index="$([ -f docs/adr/README.md ] && echo docs/adr/README.md || find . -path '*/adr/README.md' -not -path '*/.git/*' 2>/dev/null | head -1)"
+[ -n "$matrix" ] || matrix="$(find . -name 'FEATURE-MATRIX.md' -not -path '*/.git/*' 2>/dev/null | head -1)"
+[ -f "$index" ] || { echo "guardrails-adr-matrix: no ADR index found — nothing to check"; exit 0; }
+[ -f "$matrix" ] || { echo "guardrails-adr-matrix: ADR index present but no FEATURE-MATRIX.md found" >&2; exit 1; }
+
+exempt=" ${ADR_MATRIX_EXEMPT:-} "
+[ -f guardrails-adr-exempt.txt ] && exempt="$exempt $(grep -vE '^[[:space:]]*#' guardrails-adr-exempt.txt | tr '\n' ' ') "
+is_exempt() { case "$exempt" in *" $1 "*) return 0 ;; esac; return 1; }
+
+adr_dir="$(dirname "$index")"
+
+status_of() { grep -iEm1 '^[^A-Za-z]*Status:' "$1" | sed 's/.*[Ss]tatus:[[:space:]]*//' | tr -d '*'; }
+id_of() { basename "$1" | cut -c1-4; }
+
+# --- discover the ADR files (the source of truth) -----------------------------
+adr_files=()
+while IFS= read -r f; do
+  [ -n "$f" ] && adr_files+=("$f")
+done <<EOF
+$(find "$adr_dir" -maxdepth 1 -type f -name '[0-9][0-9][0-9][0-9]-*.md' 2>/dev/null | sort)
+EOF
+
+if [ "${#adr_files[@]}" -eq 0 ]; then
+  # Legacy: no ADR files to read — fall back to the index as the (weaker) input.
+  echo "guardrails-adr-matrix: no ADR files under $adr_dir — falling back to the index" >&2
+  missing=""
+  while IFS= read -r line; do
+    num="$(printf '%s' "$line" | grep -oE '\[0[0-9]{3}\]' | head -1 | tr -dc '0-9')" || true
+    [ -n "$num" ] || continue
+    printf '%s' "$line" | grep -qi 'Accepted' || continue
+    is_exempt "$num" && continue
+    grep -q "ADR-$num" "$matrix" || missing="$missing $num"
+  done <"$index"
+  if [ -n "$missing" ]; then
+    echo "✗ adr-matrix: Accepted ADR(s) not cited in $(basename "$matrix"):$missing" >&2
+    echo "  → add a row citing ADR-NNNN, or exempt it (guardrails-adr-exempt.txt / \$ADR_MATRIX_EXEMPT)." >&2
+    exit 1
+  fi
+  echo "✓ adr-matrix: every Accepted ADR is cited in $(basename "$matrix") (index-derived)"
+  exit 0
+fi
+
+# --- 1. ids must be unique ----------------------------------------------------
+dupes="$(for f in "${adr_files[@]}"; do id_of "$f"; done | sort | uniq -d | tr '\n' ' ')"
+if [ -n "${dupes// /}" ]; then
+  echo "✗ adr-matrix: duplicate ADR id(s) in $adr_dir: ${dupes% }" >&2
+  for d in $dupes; do
+    for f in "${adr_files[@]}"; do
+      [ "$(id_of "$f")" = "$d" ] && echo "    $f" >&2
+    done
+  done
+  echo "  → renumber one of them; every 'ADR-NNNN' citation is ambiguous while both exist." >&2
+  exit 1
+fi
+
+# --- 2 + 3. Accepted ADRs must reach the matrix AND the index -----------------
+missing_matrix=""
+missing_index=""
+for f in "${adr_files[@]}"; do
+  num="$(id_of "$f")"
+  case "$(status_of "$f")" in [Aa]ccepted*) ;; *) continue ;; esac
+  is_exempt "$num" && continue
+  grep -q "ADR-$num" "$matrix" || missing_matrix="$missing_matrix $num"
+  # The index row for NNNN must exist AND agree that it is Accepted.
+  grep -E "\[$num\]" "$index" | grep -qi 'Accepted' || missing_index="$missing_index $num"
+done
+
+rc=0
+if [ -n "$missing_matrix" ]; then
+  echo "✗ adr-matrix: Accepted ADR(s) not cited in $(basename "$matrix"):$missing_matrix" >&2
+  echo "  → add a row citing ADR-NNNN, or exempt it (guardrails-adr-exempt.txt / \$ADR_MATRIX_EXEMPT)." >&2
+  rc=1
+fi
+if [ -n "$missing_index" ]; then
+  echo "✗ adr-matrix: Accepted ADR(s) missing from (or not Accepted in) $index:$missing_index" >&2
+  echo "  → the index is a derived listing: add the row, or fix its Status column to match the ADR." >&2
+  rc=1
+fi
+[ "$rc" = 0 ] || exit 1
+
+echo "✓ adr-matrix: every Accepted ADR is cited in $(basename "$matrix") and listed in $(basename "$index")"

--- a/assets/guardrails/gates/ci-shim.sh
+++ b/assets/guardrails/gates/ci-shim.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# guardrails: CI is a shim over a local-runnable check.
+# A workflow that runs project logic but never invokes a nix check
+# (`nix flake check` / `nix build` / `nix develop` / `nix run`) is drift: that
+# logic cannot be run locally and re-derives the build in YAML. Nudge toward the
+# shim pattern (see docs/CONVENTIONS.md "CI = a shim over a local-runnable check").
+#
+# NUDGE by default (warn, exit 0) — a hard gate here would false-positive on
+# every not-yet-migrated repo and train `--no-verify`. Promote to a hard gate
+# per-repo with GUARDRAILS_CI_SHIM_ENFORCE=1.
+#
+# Allowlist (legit host-bound workflows — browser e2e, platform/macOS/Windows
+# bundling, release, GPU/perf): annotate the file with a `guardrails-ok` line,
+# or bulk-allow via GUARDRAILS_CI_SHIM_ALLOW (space/colon-separated path globs).
+set -uo pipefail
+roots=("${@:-.}")
+enforce="${GUARDRAILS_CI_SHIM_ENFORCE:-}"
+allow="${GUARDRAILS_CI_SHIM_ALLOW:-}"
+hits=0
+
+files() {
+  for p in "$@"; do
+    if [ -d "$p" ]; then git -C "$p" ls-files 2>/dev/null | sed "s#^#${p%/}/#" || find "$p" -type f
+    elif [ -f "$p" ]; then echo "$p"; fi
+  done
+}
+
+allowed() { # path matches a GUARDRAILS_CI_SHIM_ALLOW glob?
+  local f="$1" g
+  for g in ${allow//:/ }; do
+    # shellcheck disable=SC2254
+    case "$f" in $g) return 0 ;; esac
+  done
+  return 1
+}
+
+while IFS= read -r f; do
+  case "$f" in
+    .github/workflows/*.yml | .github/workflows/*.yaml) ;;
+    */.github/workflows/*.yml | */.github/workflows/*.yaml) ;;
+    *) continue ;;
+  esac
+  [ -f "$f" ] || continue
+  grep -q 'guardrails-ok' "$f" && continue                       # per-file allowlist (standard escape)
+  allowed "$f" && continue                                       # bulk allowlist glob
+  grep -qE '^[[:space:]]*(-[[:space:]]+)?run:' "$f" || continue   # no inline logic (matches `run:` and `- run:`) → nothing to shim
+  grep -qE 'nix (flake check|build|develop|run)' "$f" && continue # invokes a nix check → it's a shim
+  printf '  %s — has `run:` logic but no `nix flake check`\n' "$f"
+  hits=$((hits + 1))
+done < <(files "${roots[@]}")
+
+[ "$hits" -gt 0 ] || exit 0
+
+msg="guardrails/ci-shim: $hits workflow(s) run logic without a nix check. CI should be a shim over \`nix flake check\` (run-local + CI, one definition — see CONVENTIONS.md). Host-bound jobs (e2e/platform/release) are legit: annotate the file \`guardrails-ok\` or set GUARDRAILS_CI_SHIM_ALLOW."
+if [ -n "$enforce" ]; then
+  echo "$msg" >&2
+  exit 1
+fi
+echo "nudge: $msg" >&2
+exit 0

--- a/assets/guardrails/gates/derived-docs.sh
+++ b/assets/guardrails/gates/derived-docs.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+# guardrails: derived docs match their source of truth. A doc/region that says it was generated
+# from `cmd` must STILL match `cmd`'s output — otherwise the docs lie. Hand-maintained "see also"
+# tables, generated CLI help, dumped schemas: all drift the moment the source moves. This gate
+# re-runs the declared command and diffs.
+#
+# Marker syntax (anywhere in a text file):
+#   <!-- guardrails:derived cmd="<shell command>" -->
+#   ...derived content...
+#   <!-- guardrails:derived:end -->
+#
+# Check mode (default): for each region, run `sh -c "$cmd"` at the repo root, trim trailing
+# whitespace per line + normalize the final newline, diff against the region. Mismatch → exit 1
+# with a unified diff and the `--fix` hint.
+# Fix mode (`--fix`): rewrite each region in place with fresh output.
+#
+# SECURITY — the commands run with the same trust as any pre-commit hook in this repo: the gate
+# executes what the REPO declares. A malicious marker is no different from a malicious hook entry;
+# review marker commands the same way you review `.pre-commit-config.yaml`. By design, not a bug.
+set -uo pipefail
+
+fix=0
+roots=()
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --fix) fix=1; shift ;;
+    --)    shift; while [ "$#" -gt 0 ]; do roots+=("$1"); shift; done ;;
+    -h|--help)
+      sed -n '2,/^set /p' "$0" | sed 's/^# \{0,1\}//; /^set /d'
+      exit 0 ;;
+    -*) echo "guardrails/derived-docs: unknown flag '$1'" >&2; exit 2 ;;
+    *)  roots+=("$1"); shift ;;
+  esac
+done
+[ "${#roots[@]}" -eq 0 ] && roots=(".")
+
+# File list: explicit args (prek passes staged files), else git-tracked files at the root. We scan
+# tracked TEXT files only — binary blobs can't carry a marker comment anyway, and the cost of
+# `file -b` per blob is real on large repos.
+list_files() {
+  for p in "$@"; do
+    if [ -d "$p" ]; then
+      ( cd "$p" && git ls-files 2>/dev/null ) | sed "s#^#${p%/}/#" \
+        || find "$p" -type f -not -path '*/.git/*'
+    elif [ -f "$p" ]; then
+      printf '%s\n' "$p"
+    fi
+  done
+}
+
+# A region looks like:
+#   <!-- guardrails:derived cmd="..." -->\n<body>\n<!-- guardrails:derived:end -->
+# We tolerate leading whitespace on the marker lines (markdown indents inside lists etc.) but the
+# START and END markers must be on lines of their own. Quotes around the command may be " or '.
+# bash regex is POSIX ERE (no backrefs), so we accept "any quote / any quote" and let the inner
+# (.*) be greedy minus the trailing `"` / `'` — both quote forms in practice land on a balanced
+# pair because the content is a shell command (the alternative would be picking the wrong closing
+# quote, which a sane command line doesn't produce).
+START_RE_DQ='^[[:space:]]*<!--[[:space:]]*guardrails:derived[[:space:]]+cmd="(.*)"[[:space:]]*-->[[:space:]]*$'
+START_RE_SQ="^[[:space:]]*<!--[[:space:]]*guardrails:derived[[:space:]]+cmd='(.*)'[[:space:]]*-->[[:space:]]*\$"
+END_RE='^[[:space:]]*<!--[[:space:]]*guardrails:derived:end[[:space:]]*-->[[:space:]]*$'
+
+# match_start <line> → echo command on stdout, return 0; else return 1.
+match_start() {
+  if [[ "$1" =~ $START_RE_DQ ]]; then printf '%s' "${BASH_REMATCH[1]}"; return 0; fi
+  if [[ "$1" =~ $START_RE_SQ ]]; then printf '%s' "${BASH_REMATCH[1]}"; return 0; fi
+  return 1
+}
+
+# Normalize a stream: strip trailing whitespace per line; ensure exactly one trailing newline.
+# (Same shape `sed` + a final newline. POSIX-portable.)
+normalize() { sed -e 's/[[:space:]]\+$//'; }
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+
+hits=0
+errors=0
+
+process_file() {
+  local f="$1"
+  [ -f "$f" ] || return 0
+  # Quick reject: file has neither start nor end marker.
+  if ! grep -qE 'guardrails:derived' "$f" 2>/dev/null; then return 0; fi
+
+  # Walk the file line by line, tracking region state.
+  local lineno=0 in_region=0 region_start=0 body_start=0 cmd="" body=""
+  local out_lines=() change=0
+  while IFS= read -r line || [ -n "$line" ]; do
+    lineno=$((lineno + 1))
+    if [ "$in_region" = 0 ]; then
+      if cmd="$(match_start "$line")"; then
+        in_region=1
+        region_start=$lineno
+        body=""
+        out_lines+=("$line")
+        # Body position in REBUILT-OUTPUT coordinates: once an earlier region's
+        # replacement changed the line count, source line numbers no longer map
+        # onto out_lines — truncating by them eats the text between regions.
+        body_start=${#out_lines[@]}
+        continue
+      fi
+      if [[ "$line" =~ $END_RE ]]; then
+        echo "guardrails/derived-docs: $f:$lineno: stray :end marker without a matching start" >&2
+        errors=$((errors + 1))
+        out_lines+=("$line")
+        continue
+      fi
+      out_lines+=("$line")
+    else
+      # Inside a region: another start marker = nested (illegal).
+      if cmd2="$(match_start "$line")"; then
+        echo "guardrails/derived-docs: $f:$lineno: nested derived region (started at line $region_start)" >&2
+        errors=$((errors + 1))
+        # Recover: treat as a fresh start so we don't cascade.
+        region_start=$lineno
+        cmd="$cmd2"
+        body=""
+        out_lines+=("$line")
+        body_start=${#out_lines[@]}
+        continue
+      fi
+      if [[ "$line" =~ $END_RE ]]; then
+        # Run the command, normalize, compare.
+        local fresh
+        if ! fresh="$(cd "$repo_root" && sh -c "$cmd" 2>&1)"; then
+          echo "guardrails/derived-docs: $f:$region_start: command failed: $cmd" >&2
+          printf '%s\n' "$fresh" | sed 's/^/    /' >&2
+          errors=$((errors + 1))
+          out_lines+=("$line")
+          in_region=0
+          continue
+        fi
+        local fresh_n have_n
+        fresh_n="$(printf '%s\n' "$fresh" | normalize)"
+        have_n="$(printf '%s' "$body" | normalize)"
+        # Strip a single trailing newline from each side so the diff isn't noisy about it.
+        if [ "$fresh_n" != "$have_n" ]; then
+          hits=$((hits + 1))
+          if [ "$fix" = 1 ]; then
+            change=1
+            # Replace the region body with fresh content: drop the body lines already pushed
+            # (everything after the start marker, whose rebuilt-output position is body_start)
+            # and push the fresh ones instead.
+            out_lines=("${out_lines[@]:0:$body_start}")
+            # Push each line of fresh_n. printf with %s and read -r preserves embedded blanks.
+            while IFS= read -r fl; do out_lines+=("$fl"); done <<< "$fresh_n"
+          else
+            echo "guardrails/derived-docs: $f:$region_start: derived region out of date" >&2
+            echo "    command: $cmd" >&2
+            # Unified diff (have → want). Use process substitutions; bash-only is fine here.
+            diff -u --label "$f (current)" --label "$f (from: $cmd)" \
+              <(printf '%s\n' "$have_n") <(printf '%s\n' "$fresh_n") \
+              | sed 's/^/    /' >&2 || true
+            echo "    run with --fix to regenerate" >&2
+          fi
+        fi
+        out_lines+=("$line")
+        in_region=0
+        continue
+      fi
+      # Accumulate body. Join with literal newlines.
+      if [ -z "$body" ]; then body="$line"; else body="$body"$'\n'"$line"; fi
+      out_lines+=("$line")
+    fi
+  done < "$f"
+
+  if [ "$in_region" = 1 ]; then
+    echo "guardrails/derived-docs: $f:$region_start: unterminated derived region (no :end marker)" >&2
+    errors=$((errors + 1))
+  fi
+
+  # In --fix mode, write back if anything changed.
+  if [ "$fix" = 1 ] && [ "$change" = 1 ] && [ "$errors" = 0 ]; then
+    # Preserve trailing-newline semantics: every line gets one \n; the original file probably
+    # ended with \n too, so this is the right shape for tracked text files.
+    local tmp; tmp="$(mktemp)"
+    : > "$tmp"
+    local l
+    for l in "${out_lines[@]}"; do
+      printf '%s\n' "$l" >> "$tmp"
+    done
+    mv "$tmp" "$f"
+    echo "guardrails/derived-docs: $f: regenerated" >&2
+  fi
+}
+
+while IFS= read -r f; do
+  # Skip obvious binaries by extension (cheap, no `file` dep).
+  case "$f" in
+    *.png|*.jpg|*.jpeg|*.gif|*.ico|*.pdf|*.woff|*.woff2|*.ttf|*.otf|*.bin|*.zip|*.tar|*.tgz|*.lock) continue ;;
+    */.git/*) continue ;;
+  esac
+  process_file "$f"
+done < <(list_files "${roots[@]}")
+
+if [ "$errors" -gt 0 ]; then
+  echo "guardrails/derived-docs: $errors marker error(s) — fix the syntax (no escape; bad markers can't be diffed)." >&2
+  exit 1
+fi
+if [ "$hits" -gt 0 ] && [ "$fix" = 0 ]; then
+  echo "guardrails/derived-docs: $hits region(s) out of date — re-run with --fix to regenerate." >&2
+  exit 1
+fi
+exit 0

--- a/assets/guardrails/gates/duplication.sh
+++ b/assets/guardrails/gates/duplication.sh
@@ -1,0 +1,287 @@
+#!/usr/bin/env bash
+# guardrails: duplication nudge — token-window clone detector (reinvention vs reuse).
+# N hand-rolled copies of the same block (modal/confirm handlers, esc-return
+# boilerplate, ...) are drift no per-line gate can see: no single line is wrong,
+# yet the divergence is expensive (multi-round debugging to find the one copy
+# that drifted). This surfaces that class early: normalize each line (strip
+# comments, collapse whitespace), slide a window of K significant lines, and flag
+# any window that recurs at ≥2 sites. Extract a shared helper, or annotate.
+#
+# NUDGE by default (report, exit 0) — a hard gate here false-positives on
+# intentional repetition and trains `--no-verify`. Promote per-repo with
+# GUARDRAILS_DUP_ENFORCE=1.
+#
+# STALENESS ESCALATION (anti-alarm-fatigue): a flat, repeated nudge habituates —
+# so instead of nagging on a timer, the loudness tracks *persistence*. A finding
+# recorded in the ledger (`--record`, committed like perf-history.csv) carries a
+# first-seen commit; its age is counted in COMMITS to HEAD (git as the
+# deterministic clock — no wall-time, stays reproducible). A clone that survives
+# GUARDRAILS_DUP_ENFORCE_AGE commits undealt-with has a decayed false-positive
+# probability, so it AUTO-PROMOTES from nudge → hard block: the nudge earns the
+# right to become a gate. Decorate or extract it and it drops from the ledger on
+# the next `--record` (ratchet-shrink). No infinite nag: every finding resolves
+# to silence or a one-time block.
+#
+# Precision-first: an EXACT ≥K normalized-line match is a real (type-1/2) clone,
+# so noise stays near zero. Diverged (type-4 "same intent, different code")
+# clones are out of scope for v1 — that needs fuzzy token/embedding similarity,
+# whose noise floor is too high to nudge on without triage. See CONVENTIONS.md.
+#
+# Modes:
+#   guardrails-duplication [paths...]            check + nudge/escalate (default)
+#   guardrails-duplication --record [paths...]   reconcile the ledger to disk
+# Knobs:
+#   GUARDRAILS_DUP_ENFORCE=1        promote ALL hits from nudge to hard gate
+#   GUARDRAILS_DUP_ENFORCE_AGE=N    auto-promote a finding once it has persisted
+#                                   ≥N commits (0 = off; ledger-driven)
+#   GUARDRAILS_DUP_LEDGER=path      ledger file (default .guardrails/dup-ledger.tsv)
+#   GUARDRAILS_DUP_MIN_LINES=N      window size in significant lines (default 6)
+#   GUARDRAILS_DUP_EXTS="rs go ..." file extensions to scan (default below)
+#   GUARDRAILS_DUP_ALLOW="glob:..." bulk-exclude path globs (space/colon-sep)
+#   per-file escape: a `guardrails-ok` line drops the file from the corpus.
+set -uo pipefail
+
+record=""
+if [ "${1:-}" = "--record" ]; then record=1; shift; fi
+roots=("${@:-.}")
+enforce="${GUARDRAILS_DUP_ENFORCE:-}"
+enforce_age="${GUARDRAILS_DUP_ENFORCE_AGE:-0}"
+case "$enforce_age" in ''|*[!0-9]*) enforce_age=0 ;; esac # garbage knob → escalation off, not a bash error
+ledger="${GUARDRAILS_DUP_LEDGER:-.guardrails/dup-ledger.tsv}"
+allow="${GUARDRAILS_DUP_ALLOW:-}"
+min_lines="${GUARDRAILS_DUP_MIN_LINES:-6}"
+exts="${GUARDRAILS_DUP_EXTS:-rs go py ts tsx js jsx c h cc cpp hpp java rb sh nix}"
+TAB="$(printf '\t')"
+
+files() {
+  for p in "$@"; do
+    if [ -d "$p" ]; then git -C "$p" ls-files 2>/dev/null | sed "s#^#${p%/}/#" || find "$p" -type f
+    elif [ -f "$p" ]; then echo "$p"; fi
+  done
+}
+
+allowed() { # path matches a GUARDRAILS_DUP_ALLOW glob?
+  local f="$1" g
+  for g in ${allow//:/ }; do
+    # shellcheck disable=SC2254
+    case "$f" in $g) return 0 ;; esac
+  done
+  return 1
+}
+
+ext_ok() {
+  local f="$1" e
+  for e in $exts; do case "$f" in *."$e") return 0 ;; esac; done
+  return 1
+}
+
+# Surviving corpus: right extension, not annotated, not bulk-allowed. Exclude a
+# top-level tests/ component too (mirrors the other gates' relative-path skip).
+list=()
+while IFS= read -r f; do
+  [ -f "$f" ] || continue
+  case "$f" in tests/* | */tests/*) continue ;; esac
+  ext_ok "$f" || continue
+  grep -q 'guardrails-ok' "$f" && continue
+  allowed "$f" && continue
+  list+=("$f")
+done < <(files "${roots[@]}")
+
+# Detection emits one machine record per clone group:
+#   GROUP<TAB>canonical_hash<TAB>n_sites<TAB>span_lines<TAB>site1|site2|...
+groups_raw=""
+if [ "${#list[@]}" -gt 1 ]; then
+  groups_raw="$(GUARDRAILS_DUP_MIN_LINES="$min_lines" python3 - "${list[@]}" <<'PY'
+import hashlib, multiprocessing, os, sys
+
+K = max(1, int(os.environ.get("GUARDRAILS_DUP_MIN_LINES", "6")))
+paths = sorted(set(sys.argv[1:]))
+
+
+def norm(line):
+    for marker in ("//", "#"):
+        i = line.find(marker)
+        if i != -1:
+            line = line[:i]
+    return " ".join(line.split())
+
+
+def significant(nl):
+    core = "".join(ch for ch in nl if ch.isalnum() or ch == "_")
+    return len(core) >= 3
+
+
+# Per-file scan: read + normalize + K-window hash. Embarrassingly parallel — this is the
+# compute that made duplication the wall-clock ceiling of the whole gate set (#34: the
+# verdict was "parallelize the lone compute island, don't build the engine"). The union-find
+# merge below stays serial (cheap).
+def scan(f):
+    try:
+        with open(f, "r", errors="replace") as fh:
+            rows = [(ln, nl) for ln, raw in enumerate(fh, 1)
+                    if significant(nl := norm(raw))]
+    except OSError:
+        return f, None, None
+    if not rows:
+        return f, None, None
+    win = []
+    for i in range(len(rows) - K + 1):
+        text = "\n".join(rows[j][1] for j in range(i, i + K))
+        win.append((i, hashlib.sha1(text.encode("utf-8", "replace")).hexdigest()))
+    # Only line NUMBERS cross the pipe — the normalized text is dead weight once the
+    # windows are hashed here in the worker (pickle volume ≈ the whole corpus otherwise).
+    return f, [r[0] for r in rows], win
+
+
+# fork, not spawn: this script arrives on stdin, so spawn's __main__ re-import is impossible
+# (macOS default). Workers touch only hashlib/str — fork-safe. Small corpora skip the pool
+# (fork+IPC overhead beats the win under ~32 files). pool.map preserves order → deterministic.
+cpus = os.cpu_count() or 1
+workers = min(cpus, 8)
+if len(paths) >= 32 and cpus > 1 and "fork" in multiprocessing.get_all_start_methods():
+    with multiprocessing.get_context("fork").Pool(workers) as pool:
+        results = pool.map(scan, paths, chunksize=max(1, len(paths) // (workers * 4)))
+else:
+    results = [scan(f) for f in paths]
+
+sig = {}
+occ = {}
+for f, rows, win in results:
+    if rows is None:
+        continue
+    sig[f] = rows
+    for i, h in win:
+        occ.setdefault(h, []).append((f, i))
+
+dup = {h: os_ for h, os_ in occ.items() if len(os_) >= 2}
+
+cover = {}
+for h, occs in dup.items():
+    for (f, i) in occs:
+        for j in range(i, i + K):
+            cover.setdefault((f, j), set()).add(h)
+
+by_file = {}
+for (f, j) in cover:
+    by_file.setdefault(f, set()).add(j)
+regions = []
+for f in sorted(by_file):
+    idxs = sorted(by_file[f])
+    start = prev = idxs[0]
+    for x in idxs[1:]:
+        if x == prev + 1:
+            prev = x
+        else:
+            regions.append((f, start, prev))
+            start = prev = x
+    regions.append((f, start, prev))
+
+
+def region_hashes(r):
+    f, s, e = r
+    hs = set()
+    for j in range(s, e + 1):
+        hs |= cover.get((f, j), set())
+    return hs
+
+
+parent = list(range(len(regions)))
+
+
+def find(x):
+    while parent[x] != x:
+        parent[x] = parent[parent[x]]
+        x = parent[x]
+    return x
+
+
+h2r = {}
+for ri, r in enumerate(regions):
+    for h in region_hashes(r):
+        h2r.setdefault(h, []).append(ri)
+for ris in h2r.values():
+    for k in range(1, len(ris)):
+        a, b = find(ris[0]), find(ris[k])
+        if a != b:
+            parent[a] = b
+
+groups = {}
+for ri, r in enumerate(regions):
+    groups.setdefault(find(ri), []).append(r)
+
+out = []
+for members in groups.values():
+    sites = sorted(set(members))
+    if len(sites) < 2:
+        continue
+    span = max(e - s + 1 for _, s, e in sites)
+    labels = [f"{f}:{sig[f][s]}-{sig[f][e]}" for (f, s, e) in sites]
+    hs = set()
+    for r in sites:
+        hs |= region_hashes(r)
+    ghash = min(hs) if hs else ""
+    out.append((span, ghash, len(labels), labels))
+
+for span, ghash, nsites, labels in sorted(out, key=lambda t: (-t[0], t[1])):
+    print(f"GROUP\t{ghash}\t{nsites}\t{span}\t{'|'.join(labels)}")
+PY
+)"
+fi
+
+# Lifecycle (first-seen stamping, age-in-commits, growth, promotion, ledger reconcile)
+# lives in the shared nudge-ledger harness (issue #32); this gate keeps detection and
+# vocabulary only. Findings: key=clone-hash, count=nsites, label=span|nsites|sites.
+# Fail-open by design: if the harness dies mid-check (its exit is discarded by the process
+# substitution below) the nudge still fires from `hits`, just without per-clone tiers —
+# degraded and visible, never a false block.
+nl_bin="$(command -v guardrails-nudge-ledger || true)"
+[ -n "$nl_bin" ] || nl_bin="$(cd "$(dirname "$0")" && pwd)/../tools/nudge-ledger.sh"
+
+findings=""; hits=0
+while IFS="$TAB" read -r tag h nsites span labels; do
+  [ "$tag" = GROUP ] || continue
+  hits=$((hits + 1))
+  findings+="${h}${TAB}${nsites}${TAB}${span}${TAB}${nsites}${TAB}${labels}"$'\n'
+done <<< "$groups_raw"
+
+# --record: the harness reconciles the ledger (persisting keys keep first-seen, new keys
+# stamp at HEAD, resolved keys drop → only shrinks unless real drift appears; sorted).
+if [ -n "$record" ]; then
+  printf '%s' "$findings" | "$nl_bin" record --ledger "$ledger"
+  exit 0
+fi
+
+report=""; promoted=0
+while IFS="$TAB" read -r h tier span nsites labels; do
+  [ -n "$h" ] || continue
+  sites_disp="${labels//|/, }"
+  case "$tier" in
+    new) t="(new)" ;;
+    promoted:*)
+      rest="${tier#promoted:}"; age="${rest%%:*}"
+      grew=""; case "$rest" in *:grew:*) g="${rest##*:grew:}"; grew=" grew ${g%>*}→${g#*>} sites" ;; esac
+      t="(persisted ${age} commits${grew} → PROMOTED to block)"
+      promoted=$((promoted + 1)) ;;
+    persisted:*:grew:*)
+      rest="${tier#persisted:}"; age="${rest%%:*}"; g="${rest##*:grew:}"
+      t="(persisted ${age} commits grew ${g%>*}→${g#*>} sites) ⚠" ;;
+    persisted:*) t="(persisted ${tier#persisted:} commits)" ;;
+    *) t="($tier)" ;;
+  esac
+  report+="  dup: ~${span} significant lines cloned across ${nsites} sites ${t}: ${sites_disp}"$'\n'
+done < <(printf '%s' "$findings" | "$nl_bin" check --ledger "$ledger" --enforce-age "$enforce_age")
+
+[ "$hits" -gt 0 ] || exit 0
+printf '%s' "$report"
+msg="guardrails/duplication: $hits cloned block group(s) (≥${min_lines} normalized lines). Extract a shared helper, or bless intentional repetition with a \`guardrails-ok\` line / GUARDRAILS_DUP_ALLOW glob."
+if [ "$promoted" -gt 0 ]; then
+  echo "$msg" >&2
+  echo "  ↑ $promoted finding(s) auto-promoted to a hard block after persisting ≥${enforce_age} commits undealt-with." >&2
+  exit 1
+fi
+if [ -n "$enforce" ]; then
+  echo "$msg" >&2
+  exit 1
+fi
+echo "nudge: $msg" >&2
+exit 0

--- a/assets/guardrails/gates/no-commented-code.sh
+++ b/assets/guardrails/gates/no-commented-code.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# guardrails: no commented-out code (use git history, not graveyards).
+# Conservative heuristic: comment lines that end in code punctuation (; { }) — strong commented-code
+# signal — excluding doc comments (/// //! #!) and `guardrails-ok`. Tuned for low false-positives.
+set -uo pipefail
+roots=("${@:-.}")
+hits=0
+files() {
+  for p in "$@"; do
+    if [ -d "$p" ]; then git -C "$p" ls-files 2>/dev/null | sed "s#^#${p%/}/#" || find "$p" -type f
+    elif [ -f "$p" ]; then echo "$p"; fi
+  done
+}
+while IFS= read -r f; do
+  case "$f" in *.rs|*.ts|*.tsx|*.js|*.mjs|*.go) ;; *) continue ;; esac
+  case "$f" in *gates/*|tests/*|*/tests/*) continue ;; esac
+  # `//` (not /// or //!) followed by something ending in ; { or } → looks like commented-out code.
+  while IFS=: read -r no line; do
+    case "$line" in *guardrails-ok*) continue ;; esac
+    printf '  %s:%s:%s\n' "$f" "$no" "$(printf '%s' "$line" | sed 's/^[[:space:]]*//')"
+    hits=$((hits + 1))
+  done < <(grep -nE '^[[:space:]]*//[^/!].*[;{}][[:space:]]*$' "$f" 2>/dev/null)
+done < <(files "${roots[@]}")
+if [ "$hits" -gt 0 ]; then
+  echo "guardrails/no-commented-code: $hits commented-out code line(s) — delete (git remembers), or annotate 'guardrails-ok'." >&2
+  exit 1
+fi

--- a/assets/guardrails/gates/no-conflict-markers.sh
+++ b/assets/guardrails/gates/no-conflict-markers.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# guardrails: no committed merge-conflict markers. A conflicted merge can be committed with the
+# `<<<<<<<`/`=======`/`>>>>>>>` markers still in the file — git happily records it, `git status`
+# is clean afterwards, and the file is silently broken (a real incident: markers committed into a
+# flake.nix made `nix develop` unevaluable on main while every status looked green).
+#
+# Deterministic, zero-false-positive-by-construction:
+#   * `<<<<<<< ` and `>>>>>>> ` at line start are flagged unconditionally (the space+ref form git
+#     writes; a 7-char ASCII arrow run starting a line has no legitimate use in source).
+#   * a bare `=======` line is flagged ONLY if the same file also contains a `<<<<<<<` marker —
+#     setext markdown headings underlined with equals signs stay legal.
+# No escape hatch on purpose: there is no legitimate committed conflict marker.
+set -uo pipefail
+
+roots=("${@:-.}")
+hits=0
+
+# Build the file list: explicit args (prek passes staged files), else git-tracked text files.
+list_files() {
+  if [ "$#" -gt 0 ] && [ "$1" != "." ]; then
+    printf '%s\n' "$@"
+  else
+    git ls-files 2>/dev/null || find . -type f -not -path './.git/*'
+  fi
+}
+
+while IFS= read -r f; do
+  [ -f "$f" ] || continue
+  case "$f" in *.png|*.jpg|*.jpeg|*.gif|*.ico|*.pdf|*.woff*|*.bin|*.lock) continue ;; esac
+  # Markers written literally (awk interval-regex portability); they sit mid-line here, and the
+  # gate only flags them at line START, so this file does not flag itself.
+  out="$(awk '
+    /^<<<<<<<( |$)/ { print FILENAME ":" FNR ": " $0; start = 1; next }
+    /^>>>>>>>( |$)/ { print FILENAME ":" FNR ": " $0; next }
+    /^=======$/     { eq[FNR] = $0 }
+    END { if (start) for (n in eq) print FILENAME ":" n ": " eq[n] }
+  ' "$f" 2>/dev/null)"
+  if [ -n "$out" ]; then
+    printf '%s\n' "$out"
+    hits=$((hits + $(printf '%s\n' "$out" | grep -c .)))
+  fi
+done < <(list_files "${roots[@]}")
+
+if [ "$hits" -gt 0 ]; then
+  echo "guardrails/no-conflict-markers: $hits merge-conflict marker line(s) committed — resolve the conflict (no escape: there is no legitimate committed marker)." >&2
+  exit 1
+fi

--- a/assets/guardrails/gates/no-debug-leftovers.sh
+++ b/assets/guardrails/gates/no-debug-leftovers.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# guardrails: no debug-print leftovers — force the logging/tracing facade, not stdout spew.
+# Flags dbg!()/print!()/println!()/eprint!()/eprintln!() (Rust) and console.log/debug + print(
+# (TS/JS/Py) in lib/app code. Always allowed in main.rs/build.rs/bin/tests/examples (build.rs
+# uses println! for cargo: directives), and on any line annotated `guardrails-ok`.
+#
+# CLI tools legitimately write to stdout/stderr. Set GUARDRAILS_OUTPUT_GLOBS to a colon-separated
+# list of path globs for those output surfaces (e.g. "*/cli/*:*/cli.rs:*/update.rs") so the gate
+# stays high-signal on app/library code instead of drowning in command-output false positives.
+set -uo pipefail
+roots=("${@:-.}")
+hits=0
+
+IFS=: read -ra output_globs <<< "${GUARDRAILS_OUTPUT_GLOBS:-}"
+
+# A path is an allowed output surface if it's a built-in entrypoint/test path, or matches one of
+# the repo-configured GUARDRAILS_OUTPUT_GLOBS.
+allowed_output() {
+  # Dir-walks arrive './'-prefixed (files() sed); normalize so globs without a
+  # leading '*' (vendor/*, scripts/*) still match.
+  set -- "${1#./}"
+  case "$1" in *gates/*|tests/*|*/tests/*|*_test.*|*.test.*|examples/*|*/examples/*|main.rs|*/main.rs|build.rs|*/build.rs|bin/*|*/bin/*) return 0 ;; esac
+  local g
+  for g in "${output_globs[@]}"; do
+    [ -n "$g" ] || continue
+    # $g is intentionally a glob pattern for case-matching
+    # shellcheck disable=SC2254
+    case "$1" in $g) return 0 ;; esac
+  done
+  return 1
+}
+
+files() {
+  for p in "$@"; do
+    if [ -d "$p" ]; then git -C "$p" ls-files 2>/dev/null | sed "s#^#${p%/}/#" || find "$p" -type f
+    elif [ -f "$p" ]; then echo "$p"; fi
+  done
+}
+
+# Filtering is pure bash (no per-file process). Rust vs web/py use different
+# patterns, so partition into two batches, then run grep ONCE per batch instead
+# of once per file — the fork-exec per file was the whole cost on a large tree.
+rust_files=(); web_files=()
+while IFS= read -r f; do
+  case "$f" in *.rs) ;; *.ts|*.tsx|*.js|*.mjs|*.py) ;; *) continue ;; esac
+  allowed_output "$f" && continue
+  case "$f" in *.rs) rust_files+=("$f") ;; *) web_files+=("$f") ;; esac
+done < <(files "${roots[@]}")
+
+rust_pat='dbg!\(|e?println!\(|e?print!\('
+web_pat='dbg!\(|console\.(log|debug)\(|[[:space:]]print\('
+
+# grep -nHE over a NUL-delimited batch: -H forces the file: prefix even for a
+# single file, xargs -0 survives paths with spaces. Length-guarded so an empty
+# batch never feeds grep an empty arg list (which would block on stdin).
+matches=""
+if [ "${#rust_files[@]}" -gt 0 ]; then
+  matches+="$(printf '%s\0' "${rust_files[@]}" | xargs -0 grep -nHE "$rust_pat" 2>/dev/null)"$'\n'
+fi
+if [ "${#web_files[@]}" -gt 0 ]; then
+  matches+="$(printf '%s\0' "${web_files[@]}" | xargs -0 grep -nHE "$web_pat" 2>/dev/null)"$'\n'
+fi
+
+# Drop `guardrails-ok`-annotated lines (per-line escape). Scope the filter to the
+# content past the `file:line:` prefix — filtering the whole joined line would let
+# a path containing 'guardrails-ok' suppress every finding under it.
+leaks="$(printf '%s' "$matches" | awk '{ c=$0; sub(/^[^:]+:[0-9]+:/, "", c); if (c !~ /guardrails-ok/ && $0 !~ /^[[:space:]]*$/) print }')"
+if [ -n "$leaks" ]; then
+  printf '%s\n' "$leaks" | sed -E 's/^([^:]+:[0-9]+:)[[:space:]]*/  \1/'
+  hits=$(printf '%s\n' "$leaks" | grep -c .)
+fi
+
+if [ "$hits" -gt 0 ]; then
+  echo "guardrails/no-debug-leftovers: $hits debug-print(s) — use the tracing facade, or annotate 'guardrails-ok'." >&2
+  exit 1
+fi

--- a/assets/guardrails/gates/no-fake-impl.sh
+++ b/assets/guardrails/gates/no-fake-impl.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# guardrails: no fake/placeholder implementations shipped as "done".
+# Catches the #1 agent failure mode — code that *looks* finished but is a stub.
+# Escape hatch: append `guardrails-ok` on the line. Tests/examples are exempt.
+#
+# `placeholder` matches only its STUB sense — `placeholder impl[ementation]` or a `// placeholder`
+# comment marker — not the bare word, which is legitimate vocabulary (e.g. the Kitty graphics
+# `*_PLACEHOLDER` protocol constants, form/UI placeholders, sentinel vars). Bare `not implemented`
+# is dropped too: the `unimplemented!()` macro covers real stubs, while the phrase otherwise lands
+# on legitimate runtime error strings.
+set -uo pipefail
+roots=("${@:-.}")
+pat='todo!\(|unimplemented!\(|unreachable!\("?(not|todo|fixme)|FIXME|XXX:|placeholder[ _-]impl|(//+|#+)[[:space:]]*placeholder[.[:space:]]*$'
+hits=0
+files() {
+  for p in "$@"; do
+    if [ -d "$p" ]; then git -C "$p" ls-files 2>/dev/null | sed "s#^#${p%/}/#" || find "$p" -type f
+    elif [ -f "$p" ]; then echo "$p"; fi
+  done
+}
+while IFS= read -r f; do
+  case "$f" in *.rs|*.ts|*.tsx|*.js|*.mjs|*.py|*.go) ;; *) continue ;; esac
+  case "$f" in *gates/*|tests/*|*/tests/*|*_test.*|*.test.*|examples/*|*/examples/*) continue ;; esac
+  while IFS=: read -r no line; do
+    case "$line" in *guardrails-ok*) continue ;; esac
+    printf '  %s:%s:%s\n' "$f" "$no" "$(printf '%s' "$line" | sed 's/^[[:space:]]*//')"
+    hits=$((hits + 1))
+  done < <(grep -nEi "$pat" "$f" 2>/dev/null)
+done < <(files "${roots[@]}")
+if [ "$hits" -gt 0 ]; then
+  echo "guardrails/no-fake-impl: $hits placeholder/fake-impl marker(s) — implement, or annotate 'guardrails-ok'." >&2
+  exit 1
+fi

--- a/assets/guardrails/gates/no-hardcoded.sh
+++ b/assets/guardrails/gates/no-hardcoded.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# guardrails: no bare hardcoded values — wrap them in `const_tunable!` / `config!` so every magic
+# value lands in the generated TUNABLES.md (registered + auditable from one file). This is the
+# enforcement half of the decorator→registry pattern.
+#
+# Heuristic (low false-positive, documented): in scanned `crates/*/src/**/*.rs` and root
+# `src/**/*.rs` (single-crate repos), flags
+#   * float literals (except 0.0/0.5/1.0/2.0) — checked PER TOKEN, so an allowed `0.0` on the same
+#     line doesn't mask a `3.7`,
+#   * decimal integers >= 100 (hex/binary excluded; digit-group underscores normalised so `100_000`
+#     is still seen),
+#   * absolute `/Users/`, `/home/`, `/tmp/` paths — checked with string literals INTACT (that's
+#     where paths live),
+#   * bare project env-var name literals, when GUARDRAILS_ENV_PREFIXES is set (colon-separated,
+#     e.g. "MYAPP_:OTHER_") — write the shared const, not the string.
+# Exempt when the line:
+#   - is inside a `const_tunable!(...)` / `config!(...)` invocation (the sanctioned home), or
+#   - carries `guardrails-ok` / `hardcode-ok`, or sits inside a
+#     `guardrails-ok-begin` … `guardrails-ok-end` block (hardcode-ok-begin/-end work too), or
+#   - sits in the `#[cfg(test)]`-attributed item (module body or brace-less item), or
+#   - the file/prefix is listed in `guardrails-allow.txt`.
+#
+# RATCHET MODE (adoption without big-bang triage, issue #30): commit a per-file count snapshot
+# (`guardrails-no-hardcoded --record-baseline` → guardrails-baseline.txt, or point
+# GUARDRAILS_HARDCODED_BASELINE elsewhere). With a baseline present, per file:
+#   count > baseline → HARD FAIL (new magic values are gated — strict on growth),
+#   count < baseline → pass + nudge to re-record (the ratchet only tightens),
+#   count = baseline → pass, silently.
+# `--record-baseline` refuses to snapshot a count higher than the committed one. No baseline
+# file → exactly today's all-or-nothing behavior; existing consumers are unaffected.
+set -uo pipefail
+root="$(git rev-parse --show-toplevel 2>/dev/null || echo .)"
+cd "$root" || exit 2
+allow="guardrails-allow.txt"
+baseline="${GUARDRAILS_HARDCODED_BASELINE:-guardrails-baseline.txt}"
+
+record=0
+if [ "${1:-}" = "--record-baseline" ]; then record=1; shift; fi
+
+files=()
+# --record-baseline snapshots the WHOLE scan surface (a baseline of just-staged files would
+# shrink the committed snapshot to whatever happened to be in the index).
+if [ "$#" -gt 0 ] && [ "$record" = 0 ]; then for a in "$@"; do files+=("$a"); done
+else while IFS= read -r x; do files+=("$x"); done < <({ find crates -type f -name '*.rs' -path '*/src/*'; find src -type f -name '*.rs'; } 2>/dev/null); fi
+
+prefixes=()
+[ -f "$allow" ] && while IFS= read -r l; do l="${l%%#*}"; l="$(printf '%s' "$l" | tr -d '[:space:]')"; [ -n "$l" ] && prefixes+=("$l"); done < "$allow"
+
+is_exempt() {
+  # Normalise `./src/x.rs` → `src/x.rs` so the repo-root patterns below match both shapes.
+  local path="${1#./}"
+  case "$path" in *.rs) ;; *) return 0 ;; esac
+  # `src/*` covers single-crate repos (pre-commit passes RELATIVE paths from the repo root —
+  # `src/foo.rs` never matches `*/src/*`, which previously made the gate vacuously green there);
+  # `*/src/*` covers workspace `crates/*/src/**` and absolute paths.
+  case "$path" in src/*|*/src/*) ;; *) return 0 ;; esac
+  # NB: guard the empty expansion — `"${prefixes[@]:-}"` yields ONE EMPTY WORD when the array is
+  # empty, and an empty prefix `case`-matches every path: without this guard the gate silently
+  # exempted ALL files whenever guardrails-allow.txt was absent (a vacuously-green gate).
+  for p in "${prefixes[@]:-}"; do
+    [ -n "$p" ] || continue
+    case "$path" in "$p"*) return 0 ;; esac
+  done
+  return 1
+}
+
+# Colon-separated env-name prefixes to flag as bare string literals (project env vars belong in
+# one shared const). Converted to an ERE alternation for awk; empty = check disabled.
+env_re=""
+if [ -n "${GUARDRAILS_ENV_PREFIXES:-}" ]; then
+  env_re="$(printf '%s' "$GUARDRAILS_ENV_PREFIXES" | tr -s ':' '|' | sed 's/^|//; s/|$//')"
+fi
+
+hits=0
+all_out=""   # every hit line (printed straight in all-or-nothing mode, filtered in ratchet mode)
+counts=""    # "path<TAB>count" per scanned file (count 0 included — burn-down detection needs it)
+for f in "${files[@]:-}"; do
+  [ -f "$f" ] || continue
+  is_exempt "$f" && continue
+  out="$(awk -v env_re="$env_re" '
+    # #[cfg(test)] exempts only the ITEM it attributes, not the rest of the file: arm on the
+    # attribute, then skip until the item body closes (brace-counted on a string/comment-stripped
+    # copy) or a brace-less item (`use`/`mod foo;`/const) ends in `;`. Previously the flag never
+    # reset, so all prod code below any mid-file test attr/helper went unscanned to EOF.
+    /#\[cfg\(test\)\]/ { intest = 1; tdepth = 0 }
+    intest {
+      body = $0
+      sub(/\/\/.*/, "", body)
+      gsub(/"[^"]*"/, "", body)
+      opens = gsub(/{/, "", body); closes = gsub(/}/, "", body)
+      tdepth += opens - closes
+      if (opens + closes > 0 && tdepth <= 0) intest = 0
+      else if (opens == 0 && tdepth == 0 && body ~ /;[[:space:]]*$/) intest = 0
+      next
+    }
+    /guardrails-ok-begin|hardcode-ok-begin/ { inblock = 1; next }   # block escape: exempt until -end
+    /guardrails-ok-end|hardcode-ok-end/     { inblock = 0; next }
+    inblock { next }
+    /const_tunable!|config!|guardrails-ok|hardcode-ok/ { next }
+    {
+      line = $0
+      sub(/\/\/.*/, "", line)            # strip // line comments
+      # Path/env-name checks run with STRING LITERALS INTACT — that is where these values live.
+      if (line ~ /\/Users\/|\/home\/|\/tmp\//) { print FILENAME ":" FNR ": " $0; next }
+      if (env_re != "" && line ~ ("\"(" env_re ")")) { print FILENAME ":" FNR ": " $0; next }
+      # Numeric checks run on a string-blanked copy (format specs / escape sequences are not values).
+      nostr = line
+      gsub(/"[^"]*"/, "", nostr)
+      # Normalise digit-group underscores so 100_000 is still a 6-digit integer to the checks below.
+      while (nostr ~ /[0-9]_[0-9]/) { gsub(/_/, "", nostr) }
+      # Floats: PER TOKEN, so an allowed 0.0 on the line does not mask a flagged 3.7.
+      s = nostr
+      flagged = 0
+      while (match(s, /[0-9]+\.[0-9]+/)) {
+        tok = substr(s, RSTART, RLENGTH); s = substr(s, RSTART + RLENGTH)
+        if (tok != "0.0" && tok != "0.5" && tok != "1.0" && tok != "2.0") { flagged = 1; break }
+      }
+      if (flagged) { print FILENAME ":" FNR ": " $0; next }
+      # Integers >= 100 (drop hex/binary and floats from the copy first).
+      t = nostr
+      gsub(/0[xX][0-9a-fA-F]+/, "", t)
+      gsub(/0[bB][01]+/, "", t)
+      gsub(/[0-9]+\.[0-9]+/, "", t)
+      if (t ~ /(^|[^0-9a-zA-Z_.])[1-9][0-9][0-9]/) { print FILENAME ":" FNR ": " $0 }
+    }
+  ' "$f")"
+  cnt=0
+  if [ -n "$out" ]; then
+    all_out+="$out"$'\n'
+    cnt=$(printf '%s\n' "$out" | grep -c .)
+    hits=$((hits + cnt))
+  fi
+  counts+="${f#./}"$'\t'"$cnt"$'\n'
+done
+
+# --record-baseline: write the snapshot (nonzero counts only, sorted). The ratchet only
+# tightens: refuse to record any per-file count above the committed one.
+if [ "$record" = 1 ]; then
+  if [ -f "$baseline" ]; then
+    # (baseline loaded via getline, not NR==FNR — an EMPTY committed baseline must not make
+    # awk mistake the first stdin line for a baseline row)
+    regress="$(printf '%s' "$counts" | awk -F'\t' -v bl="$baseline" '
+      BEGIN { while ((getline l < bl) > 0) { n = index(l, "\t"); old[substr(l, 1, n - 1)] = substr(l, n + 1) + 0 } }
+      NF && $2 + 0 > (($1 in old) ? old[$1] : 0) { print "  " $1 ": " (($1 in old) ? old[$1] : 0) " -> " $2 }
+    ')"
+    if [ -n "$regress" ]; then
+      echo "guardrails/no-hardcoded: refusing --record-baseline — count(s) grew past the committed baseline:" >&2
+      printf '%s\n' "$regress" >&2
+      echo "  Fix the new bare values (wrap in const_tunable!/config!), then re-record." >&2
+      echo "  Renamed a file with known debt? The ratchet compares by path — move its row in $baseline to the new path, then re-record." >&2
+      exit 1
+    fi
+  fi
+  printf '%s' "$counts" | awk -F'\t' '$2 + 0 > 0' | LC_ALL=C sort > "$baseline"
+  echo "guardrails/no-hardcoded: baseline recorded → $baseline ($(grep -c . "$baseline" 2>/dev/null || echo 0) file(s) with debt). Commit it." >&2
+  exit 0
+fi
+
+# Ratchet mode: a committed baseline splits the verdict per file (growth gates, burn-down
+# nudges re-record, at-baseline stays silent — that's the adoption story).
+if [ -f "$baseline" ]; then
+  over="$(printf '%s' "$counts" | awk -F'\t' -v bl="$baseline" '
+    BEGIN { while ((getline l < bl) > 0) { n = index(l, "\t"); old[substr(l, 1, n - 1)] = substr(l, n + 1) + 0 } }
+    NF && $2 + 0 > (($1 in old) ? old[$1] : 0) { print $1 }
+  ')"
+  under="$(printf '%s' "$counts" | awk -F'\t' -v bl="$baseline" '
+    BEGIN { while ((getline l < bl) > 0) { n = index(l, "\t"); old[substr(l, 1, n - 1)] = substr(l, n + 1) + 0 } }
+    NF && ($1 in old) && $2 + 0 < old[$1] { print $1 }
+  ')"
+  if [ -n "$over" ]; then
+    printf '%s' "$all_out" | awk -F: -v overlist="$over" '
+      BEGIN { n = split(overlist, a, "\n"); for (i = 1; i <= n; i++) ov[a[i]] = 1 }
+      { p = $1; sub(/^\.\//, "", p) }   # counts/baseline keys are ./-normalized; hit lines are raw
+      ov[p]'
+    echo "guardrails/no-hardcoded: $(printf '%s\n' "$over" | grep -c .) file(s) grew past the committed baseline ($baseline) — new bare values are gated. Wrap in const_tunable!/config!, or annotate 'guardrails-ok'." >&2
+    exit 1
+  fi
+  if [ -n "$under" ]; then
+    echo "guardrails/no-hardcoded: NUDGE — $(printf '%s\n' "$under" | grep -c .) file(s) burned below the baseline. Bank the win: guardrails-no-hardcoded --record-baseline (then commit $baseline)." >&2
+  fi
+  exit 0
+fi
+
+if [ "$hits" -gt 0 ]; then
+  printf '%s' "$all_out"
+  echo "guardrails/no-hardcoded: $hits bare value(s) — wrap in const_tunable!/config! (→ TUNABLES.md), or annotate 'guardrails-ok'." >&2
+  exit 1
+fi

--- a/assets/guardrails/gates/no-raw-trace-fields.sh
+++ b/assets/guardrails/gates/no-raw-trace-fields.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# guardrails: no raw Debug/Display field formatters in `tracing` macros — keep the
+# structured-log / audit surface DELIBERATE. Flags `?expr` / `%expr` *field* formatters
+# (e.g. info!(user = ?user), debug!(%peer), error!(?e)) which splat an arbitrary value's
+# Debug/Display into the log — the classic way PII or secrets leak into the audit trail
+# by reflex. The one place raw formatting belongs is the schema/redaction surface where
+# the shaped fields are DEFINED; allowlist it with GUARDRAILS_TRACE_ALLOW_GLOBS
+# (colon-separated path globs; a matched file is skipped wholesale). Rust-only (tracing
+# is a Rust crate). tests/examples are exempt. Escape: `guardrails-ok` on the line, or on
+# a pure `//` comment line directly above it (stable under rustfmt's comment wrapping).
+#
+# Detection: a `?`/`%` in *field position* — right after a `(` or `,` field separator, or
+# after a `name =` — followed by an identifier start. The delimiter anchor excludes the
+# try operator (`foo()?`), modulo (`a % b`), and `=>` match arms. String/char literals are
+# blanked first, so regex patterns like r"(?i)…" / "(?P<n>…)" are NOT mistaken for the
+# tracing shorthand `info!(?x)` (a real field formatter is Rust code, never inside a string).
+set -uo pipefail
+roots=("${@:-.}")
+hits=0
+
+IFS=: read -ra allow_globs <<< "${GUARDRAILS_TRACE_ALLOW_GLOBS:-}"
+
+# The schema/redaction surface (allowlisted) + the standard built-in exemptions.
+allowed_file() {
+  # Dir-walks arrive './'-prefixed; normalize so allow-globs without a leading
+  # '*' still match (same class as the no-hardcoded src/* normalization).
+  set -- "${1#./}"
+  case "$1" in *gates/*|tests/*|*/tests/*|*_test.*|*.test.*|examples/*|*/examples/*) return 0 ;; esac
+  local g
+  for g in "${allow_globs[@]}"; do
+    [ -n "$g" ] || continue
+    # $g is intentionally a glob pattern, not a literal.
+    # shellcheck disable=SC2254
+    case "$1" in $g) return 0 ;; esac
+  done
+  return 1
+}
+
+files() {
+  for p in "$@"; do
+    if [ -d "$p" ]; then git -C "$p" ls-files 2>/dev/null | sed "s#^#${p%/}/#" || find "$p" -type f
+    elif [ -f "$p" ]; then echo "$p"; fi
+  done
+}
+
+# Emit one line per source line with string/char-literal content and // comments blanked,
+# so the field-formatter pattern can't match inside a string (regex `(?i)` etc.) or comment.
+# Handles "…" (with \" escapes), char '…', and single-line raw strings r"…" / r#"…"#.
+# Line count is preserved 1:1 so `grep -n` line numbers map back to the source.
+blank_strings() {
+  awk '
+  {
+    s=$0; n=length(s); out=""; i=1
+    while (i<=n) {
+      c=substr(s,i,1)
+      if (c=="/" && substr(s,i+1,1)=="/") break                       # // line comment
+      if (c=="r" && (substr(s,i+1,1)=="\"" || substr(s,i+1,1)=="#")) { # raw string r"…"/r#"…"#
+        j=i+1; h=0
+        while (substr(s,j,1)=="#") { h++; j++ }
+        if (substr(s,j,1)=="\"") {
+          j++
+          while (j<=n) {
+            if (substr(s,j,1)=="\"") { k=0; while (substr(s,j+1+k,1)=="#" && k<h) k++; if (k==h) { j=j+1+h; break } }
+            j++
+          }
+          out=out " "; i=j; continue
+        }
+      }
+      if (c=="\"") {                                                   # normal string
+        j=i+1
+        while (j<=n) { if (substr(s,j,1)=="\\") { j+=2; continue } if (substr(s,j,1)=="\"") { j++; break } j++ }
+        out=out " "; i=j; continue
+      }
+      if (c=="\x27") {                                                 # char literal (lifetimes lack a near closing quote)
+        if (substr(s,i+1,1)=="\\" && substr(s,i+3,1)=="\x27") { out=out "  "; i=i+4; continue }
+        if (substr(s,i+2,1)=="\x27") { out=out "  "; i=i+3; continue }
+      }
+      out=out c; i++
+    }
+    print out
+  }' "$1"
+}
+
+# Field-formatter in field position: after ( or , (alt 1), or after `name =` but not `=>` (alt 2).
+fmt_pat='[(,][[:space:]]*[?%][a-zA-Z_]|[^=>]=[[:space:]]*[?%][a-zA-Z_]'
+
+while IFS= read -r f; do
+  case "$f" in *.rs) ;; *) continue ;; esac
+  allowed_file "$f" && continue
+  while IFS=: read -r no _; do
+    orig="$(sed -n "${no}p" "$f")"
+    case "$orig" in *guardrails-ok*) continue ;; esac
+    # A pure-comment guardrails-ok line directly ABOVE also suppresses: rustfmt wraps
+    # over-long trailing comments onto the next line, so same-line markers aren't stable.
+    if [ "$no" -gt 1 ]; then
+      prev="$(sed -n "$((no - 1))p" "$f" | sed 's/^[[:space:]]*//')"
+      case "$prev" in //*guardrails-ok*) continue ;; esac
+    fi
+    printf '  %s:%s:%s\n' "$f" "$no" "$(printf '%s' "$orig" | sed 's/^[[:space:]]*//')"
+    hits=$((hits + 1))
+  done < <(blank_strings "$f" | grep -nE "$fmt_pat")
+done < <(files "${roots[@]}")
+
+if [ "$hits" -gt 0 ]; then
+  echo "guardrails/no-raw-trace-fields: $hits raw Debug/Display field formatter(s) in tracing macros — shape the field in your schema surface (allowlist via GUARDRAILS_TRACE_ALLOW_GLOBS), or annotate 'guardrails-ok'." >&2
+  exit 1
+fi

--- a/assets/guardrails/gates/numerical-obligation.sh
+++ b/assets/guardrails/gates/numerical-obligation.sh
@@ -1,0 +1,275 @@
+#!/usr/bin/env bash
+# guardrails: numerical-obligation — assert measured numerical values stay within their
+# checked-in baseline (a high-water-mark ratchet, not a fixed budget like perf-budget).
+#
+# Use it for any numerical quality contract: physics parity errors, HARD-count audits,
+# coverage %, dead-code %, binary-size, dependency count. Wherever you'd hand-write a
+# "current = X; if (new > X) fail; if (new < X) bump X" script, this gate is the shared
+# implementation — with the same TOML/JSON shape across repos.
+#
+# Distinct from perf-budget:
+#   * baseline = high-water mark (the best we've seen), not a fixed ceiling
+#   * `--update` ratchets the baseline IN THE IMPROVEMENT DIRECTION (never widens slack)
+#   * default tolerance is 0 (strict); perf-budget defaults to 20% for measurement noise
+#
+# Usage:
+#   guardrails-numerical-obligation                                # --check, default config
+#   guardrails-numerical-obligation [numerical-obligation.toml]    # --check, explicit config
+#   guardrails-numerical-obligation --update [config.toml]         # ratchet baselines on improvement
+#   guardrails-numerical-obligation --list   [config.toml]         # show what's wired
+#
+# numerical-obligation.toml:
+#   default_direction = "lower"    # lower-is-better (default); "higher" for throughput-style
+#   default_tolerance = 0.0        # fractional headroom before regression fires (e.g. 0.05 = 5%)
+#   default_mode      = "gate"     # gate | nudge
+#
+#   [set."audit-hard-counts"]
+#   baseline    = "tools/parity/audit-baseline.json"          # canonical, version-controlled
+#   measurement = "tmp/audit-current.json"                    # transient, written by your measurer
+#   # direction/tolerance/mode override per set
+#   # ratchet = true                                          # default true (--update writes back)
+#
+#   [set."parity-matrix"]
+#   baseline    = "tools/parity/parity-matrix-baseline.json"
+#   measurement = "${GUARDRAILS_NUMOB_PARITY:-tmp/parity-current.json}"
+#   tolerance   = 0.05
+#
+# Both JSON files must share the same nested structure. The gate walks every numeric leaf
+# (int / float, but not bool) and compares paths that exist in both files. Per-path
+# overrides (per-key direction/mode/tolerance) are not in v1 — split into multiple sets
+# instead.
+#
+# Missing measurement file = soft-skip with warning (your measurer hasn't run yet — the
+# gate doesn't itself measure anything). Missing baseline = hard error (commit the
+# baseline before wiring the gate).
+set -uo pipefail
+
+MODE=check
+CONFIG=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --check)  MODE=check; shift ;;
+    --update) MODE=update; shift ;;
+    --list)   MODE=list; shift ;;
+    -h|--help)
+      sed -n '2,40p' "$0"; exit 0 ;;
+    --) shift; break ;;
+    -*) echo "guardrails/numerical-obligation: unknown flag: $1" >&2; exit 2 ;;
+    *)  CONFIG="$1"; shift ;;
+  esac
+done
+CONFIG="${CONFIG:-numerical-obligation.toml}"
+
+if [ ! -f "$CONFIG" ]; then
+  echo "guardrails/numerical-obligation: no $CONFIG — skipping (add one to enable)." >&2
+  exit 0
+fi
+
+exec python3 - "$CONFIG" "$MODE" <<'PY'
+import json
+import os
+import pathlib
+import sys
+
+try:
+    import tomllib
+except ModuleNotFoundError:
+    sys.stderr.write("guardrails/numerical-obligation: needs python>=3.11 (tomllib).\n")
+    sys.exit(0)
+
+config_path = pathlib.Path(sys.argv[1])
+mode = sys.argv[2]
+spec = tomllib.loads(config_path.read_text())
+
+default_dir = spec.get("default_direction", "lower")
+default_tol = float(spec.get("default_tolerance", 0.0))
+default_mode = spec.get("default_mode", "gate")
+
+sets = spec.get("set", {})
+if not sets:
+    sys.stderr.write(f"guardrails/numerical-obligation: no [set.*] entries in {config_path}\n")
+    sys.exit(0)
+
+
+def walk_numeric(obj, path=()):
+    """Yield (path-tuple, float) for every numeric leaf in a JSON object. Path is
+    a tuple of (key, ...) where each key is the raw dict key or list index — never
+    a joined string, so dict keys containing '.' (energy bins like '0.1–1') stay
+    unambiguous."""
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            yield from walk_numeric(v, path + (k,))
+    elif isinstance(obj, list):
+        for i, v in enumerate(obj):
+            yield from walk_numeric(v, path + (i,))
+    elif isinstance(obj, bool):
+        return
+    elif isinstance(obj, (int, float)):
+        yield path, float(obj)
+
+
+def fmt_path(path):
+    """Render a path-tuple for human-readable output. Uses '/' so dotted dict keys
+    stay legible (e.g. 'columns/Reaction/0.1–1' not 'columns.Reaction.0.1–1')."""
+    return "/".join(str(p) for p in path)
+
+
+def set_by_path(obj, path, value):
+    """Mutate `obj` so the leaf at `path` (tuple) is `value`. Preserves int-ness
+    when possible."""
+    cur = obj
+    for p in path[:-1]:
+        cur = cur[p]
+    last = path[-1]
+    if isinstance(cur[last], int) and value.is_integer():
+        cur[last] = int(value)
+    else:
+        cur[last] = value
+
+
+def expand_env(s):
+    """Tiny ${VAR:-default} expander so config can defer paths to env."""
+    if not isinstance(s, str):
+        return s
+    out = ""
+    i = 0
+    while i < len(s):
+        if s[i : i + 2] == "${" and "}" in s[i:]:
+            j = s.index("}", i)
+            inner = s[i + 2 : j]
+            if ":-" in inner:
+                name, dflt = inner.split(":-", 1)
+            else:
+                name, dflt = inner, ""
+            out += os.environ.get(name, dflt)
+            i = j + 1
+        else:
+            out += s[i]
+            i += 1
+    return out
+
+
+all_failures = []
+all_warnings = []
+all_ok = 0
+updated_sets = []
+
+if mode == "list":
+    print(f"# {config_path}: {len(sets)} obligation set(s)")
+    for name, cfg in sets.items():
+        print(
+            f"  set.{name}: baseline={cfg.get('baseline')} measurement={cfg.get('measurement')} "
+            f"direction={cfg.get('direction', default_dir)} "
+            f"tolerance={cfg.get('tolerance', default_tol)} "
+            f"mode={cfg.get('mode', default_mode)} "
+            f"ratchet={cfg.get('ratchet', True)}"
+        )
+    sys.exit(0)
+
+for name, cfg in sets.items():
+    base_path = pathlib.Path(expand_env(cfg.get("baseline", "")))
+    meas_path = pathlib.Path(expand_env(cfg.get("measurement", "")))
+    direction = cfg.get("direction", default_dir)
+    tol = float(cfg.get("tolerance", default_tol))
+    set_mode = cfg.get("mode", default_mode)
+    ratchet = bool(cfg.get("ratchet", True))
+
+    if not base_path.is_file():
+        sys.stderr.write(
+            f"  ERROR set.{name}: baseline not found at {base_path} "
+            f"(commit the baseline before wiring the gate)\n"
+        )
+        all_failures.append(f"set.{name}: missing baseline {base_path}")
+        continue
+    if not meas_path.is_file():
+        sys.stderr.write(
+            f"  warn  set.{name}: no measurement at {meas_path} "
+            f"— skipping (run the measurer to gate this set)\n"
+        )
+        continue
+
+    try:
+        baseline = json.loads(base_path.read_text())
+        measurement = json.loads(meas_path.read_text())
+    except json.JSONDecodeError as e:
+        sys.stderr.write(f"  ERROR set.{name}: JSON parse failed: {e}\n")
+        all_failures.append(f"set.{name}: JSON parse failed")
+        continue
+
+    base_leaves = dict(walk_numeric(baseline))
+    meas_leaves = dict(walk_numeric(measurement))
+
+    common = set(base_leaves) & set(meas_leaves)
+    only_base = set(base_leaves) - set(meas_leaves)
+    only_meas = set(meas_leaves) - set(base_leaves)
+
+    set_failures = []
+    set_warnings = []
+    set_ok = 0
+    set_improved = []
+
+    for k in sorted(common):
+        b, m = base_leaves[k], meas_leaves[k]
+        if direction == "higher":
+            limit = b * (1 - tol)
+            regressed = m < limit
+            improved = m > b
+            label = f"measured {m:g} vs floor {b:g}"
+        else:
+            limit = b * (1 + tol)
+            regressed = m > limit
+            improved = m < b
+            label = f"measured {m:g} vs baseline {b:g}"
+
+        if regressed:
+            line = f"set.{name}/{fmt_path(k)}: {label}, tolerance ±{tol*100:.1f}%"
+            (set_failures if set_mode == "gate" else set_warnings).append(line)
+        else:
+            set_ok += 1
+            if improved and ratchet:
+                set_improved.append((k, m))
+
+    for k in sorted(only_base):
+        set_warnings.append(
+            f"set.{name}/{fmt_path(k)}: in baseline but not measured — measurer dropped a key?"
+        )
+    for k in sorted(only_meas):
+        set_warnings.append(
+            f"set.{name}/{fmt_path(k)}: new in measurement, no baseline entry — run --update to absorb"
+        )
+
+    print(
+        f"set.{name}: ok={set_ok} regressed={len(set_failures)} "
+        f"warn={len(set_warnings)} improvements={len(set_improved)} "
+        f"(direction={direction} tol={tol} mode={set_mode} ratchet={ratchet})"
+    )
+
+    if mode == "update" and ratchet and set_improved:
+        for k, m in set_improved:
+            set_by_path(baseline, k, m)
+        base_path.write_text(json.dumps(baseline, indent=2, sort_keys=True) + "\n")
+        updated_sets.append((name, base_path, len(set_improved)))
+
+    all_failures.extend(set_failures)
+    all_warnings.extend(set_warnings)
+    all_ok += set_ok
+
+for m in all_warnings:
+    sys.stderr.write(f"  warn  {m}\n")
+for m in all_failures:
+    sys.stderr.write(f"  FAIL  {m}\n")
+
+if mode == "update":
+    for name, path, n in updated_sets:
+        print(f"  updated set.{name}: ratcheted {n} improved key(s) into {path}")
+    if not updated_sets:
+        print("  no improvements to absorb")
+
+if all_failures and mode == "check":
+    sys.stderr.write(
+        f"guardrails/numerical-obligation: {len(all_failures)} regression(s) beyond baseline.\n"
+        "  Either improve the measurement, or after intentional regression update the\n"
+        "  baseline by hand with a recorded reason (this gate refuses to widen slack on --update).\n"
+    )
+    sys.exit(1)
+PY

--- a/assets/guardrails/gates/perf-budget.sh
+++ b/assets/guardrails/gates/perf-budget.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# guardrails: perf-budget — gate bench regressions against a checked-in budgets file.
+#
+# Run AFTER your benches. Two result sources, merged:
+#   * criterion: target/criterion/<id>/new/estimates.json medians (`cargo criterion`),
+#   * bespoke harnesses: a flat JSON map written by YOUR bench (GPU fps ceilings, MB/s throughput —
+#     anything criterion can't measure): GUARDRAILS_PERF_RESULTS (default perf-results.json),
+#     `{"bench_id": value, ...}` — values in whatever unit the budget uses.
+# This gate only COMPARES — fast and deterministic, no measurement here.
+#
+# Usage: guardrails-perf-budget [perf-budgets.toml] [target/criterion]
+#   gate-mode budgets fail the build on regression; nudge-mode only warn. The threshold is a
+#   per-budget `tolerance` (fractional headroom; default 0.20 = 20%), matching the
+#   "gate big regressions, nudge the rest" methodology in docs/CONVENTIONS.md.
+#
+# perf-budgets.toml:
+#   default_tolerance = 0.20
+#   [bench."parser/parse_frame"]   # key = criterion id (its target/criterion/<id> path) or your map key
+#   budget_ns = 1500               # `budget` works too (unit-agnostic — fps, MB/s, particles…)
+#   mode = "gate"                  # gate | nudge
+#   # direction = "higher"         # higher-is-better metrics (throughput/fps/ceiling); default lower
+#   # tolerance = 0.10             # optional per-budget override
+set -uo pipefail
+budgets="${1:-perf-budgets.toml}"
+crit_dir="${2:-target/criterion}"
+
+if [ ! -f "$budgets" ]; then
+  echo "guardrails/perf-budget: no $budgets — skipping (add one to enable perf gating)." >&2
+  exit 0
+fi
+
+exec python3 - "$budgets" "$crit_dir" <<'PY'
+import json, os, pathlib, sys
+try:
+    import tomllib
+except ModuleNotFoundError:
+    sys.stderr.write("guardrails/perf-budget: needs python>=3.11 (tomllib) on PATH.\n")
+    sys.exit(0)
+
+budgets_path, crit = pathlib.Path(sys.argv[1]), pathlib.Path(sys.argv[2])
+spec = tomllib.loads(budgets_path.read_text())
+default_tol = float(spec.get("default_tolerance", 0.20))
+benches = spec.get("bench", {})
+
+# Bespoke-harness results: a flat {"bench_id": value} map (values in the budget's unit).
+results = {}
+rp = pathlib.Path(os.environ.get("GUARDRAILS_PERF_RESULTS", "perf-results.json"))
+if rp.exists():
+    try:
+        results = {str(k): float(v) for k, v in json.loads(rp.read_text()).items()}
+    except (ValueError, AttributeError) as e:
+        sys.stderr.write(f"guardrails/perf-budget: unreadable {rp}: {e}\n")
+
+ok, warnings, failures = [], [], []
+for bid, cfg in benches.items():
+    if "budget_ns" not in cfg and "budget" not in cfg:
+        warnings.append(f"{bid}: budget entry has neither budget_ns nor budget — skipped")
+        continue
+    budget = float(cfg.get("budget_ns", cfg.get("budget")))
+    mode = cfg.get("mode", "gate")
+    tol = float(cfg.get("tolerance", default_tol))
+    higher = cfg.get("direction", "lower") == "higher"
+    est = crit / bid / "new" / "estimates.json"
+    if est.exists():
+        measured = float(json.loads(est.read_text())["median"]["point_estimate"])
+    elif bid in results:
+        measured = results[bid]
+    else:
+        warnings.append(f"{bid}: no criterion data at {est} and no entry in {rp} — run the benches first")
+        continue
+    pct = (measured / budget - 1) * 100
+    if higher:
+        limit = budget * (1 - tol)
+        over = measured < limit
+        line = f"{bid}: measured {measured:.0f} vs floor {budget:.0f} ({pct:+.1f}%, -{tol*100:.0f}% allowed, higher=better)"
+    else:
+        limit = budget * (1 + tol)
+        over = measured > limit
+        line = f"{bid}: measured {measured:.0f} vs budget {budget:.0f} ({pct:+.1f}%, +{tol*100:.0f}% allowed)"
+    if over:
+        (failures if mode == "gate" else warnings).append(line)
+    else:
+        ok.append(line)
+
+for m in ok:
+    print(f"  ok    {m}")
+for m in warnings:
+    sys.stderr.write(f"  warn  {m}\n")
+for m in failures:
+    sys.stderr.write(f"  FAIL  {m}\n")
+
+if failures:
+    sys.stderr.write(
+        f"guardrails/perf-budget: {len(failures)} gated regression(s) over budget — "
+        "optimize, or raise the budget if the cost is justified and recorded.\n"
+    )
+    sys.exit(1)
+PY

--- a/assets/guardrails/gates/perf-record.sh
+++ b/assets/guardrails/gates/perf-record.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# guardrails: perf-record — append a perf report row per benchmark to a committed CSV.
+#
+# Run after your benches. Records criterion medians AND bespoke-harness results (the same
+# GUARDRAILS_PERF_RESULTS flat JSON map perf-budget reads — GPU fps ceilings, MB/s, …), one row per
+# benchmark, into perf-history.csv (created if missing). Commit that CSV: the PR diff IS the perf
+# report, and git history IS the trend — no external service. Pairs with the perf-budget gate;
+# this is the visible per-PR delta + history. Re-running on the same commit refreshes its rows.
+#
+# Usage: guardrails-perf-record [perf-history.csv] [perf-budgets.toml] [target/criterion]
+# Columns: date,commit,bench,median_ns,budget_ns,vs_budget_pct,vs_prev_pct
+#   (for bespoke results the value columns carry the harness's own unit, not ns)
+set -uo pipefail
+csv="${1:-perf-history.csv}"
+budgets="${2:-perf-budgets.toml}"
+crit_dir="${3:-target/criterion}"
+
+# GUARDRAILS_PERF_COMMIT overrides the recorded commit (CI / tests); else the short HEAD sha.
+commit="${GUARDRAILS_PERF_COMMIT:-$(git rev-parse --short HEAD 2>/dev/null || echo unknown)}"
+if [ -z "${GUARDRAILS_PERF_COMMIT:-}" ] && ! git diff --quiet 2>/dev/null; then
+  commit="$commit-dirty"
+fi
+now="${GUARDRAILS_PERF_DATE:-$(date -u +%Y-%m-%dT%H:%M:%SZ)}"
+
+exec python3 - "$csv" "$budgets" "$crit_dir" "$commit" "$now" <<'PY'
+import csv, json, os, pathlib, sys
+csv_path, budgets_path, crit_dir, commit, now = sys.argv[1:6]
+crit = pathlib.Path(crit_dir)
+header = ["date", "commit", "bench", "median_ns", "budget_ns", "vs_budget_pct", "vs_prev_pct"]
+
+budgets = {}
+bp = pathlib.Path(budgets_path)
+if bp.exists():
+    try:
+        import tomllib
+        for bid, cfg in tomllib.loads(bp.read_text()).get("bench", {}).items():
+            if "budget_ns" in cfg or "budget" in cfg:
+                budgets[bid] = float(cfg.get("budget_ns", cfg.get("budget")))
+    except Exception:
+        pass
+
+cp = pathlib.Path(csv_path)
+existing = list(csv.DictReader(cp.open())) if cp.exists() else []
+
+# previous median per bench = last recorded row from a DIFFERENT commit (ignore -dirty suffix)
+base = commit.split("-dirty")[0]
+prev = {}
+for r in existing:
+    if r["commit"].split("-dirty")[0] != base:
+        try:
+            prev[r["bench"]] = float(r["median_ns"])
+        except ValueError:
+            pass
+
+new_rows = []
+for est in sorted(crit.glob("**/new/estimates.json")):
+    bid = str(est.parent.parent.relative_to(crit))
+    try:
+        median = float(json.loads(est.read_text())["median"]["point_estimate"])
+    except Exception:
+        continue
+    budget = budgets.get(bid)
+    vsb = f"{(median / budget - 1) * 100:+.1f}" if budget else ""
+    vsp = f"{(median / prev[bid] - 1) * 100:+.1f}" if bid in prev else ""
+    new_rows.append({
+        "date": now, "commit": commit, "bench": bid, "median_ns": f"{median:.0f}",
+        "budget_ns": f"{budget:.0f}" if budget else "", "vs_budget_pct": vsb, "vs_prev_pct": vsp,
+    })
+
+# Bespoke-harness results (same map perf-budget reads): rows for benches criterion didn't cover.
+rp = pathlib.Path(os.environ.get("GUARDRAILS_PERF_RESULTS", "perf-results.json"))
+if rp.exists():
+    try:
+        bespoke = {str(k): float(v) for k, v in json.loads(rp.read_text()).items()}
+    except (ValueError, AttributeError):
+        bespoke = {}
+    seen = {r["bench"] for r in new_rows}
+    for bid, val in sorted(bespoke.items()):
+        if bid in seen:
+            continue
+        budget = budgets.get(bid)
+        vsb = f"{(val / budget - 1) * 100:+.1f}" if budget else ""
+        vsp = f"{(val / prev[bid] - 1) * 100:+.1f}" if bid in prev else ""
+        new_rows.append({
+            "date": now, "commit": commit, "bench": bid, "median_ns": f"{val:.0f}",
+            "budget_ns": f"{budget:.0f}" if budget else "", "vs_budget_pct": vsb, "vs_prev_pct": vsp,
+        })
+
+if not new_rows:
+    sys.stderr.write(f"guardrails/perf-record: no criterion results under {crit_dir} and no {rp} — run the benches first.\n")
+    sys.exit(0)
+
+kept = [r for r in existing if r["commit"] != commit]  # refresh this commit's rows
+with cp.open("w", newline="") as f:
+    w = csv.DictWriter(f, fieldnames=header)
+    w.writeheader()
+    w.writerows(kept + new_rows)
+
+print(f"guardrails/perf-record: {len(new_rows)} benchmark(s) -> {csv_path} @ {commit}")
+for r in new_rows:
+    extra = [x for x in (
+        f"vs prev {r['vs_prev_pct']}%" if r["vs_prev_pct"] else "",
+        f"vs budget {r['vs_budget_pct']}%" if r["vs_budget_pct"] else "",
+    ) if x]
+    print(f"  {r['bench']}: {r['median_ns']}ns" + (f" ({', '.join(extra)})" if extra else ""))
+PY

--- a/assets/guardrails/gates/protect-trunk-push.sh
+++ b/assets/guardrails/gates/protect-trunk-push.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# guardrails: protect-trunk-push — refuse pushes that advance a protected REMOTE ref. The
+# pre-push half of protect-trunk: keyed on the remote ref from the push spec, NOT on HEAD, so
+# it catches what the pre-commit gate structurally can't:
+#   * `git push origin HEAD:main` from a feature branch (the exact incident refspec, issue #17)
+#   * commits that never fired pre-commit: clean cherry-pick/revert, plumbing (commit-tree)
+#
+# git feeds pre-push one line per ref on stdin: <local-ref> <local-sha> <remote-ref> <remote-sha>
+# Deletions (local-sha all-zeros) are skipped — removing a stray remote branch is not advancing
+# trunk, and trunk deletion is the forge's protection to enforce.
+#
+# prek caveat (found in review, j178/prek languages/system.rs): prek runs system hooks with
+# stdin(Stdio::null()) — the refspec lines never reach us. prek DOES parse them itself and
+# exports PRE_COMMIT_REMOTE_BRANCH = the remote REF of the first valid non-deletion push line
+# (hook_impl.rs rsplitn parse; pre-commit sets the same var). So: consume stdin when present
+# (native .git/hooks installs, full multi-ref coverage), else fall back to the env interface
+# (prek/pre-commit; first pushed ref only — a multi-ref push is checked on its first line,
+# which is also all prek itself checks).
+#
+# Same knobs as protect-trunk.sh: GUARDRAILS_PROTECTED_BRANCHES (colon-sep globs, REPLACES the
+# `main:master` default, empty disables), GUARDRAILS_ALLOW_TRUNK=1 escape (loud), CI auto-allow.
+set -uo pipefail
+
+if [ "${GUARDRAILS_ALLOW_TRUNK:-0}" = 1 ]; then
+  echo "guardrails/protect-trunk-push: GUARDRAILS_ALLOW_TRUNK=1 — intentional trunk push allowed." >&2
+  exit 0
+fi
+case "${CI:-}" in true|1) exit 0 ;; esac
+case "${GITHUB_ACTIONS:-}" in true|1) exit 0 ;; esac
+
+# Trunk-merge-gate (issue #18): "advance trunk when it's EARNED" — for solo/trusted-operator
+# repos, GUARDRAILS_TRUNK_MERGE_GATE=1 turns the hard refusal into a pass condition: the push
+# to a protected ref is allowed iff the repo's full check suite is green RIGHT NOW. Pre-push
+# is the honest seam for this (not pre-commit): the commit's own hooks already ran, and
+# `nix flake check` is a SUPERSET of the commit tier (adr-matrix, budgets, ratchets, tests) —
+# so green here means something new. Default off; PR-flow fleets keep the plain refusal.
+trunk_merge_gate() {
+  [ "${GUARDRAILS_TRUNK_MERGE_GATE:-0}" = 1 ] || return 1
+  local cmd="${GUARDRAILS_TRUNK_MERGE_CMD:-nix flake check}"
+  echo "guardrails/protect-trunk-push: trunk-merge-gate — earning the push with: $cmd" >&2
+  # Subshell re-enables globbing (callers hold set -f for branch-glob safety); the gate is
+  # only as honest as the CMD the consumer picks — a trivially-green CMD is just
+  # ALLOW_TRUNK with extra steps, same trust model, same audit trail (the echo above).
+  if ( set +f; $cmd ) >&2; then
+    echo "guardrails/protect-trunk-push: guards green — trunk push earned." >&2
+    return 0
+  fi
+  echo "guardrails/protect-trunk-push: guards NOT green — trunk push refused (fix the checks, or push a branch + PR)." >&2
+  return 2
+}
+tmg_memo="" # the check suite runs at most once per push, however many refs match
+trunk_merge_gate_once() {
+  if [ -z "$tmg_memo" ]; then trunk_merge_gate; tmg_memo=$?; fi
+  return "$tmg_memo"
+}
+
+IFS=: read -ra protected <<< "${GUARDRAILS_PROTECTED_BRANCHES-main:master}"
+
+zeros=0000000000000000000000000000000000000000
+fails=0
+check_remote_ref() { # $1 = remote ref (refs/heads/... or a bare branch name from the env path)
+  local ref="$1" branch pat
+  branch="${ref#refs/heads/}"
+  case "$ref" in refs/*) [ "$branch" = "$ref" ] && return 0 ;; esac # tags/notes/etc. — only heads are trunk
+  set -f
+  for pat in "${protected[@]:-}"; do # :- keeps bash 3.2 alive on the empty-knob opt-out path
+    [ -n "$pat" ] || continue
+    # shellcheck disable=SC2254  # $pat is intentionally a glob
+    case "$branch" in
+      $pat)
+        if trunk_merge_gate_once; then
+          : # trunk-merge-gate earned this push — green guards ARE the pass condition
+        else
+          echo "guardrails/protect-trunk-push: refusing to push to protected '$branch' — trunk advances by merge/PR only." >&2
+          echo "  Push a feature branch and open a PR:  git push origin HEAD:refs/heads/<feature-name>" >&2
+          echo "  Intentional (hotfix/release)?         GUARDRAILS_ALLOW_TRUNK=1 git push ..." >&2
+          echo "  Solo/trunk-flow with green guards?    GUARDRAILS_TRUNK_MERGE_GATE=1 (earn it — see 'guardrails info')" >&2
+          fails=$((fails + 1))
+        fi
+        ;;
+    esac
+  done
+  set +f
+}
+
+saw_stdin=0
+while read -r _local_ref local_sha remote_ref _remote_sha; do
+  [ -n "${remote_ref:-}" ] || continue
+  saw_stdin=1
+  [ "$local_sha" = "$zeros" ] && continue # deletion, not an advance
+  check_remote_ref "$remote_ref"
+done
+
+# prek/pre-commit path: stdin was nulled, but the runner parsed the push and exported the
+# remote ref of the first valid line. Without it (nothing to push), there is nothing to check.
+if [ "$saw_stdin" = 0 ] && [ -n "${PRE_COMMIT_REMOTE_BRANCH:-}" ]; then
+  check_remote_ref "$PRE_COMMIT_REMOTE_BRANCH"
+fi
+
+[ "$fails" -eq 0 ] || exit 1

--- a/assets/guardrails/gates/protect-trunk.sh
+++ b/assets/guardrails/gates/protect-trunk.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# guardrails: protect-trunk — refuse direct commits on a protected branch (trunk advances by
+# merge/PR only, never by a local commit). Catches the whole "right change, wrong place" class
+# that content gates can't see: a session cd's into a clone sitting on main and commits feature
+# work straight to trunk (real incident — four commits on main, one pushed, see issue #17).
+#
+# Detection: current branch via `git symbolic-ref`; when HEAD is detached we probe the rebase
+# state files so a rebase OF a protected branch still blocks (plain detached work is allowed —
+# bisect, checkout <sha>, cherry-pick surgery are fine).
+#
+# Knobs (the usual GUARDRAILS_* idiom):
+#   GUARDRAILS_PROTECTED_BRANCHES  colon-separated glob list; REPLACES the default `main:master`
+#                                  (set empty to disable — trunk-flow repos opt out cleanly;
+#                                  `case` globs, so `release/*` also matches `release/1.0/x`)
+#   GUARDRAILS_ALLOW_TRUNK=1       one-shot escape for an intentional trunk write (hotfix) — loud
+#   CI / GITHUB_ACTIONS            auto-allow: release bots and CI never need the escape
+set -uo pipefail
+
+# CI context is a legitimate trunk writer (release-please, merge queues) — never block there.
+if [ "${GUARDRAILS_ALLOW_TRUNK:-0}" = 1 ]; then
+  echo "guardrails/protect-trunk: GUARDRAILS_ALLOW_TRUNK=1 — intentional trunk write allowed." >&2
+  exit 0
+fi
+case "${CI:-}" in true|1) exit 0 ;; esac
+case "${GITHUB_ACTIONS:-}" in true|1) exit 0 ;; esac
+
+# Not a git repo (docs checkout, sandbox) → nothing to protect.
+git_dir="$(git rev-parse --git-dir 2>/dev/null)" || exit 0
+
+branch="$(git symbolic-ref --short -q HEAD || true)"
+if [ -z "$branch" ]; then
+  # Detached HEAD. A rebase detaches exactly while it rewrites the branch — probe the rebase
+  # state so `git rebase` ON main doesn't slip through; genuinely detached work stays allowed.
+  for state in rebase-merge rebase-apply; do
+    if [ -f "$git_dir/$state/head-name" ]; then
+      branch="$(cat "$git_dir/$state/head-name")"
+      branch="${branch#refs/heads/}"
+      break
+    fi
+  done
+  [ -n "$branch" ] || exit 0
+fi
+
+IFS=: read -ra protected <<< "${GUARDRAILS_PROTECTED_BRANCHES-main:master}"
+
+# trunk_commit_allowed: the verdict seam. Today: a protected branch never takes a direct commit.
+# extension point: #18's trunk-merge-gate swaps this body for "pass iff `guardrails gate` is
+# green" — same hook, same message shape, richer pass condition.
+trunk_commit_allowed() { # $1 = branch
+  local pat
+  set -f # branch/pattern glob chars must not pathname-expand
+  for pat in "${protected[@]:-}"; do # :- keeps bash 3.2 alive on the empty-knob opt-out path
+    [ -n "$pat" ] || continue # `:main:` boundary empties must not match everything
+    # shellcheck disable=SC2254  # $pat is intentionally a glob
+    case "$1" in $pat) set +f; return 1 ;; esac
+  done
+  set +f
+  return 0
+}
+
+if ! trunk_commit_allowed "$branch"; then
+  cat >&2 <<EOF
+guardrails/protect-trunk: HEAD is '$branch' — this repo advances trunk by merge/PR only.
+  Move your work to a feature branch (keeps staged changes):
+      git switch -c <feature-name>
+  Intentional trunk write (hotfix/release)? Say so explicitly:
+      GUARDRAILS_ALLOW_TRUNK=1 git commit ...
+  Trunk-flow repo? Opt out for good:
+      export GUARDRAILS_PROTECTED_BRANCHES=""   # e.g. in .envrc / flake devShell
+EOF
+  exit 1
+fi

--- a/assets/guardrails/gates/test-adr-matrix.sh
+++ b/assets/guardrails/gates/test-adr-matrix.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Red-green tests for the adr-matrix gate. Pure bash, no deps. Run: gates/test-adr-matrix.sh
+#
+# NOTE ON FIXTURES: these tests create real ADR *files*, because the files are the gate's source of
+# truth. The previous suite only ever wrote an index — which is why it could not express "an
+# Accepted ADR exists but was never indexed", the exact case that shipped two ADR-0005s in a
+# consumer repo. A gate's tests have to be able to state the failure the gate exists to catch.
+set -uo pipefail
+here="$(cd "$(dirname "$0")" && pwd)"
+gate="$here/adr-matrix.sh"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+fails=0
+
+# chk <desc> <want-exit> <env...> -- <index> <matrix>
+chk() {
+  local desc="$1" want="$2"; shift 2
+  local e=(); while [ "$1" != "--" ]; do e+=("$1"); shift; done; shift
+  env "${e[@]}" "$gate" "$1" "$2" >/dev/null 2>&1
+  local got=$?
+  if [ "$got" = "$want" ]; then echo "ok    — $desc"; else echo "FAIL  — $desc (want $want got $got)"; fails=$((fails + 1)); fi
+}
+
+# adr <dir> <id> <slug> <status>
+adr() { printf '# ADR %s — %s\n\n- Status: %s\n- Date: 2026-01-01\n' "$2" "$3" "$4" >"$1/$2-$3.md"; }
+
+# ---------------------------------------------------------------------------
+# A. files are the source of truth
+# ---------------------------------------------------------------------------
+d="$tmp/a"; mkdir -p "$d/adr"
+adr "$d/adr" 0001 a Accepted
+adr "$d/adr" 0002 b Accepted
+adr "$d/adr" 0003 c Proposed
+adr "$d/adr" 0004 d Accepted
+cat >"$d/adr/README.md" <<'EOF'
+| [0001](0001-a.md) | first feature  | **Accepted** |
+| [0002](0002-b.md) | second feature | **Accepted** |
+| [0003](0003-c.md) | roadmap design | **Proposed** |
+| [0004](0004-d.md) | a decision     | **Accepted** |
+EOF
+matrix="$d/FEATURE-MATRIX.md"
+
+printf 'row cites ADR-0001 only\n' >"$matrix"
+chk "Accepted-but-uncited (0002,0004) caught"            1 -- "$d/adr/README.md" "$matrix"
+chk "exempt 0004 but 0002 still uncited → caught"        1 ADR_MATRIX_EXEMPT=0004 -- "$d/adr/README.md" "$matrix"
+
+printf 'cites ADR-0001 ADR-0002 ADR-0004\n' >"$matrix"
+chk "all Accepted cited; Proposed 0003 ignored → pass"   0 -- "$d/adr/README.md" "$matrix"
+
+printf 'cites ADR-0001 only\n' >"$matrix"
+chk "0002+0004 exempt, 0001 cited → pass"                0 ADR_MATRIX_EXEMPT="0002 0004" -- "$d/adr/README.md" "$matrix"
+
+chk "missing ADR index is a no-op"                       0 -- "$d/nope/README.md" "$matrix"
+
+# ---------------------------------------------------------------------------
+# B. the case the old suite could not express: Accepted on disk, absent from
+#    the index. The gate used to read only the index, so this passed silently.
+# ---------------------------------------------------------------------------
+d="$tmp/b"; mkdir -p "$d/adr"
+adr "$d/adr" 0001 a Accepted
+adr "$d/adr" 0002 unindexed Accepted
+cat >"$d/adr/README.md" <<'EOF'
+| [0001](0001-a.md) | first feature | **Accepted** |
+EOF
+matrix="$d/FEATURE-MATRIX.md"
+printf 'cites ADR-0001 and ADR-0002\n' >"$matrix"
+chk "Accepted ADR missing from the index caught"         1 -- "$d/adr/README.md" "$matrix"
+
+# …and an index that disagrees with the file's own status is drift too.
+cat >"$d/adr/README.md" <<'EOF'
+| [0001](0001-a.md)         | first feature | **Accepted** |
+| [0002](0002-unindexed.md) | second        | **Proposed** |
+EOF
+chk "index Status disagreeing with the ADR file caught"  1 -- "$d/adr/README.md" "$matrix"
+
+cat >"$d/adr/README.md" <<'EOF'
+| [0001](0001-a.md)         | first feature | **Accepted** |
+| [0002](0002-unindexed.md) | second        | **Accepted** |
+EOF
+chk "index complete and agreeing → pass"                 0 -- "$d/adr/README.md" "$matrix"
+
+# ---------------------------------------------------------------------------
+# C. duplicate ids — every `ADR-NNNN` citation is ambiguous while both exist
+# ---------------------------------------------------------------------------
+d="$tmp/c"; mkdir -p "$d/adr"
+adr "$d/adr" 0001 one Accepted
+adr "$d/adr" 0001 other Accepted
+cat >"$d/adr/README.md" <<'EOF'
+| [0001](0001-one.md) | first | **Accepted** |
+EOF
+matrix="$d/FEATURE-MATRIX.md"
+printf 'cites ADR-0001\n' >"$matrix"
+chk "two files claiming the same id caught"              1 -- "$d/adr/README.md" "$matrix"
+
+# ---------------------------------------------------------------------------
+# D. legacy fallback: an index with no ADR files beside it still works
+# ---------------------------------------------------------------------------
+d="$tmp/d"; mkdir -p "$d/adr"
+cat >"$d/adr/README.md" <<'EOF'
+| [0001](0001-a.md) | first feature | **Accepted** |
+| [0002](0002-b.md) | second        | **Accepted** |
+EOF
+matrix="$d/FEATURE-MATRIX.md"
+printf 'cites ADR-0001 only\n' >"$matrix"
+chk "index-only repo: uncited Accepted still caught"     1 -- "$d/adr/README.md" "$matrix"
+printf 'cites ADR-0001 ADR-0002\n' >"$matrix"
+chk "index-only repo: all cited → pass"                  0 -- "$d/adr/README.md" "$matrix"
+
+if [ "$fails" = 0 ]; then echo "adr-matrix: all tests pass"; else echo "adr-matrix: $fails FAILED"; exit 1; fi

--- a/assets/guardrails/gates/test-gates.sh
+++ b/assets/guardrails/gates/test-gates.sh
@@ -1,0 +1,993 @@
+#!/usr/bin/env bash
+# Red-green tests for the guardrails gate scripts. Pure bash, no deps.
+# Run: gates/test-gates.sh   (also wired into CI via `nix flake check` is the
+# gate self-check; this harness asserts catch/allow semantics on fixtures.)
+set -uo pipefail
+here="$(cd "$(dirname "$0")" && pwd)"
+debug_gate="$here/no-debug-leftovers.sh"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+fails=0
+
+# assert <desc> <want-exit> <env-assignments...> -- <file>
+#   runs the debug gate on <file> with any leading VAR=val env, asserts exit code.
+assert() {
+  local desc="$1" want="$2"; shift 2
+  local env=()
+  while [ "$1" != "--" ]; do env+=("$1"); shift; done
+  shift
+  env "${env[@]}" "$debug_gate" "$1" >/dev/null 2>&1
+  local got=$?
+  if [ "$got" = "$want" ]; then
+    echo "ok    — $desc"
+  else
+    echo "FAIL  — $desc (want exit $want, got $got)"
+    fails=$((fails + 1))
+  fi
+}
+
+mkdir -p "$tmp/src/cli"
+
+# --- caught in library code (exit 1) -----------------------------------------
+# print!/eprint! were previously UNCAUGHT — these are the red→green cases.
+for macro in 'dbg!(x)' 'print!("x")' 'println!("x")' 'eprint!("x")' 'eprintln!("x")'; do
+  name="$(printf '%s' "$macro" | tr -cd 'a-z')"
+  printf 'fn f() { %s; }\n' "$macro" > "$tmp/src/leak_$name.rs"
+  assert "library $macro is flagged" 1 -- "$tmp/src/leak_$name.rs"
+done
+
+# --- allowed surfaces (exit 0) ------------------------------------------------
+printf 'fn main() { println!("hi"); print!("p"); }\n' > "$tmp/src/main.rs"
+assert "main.rs is allowed" 0 -- "$tmp/src/main.rs"
+
+# build.rs legitimately uses println! for cargo: directives.
+printf 'fn main() { println!("cargo:rerun-if-changed=build.rs"); }\n' > "$tmp/build.rs"
+assert "build.rs is allowed" 0 -- "$tmp/build.rs"
+
+printf 'pub fn show() { println!("status"); }\n' > "$tmp/src/cli/show.rs"
+assert "cli/ flagged WITHOUT output-glob" 1 -- "$tmp/src/cli/show.rs"
+assert "cli/ allowed WITH GUARDRAILS_OUTPUT_GLOBS" 0 \
+  "GUARDRAILS_OUTPUT_GLOBS=*/cli/*" -- "$tmp/src/cli/show.rs"
+
+printf 'fn f() { println!("x"); } // guardrails-ok\n' > "$tmp/src/annotated.rs"
+assert "guardrails-ok annotation suppresses" 0 -- "$tmp/src/annotated.rs"
+
+# Dir-walk mode prefixes every path with `./` (files() sed), so a configured glob
+# WITHOUT a leading `*` (vendor/*, scripts/*) must still match — normalize `./` off
+# before glob matching, in every gate that takes path globs.
+mkdir -p "$tmp/globroot/vendor"
+printf 'fn f() { println!("x"); }\n' > "$tmp/globroot/vendor/out.rs"
+( cd "$tmp/globroot" && GUARDRAILS_OUTPUT_GLOBS='vendor/*' "$debug_gate" ./vendor/out.rs >/dev/null 2>&1 )
+if [ $? = 0 ]; then echo "ok    — output glob matches ./-prefixed explicit path"
+else echo "FAIL  — output glob missed ./-prefixed explicit path"; fails=$((fails + 1)); fi
+( cd "$tmp/globroot" && GUARDRAILS_OUTPUT_GLOBS='vendor/*' "$debug_gate" . >/dev/null 2>&1 )
+if [ $? = 0 ]; then echo "ok    — output glob matches under dir-walk (./ prefix)"
+else echo "FAIL  — output glob missed dir-walked ./-prefixed path"; fails=$((fails + 1)); fi
+
+# --- no false positive on innocuous code -------------------------------------
+printf 'fn f() -> u32 { 1 + 1 }\n' > "$tmp/src/clean.rs"
+assert "clean code passes" 0 -- "$tmp/src/clean.rs"
+
+# --- batching regression guards (one grep per file-type, not per file) --------
+# Attribution across a multi-file batch must stay correct, and paths with spaces
+# must survive (a naive unquoted batch breaks both). Green before and after the
+# fork-storm refactor — they guard it.
+mkdir -p "$tmp/nd_multi"
+printf 'fn a() -> u32 { 1 }\n'          > "$tmp/nd_multi/a.rs"   # clean
+printf 'fn b() { println!("x"); }\n'    > "$tmp/nd_multi/b.rs"   # leak
+nd_out="$("$debug_gate" "$tmp/nd_multi" 2>/dev/null)"
+if printf '%s' "$nd_out" | grep -q 'b\.rs' && ! printf '%s' "$nd_out" | grep -q 'a\.rs'; then
+  echo "ok    — batched scan attributes the hit to the right file"
+else echo "FAIL  — batched scan mis-attributes across files"; fails=$((fails + 1)); fi
+mkdir -p "$tmp/nd_space"
+printf 'fn b() { println!("x"); }\n' > "$tmp/nd_space/weird name.rs"
+( "$debug_gate" "$tmp/nd_space" >/dev/null 2>&1 )
+if [ $? = 1 ]; then echo "ok    — filename with a space is still scanned"
+else echo "FAIL  — filename with a space slips the batched scan"; fails=$((fails + 1)); fi
+# The guardrails-ok escape is per-LINE-CONTENT; a path containing the substring
+# must not suppress findings under it (the joined file:line:content filter bug).
+mkdir -p "$tmp/nd_okpath/guardrails-ok-examples"
+printf 'fn b() { println!("x"); }\n' > "$tmp/nd_okpath/guardrails-ok-examples/leak.rs"
+( "$debug_gate" "$tmp/nd_okpath" >/dev/null 2>&1 )
+if [ $? = 1 ]; then echo "ok    — guardrails-ok in a PATH does not suppress findings"
+else echo "FAIL  — guardrails-ok path suppresses real findings"; fails=$((fails + 1)); fi
+# …while the line-content escape still works through the batched path.
+printf 'fn c() { println!("x"); } // guardrails-ok\n' > "$tmp/nd_okpath/guardrails-ok-examples/ok.rs"
+( "$debug_gate" "$tmp/nd_okpath/guardrails-ok-examples/ok.rs" >/dev/null 2>&1 )
+if [ $? = 0 ]; then echo "ok    — guardrails-ok line escape survives batching"
+else echo "FAIL  — guardrails-ok line escape broken in batched scan"; fails=$((fails + 1)); fi
+# Mixed rust+web batch: both pattern families detect through the batched path.
+mkdir -p "$tmp/nd_mixed"
+printf 'fn b() { println!("x"); }\n'  > "$tmp/nd_mixed/leak.rs"
+printf 'console.log("x");\n'          > "$tmp/nd_mixed/leak.ts"
+nd_mixed_out="$("$debug_gate" "$tmp/nd_mixed" 2>/dev/null)"
+if printf '%s' "$nd_mixed_out" | grep -q 'leak\.rs' && printf '%s' "$nd_mixed_out" | grep -q 'leak\.ts'; then
+  echo "ok    — mixed rust+web batch detects both families"
+else echo "FAIL  — mixed rust+web batch misses a family"; fails=$((fails + 1)); fi
+
+# --- no-fake-impl: stub markers flagged, vocabulary/strings are not ----------
+fake_gate="$here/no-fake-impl.sh"
+fake_assert() { # desc, want-exit, file-content
+  printf '%s\n' "$3" > "$tmp/src/fake.rs"
+  "$fake_gate" "$tmp/src/fake.rs" >/dev/null 2>&1
+  if [ "$?" = "$2" ]; then echo "ok    — $1"; else echo "FAIL  — $1"; fails=$((fails + 1)); fi
+}
+fake_assert "todo!() is flagged"                    1 'fn f() { todo!() }'
+fake_assert "unimplemented!() is flagged"           1 'fn f() { unimplemented!() }'
+fake_assert "FIXME marker is flagged"               1 'fn f() {} // FIXME finish this'
+fake_assert "// placeholder comment is flagged"     1 'fn f() {} // placeholder'
+fake_assert "placeholder implementation is flagged" 1 '// placeholder implementation for now'
+fake_assert "PLACEHOLDER protocol const is allowed" 0 'const KITTY_UNICODE_PLACEHOLDER: u32 = 0xfffd;'
+fake_assert "placeholder sentinel var is allowed"   0 'let placeholder = PaneId::from_raw(0);'
+fake_assert "not-implemented error string allowed"  0 'return Err("method not implemented yet".into());'
+fake_assert "placeholder in doc-comment prose ok"   0 '/// Uses the placeholder protocol to render.'
+fake_assert "doc comment starting with placeholder prose ok" 0 '///   placeholder and other things are kept'
+
+# --- top-level tests/ excluded for RELATIVE paths (as pre-commit passes them) -
+# `*/tests/*` matched only NESTED tests dirs; a relative `tests/x.rs` slipped
+# through. Each gate must exclude a top-level tests/ component too.
+mkdir -p "$tmp/tests"
+printf 'fn f() { eprintln!("x"); todo!(); } // %s\n' 'commented: let x = 1;' > "$tmp/tests/leak.rs"
+for gate in no-debug-leftovers no-fake-impl no-commented-code; do
+  ( cd "$tmp" && "$here/$gate.sh" tests/leak.rs >/dev/null 2>&1 )
+  if [ $? = 0 ]; then echo "ok    — $gate excludes top-level tests/ (relative)"
+  else echo "FAIL  — $gate flags top-level tests/ (relative)"; fails=$((fails + 1)); fi
+done
+
+# …and a relative root-src path is still CAUGHT (insurance: no gate may grow an
+# inclusion guard that silently exempts single-crate `src/*` — see no-hardcoded).
+( cd "$tmp" && "$here/no-debug-leftovers.sh" src/leak_dbgx.rs >/dev/null 2>&1 )
+if [ $? = 1 ]; then echo "ok    — no-debug-leftovers catches relative root-src path"
+else echo "FAIL  — no-debug-leftovers missed relative root-src path"; fails=$((fails + 1)); fi
+
+# --- perf-budget gate ---------------------------------------------------------
+# Synthesize criterion estimates + budgets; assert gate/nudge/skip semantics.
+perf_gate="$here/perf-budget.sh"
+pdir="$tmp/perf"
+mkdir -p "$pdir/crit/grp/fast/new" "$pdir/crit/grp/slow/new"
+printf '{"median":{"point_estimate":900.0}}\n'  > "$pdir/crit/grp/fast/new/estimates.json"  # under
+printf '{"median":{"point_estimate":1500.0}}\n' > "$pdir/crit/grp/slow/new/estimates.json"  # over 1000+20%
+
+perf_assert() { # desc, want-exit, budgets-file
+  "$perf_gate" "$3" "$pdir/crit" >/dev/null 2>&1
+  if [ "$?" = "$2" ]; then echo "ok    — $1"; else echo "FAIL  — $1"; fails=$((fails + 1)); fi
+}
+printf 'default_tolerance=0.20\n[bench."grp/fast"]\nbudget_ns=1000\nmode="gate"\n'  > "$pdir/under.toml"
+printf 'default_tolerance=0.20\n[bench."grp/slow"]\nbudget_ns=1000\nmode="gate"\n'  > "$pdir/gate.toml"
+printf 'default_tolerance=0.20\n[bench."grp/slow"]\nbudget_ns=1000\nmode="nudge"\n' > "$pdir/nudge.toml"
+perf_assert "perf-budget passes under budget"            0 "$pdir/under.toml"
+perf_assert "perf-budget gates an over-budget regression" 1 "$pdir/gate.toml"
+perf_assert "perf-budget nudge mode warns, never blocks"  0 "$pdir/nudge.toml"
+perf_assert "perf-budget skips when no budgets file"      0 "$pdir/missing.toml"
+
+# --- perf-record: append CSV rows, track vs-prev across commits ----------------
+rec="$here/perf-record.sh"
+rcsv="$pdir/history.csv"
+check_csv() { # desc, grep-pattern
+  if grep -q "$2" "$rcsv"; then echo "ok    — $1"; else echo "FAIL  — $1 (no '$2' in csv)"; fails=$((fails + 1)); fi
+}
+GUARDRAILS_PERF_COMMIT=aaa1 GUARDRAILS_PERF_DATE=D1 "$rec" "$rcsv" "$pdir/under.toml" "$pdir/crit" >/dev/null 2>&1
+check_csv "perf-record writes a header" '^date,commit,bench'
+check_csv "perf-record records median + budget (under)" 'aaa1,grp/fast,900,1000,-10.0,'
+check_csv "perf-record records un-budgeted bench too"   'aaa1,grp/slow,1500,,,'
+# second commit, bump grp/fast 900 -> 1080: vs_prev = +20.0%, vs_budget(1000) = +8.0%
+printf '{"median":{"point_estimate":1080.0}}\n' > "$pdir/crit/grp/fast/new/estimates.json"
+GUARDRAILS_PERF_COMMIT=bbb2 GUARDRAILS_PERF_DATE=D2 "$rec" "$rcsv" "$pdir/under.toml" "$pdir/crit" >/dev/null 2>&1
+check_csv "perf-record tracks vs_prev across commits" 'bbb2,grp/fast,1080,1000,+8.0,+20.0'
+# re-run on same commit refreshes (not duplicates) its rows
+GUARDRAILS_PERF_COMMIT=bbb2 GUARDRAILS_PERF_DATE=D3 "$rec" "$rcsv" "$pdir/under.toml" "$pdir/crit" >/dev/null 2>&1
+if [ "$(grep -c 'bbb2,grp/fast,' "$rcsv")" = 1 ]; then echo "ok    — perf-record dedups rows per commit"
+else echo "FAIL  — perf-record duplicated rows for a commit"; fails=$((fails + 1)); fi
+
+# --- perf: bespoke results map + higher-is-better budgets --------------------------
+# A GPU fps-ceiling style metric: budget is a FLOOR, results come from a JSON map (no criterion).
+printf '{"gpu/ceiling": 850000, "gpu/fast": 1300000}\n' > "$pdir/results.json"  # 850k < 1M floor −10%
+printf '[bench."gpu/ceiling"]\nbudget=1000000\nmode="gate"\ndirection="higher"\ntolerance=0.10\n' > "$pdir/floor-bad.toml"
+printf '[bench."gpu/fast"]\nbudget=1000000\nmode="gate"\ndirection="higher"\ntolerance=0.10\n' > "$pdir/floor-good.toml"
+GUARDRAILS_PERF_RESULTS="$pdir/results.json" "$perf_gate" "$pdir/floor-bad.toml" "$pdir/crit" >/dev/null 2>&1
+if [ $? = 1 ]; then echo "ok    — perf-budget gates a higher-is-better metric below its floor"
+else echo "FAIL  — higher-direction floor not gated"; fails=$((fails + 1)); fi
+GUARDRAILS_PERF_RESULTS="$pdir/results.json" "$perf_gate" "$pdir/floor-good.toml" "$pdir/crit" >/dev/null 2>&1
+if [ $? = 0 ]; then echo "ok    — perf-budget passes a higher-is-better metric above its floor"
+else echo "FAIL  — higher-direction pass case failed"; fails=$((fails + 1)); fi
+GUARDRAILS_PERF_RESULTS="$pdir/results.json" GUARDRAILS_PERF_COMMIT=ccc3 GUARDRAILS_PERF_DATE=D4 \
+  "$rec" "$rcsv" "$pdir/floor-good.toml" "$pdir/crit" >/dev/null 2>&1
+check_csv "perf-record ingests bespoke results too" 'ccc3,gpu/ceiling,850000,,'
+
+# --- no-hardcoded: token-level floats, underscores, paths-in-strings, env prefixes ---
+hard_gate="$here/no-hardcoded.sh"
+hard_assert() { # desc, want-exit, env(or --), file-content
+  local desc="$1" want="$2"; shift 2
+  local env=()
+  while [ "$1" != "--" ]; do env+=("$1"); shift; done
+  shift
+  printf '%s\n' "$1" > "$tmp/src/hard.rs"
+  env "${env[@]}" "$hard_gate" "$tmp/src/hard.rs" >/dev/null 2>&1
+  if [ "$?" = "$want" ]; then echo "ok    — $desc"; else echo "FAIL  — $desc"; fails=$((fails + 1)); fi
+}
+hard_assert "bad float flagged even with allowed 0.0 on the line" 1 -- 'let a = 0.0; let b = 3.7;'
+hard_assert "allowed floats pass (0.0/0.5/1.0/2.0)"               0 -- 'let a = 0.0 + 0.5 * 1.0 - 2.0;'
+hard_assert "underscored int 100_000 is flagged"                  1 -- 'let n = 100_000;'
+hard_assert "int below 100 passes"                                0 -- 'let n = 99;'
+hard_assert "/tmp/ path INSIDE a string literal is flagged"       1 -- 'let p = "/tmp/scratch.sock";'
+hard_assert "/Users/ path inside a string literal is flagged"     1 -- 'let p = "/Users/me/x";'
+hard_assert "env-prefix literal flagged when knob set"            1 "GUARDRAILS_ENV_PREFIXES=MYAPP_:OTHER_" -- 'std::env::var("MYAPP_MODE")'
+hard_assert "env-prefix check off by default"                     0 -- 'std::env::var("MYAPP_MODE")'
+hard_assert "hardcode-ok line escape works"                       0 -- 'let b = 3.7; // hardcode-ok: feel'
+hard_assert "const_tunable! line is the sanctioned home"          0 -- 'const_tunable!(G: f32 = 9.81, "gravity");'
+hard_assert "guardrails-ok-begin/end block escape works"          0 -- '// guardrails-ok-begin: mesh
+let v = [1.5, 2.7, 300.0];
+// guardrails-ok-end'
+hard_assert "digits inside strings are not values"                0 -- 'let s = "0123456789 and 3.14159";'
+
+# --- no-hardcoded: single-crate root src/ layout (relative paths, as pre-commit passes them) ---
+# The inclusion guard matched only `*/src/*` (workspace `crates/*/src/**`); a root-src repo's
+# `src/foo.rs` never matched, so the gate silently exempted the ENTIRE repo (vacuously green).
+hard_layout() { # desc, want-exit, root, path...
+  local desc="$1" want="$2" hroot="$3"; shift 3
+  ( cd "$hroot" && "$hard_gate" "$@" >/dev/null 2>&1 )
+  if [ "$?" = "$want" ]; then echo "ok    — $desc"; else echo "FAIL  — $desc"; fails=$((fails + 1)); fi
+}
+mkdir -p "$tmp/rootcrate/src" "$tmp/rootcrate/crates/lib/src"
+printf 'let n = 100_000;\n' > "$tmp/rootcrate/src/hard_rel.rs"
+printf 'let n = 100_000;\n' > "$tmp/rootcrate/build.rs"
+printf 'let n = 100_000;\n' > "$tmp/rootcrate/crates/lib/src/w.rs"
+hard_layout "root-src relative path is scanned"        1 "$tmp/rootcrate" src/hard_rel.rs
+hard_layout "./-prefixed root-src path is scanned"     1 "$tmp/rootcrate" ./src/hard_rel.rs
+hard_layout "non-src build.rs stays exempt"            0 "$tmp/rootcrate" build.rs
+hard_layout "workspace crates/*/src/* still scanned"   1 "$tmp/rootcrate" crates/lib/src/w.rs
+# discovery isolated to a root WITHOUT crates/, so only root src/ can trip it
+mkdir -p "$tmp/rootonly/src"
+printf 'let n = 100_000;\n' > "$tmp/rootonly/src/hard_rel.rs"
+hard_layout "no-args discovery finds root src/ too"    1 "$tmp/rootonly"
+
+# --- no-hardcoded: #[cfg(test)] exempts the FOLLOWING ITEM, not the rest of the file ---
+# The awk `intest` flag never reset — any prod code after a mid-file test attr/mod was
+# skipped to EOF. Only the attributed item's body (or a brace-less item) is exempt.
+hard_assert "prod value above trailing test mod flagged"          1 -- 'let n = 500;
+#[cfg(test)]
+mod tests { fn t() {} }'
+hard_assert "value inside cfg(test) mod stays exempt"             0 -- '#[cfg(test)]
+mod tests { const N: u32 = 500; }'
+hard_assert "prod value AFTER a cfg(test) fn is flagged"          1 -- '#[cfg(test)]
+fn helper() { let ok = 1; }
+let n = 500;'
+hard_assert "prod value between two cfg(test) mods is flagged"    1 -- '#[cfg(test)]
+mod a { const X: u32 = 900; }
+let n = 500;
+#[cfg(test)]
+mod b { const Y: u32 = 900; }'
+hard_assert "brace-less cfg(test) item does not eat the file"     1 -- '#[cfg(test)]
+use foo::bar;
+let n = 500;'
+hard_assert "multi-line cfg(test) mod body stays exempt"          0 -- '#[cfg(test)]
+mod tests {
+    const N: u32 = 500;
+    fn t() { let x = 3.7; }
+}'
+
+# --- no-hardcoded: baseline ratchet mode (issue #30) ---------------------------
+# A committed per-file count snapshot flips the gate to enforce-on-growth /
+# nudge-on-burn-down / silent-at-baseline; --record-baseline only ever tightens.
+rroot="$tmp/ratchet"; mkdir -p "$rroot/src"
+rbl="$rroot/bl.txt"
+rat_run() { # env..., --, args... (gate run from $rroot; returns gate exit)
+  local envs=()
+  while [ "$1" != "--" ]; do envs+=("$1"); shift; done
+  shift
+  ( cd "$rroot" && env GUARDRAILS_HARDCODED_BASELINE="$rbl" "${envs[@]}" "$hard_gate" "$@" )
+}
+rat_check() { # desc, want-exit, got-exit
+  if [ "$3" = "$2" ]; then echo "ok    — ratchet: $1"
+  else echo "FAIL  — ratchet: $1 (want exit $2, got $3)"; fails=$((fails + 1)); fi
+}
+printf 'let a = 3.7;\nlet b = 5.9;\n' > "$rroot/src/legacy.rs" # 2 hits of debt
+rat_run -- src/legacy.rs >/dev/null 2>&1
+rat_check "no baseline → all-or-nothing still fails" 1 $?
+rat_run -- --record-baseline >/dev/null 2>&1
+rat_check "--record-baseline snapshots the debt" 0 $?
+if grep -q "src/legacy.rs	2" "$rbl"; then echo "ok    — ratchet: baseline holds the per-file count"
+else echo "FAIL  — ratchet: baseline count wrong ($(cat "$rbl" 2>/dev/null))"; fails=$((fails + 1)); fi
+rat_run -- src/legacy.rs >/dev/null 2>&1
+rat_check "count == baseline passes" 0 $?
+rat_out="$(rat_run -- src/legacy.rs 2>&1)"
+if [ -z "$rat_out" ]; then echo "ok    — ratchet: at-baseline is SILENT (no legacy noise)"
+else echo "FAIL  — ratchet: at-baseline emitted output"; fails=$((fails + 1)); fi
+printf 'let c = 9.9;\n' >> "$rroot/src/legacy.rs" # grow: 3 hits
+rat_run -- src/legacy.rs >/dev/null 2>&1
+rat_check "growth past baseline HARD FAILS" 1 $?
+rat_run -- --record-baseline >/dev/null 2>&1
+rat_check "--record-baseline refuses a regression" 1 $?
+if grep -q "src/legacy.rs	2" "$rbl"; then echo "ok    — ratchet: refused record leaves baseline untouched"
+else echo "FAIL  — ratchet: refused record clobbered the baseline"; fails=$((fails + 1)); fi
+printf 'let a = 3.7;\n' > "$rroot/src/legacy.rs" # burn down: 1 hit
+rat_out="$(rat_run -- src/legacy.rs 2>&1)"; rat_got=$?
+rat_check "burn-down below baseline passes" 0 $rat_got
+if printf '%s' "$rat_out" | grep -q NUDGE; then echo "ok    — ratchet: burn-down nudges to re-record"
+else echo "FAIL  — ratchet: burn-down did not nudge"; fails=$((fails + 1)); fi
+rat_run -- --record-baseline >/dev/null 2>&1
+rat_check "re-record after burn-down tightens" 0 $?
+if grep -q "src/legacy.rs	1" "$rbl"; then echo "ok    — ratchet: baseline ratcheted down (2 → 1)"
+else echo "FAIL  — ratchet: baseline did not tighten"; fails=$((fails + 1)); fi
+printf 'let n = 100_000;\n' > "$rroot/src/newfile.rs" # new file = 0 budget
+rat_run -- src/newfile.rs >/dev/null 2>&1
+rat_check "new file with hits fails (absent = baseline 0)" 1 $?
+rm "$rroot/src/newfile.rs"
+printf 'let clean = 1;\n' > "$rroot/src/clean.rs"
+rat_run -- src/clean.rs >/dev/null 2>&1
+rat_check "clean staged file passes under a baseline" 0 $?
+
+# --- no-conflict-markers: committed markers are flagged; setext headings are not ---
+cm_gate="$here/no-conflict-markers.sh"
+cm_assert() { # desc, want-exit, file
+  "$cm_gate" "$1" >/dev/null 2>&1
+  local got=$?
+  if [ "$got" = "$2" ]; then echo "ok    — $3"; else echo "FAIL  — $3 (want $2, got $got)"; fails=$((fails + 1)); fi
+}
+printf '%s\n' 'fn x() {}' '<<<<<<< HEAD' 'a' '=======' 'b' '>>>>>>> other' > "$tmp/conflicted.rs"
+cm_assert "$tmp/conflicted.rs" 1 "committed conflict markers are flagged"
+printf '%s\n' 'Title' '=======' '' 'prose' > "$tmp/setext.md"
+cm_assert "$tmp/setext.md" 0 "setext ======= heading alone is allowed"
+printf '%s\n' 'clean file' > "$tmp/clean.txt"
+cm_assert "$tmp/clean.txt" 0 "clean file passes"
+
+# --- derived-docs: regions match cmd output; --fix regenerates; bad markers error ---
+dd_gate="$here/derived-docs.sh"
+dd_assert() { # desc, want-exit, file, [--fix?]
+  local desc="$1" want="$2" file="$3" flag="${4:-}"
+  if [ -n "$flag" ]; then "$dd_gate" "$flag" "$file" >/dev/null 2>&1; else "$dd_gate" "$file" >/dev/null 2>&1; fi
+  local got=$?
+  if [ "$got" = "$want" ]; then echo "ok    — $desc"
+  else echo "FAIL  — $desc (want $want, got $got)"; fails=$((fails + 1)); fi
+}
+# matching region → pass
+printf '%s\n' '# t' '<!-- guardrails:derived cmd="echo hello" -->' 'hello' '<!-- guardrails:derived:end -->' \
+  > "$tmp/dd-match.md"
+dd_assert "derived-docs passes when region matches" 0 "$tmp/dd-match.md"
+# drifted region → fail
+printf '%s\n' '# t' '<!-- guardrails:derived cmd="echo hello" -->' 'goodbye' '<!-- guardrails:derived:end -->' \
+  > "$tmp/dd-drift.md"
+dd_assert "derived-docs flags drifted region" 1 "$tmp/dd-drift.md"
+# --fix roundtrip → idempotent pass after
+dd_assert "derived-docs --fix exits 0" 0 "$tmp/dd-drift.md" --fix
+dd_assert "derived-docs passes after --fix" 0 "$tmp/dd-drift.md"
+if ! grep -q '^hello$' "$tmp/dd-drift.md"; then
+  echo "FAIL  — derived-docs --fix did not rewrite body"; fails=$((fails + 1))
+else echo "ok    — derived-docs --fix rewrites the region body"; fi
+# unterminated → marker error
+printf '%s\n' '<!-- guardrails:derived cmd="echo x" -->' 'orphan' > "$tmp/dd-unterm.md"
+dd_assert "derived-docs errors on unterminated region" 1 "$tmp/dd-unterm.md"
+# nested → marker error
+printf '%s\n' '<!-- guardrails:derived cmd="echo x" -->' '<!-- guardrails:derived cmd="echo y" -->' \
+  'y' '<!-- guardrails:derived:end -->' > "$tmp/dd-nested.md"
+dd_assert "derived-docs errors on nested start markers" 1 "$tmp/dd-nested.md"
+# stray :end → marker error
+printf '%s\n' 'prose' '<!-- guardrails:derived:end -->' > "$tmp/dd-stray.md"
+dd_assert "derived-docs errors on stray :end" 1 "$tmp/dd-stray.md"
+# failing command → marker error (regions whose cmd doesn't exist can't be diffed)
+printf '%s\n' '<!-- guardrails:derived cmd="nonexistent-binary-xyzzy" -->' 'x' \
+  '<!-- guardrails:derived:end -->' > "$tmp/dd-cmdfail.md"
+dd_assert "derived-docs errors when cmd fails to run" 1 "$tmp/dd-cmdfail.md"
+# multiple regions, one drifted → fail; --fix fixes only the drifted one
+printf '%s\n' '<!-- guardrails:derived cmd="echo one" -->' 'one' '<!-- guardrails:derived:end -->' \
+  '' '<!-- guardrails:derived cmd="echo two" -->' 'TWO' '<!-- guardrails:derived:end -->' \
+  > "$tmp/dd-multi.md"
+dd_assert "derived-docs flags one drifted of two regions" 1 "$tmp/dd-multi.md"
+dd_assert "derived-docs --fix repairs multi-region file"  0 "$tmp/dd-multi.md" --fix
+dd_assert "derived-docs passes after multi-region fix"    0 "$tmp/dd-multi.md"
+# file without any markers → no work, pass
+printf '%s\n' 'plain prose with no markers at all' > "$tmp/dd-none.md"
+dd_assert "derived-docs ignores files without markers" 0 "$tmp/dd-none.md"
+# region body LENGTH changes under --fix while another region follows: the truncation
+# point must be tracked in rebuilt-output coordinates, not source line numbers — using
+# file line numbers eats everything between the regions once the first fill shifts lines.
+printf '%s\n' '<!-- guardrails:derived cmd="seq 3" -->' '<!-- guardrails:derived:end -->' \
+  'between-regions prose' \
+  '<!-- guardrails:derived cmd="echo z" -->' 'STALE' '<!-- guardrails:derived:end -->' \
+  > "$tmp/dd-shift.md"
+dd_assert "derived-docs flags empty region needing multi-line fill" 1 "$tmp/dd-shift.md"
+dd_assert "derived-docs --fix with body-length shift exits 0"       0 "$tmp/dd-shift.md" --fix
+dd_assert "derived-docs passes after shifted multi-region fix"      0 "$tmp/dd-shift.md"
+if grep -q 'between-regions prose' "$tmp/dd-shift.md" && grep -q '^z$' "$tmp/dd-shift.md" \
+  && grep -q '^2$' "$tmp/dd-shift.md" && [ "$(grep -c 'guardrails:derived' "$tmp/dd-shift.md")" = 4 ]; then
+  echo "ok    — derived-docs --fix preserves structure across a body-length shift"
+else
+  echo "FAIL  — derived-docs --fix corrupted the file after a body-length shift"; fails=$((fails + 1))
+fi
+
+# --- ci-shim gate ------------------------------------------------------------
+ci_gate="$here/ci-shim.sh"
+mkdir -p "$tmp/.github/workflows"
+# a shim (invokes a nix check) → clean (no output, exit 0)
+printf 'jobs:\n  check:\n    runs-on: ubuntu-latest\n    steps:\n      - run: nix flake check -L\n' \
+  > "$tmp/.github/workflows/shim.yml"
+out="$("$ci_gate" "$tmp/.github/workflows/shim.yml" 2>&1)"
+[ -z "$out" ] && echo "ci-shim ok    — shim workflow passes clean" \
+  || { echo "ci-shim FAIL  — shim flagged: $out"; fails=$((fails + 1)); }
+# logic, no nix check → nudged (names the file), but exit 0 by default
+printf 'jobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - run: cargo build --release\n' \
+  > "$tmp/.github/workflows/logic.yml"
+out="$("$ci_gate" "$tmp/.github/workflows/logic.yml" 2>&1)"
+printf '%s' "$out" | grep -q 'logic.yml' && echo "ci-shim ok    — logic-only workflow nudged" \
+  || { echo "ci-shim FAIL  — logic-only not nudged"; fails=$((fails + 1)); }
+"$ci_gate" "$tmp/.github/workflows/logic.yml" >/dev/null 2>&1 \
+  && echo "ci-shim ok    — nudge exits 0 by default" \
+  || { echo "ci-shim FAIL  — default nudge should exit 0"; fails=$((fails + 1)); }
+# guardrails-ok in the file → allowlisted
+printf '# guardrails-ok: host-bound e2e\njobs:\n  e2e:\n    steps:\n      - run: npx playwright test\n' \
+  > "$tmp/.github/workflows/e2e.yml"
+out="$("$ci_gate" "$tmp/.github/workflows/e2e.yml" 2>&1)"
+[ -z "$out" ] && echo "ci-shim ok    — guardrails-ok allowlists the workflow" \
+  || { echo "ci-shim FAIL  — allowlist ignored: $out"; fails=$((fails + 1)); }
+# enforce mode → hard fail (exit 1) on a logic-only workflow
+if GUARDRAILS_CI_SHIM_ENFORCE=1 "$ci_gate" "$tmp/.github/workflows/logic.yml" >/dev/null 2>&1; then
+  echo "ci-shim FAIL  — enforce mode should exit 1"; fails=$((fails + 1))
+else
+  echo "ci-shim ok    — enforce mode exits 1"
+fi
+
+# --- no-raw-trace-fields: ?/% Debug/Display field formatters in tracing macros ------
+trace_gate="$here/no-raw-trace-fields.sh"
+trace_assert() { # desc, want-exit, env(or --), file-content
+  local desc="$1" want="$2"; shift 2
+  local env=()
+  while [ "$1" != "--" ]; do env+=("$1"); shift; done
+  shift
+  printf '%s\n' "$1" > "$tmp/src/trace.rs"
+  env "${env[@]}" "$trace_gate" "$tmp/src/trace.rs" >/dev/null 2>&1
+  if [ "$?" = "$want" ]; then echo "ok    — $desc"; else echo "FAIL  — $desc"; fails=$((fails + 1)); fi
+}
+trace_assert "info!(name = ?val) is flagged"             1 -- 'fn f() { info!(user = ?user); }'
+trace_assert "debug!(%val) shorthand is flagged"         1 -- 'fn f() { debug!(%peer); }'
+trace_assert "error!(?val, msg) shorthand is flagged"    1 -- 'fn f() { error!(?e, "boom"); }'
+trace_assert "tracing::warn!(x = ?y) qualified flagged"  1 -- 'fn f() { tracing::warn!(req = ?req); }'
+trace_assert "multi-line field formatter is flagged"     1 -- 'fn f() {
+    info!(
+        user = ?user,
+    );
+}'
+trace_assert "modulo a % b is not a formatter"           0 -- 'fn f() -> u32 { a % 4 }'
+trace_assert "try operator foo()? is not a formatter"    0 -- 'fn f() { let x = foo()?; }'
+trace_assert "match arm => is not a field assignment"    0 -- 'fn f() { match e { _ => err() } }'
+trace_assert "plain message string passes"               0 -- 'fn f() { info!("done {}", n); }'
+trace_assert "regex inline flags r\"(?i)\" not flagged"  0 -- 'fn f() { Regex::new(r"(?i)x(?:y)(?P<n>z)"); }'
+trace_assert "percent inside a message string passes"    0 -- 'fn f() { info!(pct = p, "{}% done", p); }'
+trace_assert "guardrails-ok suppresses"                  0 -- 'fn f() { info!(?e); } // guardrails-ok'
+# Own-line marker ABOVE the flagged line: rustfmt wraps over-long trailing comments onto the NEXT
+# line (where they suppress nothing), so the stable convention is a pure-comment line above.
+trace_assert "own-line guardrails-ok above suppresses next line" 0 -- 'fn f() {
+    // guardrails-ok(no-raw-trace-fields): pending migration
+    info!(user = ?user);
+}'
+trace_assert "guardrails-ok in a string above does NOT suppress" 1 -- 'fn f() {
+    let x = "guardrails-ok";
+    info!(user = ?user);
+}'
+trace_assert "marker above wrong line does not leak further down" 1 -- 'fn f() {
+    // guardrails-ok(no-raw-trace-fields): pending migration
+    let y = 1;
+    info!(user = ?user);
+}'
+trace_assert "allowlisted schema surface is skipped"     0 \
+  "GUARDRAILS_TRACE_ALLOW_GLOBS=*/src/trace.rs" -- 'fn f() { info!(user = ?user); }'
+# allow-glob without a leading `*` must survive the dir-walk `./` prefix too
+mkdir -p "$tmp/globroot/schema"
+printf 'fn f() { info!(user = ?user); }\n' > "$tmp/globroot/schema/fields.rs"
+( cd "$tmp/globroot" && GUARDRAILS_TRACE_ALLOW_GLOBS='schema/*' "$trace_gate" ./schema/fields.rs >/dev/null 2>&1 )
+if [ $? = 0 ]; then echo "ok    — trace allow-glob matches ./-prefixed path"
+else echo "FAIL  — trace allow-glob missed ./-prefixed path"; fails=$((fails + 1)); fi
+# tests/ path is exempt even for a real formatter (relative path, as pre-commit passes it)
+printf 'fn f() { info!(user = ?user); }\n' > "$tmp/tests/trace_leak.rs"
+( cd "$tmp" && "$trace_gate" tests/trace_leak.rs >/dev/null 2>&1 )
+if [ $? = 0 ]; then echo "ok    — no-raw-trace-fields excludes top-level tests/ (relative)"
+else echo "FAIL  — no-raw-trace-fields flags top-level tests/ (relative)"; fails=$((fails + 1)); fi
+
+# --- numerical-obligation: ratcheting baselines vs measurement JSON --------------
+# Verifies: regression gated, improvement ratchets the baseline on --update (never widens
+# slack), tolerance honored, higher-is-better direction works, missing measurement is a
+# soft-skip, nudge mode warns but passes, ratchet=false freezes baseline as a fixed budget.
+numob_gate="$here/numerical-obligation.sh"
+ndir="$tmp/numob"
+mkdir -p "$ndir"
+
+numob_assert() { # desc, want-exit, args...
+  local desc="$1" want="$2"; shift 2
+  "$numob_gate" "$@" >/dev/null 2>&1
+  local got=$?
+  if [ "$got" = "$want" ]; then echo "ok    — $desc"
+  else echo "FAIL  — $desc (want $want, got $got)"; fails=$((fails + 1)); fi
+}
+
+# (1) Lower-is-better: regression beyond zero tolerance is gated.
+printf '{"adapters":{"foo":{"hard":10}}}\n' > "$ndir/base.json"
+printf '{"adapters":{"foo":{"hard":11}}}\n' > "$ndir/meas.json"
+cat > "$ndir/regress.toml" <<EOF
+[set."t"]
+baseline = "$ndir/base.json"
+measurement = "$ndir/meas.json"
+EOF
+numob_assert "regression beyond tolerance is gated" 1 "$ndir/regress.toml"
+
+# (2) Same regression, nudge mode: warns but exit 0.
+cat > "$ndir/nudge.toml" <<EOF
+default_mode = "nudge"
+[set."t"]
+baseline = "$ndir/base.json"
+measurement = "$ndir/meas.json"
+EOF
+numob_assert "regression in nudge mode warns but passes" 0 "$ndir/nudge.toml"
+
+# (3) Within tolerance: 11 vs 10 with 20% tolerance allows up to 12.
+cat > "$ndir/within.toml" <<EOF
+default_tolerance = 0.20
+[set."t"]
+baseline = "$ndir/base.json"
+measurement = "$ndir/meas.json"
+EOF
+numob_assert "within tolerance passes" 0 "$ndir/within.toml"
+
+# (4) Improvement: 10 → 9 under default direction (lower). Check passes; --update ratchets.
+printf '{"adapters":{"foo":{"hard":10}}}\n' > "$ndir/base.json"
+printf '{"adapters":{"foo":{"hard":9}}}\n'  > "$ndir/meas.json"
+cat > "$ndir/improve.toml" <<EOF
+[set."t"]
+baseline = "$ndir/base.json"
+measurement = "$ndir/meas.json"
+EOF
+numob_assert "improvement passes check" 0 "$ndir/improve.toml"
+"$numob_gate" --update "$ndir/improve.toml" >/dev/null 2>&1
+new_val=$(python3 -c 'import json; print(json.load(open("'"$ndir"'/base.json"))["adapters"]["foo"]["hard"])')
+if [ "$new_val" = "9" ]; then echo "ok    — --update ratchets baseline DOWN to improvement"
+else echo "FAIL  — --update did not ratchet (baseline=$new_val, expected 9)"; fails=$((fails + 1)); fi
+
+# (5) After --update, a fresh measurement at the old level is now a regression.
+printf '{"adapters":{"foo":{"hard":10}}}\n' > "$ndir/meas.json"
+numob_assert "regression vs newly-ratcheted baseline is gated" 1 "$ndir/improve.toml"
+
+# (6) --update on a regression does NOT widen the baseline (ratchet, not budget).
+printf '{"adapters":{"foo":{"hard":9}}}\n'  > "$ndir/base.json"
+printf '{"adapters":{"foo":{"hard":20}}}\n' > "$ndir/meas.json"
+"$numob_gate" --update "$ndir/improve.toml" >/dev/null 2>&1
+val=$(python3 -c 'import json; print(json.load(open("'"$ndir"'/base.json"))["adapters"]["foo"]["hard"])')
+if [ "$val" = "9" ]; then echo "ok    — --update REFUSES to widen on regression"
+else echo "FAIL  — --update widened baseline 9 → $val"; fails=$((fails + 1)); fi
+
+# (7) Higher-is-better: throughput floor with tolerance.
+printf '{"throughput":1000}\n' > "$ndir/base.json"
+printf '{"throughput":850}\n'  > "$ndir/meas.json"
+cat > "$ndir/higher-bad.toml" <<EOF
+default_direction = "higher"
+default_tolerance = 0.10
+[set."t"]
+baseline = "$ndir/base.json"
+measurement = "$ndir/meas.json"
+EOF
+numob_assert "higher-direction floor gated when below" 1 "$ndir/higher-bad.toml"
+printf '{"throughput":950}\n' > "$ndir/meas.json"
+numob_assert "higher-direction within tolerance passes" 0 "$ndir/higher-bad.toml"
+
+# (8) Higher-is-better improvement also ratchets UP on --update.
+printf '{"throughput":1500}\n' > "$ndir/meas.json"
+"$numob_gate" --update "$ndir/higher-bad.toml" >/dev/null 2>&1
+val=$(python3 -c 'import json; print(json.load(open("'"$ndir"'/base.json"))["throughput"])')
+if [ "$val" = "1500" ]; then echo "ok    — --update ratchets higher-direction baseline UP"
+else echo "FAIL  — higher-direction --update did not ratchet (baseline=$val)"; fails=$((fails + 1)); fi
+
+# (9) Missing measurement: soft-skip (warn, exit 0).
+printf '{"a":1}\n' > "$ndir/base.json"
+rm -f "$ndir/meas.json"
+cat > "$ndir/missing-meas.toml" <<EOF
+[set."t"]
+baseline = "$ndir/base.json"
+measurement = "$ndir/missing.json"
+EOF
+numob_assert "missing measurement file is a soft-skip" 0 "$ndir/missing-meas.toml"
+
+# (10) Missing baseline: hard error.
+cat > "$ndir/missing-base.toml" <<EOF
+[set."t"]
+baseline = "$ndir/no-such.json"
+measurement = "$ndir/base.json"
+EOF
+numob_assert "missing baseline file is a hard error" 1 "$ndir/missing-base.toml"
+
+# (11) Missing config file: soft-skip (opt-in by file presence, matches perf-budget UX).
+numob_assert "missing config is a soft-skip" 0 "$ndir/no-such-config.toml"
+
+# (12) ratchet=false: --update does NOT modify even on improvement (it's a fixed budget).
+printf '{"a":10}\n' > "$ndir/base.json"
+printf '{"a":5}\n'  > "$ndir/meas.json"
+cat > "$ndir/fixed.toml" <<EOF
+[set."t"]
+baseline = "$ndir/base.json"
+measurement = "$ndir/meas.json"
+ratchet = false
+EOF
+"$numob_gate" --update "$ndir/fixed.toml" >/dev/null 2>&1
+val=$(python3 -c 'import json; print(json.load(open("'"$ndir"'/base.json"))["a"])')
+if [ "$val" = "10" ]; then echo "ok    — ratchet=false treats baseline as a fixed budget"
+else echo "FAIL  — ratchet=false was ratcheted (baseline=$val, expected 10)"; fails=$((fails + 1)); fi
+
+# (13) Nested + multi-key: every numeric leaf is independently gated.
+printf '{"col":{"A":{"x":1.0,"y":2.0},"B":{"x":3.0}}}\n' > "$ndir/base.json"
+printf '{"col":{"A":{"x":1.1,"y":1.9},"B":{"x":3.5}}}\n' > "$ndir/meas.json"
+cat > "$ndir/nested.toml" <<EOF
+[set."t"]
+baseline = "$ndir/base.json"
+measurement = "$ndir/meas.json"
+EOF
+"$numob_gate" "$ndir/nested.toml" >/dev/null 2>&1
+if [ $? = 1 ]; then echo "ok    — nested leaves are independently gated"
+else echo "FAIL  — nested gating wrong"; fails=$((fails + 1)); fi
+
+# (14) ${ENV:-default} expansion in measurement paths.
+printf '{"a":1}\n' > "$ndir/base.json"
+printf '{"a":1}\n' > "$ndir/env-meas.json"
+cat > "$ndir/env.toml" <<EOF
+[set."t"]
+baseline = "$ndir/base.json"
+measurement = "\${NUMOB_TEST_MEAS:-$ndir/env-meas.json}"
+EOF
+NUMOB_TEST_MEAS="$ndir/env-meas.json" "$numob_gate" "$ndir/env.toml" >/dev/null 2>&1
+if [ $? = 0 ]; then echo "ok    — \${ENV:-default} expansion in measurement path"
+else echo "FAIL  — env expansion broken"; fails=$((fails + 1)); fi
+
+# (15) --list mode is informational, exit 0.
+numob_assert "--list mode is informational" 0 --list "$ndir/improve.toml"
+
+# --- duplication: token-window clone nudge -----------------------------------
+# Reinvention-vs-reuse detector. Multi-file by nature, so it runs on a DIR root
+# (not a single file). Default = NUDGE (report, exit 0); GUARDRAILS_DUP_ENFORCE=1
+# promotes to a hard gate. Precision-first: an exact ≥K normalized-line match is
+# a real clone, so false positives stay near zero (a noisy nudge trains bypass).
+dup_gate="$here/duplication.sh"
+# dup_assert <desc> <want-exit> <env...> -- <dir>
+dup_assert() {
+  local desc="$1" want="$2"; shift 2
+  local env=()
+  while [ "$1" != "--" ]; do env+=("$1"); shift; done
+  shift
+  env "${env[@]}" "$dup_gate" "$1" >/dev/null 2>&1
+  local got=$?
+  if [ "$got" = "$want" ]; then echo "ok    — $desc"
+  else echo "FAIL  — $desc (want exit $want, got $got)"; fails=$((fails + 1)); fi
+}
+
+# A ≥6 significant-line block (the class of hand-rolled modal/confirm handler
+# that drifts into N near-identical copies).
+dup_block() { cat <<'RS'
+fn handle_close(state: &mut State) {
+    state.dialog = None;
+    state.mode = if state.active.is_some() {
+        Mode::Terminal
+    } else {
+        Mode::Navigate
+    };
+    state.dirty = true;
+}
+RS
+}
+
+# CAUGHT: same block in two files, differing only in indentation + comments
+# (normalization must see through whitespace/comment noise).
+mkdir -p "$tmp/dup_clone"
+dup_block > "$tmp/dup_clone/a.rs"
+{ echo "// an unrelated leading comment"; dup_block | sed 's/^/    /'; echo "    // trailing note"; } > "$tmp/dup_clone/b.rs"
+dup_assert "clone across two files is a NUDGE (exit 0)"          0 -- "$tmp/dup_clone"
+dup_assert "clone promoted to hard gate under ENFORCE"          1 "GUARDRAILS_DUP_ENFORCE=1" -- "$tmp/dup_clone"
+
+# NO FALSE POSITIVE: two genuinely distinct files.
+mkdir -p "$tmp/dup_unique"
+printf 'fn alpha() {\n    let x = compute_alpha();\n    x + 1\n}\n' > "$tmp/dup_unique/a.rs"
+printf 'fn beta() {\n    let y = compute_beta();\n    y * 2\n}\n'    > "$tmp/dup_unique/b.rs"
+dup_assert "distinct files produce no clone"                    0 "GUARDRAILS_DUP_ENFORCE=1" -- "$tmp/dup_unique"
+
+# THRESHOLD: an identical block of only 5 significant lines (< K=6) is ignored.
+mkdir -p "$tmp/dup_short"
+short_block() { cat <<'RS'
+fn s() {
+    let a = one();
+    let b = two();
+    let c = three();
+    let d = four();
+}
+RS
+}
+short_block > "$tmp/dup_short/a.rs"; short_block > "$tmp/dup_short/b.rs"
+dup_assert "shared block below the ≥6-line threshold is ignored" 0 "GUARDRAILS_DUP_ENFORCE=1" -- "$tmp/dup_short"
+
+# ESCAPE: guardrails-ok on one twin removes it from the corpus → no pair.
+mkdir -p "$tmp/dup_ok"
+dup_block > "$tmp/dup_ok/a.rs"
+{ echo "// guardrails-ok"; dup_block; } > "$tmp/dup_ok/b.rs"
+dup_assert "guardrails-ok on one twin suppresses the pair"      0 "GUARDRAILS_DUP_ENFORCE=1" -- "$tmp/dup_ok"
+
+# ESCAPE: GUARDRAILS_DUP_ALLOW glob excludes a twin the same way.
+dup_assert "GUARDRAILS_DUP_ALLOW glob excludes a twin"         0 "GUARDRAILS_DUP_ENFORCE=1" "GUARDRAILS_DUP_ALLOW=*/b.rs" -- "$tmp/dup_clone"
+
+# TUNABLE: dropping the threshold to 5 makes the short block fire.
+dup_assert "GUARDRAILS_DUP_MIN_LINES=5 catches the 5-line block" 1 "GUARDRAILS_DUP_ENFORCE=1" "GUARDRAILS_DUP_MIN_LINES=5" -- "$tmp/dup_short"
+
+# DETERMINISM: guardrails bans wall-clock/random for reproducibility — identical
+# input must yield byte-identical output across runs.
+r1="$(GUARDRAILS_DUP_ENFORCE=1 "$dup_gate" "$tmp/dup_clone" 2>&1)"
+r2="$(GUARDRAILS_DUP_ENFORCE=1 "$dup_gate" "$tmp/dup_clone" 2>&1)"
+if [ "$r1" = "$r2" ]; then echo "ok    — duplication report is deterministic"
+else echo "FAIL  — duplication report differs across runs"; fails=$((fails + 1)); fi
+
+# --- duplication: staleness escalation (ledger + git-age → auto-promote) ------
+# The nudge earns the right to become a gate: a clone that PERSISTS undealt-with
+# across commits has a decaying false-positive probability, so age promotes it
+# nudge → hard block. Ledger is committed state (like perf-history.csv); age is
+# counted in COMMITS (git as the deterministic clock — no wall-time).
+led="$tmp/dup_ledger.tsv"
+aged="$tmp/dup_aged"
+mkdir -p "$aged"
+dup_block > "$aged/a.rs"
+dup_block > "$aged/b.rs"
+git -C "$aged" init -q
+git -C "$aged" config user.email t@t; git -C "$aged" config user.name t
+git -C "$aged" add -A && git -C "$aged" commit -q -m c1
+# --record stamps the clone group's first-seen at HEAD (c1) into the ledger.
+( cd "$aged" && GUARDRAILS_DUP_LEDGER="$led" "$dup_gate" --record "$aged" >/dev/null 2>&1 )
+if [ -s "$led" ]; then echo "ok    — --record writes the clone ledger"
+else echo "FAIL  — --record did not write a ledger"; fails=$((fails + 1)); fi
+# One more commit → the clone has persisted 1 commit since first-seen.
+: > "$aged/other.txt"; git -C "$aged" add -A && git -C "$aged" commit -q -m c2
+# age(1) ≥ ENFORCE_AGE(1) → persisted clone auto-promotes to a hard block…
+( cd "$aged" && GUARDRAILS_DUP_LEDGER="$led" GUARDRAILS_DUP_ENFORCE_AGE=1 "$dup_gate" "$aged" >/dev/null 2>&1 )
+if [ $? = 1 ]; then echo "ok    — persisted clone auto-promotes to ENFORCE by age"
+else echo "FAIL  — persisted clone did not auto-promote"; fails=$((fails + 1)); fi
+# …but a threshold it has not reached keeps it a nudge (exit 0).
+( cd "$aged" && GUARDRAILS_DUP_LEDGER="$led" GUARDRAILS_DUP_ENFORCE_AGE=99 "$dup_gate" "$aged" >/dev/null 2>&1 )
+if [ $? = 0 ]; then echo "ok    — clone below the age threshold stays a nudge"
+else echo "FAIL  — clone below age threshold wrongly blocked"; fails=$((fails + 1)); fi
+# Resolving it (decorate one twin) drops it from the ledger on the next --record.
+{ echo "// guardrails-ok"; dup_block; } > "$aged/b.rs"
+git -C "$aged" add -A && git -C "$aged" commit -q -m c3
+( cd "$aged" && GUARDRAILS_DUP_LEDGER="$led" "$dup_gate" --record "$aged" >/dev/null 2>&1 )
+if [ ! -s "$led" ]; then echo "ok    — resolved clone drops from the ledger (ratchet-shrink)"
+else echo "FAIL  — resolved clone lingers in the ledger"; fails=$((fails + 1)); fi
+
+# --- protect-trunk: refuse direct commits on a protected branch ----------------
+# Workflow gate, not a content gate: HEAD's branch (or the branch a rebase is
+# rewriting) must not be in the protected set. CI / GITHUB_ACTIONS are cleared in
+# every row so the suite behaves identically locally and in CI (which sets them).
+pt_gate="$here/protect-trunk.sh"
+ptr="$tmp/pt-repo"
+git init -q -b main "$ptr" && git -C "$ptr" -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+pt_assert() { # desc, want-exit, env-assignments..., -- (runs gate inside $ptr)
+  local desc="$1" want="$2"; shift 2
+  local envs=()
+  while [ "$1" != "--" ]; do envs+=("$1"); shift; done
+  ( cd "$ptr" && env -u CI -u GITHUB_ACTIONS -u GUARDRAILS_ALLOW_TRUNK -u GUARDRAILS_PROTECTED_BRANCHES "${envs[@]}" "$pt_gate" >/dev/null 2>&1 )
+  local got=$?
+  if [ "$got" = "$want" ]; then echo "ok    — protect-trunk: $desc"
+  else echo "FAIL  — protect-trunk: $desc (want exit $want, got $got)"; fails=$((fails + 1)); fi
+}
+pt_assert "blocks a commit on main (default set)"       1 --
+git -C "$ptr" branch -m master
+pt_assert "blocks a commit on master (default set)"     1 --
+git -C "$ptr" switch -q -c feat/x
+pt_assert "feature branch passes"                        0 --
+git -C "$ptr" checkout -q --detach
+pt_assert "detached HEAD is allowed"                     0 --
+# Rebase-of-protected probe: fake the rebase state files (a real `git rebase` of a
+# single-commit branch finishes atomically; the state file is what the gate reads).
+git_dir_pt="$(git -C "$ptr" rev-parse --git-dir)"; [ "${git_dir_pt#/}" = "$git_dir_pt" ] && git_dir_pt="$ptr/$git_dir_pt"
+mkdir -p "$git_dir_pt/rebase-merge" && echo "refs/heads/master" > "$git_dir_pt/rebase-merge/head-name"
+pt_assert "rebase OF a protected branch still blocks"    1 --
+rm -rf "$git_dir_pt/rebase-merge"
+git -C "$ptr" switch -q master
+pt_assert "GUARDRAILS_ALLOW_TRUNK=1 escape passes"       0 GUARDRAILS_ALLOW_TRUNK=1 --
+pt_assert "CI context auto-allows"                       0 CI=true --
+pt_assert "GITHUB_ACTIONS context auto-allows"           0 GITHUB_ACTIONS=true --
+pt_assert "knob REPLACES default (master not protected)" 0 GUARDRAILS_PROTECTED_BRANCHES='release/*' --
+pt_assert "empty knob disables protection"               0 GUARDRAILS_PROTECTED_BRANCHES= --
+# pt_on: switch AND verify — an invalid branch name must fail the row loudly, not
+# leave HEAD on the previous branch silently mis-testing (a review caught two such rows).
+pt_on() {
+  git -C "$ptr" switch -q -c "$1" 2>/dev/null
+  [ "$(git -C "$ptr" symbolic-ref --short HEAD)" = "$1" ] && return 0
+  echo "FAIL  — protect-trunk: could not create test branch '$1'"; fails=$((fails + 1)); return 1
+}
+pt_on release/1.2/hotfix && {
+pt_assert "glob knob matches nested release branch"      1 GUARDRAILS_PROTECTED_BRANCHES='release/*' --
+pt_assert "boundary empties in ':main:' don't match-all" 0 GUARDRAILS_PROTECTED_BRANCHES=':main:' --
+}
+# git refuses space/'['/'*' in ref names, so hostile-branch rows are unrepresentable;
+# glob semantics are exercised from the PATTERN side instead (? must match exactly one char).
+pt_on weirdo && {
+pt_assert "glob ? pattern matches one extra char"        1 GUARDRAILS_PROTECTED_BRANCHES='weird?' --
+pt_assert "glob ? pattern needs its char (no match)"     0 GUARDRAILS_PROTECTED_BRANCHES='weirdo?' --
+}
+mkdir -p "$tmp/pt-notrepo"
+( cd "$tmp/pt-notrepo" && env -u CI -u GITHUB_ACTIONS "$pt_gate" >/dev/null 2>&1 )
+if [ $? = 0 ]; then echo "ok    — protect-trunk: outside a git repo is allowed"
+else echo "FAIL  — protect-trunk: blocked outside a git repo"; fails=$((fails + 1)); fi
+
+# --- protect-trunk-push: refuse pushes advancing a protected REMOTE ref --------
+# Keyed on the remote ref from pre-push stdin (catches `push origin HEAD:main`
+# from a feature branch and cherry-picked/plumbing commits pre-commit never saw).
+ptp_gate="$here/protect-trunk-push.sh"
+sha_a=1111111111111111111111111111111111111111
+sha_z=0000000000000000000000000000000000000000
+ptp_assert() { # desc, want-exit, env-assignments..., --, stdin-lines...
+  local desc="$1" want="$2"; shift 2
+  local envs=()
+  while [ "$1" != "--" ]; do envs+=("$1"); shift; done
+  shift
+  printf '%s\n' "$@" | env -u CI -u GITHUB_ACTIONS -u GUARDRAILS_ALLOW_TRUNK -u GUARDRAILS_PROTECTED_BRANCHES -u PRE_COMMIT_REMOTE_BRANCH -u GUARDRAILS_TRUNK_MERGE_GATE -u GUARDRAILS_TRUNK_MERGE_CMD "${envs[@]}" "$ptp_gate" >/dev/null 2>&1
+  local got=$?
+  if [ "$got" = "$want" ]; then echo "ok    — protect-trunk-push: $desc"
+  else echo "FAIL  — protect-trunk-push: $desc (want exit $want, got $got)"; fails=$((fails + 1)); fi
+}
+ptp_assert "push to protected remote ref blocks"      1 -- "refs/heads/feat/x $sha_a refs/heads/main $sha_a"
+ptp_assert "HEAD:main refspec from feature blocks"    1 -- "HEAD $sha_a refs/heads/main $sha_a"
+ptp_assert "feature-to-feature push passes"           0 -- "refs/heads/feat/x $sha_a refs/heads/feat/x $sha_a"
+ptp_assert "deleting a remote branch is not blocked"  0 -- "(delete) $sha_z refs/heads/main $sha_a"
+ptp_assert "tag push to a 'main' tag is not a head"   0 -- "refs/tags/main $sha_a refs/tags/main $sha_a"
+ptp_assert "mixed batch: one protected ref blocks"    1 -- "refs/heads/feat/x $sha_a refs/heads/feat/x $sha_a" "refs/heads/feat/x $sha_a refs/heads/master $sha_a"
+ptp_assert "ALLOW_TRUNK escape passes"                0 GUARDRAILS_ALLOW_TRUNK=1 -- "refs/heads/feat/x $sha_a refs/heads/main $sha_a"
+ptp_assert "CI context auto-allows"                   0 CI=true -- "refs/heads/feat/x $sha_a refs/heads/main $sha_a"
+ptp_assert "knob glob protects release/* remote ref"  1 GUARDRAILS_PROTECTED_BRANCHES='release/*' -- "refs/heads/feat/x $sha_a refs/heads/release/1.2 $sha_a"
+ptp_assert "empty knob disables push protection"      0 GUARDRAILS_PROTECTED_BRANCHES= -- "refs/heads/feat/x $sha_a refs/heads/main $sha_a"
+ptp_assert "empty stdin (nothing to push) passes"     0 -- ""
+# prek/pre-commit run system hooks with stdin nulled and export the parsed remote ref
+# instead (PRE_COMMIT_REMOTE_BRANCH, full refs/heads/... form) — the env fallback path.
+ptp_assert "env fallback blocks protected ref (prek)" 1 PRE_COMMIT_REMOTE_BRANCH=refs/heads/main -- ""
+ptp_assert "env fallback passes feature ref (prek)"   0 PRE_COMMIT_REMOTE_BRANCH=refs/heads/feat/x -- ""
+ptp_assert "stdin takes precedence over env fallback" 0 PRE_COMMIT_REMOTE_BRANCH=refs/heads/main -- "refs/heads/feat/x $sha_a refs/heads/feat/x $sha_a"
+ptp_assert "env fallback honors empty-knob opt-out"   0 GUARDRAILS_PROTECTED_BRANCHES= PRE_COMMIT_REMOTE_BRANCH=refs/heads/main -- ""
+# Trunk-merge-gate (issue #18): GUARDRAILS_TRUNK_MERGE_GATE=1 turns the refusal into
+# "pass iff the check suite is green right now" — pre-push earns the trunk advance.
+ptp_assert "trunk-merge-gate: green guards EARN the push"  0 GUARDRAILS_TRUNK_MERGE_GATE=1 GUARDRAILS_TRUNK_MERGE_CMD=true -- "refs/heads/feat/x $sha_a refs/heads/main $sha_a"
+ptp_assert "trunk-merge-gate: red guards still refuse"     1 GUARDRAILS_TRUNK_MERGE_GATE=1 GUARDRAILS_TRUNK_MERGE_CMD=false -- "refs/heads/feat/x $sha_a refs/heads/main $sha_a"
+ptp_assert "trunk-merge-gate off by default (refusal)"     1 -- "refs/heads/feat/x $sha_a refs/heads/main $sha_a"
+# The check suite runs at most ONCE per push, however many protected refs match.
+tmg_cnt="$tmp/tmg-count"
+: > "$tmg_cnt"
+printf '#!/bin/sh\necho x >> "%s"\n' "$tmg_cnt" > "$tmp/tmg-cmd" && chmod +x "$tmp/tmg-cmd"
+printf '%s\n' "refs/heads/feat/x $sha_a refs/heads/main $sha_a" "refs/heads/feat/x $sha_a refs/heads/master $sha_a" \
+  | env -u CI -u GITHUB_ACTIONS GUARDRAILS_TRUNK_MERGE_GATE=1 GUARDRAILS_TRUNK_MERGE_CMD="$tmp/tmg-cmd" "$ptp_gate" >/dev/null 2>&1
+if [ "$(grep -c x "$tmg_cnt")" = 1 ]; then echo "ok    — protect-trunk-push: merge-gate cmd memoized (1 run for 2 refs)"
+else echo "FAIL  — protect-trunk-push: merge-gate cmd ran $(grep -c x "$tmg_cnt") times"; fails=$((fails + 1)); fi
+
+# --- nudge-ledger: the shared persistence-escalation harness (issue #32) -------
+# Gate-agnostic lifecycle: new → quiet · persisted → age-in-commits (+growth) →
+# promoted past --enforce-age · resolved → dropped on record. Pins exactly the
+# transitions the #31 review flagged: oscillation and orphaned first-seen SHAs.
+nl="$here/../tools/nudge-ledger.sh"
+nrepo="$tmp/nl-repo"; mkdir -p "$nrepo"
+git init -q -b main "$nrepo"
+git -C "$nrepo" -c user.email=t@t -c user.name=t commit -q --allow-empty -m c1
+nled="$nrepo/led.tsv"
+nl_run() { ( cd "$nrepo" && "$nl" "$@" ); }
+TABC="$(printf '\t')"
+nl_check() { # desc, want-substr, got
+  if printf '%s' "$3" | grep -q "$2"; then echo "ok    — nudge-ledger: $1"
+  else echo "FAIL  — nudge-ledger: $1 (got: $3)"; fails=$((fails + 1)); fi
+}
+fnd() { printf 'k1\t%s\tlabel-one\n' "$1"; }
+out="$(fnd 2 | nl_run check --ledger "$nled")"
+nl_check "unseen finding tiers as new" "k1${TABC}new" "$out"
+fnd 2 | nl_run record --ledger "$nled"
+if grep -q "k1" "$nled"; then echo "ok    — nudge-ledger: record stamps first-seen"
+else echo "FAIL  — nudge-ledger: record wrote nothing"; fails=$((fails + 1)); fi
+git -C "$nrepo" -c user.email=t@t -c user.name=t commit -q --allow-empty -m c2
+out="$(fnd 2 | nl_run check --ledger "$nled")"
+nl_check "persisted finding ages in commits" "k1${TABC}persisted:1" "$out"
+out="$(fnd 3 | nl_run check --ledger "$nled")"
+nl_check "growth is tiered with prev>now" "persisted:1:grew:2>3" "$out"
+out="$(fnd 3 | nl_run check --ledger "$nled" --enforce-age 1)"
+nl_check "age past --enforce-age promotes (grew kept)" "promoted:1:grew:2>3" "$out"
+# resolved → dropped on record (ratchet-shrink)…
+: | nl_run record --ledger "$nled"
+if [ ! -s "$nled" ]; then echo "ok    — nudge-ledger: resolved finding drops on record"
+else echo "FAIL  — nudge-ledger: resolved finding lingered"; fails=$((fails + 1)); fi
+# …and OSCILLATION: reappearing after resolve+record restarts the age at 0 (fresh stamp).
+fnd 2 | nl_run record --ledger "$nled"
+out="$(fnd 2 | nl_run check --ledger "$nled" --enforce-age 1)"
+nl_check "reappeared finding restarts age (no stale promote)" "k1${TABC}persisted:0" "$out"
+# Orphaned first-seen (shallow clone / rewritten history): age falls back to 0 + one warning.
+printf 'k1\t%s\t2\n' "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef" > "$nled"
+err="$(fnd 2 | nl_run check --ledger "$nled" --enforce-age 1 2>&1 >/dev/null)"
+out="$(fnd 2 | nl_run check --ledger "$nled" --enforce-age 1 2>/dev/null)"
+nl_check "orphaned first-seen fails open (age 0, no promote)" "k1${TABC}persisted:0" "$out"
+nl_check "orphaned first-seen warns on stderr (not silent)" "unreachable" "$err"
+# Garbage --enforce-age is a usage error (exit 2), not a silent misread.
+( : | nl_run check --ledger "$nled" --enforce-age abc >/dev/null 2>&1 )
+if [ $? = 2 ]; then echo "ok    — nudge-ledger: garbage enforce-age is a loud usage error"
+else echo "FAIL  — nudge-ledger: garbage enforce-age accepted"; fails=$((fails + 1)); fi
+
+# --- guardrails-trace: duration+verdict JSONL wrapper (issue #14) --------------
+# Transparent wrapper: exit code + streams pass through; one atomic row per run in
+# the XDG cache; guardrails last replays the latest run and cannot be swallowed.
+trace="$here/../tools/trace.sh"
+report="$here/../tools/trace-report.sh"
+tdir="$tmp/trace-repo"; mkdir -p "$tdir"
+tr_env() { ( cd "$tdir" && env XDG_CACHE_HOME="$tmp/xdg" "$@" ); }
+tr_check() { # desc, want, got
+  if [ "$3" = "$2" ]; then echo "ok    — trace: $1"
+  else echo "FAIL  — trace: $1 (want $2, got $3)"; fails=$((fails + 1)); fi
+}
+tr_out="$(tr_env env GR_RUN_ID=run1 GR_TRIGGER=pre-commit "$trace" echo-gate -- echo hello)"
+tr_check "wrapped command's stdout passes through" hello "$tr_out"
+tr_env env GR_RUN_ID=run1 GR_TRIGGER=pre-commit "$trace" fail-gate -- sh -c 'exit 3' >/dev/null 2>&1
+tr_check "wrapped exit code is preserved" 3 $?
+tfile="$(ls "$tmp"/xdg/guardrails/runs/*.jsonl 2>/dev/null | head -1)"
+if [ -n "$tfile" ] && [ "$(grep -c . "$tfile")" = 2 ]; then echo "ok    — trace: one row per run appended"
+else echo "FAIL  — trace: expected 2 rows in $tfile"; fails=$((fails + 1)); fi
+if grep -q '"gate":"echo-gate","trigger":"pre-commit","verdict":"pass","exit_code":0' "$tfile" \
+   && grep -q '"gate":"fail-gate","trigger":"pre-commit","verdict":"fail","exit_code":3' "$tfile"; then
+  echo "ok    — trace: rows carry verdict enum + raw exit code"
+else echo "FAIL  — trace: row fields wrong: $(cat "$tfile")"; fails=$((fails + 1)); fi
+if awk '!/"duration_ms":[0-9]+/ { bad = 1 } END { exit bad }' "$tfile"; then
+  echo "ok    — trace: duration_ms is a non-negative integer"
+else echo "FAIL  — trace: bad duration_ms"; fails=$((fails + 1)); fi
+# guardrails last: latest run only, FAIL duplicated to stderr, exit 1.
+tr_env env GR_RUN_ID=run2 GR_TRIGGER=pre-push "$trace" ok-gate -- true >/dev/null 2>&1
+last_err="$(tr_env "$report" last 2>&1 >/dev/null)"; last_ec=$?
+tr_check "last exits 0 when the latest run is green" 0 $last_ec
+tr_env env GR_RUN_ID=run3 GR_TRIGGER=pre-commit "$trace" bad-gate -- false >/dev/null 2>&1
+last_out="$(tr_env "$report" last 2>/dev/null)"; last_ec=$?
+last_err="$(tr_env "$report" last 2>&1 >/dev/null)"
+tr_check "last exits 1 when the latest run has a FAIL" 1 $last_ec
+if printf '%s' "$last_err" | grep -q FAIL; then echo "ok    — trace: FAIL is duplicated on stderr (unswallowable)"
+else echo "FAIL  — trace: FAIL not on stderr"; fails=$((fails + 1)); fi
+if printf '%s' "$last_out" | grep -q run3 && ! printf '%s' "$last_out" | grep -q ok-gate; then
+  echo "ok    — trace: last shows only the latest run"
+else echo "FAIL  — trace: last mixed runs: $last_out"; fails=$((fails + 1)); fi
+# perf report aggregates without error and names the gates.
+perf_out="$(tr_env "$report" perf 2>&1)"
+if printf '%s' "$perf_out" | grep -q 'echo-gate' && printf '%s' "$perf_out" | grep -q 'p95'; then
+  echo "ok    — trace: perf report aggregates per gate"
+else echo "FAIL  — trace: perf report broken: $perf_out"; fails=$((fails + 1)); fi
+# outside any tracing (no GR_* env): still writes a row with trigger=manual.
+tr_env "$trace" manual-gate -- true >/dev/null 2>&1
+if grep -q '"gate":"manual-gate","trigger":"manual"' "$tfile"; then
+  echo "ok    — trace: bare invocation defaults to trigger=manual"
+else echo "FAIL  — trace: manual trigger default missing"; fails=$((fails + 1)); fi
+
+# --- guardrails-stale: calendar+churn staleness vs config thresholds (issue #13) ---
+stale="$here/../tools/stale.sh"
+srepo="$tmp/stale-repo"; mkdir -p "$srepo"
+git init -q -b main "$srepo" && git -C "$srepo" -c user.email=t@t -c user.name=t commit -q --allow-empty -m c1
+stop="$(git -C "$srepo" rev-parse --show-toplevel)" # macOS: /var vs /private/var — use git's answer
+sslug="$(basename "$stop")-$(printf '%s' "$stop" | git hash-object --stdin | cut -c1-6)"
+sdir="$tmp/xdg-stale/guardrails/runs"; mkdir -p "$sdir"
+st_run() { ( cd "$srepo" && env XDG_CACHE_HOME="$tmp/xdg-stale" "$stale" "$@" ); }
+# no trace + no config → silent, exit 0
+rm -f "$sdir/$sslug.jsonl" "$srepo/guardrails-stale.toml"
+s_out="$(st_run 2>&1)"; s_ec=$?
+if [ "$s_ec" = 0 ] && [ -z "$s_out" ]; then echo "ok    — stale: silent without trace/config"
+else echo "FAIL  — stale: noisy without opt-in ($s_ec: $s_out)"; fails=$((fails + 1)); fi
+# trace with an OLD green run + max_days=0 → stderr names the gate; exit stays 0
+printf '{"v":1,"ts":"2020-01-01T00:00:00Z","run_id":"r1","repo":"x","gate":"cargo-deny","trigger":"pre-push","verdict":"pass","exit_code":0,"duration_ms":5,"changed_files":0}\n' > "$sdir/$sslug.jsonl"
+printf '[cargo-deny]\nmax_days = 7\n' > "$srepo/guardrails-stale.toml"
+s_err="$(st_run 2>&1 >/dev/null)"; s_ec=$?
+if [ "$s_ec" = 0 ] && printf '%s' "$s_err" | grep -q 'cargo-deny.*d'; then echo "ok    — stale: calendar-overdue gate nudged (exit 0)"
+else echo "FAIL  — stale: calendar lever broken ($s_ec: $s_err)"; fails=$((fails + 1)); fi
+# fresh green run → quiet
+printf '{"v":1,"ts":"%s","run_id":"r2","repo":"x","gate":"cargo-deny","trigger":"pre-push","verdict":"pass","exit_code":0,"duration_ms":5,"changed_files":0}\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$sdir/$sslug.jsonl"
+s_err="$(st_run 2>&1 >/dev/null)"
+if [ -z "$s_err" ]; then echo "ok    — stale: freshly-green gate stays quiet"
+else echo "FAIL  — stale: false nudge on fresh gate ($s_err)"; fails=$((fails + 1)); fi
+# configured gate that never ran green → 'never green'
+printf '[clippy]\nmax_days = 7\n' >> "$srepo/guardrails-stale.toml"
+s_err="$(st_run 2>&1 >/dev/null)"
+if printf '%s' "$s_err" | grep -q 'clippy never green'; then echo "ok    — stale: never-green configured gate surfaces"
+else echo "FAIL  — stale: never-green gate invisible ($s_err)"; fails=$((fails + 1)); fi
+# --json works without config and carries per-gate stats
+rm "$srepo/guardrails-stale.toml"
+s_json="$(st_run --json 2>/dev/null)"
+if printf '%s' "$s_json" | grep -q '"cargo-deny"' && printf '%s' "$s_json" | grep -q 'days_since_green'; then
+  echo "ok    — stale: --json emits per-gate stats without config"
+else echo "FAIL  — stale: --json broken ($s_json)"; fails=$((fails + 1)); fi
+
+echo
+if [ "$fails" -gt 0 ]; then
+  echo "$fails test(s) FAILED" >&2
+  exit 1
+fi
+echo "all gate tests passed"

--- a/assets/guardrails/tools/diffpack.sh
+++ b/assets/guardrails/tools/diffpack.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# guardrails diffpack — one reviewable artifact for a fresh-eyes pass (issue #12).
+#
+# Authors are confirmation-blind to their own regressions; the fix is a fresh-context
+# reviewer (human or agent) with REFUTATION framing ("try to refute that this works").
+# That reviewer needs the full review surface in ONE read — not just the diff, but the
+# governance context the diff touches. This command emits exactly that, to stdout:
+#
+#   1. WHAT     — working diff vs a base (default: staged+unstaged vs HEAD; --base <ref>
+#                 for a branch review, e.g. --base origin/main).
+#   2. CONTEXT  — governance surfaces the diff touches:
+#                 * ADR sections referenced by changed hunks (ADR-NNN mentions),
+#                 * gate-config deltas (guardrails-allow.txt, guardrails-baseline.txt,
+#                   perf-budgets.toml, numerical-obligation.toml, .pre-commit-config.yaml,
+#                   deny.toml) called out loudly — reviewers rubber-stamp these last,
+#                 * escape-hatch deltas: added guardrails-ok / hardcode-ok / --no-verify
+#                   mentions in the diff (an added escape IS review surface #1).
+#   3. HOW TO REVIEW — the author≠reviewer contract (from CONVENTIONS.md), inlined so a
+#                 spawned agent needs no other context.
+#
+# Usage: guardrails diffpack [--base <ref>]    (also: guardrails-diffpack)
+set -uo pipefail
+
+base=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --base) base="${2:?--base needs a ref}"; shift 2 ;;
+    -h|--help) sed -n '2,22p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "guardrails-diffpack: unknown arg '$1' (try --base <ref>)" >&2; exit 2 ;;
+  esac
+done
+
+git rev-parse --git-dir >/dev/null 2>&1 || { echo "guardrails-diffpack: not a git repo" >&2; exit 2; }
+
+if [ -n "$base" ]; then
+  diff_cmd=(git diff "$base"...HEAD)
+  scope="$base...HEAD"
+else
+  diff_cmd=(git diff HEAD)
+  scope="working tree vs HEAD"
+fi
+
+diff_out="$("${diff_cmd[@]}" 2>/dev/null)"
+if [ -z "$diff_out" ]; then
+  echo "guardrails-diffpack: no changes in scope ($scope) — nothing to pack." >&2
+  exit 0
+fi
+
+echo "# diffpack — $scope"
+echo "# repo: $(basename "$(git rev-parse --show-toplevel)") @ $(git rev-parse --short HEAD)"
+echo
+
+# ---- 2. governance context first (a reviewer reads this BEFORE the diff) -------------
+echo "## Review surface"
+echo
+
+# Escape-hatch deltas: any ADDED line carrying an escape marker is the highest-signal
+# review target — it's the author asking for an exemption.
+escapes="$(printf '%s\n' "$diff_out" | grep -nE '^\+.*(guardrails-ok|hardcode-ok|--no-verify|GUARDRAILS_ALLOW_TRUNK)' | grep -v '^+++' || true)"
+if [ -n "$escapes" ]; then
+  echo "### ⚠ Added escape hatches (review these FIRST — each is a requested exemption)"
+  printf '%s\n' "$escapes" | sed 's/^/    /'
+  echo
+fi
+
+# Gate-config deltas: allowlists/baselines/budgets changing alongside code deserve
+# suspicion — loosening the gate is how debt sneaks in with the feature.
+gate_cfg="$(printf '%s\n' "$diff_out" | awk '/^diff --git/ { f=$3; sub(/^a\//, "", f) }
+  /^diff --git/ && f ~ /(guardrails-allow\.txt|guardrails-baseline\.txt|perf-budgets\.toml|perf-history\.csv|numerical-obligation\.toml|\.pre-commit-config\.yaml|deny\.toml)$/ { print f }')"
+if [ -n "$gate_cfg" ]; then
+  echo "### ⚠ Gate-config deltas (is the gate being loosened to admit this diff?)"
+  printf '%s\n' "$gate_cfg" | sed 's/^/    /'
+  echo
+fi
+
+# ADR references in changed hunks: the reviewer must check the diff against what the
+# cited decision actually says (drift between decided design and code is the #1 catch).
+adrs="$(printf '%s\n' "$diff_out" | grep -oE 'ADR-[0-9]+' | LC_ALL=C sort -u || true)"
+if [ -n "$adrs" ]; then
+  echo "### ADRs referenced by changed hunks (diff must match the decided design)"
+  for a in $adrs; do
+    hit="$(git grep -l "$a" -- 'docs/adr/*' 'docs/*.md' 2>/dev/null | head -1 || true)"
+    echo "    $a${hit:+ — $hit}"
+  done
+  echo
+fi
+
+# Derived-docs regions touched: hand-edits to generated regions will be reverted by the
+# gate; flag them so the reviewer checks the SOURCE was regenerated instead.
+derived="$(printf '%s\n' "$diff_out" | grep -c 'guardrails:derived' || true)"
+if [ "${derived:-0}" -gt 0 ]; then
+  echo "### Derived-docs regions in the diff ($derived marker line(s)) — was the generator re-run, or is this a hand-edit?"
+  echo
+fi
+
+changed_files="$(printf '%s\n' "$diff_out" | grep -c '^diff --git' || true)"
+echo "### Shape"
+echo "    files changed: $changed_files    (+$(printf '%s\n' "$diff_out" | grep -c '^+[^+]') / -$(printf '%s\n' "$diff_out" | grep -c '^-[^-]') lines)"
+echo
+
+# ---- 3. the reviewer contract ----------------------------------------------------------
+cat <<'EOF'
+## Reviewer contract (author ≠ reviewer)
+You are a FRESH-CONTEXT reviewer; the author's reasoning is not in your context, and that
+is the point. Review with REFUTATION framing: actively try to prove this diff wrong,
+regressive, or out of scope — do not summarize it back.
+  1. Escape hatches + gate-config deltas above are the first read: each is the author
+     asking to be exempted from a rule. Refute the justification.
+  2. If an ADR is cited, read the ADR section and refute that the code matches it.
+  3. Hunt regressions the author is blind to: retired concepts re-introduced, invariants
+     silently weakened, tests that assert the happy path but not the documented pitfalls.
+  4. Verdict format: approve / blockers (file:line) / nits. No hedging.
+
+## Diff
+EOF
+printf '%s\n' "$diff_out"

--- a/assets/guardrails/tools/freshness-nudge.sh
+++ b/assets/guardrails/tools/freshness-nudge.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# guardrails-freshness-nudge — the once/week, one-line drift reminder at PUSH time.
+#
+# Reads ONLY the cache that guardrails-freshness-refresh writes — no network, no `nix`, never
+# blocks the push. Injected near the top of the pre-push git hook by the guardrails devShell
+# (before prek's `exec`, after the toolbelt is on PATH). Prints a single line to stderr iff
+# inputs are drifting, at most once per week per repo. ALWAYS exits 0 (never fails a push), and
+# never reads stdin (pre-push's ref list must reach prek intact).
+#
+# Knob: GUARDRAILS_FRESHNESS_NAG_MIN (default 10080 = 1 week) — min gap between nudges.
+set -uo pipefail
+
+top="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 0
+cache="${XDG_CACHE_HOME:-$HOME/.cache}/guardrails"
+key="$(printf '%s' "$top" | tr -c 'A-Za-z0-9.' '_')"
+data="$cache/$key.json"
+nag="$cache/$key.nag"
+[ -f "$data" ] || exit 0 # no cache yet (refresh hasn't run) → stay silent
+
+nag_min="${GUARDRAILS_FRESHNESS_NAG_MIN:-10080}"
+# Throttle: nudged within the window → stay quiet (don't touch the stamp, so drift still surfaces later).
+if [ -f "$nag" ] && [ -z "$(find "$nag" -mmin "+$nag_min" 2>/dev/null)" ]; then
+  exit 0
+fi
+
+# Summarize the cache into one line; empty unless something is actually drifting.
+line="$(python3 - "$data" <<'PY' 2>/dev/null
+import json, sys
+try:
+    d = json.load(open(sys.argv[1]))
+except Exception:
+    sys.exit(0)
+stale = [r for r in d.get("inputs", []) if r.get("stale")]
+if not stale:
+    sys.exit(0)
+
+def tag(r):
+    name = r.get("input", "?")
+    if r.get("behind") is True:
+        return f"{name}←upstream"
+    a = r.get("age_days")
+    return f"{name} {a}d" if a is not None else name
+
+shown = ", ".join(tag(r) for r in stale[:4]) + (" …" if len(stale) > 4 else "")
+print(f"⟳ pins drifting: {shown}  — `guardrails freshness` when ready")
+PY
+)"
+
+if [ -n "$line" ]; then
+  printf '%s\n' "$line" >&2
+  mkdir -p "$cache" 2>/dev/null && touch "$nag"
+fi
+exit 0

--- a/assets/guardrails/tools/freshness-refresh.sh
+++ b/assets/guardrails/tools/freshness-refresh.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# guardrails-freshness-refresh — keep the freshness cache warm, OFF the hot path.
+#
+# Throttled to ≤ once/day per repo; meant to be fire-and-forgotten from the devShell
+# shellHook (backgrounded). The pre-push nudge reads ONLY the cache this writes, so the
+# push (and `cd`) never touch the network inline. Safe to run on every entry — when the
+# cache is fresh it returns immediately (one stat); when stale it refreshes in the
+# background it was launched in. Always exits 0-ish; never blocks a shell.
+#
+# Knob: GUARDRAILS_FRESHNESS_TTL_MIN (default 1440 = 1 day) — max cache age before refresh.
+set -uo pipefail
+
+top="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 0
+[ -f "$top/flake.lock" ] || exit 0
+
+cache="${XDG_CACHE_HOME:-$HOME/.cache}/guardrails"
+key="$(printf '%s' "$top" | tr -c 'A-Za-z0-9.' '_')" # repo path → stable, path-sanitized filename
+stamp="$cache/$key.stamp"
+ttl_min="${GUARDRAILS_FRESHNESS_TTL_MIN:-1440}"
+
+# Throttle: if the stamp exists and is younger than the TTL, there's nothing to do.
+if [ -f "$stamp" ] && [ -z "$(find "$stamp" -mmin "+$ttl_min" 2>/dev/null)" ]; then
+  exit 0
+fi
+
+mkdir -p "$cache" 2>/dev/null || exit 0
+# Single-refresher lock (atomic mkdir): several devShell entries can fire at TTL expiry, but only
+# one may run `git ls-remote` — the losers just exit rather than storm the network. Break a stale
+# lock left by a killed refresher (>10min) so freshness can't wedge forever.
+lock="$cache/$key.lock"
+[ -d "$lock" ] && [ -n "$(find "$lock" -mmin +10 2>/dev/null)" ] && rmdir "$lock" 2>/dev/null
+mkdir "$lock" 2>/dev/null || exit 0
+trap 'rmdir "$lock" 2>/dev/null || true' EXIT
+
+out="$cache/$key.json"
+tmp="$(mktemp "$cache/$key.XXXXXX" 2>/dev/null)" || exit 0 # per-run temp: no shared-tmp clobber
+# --online so the nudge can show "upstream moved"; the 8s/input bound lives in guardrails-freshness.
+if (cd "$top" && guardrails-freshness --online --json) >"$tmp" 2>/dev/null; then
+  mv -f "$tmp" "$out" && touch "$stamp"
+else
+  rm -f "$tmp"
+fi
+exit 0

--- a/assets/guardrails/tools/freshness.sh
+++ b/assets/guardrails/tools/freshness.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# guardrails-freshness — surface THIS flake's input drift, off the hot path.
+#
+# Pinning hides staleness: you're reproducible, so you never notice an input aged
+# out until something breaks. This is the on-demand "tell me now" (the once/week
+# post-push nudge just reads this command's --json cache — never the hot `cd` path).
+# Offline by default (lock age from flake.lock); --online adds an upstream behind-
+# check via `git ls-remote` (bounded, best-effort, degrades silently when offline).
+#
+#   guardrails freshness            # human table, offline (lock age)
+#   guardrails freshness --online   # also flag inputs whose upstream ref moved
+#   guardrails freshness --json     # machine output (g-fleet dashboard + push-nudge cache)
+#
+# Knob: GUARDRAILS_FRESHNESS_STALE_DAYS (default 30) — the age that counts as "drifting".
+set -uo pipefail
+
+stale_days="${GUARDRAILS_FRESHNESS_STALE_DAYS:-30}"
+online=0
+as_json=0
+for a in "$@"; do
+  case "$a" in
+    --online) online=1 ;;
+    --json) as_json=1 ;;
+    -h | --help)
+      echo "usage: guardrails freshness [--online] [--json]   (env: GUARDRAILS_FRESHNESS_STALE_DAYS)"
+      exit 0
+      ;;
+    *)
+      echo "guardrails freshness: unknown arg '$a'" >&2
+      exit 2
+      ;;
+  esac
+done
+
+root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+if [ ! -f "$root/flake.lock" ]; then
+  if [ "$as_json" = 1 ]; then echo '{"inputs":[],"note":"no flake.lock"}'; else echo "guardrails freshness: no flake.lock in $root"; fi
+  exit 0
+fi
+
+# nix flake metadata gives each input's locked {rev,lastModified,type,owner/repo/ref}.
+meta="$(nix --extra-experimental-features 'nix-command flakes' flake metadata "$root" --json 2>/dev/null)"
+if [ -z "$meta" ]; then
+  # Degrade silently (offline / nix missing). Keep --json TOTAL: the cache + post-push nudge
+  # parse our stdout, so always emit valid JSON in --json mode — never empty.
+  if [ "$as_json" = 1 ]; then echo '{"inputs":[],"note":"metadata unavailable (offline?)"}'; else echo "guardrails freshness: nix flake metadata failed (offline?)" >&2; fi
+  exit 0
+fi
+
+tmp="$(mktemp 2>/dev/null)" || tmp=""
+if [ -z "$tmp" ]; then
+  if [ "$as_json" = 1 ]; then echo '{"inputs":[],"note":"mktemp unavailable"}'; else echo "guardrails freshness: mktemp failed" >&2; fi
+  exit 0
+fi
+printf '%s' "$meta" >"$tmp"
+trap 'rm -f "$tmp"' EXIT
+
+GR_ONLINE="$online" GR_JSON="$as_json" GR_STALE="$stale_days" python3 - "$tmp" <<'PY'
+import json, os, subprocess, sys, time
+
+meta = json.load(open(sys.argv[1]))
+locks = meta.get("locks", {})
+nodes = locks.get("nodes", {})
+root = locks.get("root", "root")
+direct = nodes.get(root, {}).get("inputs", {})
+now = time.time()
+online = os.environ["GR_ONLINE"] == "1"
+as_json = os.environ["GR_JSON"] == "1"
+stale_days = int(os.environ["GR_STALE"])
+
+
+def remote_moved(locked, original):
+    """True/False if the locked ref's upstream tip differs; None if unknown/uncheckable.
+    Best-effort + advisory: branch-tracked inputs often record ref=None, so we fall back to the
+    input's `original` ref, then HEAD (default branch) — which can over-report. Treat the
+    resulting `behind` as a hint, not an authority."""
+    t = locked.get("type")
+    if t == "github":
+        url = f"https://github.com/{locked.get('owner')}/{locked.get('repo')}.git"
+    elif t in ("git", "gitlab", "sourcehut"):
+        url = locked.get("url", "")
+    else:
+        return None
+    if not url:
+        return None
+    ref = locked.get("ref") or original.get("ref") or "HEAD"
+    try:
+        out = subprocess.run(["git", "ls-remote", url, ref],
+                             capture_output=True, text=True, timeout=8)
+        tip = out.stdout.split()[0] if out.stdout.strip() else ""
+        return (tip[:40] != locked.get("rev", "")[:40]) if tip else None
+    except Exception:
+        return None
+
+
+rows = []
+for name, ref in direct.items():
+    key = ref[0] if isinstance(ref, list) else ref          # follows → [node, ...]
+    node = nodes.get(key, {})
+    locked = node.get("locked", {})
+    lm = locked.get("lastModified")
+    age = int((now - lm) // 86400) if lm else None
+    behind = remote_moved(locked, node.get("original", {})) if online else None
+    stale = (age is not None and age >= stale_days) or behind is True
+    rows.append({"input": name, "age_days": age, "rev": locked.get("rev", "")[:9],
+                 "behind": behind, "stale": stale})
+
+rows.sort(key=lambda r: (r["age_days"] is None, -(r["age_days"] or 0)))
+
+if as_json:
+    print(json.dumps({"root": meta.get("resolvedUrl", root), "checked": int(now),
+                      "stale_days": stale_days, "inputs": rows}, indent=2))
+    sys.exit(0)
+
+if not rows:
+    print("guardrails freshness: no direct flake inputs")
+    sys.exit(0)
+
+for r in rows:
+    age = f"{r['age_days']}d" if r["age_days"] is not None else "?"
+    flag = "⟳" if r["stale"] else "·"           # ⟳ drifting · fresh
+    note = "  ← upstream moved" if r["behind"] is True else ("  (unchecked)" if (online and r["behind"] is None) else "")
+    print(f"  {flag} {r['input']:<18} {age:>5} old   {r['rev']}{note}")
+
+n = sum(1 for r in rows if r["stale"])
+if n:
+    print(f"\n⟳ {n}/{len(rows)} inputs drifting (≥{stale_days}d or upstream moved) — `nix flake update` when ready")
+else:
+    print(f"\n✓ all {len(rows)} inputs fresh (<{stale_days}d)")
+PY

--- a/assets/guardrails/tools/guardrails.sh
+++ b/assets/guardrails/tools/guardrails.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# guardrails — what is this, and how do I use it. A terminal answer to "a teammate
+# added guardrails to our repo; now what?". Print with `guardrails` or `guardrails info`.
+set -uo pipefail
+case "${1:-info}" in
+  info | "" | -h | --help | help)
+    if [ "${2:-}" = "--perf" ]; then shift 2; exec guardrails-trace-report perf "$@"; fi ;;
+  last) shift; exec guardrails-trace-report last "$@" ;;
+  stale) shift; exec guardrails-stale "$@" ;;
+  freshness) shift; exec guardrails-freshness "$@" ;;
+  diffpack) shift; exec guardrails-diffpack "$@" ;;
+  *) echo "guardrails: unknown command '$1' (try: guardrails info)" >&2 ;;
+esac
+cat <<'EOF'
+guardrails — shareable code-quality / governance for this repo.
+Gates run on every commit (via prek); deep checks (cargo-deny, perf) run in CI.
+
+GATES — block a commit unless escaped:
+  protect-trunk       HEAD is a protected branch (main/master) — trunk advances by merge/PR only;
+                      the pre-push twin refuses pushes advancing a protected REMOTE ref
+                      (GUARDRAILS_PROTECTED_BRANCHES to change/disable · GUARDRAILS_ALLOW_TRUNK=1
+                      for an intentional hotfix · CI auto-allowed). Solo/trunk-flow upgrade:
+                      GUARDRAILS_TRUNK_MERGE_GATE=1 lets the push-side gate EARN a trunk push —
+                      allowed iff GUARDRAILS_TRUNK_MERGE_CMD (default `nix flake check`) is green
+  no-fake-impl        todo!()/unimplemented!()/FIXME/placeholder-impl — stubs shipped as "done"
+  no-debug-leftovers  dbg!/print!/println!/eprint!/eprintln!/console.log outside main/bin/tests
+  no-commented-code   commented-out code graveyards
+  no-hardcoded        magic values that should be tunables (src/ only). Adopting on a legacy
+                      tree? Ratchet mode: `guardrails-no-hardcoded --record-baseline` commits a
+                      per-file debt snapshot — growth hard-fails, burn-down nudges a re-record,
+                      at-baseline stays silent (no big-bang triage needed)
+  no-conflict-markers committed <<<<<<</=======/>>>>>>> merge-marker lines (no escape — never legitimate)
+  no-raw-trace-fields raw ?/% Debug/Display field formatters in tracing! macros — shape the field
+                      in your schema surface (PII/secrets leak into logs by reflex otherwise)
+  derived-docs        regions marked `<!-- guardrails:derived cmd="…" -->` must match `cmd`'s output
+                      (re-run with --fix to regenerate; commands run with repo-hook trust)
+  + gitleaks · rustfmt · clippy -D warnings · cargo-deny
+
+NUDGES — warn (exit 0); promote per-repo with the gate's *_ENFORCE knob:
+  ci-shim             a CI workflow runs logic but no `nix flake check` (GUARDRAILS_CI_SHIM_ENFORCE)
+  duplication         a ≥6-line block cloned across ≥2 sites — reinvention vs reuse; extract a
+                      helper (GUARDRAILS_DUP_ENFORCE / _MIN_LINES / _EXTS / _ALLOW)
+CI-deep (not pre-commit) — run after `cargo criterion`:
+  perf-budget             gate criterion regressions over a checked-in perf-budgets.toml
+  perf-record             append per-bench medians to perf-history.csv — the PR diff is the report,
+                          git history is the trend (no external service)
+  numerical-obligation    ratchet measured numerical contracts (parity errors, HARD counts, coverage %,
+                          binary size) against a checked-in baseline JSON. Distinct from perf-budget:
+                          the baseline MOVES on improvement (--update writes back in the improvement
+                          direction only — refuses to widen slack). Schema in numerical-obligation.toml.
+
+ESCAPE / BYPASS:
+  one line    append  // guardrails-ok
+  one commit  git commit --no-verify   (sparingly — the point is to not need it)
+
+CONFIG KNOBS (in your repo root):
+  .pre-commit-config.yaml  which gates run + their entries
+  GUARDRAILS_OUTPUT_GLOBS  no-debug-leftovers: colon-sep path globs for legit CLI output surfaces,
+                           e.g.  entry: env GUARDRAILS_OUTPUT_GLOBS=*/cli/*:scripts/* guardrails-no-debug-leftovers
+  GUARDRAILS_TRACE_ALLOW_GLOBS  no-raw-trace-fields: colon-sep path globs for the schema/redaction
+                           surface where raw ?/% field formatting is defined, e.g. src/trace_schema.rs
+  guardrails-allow.txt     no-hardcoded: blessed path prefixes to skip
+  guardrails-baseline.txt  no-hardcoded ratchet: committed per-file count snapshot (or point
+                           GUARDRAILS_HARDCODED_BASELINE elsewhere); --record-baseline refuses
+                           to loosen — the ratchet only tightens
+  GUARDRAILS_ENV_PREFIXES  no-hardcoded: colon-sep env-var name prefixes to flag as bare string
+                           literals (write the shared const instead), e.g. "MYAPP_:OTHER_"
+  perf-budgets.toml        perf-budget: criterion median ceilings (run after `cargo criterion`)
+  perf-history.csv         perf-record: committed per-bench history; the PR diff = the perf report
+  numerical-obligation.toml  numerical-obligation: [set."name"] entries → (baseline json, measurement
+                           json, direction/tolerance/mode/ratchet). Baseline files are version-controlled,
+                           measurement files written by your measurer at gate time.
+  deny.toml                cargo-deny: license allow-list + advisory ignores
+
+WIRE THE HOOKS (normally automatic via direnv / nix develop — both stages):
+  just install-hooks    or    prek install -t pre-commit -t pre-push
+
+GATE TRACING (opt-in per entry — wrap it):
+  entry: guardrails-trace <name> -- <cmd...>   append one JSONL row per gate run (duration,
+                           verdict, exit code) to the XDG cache — transparent: streams and
+                           exit code pass through untouched
+  guardrails info --perf   per-gate n/p50/p95/fail%/last-fail (+ tier-3 / retire hints)
+  guardrails last          the most recent run's verdicts; any FAIL repeats on stderr and
+                           exits 1 — a piped/truncated stdout can't swallow a red gate
+
+FRESH-EYES REVIEW (author ≠ reviewer — see CONVENTIONS.md):
+  guardrails diffpack             one reviewable artifact: escape-hatch + gate-config deltas
+                                  first, ADR refs, then the diff — pipe to a fresh-context
+                                  reviewer (agent or human) with refutation framing
+  guardrails diffpack --base origin/main    branch review instead of working tree
+
+STALE GATES (tiers by config, not by daemon — issue #13):
+  guardrails stale         which gates are overdue — calendar (days since last green run)
+                           AND churn (files/lines since) vs guardrails-stale.toml thresholds;
+                           one line, exit 0 always. --json for prompt segments / agent hooks.
+                           Delivered once/week after a push (guardrails-stale-nudge), same
+                           throttle discipline as the freshness nudge.
+
+FLAKE FRESHNESS (off the hot path — on demand, not on `cd`):
+  guardrails freshness            this flake's inputs by lock age (offline)
+  guardrails freshness --online   also flag inputs whose upstream ref moved
+  guardrails freshness --json     machine output (fleet dashboard / push-time nudge)
+
+MORE: docs/CONVENTIONS.md · github:gerchowl/guardrails
+EOF

--- a/assets/guardrails/tools/nudge-ledger.sh
+++ b/assets/guardrails/tools/nudge-ledger.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# guardrails-nudge-ledger — the shared persistence-escalation harness for debt-class nudges
+# (issue #32; mechanism extracted from the duplication gate, #31).
+#
+# The lifecycle a debt-class nudge needs is gate-agnostic: a finding is quiet when NEW, gets
+# louder while it PERSISTS (age = commits since first seen — git as the deterministic clock),
+# auto-PROMOTES to a hard block once it persists undealt-with past a threshold, and DROPS from
+# the ledger when resolved (ratchet-shrink). Only the finding-key is gate-specific. Each gate
+# shrinks to "detect → emit (key, count, label)"; this harness owns the ledger and the tiers.
+#
+# Interface (TSV on stdin, one finding per line):  key<TAB>count<TAB>label
+#   key    stable identity of the finding (clone-hash / workflow path / crate name …)
+#   count  a size the gate wants growth-tracked (sites, hits; 0 if n/a)
+#   label  display text the gate will show its user
+#
+#   guardrails-nudge-ledger check  --ledger <path> [--enforce-age <n>] < findings.tsv
+#     stdout, one line per finding:  key<TAB>tier<TAB>label
+#       tier ∈ new | persisted:<age> | persisted:<age>:grew:<a>><b> | promoted:<age>
+#     Exit 0 always — the GATE decides blocking from the tiers (it owns the vocabulary).
+#   guardrails-nudge-ledger record --ledger <path> < findings.tsv
+#     Reconciles the ledger: persisting keys keep their first-seen commit, new keys stamp at
+#     HEAD, vanished (resolved) keys drop → the ledger only shrinks unless real drift appears.
+#     Sorted output = clean diffs. Exit 0.
+#
+# Age caveat (from the #31 review): on shallow clones or after history rewrites the first-seen
+# SHA may be unreachable — `git rev-list --count` fails, age falls back to 0 (fail-open: a bad
+# ledger can silence escalation, never falsely block) and ONE warning goes to stderr so the
+# hole is visible instead of silent.
+#
+# Ledger format note: rows are key<TAB>first_seen<TAB>count. #31-era duplication ledgers had a
+# 4th span column — the reader takes the first three fields (col 3 kept its meaning), so old
+# committed ledgers load correctly and the first re-record drops the span column. LOAD-BEARING:
+# col 3 must stay "the growth-tracked count" in any future format change.
+set -uo pipefail
+TAB="$(printf '\t')"
+
+mode="${1:?usage: guardrails-nudge-ledger check|record --ledger <path> [--enforce-age <n>]}"
+shift
+ledger="" enforce_age=0
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --ledger) ledger="${2:?--ledger needs a path}"; shift 2 ;;
+    --enforce-age) enforce_age="${2:?--enforce-age needs a number}"; shift 2 ;;
+    *) echo "guardrails-nudge-ledger: unknown arg '$1'" >&2; exit 2 ;;
+  esac
+done
+[ -n "$ledger" ] || { echo "guardrails-nudge-ledger: --ledger is required" >&2; exit 2; }
+case "$enforce_age" in ''|*[!0-9]*) echo "guardrails-nudge-ledger: --enforce-age must be a non-negative integer (got '$enforce_age')" >&2; exit 2 ;; esac
+
+# Ledger rows: key<TAB>first_seen_commit<TAB>count
+declare -A led_first led_count
+if [ -f "$ledger" ]; then
+  while IFS="$TAB" read -r k fseen c _; do
+    [ -n "$k" ] || continue
+    led_first["$k"]="$fseen"; led_count["$k"]="$c"
+  done < "$ledger"
+fi
+head_sha="$(git rev-parse HEAD 2>/dev/null || true)"
+
+warned_age=""
+age_of() { # $1 = first-seen sha → commits since; 0 + one stderr warning when unreachable
+  local a
+  if a="$(git rev-list --count "$1..HEAD" 2>/dev/null)"; then
+    printf '%s' "$a"
+  else
+    if [ -z "$warned_age" ]; then
+      echo "guardrails-nudge-ledger: first-seen commit unreachable (shallow clone / rewritten history) — age treated as 0, escalation may under-fire here." >&2
+      warned_age=1
+    fi
+    printf 0
+  fi
+}
+
+out="" new_ledger=""
+while IFS="$TAB" read -r key count label; do
+  [ -n "$key" ] || continue
+  first="${led_first[$key]:-}"
+  if [ -n "$first" ]; then
+    age="$(age_of "$first")"
+    prev="${led_count[$key]:-$count}"
+    grew=""
+    [ "$count" -gt "$prev" ] 2>/dev/null && grew=":grew:$prev>$count"
+    tier="persisted:$age$grew"
+    if [ "$enforce_age" -gt 0 ] && [ "$age" -ge "$enforce_age" ] 2>/dev/null; then
+      tier="promoted:$age$grew"
+    fi
+    stamp="$first"
+  else
+    tier="new"
+    stamp="$head_sha"
+  fi
+  out+="$key$TAB$tier$TAB$label"$'\n'
+  new_ledger+="$key$TAB$stamp$TAB$count"$'\n'
+done
+
+case "$mode" in
+  check)
+    printf '%s' "$out"
+    ;;
+  record)
+    mkdir -p "$(dirname "$ledger")"
+    printf '%s' "$new_ledger" | LC_ALL=C sort > "$ledger"
+    ;;
+  *) echo "guardrails-nudge-ledger: unknown mode '$mode' (check|record)" >&2; exit 2 ;;
+esac

--- a/assets/guardrails/tools/stale-nudge.sh
+++ b/assets/guardrails/tools/stale-nudge.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# guardrails-stale-nudge — the once/week delivery wrapper around guardrails-stale (issue #13),
+# riding the SAME post-push slot and throttle discipline as the freshness nudge (#20): one
+# line at a moment you're already deciding about this repo, never per-event, never blocking.
+# Injected into the pre-push hook by the devShell; reads no stdin; ALWAYS exits 0.
+#
+# Knob: GUARDRAILS_STALE_NAG_MIN (default 10080 = 1 week) — min gap between nudges.
+set -uo pipefail
+
+top="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 0
+[ -f "$top/guardrails-stale.toml" ] || exit 0 # opt-in: no config, no nudge
+cache="${XDG_CACHE_HOME:-$HOME/.cache}/guardrails"
+key="$(printf '%s' "$top" | tr -c 'A-Za-z0-9.' '_')"
+nag="$cache/$key.stale-nag"
+
+nag_min="${GUARDRAILS_STALE_NAG_MIN:-10080}"
+case "$nag_min" in ''|*[!0-9]*) nag_min=10080 ;; esac # garbage knob → default, not silence-forever
+if [ -f "$nag" ] && [ -z "$(find "$nag" -mmin "+$nag_min" 2>/dev/null)" ]; then
+  exit 0 # nudged recently — quiet (stamp untouched, so staleness still surfaces later)
+fi
+
+line="$(guardrails-stale 2>&1 >/dev/null || true)"
+[ -n "$line" ] || exit 0
+printf '%s\n' "$line" >&2
+mkdir -p "$cache" 2>/dev/null && touch "$nag" 2>/dev/null || true
+exit 0

--- a/assets/guardrails/tools/stale.sh
+++ b/assets/guardrails/tools/stale.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# guardrails-stale — stateless "which gates are overdue?" check (issue #13).
+#
+# The motivating miss: a RUSTSEC advisory sat unnoticed for weeks with ZERO local churn —
+# the advisory DB moved on the CALENDAR while Cargo.lock sat still, and cargo-deny only
+# wakes when a commit touches the lockfile. So staleness needs two levers:
+#   * calendar — days since the gate last ran green (from the #14 trace JSONL),
+#   * churn    — files/lines changed since that last green run.
+# No daemon, no watcher (#20's lesson: an ambient banner you can't action becomes
+# blindness): this is a one-shot primitive; delivery surfaces own their throttle
+# (the once/week post-push slot ships as guardrails-stale-nudge; prompt segments and
+# agent hooks call `guardrails stale --json` themselves).
+#
+# Config: guardrails-stale.toml at the repo root (no file → silent, exit 0 — opt-in):
+#   [cargo-deny]     max_days = 7      # advisory DBs drift on the calendar
+#   [clippy]         max_files = 40    # heavy tier: nudge when churn piles up un-linted
+#   [no-fake-impl]   max_lines = 500
+# Output: one stderr line naming the overdue gates (exit 0 ALWAYS — a nudge, not a gate).
+# --json: per-gate stats to stdout (also without config — consumers bring their own policy).
+set -uo pipefail
+
+json=0
+[ "${1:-}" = "--json" ] && json=1
+
+top="$(git rev-parse --show-toplevel 2>/dev/null)" || exit 0
+repo="$(basename "$top")"
+slug="$repo-$(printf '%s' "$top" | git hash-object --stdin 2>/dev/null | cut -c1-6)"
+trace="${XDG_CACHE_HOME:-$HOME/.cache}/guardrails/runs/$slug.jsonl"
+cfg="$top/guardrails-stale.toml"
+
+[ -f "$trace" ] || { [ "$json" = 1 ] && echo '{"gates":{},"note":"no trace data — wrap hook entries with guardrails-trace"}'; exit 0; }
+if [ "$json" = 0 ] && [ ! -f "$cfg" ]; then exit 0; fi
+
+python3 - "$trace" "$cfg" "$json" <<'PY'
+import json, os, subprocess, sys
+from datetime import datetime, timezone
+
+trace, cfg_path, want_json = sys.argv[1], sys.argv[2], sys.argv[3] == "1"
+
+try:
+    import tomllib
+    cfg = tomllib.load(open(cfg_path, "rb")) if cfg_path and os.path.exists(cfg_path) else {}
+except Exception:
+    cfg = {}
+
+# Last green ts per gate from the trace JSONL (machine-written, fixed keys).
+last_green = {}
+for line in open(trace, errors="replace"):
+    try:
+        r = json.loads(line)
+    except ValueError:
+        continue
+    if r.get("verdict") == "pass" and r.get("gate"):
+        last_green[r["gate"]] = r.get("ts", "")
+
+def churn_since(ts):
+    """Files/lines touched since ts: commits since + the working tree."""
+    files, lines = set(), 0
+    try:
+        out = subprocess.run(["git", "log", f"--since={ts}", "--name-only", "--pretty=format:"],
+                             capture_output=True, text=True, timeout=10).stdout
+        files |= {f for f in out.splitlines() if f}
+        out = subprocess.run(["git", "diff", "HEAD", "--numstat"],
+                             capture_output=True, text=True, timeout=10).stdout
+        for row in out.splitlines():
+            p = row.split("\t")
+            if len(p) == 3:
+                files.add(p[2])
+                lines += (int(p[0]) if p[0].isdigit() else 0) + (int(p[1]) if p[1].isdigit() else 0)
+        out = subprocess.run(["git", "log", f"--since={ts}", "--shortstat", "--pretty=format:"],
+                             capture_output=True, text=True, timeout=10).stdout
+        for row in out.splitlines():
+            for tok in row.split(","):
+                tok = tok.strip()
+                if tok.endswith(("(+)", "(-)")) or "insertion" in tok or "deletion" in tok:
+                    n = tok.split(" ")[0]
+                    lines += int(n) if n.isdigit() else 0
+    except Exception:
+        pass
+    return len(files), lines
+
+now = datetime.now(timezone.utc)
+gates = sorted(set(cfg) | (set(last_green) if want_json else set()))
+stats, overdue = {}, []
+for g in gates:
+    ts = last_green.get(g)
+    days = None
+    if ts:
+        try:
+            days = (now - datetime.strptime(ts, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)).days
+        except ValueError:
+            pass
+    nfiles, nlines = churn_since(ts) if ts else (None, None)
+    stats[g] = {"last_green": ts, "days_since_green": days,
+                "files_since_green": nfiles, "lines_since_green": nlines}
+    rules = cfg.get(g, {}) if isinstance(cfg.get(g, {}), dict) else {}
+    for k in rules:
+        if k not in ("max_days", "max_files", "max_lines"):
+            print(f"guardrails-stale: unknown key '{k}' in [{g}] (want max_days/max_files/max_lines)", file=sys.stderr)
+    why = []
+    if ts is None and rules:
+        why.append("never green")
+    if days is not None and "max_days" in rules and days > rules["max_days"]:
+        why.append(f"{days}d")
+    if nfiles is not None and "max_files" in rules and nfiles > rules["max_files"]:
+        why.append(f"{nfiles} files")
+    if nlines is not None and "max_lines" in rules and nlines > rules["max_lines"]:
+        why.append(f"{nlines} lines")
+    if why:
+        overdue.append(f"{g} {' + '.join(why)}")
+        stats[g]["overdue"] = why
+
+if want_json:
+    print(json.dumps({"gates": stats}, sort_keys=True))
+if overdue:
+    print("⚠ stale: " + " · ".join(overdue) + " — run the gate, or `guardrails last` for the latest verdicts.",
+          file=sys.stderr)
+PY
+exit 0

--- a/assets/guardrails/tools/trace-report.sh
+++ b/assets/guardrails/tools/trace-report.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# guardrails-trace-report — read the per-repo trace JSONL (written by guardrails-trace) and
+# answer the two questions that justify its existence (issue #14):
+#
+#   perf [--window <days>]   per-gate n · p50 · p95 · fail% · last-fail over the window
+#                            (default 30d) + the tiering hints: a p95 way past the commit
+#                            budget is a tier-3 candidate (#13); a gate that never fired
+#                            in the window may not be earning its place.
+#   last                     the most recent run's verdicts — the out-of-band answer to a
+#                            `git commit | tail` pipeline swallowing a FAILED gate. Any FAIL
+#                            is duplicated to stderr and exits 1: impossible to miss.
+#
+# Reads only the local XDG cache; no network, no repo writes.
+set -uo pipefail
+
+mode="${1:-perf}"
+shift 2>/dev/null || true
+window_days=30
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --window) window_days="${2:?--window needs days}"; shift 2 ;;
+    *) echo "guardrails-trace-report: unknown arg '$1'" >&2; exit 2 ;;
+  esac
+done
+
+repo_top="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+slug="$(basename "$repo_top")-$(printf '%s' "$repo_top" | git hash-object --stdin 2>/dev/null | cut -c1-6)"
+f="${XDG_CACHE_HOME:-$HOME/.cache}/guardrails/runs/$slug.jsonl"
+if [ ! -s "$f" ]; then
+  echo "guardrails: no trace data for this repo yet ($f)." >&2
+  echo "Wrap hook entries with guardrails-trace to start recording — see 'guardrails info'." >&2
+  exit 0
+fi
+
+# Rows are machine-written with fixed key order — extract fields by key, no jq dependency.
+case "$mode" in
+  perf)
+    cutoff="$(date -u -v-"${window_days}"d +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+             || date -u -d "-${window_days} days" +%Y-%m-%dT%H:%M:%SZ)"
+    awk -v cutoff="$cutoff" '
+      function field(s, k,   r) { r = ""; if (match(s, "\"" k "\":\"[^\"]*\"")) { r = substr(s, RSTART, RLENGTH); sub("\"" k "\":\"", "", r); sub(/"$/, "", r) } return r }
+      function nfield(s, k,  r) { r = ""; if (match(s, "\"" k "\":[0-9-]+"))    { r = substr(s, RSTART, RLENGTH); sub("\"" k "\":", "", r) } return r }
+      {
+        ts = field($0, "ts"); if (ts < cutoff) next
+        g = field($0, "gate"); if (g == "") next
+        n[g]++
+        durs[g, n[g]] = nfield($0, "duration_ms") + 0
+        if (field($0, "verdict") == "fail") { fails[g]++; lastfail[g] = ts }
+      }
+      END {
+        if (!length(n)) { print "no rows in the last window — widen with --window <days>"; exit }
+        printf "%-24s %5s %8s %8s %6s  %-20s %s\n", "gate", "n", "p50", "p95", "fail%", "last-fail", "hint"
+        for (g in n) {
+          m = n[g]
+          # insertion sort — m is small (hundreds)
+          for (i = 2; i <= m; i++) { v = durs[g, i]; j = i - 1
+            while (j >= 1 && durs[g, j] > v) { durs[g, j + 1] = durs[g, j]; j-- } durs[g, j + 1] = v }
+          p50 = durs[g, int((m + 1) * 0.50) < 1 ? 1 : int((m + 1) * 0.50)]
+          p95i = int((m + 1) * 0.95); if (p95i < 1) p95i = 1; if (p95i > m) p95i = m
+          p95 = durs[g, p95i]
+          fr = (fails[g] + 0) * 100.0 / m
+          hint = ""
+          if (p95 > 5000) hint = "tier-3 candidate (p95 > 5s commit budget)"
+          else if ((fails[g] + 0) == 0 && m >= 20) hint = "never fired in window — earning its place?"
+          printf "%-24s %5d %7.2fs %7.2fs %5.1f%%  %-20s %s\n", g, m, p50 / 1000.0, p95 / 1000.0, fr, (g in lastfail ? lastfail[g] : "never"), hint
+        }
+      }' "$f" | { IFS= read -r hdr; printf '%s\n' "$hdr"; LC_ALL=C sort; }
+    ;;
+  last)
+    last_id="$(awk 'match($0, /"run_id":"[^"]*"/) { r = substr($0, RSTART + 10, RLENGTH - 11) } END { print r }' "$f")"
+    [ -n "$last_id" ] || { echo "guardrails: trace file has no run ids." >&2; exit 0; }
+    out="$(awk -v id="$last_id" '
+      function field(s, k,   r) { r = ""; if (match(s, "\"" k "\":\"[^\"]*\"")) { r = substr(s, RSTART, RLENGTH); sub("\"" k "\":\"", "", r); sub(/"$/, "", r) } return r }
+      function nfield(s, k,  r) { r = ""; if (match(s, "\"" k "\":[0-9-]+"))    { r = substr(s, RSTART, RLENGTH); sub("\"" k "\":", "", r) } return r }
+      index($0, "\"run_id\":\"" id "\"") {
+        v = field($0, "verdict"); up = toupper(v)
+        printf "  %-6s %-24s %6.2fs\n", up, field($0, "gate"), nfield($0, "duration_ms") / 1000.0
+        if (v == "fail") bad = 1
+      }
+      END { exit bad ? 1 : 0 }' "$f")"
+    bad=$?
+    first_ts="$(awk -v id="$last_id" 'index($0, "\"run_id\":\"" id "\"") { if (match($0, /"ts":"[^"]*"/)) { print substr($0, RSTART + 6, RLENGTH - 7); exit } }' "$f")"
+    trig="$(awk -v id="$last_id" 'index($0, "\"run_id\":\"" id "\"") { if (match($0, /"trigger":"[^"]*"/)) { print substr($0, RSTART + 11, RLENGTH - 12); exit } }' "$f")"
+    echo "guardrails last — run $last_id · $first_ts · $trig"
+    printf '%s\n' "$out"
+    if [ "$bad" -ne 0 ]; then
+      printf '%s\n' "$out" | grep '  FAIL' >&2
+      echo "guardrails last: FAILED gate(s) in the most recent run — see above." >&2
+      exit 1
+    fi
+    ;;
+  *)
+    echo "guardrails-trace-report: unknown mode '$mode' (perf|last)" >&2; exit 2 ;;
+esac

--- a/assets/guardrails/tools/trace.sh
+++ b/assets/guardrails/tools/trace.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# guardrails-trace — wrap one gate/hook command, append a duration+verdict JSONL row (issue #14).
+#
+#   entry: guardrails-trace no-fake-impl -- guardrails-no-fake-impl
+#
+# Two motivations (both from real incidents):
+#   * perf tuning needs per-gate timing history (deciding what belongs in a soft tier, #13);
+#   * verdicts must survive stdout — a `git commit | tail` pipeline once masked a FAILED gate;
+#     the JSONL is the durable out-of-band record `guardrails last` replays.
+#
+# The wrapper is transparent: stdout/stderr inherit, the wrapped command's exit code is
+# propagated untouched. One row per run, single O_APPEND write ≪ PIPE_BUF → atomic without
+# locks, safe across concurrent worktree commits. Rows go per-repo to
+#   ${XDG_CACHE_HOME:-~/.cache}/guardrails/runs/<repo>-<pathhash>.jsonl   (10MB, 1 rotation)
+#
+# Row (v1, fixed key order): {"v":1,"ts","run_id","repo","gate","trigger","verdict","exit_code",
+# "duration_ms","changed_files"} — verdict pass|fail AND the raw exit code (clippy 101 vs 1 is
+# signal). GR_RUN_ID/GR_TRIGGER come from the injected hook bootstrap; absent (manual run) a
+# per-invocation id + trigger=manual are stamped so rows never collide.
+set -uo pipefail
+
+gate="${1:?usage: guardrails-trace <name> -- <cmd...>}"
+shift
+[ "${1:-}" = "--" ] && shift
+[ "$#" -gt 0 ] || { echo "guardrails-trace: nothing to run (usage: guardrails-trace <name> -- <cmd...>)" >&2; exit 2; }
+
+# Millisecond clock. GNU date has %N (wall-clock ms — the dur<0 clamp below absorbs NTP
+# steps); BSD (macOS) prints a literal 'N' → python3 monotonic_ns fallback (in the toolbelt).
+# Probe ONCE at top level — inside $(now_ms) the assignment would die with the subshell.
+GR_DATE_HAS_NS="$([ "$(date +%N)" != "N" ] && echo 1 || echo 0)"
+now_ms() {
+  if [ "$GR_DATE_HAS_NS" = 1 ]; then
+    date +%s%3N
+  else
+    python3 -c 'import time; print(time.monotonic_ns() // 1000000)'
+  fi
+}
+
+# changed_files ≈ trailing args that are existing files (prek appends the staged list after
+# the command; a gate invoked bare scans the tree — count 0 means "whole tree / unknown").
+# Skip $1 — the wrapped executable itself may be a file path and is not a changed file.
+changed=0; skip_cmd=1
+for a in "$@"; do
+  if [ "$skip_cmd" = 1 ]; then skip_cmd=0; continue; fi
+  [ -f "$a" ] && changed=$((changed + 1))
+done
+
+start="$(now_ms)"
+"$@"
+ec=$?
+dur=$(( $(now_ms) - start ))
+[ "$dur" -lt 0 ] && dur=0
+
+repo_top="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+repo="$(basename "$repo_top")"
+slug="$repo-$(printf '%s' "$repo_top" | git hash-object --stdin 2>/dev/null | cut -c1-6)"
+dir="${XDG_CACHE_HOME:-$HOME/.cache}/guardrails/runs"
+f="$dir/$slug.jsonl"
+mkdir -p "$dir" 2>/dev/null || { exit "$ec"; }  # tracing must never break the gate
+
+# Rotate at ~10MB, keep one generation (p95 stabilizes at ~200 samples/gate; this is years).
+size=0; [ -f "$f" ] && size="$(wc -c < "$f")"
+# (Concurrent hooks racing the threshold: the first mv wins, the loser's mv ENOENTs
+# silently — worst case one rotation generation, never the live file.)
+[ "${size:-0}" -gt 10485760 ] && mv -f "$f" "$f.1" 2>/dev/null
+
+# JSON-escape interpolated strings (a repo dir named weird"repo must not corrupt the row).
+esc() { printf '%s' "$1" | sed 's/[\\"]/\\&/g'; }
+verdict=pass; [ "$ec" -ne 0 ] && verdict=fail
+ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+run_id="${GR_RUN_ID:-$(date +%s)-$$}"
+trigger="${GR_TRIGGER:-manual}"
+printf '{"v":1,"ts":"%s","run_id":"%s","repo":"%s","gate":"%s","trigger":"%s","verdict":"%s","exit_code":%d,"duration_ms":%d,"changed_files":%d}\n' \
+  "$ts" "$(esc "$run_id")" "$(esc "$repo")" "$(esc "$gate")" "$(esc "$trigger")" "$verdict" "$ec" "$dur" "$changed" >> "$f" 2>/dev/null || true
+
+exit "$ec"

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -9,6 +9,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`guardrails` capability module — the org's semantic gates, now devkit-owned**
+  ([#1488](https://github.com/vig-os/devkit/issues/1488),
+  [#1492](https://github.com/vig-os/devkit/issues/1492))
+  - devkit shipped 26 hooks to consumers and every one was syntactic. These 15
+    gates are the semantic half: no fake implementations, no hardcoded magic
+    values, no commented-out code, generated docs matching their source
+    command, no debug prints, trunk protection, ADR/feature-matrix coherence
+  - Vendored from `gerchowl/guardrails` under Apache-2.0 (the same licence and
+    holder as devkit, so the copies need no separate attribution). devkit is
+    now the source of truth; the upstream personal repo is being retired, so
+    the org's semantic enforcement no longer depends on one person's account
+  - **The module contributes `packages` only — no contract change.** Hook
+    ENTRIES are a scaffold concern, not a shell one: `.pre-commit-config.yaml`
+    is read by the runner from a bare git tree, by CI containers that never
+    enter `nix develop`, and by humans reading a diff. #1492 records why this
+    resolves the opposite way to `checks` (#1427) despite looking similar
+  - New `checks.guardrails-canary`: every gate is fed a known-bad fixture and
+    must reject it, and a known-good one and must stay quiet. This is the
+    assurance half — "protected" means *the gate rejected a known-bad input*,
+    not *the entry is in the config*, because four of this org's eight
+    recorded gate failures were "listed, did not run"
+  - New `checks.guardrails-shellcheck` at error+warning over the vendored
+    shell; the repo-wide hook (which runs at `style`) skips that tree rather
+    than force a rewrite of 3,000 lines of working, fixture-covered script
+
 - **Rust performance tooling: `@perf` tool groups + a deterministic ratchet**
   ([#1400](https://github.com/vig-os/devkit/issues/1400),
   [#1440](https://github.com/vig-os/devkit/issues/1440))

--- a/assets/workspace/.pre-commit-config.yaml
+++ b/assets/workspace/.pre-commit-config.yaml
@@ -84,7 +84,7 @@ repos:
         # .envrc files (root + the scaffolded template stub) are direnv stdlib
         # scripts with no shebang; exclude them from SC2148 at any path.
         args: ["-x"]
-        exclude: (^|/)\.envrc$
+        exclude: (^|/)\.envrc$|^assets/guardrails/
 
   # Markdown linting (pymarkdown from the flake toolchain; excludes auto-generated
   # docs). Packaged in nix/pymarkdown.nix and promoted to a language: system hook

--- a/assets/workspace/.typos.toml
+++ b/assets/workspace/.typos.toml
@@ -13,3 +13,11 @@ unexcepted = "unexcepted"
 Nd = "Nd"
 # podman rootless-networking helper package name (#1106), not a misspelling
 passt = "passt"
+# Vendored guardrails gates (#1488). All three are false positives in shell:
+# `tatus` is the tail of the regex class `[Ss]tatus:`, `fnd` is a shell
+# function name in the test harness, and `mis-attributes` is a real word.
+# Added as words rather than excluding assets/guardrails/ wholesale, so the
+# prose in those files stays spell-checked.
+tatus = "tatus"
+fnd = "fnd"
+mis = "mis"

--- a/flake.nix
+++ b/flake.nix
@@ -838,6 +838,11 @@
           config.allowUnfree = true;
         };
 
+        # The vendored semantic gates (#1488). Built once per system and used
+        # both by the `guardrails` capability module (via callPackage) and by
+        # the canary check below.
+        guardrailsPkg = pkgs.callPackage ./nix/guardrails.nix { };
+
         # treefmt-nix: one `nix fmt` entrypoint + a `checks.formatting` gate over
         # the whole repo. The enabled programs mirror the pre-commit formatters —
         # nixfmt (same package as devTools/the hook), ruff-format, and
@@ -1198,6 +1203,54 @@
             statix check ${./nix}
             touch "$out"
           '';
+
+          # error+warning shellcheck over the vendored gates. They are
+          # excluded from the repo-wide hook (which runs at `style`) because
+          # rewriting working, fixture-covered shell for SC2181 is a bad
+          # trade — but "excluded from the strict hook" must not become
+          # "unchecked", so the real bar is enforced here. Refs #1488.
+          guardrails-shellcheck =
+            pkgs.runCommand "guardrails-shellcheck" { nativeBuildInputs = [ pkgs.shellcheck ]; }
+              ''
+                shellcheck -S warning -x ${./assets/guardrails}/gates/*.sh \
+                                        ${./assets/guardrails}/tools/*.sh
+                touch "$out"
+              '';
+
+          # Every guardrails gate is fed a KNOWN-BAD fixture and must reject
+          # it, and a known-good one and must stay quiet (#1488, #1492).
+          #
+          # This is the assurance half of the guardrails module, and it is
+          # deliberately not a check that the gates are *configured*. This
+          # org's record is eight instances of something configured, believed
+          # active and never executed — four of them "listed in the config,
+          # did not run". A check that reads YAML would have caught none of
+          # them. "Protected" has to mean the gate rejected a known-bad input,
+          # because that is the only claim config drift cannot counterfeit.
+          #
+          # It runs upstream's own fixtures against the PACKAGED scripts —
+          # the exact files a consumer gets, not a copy — so a packaging
+          # mistake (a missing runtime dependency in the wrapper, say) fails
+          # here rather than in someone's repo.
+          guardrails-canary =
+            pkgs.runCommand "guardrails-canary"
+              {
+                nativeBuildInputs = [
+                  pkgs.git
+                  guardrailsPkg
+                ]
+                ++ guardrailsPkg.runtimeInputs;
+              }
+              ''
+                export HOME="$TMPDIR"
+                git config --global user.email ci@vig-os.invalid
+                git config --global user.name CI
+                git config --global init.defaultBranch main
+                set -e
+                bash ${guardrailsPkg}/share/guardrails/gates/test-gates.sh
+                bash ${guardrailsPkg}/share/guardrails/gates/test-adr-matrix.sh
+                touch "$out"
+              '';
 
           # The sandbox-pure subset of the pre-commit hooks, run by the prek
           # runner via git-hooks.nix (see preCommitCheck above). Refs #778.

--- a/nix/guardrails.nix
+++ b/nix/guardrails.nix
@@ -1,0 +1,111 @@
+# Packaging for the vendored guardrails gates (#1488).
+#
+# Each script in assets/guardrails/gates/ becomes `guardrails-<name>` on PATH,
+# and the three tools become `guardrails`, `guardrails-trace` and
+# `guardrails-trace-report`. The names are preserved EXACTLY as upstream
+# published them, and that is a deliberate compatibility decision rather than
+# inertia: `guardrails-ok` is an annotation that lives in consumer SOURCE
+# (21 sites in the first consumer alone), `GUARDRAILS_*` env vars are set in
+# consumer flakes, and the hook ids appear in committed `.pre-commit-config.yaml`
+# files. Renaming any of that to match devkit would be a breaking change to
+# every consumer's source code for no functional gain — devkit already ships
+# `ruff` and `typos` under their upstream ids without renaming them either.
+#
+# The scripts are wrapped rather than copied so their runtime dependencies
+# resolve from the store instead of from whatever the consumer happens to have
+# on PATH. That is not hypothetical tidiness: the first consumer's entire hook
+# stack once resolved from a developer's global profile, worked on that
+# machine, and would have failed in CI and for every new contributor.
+{
+  lib,
+  stdenvNoCC,
+  makeWrapper,
+  bash,
+  coreutils,
+  findutils,
+  gnugrep,
+  gnused,
+  gawk,
+  diffutils,
+  git,
+  jq,
+  ripgrep,
+  python3,
+}:
+
+let
+  # Everything the gates shell out to. Kept explicit — a gate that silently
+  # falls back to a missing tool is the failure this whole set exists to catch.
+  runtimeInputs = [
+    bash
+    coreutils
+    findutils
+    gnugrep
+    gnused
+    gawk
+    diffutils
+    git
+    jq
+    ripgrep
+    python3
+  ];
+in
+stdenvNoCC.mkDerivation {
+  pname = "guardrails";
+  version = "0-unstable-2026-08-13";
+
+  src = ../assets/guardrails;
+
+  nativeBuildInputs = [ makeWrapper ];
+
+  dontConfigure = true;
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p "$out/bin" "$out/share/guardrails"
+
+    # Gates: gates/<name>.sh -> guardrails-<name>.
+    #
+    # test-*.sh live in this directory because they resolve their subjects via
+    # `dirname "$0"` — upstream's layout, kept so the scripts run unmodified.
+    # They are fixtures, not gates, so they do not become executables; the
+    # canary check runs them from share/ instead.
+    for f in gates/*.sh; do
+      base="$(basename "$f" .sh)"
+      case "$base" in test-*) continue ;; esac
+      name="guardrails-$base"
+      install -Dm755 "$f" "$out/bin/$name"
+      wrapProgram "$out/bin/$name" --prefix PATH : ${lib.makeBinPath runtimeInputs}
+    done
+
+    # Tools: tools/trace.sh -> guardrails-trace, tools/guardrails.sh -> guardrails
+    for f in tools/*.sh; do
+      base="$(basename "$f" .sh)"
+      if [ "$base" = "guardrails" ]; then name="guardrails"; else name="guardrails-$base"; fi
+      install -Dm755 "$f" "$out/bin/$name"
+      wrapProgram "$out/bin/$name" --prefix PATH : ${lib.makeBinPath runtimeInputs}
+    done
+
+    # The whole tree ships to share/ so the canary check runs the fixtures
+    # against the SAME scripts a consumer gets, not a copy — and because the
+    # fixtures resolve siblings relatively, they need the layout intact.
+    cp -r gates tools "$out/share/guardrails/"
+    [ -d templates ] && cp -r templates "$out/share/guardrails/" || true
+
+    runHook postInstall
+  '';
+
+  # Exposed so the canary check can put the SAME dependency set on PATH.
+  # The fixtures resolve their subjects as siblings via `dirname "$0"`, so
+  # they run the unwrapped share/ copies — which means the wrapper's PATH is
+  # not in effect and the check has to supply it. One list, two consumers:
+  # a dependency added here cannot be forgotten there.
+  passthru = { inherit runtimeInputs; };
+
+  meta = {
+    description = "Semantic code gates (vendored from gerchowl/guardrails, now devkit-owned)";
+    license = lib.licenses.asl20;
+    platforms = lib.platforms.unix;
+  };
+}

--- a/nix/hooks.nix
+++ b/nix/hooks.nix
@@ -143,7 +143,21 @@ let
   };
 
   # Shared per-hook filters used by more than one artifact of the same hook.
-  shellcheckExclude = "(^|/)\\.envrc$";
+  # .envrc files are direnv stdlib scripts with no shebang (SC2148).
+  #
+  # assets/guardrails/ is VENDORED shell (#1488). It is clean at
+  # `-S warning` — the severity where real bugs live — and is covered by
+  # `checks.guardrails-canary`, which runs every gate against a known-bad
+  # fixture and asserts it fires. What it is NOT clean at is the default
+  # `style` severity: 18 findings, ten of them SC2181 (`$?` rather than
+  # `if cmd;`), several of them deliberate in a test harness.
+  #
+  # Rewriting 3,000 lines of working, fixture-covered shell for style points
+  # is the trade this repo already declined once when it decided not to port
+  # these gates to Python: the risk is asymmetric, because a subtly broken
+  # gate REPORTS SUCCESS. The bar kept here is error+warning, enforced by
+  # `checks.guardrails-shellcheck`, not an exemption from review.
+  shellcheckExclude = "(^|/)\\.envrc$|^assets/guardrails/";
   # The three JSONC scaffold files carry a `//` provenance banner (#1053) that
   # VS Code and the devcontainer CLI accept but check-json's strict parser
   # rejects. Exclude them from every check-json surface (matched at repo root or

--- a/nix/modules/default.nix
+++ b/nix/modules/default.nix
@@ -13,10 +13,13 @@
 #
 # Candidate modules — geant4, fortran/f2py, root — are deliberately NOT
 # defined until a concrete consumer asks (YAGNI; see the ADR). `rust` was such
-# a candidate and shipped on gerchowl/filesender's ask (#1400).
+# a candidate and shipped on gerchowl/filesender's ask (#1400); `guardrails`
+# (#1488) is not from that list — it absorbs the org's semantic gates from a
+# personal repo so devkit stops depending on one.
 {
   native = import ./native.nix;
   node = import ./node.nix;
   docs = import ./docs.nix;
   rust = import ./rust.nix;
+  guardrails = import ./guardrails.nix;
 }

--- a/nix/modules/guardrails.nix
+++ b/nix/modules/guardrails.nix
@@ -1,0 +1,100 @@
+# `guardrails` capability module (#1488): the semantic-gate capability.
+#
+# devkit ships 26 hooks to consumers and every one of them is syntactic —
+# formatting, whitespace, YAML/TOML validity, typos, commit-message shape.
+# Useful, and not one of them can tell you the code does what it says. These
+# 15 gates are the semantic half: no fake implementations, no hardcoded magic
+# values, no commented-out code, generated docs still matching their source
+# command, no debug prints left behind, trunk protection.
+#
+# ---------------------------------------------------------------------------
+# WHY THIS CONTRIBUTES `packages` AND NOTHING ELSE
+# ---------------------------------------------------------------------------
+# A gate is only useful once a hook entry invokes it, so the obvious design is
+# for this module to contribute hook entries too — which is what the ADR
+# deferred ("hooks contribution … open design question") and what #1488
+# originally proposed as a v2 contract field.
+#
+# That was wrong, and #1492 settled why. `.pre-commit-config.yaml` is read by
+# the runner from a bare git working tree, by CI containers that never enter
+# `nix develop`, and by humans reading a PR diff. Its whole lifecycle sits on
+# the SCAFFOLD side, not the shell side. The flake CAN generate one, but every
+# consumer today owns a committed file, and the generated path refuses to
+# overwrite it — so flake-contributed entries would be silently discarded, or
+# discarded with a warning on every shell entry. Configured, believed active,
+# enforcing nothing: the exact failure these gates exist to catch, caused by
+# the module shipping them.
+#
+# It is also closed at the tool level, independently: neither prek nor
+# pre-commit has `include`/`extends` (pre-commit refused it explicitly,
+# pre-commit#1203), one `repo:` stanza cannot pull a hook set, and prek's
+# workspace mode scopes each sub-config to its own directory tree.
+#
+# So hook ENTRIES are rendered by the installer from `DEVKIT_MODULES`, and
+# this module does the one thing the v1 contract already allows: it puts the
+# gate executables on PATH. No contract change, no ADR amendment, no fourth
+# field.
+#
+# And because "the entry is in the file" has never once implied "the gate
+# ran" in this org's recorded history, execution is proven separately by the
+# canary check (`checks.guardrails-canary`), which feeds every gate a
+# known-bad fixture and asserts it rejects it.
+pkgs:
+{
+  gates ? null,
+  tools ? true,
+  ...
+}@options:
+let
+  inherit (pkgs) lib;
+
+  knownOptions = [
+    "gates"
+    "tools"
+  ];
+  unknownOptions = builtins.filter (k: !builtins.elem k knownOptions) (builtins.attrNames options);
+
+  guardrails = pkgs.callPackage ../guardrails.nix { };
+
+  # The full set, derived from what is actually vendored rather than a
+  # hand-kept list — a list that can disagree with the directory is one more
+  # thing to drift.
+  available = lib.pipe (builtins.readDir ../../assets/guardrails/gates) [
+    (lib.filterAttrs (n: t: t == "regular" && lib.hasSuffix ".sh" n))
+    builtins.attrNames
+    (map (n: lib.removeSuffix ".sh" n))
+    lib.naturalSort
+  ];
+
+  requested = if gates == null then available else gates;
+  unknownGates = builtins.filter (g: !builtins.elem g available) requested;
+in
+if unknownOptions != [ ] then
+  throw (
+    "guardrails module: unknown option(s): "
+    + lib.concatStringsSep ", " unknownOptions
+    + "; recognized options are "
+    + lib.concatStringsSep ", " knownOptions
+  )
+else if unknownGates != [ ] then
+  throw (
+    "guardrails module: unknown gate(s): "
+    + lib.concatStringsSep ", " unknownGates
+    + "; available: "
+    + lib.concatStringsSep ", " available
+  )
+else
+  {
+    # One derivation carries every gate, so `gates` selects which are
+    # SUPPORTED rather than which are built — there is nothing to save by
+    # splitting 3,000 lines of shell into fifteen derivations, and a consumer
+    # narrowing the list still wants a coherent `guardrails` CLI.
+    packages = [ guardrails ];
+
+    env = lib.optionalAttrs tools {
+      # Where `guardrails-trace` appends its per-hook JSONL. Set here so the
+      # trace lands in one place per repo rather than wherever each hook
+      # happened to run from.
+      GUARDRAILS_TRACE_ENABLED = "1";
+    };
+  }

--- a/tests/test_flake_modules.py
+++ b/tests/test_flake_modules.py
@@ -951,3 +951,80 @@ def test_mk_rust_project_accepts_crane_args_and_the_deprecated_alias(
         assert result.returncode == 0, (
             f"`{arg}` must be accepted by mkRustProject; got: {result.stderr[-500:]}"
         )
+
+
+# ---------------------------------------------------------------------------
+# guardrails module (#1488) — the semantic-gate capability. Unlike `rust`, it
+# contributes `packages` ONLY: hook ENTRIES are a scaffold concern (#1492), so
+# there is no contract change to test here. What must hold is that the gates
+# are on PATH, that the option validation is loud, and — the part that
+# actually matters — that every gate still rejects a known-bad fixture, which
+# `checks.<system>.guardrails-canary` asserts.
+# ---------------------------------------------------------------------------
+
+
+def _guardrails_expr(entry: str, attr: str = ".drvPath") -> str:
+    return f"""
+    let
+      flake = builtins.getFlake "path:{REPO_ROOT}";
+      system = builtins.currentSystem;
+      pkgs = import flake.inputs.nixpkgs {{
+        inherit system;
+        overlays = [ flake.overlays.default ];
+        config.allowUnfree = true;
+      }};
+    in (flake.lib.mkProjectShell {{ inherit pkgs; modules = [ {entry} ]; }}){attr}
+    """
+
+
+def test_guardrails_is_in_capability_module_registry() -> None:
+    """The registry resolves ``guardrails`` (#1488)."""
+    result = _nix_eval_expr(_guardrails_expr('"guardrails"'))
+    assert result.returncode == 0, (
+        f"the guardrails module must resolve from the registry; got: {result.stderr[-500:]}"
+    )
+
+
+def test_guardrails_puts_the_gates_on_path(current_system: str) -> None:
+    """The shell exposes the gate executables (#1488).
+
+    The bare-name form must work: unlike ``rust``, this module has no
+    mandatory option, because contributing packages is the whole of what it
+    does and there is no second half a consumer could forget to wire.
+    """
+    proc = _develop_module(
+        current_system,
+        "guardrails",
+        "for b in guardrails guardrails-trace guardrails-no-fake-impl "
+        "guardrails-no-hardcoded guardrails-derived-docs; do command -v $b; done",
+    )
+    assert proc.returncode == 0, (
+        "guardrails devshell is missing gate executables: "
+        f"rc={proc.returncode} stdout={proc.stdout.strip()!r} stderr={proc.stderr.strip()[:300]}"
+    )
+
+
+def test_guardrails_rejects_an_unknown_gate() -> None:
+    """A mistyped gate name fails eval and lists the real ones (#1488).
+
+    The available set is derived from the vendored directory rather than a
+    hand-kept list, so this also pins that the two cannot disagree.
+    """
+    result = _nix_eval_expr(
+        _guardrails_expr('{ name = "guardrails"; gates = [ "no-such-gate" ]; }')
+    )
+    assert result.returncode != 0, "an unknown gate name must fail eval, not pass"
+    assert "no-such-gate" in result.stderr and "no-fake-impl" in result.stderr, (
+        f"error must name the bad gate and list the available ones; got: {result.stderr[-600:]}"
+    )
+
+
+def test_guardrails_rejects_an_unknown_option() -> None:
+    """Unknown options throw rather than silently doing nothing (#1488)."""
+    result = _nix_eval_expr(
+        _guardrails_expr('{ name = "guardrails"; frobnicate = 1; }')
+    )
+    assert result.returncode != 0, "an unknown option must fail eval"
+    assert "frobnicate" in result.stderr and "guardrails module" in result.stderr, (
+        f"error must name the option and the module; got: {result.stderr[-500:]}"
+    )


### PR DESCRIPTION
Implements #1488 with the layer decision from #1492. Closes the guardrails half of #1400.

## What lands

devkit shipped **26 hooks to consumers and every one was syntactic** — formatting, whitespace, YAML validity, typos, commit-message shape. Useful, and not one of them can tell you the code does what it says. Every *semantic* gate the org relies on lived in `gerchowl/guardrails`, a personal repo that both devkit consumers and filesender depended on.

Those 15 gates are now devkit's:

`no-fake-impl` · `no-hardcoded` · `no-commented-code` · `no-debug-leftovers` · `no-raw-trace-fields` · `derived-docs` · `duplication` · `ci-shim` · `protect-trunk` · `protect-trunk-push` · `adr-matrix` · `numerical-obligation` · `no-conflict-markers` · `perf-budget` · `perf-record`

plus the `guardrails` CLI, the `guardrails-trace` per-hook JSONL wrapper, and the freshness/stale/ledger tools — 25 executables, matching upstream exactly.

## Packages only — no contract change

#1488 originally proposed a **v2 `hooks` field**. That was wrong, and #1492 settled why with four independent reviews.

`.pre-commit-config.yaml` is read by the runner from a bare git working tree, by **CI containers that never enter `nix develop`**, and by humans reading a PR diff. Its lifecycle is the **scaffold's**, not the shell's. Every consumer today owns a committed config, and the generated path refuses to overwrite it — so flake-contributed entries would be silently discarded, or discarded with a warning on every shell entry.

It is closed at the tool level too, independently confirmed: neither prek nor pre-commit has `include`/`extends` ([pre-commit#1203](https://github.com/pre-commit/pre-commit/issues/1203): *"multiple configs / inclusion is not going to be implemented, sorry"*), one `repo:` stanza cannot pull a hook set, and prek's workspace mode scopes each sub-config to its own directory tree.

So the module does the one thing v1 already allows: **puts the gates on PATH.** Hook entries stay a scaffold concern.

## The canary is the point

`checks.guardrails-canary` feeds every gate a known-bad fixture and asserts it fires, and a known-good one and asserts it stays quiet — running upstream's own harness against the **packaged** scripts, not a copy.

Four of this org's eight recorded gate failures were *"listed in the config, did not run"*. A check that reads YAML would have caught **none** of them. "Protected" has to mean *the gate rejected a known-bad input*, because that is the only claim config drift cannot counterfeit.

It earned itself during this PR: it caught that the `share/` copies the fixtures execute are **unwrapped**, so their runtime dependencies were absent in the sandbox. One `passthru` list now feeds both the wrapper and the check, so a dependency added to one cannot be forgotten in the other.

## Verified

- `nix flake check` green, including the new `guardrails-canary` and `guardrails-shellcheck`
- 67 Python tests, 4 new for this module (registry, gates on PATH, unknown gate, unknown option)
- Hook drift gate green — both committed YAMLs re-synced to `nix/hooks.nix`
- **Consumer proof**: `gerchowl/filesender` migrated off the flake input onto `modules = [ "guardrails" ]`. **Six lock nodes removed.** All 21 `guardrails-ok` source annotations, the `GUARDRAILS_*` env vars and every hook id unchanged. Its `just precommit` (both stages + `nix flake check`) and 77 tests green

## Decisions worth reviewing

1. **Names kept exactly.** `guardrails-ok` is an annotation living in consumer *source* (21 sites in one repo). Renaming to match devkit would break every consumer's source for no gain — devkit already ships `ruff` and `typos` under upstream ids.
2. **Vendored, not an input.** 3,000 lines of dependency-free shell: no lock node, nothing fetched at eval, and the bus-factor problem removed rather than formalised. The upstream repo gets archived (still needs `crates/tunables` → Rust pack and a decision on `tools/`).
3. **Shell kept, not ported.** Re-decided rather than inherited: shellcheck-clean at `-S warning`, every gate has a fixture, and the absent `set -e` is correct (these gates `grep`; `-e` would abort on the quiet path). New gates go in Python; port only the stateful ones.
4. **Vendored tree excluded from the `style`-severity shellcheck hook**, with `checks.guardrails-shellcheck` enforcing error+warning instead. Rewriting 3,000 lines of working, fixture-covered shell for SC2181 is the trade this repo already declined.

## Known wart

The shellcheck exclude is shared between the runner config and the scaffold copy, because `portableFor`'s `includeAll` selects *which* hooks render, not per-artifact fields. Consumers get a dead `^assets/guardrails/` regex — no behaviour change. Fixing it properly means a `runnerYaml` override plus a drift-gate update; worth doing, not worth bundling here.

## Also in this PR

One real shellcheck **error** fixed in the vendored tree — a malformed `# shellcheck disable=SC2254 -- reason` directive that parsed as garbage and therefore disabled nothing. Three `typos` false positives whitelisted rather than edited into the scripts (`[Ss]tatus:`, an `fnd()` helper, and the real word "mis-attributes"). Upstream's `templates/` deliberately **not** vendored — devkit *is* the scaffolding system.

Blocked on nothing: `gerchowl/guardrails` is now Apache-2.0 (gerchowl/guardrails#50), same holder as devkit, so the vendored copies need no separate attribution.
