### PR TITLE
fix(workspace): reword mirror-fold comment to lint under a stock typos seed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Generated mirror-fold comment now lints under the stock consumer typos
+  seed** ([#1529](https://github.com/vig-os/devkit/issues/1529))
+  - A comment the `DEVKIT_SYNC_TARGET` block renders into the managed
+    `release-core.yml` used a token that only devkit's own `.typos.toml`
+    allowlists, so every mirror-mode consumer whose seeded `.typos.toml`
+    predates that entry failed its `devkit-upgrade` at the commit step —
+    `.typos.toml` is seeded once and never overwritten, so the consumer could
+    not receive the entry. Reworded; the tree the scaffold generates is now
+    typo-clean with no allowlist at all
+  - Pinned by a new bats fixture that renders a mirror-mode workspace in both
+    workflow models and runs `typos` (no allowlist) plus `actionlint` over it
+    ([#1531](https://github.com/vig-os/devkit/issues/1531)) — the fold block
+    has one consumer in the org, so nothing else linted it
+
 ### Security
 
 ## [1.10.0](https://github.com/vig-os/devkit/releases/tag/1.10.0) - 2026-08-14

--- a/assets/init-workspace.sh
+++ b/assets/init-workspace.sh
@@ -1788,7 +1788,7 @@ YAML
           # newline-joined value folds NOTHING while every step stays green
           # (#1502). Build the list from the staged diff with NUL framing:
           # git status --porcelain C-quotes paths containing spaces and renders
-          # renames as "R old -> new", both of which mis-parse. The tr has to
+          # renames as "R old -> new", both of which parse wrong. The tr has to
           # run inside the pipeline — command substitution drops NUL bytes.
           mirror_paths() {
             git diff --cached --name-only --no-renames --diff-filter=ACM -z -- docs/issues docs/pull-requests

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -17,6 +17,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Generated mirror-fold comment now lints under the stock consumer typos
+  seed** ([#1529](https://github.com/vig-os/devkit/issues/1529))
+  - A comment the `DEVKIT_SYNC_TARGET` block renders into the managed
+    `release-core.yml` used a token that only devkit's own `.typos.toml`
+    allowlists, so every mirror-mode consumer whose seeded `.typos.toml`
+    predates that entry failed its `devkit-upgrade` at the commit step —
+    `.typos.toml` is seeded once and never overwritten, so the consumer could
+    not receive the entry. Reworded; the tree the scaffold generates is now
+    typo-clean with no allowlist at all
+  - Pinned by a new bats fixture that renders a mirror-mode workspace in both
+    workflow models and runs `typos` (no allowlist) plus `actionlint` over it
+    ([#1531](https://github.com/vig-os/devkit/issues/1531)) — the fold block
+    has one consumer in the org, so nothing else linted it
+
 ### Security
 
 ## [1.10.0](https://github.com/vig-os/devkit/releases/tag/1.10.0) - 2026-08-14

--- a/tests/bats/release-mirror-fold-lint.bats
+++ b/tests/bats/release-mirror-fold-lint.bats
@@ -1,0 +1,110 @@
+#!/usr/bin/env bats
+# BATS tests: the DEVKIT_SYNC_TARGET mirror-fold render must LINT inside a
+# consumer repo (#1531).
+#
+# The sibling files cover the other two halves of this render: init-workspace.bats
+# pins that the fold steps are RENDERED, release-mirror-fold.bats EXECUTES the
+# rendered `run:` blocks. Neither looks at the rendered tree the way a consumer's
+# own hooks do — and the fold block has exactly one consumer in the org, so a
+# lint regression inside it is discovered by that consumer's scheduled upgrade,
+# in production (#1529).
+#
+# Two lints, over a fully rendered mirror-mode workspace in both workflow models:
+#
+#   typos      — with NO allowlist at all (`--isolated`, no `--config`). A
+#                consumer's `.typos.toml` is seeded once and never overwritten by
+#                an upgrade, so generated content may not rely on ANY entry in
+#                it: not one devkit later added to its own config (#1488's `mis`,
+#                which is exactly what broke the org-config upgrade in #1529),
+#                and not one the current seed happens to carry, because the
+#                consumer's copy predates it. `--hidden` is needed because the
+#                interesting files live under the dot-directory `.github/`, which
+#                typos' tree walk skips by default (a consumer's hook never
+#                walks: prek hands it the file list).
+#   actionlint — over the rendered workflows. The existing per-mode actionlint
+#                fixtures render the DEFAULT path; the fold injects steps into
+#                release-core.yml and a whole job into promote-release.yml, which
+#                nothing linted before.
+#
+# The workspace is rendered in `direnv` mode, the shape of the sole mirror-mode
+# consumer. A devcontainer-mode tree additionally ships `.devcontainer/` — the
+# synced devkit CHANGELOG and `version-check.sh` — whose prose does lean on seed
+# entries (`Nd`, `passt`, and released changelog text that may never be edited).
+# Whether the seed should carry words for those at all is the open question in
+# #1529, not the subject of this pin.
+
+setup() {
+    load test_helper
+    MIRROR_GITFLOW="$BATS_FILE_TMPDIR/mirror-gitflow"
+    MIRROR_TRUNK="$BATS_FILE_TMPDIR/mirror-trunk"
+}
+
+# Render both mirror-mode workspaces ONCE for the whole file: the tests only
+# lint the rendered trees, and scaffold+upgrade is the slow part.
+setup_file() {
+    local root
+    root="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+    _render_mirror "$root" gitflow "$BATS_FILE_TMPDIR/mirror-gitflow" || return 1
+    _render_mirror "$root" trunk "$BATS_FILE_TMPDIR/mirror-trunk" || return 1
+}
+
+# Render a mirror-mode consumer workspace for workflow model $2 into $3.
+# Mirror mode is not a scaffold flag: the manifest key is set on the scaffolded
+# workspace and a second (upgrade) pass injects the fold block, which is how a
+# consumer reaches this state.
+_render_mirror() {
+    local root="$1" model="$2" ws="$3"
+    local stub="$BATS_FILE_TMPDIR/stub-bin"
+    mkdir -p "$ws" "$stub"
+    printf '#!/usr/bin/env bash\nexit 0\n' >"$stub/just"
+    chmod +x "$stub/just"
+    env PATH="$stub:$PATH" \
+        TEMPLATE_DIR="$root/assets/workspace" \
+        WORKSPACE_DIR="$ws" \
+        SHORT_NAME=testproj \
+        GITHUB_REPOSITORY=test/repo \
+        bash "$root/assets/init-workspace.sh" --force --no-prompts \
+        --mode direnv --workflow "$model" \
+        >"$ws.log" 2>&1 || { cat "$ws.log" >&2; return 1; }
+    sed -i 's#^DEVKIT_SYNC_TARGET=.*#DEVKIT_SYNC_TARGET=sync/issue-mirror#' "$ws/.vig-os"
+    env PATH="$stub:$PATH" \
+        TEMPLATE_DIR="$root/assets/workspace" \
+        WORKSPACE_DIR="$ws" \
+        bash "$root/assets/init-workspace.sh" --force --no-prompts \
+        >>"$ws.log" 2>&1 || { cat "$ws.log" >&2; return 1; }
+    # Fixture precondition, not a test: without the fold block the lints below
+    # would pass over a workspace that never rendered it — green and vacuous.
+    local rc="$ws/.github/workflows/release-core.yml"
+    grep -qF 'name: Stage sync mirror archive for fold' "$rc" ||
+        { echo "$model render: fold steps missing from release-core.yml" >&2; return 1; }
+    grep -qF -- '-f "target-branch=sync/issue-mirror"' "$rc" ||
+        { echo "$model render: sync dispatch not retargeted to the mirror" >&2; return 1; }
+    # actionlint resolves `./.github/workflows/<reusable>` against the git root,
+    # so it needs one — a real consumer repo is a git repo.
+    git -C "$ws" init -q
+}
+
+# typos as a consumer with an untouched seed would see it: no allowlist.
+_typos_strict() { (cd "$1" && typos --hidden --isolated); }
+
+_actionlint() { (cd "$1" && actionlint); }
+
+@test "the gitflow mirror-fold render is typos-clean with no allowlist (#1529)" {
+    run _typos_strict "$MIRROR_GITFLOW"
+    assert_success
+}
+
+@test "the trunk mirror-fold render is typos-clean with no allowlist (#1529)" {
+    run _typos_strict "$MIRROR_TRUNK"
+    assert_success
+}
+
+@test "actionlint passes over the gitflow mirror-fold render (#1531)" {
+    run _actionlint "$MIRROR_GITFLOW"
+    assert_success
+}
+
+@test "actionlint passes over the trunk mirror-fold render (#1531)" {
+    run _actionlint "$MIRROR_TRUNK"
+    assert_success
+}


### PR DESCRIPTION
## Summary

Fixes the 1.10.0 upgrade regression that broke `vig-os/org-config` (run [32002045870](https://github.com/vig-os/org-config/actions/runs/32002045870)) and adds the lint guard whose absence let it ship:

- **Reword** (#1529): the `DEVKIT_SYNC_TARGET` fold block rendered `mis-parse` into the consumer's managed `release-core.yml` — spell-clean only under devkit's own `.typos.toml` (#1488 entry), not under a pre-#1488 consumer seed, which upgrades never overwrite. Now reads "parse wrong"; no consumer action needed.
- **Stock-seed lint guard** (#1531): new `tests/bats/release-mirror-fold-lint.bats` renders a full mirror-mode workspace in **both workflow models** and lints each tree with `typos --isolated` (**no allowlist at all** — stricter than the issue asked, because real consumer seeds predate entries the current seed carries: commit-action's has only 3 of the 7 words) and `actionlint` (first actionlint coverage of the fold-injected steps/job). Fixture preconditions assert the fold actually rendered, so the lints can't pass vacuously.

Deliberately untouched: whether #1488's vendored-asset words belong in the consumer seed at all (issue #1529 point 3), and the residual exposure of the *synced devkit changelog* in devcontainer-mode consumers (released 1.10.0 text contains `mis-parses`; no consumer is affected today — noted in the test header, follow-up candidate).

## Test plan

- TDD red: the typos legs failed on the current render (`error: \`mis\` should be \`miss\`, \`mist\` — release-core.yml:641`) before the reword, green after
- `bats tests/bats/` 543/543 green; scaffold-adjacent pytest suites (1165 tests) green; `prek run --all-files` green (verified independently of the implementation run)

Closes #1529
Closes #1531