### PR TITLE
feat(upgrade): report a failed devkit upgrade as a tracking issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **A failed `devkit-upgrade` now leaves a tracking issue in the consumer repo**
+  ([#1530](https://github.com/vig-os/devkit/issues/1530))
+  - The adoption branch only reaches the remote in the publish step, so a
+    failure before it (version resolve, scaffold run, in-shell commit) was
+    visible only as a red scheduled run — and the consumer's `DEVKIT_VERSION`
+    then stopped moving, silently, week after week
+  - A new `report` job files **one** issue per repo carrying the run URL, the
+    failing step (read off the run's own job records) and the pinned vs target
+    version; every repeat failure comments on that same issue, and the next
+    fully green run closes it with a link to the green run
+  - Not a revert of [#1405](https://github.com/vig-os/devkit/issues/1405): that
+    dropped the per-adoption issue on the **success** path, where the bot PR is
+    the artifact. This one exists only where there is no artifact
+  - Reporting is best-effort by design: the `issues: write` grant is minted as
+    a **separate**, `continue-on-error` token, so an App installation that
+    never received it degrades to a warning instead of turning a working
+    upgrade red. Grant `issues: write` to the devkit-upgrade App to switch
+    reporting on
+
 ### Changed
 
 ### Deprecated

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -9,6 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **A failed `devkit-upgrade` now leaves a tracking issue in the consumer repo**
+  ([#1530](https://github.com/vig-os/devkit/issues/1530))
+  - The adoption branch only reaches the remote in the publish step, so a
+    failure before it (version resolve, scaffold run, in-shell commit) was
+    visible only as a red scheduled run — and the consumer's `DEVKIT_VERSION`
+    then stopped moving, silently, week after week
+  - A new `report` job files **one** issue per repo carrying the run URL, the
+    failing step (read off the run's own job records) and the pinned vs target
+    version; every repeat failure comments on that same issue, and the next
+    fully green run closes it with a link to the green run
+  - Not a revert of [#1405](https://github.com/vig-os/devkit/issues/1405): that
+    dropped the per-adoption issue on the **success** path, where the bot PR is
+    the artifact. This one exists only where there is no artifact
+  - Reporting is best-effort by design: the `issues: write` grant is minted as
+    a **separate**, `continue-on-error` token, so an App installation that
+    never received it degrades to a warning instead of turning a working
+    upgrade red. Grant `issues: write` to the devkit-upgrade App to switch
+    reporting on
+
 ### Changed
 
 ### Deprecated

--- a/assets/workspace/.github/workflows/devkit-upgrade.yml
+++ b/assets/workspace/.github/workflows/devkit-upgrade.yml
@@ -10,10 +10,17 @@
 # adoption issue (vig-os/devkit#1405) — like a Renovate PR, the bot PR is the
 # traceable artifact and the changelog entry (vig-os/devkit#1404) links it.
 #
+# A FAILED run does leave an artifact (vig-os/devkit#1530): the `report` job
+# files one tracking issue per repo, comments on it on every repeat failure and
+# closes it on the next green run. Without it a failure is visible only as a red
+# scheduled run and the pin silently stops moving.
+#
 # Requires a dedicated GitHub App identity: DEVKIT_UPGRADE_APP_CLIENT_ID +
 # DEVKIT_UPGRADE_APP_PRIVATE_KEY (repo or org secrets) feed a per-run
 # installation token minted in-workflow — contents:write + pull-requests:write +
-# workflows:write on this repo. The legacy numeric
+# workflows:write on this repo, plus issues:write for the failure report (the
+# only optional grant: the report degrades to a warning without it, the upgrade
+# itself is unaffected). The legacy numeric
 # DEVKIT_UPGRADE_APP_ID still works this release (either value is a valid App
 # JWT issuer); vig-os/devkit#1366 retires it. The default GITHUB_TOKEN cannot
 # open the PR: PRs it creates do not trigger CI. A static PAT is not supported
@@ -53,6 +60,11 @@ jobs:
       # identity, so the PR triggers CI); the default token stays read-only
       # for the public releases/latest query.
       contents: read
+    outputs:
+      # Consumed by the `report` job (#1530) so a failure alert can name the
+      # versions. Both are empty when the resolve step never got that far.
+      current: ${{ steps.resolve.outputs.current }}
+      target: ${{ steps.resolve.outputs.target }}
     steps:
       - name: Require the upgrade App identity
         env:
@@ -62,7 +74,7 @@ jobs:
         run: |
           set -euo pipefail
           if { [ -z "${APP_CLIENT_ID}" ] && [ -z "${APP_ID_LEGACY}" ]; } || [ -z "${APP_PRIVATE_KEY}" ]; then
-            echo "::error::DEVKIT_UPGRADE_APP_CLIENT_ID / DEVKIT_UPGRADE_APP_PRIVATE_KEY secrets are not configured. This workflow needs a dedicated GitHub App identity (contents:write + pull-requests:write + workflows:write): the default GITHUB_TOKEN cannot open a PR that triggers CI, and a static PAT is not supported. See https://github.com/vig-os/devkit/issues/1302."
+            echo "::error::DEVKIT_UPGRADE_APP_CLIENT_ID / DEVKIT_UPGRADE_APP_PRIVATE_KEY secrets are not configured. This workflow needs a dedicated GitHub App identity (contents:write + pull-requests:write + workflows:write, plus optional issues:write for the failure report): the default GITHUB_TOKEN cannot open a PR that triggers CI, and a static PAT is not supported. See https://github.com/vig-os/devkit/issues/1302."
             exit 1
           fi
           if [ -z "${APP_CLIENT_ID}" ]; then
@@ -139,6 +151,9 @@ jobs:
             echo "::error::.vig-os has no DEVKIT_VERSION pin."
             exit 1
           fi
+          # Published before anything below can fail, so a failure report always
+          # names the pin the repo is stuck on (#1530).
+          echo "current=${CURRENT}" >> "$GITHUB_OUTPUT"
 
           if [ "$EVENT_NAME" = "schedule" ]; then
             # Opt-out knob: gates the schedule path only. Empty (default) or any
@@ -371,3 +386,121 @@ jobs:
             gh pr create --base "$BASE" --head "$BRANCH" --title "$TITLE" --body "$BODY"
             echo "Opened the adoption PR."
           fi
+
+  # Failure reporting (#1530). A failed upgrade leaves nothing in the repo: the
+  # adoption branch only reaches the remote in the publish step above, so an
+  # earlier failure (version resolve, scaffold run, in-shell commit) shows up
+  # only as a red scheduled run — and the pin then sits still, week after week.
+  # This is NOT the adoption issue #1405 removed: that one tracked the SUCCESS
+  # path, where the bot PR is already the artifact. Here there is no artifact by
+  # construction, so one tracking issue per repo carries the failure and closes
+  # itself when the upgrade works again.
+  #
+  # A separate job rather than a late `if: failure()` step: a step never runs
+  # once the job itself is aborted (the 30-minute timeout, a lost runner), which
+  # is exactly one of the silent failures this closes. Keying both legs on
+  # `needs.upgrade.result` also reports nothing for a cancelled run.
+  report:
+    name: Report upgrade outcome
+    needs: upgrade
+    if: needs.upgrade.result == 'failure' || needs.upgrade.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      # Reads this run's own step conclusions to name the failing step; the
+      # tracking issue itself is written with the App token minted below.
+      actions: read
+    steps:
+      - name: Mint an issues-scoped App token
+        id: issues-token
+        # Best-effort, and load-bearing that it is: create-github-app-token
+        # FAILS the mint when it requests a permission the installation lacks,
+        # and this App has needed no Issues grant since #1405. Requesting it on
+        # the upgrade job's token would therefore turn every green upgrade red
+        # on an org that has not re-granted it — reporting may never break the
+        # path it reports on. Both legs below degrade to a warning instead.
+        continue-on-error: true
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3
+        with:
+          client-id: ${{ secrets.DEVKIT_UPGRADE_APP_CLIENT_ID || secrets.DEVKIT_UPGRADE_APP_ID }}
+          private-key: ${{ secrets.DEVKIT_UPGRADE_APP_PRIVATE_KEY }}
+          # Least-privilege mint (zizmor github-app): the report writes issues
+          # and nothing else — no contents, no PRs, no workflows.
+          permission-issues: write
+
+      - name: File or update the upgrade-failure issue
+        if: needs.upgrade.result == 'failure'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ steps.issues-token.outputs.token }}
+          # No checkout in this job, so gh resolves the repo from the env.
+          GH_REPO: ${{ github.repository }}
+          # The default token reads this run's job records (actions: read).
+          RUN_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          CURRENT: ${{ needs.upgrade.outputs.current }}
+          TARGET: ${{ needs.upgrade.outputs.target }}
+        run: |
+          set -euo pipefail
+          if [ -z "${GH_TOKEN}" ]; then
+            echo "::warning::This failure was not filed as a tracking issue: the devkit-upgrade App installation is missing the Issues (write) grant. Grant it and the next failure reports itself. See https://github.com/vig-os/devkit/issues/1530."
+            exit 0
+          fi
+          # The lookup keys on a body marker, not on the title: the title stays
+          # version-free so a failure on a NEW target still finds the one open
+          # issue (and no title goes stale), and a marker cannot collide with a
+          # human's issue the way a title prefix can. The plain issue listing is
+          # deliberate over `--search`: it enumerates the repo's open issues
+          # directly instead of the eventually-consistent search index, so an
+          # issue filed minutes ago is already visible. Bound: the 100 most
+          # recent open issues.
+          MARKER='<!-- devkit-upgrade-failure -->'
+          TITLE='chore(devkit): automated devkit upgrade is failing'
+          # Name the failing step from this run's own job records — no per-step
+          # instrumentation to keep in sync with the steps above.
+          FAILED="$(GH_TOKEN="$RUN_TOKEN" gh api \
+            "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/jobs" \
+            --jq '[.jobs[].steps[]? | select(.conclusion == "failure") | .name] | join(", ")' \
+            2>/dev/null || true)"
+          [ -n "$FAILED" ] || FAILED='unknown, see the run log'
+          DETAILS="$(printf -- '- Run: %s\n- Failing step: %s\n- Pinned devkit version: %s\n- Target devkit version: %s\n' \
+            "$RUN_URL" "$FAILED" "${CURRENT:-unknown}" "${TARGET:-unknown (the version resolve did not complete)}")"
+          NUM="$(gh issue list --state open --limit 100 --json number,body \
+            | jq -r --arg m "$MARKER" \
+              'map(select((.body // "") | contains($m))) | first | .number // empty')"
+          if [ -n "$NUM" ]; then
+            gh issue comment "$NUM" --body "$(printf 'The devkit upgrade failed again.\n\n%s' "$DETAILS")"
+            echo "Updated tracking issue #${NUM}."
+          else
+            gh issue create --title "$TITLE" --body "$(printf '%s\n\nThe managed devkit-upgrade workflow is failing, so this repo has stopped adopting new devkit releases.\n\n%s\nNothing was pushed: the adoption branch only reaches the remote once the upgrade commit is published, so there is no half-applied state to clean up. Fix the cause and re-run the workflow (or dispatch it with an explicit version) — this issue is filed, updated and closed by the workflow itself.\n' "$MARKER" "$DETAILS")"
+            echo "Filed a tracking issue."
+          fi
+
+      - name: Close the upgrade-failure issue
+        if: needs.upgrade.result == 'success'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ steps.issues-token.outputs.token }}
+          GH_REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          # ANY fully green run self-cleans the alert, including the no-op
+          # "already current" and DEVKIT_AUTO_UPGRADE=false paths: the workflow
+          # ran end to end, so whatever was recorded no longer reproduces — and
+          # a consumer that opted out should not keep an open alert either.
+          if [ -z "${GH_TOKEN}" ]; then
+            echo "No issues-scoped token; nothing to close."
+            exit 0
+          fi
+          MARKER='<!-- devkit-upgrade-failure -->'
+          NUM="$(gh issue list --state open --limit 100 --json number,body \
+            | jq -r --arg m "$MARKER" \
+              'map(select((.body // "") | contains($m))) | first | .number // empty')"
+          if [ -z "$NUM" ]; then
+            echo "No open devkit-upgrade tracking issue; nothing to close."
+            exit 0
+          fi
+          gh issue close "$NUM" \
+            --comment "$(printf 'The devkit upgrade ran green again: %s\n' "$RUN_URL")"
+          echo "Closed tracking issue #${NUM}."

--- a/assets/workspace/.github/workflows/devkit-upgrade.yml
+++ b/assets/workspace/.github/workflows/devkit-upgrade.yml
@@ -403,7 +403,10 @@ jobs:
   report:
     name: Report upgrade outcome
     needs: upgrade
-    if: needs.upgrade.result == 'failure' || needs.upgrade.result == 'success'
+    # The !cancelled() is load-bearing: a job-level `if` without a status-check
+    # function gets an implicit success() gate, which would skip this job on
+    # exactly the failed runs it exists to report.
+    if: ${{ !cancelled() && (needs.upgrade.result == 'failure' || needs.upgrade.result == 'success') }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:

--- a/tests/bats/devkit-upgrade-alert.bats
+++ b/tests/bats/devkit-upgrade-alert.bats
@@ -1,0 +1,189 @@
+#!/usr/bin/env bats
+# BATS tests for the devkit-upgrade failure report (#1530).
+#
+# tests/test_workflow_devkit_upgrade.py pins that the `report` job is WIRED —
+# the result gate, the issues-scoped mint, the env plumbing. It cannot pin that
+# the legs BEHAVE: that a second weekly failure comments instead of filing issue
+# number two, that a green run closes the one that is open, and that a missing
+# App grant is a warning rather than a red run. That branching is the whole
+# feature, so it is executed here.
+#
+# Same idiom as release-mirror-fold.bats: the rendered `run:` block is extracted
+# from the shipped workflow and run against a stub `gh` — real bash, real jq,
+# no network and no GitHub.
+
+setup() {
+    load test_helper
+    WF="$PROJECT_ROOT/assets/workspace/.github/workflows/devkit-upgrade.yml"
+    FAIL_LEG="$BATS_TEST_TMPDIR/fail.sh"
+    CLOSE_LEG="$BATS_TEST_TMPDIR/close.sh"
+    STUBS="$BATS_TEST_TMPDIR/stubs"
+    GH_LOG="$BATS_TEST_TMPDIR/gh.log"
+    GH_ISSUES="$BATS_TEST_TMPDIR/issues.json"
+    GH_JOBS="$BATS_TEST_TMPDIR/jobs.txt"
+    RUN_URL="https://github.example/test/repo/actions/runs/42"
+    mkdir -p "$STUBS"
+    : >"$GH_LOG"
+    printf '[]\n' >"$GH_ISSUES"
+    : >"$GH_JOBS"
+    _extract_run "$WF" "File or update the upgrade-failure issue" >"$FAIL_LEG"
+    _extract_run "$WF" "Close the upgrade-failure issue" >"$CLOSE_LEG"
+    _stub_gh
+}
+
+# Print the dedented body of the `run: |` block of step "$2" in workflow "$1".
+# Steps sit at 6 spaces, their keys at 8, the run body at 10.
+_extract_run() {
+    awk -v step="$2" '
+        index($0, "- name: " step) { found = 1; next }
+        found && /^[[:space:]]*run: \|[[:space:]]*$/ { inrun = 1; next }
+        inrun {
+            if ($0 ~ /^[[:space:]]*$/) { print ""; next }
+            if ($0 !~ /^          /) { exit }
+            sub(/^          /, "")
+            print
+        }
+    ' "$1"
+}
+
+# Stub gh: records every invocation and answers the three calls the legs make.
+# `api` returns the value a real `--jq` filter would print (the stub cannot run
+# the filter); `issue list` returns raw JSON, which the leg pipes into real jq.
+_stub_gh() {
+    cat >"$STUBS/gh" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"$GH_LOG"
+case "${1:-} ${2:-}" in
+    "api "*)          cat "$GH_JOBS" ;;
+    "issue list")     cat "$GH_ISSUES" ;;
+    "issue create")   echo "https://github.example/test/repo/issues/7" ;;
+esac
+exit 0
+STUB
+    chmod +x "$STUBS/gh"
+}
+
+# Run an extracted leg. Extra args are `NAME=value` step env vars.
+_run_leg() {
+    local block="$1"
+    shift
+    env PATH="$STUBS:$PATH" \
+        GH_LOG="$GH_LOG" GH_ISSUES="$GH_ISSUES" GH_JOBS="$GH_JOBS" \
+        GH_REPO=test/repo RUN_TOKEN=run-token RUN_URL="$RUN_URL" \
+        GITHUB_REPOSITORY=test/repo GITHUB_RUN_ID=42 \
+        "$@" bash "$block"
+}
+
+_log() { cat "$GH_LOG"; }
+
+# One open issue carrying the tracker's body marker.
+_open_tracker() {
+    cat >"$GH_ISSUES" <<'JSON'
+[{"number": 3, "body": "history\n<!-- devkit-upgrade-failure -->\nmore"}]
+JSON
+}
+
+# ── the failure leg ───────────────────────────────────────────────────────────
+
+@test "failure leg files a tracking issue when none is open (#1530)" {
+    run _run_leg "$FAIL_LEG" GH_TOKEN=app-token CURRENT=1.9.0 TARGET=1.11.0
+    assert_success
+
+    run _log
+    assert_output --partial 'issue create'
+    assert_output --partial 'chore(devkit): automated devkit upgrade is failing'
+    # The marker is what the next run and the close leg key on.
+    assert_output --partial '<!-- devkit-upgrade-failure -->'
+    assert_output --partial "$RUN_URL"
+    refute_output --partial 'issue comment'
+}
+
+@test "failure leg re-uses the open tracking issue (#1530)" {
+    _open_tracker
+
+    run _run_leg "$FAIL_LEG" GH_TOKEN=app-token CURRENT=1.9.0 TARGET=1.11.0
+    assert_success
+    assert_output --partial '#3'
+
+    # At most one open tracker per repo: a repeat failure comments on it.
+    run _log
+    assert_output --partial 'issue comment 3'
+    refute_output --partial 'issue create'
+}
+
+@test "failure leg ignores an unrelated open issue (#1530)" {
+    printf '[{"number": 9, "body": "a human wrote this"}]\n' >"$GH_ISSUES"
+
+    run _run_leg "$FAIL_LEG" GH_TOKEN=app-token CURRENT=1.9.0 TARGET=1.11.0
+    assert_success
+
+    run _log
+    assert_output --partial 'issue create'
+    refute_output --partial 'issue comment'
+}
+
+@test "failure leg names the failing step and both versions (#1530)" {
+    printf 'Commit the upgrade in the project shell\n' >"$GH_JOBS"
+
+    run _run_leg "$FAIL_LEG" GH_TOKEN=app-token CURRENT=1.9.0 TARGET=1.11.0
+    assert_success
+
+    run _log
+    assert_output --partial 'Commit the upgrade in the project shell'
+    assert_output --partial '1.9.0'
+    assert_output --partial '1.11.0'
+}
+
+@test "failure leg reports an unresolved target as unknown (#1530)" {
+    # The resolve step itself failed: no target, and possibly no pin either.
+    run _run_leg "$FAIL_LEG" GH_TOKEN=app-token CURRENT= TARGET=
+    assert_success
+
+    run _log
+    assert_output --partial 'unknown'
+    assert_output --partial 'Failing step: unknown'
+}
+
+@test "failure leg warns instead of failing without the Issues grant (#1530)" {
+    # The mint is continue-on-error, so an installation that never received the
+    # Issues grant reaches this leg with an empty token. Reporting may never
+    # break the upgrade path it reports on.
+    run _run_leg "$FAIL_LEG" GH_TOKEN= CURRENT=1.9.0 TARGET=1.11.0
+    assert_success
+    assert_output --partial '::warning::'
+
+    run _log
+    refute_output --partial 'issue'
+}
+
+# ── the success leg ───────────────────────────────────────────────────────────
+
+@test "success leg closes the open tracking issue (#1530)" {
+    _open_tracker
+
+    run _run_leg "$CLOSE_LEG" GH_TOKEN=app-token
+    assert_success
+    assert_output --partial '#3'
+
+    run _log
+    assert_output --partial 'issue close 3'
+    assert_output --partial "$RUN_URL"
+}
+
+@test "success leg is a clean no-op when nothing is open (#1530)" {
+    run _run_leg "$CLOSE_LEG" GH_TOKEN=app-token
+    assert_success
+
+    run _log
+    refute_output --partial 'issue close'
+}
+
+@test "success leg no-ops without the Issues grant (#1530)" {
+    _open_tracker
+
+    run _run_leg "$CLOSE_LEG" GH_TOKEN=
+    assert_success
+
+    run _log
+    refute_output --partial 'issue close'
+}

--- a/tests/test_workflow_devkit_upgrade.py
+++ b/tests/test_workflow_devkit_upgrade.py
@@ -332,6 +332,10 @@ def test_report_is_a_separate_result_gated_job() -> None:
     cond = str(report["if"])
     assert "needs.upgrade.result == 'failure'" in cond
     assert "needs.upgrade.result == 'success'" in cond
+    # Without a status-check function in the expression, Actions applies an
+    # implicit success() to a job-level `if` — the report job would be skipped
+    # on exactly the failed runs it exists for.
+    assert "!cancelled()" in cond
     # Reading this run's own step conclusions is all the default token needs.
     assert report["permissions"] == {"actions": "read"}
     assert "timeout-minutes" in report

--- a/tests/test_workflow_devkit_upgrade.py
+++ b/tests/test_workflow_devkit_upgrade.py
@@ -19,6 +19,10 @@ release time. These tests pin the deliverable without executing the workflow:
   (zizmor template-injection: every such value is routed through ``env:``);
 - the base branch is workflow-model aware (``dev`` gitflow / ``main`` trunk),
   realized by the scaffold-time ``render_workflow_model`` retarget;
+- a failed run leaves an artifact in the repo (#1530): the ``report`` job files
+  and re-uses ONE marker-tracked issue per repo and closes it on the next green
+  run, with every leg best-effort so a missing App grant cannot break the
+  upgrade path it reports on;
 - the ``devkit-upgrade`` feature group (#1284) opts the whole file out.
 
 Refs: #1296
@@ -35,16 +39,30 @@ from tests.workflow_scaffold import (
     INIT_WORKSPACE,
     WORKSPACE,
     cached_tree,
+    needs_of,
+    run_text_of_job,
     scaffold,
+    step_by_id,
+    step_by_name,
 )
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 TEMPLATE = WORKSPACE / ".github" / "workflows" / "devkit-upgrade.yml"
 REL = ".github/workflows/devkit-upgrade.yml"
 
+# The failure-report contract (#1530): a body marker is the de-duplication key
+# and the title carries no version, so a failure on a different target still
+# finds the same open issue.
+MARKER = "<!-- devkit-upgrade-failure -->"
+TITLE = "chore(devkit): automated devkit upgrade is failing"
+
 
 def _rendered(workflow: str | None = None) -> str:
     return (cached_tree(workflow) / REL).read_text(encoding="utf-8")
+
+
+def _jobs(text: str | None = None) -> dict:
+    return yaml.safe_load(text or TEMPLATE.read_text(encoding="utf-8"))["jobs"]
 
 
 def _steps(text: str) -> list[dict]:
@@ -132,23 +150,26 @@ def test_requires_app_identity_and_never_uses_github_token_for_pr() -> None:
         assert re.search(r"create-github-app-token@[0-9a-f]{40}", s["uses"]), (
             "app-token action must be SHA-pinned"
         )
-        # The mint uses the preferred client-id input (with the one-release
+        # Every mint uses the preferred client-id input (with the one-release
         # legacy fallback), never the deprecated numeric app-id input.
         with_block = s.get("with", {})
         assert with_block.get("client-id") == (
             "${{ secrets.DEVKIT_UPGRADE_APP_CLIENT_ID || secrets.DEVKIT_UPGRADE_APP_ID }}"
         )
         assert "app-id" not in with_block
-        # Least-privilege mint (zizmor github-app audit): the token must be
-        # scoped to exactly the permissions the workflow exercises. With the
-        # adoption issue gone (#1405) no issues permission remains.
-        for perm in (
-            "permission-contents",
-            "permission-pull-requests",
-            "permission-workflows",
-        ):
-            assert with_block.get(perm) == "write", f"missing {perm}: write"
-        assert "permission-issues" not in with_block
+    # Least-privilege mint (zizmor github-app audit): the upgrade job's token is
+    # scoped to exactly the permissions that job exercises. It must stay
+    # issues-free — the report job (#1530) mints its own issues-scoped token, so
+    # an installation without the Issues grant cannot break the upgrade path.
+    upgrade_mint = step_by_id(_jobs(text)["upgrade"]["steps"], "app-token")
+    with_block = upgrade_mint["with"]
+    for perm in (
+        "permission-contents",
+        "permission-pull-requests",
+        "permission-workflows",
+    ):
+        assert with_block.get(perm) == "write", f"missing {perm}: write"
+    assert "permission-issues" not in with_block
     # The PR step authenticates gh with the minted token (not github.token),
     # otherwise the created PR would not trigger CI.
     pr_steps = [s for s in steps if "gh pr create" in str(s.get("run", ""))]
@@ -232,8 +253,7 @@ def test_upgrade_step_captures_the_flake_bump_report() -> None:
     skipped-with-reason / no input recognized). A silent decline was the whole
     bug — the workflow must capture the line so the adoption PR can carry it.
     """
-    doc = yaml.safe_load(TEMPLATE.read_text(encoding="utf-8"))
-    (job,) = doc["jobs"].values()
+    job = _jobs()["upgrade"]
     step = next(
         s
         for s in job["steps"]
@@ -252,8 +272,7 @@ def test_pr_body_carries_the_flake_bump_report_via_env() -> None:
     Routed through ``env:`` (never ``${{ }}`` inside ``run:``) per the
     template-injection doctrine pinned below.
     """
-    doc = yaml.safe_load(TEMPLATE.read_text(encoding="utf-8"))
-    (job,) = doc["jobs"].values()
+    job = _jobs()["upgrade"]
     step = next(s for s in job["steps"] if "adoption PR" in str(s.get("name", "")))
     assert step["env"]["FLAKE_BUMP"] == "${{ steps.upgrade.outputs.flake-bump }}"
     assert "$FLAKE_BUMP" in str(step["run"])
@@ -267,7 +286,7 @@ def test_reset_excluded_paths() -> None:
 
 
 def test_no_adoption_issue_lifecycle() -> None:
-    """The workflow manages no adoption issue at all (#1405).
+    """The upgrade job manages no adoption issue at all (#1405).
 
     Adoption PRs are bot PRs like Renovate's: the PR is the traceable
     artifact and the changelog entry (#1404) links it. Dropping the issue
@@ -275,16 +294,144 @@ def test_no_adoption_issue_lifecycle() -> None:
     ``Closes #`` body marker, the issues:write grant, and the #1347 no-diff
     cleanup step that existed only to garbage-collect stranded issues
     (`Closes #` never auto-closes on a dev-targeted PR anyway).
+
+    The failure tracking issue (#1530) is a different lifecycle in a different
+    job — opened only on failure, one per repo, closed by the next green run —
+    so the no-adoption-issue rule is asserted on the ``upgrade`` job alone.
     """
     text = TEMPLATE.read_text(encoding="utf-8")
-    # No issue commands, no Refs/Closes markers, no issue-numbered branch.
-    assert "gh issue" not in text
+    # No issue commands on the adoption path, no Refs/Closes markers anywhere.
+    assert "gh issue" not in run_text_of_job(_jobs(text)["upgrade"])
     assert "Refs: #" not in text
     assert "Closes #" not in text
     # The branch is the guard-legal chore/<summary> shape, keyed on the train.
     assert 'BRANCH="chore/devkit-${SUFFIX}"' in text
     # The PR body points reviewers at the devkit release notes instead.
     assert "releases/tag/" in text
+
+
+# ── failure reporting (#1530) ─────────────────────────────────────────────────
+
+
+def _report_job(text: str | None = None) -> dict:
+    return _jobs(text)["report"]
+
+
+def test_report_is_a_separate_result_gated_job() -> None:
+    """Reporting lives in its own ``needs:``-gated job, not a late step (#1530).
+
+    A step-level ``if: failure()`` never runs once the job itself is aborted —
+    the 30-minute timeout, a lost runner — which is one of the silent-failure
+    modes this closes. A ``needs`` job keyed on ``needs.upgrade.result`` covers
+    those, covers a resolve-step failure (malformed pin / missing
+    ``DEVKIT_VERSION``) and reports nothing on a cancelled run.
+    """
+    jobs = _jobs()
+    report = _report_job()
+    assert needs_of(report) == ["upgrade"]
+    cond = str(report["if"])
+    assert "needs.upgrade.result == 'failure'" in cond
+    assert "needs.upgrade.result == 'success'" in cond
+    # Reading this run's own step conclusions is all the default token needs.
+    assert report["permissions"] == {"actions": "read"}
+    assert "timeout-minutes" in report
+    # Not a step in the upgrade job: nothing there touches issues.
+    assert "gh issue" not in run_text_of_job(jobs["upgrade"])
+
+
+def test_report_mint_is_issues_scoped_and_best_effort() -> None:
+    """The issues grant is minted separately and may fail harmlessly (#1530).
+
+    ``create-github-app-token`` fails the mint when it requests a permission the
+    installation lacks, and the devkit-upgrade App has needed no Issues grant
+    since #1405. Requesting it on the upgrade job's mint would therefore turn a
+    green upgrade red on every org that has not re-granted it, so the report
+    mints its own token and every leg is ``continue-on-error``.
+    """
+    report = _report_job()
+    mint = step_by_id(report["steps"], "issues-token")
+    assert re.search(r"create-github-app-token@[0-9a-f]{40}", mint["uses"])
+    with_block = mint["with"]
+    assert with_block["permission-issues"] == "write"
+    # Least privilege: the report writes issues and nothing else.
+    assert [k for k in with_block if k.startswith("permission-")] == [
+        "permission-issues"
+    ]
+    for step in report["steps"]:
+        assert step.get("continue-on-error") is True, (
+            f"report step {step.get('name')!r} may not fail the run"
+        )
+
+
+def test_failure_leg_files_or_reuses_one_marker_tracked_issue() -> None:
+    """At most one open tracking issue per repo; repeats comment on it (#1530)."""
+    step = step_by_name(_report_job()["steps"], "File or update")
+    assert step["if"] == "needs.upgrade.result == 'failure'"
+    run = str(step["run"])
+    # De-duplication keys on a body marker (exact, and immediately visible in
+    # the REST issue list — unlike the eventually-consistent search index).
+    assert MARKER in run
+    assert "gh issue list" in run
+    assert run.index("gh issue list") < run.index("gh issue create"), (
+        "the lookup must precede creation, else a new issue is filed weekly"
+    )
+    assert "gh issue comment" in run
+    # The title is version-free, so a failure on a different target finds the
+    # same issue and no title ever goes stale.
+    assert f"TITLE='{TITLE}'" in run
+
+
+def test_failure_leg_body_carries_run_phase_and_versions() -> None:
+    """The issue names the run, the failing step and current vs target (#1530)."""
+    step = step_by_name(_report_job()["steps"], "File or update")
+    env = step["env"]
+    assert env["GH_TOKEN"] == "${{ steps.issues-token.outputs.token }}"
+    # No checkout in this job, so gh resolves the repo from the environment.
+    assert env["GH_REPO"] == "${{ github.repository }}"
+    assert "${{ github.run_id }}" in env["RUN_URL"]
+    # Versions come from the resolve step's outputs, promoted to job outputs.
+    assert env["CURRENT"] == "${{ needs.upgrade.outputs.current }}"
+    assert env["TARGET"] == "${{ needs.upgrade.outputs.target }}"
+    run = str(step["run"])
+    for var in ("$RUN_URL", "$FAILED", "${CURRENT:-", "${TARGET:-"):
+        assert var in run, f"the issue body must report {var}"
+    # The failing step is read off this run's own job records with the default
+    # token — no per-step instrumentation to keep in sync with the steps above.
+    assert env["RUN_TOKEN"] == "${{ github.token }}"
+    assert 'GH_TOKEN="$RUN_TOKEN" gh api' in run
+    assert "/actions/runs/${GITHUB_RUN_ID}/jobs" in run
+
+
+def test_failure_leg_degrades_when_the_app_lacks_the_issues_grant() -> None:
+    """A missing grant yields a warning, never a failed step (#1530)."""
+    run = str(step_by_name(_report_job()["steps"], "File or update")["run"])
+    assert '[ -z "${GH_TOKEN}" ]' in run
+    assert "::warning::" in run
+
+
+def test_success_leg_closes_the_tracking_issue() -> None:
+    """A fully green run self-cleans the alert with a link to that run (#1530)."""
+    step = step_by_name(_report_job()["steps"], "Close the upgrade-failure issue")
+    assert step["if"] == "needs.upgrade.result == 'success'"
+    run = str(step["run"])
+    assert MARKER in run
+    assert run.index("gh issue list") < run.index("gh issue close")
+    assert "$RUN_URL" in run
+    assert step["env"]["GH_TOKEN"] == "${{ steps.issues-token.outputs.token }}"
+
+
+def test_resolve_publishes_the_versions_the_report_names() -> None:
+    """``current`` is a job output emitted before any later failure (#1530).
+
+    A resolve failure on the target (malformed dispatch input, unreachable
+    release query) must still report the pin the repo is stuck on, so the
+    ``current`` output is written as soon as ``.vig-os`` is read.
+    """
+    upgrade = _jobs()["upgrade"]
+    assert upgrade["outputs"]["current"] == "${{ steps.resolve.outputs.current }}"
+    assert upgrade["outputs"]["target"] == "${{ steps.resolve.outputs.target }}"
+    run = str(step_by_id(upgrade["steps"], "resolve")["run"])
+    assert run.index('echo "current=') < run.index("malformed target version")
 
 
 # ── security: no template injection (zizmor) ──────────────────────────────────


### PR DESCRIPTION
## Summary

Implements the failure alert from #1530: today a failed `devkit-upgrade` run leaves no artifact in the consumer repo (the remote ref only appears in the late Publish step), so a broken upgrade fails silently every week — observed live at org-config run [32002045870](https://github.com/vig-os/org-config/actions/runs/32002045870).

- **New `report` job** in the scaffold `devkit-upgrade.yml`, gated `!cancelled() && (needs.upgrade.result == 'failure' || == 'success')` — a separate job rather than a late step so a job abort (timeout, lost runner) still reports, and resolve-step failures are covered for free. Silent on cancelled runs.
- **Failure leg**: opens or re-uses a single tracking issue per repo, found by an HTML body marker with a version-free title (`chore(devkit): automated devkit upgrade is failing`) so a different target on the next failure lands in the same issue. Body carries the run URL, the failing step (read from the run's own job records via `actions: read`), and pinned vs target version (`unknown` when resolve itself died). Lookup via direct `gh issue list`, not the eventually-consistent search index. No label dependency.
- **Success leg**: any fully green run (including no-ops) closes the open tracking issue with the green run URL — a fixed upgrade self-cleans, per the issue spec.
- **Degraded mode**: the Issues grant is minted as a *separate* `permission-issues: write` token with `continue-on-error` — `create-github-app-token` fails a mint requesting an ungranted permission, so putting it on the primary mint would turn green upgrades red. All report steps are best-effort: without the grant the leg degrades to a `::warning::` and the upgrade path behaves exactly as today. (Both org installations of `vigos-devkit-upgrade` already have `issues: write` accepted, verified via API — so this fires for real from day one.)
- **Not** a revert of #1405: the success path still produces no adoption issue (pinned by test).

Review caught and fixed one real bug in the initial implementation: the job-level `if` lacked a status-check function, so the implicit `success()` gate would have skipped the report job on exactly the failed runs it exists for — now `!cancelled()`-gated and pinned by test.

Rollout note: consumers get this one train after it ships (the cron runs the workflow from their base branch).

## Test plan

- `tests/test_workflow_devkit_upgrade.py`: 26 passed (7 new structural pins: result-gated job, issues-only mint, marker + list-before-create, version-free title, env plumbing, close leg, `!cancelled()` gate; TDD red first: 7 failed)
- `tests/bats/devkit-upgrade-alert.bats` (new): 9/9 — executes the extracted `run:` blocks against a stub `gh` (create vs comment vs close branching, unknown-target, missing-grant no-ops)
- `bats tests/bats/init-workspace.bats` 257/257; `release-mirror-fold-lint.bats` 4/4 (typos + actionlint over the full render, both models)
- `prek run --all-files` exit 0 (verified independently of the implementation run)

Closes #1530