### PR TITLE
fix(release): classify commit-status states in the CI-green gate

### DIFF
--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -365,21 +365,26 @@ jobs:
           # actually green (#1516). Recency key is startedAt, not completedAt —
           # completedAt is null while a rerun is in flight. StatusContexts key
           # on context/createdAt and are each their own latest.
+          # Classify on a normalized verdict (#1538): CheckRuns carry
+          # `conclusion`, StatusContexts `state`, and neither has the other's
+          # field, so `.conclusion // .state` buckets both kinds without
+          # double-counting — an in-progress CheckRun still resolves to null
+          # and counts as pending.
           LATEST_CHECKS=$(echo "$STATUS_ROLLUP" | jq '[group_by(.name // .context // "?")[] | max_by(.startedAt // .createdAt // "")]')
 
-          CI_FAILED=$(echo "$LATEST_CHECKS" | jq '[.[] | select(.conclusion == "FAILURE" or .conclusion == "ERROR")] | length')
+          CI_FAILED=$(echo "$LATEST_CHECKS" | jq '[.[] | (.conclusion // .state) as $v | select($v == "FAILURE" or $v == "ERROR")] | length')
           if [ "$CI_FAILED" != "0" ]; then
             echo "ERROR: PR #$PR_NUMBER has failed CI checks"
             exit 1
           fi
 
-          CI_PENDING=$(echo "$LATEST_CHECKS" | jq '[.[] | select(.conclusion == null or .conclusion == "" or .conclusion == "PENDING" or .conclusion == "IN_PROGRESS" or .conclusion == "QUEUED")] | length')
+          CI_PENDING=$(echo "$LATEST_CHECKS" | jq '[.[] | (.conclusion // .state) as $v | select($v == null or $v == "" or $v == "PENDING" or $v == "IN_PROGRESS" or $v == "QUEUED" or $v == "EXPECTED")] | length')
           if [ "$CI_PENDING" != "0" ]; then
             echo "ERROR: PR #$PR_NUMBER has checks still in progress"
             exit 1
           fi
 
-          CI_SUCCESS=$(echo "$LATEST_CHECKS" | jq '[.[] | select(.conclusion == "SUCCESS")] | length')
+          CI_SUCCESS=$(echo "$LATEST_CHECKS" | jq '[.[] | (.conclusion // .state) as $v | select($v == "SUCCESS")] | length')
           if [ "$CI_SUCCESS" = "0" ]; then
             echo "ERROR: PR #$PR_NUMBER has no successful CI checks"
             exit 1
@@ -601,21 +606,26 @@ jobs:
           # actually green (#1516). Recency key is startedAt, not completedAt —
           # completedAt is null while a rerun is in flight. StatusContexts key
           # on context/createdAt and are each their own latest.
+          # Classify on a normalized verdict (#1538): CheckRuns carry
+          # `conclusion`, StatusContexts `state`, and neither has the other's
+          # field, so `.conclusion // .state` buckets both kinds without
+          # double-counting — an in-progress CheckRun still resolves to null
+          # and counts as pending.
           LATEST_CHECKS=$(echo "$STATUS_ROLLUP" | jq '[group_by(.name // .context // "?")[] | max_by(.startedAt // .createdAt // "")]')
 
-          CI_FAILED=$(echo "$LATEST_CHECKS" | jq '[.[] | select(.conclusion == "FAILURE" or .conclusion == "ERROR")] | length')
+          CI_FAILED=$(echo "$LATEST_CHECKS" | jq '[.[] | (.conclusion // .state) as $v | select($v == "FAILURE" or $v == "ERROR")] | length')
           if [ "$CI_FAILED" != "0" ]; then
             echo "ERROR: PR #$PR_NUMBER has failed CI checks"
             exit 1
           fi
 
-          CI_PENDING=$(echo "$LATEST_CHECKS" | jq '[.[] | select(.conclusion == null or .conclusion == "" or .conclusion == "PENDING" or .conclusion == "IN_PROGRESS" or .conclusion == "QUEUED")] | length')
+          CI_PENDING=$(echo "$LATEST_CHECKS" | jq '[.[] | (.conclusion // .state) as $v | select($v == null or $v == "" or $v == "PENDING" or $v == "IN_PROGRESS" or $v == "QUEUED" or $v == "EXPECTED")] | length')
           if [ "$CI_PENDING" != "0" ]; then
             echo "ERROR: PR #$PR_NUMBER has checks still in progress"
             exit 1
           fi
 
