### PR TITLE
fix(release): count only the latest check run per name in the CI-green gate

### DIFF
--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -358,19 +358,28 @@ jobs:
           fi
 
           STATUS_ROLLUP=$(echo "$PR_JSON" | jq -r '.[0].statusCheckRollup // []')
-          CI_FAILED=$(echo "$STATUS_ROLLUP" | jq '[.[] | select(.conclusion == "FAILURE" or .conclusion == "ERROR")] | length')
+
+          # Evaluate only the LATEST run of each check name (#1522), the way
+          # `gh pr checks` does: a superseded workflow run leaves its FAILURE
+          # check runs on the same head SHA and would refuse a branch that is
+          # actually green (#1516). Recency key is startedAt, not completedAt —
+          # completedAt is null while a rerun is in flight. StatusContexts key
+          # on context/createdAt and are each their own latest.
+          LATEST_CHECKS=$(echo "$STATUS_ROLLUP" | jq '[group_by(.name // .context // "?")[] | max_by(.startedAt // .createdAt // "")]')
+
+          CI_FAILED=$(echo "$LATEST_CHECKS" | jq '[.[] | select(.conclusion == "FAILURE" or .conclusion == "ERROR")] | length')
           if [ "$CI_FAILED" != "0" ]; then
             echo "ERROR: PR #$PR_NUMBER has failed CI checks"
             exit 1
           fi
 
-          CI_PENDING=$(echo "$STATUS_ROLLUP" | jq '[.[] | select(.conclusion == null or .conclusion == "" or .conclusion == "PENDING" or .conclusion == "IN_PROGRESS" or .conclusion == "QUEUED")] | length')
+          CI_PENDING=$(echo "$LATEST_CHECKS" | jq '[.[] | select(.conclusion == null or .conclusion == "" or .conclusion == "PENDING" or .conclusion == "IN_PROGRESS" or .conclusion == "QUEUED")] | length')
           if [ "$CI_PENDING" != "0" ]; then
             echo "ERROR: PR #$PR_NUMBER has checks still in progress"
             exit 1
           fi
 
-          CI_SUCCESS=$(echo "$STATUS_ROLLUP" | jq '[.[] | select(.conclusion == "SUCCESS")] | length')
+          CI_SUCCESS=$(echo "$LATEST_CHECKS" | jq '[.[] | select(.conclusion == "SUCCESS")] | length')
           if [ "$CI_SUCCESS" = "0" ]; then
             echo "ERROR: PR #$PR_NUMBER has no successful CI checks"
             exit 1
@@ -585,19 +594,28 @@ jobs:
           fi
 
           STATUS_ROLLUP=$(echo "$PR_JSON" | jq -r '.[0].statusCheckRollup // []')
-          CI_FAILED=$(echo "$STATUS_ROLLUP" | jq '[.[] | select(.conclusion == "FAILURE" or .conclusion == "ERROR")] | length')
+
+          # Evaluate only the LATEST run of each check name (#1522), the way
+          # `gh pr checks` does: a superseded workflow run leaves its FAILURE
+          # check runs on the same head SHA and would refuse a branch that is
+          # actually green (#1516). Recency key is startedAt, not completedAt —
+          # completedAt is null while a rerun is in flight. StatusContexts key
+          # on context/createdAt and are each their own latest.
+          LATEST_CHECKS=$(echo "$STATUS_ROLLUP" | jq '[group_by(.name // .context // "?")[] | max_by(.startedAt // .createdAt // "")]')
+
+          CI_FAILED=$(echo "$LATEST_CHECKS" | jq '[.[] | select(.conclusion == "FAILURE" or .conclusion == "ERROR")] | length')
           if [ "$CI_FAILED" != "0" ]; then
             echo "ERROR: PR #$PR_NUMBER has failed CI checks"
             exit 1
           fi
 
