### PR TITLE
fix(ci): make upgrade staleness observable on both axes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Upgrade staleness is observable on both axes**
+  ([#1497](https://github.com/vig-os/devkit/issues/1497))
+  - The flake auto-bump is name-agnostic: any input at the floating
+    `github:vig-os/devkit` URL is advanced, whatever the consumer named it;
+    pinned refs (`?ref=X` or the `/X` path form) are never auto-bumped but
+    the skip is reported — every `install.sh --force` run prints one
+    `flake-bump:` outcome line, and `devkit-upgrade.yml` carries it into the
+    adoption PR body and the step summary
+  - The #1093 pin-skew warning is likewise name-agnostic and now recognizes
+    the `/X` path-ref form
+  - New warn-only `devkit-staleness` job in the scaffolded `ci.yml`: compares
+    `DEVKIT_VERSION` against the latest devkit release and annotates PRs with
+    "N release(s) behind" — cheap API query, not gated on
+    `DEVKIT_DRIFT_CHECK`, never fails the build, and deliberately outside the
+    summary gate
+
 - **`install.sh --force` no longer wipes `.vig-os` on a mid-run failure**
   ([#1480](https://github.com/vig-os/devkit/issues/1480))
   - `.vig-os` and the root `.gitignore` are snapshotted before the template

--- a/assets/init-workspace.sh
+++ b/assets/init-workspace.sh
@@ -2677,21 +2677,31 @@ if [[ -n "${VIG_OS_VERSION:-}" && -f "$WORKSPACE_DIR/.vig-os" ]]; then
         # `|| true`: a floating input yields no grep match (exit 1), which would
         # abort under `set -o pipefail`; an empty pinned_ref is the intended
         # "unpinned, no warning" signal.
-        # Anchor on `^[[:space:]]*vigos\.url` so we read the REAL input line only:
-        # the standard-layout flake.nix ships a doc-comment EXAMPLE line
+        # Anchor on `^[[:space:]]*<name>\.url` so we read the REAL input line
+        # only: the standard-layout flake.nix ships a doc-comment EXAMPLE line
         # (`#   vigos.url = "github:vig-os/devkit?ref=<tag>";`) above it, and an
         # unanchored match picked that comment first, reporting the literal
         # `<tag>` and false-firing even on an aligned pin (#1110).
-        pinned_ref="$(grep -oE '^[[:space:]]*vigos\.url[[:space:]]*=[[:space:]]*"github:vig-os/devkit\?ref=[^"]+"' \
-            "$WORKSPACE_DIR/flake.nix" 2>/dev/null \
-            | sed -E 's/.*\?ref=([^"]+)".*/\1/' | head -n1 || true)"
+        # Name-agnostic and pin-form-agnostic (#1497): flake.nix is a
+        # PRESERVE_FILE, so the input may be named anything, and a ref pins in
+        # either form (?ref=X, or the /X path suffix the field case carried) —
+        # the literal-`vigos`/`?ref=`-only match left exactly those consumers
+        # with neither a bump nor a warning from any mechanism.
+        pinned_line="$(grep -E '^[[:space:]]*(inputs\.)?[A-Za-z0-9_-]+\.url[[:space:]]*=[[:space:]]*"github:vig-os/devkit[/?][^"]+"' \
+            "$WORKSPACE_DIR/flake.nix" 2>/dev/null | head -n1 || true)"
+        pinned_input=""
+        pinned_ref=""
+        if [[ -n "$pinned_line" ]]; then
+            pinned_input="$(sed -E 's/^[[:space:]]*(inputs\.)?([A-Za-z0-9_-]+)\.url.*/\2/' <<<"$pinned_line")"
+            pinned_ref="$(sed -E 's|.*"github:vig-os/devkit[/?](ref=)?([^"]+)".*|\2|' <<<"$pinned_line")"
+        fi
         if [[ -n "$pinned_ref" && "$pinned_ref" != "$VIG_OS_VERSION" ]]; then
             echo "" >&2
-            echo "WARNING: scaffold upgraded to ${VIG_OS_VERSION}, but the pinned vigos flake input is still ${pinned_ref}." >&2
+            echo "WARNING: scaffold upgraded to ${VIG_OS_VERSION}, but the pinned ${pinned_input} flake input is still ${pinned_ref}." >&2
             echo "         The two must move together — they deliver coupled halves of the same" >&2
             echo "         change (e.g. #1053's JSONC banner + its check-json exclude). Update your" >&2
-            echo "         flake.nix to 'vigos.url = \"github:vig-os/devkit?ref=${VIG_OS_VERSION}\";' and run" >&2
-            echo "         'nix flake update vigos', else strict hooks may reject files this scaffold wrote." >&2
+            echo "         flake.nix to '${pinned_input}.url = \"github:vig-os/devkit?ref=${VIG_OS_VERSION}\";' and run" >&2
+            echo "         'nix flake update ${pinned_input}', else strict hooks may reject files this scaffold wrote." >&2
             echo "" >&2
         fi
     fi

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -70,6 +70,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Upgrade staleness is observable on both axes**
+  ([#1497](https://github.com/vig-os/devkit/issues/1497))
+  - The flake auto-bump is name-agnostic: any input at the floating
+    `github:vig-os/devkit` URL is advanced, whatever the consumer named it;
+    pinned refs (`?ref=X` or the `/X` path form) are never auto-bumped but
+    the skip is reported — every `install.sh --force` run prints one
+    `flake-bump:` outcome line, and `devkit-upgrade.yml` carries it into the
+    adoption PR body and the step summary
+  - The #1093 pin-skew warning is likewise name-agnostic and now recognizes
+    the `/X` path-ref form
+  - New warn-only `devkit-staleness` job in the scaffolded `ci.yml`: compares
+    `DEVKIT_VERSION` against the latest devkit release and annotates PRs with
+    "N release(s) behind" — cheap API query, not gated on
+    `DEVKIT_DRIFT_CHECK`, never fails the build, and deliberately outside the
+    summary gate
+
 - **`install.sh --force` no longer wipes `.vig-os` on a mid-run failure**
   ([#1480](https://github.com/vig-os/devkit/issues/1480))
   - `.vig-os` and the root `.gitignore` are snapshotted before the template

--- a/assets/workspace/.github/workflows/ci.yml
+++ b/assets/workspace/.github/workflows/ci.yml
@@ -466,6 +466,71 @@ jobs:
               exit 1
             '
 
+  # Warn-only staleness report (#1497): scaffold-drift resolves its comparison
+  # image from the consumer's own DEVKIT_VERSION pin, so "behind the latest
+  # devkit release" is invisible to it by construction — a consumer sat two
+  # minor versions behind with a green drift check. This job answers that
+  # question with a cheap API query and NEVER fails the build: the report is a
+  # ::warning annotation plus a step-summary block, not a gate. Deliberately
+  # not gated on DEVKIT_DRIFT_CHECK (no docker, no image pull — disabling the
+  # expensive drift gate must not silence the cheap staleness report) and
+  # deliberately absent from the summary gate's needs (warn-only must never
+  # block a merge).
+  devkit-staleness:
+    name: Devkit staleness
+    needs: [resolve-toolchain]
+    runs-on: ${{ fromJSON(needs.resolve-toolchain.outputs.runner-json) }}
+    timeout-minutes: 5
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+
+    steps:
+      - name: Compare DEVKIT_VERSION against the latest devkit release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PIN: ${{ needs.resolve-toolchain.outputs.image-tag }}
+        run: |
+          set -euo pipefail
+          if [ -z "$PIN" ]; then
+            echo "No DEVKIT_VERSION pin resolved; nothing to compare."
+            exit 0
+          fi
+          # Stable releases only: drafts and prereleases never count as "the
+          # release you are behind". Every failure path (offline runner, API
+          # error, missing gh on a self-hosted runner) degrades to a skip.
+          RELEASES="$(gh api repos/vig-os/devkit/releases --paginate \
+            --jq '.[] | select((.draft or .prerelease) | not) | .tag_name' 2>/dev/null || true)"
+          if [ -z "$RELEASES" ]; then
+            echo "Could not list devkit releases (offline or API error); skipping the staleness report."
+            exit 0
+          fi
+          LATEST="$(printf '%s\n' "$RELEASES" | sort -V | tail -n1)"
+          if [ "$PIN" = "$LATEST" ]; then
+            echo "DEVKIT_VERSION ${PIN} is the latest devkit release."
+            exit 0
+          fi
+          # Count the stable releases strictly newer than the pin. GNU
+          # `sort -V` orders `X.Y.Z-rcN` AFTER `X.Y.Z` (Debian convention, the
+          # opposite of semver), so map the prerelease dash to a tilde — which
+          # version-sorts before the final — and an rc pin counts as behind
+          # its own published final.
+          SORT_PIN="$(printf '%s' "$PIN" | sed 's/-/~/')"
+          BEHIND="$(printf '%s\n%s\n' "$RELEASES" "$SORT_PIN" | sort -uV \
+            | awk -v pin="$SORT_PIN" 'f { c++ } $0 == pin { f = 1 } END { print c + 0 }')"
+          if [ "$BEHIND" -eq 0 ]; then
+            echo "DEVKIT_VERSION ${PIN} is ahead of the latest published release (${LATEST})."
+            exit 0
+          fi
+          echo "::warning::DEVKIT_VERSION ${PIN} is ${BEHIND} release(s) behind the latest devkit release (${LATEST}). Run the devkit-upgrade workflow or 'install.sh --force --version ${LATEST}' to catch up."
+          {
+            echo "## Devkit staleness"
+            echo ""
+            echo "- **Pinned:** \`${PIN}\`"
+            echo "- **Latest:** \`${LATEST}\`"
+            echo "- **Behind:** ${BEHIND} stable release(s)"
+          } >> "$GITHUB_STEP_SUMMARY"
+
   # Blocks PRs that introduce known-vulnerable dependencies, off GitHub's
   # dependency graph (lockfiles + action pins alike) — no toolchain, no
   # container, no resolve-toolchain. Doubly guarded, mirroring the codeql.yml

--- a/assets/workspace/.github/workflows/devkit-upgrade.yml
+++ b/assets/workspace/.github/workflows/devkit-upgrade.yml
@@ -203,20 +203,32 @@ jobs:
             experimental-features = nix-command flakes
 
       - name: Run the devkit upgrade (install.sh --force)
+        id: upgrade
         if: steps.resolve.outputs.proceed == 'true'
         env:
           TARGET: ${{ steps.resolve.outputs.target }}
         run: |
           set -euo pipefail
           # docker is present on ubuntu-latest (install.sh auto-detects it); nix
-          # (installed above) advances the floating `vigos` flake.lock node. The
+          # (installed above) advances the floating devkit flake.lock node. The
           # workflow owns the branch, so bypass install.sh's own preflight guard.
           # --docker pins the runner's first-class runtime explicitly: the
           # preinstalled podman can pair with a stale system crun that rejects
           # podman >= 5's OCI configs (#1305) — auto-detection now prefers a
           # responsive docker anyway, this makes the choice self-documenting.
           curl -sSfL https://raw.githubusercontent.com/vig-os/devkit/main/install.sh \
-            | bash -s -- --force --version "$TARGET" --skip-preflight --docker .
+            | bash -s -- --force --version "$TARGET" --skip-preflight --docker . \
+            | tee "$RUNNER_TEMP/install.log"
+          # Surface the flake-input advance outcome (#1497): install.sh prints
+          # exactly one plain `flake-bump:` line per run — advanced, or skipped
+          # with the reason (pinned ref, no recognized input, no nix). A silent
+          # decline was the whole bug; the line rides into the step summary here
+          # and the adoption PR body below, so the consumer can decide.
+          FLAKE_BUMP="$(grep -E '^flake-bump:' "$RUNNER_TEMP/install.log" | tail -n1 || true)"
+          echo "flake-bump=${FLAKE_BUMP}" >> "$GITHUB_OUTPUT"
+          if [ -n "$FLAKE_BUMP" ]; then
+            echo "- ${FLAKE_BUMP}" >> "$GITHUB_STEP_SUMMARY"
+          fi
 
       - name: Reset excluded paths
         if: steps.resolve.outputs.proceed == 'true'
@@ -337,6 +349,7 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           TARGET: ${{ steps.resolve.outputs.target }}
           BRANCH: ${{ steps.branch.outputs.name }}
+          FLAKE_BUMP: ${{ steps.upgrade.outputs.flake-bump }}
           # PR base per workflow model (retargeted dev -> main at scaffold time).
           BASE: dev
         run: |
@@ -346,6 +359,11 @@ jobs:
           # stranded-issue cleanup this replaced was #1347).
           TITLE="chore: adopt devkit ${TARGET}"
           BODY="$(printf 'Automated devkit upgrade to %s via install.sh --force.\n\nReview the scaffold + flake.lock diff and merge. Release notes: https://github.com/vig-os/devkit/releases/tag/%s\n' "$TARGET" "$TARGET")"
+          # The flake-input outcome (#1497): a skipped advance is a decision
+          # the consumer makes, not a silent no-op — put it where they review.
+          if [ -n "$FLAKE_BUMP" ]; then
+            BODY="$(printf '%s\n%s\n' "$BODY" "$FLAKE_BUMP")"
+          fi
           if gh pr view "$BRANCH" --json number >/dev/null 2>&1; then
             gh pr edit "$BRANCH" --title "$TITLE" --body "$BODY"
             echo "Updated the existing adoption PR."

--- a/assets/workspace/docs/DOWNSTREAM_RELEASE.md
+++ b/assets/workspace/docs/DOWNSTREAM_RELEASE.md
@@ -368,3 +368,10 @@ jobs:
 Release workflow logic is centralized in shipped local reusable workflows (`release-core.yml`, `release-publish.yml`) while extension logic remains project-owned (`release-extension.yml`).
 
 This reduces drift in release safety checks while preserving downstream customization boundaries.
+
+Two independent staleness axes are reported in CI ([#1497](https://github.com/vig-os/devkit/issues/1497)):
+
+- **Scaffold drift** (`scaffold-drift` job, gate): the working tree diverges from what the *pinned* `DEVKIT_VERSION` would scaffold. Opt out with `DEVKIT_DRIFT_CHECK=false`.
+- **Pin staleness** (`devkit-staleness` job, warn-only): the pin itself is behind the latest devkit release — invisible to the drift gate by construction, since it compares the pin against itself. The report is a `::warning` annotation plus a step-summary block; it never fails the build and is not silenced by the drift opt-out.
+
+The flake-input axis is reported by the upgrade lane itself: `install.sh --force` prints one `flake-bump:` line per run — advanced (any input name at the floating `github:vig-os/devkit` URL), or skipped with the reason (a pinned ref, in either `?ref=X` or `/X` form, is never auto-bumped) — and `devkit-upgrade.yml` carries that line into the adoption PR body.

--- a/docs/DOWNSTREAM_RELEASE.md
+++ b/docs/DOWNSTREAM_RELEASE.md
@@ -365,3 +365,10 @@ jobs:
 Release workflow logic is centralized in shipped local reusable workflows (`release-core.yml`, `release-publish.yml`) while extension logic remains project-owned (`release-extension.yml`).
 
 This reduces drift in release safety checks while preserving downstream customization boundaries.
+
+Two independent staleness axes are reported in CI ([#1497](https://github.com/vig-os/devkit/issues/1497)):
+
+- **Scaffold drift** (`scaffold-drift` job, gate): the working tree diverges from what the *pinned* `DEVKIT_VERSION` would scaffold. Opt out with `DEVKIT_DRIFT_CHECK=false`.
+- **Pin staleness** (`devkit-staleness` job, warn-only): the pin itself is behind the latest devkit release — invisible to the drift gate by construction, since it compares the pin against itself. The report is a `::warning` annotation plus a step-summary block; it never fails the build and is not silenced by the drift opt-out.
+
+The flake-input axis is reported by the upgrade lane itself: `install.sh --force` prints one `flake-bump:` line per run — advanced (any input name at the floating `github:vig-os/devkit` URL), or skipped with the reason (a pinned ref, in either `?ref=X` or `/X` form, is never auto-bumped) — and `devkit-upgrade.yml` carries that line into the adoption PR body.

--- a/install.sh
+++ b/install.sh
@@ -1073,40 +1073,61 @@ if ! setup_git_repo "$PROJECT_PATH"; then
     echo "    cd $PROJECT_PATH && git init -b main && git add -A && git commit -m 'chore: initial project scaffold'"
 fi
 
-# 3. Floating vigos flake-lock advance (#1263)
+# 3. Floating devkit flake-lock advance (#1263, name-agnostic since #1497)
 # An upgrade advances .vig-os DEVKIT_VERSION (scaffold + image), but a FLOATING
-# `vigos` input's dev shell is governed by flake.lock, which stays wherever the
-# last `nix flake update vigos` left it — so the direnv toolchain (vig-utils,
+# devkit input's dev shell is governed by flake.lock, which stays wherever the
+# last `nix flake update <input>` left it — so the direnv toolchain (vig-utils,
 # hook sets) silently keeps running the previous release. Advance the lock
 # here, on the host, after the ownership repair and git phase: a direnv
 # consumer has nix by definition, and the scaffold container must not write the
 # lock (network dependence + root-owned output hazards, #1235/#1248). Pinned
-# (?ref=) inputs are the consumer's explicit choice and get the #1093
-# init-workspace.sh warning instead; a missing flake.lock (fresh scaffold)
-# locks current content on first shell entry anyway. Upgrades only (--force):
-# the skew needs a pre-existing lock to lag behind. Non-fatal on failure
-# (e.g. offline): print the manual step. The anchored grep matches the REAL
-# floating input line only — the doc-comment example and any ?ref= pin do not
-# match (same anchoring rationale as #1110).
+# inputs are the consumer's explicit choice and are never auto-bumped; a
+# missing flake.lock (fresh scaffold) locks current content on first shell
+# entry anyway. Upgrades only (--force): the skew needs a pre-existing lock to
+# lag behind. Non-fatal on failure (e.g. offline): print the manual step.
+#
+# flake.nix is a PRESERVE_FILE, so the input may be named anything and may pin
+# a ref in either form (?ref=X, or the /X path suffix). The advance is keyed
+# on the URL, not on a literal `vigos` name (#1497), and EVERY outcome prints
+# one plain `flake-bump:` line — a silent decline left the weekly upgrade
+# green while the flake input stayed frozen; the upgrade workflow surfaces the
+# line in the adoption PR. One-liner `<name>.url = "..."` declarations are
+# recognized; the anchored grep never matches the doc-comment example (#1110).
 if [ -n "$FORCE" ] && { [ "$MODE" = "direnv" ] || [ "$MODE" = "both" ]; } \
-    && [ -f "$PROJECT_PATH/flake.nix" ] && [ -f "$PROJECT_PATH/flake.lock" ] \
-    && grep -qE '^[[:space:]]*vigos\.url[[:space:]]*=[[:space:]]*"github:vig-os/devkit"' \
-        "$PROJECT_PATH/flake.nix"; then
-    if command -v nix >/dev/null 2>&1; then
-        info "Advancing the floating vigos flake input (nix flake update vigos)..."
-        if nix --extra-experimental-features "nix-command flakes" \
-            flake update vigos --flake "$PROJECT_PATH"; then
-            info "flake.lock advanced; review and commit it with the upgrade."
-        else
-            warn "nix flake update vigos failed (non-fatal)"
-            echo "  The dev-shell toolchain still points at the previously locked release."
-            echo "  Advance it manually:"
-            echo "    cd $PROJECT_PATH && nix flake update vigos"
-        fi
+    && [ -f "$PROJECT_PATH/flake.nix" ] && [ -f "$PROJECT_PATH/flake.lock" ]; then
+    DEVKIT_INPUT_LINE="$(grep -E '^[[:space:]]*(inputs\.)?[A-Za-z0-9_-]+\.url[[:space:]]*=[[:space:]]*"github:vig-os/devkit["/?]' \
+        "$PROJECT_PATH/flake.nix" | head -n1 || true)"
+    if [ -z "$DEVKIT_INPUT_LINE" ]; then
+        echo "flake-bump: no devkit input recognized in flake.nix; nothing to advance"
     else
-        warn "nix not found on PATH; the dev-shell toolchain keeps the previously locked release"
-        echo "  Advance it from a machine with nix:"
-        echo "    cd $PROJECT_PATH && nix flake update vigos"
+        DEVKIT_INPUT_NAME="$(printf '%s' "$DEVKIT_INPUT_LINE" \
+            | sed -E 's/^[[:space:]]*(inputs\.)?([A-Za-z0-9_-]+)\.url.*/\2/')"
+        DEVKIT_INPUT_URL="$(printf '%s' "$DEVKIT_INPUT_LINE" \
+            | sed -E 's/.*"(github:vig-os\/devkit[^"]*)".*/\1/')"
+        if [ "$DEVKIT_INPUT_URL" = "github:vig-os/devkit" ]; then
+            if command -v nix >/dev/null 2>&1; then
+                info "Advancing the floating '$DEVKIT_INPUT_NAME' flake input (nix flake update $DEVKIT_INPUT_NAME)..."
+                if nix --extra-experimental-features "nix-command flakes" \
+                    flake update "$DEVKIT_INPUT_NAME" --flake "$PROJECT_PATH"; then
+                    echo "flake-bump: advanced input '$DEVKIT_INPUT_NAME'; review and commit flake.lock with the upgrade"
+                else
+                    echo "flake-bump: failed — nix flake update $DEVKIT_INPUT_NAME did not succeed (non-fatal)"
+                    echo "  The dev-shell toolchain still points at the previously locked release."
+                    echo "  Advance it manually:"
+                    echo "    cd $PROJECT_PATH && nix flake update $DEVKIT_INPUT_NAME"
+                fi
+            else
+                echo "flake-bump: skipped — nix not found on PATH; the dev-shell toolchain keeps the previously locked release"
+                echo "  Advance it from a machine with nix:"
+                echo "    cd $PROJECT_PATH && nix flake update $DEVKIT_INPUT_NAME"
+            fi
+        else
+            DEVKIT_PINNED_REF="$(printf '%s' "$DEVKIT_INPUT_URL" \
+                | sed -E 's|^github:vig-os/devkit[/?](ref=)?||')"
+            echo "flake-bump: skipped — input '$DEVKIT_INPUT_NAME' is pinned to '$DEVKIT_PINNED_REF' (your explicit choice; never auto-bumped)"
+            echo "  To follow releases automatically: $DEVKIT_INPUT_NAME.url = \"github:vig-os/devkit\""
+            echo "  To advance the pin: point it at the new release, then run 'nix flake update $DEVKIT_INPUT_NAME'."
+        fi
     fi
 fi
 

--- a/tests/bats/init-workspace.bats
+++ b/tests/bats/init-workspace.bats
@@ -1146,16 +1146,17 @@ _scaffold_with_version_file() {
 # a pinned vigos ref in the consumer's flake.nix differs from the DEVKIT_VERSION
 # being written. A floating (unpinned) input is intentional and never warns.
 
-# Pre-seed $ws/flake.nix carrying a $url vigos input, then --force upgrade the
-# direnv scaffold to $target (via the image built-tag record).
+# Pre-seed $ws/flake.nix carrying a $url devkit input (named $4, default
+# vigos — the input name is the consumer's choice, #1497), then --force
+# upgrade the direnv scaffold to $target (via the image built-tag record).
 _upgrade_direnv_with_flake_url() {
-    local ws="$1" target="$2" url="$3"
+    local ws="$1" target="$2" url="$3" name="${4:-vigos}"
     mkdir -p "$ws"
     cat >"$ws/flake.nix" <<EOF
 {
   inputs = {
-    vigos.url = "$url";
-    nixpkgs.follows = "vigos/nixpkgs";
+    $name.url = "$url";
+    nixpkgs.follows = "$name/nixpkgs";
   };
 }
 EOF
@@ -1180,7 +1181,32 @@ EOF
 @test "init-workspace is silent when the vigos flake input floats unpinned (#1093)" {
     run _upgrade_direnv_with_flake_url "$BATS_TEST_TMPDIR/e2e-1093-float" 1.2.0 "github:vig-os/devkit"
     assert_success
-    refute_output --partial "pinned vigos flake input is still"
+    refute_output --partial "flake input is still"
+}
+
+# ── the skew warning is name-agnostic and knows both pin forms (#1497) ────────
+# flake.nix is a PRESERVE_FILE: an input named `devkit`, or pinned with the
+# `/ref` path suffix instead of `?ref=`, is a legitimate consumer choice — the
+# field case carried `devkit.url = "github:vig-os/devkit/dev"` and got neither
+# a bump nor a warning from any mechanism.
+
+@test "init-workspace warns on a path-ref pin that lags the target (#1497)" {
+    run _upgrade_direnv_with_flake_url "$BATS_TEST_TMPDIR/e2e-1497-pathref" 1.2.0 "github:vig-os/devkit/1.1.0"
+    assert_success
+    assert_output --partial "flake input is still 1.1.0"
+}
+
+@test "init-workspace warns on a renamed pinned input, naming it (#1497)" {
+    run _upgrade_direnv_with_flake_url "$BATS_TEST_TMPDIR/e2e-1497-renamed" 1.2.0 "github:vig-os/devkit?ref=1.1.0" devkit
+    assert_success
+    assert_output --partial "pinned devkit flake input is still 1.1.0"
+    assert_output --partial "nix flake update devkit"
+}
+
+@test "init-workspace stays silent on an aligned path-ref pin (#1497)" {
+    run _upgrade_direnv_with_flake_url "$BATS_TEST_TMPDIR/e2e-1497-aligned" 1.2.0 "github:vig-os/devkit/1.2.0"
+    assert_success
+    refute_output --partial "flake input is still"
 }
 
 # ── skew warning reads the real pin, not the doc-comment (#1110) ──────────────

--- a/tests/bats/install.bats
+++ b/tests/bats/install.bats
@@ -1051,3 +1051,82 @@ STUB
     assert_success
     assert_output --partial "nix flake update vigos"
 }
+
+# ── name-agnostic devkit input discovery + loud skip (#1497) ──────────────────
+# flake.nix is a PRESERVE_FILE, so the consumer's devkit input may be named
+# anything and may pin a ref in either form (?ref=X, or the /X path suffix the
+# field case used). The #1263 advance was guarded by a grep matching only an
+# input literally named `vigos` at the unpinned URL — every other spelling was
+# skipped with no message at all, so the weekly upgrade reported success while
+# the flake input (where the Rust pack lives entirely) stayed frozen. The
+# advance is now keyed on the URL, not the name, and EVERY outcome prints a
+# `flake-bump:` line the upgrade workflow surfaces in the adoption PR.
+
+@test "upgrade advances a floating input named devkit (#1497)" {
+    dir="$BATS_TEST_TMPDIR/flake-renamed"
+    log="$BATS_TEST_TMPDIR/flake-renamed-nix.log"
+    _make_flake_workspace "$dir" 'devkit.url = "github:vig-os/devkit";'
+    _run_install_nix_stub "$dir" "$log" 0 --force
+    assert_success
+    assert_output --partial "flake-bump: advanced"
+    run grep -F "flake update devkit --flake $dir" "$log"
+    assert_success
+}
+
+@test "the floating vigos advance reports flake-bump: advanced (#1497)" {
+    dir="$BATS_TEST_TMPDIR/flake-report-advanced"
+    log="$BATS_TEST_TMPDIR/flake-report-advanced-nix.log"
+    _make_flake_workspace "$dir" 'vigos.url = "github:vig-os/devkit";'
+    _run_install_nix_stub "$dir" "$log" 0 --force
+    assert_success
+    assert_output --partial "flake-bump: advanced"
+}
+
+@test "a path-ref pinned input is left alone but reported (#1497)" {
+    dir="$BATS_TEST_TMPDIR/flake-path-ref"
+    log="$BATS_TEST_TMPDIR/flake-path-ref-nix.log"
+    _make_flake_workspace "$dir" 'devkit.url = "github:vig-os/devkit/dev";'
+    _run_install_nix_stub "$dir" "$log" 0 --force
+    assert_success
+    assert_output --partial "flake-bump: skipped"
+    assert_output --partial "dev"
+    run grep -F "flake update" "$log"
+    assert_failure
+}
+
+@test "a ?ref= pinned input reports the skip (#1497)" {
+    dir="$BATS_TEST_TMPDIR/flake-qref-report"
+    log="$BATS_TEST_TMPDIR/flake-qref-report-nix.log"
+    _make_flake_workspace "$dir" 'vigos.url = "github:vig-os/devkit?ref=1.4.1";'
+    _run_install_nix_stub "$dir" "$log" 0 --force
+    assert_success
+    assert_output --partial "flake-bump: skipped"
+    assert_output --partial "1.4.1"
+    run grep -F "flake update" "$log"
+    assert_failure
+}
+
+@test "no recognized devkit input reports it and advances nothing (#1497)" {
+    dir="$BATS_TEST_TMPDIR/flake-no-input"
+    log="$BATS_TEST_TMPDIR/flake-no-input-nix.log"
+    _make_flake_workspace "$dir" 'scitadel.url = "github:vig-os/scitadel";'
+    _run_install_nix_stub "$dir" "$log" 0 --force
+    assert_success
+    assert_output --partial "flake-bump: no devkit input"
+    run grep -F "flake update" "$log"
+    assert_failure
+}
+
+@test "the doc-comment example never counts as the devkit input (#1497)" {
+    # _make_flake_workspace always writes the commented example line above the
+    # real input; with no real devkit input present, the comment alone must not
+    # trigger an advance or a pinned-skip report.
+    dir="$BATS_TEST_TMPDIR/flake-comment-only"
+    log="$BATS_TEST_TMPDIR/flake-comment-only-nix.log"
+    _make_flake_workspace "$dir" 'scitadel.url = "github:vig-os/scitadel";'
+    _run_install_nix_stub "$dir" "$log" 0 --force
+    assert_success
+    refute_output --partial "flake-bump: skipped"
+    run grep -F "flake update" "$log"
+    assert_failure
+}

--- a/tests/test_devkit_staleness.py
+++ b/tests/test_devkit_staleness.py
@@ -1,0 +1,140 @@
+"""Workflow-shape + behavioral tests: the warn-only devkit-staleness job (#1497).
+
+``scaffold-drift`` resolves its comparison image from the consumer's own
+``DEVKIT_VERSION`` pin, so it compares the pin against itself — being behind is
+invisible to it *by construction* (the field case sat two minor versions behind
+with a green drift check). This job answers the other question — is the pin
+behind the latest devkit release? — and never fails the build: the report is a
+``::warning`` annotation plus a step-summary line, not a gate. Deliberately:
+
+- **not** gated on ``DEVKIT_DRIFT_CHECK`` and needing no docker runner — a
+  consumer who disabled the (expensive, containerized) drift gate still sees
+  the (cheap, API-only) staleness report;
+- **not** in the ``summary`` gate's ``needs`` — a warn-only job must never
+  block a merge (the summary needs-set is pinned in
+  ``test_workflow_summary_gate.py``).
+
+Refs: #1497
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from typing import TYPE_CHECKING
+
+import pytest
+
+from tests.workflow_scaffold import WORKFLOWS, jobs, load_workflow, needs_of
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+JOB = "devkit-staleness"
+
+
+def _job() -> dict:
+    return jobs(load_workflow(WORKFLOWS / "ci.yml"))[JOB]
+
+
+def _step_run() -> str:
+    (step,) = [s for s in _job()["steps"] if "run" in s]
+    return str(step["run"])
+
+
+# ── shape ─────────────────────────────────────────────────────────────────────
+
+
+def test_ci_declares_the_staleness_job() -> None:
+    assert JOB in jobs(load_workflow(WORKFLOWS / "ci.yml"))
+
+
+def test_staleness_is_pr_only_and_not_drift_gated() -> None:
+    """PR-gated like drift, but immune to the DEVKIT_DRIFT_CHECK opt-out."""
+    job = _job()
+    assert "pull_request" in str(job["if"])
+    assert "drift-check" not in str(job["if"])
+
+
+def test_staleness_reads_the_resolved_pin() -> None:
+    """The pin comes from resolve-toolchain (legacy-key handling included)."""
+    job = _job()
+    assert "resolve-toolchain" in needs_of(job)
+    (step,) = [s for s in job["steps"] if "run" in s]
+    assert step["env"]["PIN"] == "${{ needs.resolve-toolchain.outputs.image-tag }}"
+    assert step["env"]["GH_TOKEN"] == "${{ github.token }}"
+
+
+def test_staleness_warns_and_never_fails() -> None:
+    run = _step_run()
+    assert "::warning::" in run
+    assert "::error::" not in run
+    assert "exit 1" not in run, "the staleness report must never fail the build"
+
+
+def test_staleness_stays_out_of_the_summary_gate() -> None:
+    """Warn-only: a red/missing staleness job must never block a merge."""
+    summary = jobs(load_workflow(WORKFLOWS / "ci.yml"))["summary"]
+    assert JOB not in needs_of(summary)
+
+
+# ── behavior: execute the real run block against a stubbed gh ─────────────────
+
+RELEASES = ["1.8.0", "1.9.0", "1.10.0"]
+
+
+def _run_staleness(
+    tmp_path: Path, pin: str, gh_exit: int = 0
+) -> subprocess.CompletedProcess:
+    stub_dir = tmp_path / "bin"
+    stub_dir.mkdir()
+    gh = stub_dir / "gh"
+    body = "\n".join(RELEASES)
+    gh.write_text(
+        f"#!/usr/bin/env bash\n[ {gh_exit} -ne 0 ] && exit {gh_exit}\nprintf '%s\\n' \"{body}\"\n"
+    )
+    gh.chmod(0o755)
+    summary = tmp_path / "summary.md"
+    summary.touch()
+    return subprocess.run(
+        ["bash", "-c", _step_run()],
+        cwd=tmp_path,
+        env={
+            **os.environ,
+            "PATH": f"{stub_dir}:{os.environ['PATH']}",
+            "PIN": pin,
+            "GH_TOKEN": "test-token",
+            "GITHUB_STEP_SUMMARY": str(summary),
+        },
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_behind_pin_emits_a_counted_warning(tmp_path: Path) -> None:
+    proc = _run_staleness(tmp_path, "1.8.0")
+    assert proc.returncode == 0, proc.stderr
+    assert "::warning::" in proc.stdout
+    assert "2" in proc.stdout, f"expected the behind-count in:\n{proc.stdout}"
+    assert "1.10.0" in proc.stdout
+    assert "1.10.0" in (tmp_path / "summary.md").read_text()
+
+
+def test_current_pin_is_silent(tmp_path: Path) -> None:
+    proc = _run_staleness(tmp_path, "1.10.0")
+    assert proc.returncode == 0, proc.stderr
+    assert "::warning::" not in proc.stdout
+
+
+@pytest.mark.parametrize("pin", ["", "1.8.0"])
+def test_api_failure_and_empty_pin_never_fail(tmp_path: Path, pin: str) -> None:
+    proc = _run_staleness(tmp_path, pin, gh_exit=1 if pin else 0)
+    assert proc.returncode == 0, proc.stderr
+    assert "::warning::" not in proc.stdout
+
+
+def test_rc_pin_counts_as_behind_its_final(tmp_path: Path) -> None:
+    """A 1.10.0-rc1 pin sorts before 1.10.0 and reports 1 release behind."""
+    proc = _run_staleness(tmp_path, "1.10.0-rc1")
+    assert proc.returncode == 0, proc.stderr
+    assert "::warning::" in proc.stdout

--- a/tests/test_workflow_devkit_upgrade.py
+++ b/tests/test_workflow_devkit_upgrade.py
@@ -225,6 +225,40 @@ def test_bootstraps_installsh_and_commits_in_project_shell() -> None:
     assert "install-nix-action" in text
 
 
+def test_upgrade_step_captures_the_flake_bump_report() -> None:
+    """The install.sh output's ``flake-bump:`` line becomes a step output (#1497).
+
+    install.sh prints exactly one ``flake-bump:`` line per run (advanced /
+    skipped-with-reason / no input recognized). A silent decline was the whole
+    bug — the workflow must capture the line so the adoption PR can carry it.
+    """
+    doc = yaml.safe_load(TEMPLATE.read_text(encoding="utf-8"))
+    (job,) = doc["jobs"].values()
+    step = next(
+        s
+        for s in job["steps"]
+        if str(s.get("name", "")).startswith("Run the devkit upgrade")
+    )
+    assert step.get("id") == "upgrade"
+    run = str(step["run"])
+    assert "tee" in run, "install.sh output must be captured, not discarded"
+    assert "flake-bump:" in run
+    assert "flake-bump=" in run and "GITHUB_OUTPUT" in run
+
+
+def test_pr_body_carries_the_flake_bump_report_via_env() -> None:
+    """The adoption PR body includes the flake-bump outcome, env-routed (#1497).
+
+    Routed through ``env:`` (never ``${{ }}`` inside ``run:``) per the
+    template-injection doctrine pinned below.
+    """
+    doc = yaml.safe_load(TEMPLATE.read_text(encoding="utf-8"))
+    (job,) = doc["jobs"].values()
+    step = next(s for s in job["steps"] if "adoption PR" in str(s.get("name", "")))
+    assert step["env"]["FLAKE_BUMP"] == "${{ steps.upgrade.outputs.flake-bump }}"
+    assert "$FLAKE_BUMP" in str(step["run"])
+
+
 def test_reset_excluded_paths() -> None:
     """DEVKIT_UPGRADE_EXCLUDE paths are reset to the base branch before commit."""
     text = TEMPLATE.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

Fixes both unobservable staleness axes from #1497 (found auditing the Rust pack's upgrade story — the field consumer sat two minor versions behind with a green weekly upgrade *and* a green drift check):

**Axis 1 — flake auto-bump (`install.sh`)**
- The advance is keyed on the `github:vig-os/devkit` URL, not a literal input named `vigos`: a floating input under **any name** is advanced (`nix flake update <name>`)
- Pinned refs — `?ref=X` **or** the `/X` path-suffix form the field case used — are never auto-bumped (a pin is the consumer's explicit choice), but the skip is now **reported with the reason**
- Every run prints exactly one plain `flake-bump:` outcome line (advanced / skipped-pinned / skipped-no-nix / failed / no input recognized); the doc-comment example line still never matches (#1110 anchoring preserved)
- The #1093 pin-skew warning in `init-workspace.sh` learns the same name-agnostic, both-forms discovery and names the actual input in its guidance
- `devkit-upgrade.yml` tees the install output, captures the `flake-bump:` line as a step output, and carries it into the **adoption PR body** and the step summary (env-routed, no run-block interpolation)

**Axis 2 — pin staleness (scaffolded `ci.yml`)**
- New warn-only `devkit-staleness` job: cheap API query comparing `DEVKIT_VERSION` against the latest stable devkit release, annotating PRs with `::warning` ("N release(s) behind") plus a step-summary block
- Deliberately **not** gated on `DEVKIT_DRIFT_CHECK` (no docker/image pull — disabling the expensive drift gate must not silence the cheap report), **never fails the build** (every failure path degrades to a skip, including missing `gh` on self-hosted runners), and deliberately **outside the summary gate**
- An rc pin counts as behind its own published final (GNU `sort -V` orders `-rcN` after the final, so the compare maps the dash to a tilde)

**Out of scope** (deliberate): the mkRustProject eval-time notice (issue suggestion 4) — the acceptance criteria are met without it and it would be the codebase's first Nix eval-warn mechanism.

## Acceptance criteria from the issue

- [x] A consumer whose input is named anything, pinned or not, either gets bumped or is **told** why not
- [x] Something answers "is this repo behind?" without deriving the answer from the repo's own pin

## Test plan

- `install.bats`: 6 new tests (renamed floating input advanced; path-ref and `?ref=` pins skipped-and-reported; no-input reported; doc-comment decoy immune) — existing #1263 suite untouched and green
- `init-workspace.bats`: 3 new #1093-extension tests (path-ref lag warns; renamed pinned input warns naming the input; aligned path-ref silent)
- New `tests/test_devkit_staleness.py`: shape tests (PR-only, not drift-gated, resolved pin via `resolve-toolchain`, warn-never-fail, outside the summary gate) + behavioral tests executing the real run block against a stubbed `gh` (behind-count, current-silent, API-failure/empty-pin tolerance, rc-behind-final)
- `test_workflow_devkit_upgrade.py`: 2 new tests (flake-bump capture; env-routed PR-body threading)
- Full local run: bats 546/546 green, pytest 1504 passed (2 known local-env failures unrelated), `prek run --all-files` green

Refs: #1497