-          CI_SUCCESS=$(echo "$LATEST_CHECKS" | jq '[.[] | select(.conclusion == "SUCCESS")] | length')
+          CI_SUCCESS=$(echo "$LATEST_CHECKS" | jq '[.[] | (.conclusion // .state) as $v | select($v == "SUCCESS")] | length')
           if [ "$CI_SUCCESS" = "0" ]; then
             echo "ERROR: PR #$PR_NUMBER has no successful CI checks"
             exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -364,12 +364,16 @@ jobs:
           # while a rerun is in flight, which would rank the live run oldest
           # and let the stale FAILURE win. StatusContexts carry
           # context/createdAt instead of name/startedAt and have no rerun
-          # history, so each one is its own latest and keeps counting as
-          # before.
+          # history, so each one is its own latest.
+          # Classify on a normalized verdict (#1538): CheckRuns carry
+          # `conclusion`, StatusContexts `state`, and neither has the other's
+          # field, so `.conclusion // .state` buckets both kinds without
+          # double-counting — an in-progress CheckRun still resolves to null
+          # and counts as pending.
           LATEST_CHECKS=$(echo "$STATUS_ROLLUP" | jq '[group_by(.name // .context // "?")[] | max_by(.startedAt // .createdAt // "")]')
 
           # Reject if any checks have failed or errored
-          CI_FAILED=$(echo "$LATEST_CHECKS" | jq '[.[] | select(.conclusion == "FAILURE" or .conclusion == "ERROR")] | length')
+          CI_FAILED=$(echo "$LATEST_CHECKS" | jq '[.[] | (.conclusion // .state) as $v | select($v == "FAILURE" or $v == "ERROR")] | length')
           if [ "$CI_FAILED" != "0" ]; then
             echo "ERROR: PR #$PR_NUMBER has failed CI checks"
             echo "Fix CI issues before releasing"
@@ -377,7 +381,7 @@ jobs:
           fi
 
           # Reject if any checks are still pending, in progress, queued, or null (non-terminal state)
-          CI_PENDING=$(echo "$LATEST_CHECKS" | jq '[.[] | select(.conclusion == null or .conclusion == "" or .conclusion == "PENDING" or .conclusion == "IN_PROGRESS" or .conclusion == "QUEUED")] | length')
+          CI_PENDING=$(echo "$LATEST_CHECKS" | jq '[.[] | (.conclusion // .state) as $v | select($v == null or $v == "" or $v == "PENDING" or $v == "IN_PROGRESS" or $v == "QUEUED" or $v == "EXPECTED")] | length')
           if [ "$CI_PENDING" != "0" ]; then
             echo "ERROR: PR #$PR_NUMBER has $CI_PENDING checks still in progress"
             echo "Wait for all CI checks to complete before releasing"
@@ -385,7 +389,7 @@ jobs:
           fi
 
           # Check that at least some checks have passed
-          CI_SUCCESS=$(echo "$LATEST_CHECKS" | jq '[.[] | select(.conclusion == "SUCCESS")] | length')
+          CI_SUCCESS=$(echo "$LATEST_CHECKS" | jq '[.[] | (.conclusion // .state) as $v | select($v == "SUCCESS")] | length')
           if [ "$CI_SUCCESS" = "0" ]; then
             echo "ERROR: PR #$PR_NUMBER has no successful CI checks"
             echo "Ensure CI has run on the release branch"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     `promote-release.yml` (validate and merge). A re-run still in flight is the
     latest, so it holds the gate open as before, and a genuinely failing latest
     run still blocks
