### PR TITLE
fix(workspace): survive a mid-scaffold abort without wiping .vig-os

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`install.sh --force` no longer wipes `.vig-os` on a mid-run failure**
+  ([#1480](https://github.com/vig-os/devkit/issues/1480))
+  - `.vig-os` and the root `.gitignore` are snapshotted before the template
+    copy and restored byte-for-byte on any failing exit inside the refill
+    window, with a loud message naming what was restored and warning that
+    other scaffold files may be half-applied
+  - The `u+w` permission sweep is scoped to template-derived paths (keyed on
+    the template tree, like the #1195 `+x` sweep) — it no longer walks the
+    consumer's `.git`, `target/`, or `node_modules`, the surface of the
+    transient walk failure that aborted the field run destructively
+
 - **Smoke listener: a partially-created deploy PR is recoverable again**
   ([#1499](https://github.com/vig-os/devkit/issues/1499))
   - `gh pr create --label` labels in a second mutation. When that mutation hit

--- a/assets/init-workspace.sh
+++ b/assets/init-workspace.sh
@@ -2287,6 +2287,65 @@ fi
 
 # Copy template contents to workspace
 echo "Initializing workspace from template..."
+# ── Torn-window guard (#1480) ────────────────────────────────────────────────
+# The template copy below overwrites .vig-os and the root .gitignore with
+# template content (every knob empty, consumer sections gone) that is only
+# refilled by the write-backs hundreds of lines further down. .vig-os is the
+# INPUT of the next --force run, so an abort inside that window must not
+# persist the blanked state: a run in the field aborted there and silently
+# erased the repo's identity and feature opt-outs. Snapshot both files before
+# the copy, restore them on any failing exit, and disarm once the late
+# write-back has completed.
+TORN_WINDOW_SNAPSHOT_DIR=""
+
+restore_torn_window() {
+    local status=$?
+    if [[ "$status" -eq 0 || -z "$TORN_WINDOW_SNAPSHOT_DIR" ]]; then
+        return 0
+    fi
+    local restored=()
+    if [[ -f "$TORN_WINDOW_SNAPSHOT_DIR/vig-os" ]]; then
+        cp -f "$TORN_WINDOW_SNAPSHOT_DIR/vig-os" "$VIG_OS_MANIFEST"
+        restored+=(".vig-os")
+    fi
+    if [[ -f "$TORN_WINDOW_SNAPSHOT_DIR/gitignore" ]]; then
+        cp -f "$TORN_WINDOW_SNAPSHOT_DIR/gitignore" "$WORKSPACE_DIR/.gitignore"
+        restored+=(".gitignore")
+    fi
+    {
+        echo ""
+        echo "ERROR: workspace initialization failed mid-scaffold."
+        if [[ ${#restored[@]} -gt 0 ]]; then
+            echo "Restored the pre-run ${restored[*]} (the scaffold copy had already overwritten them)."
+        fi
+        echo "Other scaffold files may be half-applied — review with 'git status' and"
+        echo "recover with 'git checkout -- <path>' where needed."
+    } >&2
+    rm -rf "$TORN_WINDOW_SNAPSHOT_DIR"
+    return 0
+}
+
+arm_torn_window_guard() {
+    TORN_WINDOW_SNAPSHOT_DIR="$(mktemp -d "${TMPDIR:-/tmp}/vig-os-preimage.XXXXXX")"
+    if [[ -f "$VIG_OS_MANIFEST" ]]; then
+        cp "$VIG_OS_MANIFEST" "$TORN_WINDOW_SNAPSHOT_DIR/vig-os"
+    fi
+    if [[ -f "$WORKSPACE_DIR/.gitignore" ]]; then
+        cp "$WORKSPACE_DIR/.gitignore" "$TORN_WINDOW_SNAPSHOT_DIR/gitignore"
+    fi
+    trap restore_torn_window EXIT
+}
+
+disarm_torn_window_guard() {
+    trap - EXIT
+    if [[ -n "$TORN_WINDOW_SNAPSHOT_DIR" ]]; then
+        rm -rf "$TORN_WINDOW_SNAPSHOT_DIR"
+        TORN_WINDOW_SNAPSHOT_DIR=""
+    fi
+}
+
+arm_torn_window_guard
+
 echo "Copying files from $TEMPLATE_DIR to $WORKSPACE_DIR..."
 
 # Note: Excluding .venv - it is used directly from the container image
@@ -2401,7 +2460,29 @@ fi
 # files, but those inherit the store's read-only (0444) mode. Make the scaffold
 # user-writable so the placeholder substitution below — and the user's own edits
 # — work. No-op on the Debian image (its template files are already writable).
-chmod -R u+w "$WORKSPACE_DIR"
+# Scoped to template-derived paths (#1480), keyed on the template tree like the
+# +x sweep below (#1195): a blanket `chmod -R` walked the consumer's ENTIRE
+# workspace — .git object packs (deliberately 0444), a multi-GB Cargo target/,
+# node_modules — none of which the scaffold writes, and every one of them a
+# surface for the transient fts walk failure that aborted a run in the field.
+# Symlinks are skipped: chmod would follow them to a target the scaffold does
+# not own (a preserved store symlink target is read-only by design, #1117).
+sweep_scaffold_writable() {
+    local src_dir="$1" src_path rel dest
+    while IFS= read -r -d '' src_path; do
+        rel="${src_path#"$src_dir"/}"
+        dest="$WORKSPACE_DIR/$rel"
+        if [[ -e "$dest" && ! -L "$dest" ]]; then
+            chmod u+w "$dest"
+        fi
+    done < <(find -L "$src_dir" -mindepth 1 -print0)
+}
+chmod u+w "$WORKSPACE_DIR"
+sweep_scaffold_writable "$TEMPLATE_DIR"
+# Smoke overlays land outside the template tree; sweep them the same way.
+if [[ "$SMOKE_TEST" == "true" && -n "${SMOKE_TEST_DIR:-}" && -d "$SMOKE_TEST_DIR" ]]; then
+    sweep_scaffold_writable "$SMOKE_TEST_DIR"
+fi
 
 # Early write-back (#885): the rsync above just replaced .vig-os with the
 # template, so until the late write-back below the manifest would claim the
@@ -2816,6 +2897,10 @@ if [[ -f "$VIG_OS_MANIFEST" ]]; then
         write_manifest_value DEVKIT_LANGUAGES "$(IFS=','; echo "${DECLARED_LANGUAGES[*]}")"
     fi
 fi
+
+# The late write-back above completed: .vig-os and .gitignore hold this run's
+# resolved values again, so a later failure must NOT roll them back (#1480).
+disarm_torn_window_guard
 
 # Restore executable permissions on shell scripts and hooks (must be after sed -i).
 # Scope the +x to the scaffold-delivered script set only: key the sweep on the

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -70,6 +70,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`install.sh --force` no longer wipes `.vig-os` on a mid-run failure**
+  ([#1480](https://github.com/vig-os/devkit/issues/1480))
+  - `.vig-os` and the root `.gitignore` are snapshotted before the template
+    copy and restored byte-for-byte on any failing exit inside the refill
+    window, with a loud message naming what was restored and warning that
+    other scaffold files may be half-applied
+  - The `u+w` permission sweep is scoped to template-derived paths (keyed on
+    the template tree, like the #1195 `+x` sweep) — it no longer walks the
+    consumer's `.git`, `target/`, or `node_modules`, the surface of the
+    transient walk failure that aborted the field run destructively
+
 - **Smoke listener: a partially-created deploy PR is recoverable again**
   ([#1499](https://github.com/vig-os/devkit/issues/1499))
   - `gh pr create --label` labels in a second mutation. When that mutation hit

--- a/tests/bats/init-workspace.bats
+++ b/tests/bats/init-workspace.bats
@@ -965,10 +965,16 @@ EOF
     assert_failure
 }
 
-@test "init-workspace.sh makes the scaffold user-writable (#664)" {
+@test "init-workspace.sh makes the scaffold user-writable (#664/#1480)" {
+    # Scoped to template-derived paths since #1480 (behavior covered in
+    # tests/bats/upgrade-atomicity.bats); the blanket -R over the whole
+    # workspace must not come back — it walked .git and consumer build trees.
+    # shellcheck disable=SC2016
+    run grep -F 'sweep_scaffold_writable "$TEMPLATE_DIR"' "$INIT_WORKSPACE_SH"
+    assert_success
     # shellcheck disable=SC2016
     run grep -E 'chmod -R u\+w "\$WORKSPACE_DIR"' "$INIT_WORKSPACE_SH"
-    assert_success
+    assert_failure
 }
 
 # ── parse-github-remote-lib (#509) ─────────────────────────────────────────

--- a/tests/bats/upgrade-atomicity.bats
+++ b/tests/bats/upgrade-atomicity.bats
@@ -1,0 +1,139 @@
+#!/usr/bin/env bats
+# #1480: `install.sh --force` is not atomic. The template rsync in
+# init-workspace.sh replaces .vig-os and the root .gitignore with template
+# content whose values (mode, identity, feature opt-outs, consumer gitignore
+# sections) are only refilled hundreds of lines later — and .vig-os is the
+# INPUT of the very next --force run, so an abort inside that window persisted
+# a blanked manifest the consumer never chose.
+#
+# These tests EXECUTE the real script and abort it inside the torn window (the
+# VIG_OS_VERSION validation exit, which sits between the copy and the late
+# write-back), then assert the pre-run files come back byte-for-byte and the
+# failure names what was restored.
+#
+# Companion (#1480 suggestion 3): the u+w permission sweep is scoped to
+# template-derived paths, so a consumer's .git objects and build trees
+# (target/, node_modules) are never walked or touched.
+
+setup() {
+    load test_helper
+    INIT_WORKSPACE_SH="$PROJECT_ROOT/assets/init-workspace.sh"
+}
+
+# Run the real script against $2 in mode $1; extra env pairs come after.
+_run_init() {
+    local mode="$1" ws="$2"
+    shift 2
+    local stub="$BATS_TEST_TMPDIR/stub-bin"
+    mkdir -p "$stub"
+    printf '#!/usr/bin/env bash\nexit 0\n' >"$stub/just"
+    printf '#!/usr/bin/env bash\nexit 0\n' >"$stub/uv"
+    chmod +x "$stub/just" "$stub/uv"
+    env PATH="$stub:$PATH" \
+        TEMPLATE_DIR="$PROJECT_ROOT/assets/workspace" \
+        WORKSPACE_DIR="$ws" \
+        SHORT_NAME=testproj \
+        GITHUB_REPOSITORY=test/repo \
+        "$@" \
+        bash "$INIT_WORKSPACE_SH" --force --no-prompts --mode "$mode"
+}
+
+# 'not a version!' fails the ^[A-Za-z0-9._-]+$ pin validation AFTER the copy
+# has replaced .vig-os/.gitignore and BEFORE the write-backs refill them —
+# a real, deterministic in-window abort (no stubs, no signals).
+_upgrade_aborting_in_window() {
+    _run_init both "$1" VIG_OS_VERSION='not a version!'
+}
+
+@test "an in-window abort restores .vig-os and .gitignore byte-for-byte (#1480)" {
+    ws="$BATS_TEST_TMPDIR/e2e-1480-restore"
+    mkdir -p "$ws"
+    run _run_init both "$ws"
+    assert_success
+
+    # Consumer state the template ships empty: exactly what the field failure
+    # blanked (mode/identity land earlier; the opt-outs went unnoticed longest).
+    sed -i 's#^DEVKIT_FEATURES_DISABLED=.*#DEVKIT_FEATURES_DISABLED=skills,worktree#' "$ws/.vig-os"
+    sed -i 's#^DEVKIT_TAG_PREFIX=.*#DEVKIT_TAG_PREFIX=v#' "$ws/.vig-os"
+    printf '/target/\nresult\n' >>"$ws/.gitignore"
+    cp "$ws/.vig-os" "$BATS_TEST_TMPDIR/manifest.before"
+    cp "$ws/.gitignore" "$BATS_TEST_TMPDIR/gitignore.before"
+
+    run _upgrade_aborting_in_window "$ws"
+    assert_failure
+    assert_output --partial "Restored the pre-run"
+    assert_output --partial ".vig-os"
+
+    run cmp "$ws/.vig-os" "$BATS_TEST_TMPDIR/manifest.before"
+    assert_success
+    run cmp "$ws/.gitignore" "$BATS_TEST_TMPDIR/gitignore.before"
+    assert_success
+}
+
+@test "a restored workspace upgrades cleanly on the retry (#1480)" {
+    # The field recovery: after the failed run, a plain retry must succeed and
+    # keep the consumer's opt-outs — the restored manifest is a valid input.
+    ws="$BATS_TEST_TMPDIR/e2e-1480-retry"
+    mkdir -p "$ws"
+    run _run_init both "$ws"
+    assert_success
+    sed -i 's#^DEVKIT_FEATURES_DISABLED=.*#DEVKIT_FEATURES_DISABLED=skills,worktree#' "$ws/.vig-os"
+    run _upgrade_aborting_in_window "$ws"
+    assert_failure
+
+    run _run_init both "$ws"
+    assert_success
+    run grep -x 'DEVKIT_FEATURES_DISABLED=skills,worktree' "$ws/.vig-os"
+    assert_success
+    run test -e "$ws/.claude/skills/tdd"
+    assert_failure
+}
+
+@test "a fresh-scaffold abort still exits loudly without a pre-image (#1480)" {
+    # No .vig-os/.gitignore existed before the run, so there is nothing to
+    # restore — the guard must not mask the failure or die itself (set -e
+    # inside the trap), and the half-applied warning still prints.
+    ws="$BATS_TEST_TMPDIR/e2e-1480-fresh"
+    mkdir -p "$ws"
+    run _upgrade_aborting_in_window "$ws"
+    assert_failure
+    assert_output --partial "half-applied"
+    refute_output --partial "Restored the pre-run"
+}
+
+@test "the u+w sweep never touches consumer .git or build trees (#1480)" {
+    # The blanket `chmod -R u+w $WORKSPACE_DIR` walked the consumer's entire
+    # workspace — .git object packs are deliberately 0444, and a multi-GB
+    # target/ is both slow and a surface for the transient fts walk failures
+    # that caused the field abort. The sweep is keyed on the template tree.
+    ws="$BATS_TEST_TMPDIR/e2e-1480-chmod-scope"
+    mkdir -p "$ws"
+    run _run_init both "$ws"
+    assert_success
+
+    mkdir -p "$ws/.git/objects/pack" "$ws/target/debug"
+    printf 'x' >"$ws/.git/objects/pack/pack-feed.pack"
+    printf 'x' >"$ws/target/debug/artifact"
+    chmod 0444 "$ws/.git/objects/pack/pack-feed.pack" "$ws/target/debug/artifact"
+
+    run _run_init both "$ws"
+    assert_success
+    run stat -c '%a' "$ws/.git/objects/pack/pack-feed.pack"
+    assert_output "444"
+    run stat -c '%a' "$ws/target/debug/artifact"
+    assert_output "444"
+}
+
+@test "template-derived scaffold files still end up user-writable (#1480)" {
+    # The scoping must not regress the sweep's purpose: store-inherited 0444
+    # modes on freshly copied scaffold files are lifted so the placeholder
+    # substitution (and the consumer's own edits) keep working.
+    ws="$BATS_TEST_TMPDIR/e2e-1480-still-writable"
+    mkdir -p "$ws"
+    run _run_init both "$ws"
+    assert_success
+    run test -w "$ws/.vig-os"
+    assert_success
+    run test -w "$ws/.github/workflows/ci.yml"
+    assert_success
+}


### PR DESCRIPTION
## Summary

Fixes the destructive non-atomicity from the field failure in #1480 (filesender 1.6.0→1.8.0):

- **Torn-window guard**: `init-workspace.sh` snapshots `.vig-os` and the root `.gitignore` immediately before the template rsync (the point where both are replaced by template content whose values are only refilled by the write-backs hundreds of lines later). An EXIT trap restores both byte-for-byte on any failing exit inside that window and prints a loud message naming what was restored and warning that other scaffold files may be half-applied (with `git checkout -- <path>` guidance). The guard disarms after the late write-back completes, so later non-window failures never roll back this run's resolved values. Covers both the normal and smoke copy paths.
- **Scoped `u+w` sweep** (suggestion 3): the blanket `chmod -R u+w $WORKSPACE_DIR` walked the consumer's entire workspace — `.git` object packs (deliberately 0444), multi-GB `target/`, `node_modules` — the exact surface of the transient `fts_read` failure that aborted the field run. The sweep is now keyed on the template tree (same shape as the #1195 `+x` sweep), skips symlinks, and additionally covers smoke overlays.

Suggestion 4 from the issue (dirty-tree preflight) already exists (`install.sh` `run_preflight_guard`, #1283); suggestions 1–3 are what this PR delivers. The related nix-detection gap is tracked on #1400.

## Test plan

New `tests/bats/upgrade-atomicity.bats` (5 tests, executing the real script with a deterministic in-window abort via the `VIG_OS_VERSION` validation exit — no stubs or signals):
- in-window abort restores `.vig-os` + `.gitignore` byte-for-byte, with the restore named in output
- a restored workspace upgrades cleanly on retry, opt-outs intact
- a fresh-scaffold abort exits loudly without a pre-image (trap is set-e-safe)
- consumer `.git`/`target/` files stay 0444 through an upgrade
- template-derived scaffold files still end up user-writable

The #664 structural pin updated to assert the scoped sweep and the *absence* of the blanket `-R`. Full local run: bats 530/530 green, scaffold-driven pytest suites (173 tests) green, `prek run --all-files` green.

Refs: #1480