-          CI_PENDING=$(echo "$STATUS_ROLLUP" | jq '[.[] | select(.conclusion == null or .conclusion == "" or .conclusion == "PENDING" or .conclusion == "IN_PROGRESS" or .conclusion == "QUEUED")] | length')
+          CI_PENDING=$(echo "$LATEST_CHECKS" | jq '[.[] | select(.conclusion == null or .conclusion == "" or .conclusion == "PENDING" or .conclusion == "IN_PROGRESS" or .conclusion == "QUEUED")] | length')
           if [ "$CI_PENDING" != "0" ]; then
             echo "ERROR: PR #$PR_NUMBER has checks still in progress"
             exit 1
           fi
 
-          CI_SUCCESS=$(echo "$STATUS_ROLLUP" | jq '[.[] | select(.conclusion == "SUCCESS")] | length')
+          CI_SUCCESS=$(echo "$LATEST_CHECKS" | jq '[.[] | select(.conclusion == "SUCCESS")] | length')
           if [ "$CI_SUCCESS" = "0" ]; then
             echo "ERROR: PR #$PR_NUMBER has no successful CI checks"
             exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -355,8 +355,21 @@ jobs:
           # Check CI status
           STATUS_ROLLUP=$(echo "$PR_JSON" | jq -r '.[0].statusCheckRollup // []')
 
+          # Evaluate only the LATEST run of each check name (#1522), the way
+          # `gh pr checks` does. A superseded workflow run leaves its FAILURE
+          # check runs attached to the same head SHA, so counting every entry
+          # refuses a branch that is actually green — during the 1.10.0 train
+          # that forced deleting the superseded run to proceed (#1516).
+          # Recency key is startedAt, not completedAt: completedAt is null
+          # while a rerun is in flight, which would rank the live run oldest
+          # and let the stale FAILURE win. StatusContexts carry
+          # context/createdAt instead of name/startedAt and have no rerun
+          # history, so each one is its own latest and keeps counting as
+          # before.
+          LATEST_CHECKS=$(echo "$STATUS_ROLLUP" | jq '[group_by(.name // .context // "?")[] | max_by(.startedAt // .createdAt // "")]')
+
           # Reject if any checks have failed or errored
-          CI_FAILED=$(echo "$STATUS_ROLLUP" | jq '[.[] | select(.conclusion == "FAILURE" or .conclusion == "ERROR")] | length')
+          CI_FAILED=$(echo "$LATEST_CHECKS" | jq '[.[] | select(.conclusion == "FAILURE" or .conclusion == "ERROR")] | length')
           if [ "$CI_FAILED" != "0" ]; then
             echo "ERROR: PR #$PR_NUMBER has failed CI checks"
             echo "Fix CI issues before releasing"
@@ -364,7 +377,7 @@ jobs:
           fi
 
           # Reject if any checks are still pending, in progress, queued, or null (non-terminal state)
-          CI_PENDING=$(echo "$STATUS_ROLLUP" | jq '[.[] | select(.conclusion == null or .conclusion == "" or .conclusion == "PENDING" or .conclusion == "IN_PROGRESS" or .conclusion == "QUEUED")] | length')
+          CI_PENDING=$(echo "$LATEST_CHECKS" | jq '[.[] | select(.conclusion == null or .conclusion == "" or .conclusion == "PENDING" or .conclusion == "IN_PROGRESS" or .conclusion == "QUEUED")] | length')
           if [ "$CI_PENDING" != "0" ]; then
             echo "ERROR: PR #$PR_NUMBER has $CI_PENDING checks still in progress"
             echo "Wait for all CI checks to complete before releasing"
@@ -372,7 +385,7 @@ jobs:
           fi
 
           # Check that at least some checks have passed
-          CI_SUCCESS=$(echo "$STATUS_ROLLUP" | jq '[.[] | select(.conclusion == "SUCCESS")] | length')
+          CI_SUCCESS=$(echo "$LATEST_CHECKS" | jq '[.[] | select(.conclusion == "SUCCESS")] | length')
           if [ "$CI_SUCCESS" = "0" ]; then
             echo "ERROR: PR #$PR_NUMBER has no successful CI checks"
             echo "Ensure CI has run on the release branch"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Release CI gate now counts only the latest run of each check**
