### PR TITLE
docs(changelog): avoid agent-fingerprint literal in 1.10.0 entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,8 +147,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `promote-release.yml`'s `reset-sync-mirror` embedded the Commit App token
     in the push URL, but `actions/checkout` persists its own credentials as
     `http.<host>.extraheader`, which outranks URL userinfo. The force-push
-    therefore ran as `github-actions[bot]` under `contents: read` and failed
-    with a 403 on every mirror-mode consumer — after the release was already
+    therefore ran as the default GitHub Actions identity under `contents: read`
+    and failed with a 403 on every mirror-mode consumer — after the release was already
     published, so the red run misrepresented an otherwise healthy promote.
     The job now generates the App token *before* checkout and checks out with
     it, and `contents: read` stays deliberately in place

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -147,8 +147,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `promote-release.yml`'s `reset-sync-mirror` embedded the Commit App token
     in the push URL, but `actions/checkout` persists its own credentials as
     `http.<host>.extraheader`, which outranks URL userinfo. The force-push
-    therefore ran as `github-actions[bot]` under `contents: read` and failed
-    with a 403 on every mirror-mode consumer — after the release was already
+    therefore ran as the default GitHub Actions identity under `contents: read`
+    and failed with a 403 on every mirror-mode consumer — after the release was already
     published, so the red run misrepresented an otherwise healthy promote.
     The job now generates the App token *before* checkout and checks out with
     it, and `contents: read` stays deliberately in place


### PR DESCRIPTION
## Summary

Rewords the #1503 entry in the frozen `[1.10.0] - TBD` section: the entry named the Actions bot identity literally, and `prepare-release` copies the CHANGELOG into the release PR body, where the agent-fingerprint check (`Commit Messages` job) blocks that string — CI on release PR #1515 is red solely because of it.

Descriptive prose ("the default GitHub Actions identity") carries the same information without the literal. Verified locally: `check-pr-agent-fingerprints` passes on the reworded section.

`dev` intentionally untouched — the post-promote sync merge carries the reworded `[1.10.0]` section back cleanly (dev's copy stays at the merge base).

Checker-side hardening (contextual email matching / code-span stripping) stays open in the issue for a later milestone.

Closes #1516

## Checklist
- [x] CHANGELOG: no entry needed (wording-only fix inside the frozen 1.10.0 section itself)
- [x] Full pre-commit suite green locally
