### PR TITLE
feat(release): ship the consumer abandon-release workflow and recipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     idempotent and re-runnable, with a fail-closed verification pass
   - Hard-refuses a **published** release: deleting one tombstones its tag
     name permanently (the 1.5.0 ghost); fix forward instead
-  - Devkit-only for now (a manifest `RemoveBlock` keeps the recipe out of the
-    consumer scaffold until the consumer variant ships the workflow)
+
+- **Consumer abandon-release: the scaffold ships the workflow the recipe
+  dispatches** ([#1511](https://github.com/vig-os/devkit/issues/1511))
+  - `.github/workflows/abandon-release.yml` joins the scaffolded release set:
+    the same draft-only server-side guards as devkit's, with the tag composed
+    as `<DEVKIT_TAG_PREFIX>X.Y.Z` via a leading `resolve-toolchain` job and
+    the consumer `publish-release` concurrency lane
+  - The `just abandon-release` recipe now syncs into the consumer
+    `justfile.gh` (the devkit-only `RemoveBlock` is dropped), and the
+    workflow is part of the `release` feature group
+  - Documented in `docs/DOWNSTREAM_RELEASE.md` as the guarded exception to
+    the no-tag-deletion rollback policy
 
 ### Changed
 

--- a/assets/init-workspace.sh
+++ b/assets/init-workspace.sh
@@ -1378,6 +1378,7 @@ feature_paths() {
                 ".github/workflows/prepare-release.yml" \
                 ".github/workflows/prepare-release-extension.yml" \
                 ".github/workflows/promote-release.yml" \
+                ".github/workflows/abandon-release.yml" \
                 ".github/workflows/sync-main-to-dev.yml" \
                 "docs/DOWNSTREAM_RELEASE.md"
             ;;

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -18,8 +18,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     idempotent and re-runnable, with a fail-closed verification pass
   - Hard-refuses a **published** release: deleting one tombstones its tag
     name permanently (the 1.5.0 ghost); fix forward instead
-  - Devkit-only for now (a manifest `RemoveBlock` keeps the recipe out of the
-    consumer scaffold until the consumer variant ships the workflow)
+
+- **Consumer abandon-release: the scaffold ships the workflow the recipe
+  dispatches** ([#1511](https://github.com/vig-os/devkit/issues/1511))
+  - `.github/workflows/abandon-release.yml` joins the scaffolded release set:
+    the same draft-only server-side guards as devkit's, with the tag composed
+    as `<DEVKIT_TAG_PREFIX>X.Y.Z` via a leading `resolve-toolchain` job and
+    the consumer `publish-release` concurrency lane
+  - The `just abandon-release` recipe now syncs into the consumer
+    `justfile.gh` (the devkit-only `RemoveBlock` is dropped), and the
+    workflow is part of the `release` feature group
+  - Documented in `docs/DOWNSTREAM_RELEASE.md` as the guarded exception to
+    the no-tag-deletion rollback policy
 
 ### Changed
 

--- a/assets/workspace/.devcontainer/justfile.gh
+++ b/assets/workspace/.devcontainer/justfile.gh
@@ -108,6 +108,22 @@ publish-candidate version ref="" create-release="false" *flags:
     echo "✓ Candidate release workflow triggered for version {{ version }}"
     echo "Monitor progress: gh run list --workflow release.yml"
 
+# Abandon a finalized-but-unpublished release: delete draft Release + tag, close PR, delete branch (draft-only, enforced server-side)
+[group('release')]
+abandon-release version ref="" *flags:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    # Safe only while the X.Y.Z Release is a DRAFT — the workflow hard-refuses
+    # a published release (publishing tombstones the tag name permanently).
+    REF="{{ ref }}"
+    if [ -z "$REF" ]; then
+        REF="dev"
+    fi
+    gh workflow run abandon-release.yml --ref "$REF" -f "version={{ version }}" {{ flags }}
+    echo ""
+    echo "✓ Abandon workflow triggered for version {{ version }}"
+    echo "Monitor progress: gh run list --workflow abandon-release.yml"
+
 # Reset CHANGELOG Unreleased section (after merging release to dev)
 [group('release')]
 reset-changelog:

--- a/assets/workspace/.github/renovate-default.json
+++ b/assets/workspace/.github/renovate-default.json
@@ -68,6 +68,7 @@
     {
       "description": "Devkit-managed workflows and composite actions are regenerated wholesale on every devkit upgrade, so their SHA-pinned action digests are advanced upstream by devkit's own Renovate and shipped with each devkit release — never here. Disabling them stops duplicate/clobbering pin-bump PRs in consumer repos. This rule is intentionally last so a consumer's own later packageRules (in their preserved renovate.json) win: a consumer that wants to manage a specific managed file can re-enable it there. Refs vig-os/devkit#1332.",
       "matchFileNames": [
+        ".github/workflows/abandon-release.yml",
         ".github/workflows/ci.yml",
         ".github/workflows/codeql.yml",
         ".github/workflows/devkit-upgrade.yml",

--- a/assets/workspace/.github/workflows/abandon-release.yml
+++ b/assets/workspace/.github/workflows/abandon-release.yml
@@ -1,0 +1,220 @@
+# Managed by vigOS devkit — regenerated on upgrade; local edits are lost.
+# Customize in justfile.project. Bugs / missing tools: https://github.com/vig-os/devkit/issues
+
+# Abandon Release — first-class rejection path at promote time
+#
+# With the single human approval collected at promote, rejecting a release
+# happens after finalize has already burned artifacts. This workflow reverses
+# a finalized-but-unpublished release: it deletes the DRAFT GitHub Release and
+# the release tag as the Release App (Tag-protection bypass — the same
+# machinery as promote-release's RC prune), closes the release PR, and deletes
+# release/X.Y.Z. The tag carries DEVKIT_TAG_PREFIX (consumers may tag vX.Y.Z);
+# the version input and the release branch stay bare.
+#
+# Safe ONLY while the Release is a draft: publishing a release tombstones its
+# tag name permanently, so a published release is hard-refused here — fix
+# forward with the next version instead. RC artifacts (rcN tags) are NOT
+# pruned: a re-cut of the same version reclaims them at its promote.
+#
+# Every step is idempotent (absent pieces count as already-abandoned), so a
+# partially failed run can simply be re-dispatched.
+#
+# See docs/DOWNSTREAM_RELEASE.md.
+
+name: Abandon Release
+
+on:  # yamllint disable-line rule:truthy
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Semantic version to abandon (e.g., 1.2.3)'
+        required: true
+        type: string
+
+# Shares the promote lane: abandoning a version while its promote runs (or
+# vice versa) must never interleave.
+concurrency:
+  group: publish-release
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  resolve-toolchain:
+    name: Resolve toolchain
+    runs-on: ubuntu-24.04
+    timeout-minutes: 2
+    outputs:
+      tag-prefix: ${{ steps.resolve.outputs.tag-prefix }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          sparse-checkout: |
+            .vig-os
+            .github/actions/resolve-toolchain
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+
+      - name: Resolve toolchain
+        id: resolve
+        uses: ./.github/actions/resolve-toolchain
+        with:
+          registry-token: ${{ secrets.GHCR_PULL_TOKEN || github.token }}
+          registry-username: ${{ github.actor }}
+
+  validate:
+    name: Validate abandon preconditions
+    needs: [resolve-toolchain]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      # Draft releases are only visible with push access, mirroring
+      # promote-release's validate job.
+      contents: write
+      pull-requests: read
+    outputs:
+      version: ${{ steps.check.outputs.version }}
+      release_id: ${{ steps.check.outputs.release_id }}
+      pr_number: ${{ steps.check.outputs.pr_number }}
+
+    steps:
+      - name: Verify draft-only precondition
+        id: check
+        env:
+          VERSION: ${{ inputs.version }}
+          TAG_PREFIX: ${{ needs.resolve-toolchain.outputs.tag-prefix }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "ERROR: version '$VERSION' is not a bare semantic version (X.Y.Z)"
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+          # The Release/tag published by release.yml carries the prefix (#1044).
+          TAG="${TAG_PREFIX}${VERSION}"
+
+          RELEASE_JSON=$(gh api --paginate "repos/${GITHUB_REPOSITORY}/releases" \
+            | jq -s --arg t "$TAG" 'add // [] | map(select(.tag_name == $t)) | first // empty')
+
+          if [ -z "$RELEASE_JSON" ]; then
+            echo "No GitHub Release found for tag $TAG — treating as already deleted (idempotent)"
+            echo "release_id=" >> "$GITHUB_OUTPUT"
+          else
+            IS_DRAFT=$(printf '%s' "$RELEASE_JSON" | jq -r '.draft')
+            RELEASE_ID=$(printf '%s' "$RELEASE_JSON" | jq -r '.id')
+            if [ "$IS_DRAFT" != "true" ]; then
+              echo "ERROR: the $TAG Release is PUBLISHED — abandoning it would tombstone the tag name permanently."
+              echo "Published releases are immutable; fix forward with the next version instead (docs/DOWNSTREAM_RELEASE.md)."
+              exit 1
+            fi
+            echo "Draft Release for $TAG found (release id $RELEASE_ID)"
+            echo "release_id=$RELEASE_ID" >> "$GITHUB_OUTPUT"
+          fi
+
+          PR_NUMBER=$(gh pr list --repo "$GITHUB_REPOSITORY" \
+            --head "release/$VERSION" --base main --state open \
+            --json number --jq '.[0].number // empty')
+          if [ -z "$PR_NUMBER" ]; then
+            echo "No open release PR from release/$VERSION — treating as already closed (idempotent)"
+          else
+            echo "Open release PR: #$PR_NUMBER"
+          fi
+          echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+
+  abandon:
+    name: Delete draft release, tag, PR, and branch
+    needs: [resolve-toolchain, validate]
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3
+        with:
+          client-id: ${{ secrets.RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
+      - name: Abandon the release
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          VERSION: ${{ needs.validate.outputs.version }}
+          TAG_PREFIX: ${{ needs.resolve-toolchain.outputs.tag-prefix }}
+          RELEASE_ID: ${{ needs.validate.outputs.release_id }}
+          PR_NUMBER: ${{ needs.validate.outputs.pr_number }}
+        run: |
+          set -euo pipefail
+
+          TAG="${TAG_PREFIX}${VERSION}"
+
+          # 1. Delete the draft Release by id — drafts cannot be resolved by
+          #    tag (`gh release delete <tag>` fails), mirroring the RC prune.
+          if [ -n "$RELEASE_ID" ]; then
+            echo "Deleting draft Release $TAG (release id $RELEASE_ID)"
+            if ! gh api -X DELETE "repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}"; then
+              if gh api "repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}" >/dev/null 2>&1; then
+                echo "ERROR: failed to delete draft Release $TAG (release id $RELEASE_ID)"
+                exit 1
+              fi
+              echo "Release id $RELEASE_ID already absent (idempotent success after 404)"
+            fi
+          else
+            echo "No draft Release to delete"
+          fi
+
+          # 2. Delete the tag — but never a tag that still has any GitHub
+          #    Release attached (same guard as the RC prune): a surviving
+          #    release means step 1 did not truly land.
+          HAS_RELEASE=$(gh api --paginate "repos/${GITHUB_REPOSITORY}/releases" \
+            | jq -s -r --arg t "$TAG" 'add // [] | any(.[]; .tag_name == $t)')
+          if [ "$HAS_RELEASE" = "true" ]; then
+            echo "ERROR: a GitHub Release is still attached to tag $TAG — refusing to delete the tag"
+            exit 1
+          fi
+          if gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${TAG}" >/dev/null 2>&1; then
+            echo "Deleting tag $TAG"
+            gh api -X DELETE "repos/${GITHUB_REPOSITORY}/git/refs/tags/${TAG}"
+          else
+            echo "Tag $TAG already absent"
+          fi
+
+          # 3. Close the release PR before deleting its head branch, so the
+          #    closure carries the audit comment.
+          if [ -n "$PR_NUMBER" ]; then
+            echo "Closing release PR #$PR_NUMBER"
+            gh pr close "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
+              --comment "Release $VERSION abandoned via abandon-release before publication: draft Release, tag, and release branch deleted. The version number remains available for a re-cut." \
+              || echo "PR #$PR_NUMBER already closed"
+          else
+            echo "No open release PR to close"
+          fi
+
+          # 4. Delete the release branch.
+          if gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/release/${VERSION}" >/dev/null 2>&1; then
+            echo "Deleting branch release/$VERSION"
+            gh api -X DELETE "repos/${GITHUB_REPOSITORY}/git/refs/heads/release/${VERSION}"
+          else
+            echo "Branch release/$VERSION already absent"
+          fi
+
+          # Verify and fail closed: nothing abandoned may survive.
+          LEFTOVERS=()
+          gh api --paginate "repos/${GITHUB_REPOSITORY}/releases" \
+            | jq -s -e --arg t "$TAG" 'add // [] | any(.[]; .tag_name == $t) | not' >/dev/null \
+            || LEFTOVERS+=("GitHub Release $TAG")
+          gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${TAG}" >/dev/null 2>&1 \
+            && LEFTOVERS+=("tag $TAG")
+          gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/release/${VERSION}" >/dev/null 2>&1 \
+            && LEFTOVERS+=("branch release/$VERSION")
+          if [ ${#LEFTOVERS[@]} -gt 0 ]; then
+            echo "ERROR: abandon incomplete — still present: ${LEFTOVERS[*]}"
+            exit 1
+          fi
+          echo "✓ Release $VERSION abandoned: draft Release, tag, PR, and branch are gone"

--- a/assets/workspace/docs/DOWNSTREAM_RELEASE.md
+++ b/assets/workspace/docs/DOWNSTREAM_RELEASE.md
@@ -75,6 +75,12 @@ On a repository whose `main` ruleset requires **no** approving reviews (solo pro
 
 This template does **not** implement upstream-only steps (GHCR `:latest`, cosign, cross-repo smoke-test gate). Projects that need registry or deploy promotion after merge should run separate automation or extend their `release-extension.yml` / own workflows; see [Extension Hook](#extension-hook).
 
+## Abandon release (draft-only rejection path)
+
+To **reject** a finalized-but-unpublished release instead of promoting it, run **`abandon-release.yml`** (or `just abandon-release X.Y.Z`; dispatches on `dev` by default — the release branch is about to be deleted, so it cannot be the dispatch ref; under the trunk model pass the ref explicitly: `just abandon-release X.Y.Z main`). As the Release App (tag-ruleset bypass, the same machinery as promote's RC prune) it deletes the **draft** GitHub Release, deletes the `<DEVKIT_TAG_PREFIX>X.Y.Z` tag, closes the release PR with an audit comment, and deletes `release/X.Y.Z`. The version number remains available for a re-cut; RC artifacts are **not** pruned (a re-cut of the same version reclaims them at its promote). Every step is idempotent, so a partially failed run can simply be re-dispatched.
+
+This is the explicit, guarded exception to the no-tag-deletion rollback policy above: it is safe **only while the Release is a draft**, and the workflow hard-refuses a published release ([#1511](https://github.com/vig-os/devkit/issues/1511)). Publishing tombstones the tag name permanently — after promote, the only path is fixing forward with the next version.
+
 ## Workflow models
 
 The whole release flow above is the same under either **workflow model** a

--- a/assets/workspace/zizmor.yml
+++ b/assets/workspace/zizmor.yml
@@ -59,6 +59,7 @@ rules:
       - sync-main-to-dev.yml
   github-app:
     ignore:
+      - abandon-release.yml
       - prepare-release.yml
       - promote-release.yml
       - release-core.yml

--- a/docs/DOWNSTREAM_RELEASE.md
+++ b/docs/DOWNSTREAM_RELEASE.md
@@ -72,6 +72,12 @@ On a repository whose `main` ruleset requires **no** approving reviews (solo pro
 
 This template does **not** implement upstream-only steps (GHCR `:latest`, cosign, cross-repo smoke-test gate). Projects that need registry or deploy promotion after merge should run separate automation or extend their `release-extension.yml` / own workflows; see [Extension Hook](#extension-hook).
 
+## Abandon release (draft-only rejection path)
+
+To **reject** a finalized-but-unpublished release instead of promoting it, run **`abandon-release.yml`** (or `just abandon-release X.Y.Z`; dispatches on `dev` by default — the release branch is about to be deleted, so it cannot be the dispatch ref; under the trunk model pass the ref explicitly: `just abandon-release X.Y.Z main`). As the Release App (tag-ruleset bypass, the same machinery as promote's RC prune) it deletes the **draft** GitHub Release, deletes the `<DEVKIT_TAG_PREFIX>X.Y.Z` tag, closes the release PR with an audit comment, and deletes `release/X.Y.Z`. The version number remains available for a re-cut; RC artifacts are **not** pruned (a re-cut of the same version reclaims them at its promote). Every step is idempotent, so a partially failed run can simply be re-dispatched.
+
+This is the explicit, guarded exception to the no-tag-deletion rollback policy above: it is safe **only while the Release is a draft**, and the workflow hard-refuses a published release ([#1511](https://github.com/vig-os/devkit/issues/1511)). Publishing tombstones the tag name permanently — after promote, the only path is fixing forward with the next version.
+
 ## Workflow models
 
 The whole release flow above is the same under either **workflow model** a

--- a/scripts/manifest.toml
+++ b/scripts/manifest.toml
@@ -98,9 +98,6 @@ transforms = [
   # Downstream release.yml declares create-release; upstream root justfile.gh does not pass it.
   { type = "Sed", pattern = '(?m)^publish-candidate version ref="" \*flags:', replace = 'publish-candidate version ref="" create-release="false" *flags:' },
   { type = "Sed", pattern = '-f "release-kind=candidate" \{\{ flags \}\}', replace = '-f "release-kind=candidate" -f "create-release={{ create-release }}" {{ flags }}' },
-  # abandon-release stays devkit-only until the consumer variant ships the
-  # workflow it dispatches (follow-up to #1504).
-  { type = "RemoveBlock", start_pattern = "^# Abandon a finalized-but-unpublished release", end_pattern = "^$" },
   { type = "RemoveBlock", start_pattern = "^# Pull image from registry", end_pattern = "^\\s+podman pull" },
   { type = "StripTrailingBlankLines" },
 ]

--- a/tests/bats/init-workspace.bats
+++ b/tests/bats/init-workspace.bats
@@ -4430,6 +4430,8 @@ _scaffold_seeded() {
     assert_success
     run test -f "$ws/.github/workflows/release.yml"
     assert_success
+    run test -f "$ws/.github/workflows/abandon-release.yml"
+    assert_success
     _seed_features_disabled "$ws" "release,skills"
     run _upgrade_no_flags "$ws"
     assert_success
@@ -4437,6 +4439,8 @@ _scaffold_seeded() {
     run test -e "$ws/.github/workflows/release.yml"
     assert_failure
     run test -e "$ws/.github/workflows/promote-release.yml"
+    assert_failure
+    run test -e "$ws/.github/workflows/abandon-release.yml"
     assert_failure
     run test -e "$ws/.claude/skills/tdd"
     assert_failure

--- a/tests/test_abandon_release.py
+++ b/tests/test_abandon_release.py
@@ -1,0 +1,127 @@
+"""Workflow-shape tests: the abandon-release rejection path, both copies.
+
+#1504 added ``abandon-release.yml`` to devkit as the draft-only rejection path
+at promote time; #1511 ships the consumer variant in the scaffold. Both copies
+carry the same server-side guards (published release ⇒ hard refusal, tag
+deletion only when no GitHub Release remains attached, fail-closed leftovers
+sweep). The scaffold copy additionally threads ``DEVKIT_TAG_PREFIX`` through a
+leading ``resolve-toolchain`` job — consumers may tag ``vX.Y.Z`` (#1044) — and
+shares the consumer promote lane (``publish-release``) instead of devkit's
+image lane (``publish-image``).
+
+Refs: #1511
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.workflow_scaffold import (
+    both_copies,
+    jobs,
+    load_workflow,
+    needs_of,
+    run_text_of_job,
+    step_by_name,
+    steps_of_job,
+)
+
+DEVKIT_COPY, SCAFFOLD_COPY = both_copies("abandon-release.yml")
+COPIES = {"devkit": DEVKIT_COPY, "scaffold": SCAFFOLD_COPY}
+
+
+def test_scaffold_ships_abandon_release() -> None:
+    """The consumer scaffold ships the workflow the synced recipe dispatches."""
+    assert SCAFFOLD_COPY.is_file(), (
+        "assets/workspace/.github/workflows/abandon-release.yml missing — the "
+        "synced `just abandon-release` recipe would dispatch a nonexistent "
+        "workflow"
+    )
+
+
+@pytest.mark.parametrize("copy", COPIES)
+def test_published_release_is_hard_refused(copy: str) -> None:
+    """A published release must never be abandoned (tombstone protection)."""
+    doc = load_workflow(COPIES[copy])
+    validate_run = run_text_of_job(jobs(doc)["validate"])
+    assert '"$IS_DRAFT" != "true"' in validate_run
+    assert "tombstone" in validate_run
+
+
+@pytest.mark.parametrize("copy", COPIES)
+def test_tag_deleted_only_without_attached_release(copy: str) -> None:
+    """Tag deletion is refused while any GitHub Release still points at it."""
+    doc = load_workflow(COPIES[copy])
+    abandon_run = run_text_of_job(jobs(doc)["abandon"])
+    assert "refusing to delete the tag" in abandon_run
+    assert "git/refs/tags/" in abandon_run
+
+
+@pytest.mark.parametrize("copy", COPIES)
+def test_abandon_deletes_as_the_release_app(copy: str) -> None:
+    """Ref/release deletion runs as the Release App (tag-ruleset bypass)."""
+    doc = load_workflow(COPIES[copy])
+    steps = steps_of_job(doc, "abandon")
+    token_step = next(
+        s for s in steps if "create-github-app-token" in str(s.get("uses", ""))
+    )
+    assert "RELEASE_APP_CLIENT_ID" in str(token_step["with"]["client-id"])
+    assert "RELEASE_APP_PRIVATE_KEY" in str(token_step["with"]["private-key"])
+
+
+@pytest.mark.parametrize("copy", COPIES)
+def test_abandon_fails_closed_on_leftovers(copy: str) -> None:
+    """The final sweep must fail the run if anything abandoned survives."""
+    doc = load_workflow(COPIES[copy])
+    abandon_run = run_text_of_job(jobs(doc)["abandon"])
+    assert "abandon incomplete" in abandon_run
+
+
+def test_concurrency_lanes_differ_by_copy() -> None:
+    """Devkit shares the image promote lane; consumers the release lane."""
+    assert load_workflow(DEVKIT_COPY)["concurrency"]["group"] == "publish-image"
+    assert load_workflow(SCAFFOLD_COPY)["concurrency"]["group"] == "publish-release"
+
+
+def test_scaffold_resolve_job_exposes_tag_prefix() -> None:
+    """The scaffold copy resolves DEVKIT_TAG_PREFIX before acting on tags."""
+    doc = load_workflow(SCAFFOLD_COPY)
+    resolve = jobs(doc)["resolve-toolchain"]
+    assert "tag-prefix" in resolve["outputs"]
+    assert "resolve-toolchain" in needs_of(jobs(doc)["validate"])
+    assert "resolve-toolchain" in needs_of(jobs(doc)["abandon"])
+
+
+@pytest.mark.parametrize("job", ["validate", "abandon"])
+def test_scaffold_threads_tag_prefix_into_tag_operations(job: str) -> None:
+    """Release lookup and tag deletion use the composed ``<prefix>X.Y.Z`` tag.
+
+    The release branch and the ``version`` input stay bare — only the git tag
+    and its GitHub Release carry the prefix (#1044).
+    """
+    doc = load_workflow(SCAFFOLD_COPY)
+    steps = steps_of_job(doc, job)
+    acting = step_by_name(
+        steps, "draft-only" if job == "validate" else "Abandon the release"
+    )
+    assert (
+        acting["env"]["TAG_PREFIX"]
+        == "${{ needs.resolve-toolchain.outputs.tag-prefix }}"
+    )
+    run = str(acting["run"])
+    assert 'TAG="${TAG_PREFIX}${VERSION}"' in run
+    assert "git/refs/tags/${VERSION}" not in run
+    if job == "abandon":
+        # Branch refs stay bare: release/X.Y.Z never carries the prefix.
+        assert "git/refs/heads/release/${VERSION}" in run
+
+
+def test_scaffold_copy_carries_no_devkit_issue_refs_in_comments_to_prs() -> None:
+    """The audit comment must not reference devkit issue numbers.
+
+    ``#NNNN`` in a PR comment autolinks to the *consumer's* issue NNNN, which
+    is unrelated — the scaffold copy drops the bare reference.
+    """
+    doc = load_workflow(SCAFFOLD_COPY)
+    abandon_run = run_text_of_job(jobs(doc)["abandon"])
+    assert "(#1504)" not in abandon_run

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1341,6 +1341,7 @@ class TestJustRecipes:
             "finalize-release",
             "promote-release",
             "publish-candidate",
+            "abandon-release",
             "reset-changelog",
         ]:
             assert re.search(rf"(?m)^{recipe_name}(?:\s+.*)?:$", content), (
@@ -1357,6 +1358,7 @@ class TestJustRecipes:
         assert 'REF="dev"' in content
         assert 'gh workflow run release.yml --ref "$REF"' in content
         assert 'gh workflow run promote-release.yml --ref "$REF"' in content
+        assert 'gh workflow run abandon-release.yml --ref "$REF"' in content
         assert "release-kind=final" in content
         assert "release-kind=candidate" in content
         assert "create-release={{ create-release }}" in content

--- a/zizmor.yml
+++ b/zizmor.yml
@@ -56,6 +56,7 @@ rules:
       - sync-main-to-dev.yml
   github-app:
     ignore:
+      - abandon-release.yml
       - prepare-release.yml
       - promote-release.yml
       - release-core.yml


### PR DESCRIPTION
## Summary

Ships the consumer variant of the abandon-release rejection path (split out of #1504):

- **New scaffold workflow** `assets/workspace/.github/workflows/abandon-release.yml` — same draft-only server-side guards as devkit's copy (published release ⇒ hard refusal / tombstone protection; tag deleted only when no GitHub Release remains attached; fail-closed leftovers sweep; every step idempotent), with two consumer adaptations:
  - the tag is composed as `<DEVKIT_TAG_PREFIX>X.Y.Z` via a leading `resolve-toolchain` job (#1044 pattern); the `version` input and `release/X.Y.Z` branch stay bare
  - concurrency joins the consumer `publish-release` lane (devkit's copy shares `publish-image`)
- **Recipe sync**: the `justfile.gh` `RemoveBlock` is dropped from `scripts/manifest.toml`, so `just abandon-release` now syncs into the consumer scaffold
- **Registrations**: `release` feature group (prunes/disables with the rest of the release set), zizmor `github-app` baseline, renovate managed-file exclusion
- **Docs**: new "Abandon release (draft-only rejection path)" section in `docs/DOWNSTREAM_RELEASE.md`

## Test plan

- New `tests/test_abandon_release.py`: both-copies shape tests (draft-only guard, tag-delete guard, Release App, fail-closed sweep) + scaffold-only tag-prefix threading, concurrency-lane split, and no-devkit-issue-refs in PR comments
- Extended recipe-list/dispatch assertions in `test_integration.py` and the #1284 feature-prune bats test
- Full local run: pytest: full suite green after the renovate-preset fix (2 known local-env failures unrelated: stale local image checksum, container gh auth), bats 525/525, `prek run --all-files` green

Refs: #1511