+- **Release CI gate now reads commit-status results**
+  ([#1538](https://github.com/vig-os/devkit/issues/1538))
+  - The gate classified every `statusCheckRollup` entry by `.conclusion`, a
+    field only Checks-API entries carry. A commit status reports `state`
+    instead, so it always landed in the pending bucket and held the gate open
+    **forever**: a red status could never block, a green one never stop
+    counting as pending
+  - All six copies now classify each entry on a normalized verdict that falls
+    back from `.conclusion` to `.state`: `FAILURE`/`ERROR` block,
+    `PENDING`/`EXPECTED` wait, `SUCCESS` counts as a passing check. Checks-API
+    entries are unaffected — an in-progress one still resolves to null and
+    counts as pending
+  - Latent today (nothing in the org publishes commit statuses); it becomes
+    live the day a consumer adopts a tool that reports through the status API
 - **Describing a bot-identity bug no longer trips the agent-fingerprint check**
   ([#1521](https://github.com/vig-os/devkit/issues/1521))
   - The `emails` blocklist was matched as a bare substring over the whole

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -50,6 +50,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     `promote-release.yml` (validate and merge). A re-run still in flight is the
     latest, so it holds the gate open as before, and a genuinely failing latest
     run still blocks
+- **Release CI gate now reads commit-status results**
+  ([#1538](https://github.com/vig-os/devkit/issues/1538))
+  - The gate classified every `statusCheckRollup` entry by `.conclusion`, a
+    field only Checks-API entries carry. A commit status reports `state`
+    instead, so it always landed in the pending bucket and held the gate open
+    **forever**: a red status could never block, a green one never stop
+    counting as pending
+  - All six copies now classify each entry on a normalized verdict that falls
+    back from `.conclusion` to `.state`: `FAILURE`/`ERROR` block,
+    `PENDING`/`EXPECTED` wait, `SUCCESS` counts as a passing check. Checks-API
+    entries are unaffected — an in-progress one still resolves to null and
+    counts as pending
+  - Latent today (nothing in the org publishes commit statuses); it becomes
+    live the day a consumer adopts a tool that reports through the status API
 - **Describing a bot-identity bug no longer trips the agent-fingerprint check**
   ([#1521](https://github.com/vig-os/devkit/issues/1521))
   - The `emails` blocklist was matched as a bare substring over the whole

--- a/assets/workspace/.github/workflows/promote-release.yml
+++ b/assets/workspace/.github/workflows/promote-release.yml
@@ -244,21 +244,26 @@ jobs:
           # actually green (#1516). Recency key is startedAt, not completedAt —
           # completedAt is null while a rerun is in flight. StatusContexts key
           # on context/createdAt and are each their own latest.
+          # Classify on a normalized verdict (#1538): CheckRuns carry
+          # `conclusion`, StatusContexts `state`, and neither has the other's
+          # field, so `.conclusion // .state` buckets both kinds without
+          # double-counting — an in-progress CheckRun still resolves to null
+          # and counts as pending.
           LATEST_CHECKS=$(echo "$STATUS_ROLLUP" | jq '[group_by(.name // .context // "?")[] | max_by(.startedAt // .createdAt // "")]')
 
-          CI_FAILED=$(echo "$LATEST_CHECKS" | jq '[.[] | select(.conclusion == "FAILURE" or .conclusion == "ERROR")] | length')
+          CI_FAILED=$(echo "$LATEST_CHECKS" | jq '[.[] | (.conclusion // .state) as $v | select($v == "FAILURE" or $v == "ERROR")] | length')
           if [ "$CI_FAILED" != "0" ]; then
             echo "ERROR: PR #$PR_NUMBER has failed CI checks"
             exit 1
           fi
 
-          CI_PENDING=$(echo "$LATEST_CHECKS" | jq '[.[] | select(.conclusion == null or .conclusion == "" or .conclusion == "PENDING" or .conclusion == "IN_PROGRESS" or .conclusion == "QUEUED")] | length')
+          CI_PENDING=$(echo "$LATEST_CHECKS" | jq '[.[] | (.conclusion // .state) as $v | select($v == null or $v == "" or $v == "PENDING" or $v == "IN_PROGRESS" or $v == "QUEUED" or $v == "EXPECTED")] | length')
           if [ "$CI_PENDING" != "0" ]; then
             echo "ERROR: PR #$PR_NUMBER has checks still in progress"
             exit 1
           fi
 
-          CI_SUCCESS=$(echo "$LATEST_CHECKS" | jq '[.[] | select(.conclusion == "SUCCESS")] | length')
+          CI_SUCCESS=$(echo "$LATEST_CHECKS" | jq '[.[] | (.conclusion // .state) as $v | select($v == "SUCCESS")] | length')
           if [ "$CI_SUCCESS" = "0" ]; then
             echo "ERROR: PR #$PR_NUMBER has no successful CI checks"
             exit 1
@@ -473,21 +478,26 @@ jobs:
           # actually green (#1516). Recency key is startedAt, not completedAt —
           # completedAt is null while a rerun is in flight. StatusContexts key
           # on context/createdAt and are each their own latest.
+          # Classify on a normalized verdict (#1538): CheckRuns carry
+          # `conclusion`, StatusContexts `state`, and neither has the other's
+          # field, so `.conclusion // .state` buckets both kinds without
+          # double-counting — an in-progress CheckRun still resolves to null
+          # and counts as pending.
           LATEST_CHECKS=$(echo "$STATUS_ROLLUP" | jq '[group_by(.name // .context // "?")[] | max_by(.startedAt // .createdAt // "")]')
 
-          CI_FAILED=$(echo "$LATEST_CHECKS" | jq '[.[] | select(.conclusion == "FAILURE" or .conclusion == "ERROR")] | length')
+          CI_FAILED=$(echo "$LATEST_CHECKS" | jq '[.[] | (.conclusion // .state) as $v | select($v == "FAILURE" or $v == "ERROR")] | length')
           if [ "$CI_FAILED" != "0" ]; then
             echo "ERROR: PR #$PR_NUMBER has failed CI checks"
             exit 1
           fi
 
-          CI_PENDING=$(echo "$LATEST_CHECKS" | jq '[.[] | select(.conclusion == null or .conclusion == "" or .conclusion == "PENDING" or .conclusion == "IN_PROGRESS" or .conclusion == "QUEUED")] | length')
+          CI_PENDING=$(echo "$LATEST_CHECKS" | jq '[.[] | (.conclusion // .state) as $v | select($v == null or $v == "" or $v == "PENDING" or $v == "IN_PROGRESS" or $v == "QUEUED" or $v == "EXPECTED")] | length')
           if [ "$CI_PENDING" != "0" ]; then
             echo "ERROR: PR #$PR_NUMBER has checks still in progress"
             exit 1
           fi
 
-          CI_SUCCESS=$(echo "$LATEST_CHECKS" | jq '[.[] | select(.conclusion == "SUCCESS")] | length')
+          CI_SUCCESS=$(echo "$LATEST_CHECKS" | jq '[.[] | (.conclusion // .state) as $v | select($v == "SUCCESS")] | length')
           if [ "$CI_SUCCESS" = "0" ]; then
             echo "ERROR: PR #$PR_NUMBER has no successful CI checks"
             exit 1

--- a/assets/workspace/.github/workflows/release-core.yml
+++ b/assets/workspace/.github/workflows/release-core.yml
@@ -331,9 +331,14 @@ jobs:
           # would rank the live run oldest and let the stale FAILURE win.
           # StatusContexts carry context/createdAt instead of name/startedAt
           # and have no rerun history, so each one is its own latest.
+          # Classify on a normalized verdict (#1538): CheckRuns carry
+          # `conclusion`, StatusContexts `state`, and neither has the other's
+          # field, so `.conclusion // .state` buckets both kinds without
+          # double-counting — an in-progress CheckRun still resolves to null
+          # and counts as pending.
           LATEST_CHECKS=$(echo "$STATUS_ROLLUP" | jq '[group_by(.name // .context // "?")[] | max_by(.startedAt // .createdAt // "")]')
 
-          CI_FAILED=$(echo "$LATEST_CHECKS" | jq '[.[] | select(.conclusion == "FAILURE" or .conclusion == "ERROR")] | length')
+          CI_FAILED=$(echo "$LATEST_CHECKS" | jq '[.[] | (.conclusion // .state) as $v | select($v == "FAILURE" or $v == "ERROR")] | length')
           if [ "$CI_FAILED" != "0" ]; then
             echo "ERROR: PR #$PR_NUMBER has failed CI checks"
             exit 1

--- a/tests/test_ci_green_gate.py
+++ b/tests/test_ci_green_gate.py
@@ -20,7 +20,15 @@ All six gate sites are covered: the two named in the issue (devkit's
 ``release.yml``, the scaffold's ``release-core.yml``) plus the four promote
 gates, which carry the identical logic and the identical hazard.
 
-Refs: #1516, #1522
+Issue #1538 extends the same executed fixtures to **StatusContext** entries.
+The counts classified on ``.conclusion`` alone — a CheckRun-only field — so a
+commit status (which carries ``state``) always fell into the pending bucket and
+held the gate open forever: a red status could never block, a green one never
+stop counting as pending. The gates now classify on a normalized verdict,
+``.conclusion // .state``, which is unambiguous because CheckRuns have no
+``state`` and StatusContexts no ``conclusion``.
+
+Refs: #1516, #1522, #1538
 """
 
 from __future__ import annotations
@@ -190,17 +198,57 @@ def test_failure_on_a_distinct_name_still_blocks(site: str) -> None:
 
 
 @pytest.mark.parametrize("site", SITES)
-def test_status_contexts_keep_their_current_treatment(site: str) -> None:
-    """A StatusContext has no ``conclusion``, so it counts as pending — as before.
+@pytest.mark.parametrize("state", ["FAILURE", "ERROR"])
+def test_red_status_context_blocks_as_failed(site: str, state: str) -> None:
+    """#1538: a red commit status must count as failed, not as pending.
 
-    Dedup must not quietly reclassify commit statuses: this pins the pre-#1522
-    behavior rather than blessing it.
+    The sharpest case is ``release-core.yml``, whose gate checks failures only:
+    while a red status counted as pending it did not block that copy at all.
+    """
+    proc = run_ci_gate(
+        _gate(site),
+        [
+            status_context("ci/legacy", state, T1),
+            check_run("Test Summary", "SUCCESS", T1),
+        ],
+    )
+    assert proc.returncode != 0
+    assert "failed CI checks" in _output(proc)
+
+
+@pytest.mark.parametrize("site", SITES)
+def test_green_status_context_lets_the_gate_pass(site: str) -> None:
+    """#1538: a SUCCESS commit status alongside green checks must not hold the gate."""
+    proc = run_ci_gate(
+        _gate(site),
+        [
+            status_context("ci/legacy", "SUCCESS", T1),
+            check_run("Test Summary", "SUCCESS", T1),
+        ],
+    )
+    assert proc.returncode == 0, _output(proc)
+
+
+@pytest.mark.parametrize("site", SITES)
+def test_green_status_context_alone_is_a_successful_check(site: str) -> None:
+    """A rollup of nothing but green commit statuses satisfies the success count."""
+    proc = run_ci_gate(_gate(site), [status_context("ci/legacy", "SUCCESS", T1)])
+    assert proc.returncode == 0, _output(proc)
+
+
+@pytest.mark.parametrize("site", SITES)
+@pytest.mark.parametrize("state", ["PENDING", "EXPECTED"])
+def test_unfinished_status_context_still_holds_the_gate(site: str, state: str) -> None:
+    """A non-terminal commit status keeps waiting — ``EXPECTED`` included.
+
+    ``release-core.yml`` gates on failures only, so there the gate passes; what
+    matters everywhere is that an unfinished status is never read as failed.
     """
     gate = _gate(site)
     proc = run_ci_gate(
         gate,
         [
-            status_context("ci/legacy", "SUCCESS", T1),
+            status_context("ci/legacy", state, T1),
             check_run("Test Summary", "SUCCESS", T1),
         ],
     )
@@ -208,6 +256,32 @@ def test_status_contexts_keep_their_current_treatment(site: str) -> None:
     if "CI_PENDING" in gate:
         assert proc.returncode != 0
         assert "in progress" in _output(proc)
+    else:
+        assert proc.returncode == 0, _output(proc)
+
+
+@pytest.mark.parametrize("site", SITES)
+def test_mixed_rollup_classifies_each_kind_independently(site: str) -> None:
+    """CheckRuns and StatusContexts share the buckets without contaminating them.
+
+    A green status must drop out of the pending count while an in-progress
+    CheckRun (``conclusion: null``) stays in it — and is never counted failed,
+    which a normalized verdict falling through to a missing field could do.
+    """
+    gate = _gate(site)
+    proc = run_ci_gate(
+        gate,
+        [
+            status_context("ci/legacy", "SUCCESS", T1),
+            check_run("Test Summary", "SUCCESS", T1),
+            check_run("Project Checks", None, T2),
+        ],
+    )
+    assert "failed CI checks" not in _output(proc)
+    if "$CI_PENDING checks" in gate:  # only this copy prints the count
+        assert "has 1 checks still in progress" in _output(proc)
+    elif "CI_PENDING" in gate:
+        assert proc.returncode != 0
     else:
         assert proc.returncode == 0, _output(proc)
 
@@ -223,8 +297,8 @@ def test_distinct_status_contexts_are_not_collapsed(site: str) -> None:
     proc = run_ci_gate(
         gate,
         [
-            status_context("ci/one", "SUCCESS", T1),
-            status_context("ci/two", "SUCCESS", T2),
+            status_context("ci/one", "PENDING", T1),
+            status_context("ci/two", "PENDING", T2),
             check_run("Test Summary", "SUCCESS", T2),
         ],
     )
@@ -234,6 +308,39 @@ def test_distinct_status_contexts_are_not_collapsed(site: str) -> None:
         assert proc.returncode != 0
     else:
         assert proc.returncode == 0, _output(proc)
+
+
+@pytest.mark.parametrize("site", SITES)
+def test_status_context_supersedes_a_same_keyed_check_run(site: str) -> None:
+    """A context colliding with a check name shares its dedup bucket.
+
+    #1522 keys on ``.name // .context``, so a status whose context equals a
+    check name groups with it and the newer entry wins whichever kind it is.
+    Pinned as-is: classifying ``state`` does not change the grouping.
+    """
+    proc = run_ci_gate(
+        _gate(site),
+        [
+            check_run("Project Checks", "FAILURE", T1),
+            status_context("Project Checks", "SUCCESS", T2),
+            check_run("Test Summary", "SUCCESS", T2),
+        ],
+    )
+    assert proc.returncode == 0, _output(proc)
+
+
+@pytest.mark.parametrize("site", SITES)
+def test_differently_keyed_status_context_stays_a_separate_entry(site: str) -> None:
+    """A red status under its own key is not absorbed by a green check run."""
+    proc = run_ci_gate(
+        _gate(site),
+        [
+            check_run("Project Checks", "SUCCESS", T2),
+            status_context("ci/project-checks", "FAILURE", T1),
+        ],
+    )
+    assert proc.returncode != 0
+    assert "failed CI checks" in _output(proc)
 
 
 @pytest.mark.parametrize("site", SITES)


### PR DESCRIPTION
## Summary

Implements #1538 (follow-up to #1537): the six CI-green gates classified every rollup entry by `.conclusion` — a CheckRun-only field — so a StatusContext (commit status API, which carries `state`) always fell into the pending bucket: a red commit status could never block as failed (on the failures-only `release-core.yml` gate it passed outright), and a green one held the pending gates open forever. Latent today (no org repo publishes commit statuses); real the day a consumer adds a status-API tool.

All three counts now bind one normalized verdict per entry — `(.conclusion // .state) as $v` — and compare against it: FAILURE/ERROR → failed, SUCCESS → success, null/""/PENDING/IN_PROGRESS/QUEUED/**EXPECTED** → pending. Field shapes were verified live via GraphQL introspection, not assumed: `StatusState` is exactly `EXPECTED, ERROR, FAILURE, PENDING, SUCCESS`, and CheckRun has no `state` field, so nothing can double-classify; an in-progress CheckRun (`conclusion: null`) resolves `null // null` → still pending, and `conclusion: ""` stays pending via the retained `== ""` arm (empty string is truthy in jq, no fall-through). Applied at all six sites (#1537 scope); the #1537 dedup expression is untouched, and its comment blocks were corrected where they claimed StatusContexts "keep counting as before".

## Test plan

`tests/test_ci_green_gate.py`: the deliberately-pinned StatusContext test from #1537 is inverted as the issue prescribed, replaced by seven new scenario families x six sites — red status blocks as failed (sharpest red case: previously *passed* the release-core gate), green status passes / counts as a successful check, PENDING/EXPECTED still hold, mixed rollups classify each kind independently, same-keyed vs distinctly-keyed StatusContext/CheckRun grouping pinned as #1537 actually behaves. TDD red: 34 failed before the fix; 90 passed after. Combined gate suites: 128 passed; `prek run --all-files` exit 0 (verified independently of the implementation run).

Closes #1538