### PR TITLE
fix(vig-utils): key check dedup recency on startedAt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     counts as pending
   - Latent today (nothing in the org publishes commit statuses); it becomes
     live the day a consumer adopts a tool that reports through the status API
+- **`just gh-issues` CI column now shows the live re-run, not the failure it
+  supersedes**
+  ([#1539](https://github.com/vig-os/devkit/issues/1539))
+  - The PR table's latest-per-name check dedup keyed recency on `completedAt`,
+    which is null while a re-run is in flight: the live run ranked as the
+    *oldest* run of its name, so the column reported the superseded FAILURE
+    during exactly the window someone watches a re-run
+  - Recency is now keyed on `startedAt` (set at creation, never null) with a
+    `createdAt` fallback for commit statuses, matching the release CI gates
+    ([#1522](https://github.com/vig-os/devkit/issues/1522)). Display-only — the
+    table is not a gate
 - **Describing a bot-identity bug no longer trips the agent-fingerprint check**
   ([#1521](https://github.com/vig-os/devkit/issues/1521))
   - The `emails` blocklist was matched as a bare substring over the whole

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -64,6 +64,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     counts as pending
   - Latent today (nothing in the org publishes commit statuses); it becomes
     live the day a consumer adopts a tool that reports through the status API
+- **`just gh-issues` CI column now shows the live re-run, not the failure it
+  supersedes**
+  ([#1539](https://github.com/vig-os/devkit/issues/1539))
+  - The PR table's latest-per-name check dedup keyed recency on `completedAt`,
+    which is null while a re-run is in flight: the live run ranked as the
+    *oldest* run of its name, so the column reported the superseded FAILURE
+    during exactly the window someone watches a re-run
+  - Recency is now keyed on `startedAt` (set at creation, never null) with a
+    `createdAt` fallback for commit statuses, matching the release CI gates
+    ([#1522](https://github.com/vig-os/devkit/issues/1522)). Display-only — the
+    table is not a gate
 - **Describing a bot-identity bug no longer trips the agent-fingerprint check**
   ([#1521](https://github.com/vig-os/devkit/issues/1521))
   - The `emails` blocklist was matched as a bare substring over the whole

--- a/packages/vig-utils/src/vig_utils/gh_issues.py
+++ b/packages/vig-utils/src/vig_utils/gh_issues.py
@@ -374,19 +374,25 @@ def _infer_review(pr: dict) -> tuple[str, str]:
     return ("", "—")
 
 
+def _started(check: dict) -> str:
+    """Return a check's recency key, mirroring the release gates' jq expression.
+
+    Recency is keyed on startedAt, not completedAt: completedAt is null while
+    a rerun is in flight, which would rank the live run oldest and let the
+    stale FAILURE it supersedes win (#1539, same pitfall as #1537).
+    StatusContexts carry createdAt instead of startedAt.
+    """
+    return check.get("startedAt") or check.get("createdAt") or ""
+
+
 def _dedupe_status_checks(rollup: list[dict]) -> list[dict]:
-    """Deduplicate statusCheckRollup by check name, keeping latest by completedAt."""
+    """Deduplicate statusCheckRollup by check name, keeping latest by startedAt."""
     by_name: dict[str, dict] = {}
     for check in rollup:
         name = check.get("name") or "?"
-        completed = check.get("completedAt") or ""
         existing = by_name.get(name)
-        if existing is None:
+        if existing is None or _started(check) >= _started(existing):
             by_name[name] = check
-        else:
-            existing_completed = existing.get("completedAt") or ""
-            if completed >= existing_completed:
-                by_name[name] = check
     return list(by_name.values())
 
 

--- a/packages/vig-utils/tests/test_gh_issues.py
+++ b/packages/vig-utils/tests/test_gh_issues.py
@@ -130,6 +130,132 @@ class TestFormatCiStatus:
         assert "1/1" in result
 
 
+class TestDedupeStatusChecks:
+    """Test _dedupe_status_checks recency keying.
+
+    Ref: #1539
+    """
+
+    def test_in_progress_rerun_beats_older_completed_failure(self):
+        """A live rerun (completedAt null) wins over the FAILURE it supersedes."""
+        rollup = [
+            {
+                "name": "Project Checks",
+                "conclusion": "FAILURE",
+                "status": "COMPLETED",
+                "startedAt": "2026-08-17T12:00:00Z",
+                "completedAt": "2026-08-17T12:05:00Z",
+            },
+            {
+                "name": "Project Checks",
+                "conclusion": None,
+                "status": "IN_PROGRESS",
+                "startedAt": "2026-08-17T12:30:00Z",
+                "completedAt": None,
+            },
+        ]
+        result = gh_issues._dedupe_status_checks(rollup)
+        assert len(result) == 1
+        assert result[0]["status"] == "IN_PROGRESS"
+
+    def test_newer_completed_success_beats_older_failure(self):
+        """A completed rerun that passed wins over the older FAILURE."""
+        rollup = [
+            {
+                "name": "Project Checks",
+                "conclusion": "FAILURE",
+                "startedAt": "2026-08-17T12:00:00Z",
+                "completedAt": "2026-08-17T12:05:00Z",
+            },
+            {
+                "name": "Project Checks",
+                "conclusion": "SUCCESS",
+                "startedAt": "2026-08-17T12:30:00Z",
+                "completedAt": "2026-08-17T12:35:00Z",
+            },
+        ]
+        result = gh_issues._dedupe_status_checks(rollup)
+        assert [c["conclusion"] for c in result] == ["SUCCESS"]
+
+    def test_distinct_names_are_untouched(self):
+        """Different check names all survive dedup."""
+        rollup = [
+            {
+                "name": "Build",
+                "conclusion": "SUCCESS",
+                "startedAt": "2026-08-17T12:00:00Z",
+            },
+            {
+                "name": "Test",
+                "conclusion": "FAILURE",
+                "startedAt": "2026-08-17T11:00:00Z",
+            },
+        ]
+        result = gh_issues._dedupe_status_checks(rollup)
+        assert {c["name"] for c in result} == {"Build", "Test"}
+        assert len(result) == 2
+
+    def test_winner_is_order_independent(self):
+        """Input order does not change which run of a name survives."""
+        older = {
+            "name": "Project Checks",
+            "conclusion": "FAILURE",
+            "startedAt": "2026-08-17T12:00:00Z",
+            "completedAt": "2026-08-17T12:05:00Z",
+        }
+        newer = {
+            "name": "Project Checks",
+            "conclusion": None,
+            "status": "IN_PROGRESS",
+            "startedAt": "2026-08-17T12:30:00Z",
+            "completedAt": None,
+        }
+        forward = gh_issues._dedupe_status_checks([older, newer])
+        backward = gh_issues._dedupe_status_checks([newer, older])
+        assert forward == backward == [newer]
+
+    def test_status_context_falls_back_to_created_at(self):
+        """StatusContexts carry createdAt, not startedAt; recency still works."""
+        rollup = [
+            {
+                "name": "legacy/status",
+                "state": "FAILURE",
+                "createdAt": "2026-08-17T12:00:00Z",
+            },
+            {
+                "name": "legacy/status",
+                "state": "SUCCESS",
+                "createdAt": "2026-08-17T12:30:00Z",
+            },
+        ]
+        result = gh_issues._dedupe_status_checks(rollup)
+        assert [c["state"] for c in result] == ["SUCCESS"]
+
+    def test_in_progress_rerun_shown_as_pending_in_ci_cell(self):
+        """The CI cell reports the live rerun as pending, not as a failure."""
+        pr = {
+            "number": 7,
+            "statusCheckRollup": [
+                {
+                    "name": "Project Checks",
+                    "conclusion": "FAILURE",
+                    "startedAt": "2026-08-17T12:00:00Z",
+                    "completedAt": "2026-08-17T12:05:00Z",
+                },
+                {
+                    "name": "Project Checks",
+                    "conclusion": None,
+                    "startedAt": "2026-08-17T12:30:00Z",
+                    "completedAt": None,
+                },
+            ],
+        }
+        result = gh_issues._format_ci_status(pr, "a/b")
+        assert "⏳" in result
+        assert "0/1" in result
+        assert "yellow" in result
+
+
 class TestGhLink:
     """Test _gh_link helper for clickable issue/PR numbers."""
 


### PR DESCRIPTION
## Summary

Implements #1539 (follow-up to #1537): `_dedupe_status_checks` — feeding the `just gh-issues` PR table — keyed recency on `completedAt`, which is null while a re-run is in flight, so the table showed the superseded FAILURE during exactly the window someone is watching a re-run.

The recency key is now a helper mirroring the release gates' jq expression: `startedAt or createdAt or ""` (the `createdAt` arm covers StatusContexts, which have no `startedAt`; `completedAt` is deliberately absent — a completed CheckRun always has `startedAt`, so it would only reintroduce the skew). Grouping key, tie-breaking (`>=`, last wins), insertion order, and output shape unchanged; the #176-era no-timestamps behavior (last in list wins) is preserved and still pinned.

Display-only fix — no gate behavior changes.

## Found during implementation, deliberately out of scope

Two more latent StatusContext gaps in the same file, the display-table analogues of #1538: grouping uses `name` only (all commit statuses would collapse into one `"?"` bucket; gates use `.name // .context`), and `_format_ci_status` classifies on `conclusion` only (a red commit status would render pending). Latent today — zero StatusContext entries across the last 40 devkit PRs. Follow-up candidates.

## Test plan

New `TestDedupeStatusChecks` (6 tests): in-progress re-run beats older completed FAILURE (TDD red: 3 failed pre-fix), newer SUCCESS beats older FAILURE, distinct names untouched, order-independence, StatusContext `createdAt` fallback, and an end-to-end pin that the CI cell renders `⏳ 0/1` rather than `✗ 0/1`. `packages/vig-utils/tests`: 529 passed; `prek run --all-files` exit 0 (verified independently of the implementation run).

Closes #1539