+  ([#1522](https://github.com/vig-os/devkit/issues/1522))
+  - The gate counted **every** FAILURE entry in the release PR head SHA's
+    `statusCheckRollup`. A superseded workflow run leaves its check runs
+    attached to that same SHA, so the gate refused a branch `gh pr checks` —
+    which keeps only the latest run per name — reported green. During the
+    1.10.0 train that forced deleting the superseded run to proceed
+    ([#1516](https://github.com/vig-os/devkit/issues/1516))
+  - All six copies of the gate now group the rollup by check name and evaluate
+    the most recent run of each: devkit's `release.yml` and `promote-release.yml`
+    (validate and merge), and the consumer `release-core.yml` and
+    `promote-release.yml` (validate and merge). A re-run still in flight is the
+    latest, so it holds the gate open as before, and a genuinely failing latest
+    run still blocks
 - **Describing a bot-identity bug no longer trips the agent-fingerprint check**
   ([#1521](https://github.com/vig-os/devkit/issues/1521))
   - The `emails` blocklist was matched as a bare substring over the whole

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -36,6 +36,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Release CI gate now counts only the latest run of each check**
+  ([#1522](https://github.com/vig-os/devkit/issues/1522))
+  - The gate counted **every** FAILURE entry in the release PR head SHA's
+    `statusCheckRollup`. A superseded workflow run leaves its check runs
+    attached to that same SHA, so the gate refused a branch `gh pr checks` —
+    which keeps only the latest run per name — reported green. During the
+    1.10.0 train that forced deleting the superseded run to proceed
+    ([#1516](https://github.com/vig-os/devkit/issues/1516))
+  - All six copies of the gate now group the rollup by check name and evaluate
+    the most recent run of each: devkit's `release.yml` and `promote-release.yml`
+    (validate and merge), and the consumer `release-core.yml` and
+    `promote-release.yml` (validate and merge). A re-run still in flight is the
+    latest, so it holds the gate open as before, and a genuinely failing latest
+    run still blocks
 - **Describing a bot-identity bug no longer trips the agent-fingerprint check**
   ([#1521](https://github.com/vig-os/devkit/issues/1521))
   - The `emails` blocklist was matched as a bare substring over the whole

--- a/assets/workspace/.github/workflows/promote-release.yml
+++ b/assets/workspace/.github/workflows/promote-release.yml
@@ -237,19 +237,28 @@ jobs:
           fi
 
           STATUS_ROLLUP=$(echo "$PR_JSON" | jq -r '.[0].statusCheckRollup // []')
-          CI_FAILED=$(echo "$STATUS_ROLLUP" | jq '[.[] | select(.conclusion == "FAILURE" or .conclusion == "ERROR")] | length')
+
+          # Evaluate only the LATEST run of each check name (#1522), the way
+          # `gh pr checks` does: a superseded workflow run leaves its FAILURE
+          # check runs on the same head SHA and would refuse a branch that is
+          # actually green (#1516). Recency key is startedAt, not completedAt —
+          # completedAt is null while a rerun is in flight. StatusContexts key
+          # on context/createdAt and are each their own latest.
+          LATEST_CHECKS=$(echo "$STATUS_ROLLUP" | jq '[group_by(.name // .context // "?")[] | max_by(.startedAt // .createdAt // "")]')
+
+          CI_FAILED=$(echo "$LATEST_CHECKS" | jq '[.[] | select(.conclusion == "FAILURE" or .conclusion == "ERROR")] | length')
           if [ "$CI_FAILED" != "0" ]; then
             echo "ERROR: PR #$PR_NUMBER has failed CI checks"
             exit 1
           fi
 
-          CI_PENDING=$(echo "$STATUS_ROLLUP" | jq '[.[] | select(.conclusion == null or .conclusion == "" or .conclusion == "PENDING" or .conclusion == "IN_PROGRESS" or .conclusion == "QUEUED")] | length')
+          CI_PENDING=$(echo "$LATEST_CHECKS" | jq '[.[] | select(.conclusion == null or .conclusion == "" or .conclusion == "PENDING" or .conclusion == "IN_PROGRESS" or .conclusion == "QUEUED")] | length')
           if [ "$CI_PENDING" != "0" ]; then
             echo "ERROR: PR #$PR_NUMBER has checks still in progress"
             exit 1
           fi
 
-          CI_SUCCESS=$(echo "$STATUS_ROLLUP" | jq '[.[] | select(.conclusion == "SUCCESS")] | length')
+          CI_SUCCESS=$(echo "$LATEST_CHECKS" | jq '[.[] | select(.conclusion == "SUCCESS")] | length')
           if [ "$CI_SUCCESS" = "0" ]; then
             echo "ERROR: PR #$PR_NUMBER has no successful CI checks"
             exit 1
@@ -457,19 +466,28 @@ jobs:
           fi
 
           STATUS_ROLLUP=$(echo "$PR_JSON" | jq -r '.[0].statusCheckRollup // []')
-          CI_FAILED=$(echo "$STATUS_ROLLUP" | jq '[.[] | select(.conclusion == "FAILURE" or .conclusion == "ERROR")] | length')
+
+          # Evaluate only the LATEST run of each check name (#1522), the way
+          # `gh pr checks` does: a superseded workflow run leaves its FAILURE
+          # check runs on the same head SHA and would refuse a branch that is
+          # actually green (#1516). Recency key is startedAt, not completedAt —
+          # completedAt is null while a rerun is in flight. StatusContexts key
+          # on context/createdAt and are each their own latest.
+          LATEST_CHECKS=$(echo "$STATUS_ROLLUP" | jq '[group_by(.name // .context // "?")[] | max_by(.startedAt // .createdAt // "")]')
+
+          CI_FAILED=$(echo "$LATEST_CHECKS" | jq '[.[] | select(.conclusion == "FAILURE" or .conclusion == "ERROR")] | length')
           if [ "$CI_FAILED" != "0" ]; then
             echo "ERROR: PR #$PR_NUMBER has failed CI checks"
             exit 1
           fi
 
-          CI_PENDING=$(echo "$STATUS_ROLLUP" | jq '[.[] | select(.conclusion == null or .conclusion == "" or .conclusion == "PENDING" or .conclusion == "IN_PROGRESS" or .conclusion == "QUEUED")] | length')
+          CI_PENDING=$(echo "$LATEST_CHECKS" | jq '[.[] | select(.conclusion == null or .conclusion == "" or .conclusion == "PENDING" or .conclusion == "IN_PROGRESS" or .conclusion == "QUEUED")] | length')
           if [ "$CI_PENDING" != "0" ]; then
             echo "ERROR: PR #$PR_NUMBER has checks still in progress"
             exit 1
           fi
 
-          CI_SUCCESS=$(echo "$STATUS_ROLLUP" | jq '[.[] | select(.conclusion == "SUCCESS")] | length')
+          CI_SUCCESS=$(echo "$LATEST_CHECKS" | jq '[.[] | select(.conclusion == "SUCCESS")] | length')
           if [ "$CI_SUCCESS" = "0" ]; then
             echo "ERROR: PR #$PR_NUMBER has no successful CI checks"
             exit 1

--- a/assets/workspace/.github/workflows/release-core.yml
+++ b/assets/workspace/.github/workflows/release-core.yml
@@ -322,7 +322,18 @@ jobs:
           fi
 
           STATUS_ROLLUP=$(echo "$PR_JSON" | jq -r '.[0].statusCheckRollup // []')
-          CI_FAILED=$(echo "$STATUS_ROLLUP" | jq '[.[] | select(.conclusion == "FAILURE" or .conclusion == "ERROR")] | length')
+
+          # Evaluate only the LATEST run of each check name (#1522), the way
+          # `gh pr checks` does: a superseded workflow run leaves its FAILURE
+          # check runs attached to the same head SHA and would refuse a branch
+          # that is actually green (#1516). Recency key is startedAt, not
+          # completedAt — completedAt is null while a rerun is in flight, which
+          # would rank the live run oldest and let the stale FAILURE win.
+          # StatusContexts carry context/createdAt instead of name/startedAt
+          # and have no rerun history, so each one is its own latest.
+          LATEST_CHECKS=$(echo "$STATUS_ROLLUP" | jq '[group_by(.name // .context // "?")[] | max_by(.startedAt // .createdAt // "")]')
+
+          CI_FAILED=$(echo "$LATEST_CHECKS" | jq '[.[] | select(.conclusion == "FAILURE" or .conclusion == "ERROR")] | length')
           if [ "$CI_FAILED" != "0" ]; then
             echo "ERROR: PR #$PR_NUMBER has failed CI checks"
             exit 1

--- a/tests/test_ci_green_gate.py
+++ b/tests/test_ci_green_gate.py
@@ -1,0 +1,248 @@
+"""Behavior tests: the release-PR CI-green gate, executed (#1522).
+
+Issue #1516: during the 1.10.0 train a release PR was closed/reopened to fire a
+fresh ``pull_request`` event (a rerun replays the frozen payload and could not
+pick up the corrected PR body). The new run went 13/13 green, but the
+superseded run's two FAILURE check runs stayed attached to the same head SHA.
+The gate counted **every** FAILURE entry in ``statusCheckRollup``, so it refused
+a branch ``gh pr checks`` — which keeps only the latest run per name — reported
+green. The operator had to ``gh run delete`` the superseded run to proceed.
+
+Issue #1522 makes every copy of the gate group the rollup by check name and
+evaluate only the most recent run of each. That is behavior, not shape: a
+string assertion cannot tell a correct dedup filter from a plausible one, and
+picking the wrong recency key (``completedAt``, null while a rerun is in
+flight) would silently let a stale FAILURE win again. So these tests EXTRACT
+the gate's real bash and EXECUTE it against fixture rollups — the idiom
+``tests/bats/release-mirror-fold.bats`` uses for the mirror fold.
+
+All six gate sites are covered: the two named in the issue (devkit's
+``release.yml``, the scaffold's ``release-core.yml``) plus the four promote
+gates, which carry the identical logic and the identical hazard.
+
+Refs: #1516, #1522
+"""
+
+from __future__ import annotations
+
+from itertools import permutations
+from typing import TYPE_CHECKING
+
+import pytest
+
+from tests.workflow_scaffold import (
+    REPO_ROOT,
+    WORKFLOWS,
+    extract_ci_gate,
+    load_workflow,
+    run_ci_gate,
+    step_by_name,
+    steps_of_job,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+DEVKIT_WORKFLOWS = REPO_ROOT / ".github" / "workflows"
+
+# site id -> (workflow file, job, step-name fragment carrying the gate)
+GATE_SITES: dict[str, tuple[Path, str, str]] = {
+    "release/devkit": (
+        DEVKIT_WORKFLOWS / "release.yml",
+        "validate",
+        "Find and verify PR",
+    ),
+    "release-core/scaffold": (
+        WORKFLOWS / "release-core.yml",
+        "validate",
+        "Find and verify PR",
+    ),
+    "promote/devkit/validate": (
+        DEVKIT_WORKFLOWS / "promote-release.yml",
+        "validate",
+        "Find and verify release PR",
+    ),
+    "promote/devkit/merge": (
+        DEVKIT_WORKFLOWS / "promote-release.yml",
+        "merge",
+        "Find and verify release PR",
+    ),
+    "promote/scaffold/validate": (
+        WORKFLOWS / "promote-release.yml",
+        "validate",
+        "Find and verify release PR",
+    ),
+    "promote/scaffold/merge": (
+        WORKFLOWS / "promote-release.yml",
+        "merge",
+        "Find and verify release PR",
+    ),
+}
+SITES = list(GATE_SITES)
+
+T1 = "2026-08-14T10:00:00Z"
+T2 = "2026-08-14T11:00:00Z"
+
+
+def _gate(site: str) -> str:
+    path, job, step_name = GATE_SITES[site]
+    step = step_by_name(steps_of_job(load_workflow(path), job), step_name)
+    return extract_ci_gate(step["run"])
+
+
+def check_run(name: str, conclusion: str | None, started: str) -> dict:
+    """A CheckRun rollup node. ``conclusion=None`` means still in progress."""
+    return {
+        "__typename": "CheckRun",
+        "name": name,
+        "status": "IN_PROGRESS" if conclusion is None else "COMPLETED",
+        "conclusion": conclusion,
+        "startedAt": started,
+        # Null while the run is in flight — the trap a ``completedAt`` recency
+        # key would fall into.
+        "completedAt": None if conclusion is None else started,
+    }
+
+
+def status_context(context: str, state: str, created: str) -> dict:
+    """A StatusContext rollup node: no ``name``, no ``conclusion``, no run history."""
+    return {
+        "__typename": "StatusContext",
+        "context": context,
+        "state": state,
+        "createdAt": created,
+        "targetUrl": None,
+    }
+
+
+def _output(proc: object) -> str:
+    return proc.stdout + proc.stderr  # type: ignore[attr-defined]
+
+
+# The #1516 rollup: a superseded FAILURE and the operative SUCCESS of the same
+# check name on one head SHA, alongside a second green check.
+SUPERSEDED_FAILURE = [
+    check_run("Project Checks", "FAILURE", T1),
+    check_run("Project Checks", "SUCCESS", T2),
+    check_run("Test Summary", "SUCCESS", T2),
+]
+
+# The inverse: the newest run is the failing one. Dedup must not simply prefer
+# a SUCCESS over a FAILURE.
+LATEST_FAILURE = [
+    check_run("Project Checks", "SUCCESS", T1),
+    check_run("Project Checks", "FAILURE", T2),
+    check_run("Test Summary", "SUCCESS", T2),
+]
+
+
+@pytest.mark.parametrize("site", SITES)
+def test_superseded_failure_does_not_block(site: str) -> None:
+    """#1516: a stale FAILURE replaced by a newer SUCCESS must let the gate pass."""
+    proc = run_ci_gate(_gate(site), SUPERSEDED_FAILURE)
+    assert proc.returncode == 0, _output(proc)
+
+
+@pytest.mark.parametrize("site", SITES)
+def test_latest_run_failure_still_blocks(site: str) -> None:
+    """An older SUCCESS superseded by a FAILURE keeps the gate shut."""
+    proc = run_ci_gate(_gate(site), LATEST_FAILURE)
+    assert proc.returncode != 0
+    assert "failed CI checks" in _output(proc)
+
+
+@pytest.mark.parametrize("site", SITES)
+def test_in_progress_rerun_counts_as_pending_not_failed(site: str) -> None:
+    """A rerun in flight over an older FAILURE waits; it is never a failure.
+
+    ``release-core.yml`` gates on failures only, so there the gate passes —
+    what matters everywhere is that the superseded FAILURE stops counting.
+    """
+    gate = _gate(site)
+    proc = run_ci_gate(
+        gate,
+        [
+            check_run("Project Checks", "FAILURE", T1),
+            check_run("Project Checks", None, T2),
+            check_run("Test Summary", "SUCCESS", T2),
+        ],
+    )
+    assert "failed CI checks" not in _output(proc)
+    if "CI_PENDING" in gate:
+        assert proc.returncode != 0
+        assert "in progress" in _output(proc)
+    else:
+        assert proc.returncode == 0, _output(proc)
+
+
+@pytest.mark.parametrize("site", SITES)
+def test_failure_on_a_distinct_name_still_blocks(site: str) -> None:
+    """Dedup is per name: a red check A is not excused by a green check B."""
+    proc = run_ci_gate(
+        _gate(site),
+        [
+            check_run("Project Checks", "FAILURE", T2),
+            check_run("Test Summary", "SUCCESS", T2),
+        ],
+    )
+    assert proc.returncode != 0
+    assert "failed CI checks" in _output(proc)
+
+
+@pytest.mark.parametrize("site", SITES)
+def test_status_contexts_keep_their_current_treatment(site: str) -> None:
+    """A StatusContext has no ``conclusion``, so it counts as pending — as before.
+
+    Dedup must not quietly reclassify commit statuses: this pins the pre-#1522
+    behavior rather than blessing it.
+    """
+    gate = _gate(site)
+    proc = run_ci_gate(
+        gate,
+        [
+            status_context("ci/legacy", "SUCCESS", T1),
+            check_run("Test Summary", "SUCCESS", T1),
+        ],
+    )
+    assert "failed CI checks" not in _output(proc)
+    if "CI_PENDING" in gate:
+        assert proc.returncode != 0
+        assert "in progress" in _output(proc)
+    else:
+        assert proc.returncode == 0, _output(proc)
+
+
+@pytest.mark.parametrize("site", SITES)
+def test_distinct_status_contexts_are_not_collapsed(site: str) -> None:
+    """Two commit statuses stay two entries: they key on ``context``, not ``name``.
+
+    Grouping on ``name`` alone would fold every StatusContext (whose ``name``
+    is null) into a single bucket and drop entries from the counts.
+    """
+    gate = _gate(site)
+    proc = run_ci_gate(
+        gate,
+        [
+            status_context("ci/one", "SUCCESS", T1),
+            status_context("ci/two", "SUCCESS", T2),
+            check_run("Test Summary", "SUCCESS", T2),
+        ],
+    )
+    if "$CI_PENDING checks" in gate:  # only this copy prints the count
+        assert "has 2 checks still in progress" in _output(proc)
+    elif "CI_PENDING" in gate:
+        assert proc.returncode != 0
+    else:
+        assert proc.returncode == 0, _output(proc)
+
+
+@pytest.mark.parametrize("site", SITES)
+def test_recency_comes_from_timestamps_not_array_order(site: str) -> None:
+    """Every ordering of the same rollup yields the same verdict."""
+    gate = _gate(site)
+    for rollup in permutations(SUPERSEDED_FAILURE):
+        proc = run_ci_gate(gate, list(rollup))
+        assert proc.returncode == 0, _output(proc)
+    proc = run_ci_gate(gate, list(reversed(LATEST_FAILURE)))
+    assert proc.returncode != 0
+    assert "failed CI checks" in _output(proc)

--- a/tests/workflow_scaffold.py
+++ b/tests/workflow_scaffold.py
@@ -12,14 +12,19 @@ Two families live here:
   the loader, the ``on:``-key quirk handling, job/step lookups, and the
   resolve-toolchain executed-bash harness live here once instead of as
   per-file private copies.
+- The CI-green gate harness (#1522): ``extract_ci_gate``/``run_ci_gate`` slice
+  the release-PR CI gate out of a workflow step and EXECUTE it against a
+  fixture ``statusCheckRollup``. Shape assertions cannot tell a correct jq
+  filter from a plausible one — the #1516 stale-FAILURE hazard is behavior.
 
-Refs: #1210, #1413
+Refs: #1210, #1413, #1522
 """
 
 from __future__ import annotations
 
 import atexit
 import functools
+import json
 import os
 import re
 import shutil
@@ -125,6 +130,55 @@ def run_resolve_toolchain(
         text=True,
     )
     return parse_github_output(github_output)
+
+
+_GATE_START_RE = re.compile(r"^\s*STATUS_ROLLUP=")
+_GATE_ASSIGN_RE = re.compile(r"^\s*CI_[A-Z_]+=")
+
+
+def extract_ci_gate(run: str) -> str:
+    """Slice the release-PR CI-green gate out of a verification step's bash.
+
+    The gate runs from the ``STATUS_ROLLUP=`` assignment through the ``fi`` of
+    the last ``CI_*`` check, so the slice adapts to copies that carry only the
+    failure check (``release-core.yml``) as well as those that also gate on
+    pending/success. Everything around it (``gh pr list``, draft, approval and
+    mergeability gates) needs GitHub and is left out.
+    """
+    lines = run.splitlines()
+    starts = [i for i, line in enumerate(lines) if _GATE_START_RE.match(line)]
+    assert len(starts) == 1, f"expected exactly one STATUS_ROLLUP gate, got {starts}"
+    start = starts[0]
+    assigns = [
+        i for i, line in enumerate(lines) if i > start and _GATE_ASSIGN_RE.match(line)
+    ]
+    assert assigns, "no CI_* assignment after STATUS_ROLLUP"
+    end = next(i for i in range(assigns[-1], len(lines)) if lines[i].strip() == "fi")
+    return "\n".join(lines[start : end + 1])
+
+
+def run_ci_gate(gate: str, rollup: list[dict]) -> subprocess.CompletedProcess[str]:
+    """Execute an extracted CI gate against a fixture ``statusCheckRollup``.
+
+    ``rollup`` is wrapped in the ``gh pr list`` envelope the gate reads
+    (``PR_JSON`` = a one-element array). Returns the completed process so
+    callers assert on both the exit code and the operator-facing message.
+    """
+    payload = json.dumps([{"statusCheckRollup": rollup}])
+    script = "\n".join(
+        [
+            "set -euo pipefail",
+            "PR_NUMBER=1",
+            "PR_JSON=$(cat <<'DEVKIT_PR_JSON'",
+            payload,
+            "DEVKIT_PR_JSON",
+            ")",
+            gate,
+        ]
+    )
+    return subprocess.run(
+        ["bash", "-c", script], capture_output=True, text=True, check=False
+    )
 
 
 def parse_github_output(path: Path) -> dict[str, str]:


### PR DESCRIPTION
## Summary

Implements #1522 (follow-up to the #1516 train blocker): the CI-green gate counted **every** FAILURE/ERROR in the release PR head SHA's `statusCheckRollup`, so stale check runs left by a superseded workflow run (e.g. after a close/reopen re-run) blocked a branch that `gh pr checks` correctly reported green — during the 1.10.0 train this forced deleting the superseded run.

The gate now dedups the rollup **once** into a latest-per-name set and derives all three counts (`CI_FAILED`, `CI_PENDING`, `CI_SUCCESS`) from it, matching `gh pr checks` semantics:

```
jq '[group_by(.name // .context // "?")[] | max_by(.startedAt // .createdAt // "")]'
```

- **Recency key `startedAt`, not `completedAt`**: `completedAt` is null while a re-run is in flight, which would rank the live run oldest and let the superseded FAILURE win — the exact inversion of the intended behavior.
- **Group key `.name // .context`**: StatusContexts have no `name`; they key on `context`, are each their own latest, and keep their pre-existing pending treatment (pinned by test, not changed).
- Applied to **all six sites** (approved scope beyond the two the issue names — the promote gates share the identical logic and hazard): `release.yml`, both `promote-release.yml` gates (devkit + scaffold), and the consumer `release-core.yml`. Sync topology verified first: none of these four files is manifest-generated, so each was edited as an independent source.

## Test plan

New `tests/test_ci_green_gate.py`: 7 scenarios x 6 sites = 42 tests that **execute the real extracted bash+jq** against fixture rollups (harness in `tests/workflow_scaffold.py`) — superseded FAILURE passes (the #1516 case, red before the fix: 18 failed), latest-run FAILURE still blocks, in-progress re-run counts pending not failed, distinct-name FAILURE still blocks, StatusContext treatment unchanged, distinct StatusContexts not collapsed, order-independence across permutations. Naming each site explicitly also closes the historical scaffold-vs-devkit copy blind spot.

Existing suites untouched and green: `test_release_validate_gate.py` + `test_promote_release.py` + `test_release_core.py` (80 passed with the new suite), `just test-bats` 552 passed, `prek run --all-files` exit 0 (verified independently of the implementation run).

Follow-up candidates noted in review (not in scope): StatusContexts always count as pending in these gates (pre-existing), and `vig_utils/gh_issues.py::_dedupe_status_checks` still keys on `completedAt`.

Closes #1522