### PR TITLE
fix(ci): push floating tags as the Release App, and cover the move with real tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     archive path the mirror carries, and skips with a `::warning::` otherwise —
     a stale mirror self-heals at the next nightly sync; deleted snapshots do not
 
+- **Floating tags: the promote-time push ran under the wrong identity**
+  ([#1508](https://github.com/vig-os/devkit/issues/1508))
+  - `promote-release.yml`'s `floating-tags` job embedded the Release App token
+    in the push URL, but `actions/checkout` persists its own credentials as
+    `http.<host>.extraheader`, which outranks URL userinfo. The push therefore
+    authenticated as the Actions identity — which the job denies
+    (`contents: read`) and the Tag ruleset does not bypass — so the token the
+    step went out of its way to plumb through was never used
+  - The App token is now generated **before** checkout and passed to it, so the
+    shallow tag fetch and the force-push both carry the App identity;
+    `contents: read` stays, deliberately
+  - This affected the `git push` form introduced in 1.7.0
+    ([#1377](https://github.com/vig-os/devkit/issues/1377)). No consumer had
+    adopted it — the only two repos that set `DEVKIT_FLOATING_TAGS` are still on
+    1.6.0, where the move went through `gh api` — so **no released floating tag
+    was ever wrong**; the path had simply never executed
+  - The move script is now covered by tests that run its real bash against a
+    throwaway `file://` remote: create (the first release of a level, the
+    `#1157` case), move, idempotent skip, annotated-tag peel, and a refused push
+    still failing loud with its remediation annotation
+
 ### Security
 
 ## [1.9.0](https://github.com/vig-os/devkit/releases/tag/1.9.0) - 2026-08-13

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -70,6 +70,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     archive path the mirror carries, and skips with a `::warning::` otherwise —
     a stale mirror self-heals at the next nightly sync; deleted snapshots do not
 
+- **Floating tags: the promote-time push ran under the wrong identity**
+  ([#1508](https://github.com/vig-os/devkit/issues/1508))
+  - `promote-release.yml`'s `floating-tags` job embedded the Release App token
+    in the push URL, but `actions/checkout` persists its own credentials as
+    `http.<host>.extraheader`, which outranks URL userinfo. The push therefore
+    authenticated as the Actions identity — which the job denies
+    (`contents: read`) and the Tag ruleset does not bypass — so the token the
+    step went out of its way to plumb through was never used
+  - The App token is now generated **before** checkout and passed to it, so the
+    shallow tag fetch and the force-push both carry the App identity;
+    `contents: read` stays, deliberately
+  - This affected the `git push` form introduced in 1.7.0
+    ([#1377](https://github.com/vig-os/devkit/issues/1377)). No consumer had
+    adopted it — the only two repos that set `DEVKIT_FLOATING_TAGS` are still on
+    1.6.0, where the move went through `gh api` — so **no released floating tag
+    was ever wrong**; the path had simply never executed
+  - The move script is now covered by tests that run its real bash against a
+    throwaway `file://` remote: create (the first release of a level, the
+    `#1157` case), move, idempotent skip, annotated-tag peel, and a refused push
+    still failing loud with its remediation annotation
+
 ### Security
 
 ## [1.9.0](https://github.com/vig-os/devkit/releases/tag/1.9.0) - 2026-08-13

--- a/assets/workspace/.github/workflows/promote-release.yml
+++ b/assets/workspace/.github/workflows/promote-release.yml
@@ -614,21 +614,32 @@ jobs:
       GH_REPO: ${{ github.repository }}
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
-
-      - name: Set up devkit toolchain
-        uses: ./.github/actions/setup-devkit-toolchain
-        with:
-          mode: ${{ needs.resolve-toolchain.outputs.mode }}
-          devkit-version: ${{ needs.resolve-toolchain.outputs.image-tag }}
-
+      # Token FIRST, then check out with it. Tag pushes must authenticate as the
+      # Release App: the default github.token is not a bypass actor for the Tag
+      # ruleset, and this job deliberately keeps `contents: read` so it cannot
+      # push under the Actions identity at all. The token has to arrive through
+      # CHECKOUT — git authenticates via the credentials checkout persists as
+      # http.<host>.extraheader, and that header outranks any token embedded in
+      # a remote URL, so the previous "App token in the push URL" form was
+      # silently ignored (#1508). Do not "fix" a future 403 here by granting
+      # contents: write; that would move tag pushes to the Actions identity.
       - name: Generate release app token
         id: release_app_token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3
         with:
           client-id: ${{ secrets.RELEASE_APP_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          token: ${{ steps.release_app_token.outputs.token }}
+
+      - name: Set up devkit toolchain
+        uses: ./.github/actions/setup-devkit-toolchain
+        with:
+          mode: ${{ needs.resolve-toolchain.outputs.mode }}
+          devkit-version: ${{ needs.resolve-toolchain.outputs.image-tag }}
 
       - name: Move floating major/minor tags
         env:
@@ -663,16 +674,13 @@ jobs:
           REST="${VERSION#*.}"
           MINOR="${REST%%.*}"
 
-          # Tag pushes must authenticate as the Release App EXPLICITLY: the
-          # checkout step's persisted credentials are the default github.token,
-          # which is not a bypass actor for the Tag ruleset.
-          REMOTE_URL="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
-
           # `git push <sha>:<ref>` requires the commit object locally, and the
           # checkout above is a shallow clone of the workflow head — fetch the
-          # release tag so its peeled commit is available to push.
+          # release tag so its peeled commit is available to push. `origin`
+          # carries the Release App credentials the checkout persisted (#1508),
+          # which an unauthenticated fetch would lack on a private repo.
           retry --retries 3 --backoff 5 --max-backoff 30 -- \
-            git fetch --no-tags --depth 1 "$REMOTE_URL" "refs/tags/${RELEASE_TAG}"
+            git fetch --no-tags --depth 1 origin "refs/tags/${RELEASE_TAG}"
 
           # Create-or-update a lightweight floating tag at the release commit,
           # idempotently (skip when it already points there). Force is required
@@ -692,11 +700,12 @@ jobs:
             # (#1157, #1377) — while the very same installation token pushing
             # tags over git is bypassed fine (exactly how release-publish.yml
             # creates the release tags). Push also unifies create and move
-            # into one branch-free path. Publish + merge already succeeded, so
-            # on failure fail loud with actionable remediation rather than
-            # leaving the advertised `@${name}` pin silently missing or stale.
+            # into one branch-free path. `origin` is the App-authenticated
+            # remote (#1508). Publish + merge already succeeded, so on failure
+            # fail loud with actionable remediation rather than leaving the
+            # advertised `@${name}` pin silently missing or stale.
             if ! retry --retries 3 --backoff 5 --max-backoff 30 -- \
-                git push --force "$REMOTE_URL" "${TARGET_SHA}:refs/tags/${name}"; then
+                git push --force origin "${TARGET_SHA}:refs/tags/${name}"; then
               echo "::error title=Floating tag ${name} not moved::Could not force-push floating tag '${name}' to ${TARGET_SHA}. The GitHub Release is published and the release PR merged — only this floating tag is missing or stale, which silently breaks the advertised 'uses: ...@${name}' pin. The push authenticates as the Release App, which the repo Tag ruleset must list as a bypass actor; verify the ruleset's bypass list and the RELEASE_APP_CLIENT_ID / RELEASE_APP_PRIVATE_KEY secrets, or remediate once by hand (temporarily add an admin bypass to the ruleset, force-move refs/tags/${name} -> ${TARGET_SHA}, then revert). See https://github.com/vig-os/devkit/blob/main/docs/MIGRATION.md#first-release-floating-tags."
               return 1
             fi

--- a/tests/test_floating_tag_move.py
+++ b/tests/test_floating_tag_move.py
@@ -1,0 +1,315 @@
+"""Floating-tag move: the promote step's real bash against a real git remote.
+
+Issue #1508: ``promote-release.yml``'s ``floating-tags`` job pushed with the
+Release App token embedded in the push URL, while ``actions/checkout`` persisted
+the default ``GITHUB_TOKEN`` as ``http.<host>.extraheader`` — and the extraheader
+outranks URL userinfo. The push therefore ran under the Actions identity, which
+the job denies (``contents: read``) and the Tag ruleset does not bypass.
+
+It went unnoticed because the code is **unreachable from every current
+consumer**: the push form arrived in devkit 1.7.0 (e76c31da, ``Refs: #1377``),
+and the only two repos that set ``DEVKIT_FLOATING_TAGS`` — ``vig-os/commit-action``
+and ``vig-os/sync-issues-action`` — are both pinned to 1.6.0, where ``move_tag``
+used ``gh api`` and no checkout credentials were involved. devkit's own promote
+workflow has no floating-tags job at all. So nothing has ever executed this
+script, and the shape pins in ``test_promote_release.py`` asserted only that the
+steps existed.
+
+These tests execute the step's ``run:`` body against a throwaway ``file://``
+remote, with ``gh`` stubbed by a shim that answers the REST ref queries from
+that same remote — so create, move, skip and failure are exercised for real. An
+identity bug cannot be caught locally (a local remote has no auth), which is why
+identity stays pinned structurally in ``test_promote_release.py``; what is
+covered here is everything downstream of it.
+
+Refs: #1508, #1377, #1157, #1045
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from typing import TYPE_CHECKING
+
+import pytest
+
+from tests.workflow_scaffold import WORKFLOWS, load_workflow, steps_of_job
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+PROMOTE = WORKFLOWS / "promote-release.yml"
+
+REPO = "vig-os/testrepo"
+VERSION = "1.2.3"
+RELEASE_TAG = "v1.2.3"
+
+# A `gh` that answers the two ref reads the step makes, straight from the local
+# remote — so the stub can never drift from the fixture it describes.
+GH_STUB = r"""#!/usr/bin/env python3
+import json
+import os
+import pathlib
+import subprocess
+import sys
+
+argv = sys.argv[1:]
+origin = os.environ["GH_STUB_ORIGIN"]
+with pathlib.Path(os.environ["GH_STUB_LOG"]).open("a") as fh:
+    fh.write(json.dumps(argv) + "\n")
+
+
+def refs():
+    out = subprocess.run(
+        ["git", "ls-remote", "--tags", origin], capture_output=True, text=True
+    ).stdout
+    table = {}
+    for line in out.splitlines():
+        sha, _, ref = line.partition("\t")
+        table[ref] = sha
+    return table
+
+
+def emit(payload):
+    jq = argv[argv.index("--jq") + 1] if "--jq" in argv else None
+    if jq is None:
+        print(json.dumps(payload))
+        return
+    proc = subprocess.run(
+        ["jq", "-r", jq], input=json.dumps(payload), capture_output=True, text=True
+    )
+    if proc.returncode != 0:
+        sys.exit(f"gh stub: jq failed for {jq!r}: {proc.stderr}")
+    sys.stdout.write(proc.stdout)
+
+
+if argv and argv[0] == "api":
+    path = argv[1]
+    table = refs()
+    if "/git/ref/tags/" in path:
+        name = path.split("/git/ref/tags/", 1)[1]
+        ref = f"refs/tags/{name}"
+        if ref not in table:
+            # gh exits non-zero on 404, which the step treats as "absent".
+            sys.exit(f"gh: Not Found ({ref})")
+        peeled = table.get(ref + "^{}")
+        kind = "tag" if peeled else "commit"
+        emit({"object": {"sha": table[ref], "type": kind}})
+        sys.exit(0)
+    if "/git/tags/" in path:
+        # Peel an annotated tag object to the commit it points at.
+        sha = path.rsplit("/", 1)[1]
+        for ref, value in table.items():
+            if value == sha and (ref + "^{}") in table:
+                emit({"object": {"sha": table[ref + "^{}"]}})
+                sys.exit(0)
+        sys.exit(f"gh: no annotated tag object {sha}")
+
+sys.exit(f"gh stub: unsupported invocation {argv!r}")
+"""
+
+
+def _move_step_script() -> str:
+    steps = steps_of_job(load_workflow(PROMOTE), "floating-tags")
+    move = next(s for s in steps if "floating" in str(s.get("name", "")).lower())
+    return str(move["run"])
+
+
+def _git(*args: str, cwd: Path) -> str:
+    proc = subprocess.run(
+        ["git", *args], cwd=cwd, capture_output=True, text=True, check=True
+    )
+    return proc.stdout.strip()
+
+
+class _Remote:
+    """A throwaway origin plus a workspace, mimicking the promote checkout."""
+
+    def __init__(self, tmp_path: Path, *, annotated: bool = False) -> None:
+        self.origin = tmp_path / "origin.git"
+        self.work = tmp_path / "work"
+        seed = tmp_path / "seed"
+        subprocess.run(
+            ["git", "init", "-q", "-b", "main", "--bare", str(self.origin)], check=True
+        )
+        # `file://` (not a bare path): a local-path clone silently ignores
+        # --depth, and the step's shallow fetch is part of what is under test.
+        self.url = f"file://{self.origin}"
+        subprocess.run(["git", "clone", "-q", self.url, str(seed)], check=True)
+        for key, value in (
+            ("user.email", "test@example.com"),
+            ("user.name", "Test User"),
+            ("commit.gpgsign", "false"),
+            ("tag.gpgsign", "false"),
+        ):
+            _git("config", key, value, cwd=seed)
+
+        (seed / "README.md").write_text("old\n", encoding="utf-8")
+        _git("add", "-A", cwd=seed)
+        _git("commit", "-qm", "chore: previous release", cwd=seed)
+        self.previous_sha = _git("rev-parse", "HEAD", cwd=seed)
+        (seed / "README.md").write_text("new\n", encoding="utf-8")
+        _git("commit", "-qam", "chore: release 1.2.3", cwd=seed)
+        self.target_sha = _git("rev-parse", "HEAD", cwd=seed)
+        _git("push", "-q", "origin", "HEAD:refs/heads/main", cwd=seed)
+
+        if annotated:
+            _git("tag", "-a", RELEASE_TAG, "-m", "release", cwd=seed)
+        else:
+            _git("tag", RELEASE_TAG, cwd=seed)
+        _git("push", "-q", "origin", f"refs/tags/{RELEASE_TAG}", cwd=seed)
+        self._seed = seed
+
+        # The workspace the job pushes from: a fresh checkout of the remote.
+        subprocess.run(["git", "clone", "-q", self.url, str(self.work)], check=True)
+
+        stub_dir = tmp_path / "stub-bin"
+        stub_dir.mkdir()
+        gh = stub_dir / "gh"
+        gh.write_text(GH_STUB, encoding="utf-8")
+        gh.chmod(0o755)
+        self._log = tmp_path / "gh-calls.jsonl"
+        self._env = {
+            **os.environ,
+            "PATH": f"{stub_dir}{os.pathsep}{os.environ['PATH']}",
+            "GH_STUB_ORIGIN": self.url,
+            "GH_STUB_LOG": str(self._log),
+            "GH_TOKEN": "stub-token",
+            "GITHUB_REPOSITORY": REPO,
+            "VERSION": VERSION,
+            "TAG_PREFIX": "v",
+            "FLOATING_TAGS": "major,minor",
+        }
+
+    def place_tag(self, name: str, sha: str) -> None:
+        """Pre-existing floating tag on the remote."""
+        _git("push", "-q", "-f", "origin", f"{sha}:refs/tags/{name}", cwd=self._seed)
+
+    def reject_pushes(self) -> None:
+        """Make the remote refuse every push, standing in for a ruleset denial."""
+        hook = self.origin / "hooks" / "pre-receive"
+        hook.write_text(
+            "#!/usr/bin/env bash\necho 'refusing (test)' >&2\nexit 1\n",
+            encoding="utf-8",
+        )
+        hook.chmod(0o755)
+
+    def remote_tag(self, name: str) -> str:
+        out = _git("ls-remote", self.url, f"refs/tags/{name}", cwd=self.work)
+        return out.split()[0] if out else ""
+
+    def run(self, **env: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            ["bash", "-c", _move_step_script()],
+            cwd=self.work,
+            env={**self._env, **env},
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    @property
+    def pushes(self) -> list[list[str]]:
+        if not self._log.exists():
+            return []
+        return [json.loads(line) for line in self._log.read_text().splitlines()]
+
+
+def _ok(proc: subprocess.CompletedProcess[str]) -> None:
+    assert proc.returncode == 0, f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+
+
+def test_first_release_of_a_level_creates_the_tag(tmp_path: Path) -> None:
+    """The #1157 case: a floating level that does not exist yet must be created.
+
+    This is the scenario the whole push rewrite (#1377) exists for, and the one
+    that still needed a manual fix on ``sync-issues-action`` v0.5.0.
+    """
+    remote = _Remote(tmp_path)
+
+    proc = remote.run()
+
+    _ok(proc)
+    assert remote.remote_tag("v1") == remote.target_sha, (
+        "the major floating tag must be created at the release commit"
+    )
+    assert remote.remote_tag("v1.2") == remote.target_sha, (
+        "the minor floating tag must be created at the release commit"
+    )
+
+
+def test_existing_level_is_force_moved(tmp_path: Path) -> None:
+    """A floating tag from the previous release moves to the new commit."""
+    remote = _Remote(tmp_path)
+    remote.place_tag("v1", remote.previous_sha)
+
+    proc = remote.run()
+
+    _ok(proc)
+    assert remote.remote_tag("v1") == remote.target_sha
+    assert "v1 -> " in proc.stdout
+
+
+def test_tag_already_at_target_is_skipped(tmp_path: Path) -> None:
+    """Re-running promote must be a no-op, not a redundant force-push."""
+    remote = _Remote(tmp_path)
+    remote.place_tag("v1", remote.target_sha)
+    remote.place_tag("v1.2", remote.target_sha)
+
+    proc = remote.run()
+
+    _ok(proc)
+    assert "already at" in proc.stdout
+    assert remote.remote_tag("v1") == remote.target_sha
+
+
+def test_annotated_release_tag_is_peeled_to_its_commit(tmp_path: Path) -> None:
+    """Older scaffolds published ANNOTATED release tags; floating tags are
+    lightweight refs at the commit, so the tag object must be peeled first."""
+    remote = _Remote(tmp_path, annotated=True)
+
+    proc = remote.run()
+
+    _ok(proc)
+    assert remote.remote_tag("v1") == remote.target_sha, (
+        "a floating tag must point at the commit, never at the tag object"
+    )
+
+
+def test_refused_push_fails_loud_with_remediation(tmp_path: Path) -> None:
+    """A denied push must not pass silently: the release is already published,
+    so only the advertised ``@v1`` pin would be missing (#1157, #1158)."""
+    remote = _Remote(tmp_path)
+    remote.reject_pushes()
+
+    proc = remote.run()
+
+    assert proc.returncode != 0, "a refused tag push must fail the job"
+    combined = proc.stdout + proc.stderr
+    assert "::error title=Floating tag" in combined
+    assert "ruleset" in combined.lower()
+
+
+def test_unknown_level_warns_without_failing(tmp_path: Path) -> None:
+    """An unrecognised DEVKIT_FLOATING_TAGS entry is a warning, not a failure."""
+    remote = _Remote(tmp_path)
+
+    proc = remote.run(FLOATING_TAGS="major,patch")
+
+    _ok(proc)
+    assert "::warning::Unknown DEVKIT_FLOATING_TAGS level 'patch'" in proc.stdout
+    assert remote.remote_tag("v1") == remote.target_sha
+
+
+@pytest.mark.parametrize("levels", ["major", "minor"])
+def test_single_level_moves_only_that_level(tmp_path: Path, levels: str) -> None:
+    """Each opt-in level is independent."""
+    remote = _Remote(tmp_path)
+
+    proc = remote.run(FLOATING_TAGS=levels)
+
+    _ok(proc)
+    moved, untouched = ("v1", "v1.2") if levels == "major" else ("v1.2", "v1")
+    assert remote.remote_tag(moved) == remote.target_sha
+    assert remote.remote_tag(untouched) == ""

--- a/tests/test_promote_release.py
+++ b/tests/test_promote_release.py
@@ -103,21 +103,78 @@ def _move_step_script() -> str:
     return move["run"]
 
 
-def test_move_tag_force_pushes_with_explicit_app_token() -> None:
-    """Floating tags are mutated via ``git push --force`` with the App token.
+def _floating_tags_job() -> dict:
+    return load_workflow(PROMOTE)["jobs"]["floating-tags"]
+
+
+def test_move_tag_force_pushes_as_the_release_app() -> None:
+    """Floating tags are mutated via ``git push --force`` as the Release App.
 
     #1377: ``POST /git/refs`` does not honor the Release App's Integration
     ruleset bypass for the ``creation`` rule (first release of every new
     floating level fails HTTP 422), while the very same installation token
-    creating tags via ``git push`` is bypassed fine. The token must be plumbed
-    explicitly into the push URL — the checkout step's persisted credentials
-    are the default ``github.token``, which has no bypass.
+    creating tags via ``git push`` is bypassed fine.
+
+    #1508: plumbing that token into the push URL does not deliver it. Checkout
+    persists its own credentials as ``http.<host>.extraheader``, and that header
+    outranks URL userinfo — so the push authenticated as the Actions identity,
+    which this job denies (``contents: read``) and the ruleset does not bypass.
+    The token has to reach git through the CHECKOUT.
     """
+    job = _floating_tags_job()
+    steps = job["steps"]
+    token = next(i for i, s in enumerate(steps) if s.get("id") == "release_app_token")
+    checkout = next(
+        i for i, s in enumerate(steps) if "checkout" in str(s.get("uses", ""))
+    )
+
+    assert token < checkout, (
+        "the App token must be generated BEFORE checkout, so checkout can "
+        "persist it as the credentials git actually uses (#1508)"
+    )
+    assert steps[checkout].get("with", {}).get("token") == (
+        "${{ steps.release_app_token.outputs.token }}"
+    ), "checkout must carry the Release App token, not the default github.token"
+
     script = _move_step_script()
     assert "git push" in script
     assert "--force" in script
-    # Explicit App-token auth, not checkout's persisted credentials.
-    assert "x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}" in script
+    assert "git push --force origin" in script, (
+        "push to the remote checkout authenticated; a URL with embedded "
+        "userinfo is silently ignored in favour of the extraheader (#1508)"
+    )
+
+
+def test_floating_tags_job_embeds_no_token_in_a_url() -> None:
+    """No git remote in the job may carry userinfo — it would be ignored (#1508)."""
+    steps = _floating_tags_job()["steps"]
+    body = "\n".join(str(s.get("run", "")) for s in steps)
+
+    assert "x-access-token" not in body, (
+        "a token in the push/fetch URL is dead weight: checkout's extraheader "
+        "wins, so the operation runs under the WRONG identity (#1508)"
+    )
+    assert "REMOTE_URL" not in body
+
+
+def test_floating_tags_job_keeps_the_actions_token_read_only() -> None:
+    """The fix is the App identity, never a wider GITHUB_TOKEN (#1508)."""
+    perms = _floating_tags_job()["permissions"]
+
+    assert perms["contents"] == "read", (
+        "granting contents: write would make the push succeed under the "
+        "ACTIONS identity, defeating the App-identity model (#1508)"
+    )
+
+
+def test_release_tag_is_fetched_from_the_authenticated_remote() -> None:
+    """The shallow tag fetch rides the same credentials as the push (#1508).
+
+    Not cosmetic: on a private consumer an unauthenticated fetch fails outright,
+    so the remote must be the one checkout configured.
+    """
+    script = _move_step_script()
+    assert "git fetch --no-tags --depth 1 origin" in script
 
 
 def test_move_tag_never_mutates_refs_via_rest() -> None:


### PR DESCRIPTION
## Description

Third instance of the identity bug from #1503, this time in the `floating-tags`
job. The Release App token was embedded in the push URL while `actions/checkout`
persisted the default `GITHUB_TOKEN` as `http.<host>.extraheader` — and the
extraheader outranks URL userinfo, so the push authenticated as the Actions
identity, which the job denies (`contents: read`) and the Tag ruleset does not
bypass. The token the step went out of its way to plumb through was never used.

**No released floating tag was ever wrong.** The `git push` form arrived in
devkit 1.7.0 (`e76c31da`, `Refs: #1377`); the only two repos that set
`DEVKIT_FLOATING_TAGS` — `vig-os/commit-action` and `vig-os/sync-issues-action` —
are both still on 1.6.0, where `move_tag` used `gh api` and no checkout
credentials were involved. devkit's own promote workflow has no floating-tags
job. The path had simply never executed anywhere, which is why nothing caught it.

## Type of Change

- [x] `fix` -- Bug fix
- [x] `test` -- Adding or updating tests

## Changes Made

**The fix** (`assets/workspace/.github/workflows/promote-release.yml`):

- `Generate release app token` moves **before** `Checkout repository`, and
  checkout takes `token: ${{ steps.release_app_token.outputs.token }}` — so the
  credentials git actually uses are the App's.
- `REMOTE_URL` is gone; the shallow tag fetch and the force-push both use
  `origin`. The fetch matters as much as the push: on a private consumer an
  unauthenticated fetch fails outright.
- `contents: read` stays, with an inline comment saying why — granting
  `contents: write` would "fix" a future 403 by moving tag pushes to the Actions
  identity, defeating the App-identity model the Tag ruleset depends on.

**The tests.** One existing pin, `test_move_tag_force_pushes_with_explicit_app_token`,
asserted the defect itself:

```python
assert "x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}" in script
```

That is why #1377 looked done. It is replaced by pins on the ordering, the
checkout token, the absence of any URL userinfo in the job, and `contents: read`.

New `tests/test_floating_tag_move.py` runs the move step's **real bash** against
a throwaway `file://` remote, with `gh` stubbed by a shim that answers the REST
ref reads from that same remote (so stub and fixture cannot drift):

- first release of a level → tag **created** (the #1157 case)
- existing level → force-moved to the release commit
- already at target → skipped, no push
- annotated release tag → peeled to its commit, not left at the tag object
- push refused (a `pre-receive` hook standing in for a ruleset denial) → job
  fails with the `::error title=Floating tag` annotation and its remediation
- unknown level → `::warning::`, no failure; each level moves independently

An identity bug cannot be reproduced against a local remote (no auth), so
identity stays pinned structurally — but everything downstream of it is now
executed rather than grepped.

## Changelog Entry

```
### Fixed

- **Floating tags: the promote-time push ran under the wrong identity**
  ([#1508](https://github.com/vig-os/devkit/issues/1508))
  ...
```

(Full entry in `CHANGELOG.md` under `## Unreleased` → `### Fixed`.)

## Testing

- [x] Tests pass locally (`just test`, `just test-bats`, `prek run --all-files`)
- [x] Manual testing performed (describe below)

RED-before-GREEN. Against the unfixed workflow the three new shape pins failed,
and all 8 behaviour tests failed — informatively: the old script builds its
remote from `GITHUB_REPOSITORY`, so it tried to reach the real
`github.com/vig-os/testrepo` and died on `Authentication failed` after 130s of
retry backoff. After the fix the same suite runs against `origin` in 18s, 28
passed.

Full local run: `prek run --all-files` clean; `1466 passed, 3 skipped` (the two
known-environmental failures deselected — stale locally-built image vs. an edited
`CHANGELOG.md`, and a missing `dbus-launch`); full bats suite clean.

### Manual Testing Details

Evidence gathered while confirming the report, all on the 1.6.0 (REST) path:

- `vig-os/commit-action` run
  [30994674616](https://github.com/vig-os/commit-action/actions/runs/30994674616)
  — `Moved floating tag v0 -> 0361e9aa…`, `v0.3 -> 0361e9aa…`, green.
- `vig-os/sync-issues-action` run
  [31186320919](https://github.com/vig-os/sync-issues-action/actions/runs/31186320919)
  — `v0` moved, then exit 1 **creating** `v0.5` (the #1157 denial); `v0.5` was
  created by hand afterwards per the step's own remediation message.

The extraheader precedence itself was reproduced outside CI against a private
repo with the credential helper disabled: valid token in the extraheader plus a
deliberately bogus token in the URL userinfo still authenticates, while the bogus
userinfo alone fails.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly — none needed:
      `docs/MIGRATION.md#first-release-floating-tags` documents the *human*
      bootstrap for a repo whose promote workflow does not exist yet, which this
      does not change
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

**This unblocks an upgrade.** `commit-action` and `sync-issues-action` cannot
safely leave 1.6.0 until this ships: today their tag *moves* work and only the
first *creation* of a new level fails (#1157); on 1.7.0–1.9.x the push runs as
the wrong identity, so the moves would break too. With this fix, both cases go
through the App identity for the first time.

**Whether #1377 actually fixed #1157 is now testable but still unproven in
production.** The premise — the App is a bypass actor for `git push` where it is
not for `POST /git/refs` — is unchanged and untested against a live ruleset,
because the push never ran as the App. The first real confirmation will be the
next new floating level on one of those two repos after they adopt this.

**Deliberately untouched.** The `Cleanup git RC tags` job still builds a
`x-access-token:` URL for a `git ls-remote` (`promote-release.yml:562`, and the
same line in devkit's own copy). The token there is likewise ignored, but the
operation is a *read* that succeeds under either identity, and its ref deletions
go through `gh api -X DELETE`, which uses `GH_TOKEN` correctly. Dead weight, not
a defect — out of scope here.

Refs: #1508
