### PR TITLE
fix(upgrade): fetch install.sh from the target release tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **`devkit-upgrade` fetches `install.sh` from the target release tag, not
+  `main`** ([#1532](https://github.com/vig-os/devkit/issues/1532))
+  - The managed workflow ran a `main`-tip installer while scaffolding a pinned
+    `$TARGET` payload — an untested pairing, and the one every *scheduled*
+    consumer run got whenever `main` was ahead of the latest release. It also
+    meant any push to devkit `main` immediately changed code executing with
+    `contents: write` in every consumer repo, with no review gate
+  - The fetch is now `refs/tags/${TARGET}/install.sh`, so installer and payload
+    move together and only a published release can change what runs. No `main`
+    fallback is needed: the resolve step admits only `X.Y.Z[-prerelease]`
+    versions, and every devkit tag of that shape carries a root-level
+    `install.sh`
+  - Scorecard's `Pinned-Dependencies` finding on the consumer copy is expected
+    to remain — it wants a commit SHA, and SHA-pinning a self-upgrading
+    installer is circular by construction; dismiss it consumer-side
+
 ## [1.10.0](https://github.com/vig-os/devkit/releases/tag/1.10.0) - 2026-08-14
 
 ### Added

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -80,6 +80,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **`devkit-upgrade` fetches `install.sh` from the target release tag, not
+  `main`** ([#1532](https://github.com/vig-os/devkit/issues/1532))
+  - The managed workflow ran a `main`-tip installer while scaffolding a pinned
+    `$TARGET` payload — an untested pairing, and the one every *scheduled*
+    consumer run got whenever `main` was ahead of the latest release. It also
+    meant any push to devkit `main` immediately changed code executing with
+    `contents: write` in every consumer repo, with no review gate
+  - The fetch is now `refs/tags/${TARGET}/install.sh`, so installer and payload
+    move together and only a published release can change what runs. No `main`
+    fallback is needed: the resolve step admits only `X.Y.Z[-prerelease]`
+    versions, and every devkit tag of that shape carries a root-level
+    `install.sh`
+  - Scorecard's `Pinned-Dependencies` finding on the consumer copy is expected
+    to remain — it wants a commit SHA, and SHA-pinning a self-upgrading
+    installer is circular by construction; dismiss it consumer-side
+
 ## [1.10.0](https://github.com/vig-os/devkit/releases/tag/1.10.0) - 2026-08-14
 
 ### Added

--- a/assets/workspace/.github/workflows/devkit-upgrade.yml
+++ b/assets/workspace/.github/workflows/devkit-upgrade.yml
@@ -231,7 +231,16 @@ jobs:
           # preinstalled podman can pair with a stale system crun that rejects
           # podman >= 5's OCI configs (#1305) — auto-detection now prefers a
           # responsive docker anyway, this makes the choice self-documenting.
-          curl -sSfL https://raw.githubusercontent.com/vig-os/devkit/main/install.sh \
+          #
+          # The installer comes from the TARGET's own tag, not main (#1532):
+          # installer and scaffold payload must move together — a main-tip
+          # installer paired with a released payload is an untested combination,
+          # and it is what every scheduled run got while main was ahead of the
+          # latest release. It also removes the window where any push to devkit
+          # main changes code executing here with contents: write. No main
+          # fallback: the resolve step above admits only X.Y.Z[-pre] versions,
+          # and every devkit tag of that shape carries a root-level install.sh.
+          curl -sSfL "https://raw.githubusercontent.com/vig-os/devkit/refs/tags/${TARGET}/install.sh" \
             | bash -s -- --force --version "$TARGET" --skip-preflight --docker . \
             | tee "$RUNNER_TEMP/install.log"
           # Surface the flake-input advance outcome (#1497): install.sh prints

--- a/tests/test_workflow_devkit_upgrade.py
+++ b/tests/test_workflow_devkit_upgrade.py
@@ -239,11 +239,45 @@ def test_publishes_a_verified_commit_via_api_not_git_push() -> None:
 def test_bootstraps_installsh_and_commits_in_project_shell() -> None:
     """The upgrade runs install.sh --force --version and commits inside nix develop."""
     text = TEMPLATE.read_text(encoding="utf-8")
-    assert "raw.githubusercontent.com/vig-os/devkit/main/install.sh" in text
+    # The installer is fetched over the network; which ref it comes from is
+    # pinned by the test below.
+    assert "raw.githubusercontent.com/vig-os/devkit/" in text
+    assert "install.sh" in text
     assert "--force" in text and "--version" in text
     assert "nix develop -c git commit" in text
     # A nix installer action provides the `flake update vigos` leg.
     assert "install-nix-action" in text
+
+
+def test_installer_is_fetched_from_the_target_release_tag() -> None:
+    """The installer comes from ``$TARGET``'s tag, never ``main`` tip (#1532).
+
+    Fetching ``install.sh`` from ``main`` while installing a pinned ``$TARGET``
+    pairs an installer with a scaffold payload from a different ref — an
+    untested combination, and precisely the one every *scheduled* consumer run
+    gets whenever ``main`` is ahead of the latest release. It also means any
+    push to devkit ``main`` immediately changes code that executes with
+    ``contents: write`` in every consumer repo, with no review gate between the
+    commit and the fleet. Pinning the fetch to the target tag closes both:
+    installer and payload move together, and only a published release can
+    change what runs.
+
+    No ``main`` fallback: the resolve step accepts only a strict
+    ``X.Y.Z[-prerelease]`` semver, and every devkit tag of that shape carries a
+    root-level ``install.sh``.
+    """
+    text = TEMPLATE.read_text(encoding="utf-8")
+    step = step_by_id(_jobs(text)["upgrade"]["steps"], "upgrade")
+    run = str(step["run"])
+    # Double-quoted: the URL now interpolates $TARGET.
+    assert (
+        'curl -sSfL "https://raw.githubusercontent.com/vig-os/devkit'
+        '/refs/tags/${TARGET}/install.sh"' in run
+    )
+    # TARGET is already env-routed into this step — no new plumbing.
+    assert step["env"]["TARGET"] == "${{ steps.resolve.outputs.target }}"
+    # No main-tip installer fetch survives anywhere in the template.
+    assert "devkit/main/install.sh" not in text
 
 
 def test_upgrade_step_captures_the_flake_bump_report() -> None:


### PR DESCRIPTION
## Summary

Implements #1532 (surfaced by a Scorecard `Pinned-Dependencies` alert on commit-action): the managed `devkit-upgrade.yml` fetched `install.sh` from **`main` tip** while installing a pinned `$TARGET` — an untested installer/payload combination on most scheduled runs, and a window where any push to devkit `main` immediately changes code executing with `contents: write` in every consumer repo.

One functional line: the fetch is now `refs/tags/${TARGET}/install.sh` (double-quoted; `$TARGET` reused from the step's existing `env:`), with a rationale comment. The #1530 `report` job is untouched.

- **No `main` fallback, verified**: `git ls-tree` over all 61 tags shows root-level `install.sh` in every tag from 0.2.0 through 1.10.0 including every rc; the sole miss (`0.1`) is unreachable — the resolve step's `^X.Y.Z[-pre]$` regex rejects it and `releases/latest` never returns it.
- **Every other `main/install.sh` URL audited and kept**: all remaining hits are unversioned human-driven bootstrap paths (README/template one-liners, `install.sh` self-help text, `version-check.sh`'s no-workflow hint, SOLO_ADOPTION/MIGRATION docs, archived issue text) — bootstrap from `main` is correct when no version exists yet. The smoke-test workflows already fetch `${TAG}/install.sh`.
- **Out of scope per the issue**: SHA-pinning (circular for a self-upgrading installer — the Scorecard alert is expected to remain and be dismissed consumer-side) and installer self-verification of its version (possible stronger follow-up).

## Test plan

- New `test_installer_is_fetched_from_the_target_release_tag`: asserts the exact double-quoted `refs/tags/${TARGET}` curl, the `env.TARGET` wiring, and that `devkit/main/install.sh` appears nowhere in the template (TDD red first: 1 failed against the `main` URL).
- `test_bootstraps_installsh_and_commits_in_project_shell` relaxed to ref-agnostic — the ref pin is owned by the new test (DRY).
- `tests/test_workflow_devkit_upgrade.py`: 27 passed; `prek run --all-files` exit 0 (verified independently of the implementation run).

Rollout note: consumers pick this up one train after it ships (the workflow runs from their base branch).

Closes #1532