### PR TITLE
fix(workspace): sanitize the synced changelog and guard unreleased entries

### DIFF
--- a/.github/workflows/prepare-release-extension.yml
+++ b/.github/workflows/prepare-release-extension.yml
@@ -7,14 +7,15 @@
 # What it does, in order:
 #
 # 1. Release branch: regenerates the synced workspace mirror
-#    (assets/workspace/.devcontainer/CHANGELOG.md, a verbatim copy of the root
-#    CHANGELOG.md) so it matches the frozen root on the release branch, then
-#    commits it via the COMMIT_APP token — the same identity/mechanism as the
-#    freeze commit. This is the devkit-specific `sync_manifest.py sync` step that
-#    used to be hardcoded in prepare-release.yml (#1059); moving it here makes
-#    prepare-release.yml scaffold-shaped and keeps the mirror correct on the
-#    branch the image is built from (tests/test_image.py::test_manifest_files
-#    checksums mirror == root).
+#    (assets/workspace/.devcontainer/CHANGELOG.md, the root CHANGELOG.md plus the
+#    #1534 sanitizing transforms) so it matches the frozen root on the release
+#    branch, then commits it via the COMMIT_APP token — the same
+#    identity/mechanism as the freeze commit. This is the devkit-specific
+#    `sync_manifest.py sync` step that used to be hardcoded in prepare-release.yml
+#    (#1059); moving it here makes prepare-release.yml scaffold-shaped and keeps
+#    the mirror correct on the branch the image is built from (the mirror is a
+#    transformed manifest entry, so tests/test_transforms.py pins it against the
+#    root and tests/test_image.py::test_manifest_files checks it ships).
 #
 # 2. Dev reconciliation: the freeze commit is scaffold-verbatim (root
 #    CHANGELOG.md only), so dev's mirror is stale after every prepare — the

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -169,6 +169,20 @@ repos:
         pass_filenames: false
         stages: [pre-commit]
 
+  # Changelog Unreleased typo gate (devkit-only, Refs: #1534). The synced mirror
+  # (assets/workspace/.devcontainer/CHANGELOG.md) is git-tracked by every
+  # devcontainer-mode consumer, whose .typos.toml is seeded once and never
+  # overwritten — so no released entry may need an allowlist entry to lint.
+  - repo: local
+    hooks:
+      - id: check-unreleased-typos
+        name: check-unreleased-typos (no-allowlist lint of the Unreleased section)
+        entry: uv run python scripts/check_unreleased_typos.py
+        language: system
+        files: ^CHANGELOG\.md$
+        pass_filenames: false
+        stages: [pre-commit]
+
   # Typo Linting (typos sourced from the flake dev-shell)
   - repo: local
     hooks:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     workflow models and runs `typos` (no allowlist) plus `actionlint` over it
     ([#1531](https://github.com/vig-os/devkit/issues/1531)) — the fold block
     has one consumer in the org, so nothing else linted it
+- **Synced devkit changelog no longer leans on a typos allowlist entry the
+  consumer may not have**
+  ([#1534](https://github.com/vig-os/devkit/issues/1534))
+  - `assets/workspace/.devcontainer/CHANGELOG.md` is a manifest-synced copy of
+    the root changelog, and devcontainer-mode consumers **git-track** it — so
+    their own typos hook lints it against a `.typos.toml` that is seeded once
+    and never overwritten. The released 1.10.0 entry carries two hyphenated
+    compounds that lint only under
+    [#1488](https://github.com/vig-os/devkit/issues/1488)'s allowlist entry, so
+    a consumer seeded before that release would fail its upgrade at the commit
+    step, exactly as org-config did in
+    [#1529](https://github.com/vig-os/devkit/issues/1529) — and neither of the
+    two config files that could fix it is ever overwritten
+  - Released changelog text is immutable, so the manifest de-hyphenates those
+    two spellings in the generated **dest** only: the root file keeps its
+    released bytes and the mirror is clean under `typos --isolated`, with no
+    allowlist at all
+  - A new devkit-only `check-unreleased-typos` hook lints the `## Unreleased`
+    section with no allowlist before it can be committed, so no future release
+    can freeze another seed-dependent word into immutable text — catching one
+    after the release is useless. Released sections keep their allowlisted
+    tokens and are out of scope
+  - The [#1531](https://github.com/vig-os/devkit/issues/1531) render lint gains
+    a devcontainer-mode leg: that tracked tree — synced changelog and
+    `version-check.sh` included — must need no allowlist entry newer than the
+    grandfathered words every live consumer's seed predates
 
 ### Security
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -102,6 +102,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     workflow models and runs `typos` (no allowlist) plus `actionlint` over it
     ([#1531](https://github.com/vig-os/devkit/issues/1531)) — the fold block
     has one consumer in the org, so nothing else linted it
+- **Synced devkit changelog no longer leans on a typos allowlist entry the
+  consumer may not have**
+  ([#1534](https://github.com/vig-os/devkit/issues/1534))
+  - `assets/workspace/.devcontainer/CHANGELOG.md` is a manifest-synced copy of
+    the root changelog, and devcontainer-mode consumers **git-track** it — so
+    their own typos hook lints it against a `.typos.toml` that is seeded once
+    and never overwritten. The released 1.10.0 entry carries two hyphenated
+    compounds that lint only under
+    [#1488](https://github.com/vig-os/devkit/issues/1488)'s allowlist entry, so
+    a consumer seeded before that release would fail its upgrade at the commit
+    step, exactly as org-config did in
+    [#1529](https://github.com/vig-os/devkit/issues/1529) — and neither of the
+    two config files that could fix it is ever overwritten
+  - Released changelog text is immutable, so the manifest de-hyphenates those
+    two spellings in the generated **dest** only: the root file keeps its
+    released bytes and the mirror is clean under `typos --isolated`, with no
+    allowlist at all
+  - A new devkit-only `check-unreleased-typos` hook lints the `## Unreleased`
+    section with no allowlist before it can be committed, so no future release
+    can freeze another seed-dependent word into immutable text — catching one
+    after the release is useless. Released sections keep their allowlisted
+    tokens and are out of scope
+  - The [#1531](https://github.com/vig-os/devkit/issues/1531) render lint gains
+    a devcontainer-mode leg: that tracked tree — synced changelog and
+    `version-check.sh` included — must need no allowlist entry newer than the
+    grandfathered words every live consumer's seed predates
 
 ### Security
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -236,9 +236,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     path(s)" and the release branch never moved, taking the issue/PR snapshots
     out of `main`. Single-file callers could never expose it
   - The list is now comma-joined from `git diff --cached -z`, which also fixes
-    two latent mis-parses in the old `git status --porcelain | awk '{print $2}'`
+    two latent misparses in the old `git status --porcelain | awk '{print $2}'`
     (C-quoted paths containing spaces, and `R old -> new` renames), and fails
-    loudly on a path containing a comma rather than mis-splitting it
+    loudly on a path containing a comma rather than missplitting it
   - The re-pull step now **verifies the post-condition**: if the release branch
     does not carry the mirror's archive after the fold, the leg fails instead
     of reporting success

--- a/docs/NIX.md
+++ b/docs/NIX.md
@@ -442,7 +442,8 @@ enables it for itself.
   Hooks that cannot run in the sandbox stay **runner-only** in the committed
   render and carry no gate profile in `nix/hooks.nix`: the generators
   `generate-docs`/`sync-manifest`, `pip-licenses` (reads `uv.lock`),
-  `no-commit-to-branch` and `destroyed-symlinks`
+  `check-unreleased-typos` (a repo script over this repo's own `CHANGELOG.md`,
+  #1534), `no-commit-to-branch` and `destroyed-symlinks`
   (git-state-dependent), `check-agent-identity` (inspects the commit
   author/committer), and the `commit-msg`/`prepare-commit-msg`-stage hooks (never
   run by `--all-files`). `checks.pre-commit` is thus a Nix-verified guarantee that

--- a/nix/hooks.nix
+++ b/nix/hooks.nix
@@ -703,6 +703,27 @@ let
         stages = [ "pre-commit" ];
       };
     };
+    # Runner-only and devkit-only (#1534): it guards THIS repo's CHANGELOG.md,
+    # which is manifest-synced into the scaffold and git-tracked by every
+    # devcontainer-mode consumer — whose `.typos.toml` is seeded once and never
+    # overwritten, so a word needing a newer allowlist entry than that seed
+    # breaks the consumer's upgrade at the commit step (#1529) and can never be
+    # reworded once released. The gate lints the `## Unreleased` section with NO
+    # allowlist (`typos --isolated`), before the text can reach a release;
+    # released sections keep their allowlisted tokens and are out of scope. Not
+    # scaffolded: a consumer's changelog is synced nowhere, and the entry is a
+    # `uv run` script from this repo. Filtered + pre-commit-pinned so an ordinary
+    # commit pays nothing for it (#1491).
+    check-unreleased-typos = {
+      yaml = {
+        name = "check-unreleased-typos (no-allowlist lint of the Unreleased section)";
+        entry = "uv run python scripts/check_unreleased_typos.py";
+        language = "system";
+        files = "^CHANGELOG\\.md$";
+        pass_filenames = false;
+        stages = [ "pre-commit" ];
+      };
+    };
     pip-licenses = {
       yaml = {
         name = "pip-licenses (check dependency licenses)";

--- a/scripts/check_unreleased_typos.py
+++ b/scripts/check_unreleased_typos.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Lint the changelog's ``## Unreleased`` section with no typos allowlist (#1534).
+
+Devkit's ``CHANGELOG.md`` is manifest-synced into the scaffold
+(``assets/workspace/.devcontainer/CHANGELOG.md``) and devcontainer-mode consumers
+**git-track** that copy, so their own typos hook has to lint it against a
+``.typos.toml`` that is seeded once and never overwritten by an upgrade. A word
+that lints only under an allowlist entry devkit added later therefore breaks such
+a consumer's upgrade at the commit step (#1529) — and a released changelog entry
+is immutable by policy, so it can never be reworded afterwards. Catching it after
+the release is useless; the only place to catch it is before the text is
+committed.
+
+Hence this gate: the ``## Unreleased`` section, linted with ``typos --isolated``
+(no config, no allowlist), so nothing that needs one can ever be frozen into a
+release. Scope is the Unreleased section ONLY — released sections legitimately
+carry allowlisted tokens (1.10.0's ``mis-parses``, which the manifest transform
+sanitizes in the synced copy) and must not fail the gate. A changelog with no
+Unreleased section at all (the release window, where prepare-release has renamed
+it to ``## [X.Y.Z]``) has nothing to check and passes.
+
+Lines outside the section are blanked rather than dropped, so typos reports the
+real line numbers of the real file.
+
+Usage:
+    uv run python scripts/check_unreleased_typos.py [CHANGELOG.md]
+
+Called by:
+    - the check-unreleased-typos pre-commit hook (nix/hooks.nix; devkit-only)
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+# Section boundaries, as in vig_utils.prepare_changelog: the Unreleased block
+# runs from its own heading to the next top-level (``## ``) heading.
+UNRELEASED_HEADING = "## Unreleased"
+SECTION_PREFIX = "## "
+
+TYPOS_ARGV = ["typos", "--isolated", "--format", "brief", "-"]
+
+ADVICE = (
+    "The `## Unreleased` text above needs a typos allowlist entry to lint. Once "
+    "released it is immutable, and it is synced into every devcontainer-mode "
+    "consumer's worktree (.devcontainer/CHANGELOG.md), where a `.typos.toml` "
+    "seeded before that entry cannot lint it — the #1529 upgrade break. Reword "
+    "the entry instead of extending .typos.toml (#1534)."
+)
+
+
+def mask_outside_unreleased(text: str) -> str | None:
+    """Blank every line outside ``## Unreleased``, or return None if absent.
+
+    Line count is preserved so typos' line numbers match the source file.
+    """
+    inside = False
+    seen = False
+    masked: list[str] = []
+    for line in text.splitlines():
+        if line.strip() == UNRELEASED_HEADING:
+            inside = True
+            seen = True
+            masked.append("")
+            continue
+        if inside and line.startswith(SECTION_PREFIX):
+            inside = False
+        masked.append(line if inside else "")
+    if not seen:
+        return None
+    return "\n".join(masked) + "\n"
+
+
+def _report(output: str, path: Path) -> None:
+    """Print typos' findings, re-anchored from stdin (``-``) onto ``path``."""
+    for line in output.splitlines():
+        print(f"{path}:{line[2:]}" if line.startswith("-:") else line, file=sys.stderr)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "path",
+        nargs="?",
+        default="CHANGELOG.md",
+        type=Path,
+        help="changelog to check (default: CHANGELOG.md)",
+    )
+    args = parser.parse_args(argv)
+
+    masked = mask_outside_unreleased(args.path.read_text(encoding="utf-8"))
+    if masked is None:
+        return 0
+
+    try:
+        result = subprocess.run(  # noqa: S603 - fixed argv, no shell
+            TYPOS_ARGV, input=masked, capture_output=True, text=True, check=False
+        )
+    except FileNotFoundError:
+        print(
+            "check-unreleased-typos: `typos` not found on PATH (it ships in the "
+            "devkit dev-shell/image toolchain)",
+            file=sys.stderr,
+        )
+        return 1
+
+    if result.returncode == 0:
+        return 0
+    _report(result.stdout, args.path)
+    if result.stderr:
+        print(result.stderr.rstrip(), file=sys.stderr)
+    print(ADVICE, file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/manifest.toml
+++ b/scripts/manifest.toml
@@ -57,9 +57,24 @@ src = ".pymarkdown"
 [[entries]]
 src = ".pymarkdown.config.md"
 
+# Devkit's changelog, git-tracked by every devcontainer-mode consumer — so their
+# own typos hook lints it against a `.typos.toml` that was seeded once and is
+# never overwritten by an upgrade. The released 1.10.0 entry's `mis-parses` /
+# `mis-splitting` lint only under #1488's `mis` entry, so a consumer seeded
+# before that fails its upgrade at the commit step, exactly as org-config did in
+# #1529. Released changelog text is immutable, so the tokens are de-hyphenated in
+# the generated DEST only: `misparses` / `missplitting` are clean under
+# `typos --isolated` (no allowlist at all), which the hyphenated forms are not.
+# Idempotent by construction — neither replacement contains its own pattern — and
+# no future entry can freeze another such token in, because the
+# check-unreleased-typos hook lints `## Unreleased` with no allowlist. Refs #1534.
 [[entries]]
 src = "CHANGELOG.md"
 dest = ".devcontainer/CHANGELOG.md"
+transforms = [
+  { type = "Sed", pattern = "mis-parses", replace = "misparses" },
+  { type = "Sed", pattern = "mis-splitting", replace = "missplitting" },
+]
 
 [[entries]]
 src = ".vscode/settings.json"

--- a/tests/bats/release-mirror-fold-lint.bats
+++ b/tests/bats/release-mirror-fold-lint.bats
@@ -26,34 +26,46 @@
 #                release-core.yml and a whole job into promote-release.yml, which
 #                nothing linted before.
 #
-# The workspace is rendered in `direnv` mode, the shape of the sole mirror-mode
-# consumer. A devcontainer-mode tree additionally ships `.devcontainer/` — the
-# synced devkit CHANGELOG and `version-check.sh` — whose prose does lean on seed
-# entries (`Nd`, `passt`, and released changelog text that may never be edited).
-# Whether the seed should carry words for those at all is the open question in
-# #1529, not the subject of this pin.
+# The two `--isolated` legs render `direnv` mode, the shape of the sole
+# mirror-mode consumer, which tracks zero `.devcontainer/` files. A
+# devcontainer-mode tree additionally ships `.devcontainer/` — the synced devkit
+# CHANGELOG and `version-check.sh` — and a consumer git-tracks those, so a third
+# render covers that mode (#1534). Its bar cannot be `--isolated`: released
+# changelog text is immutable and legitimately carries `passt` (a package name),
+# `unexcepted` (the CVE-policy term), abbreviated SHAs typos reads as `ba`, and
+# `version-check.sh`'s `Nd` duration syntax. The bar that *is* meaningful — and
+# the one #1529 broke — is that generated content must not depend on an allowlist
+# entry NEWER than the consumer's seed, since `.typos.toml` is seeded once and
+# never overwritten. So that leg runs `--isolated --config` against a frozen,
+# grandfathered word set (`_GRANDFATHERED_WORDS`): the four entries that predate
+# every live consumer's seed, and none of #1488's, which is exactly what the
+# org-config upgrade lacked.
 
 setup() {
     load test_helper
     MIRROR_GITFLOW="$BATS_FILE_TMPDIR/mirror-gitflow"
     MIRROR_TRUNK="$BATS_FILE_TMPDIR/mirror-trunk"
+    MIRROR_DEVCONTAINER="$BATS_FILE_TMPDIR/mirror-devcontainer"
 }
 
-# Render both mirror-mode workspaces ONCE for the whole file: the tests only
-# lint the rendered trees, and scaffold+upgrade is the slow part.
+# Render every mirror-mode workspace ONCE for the whole file: the tests only
+# lint the rendered trees, and scaffold+upgrade is the slow part (~0.6s each).
 setup_file() {
     local root
     root="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
     _render_mirror "$root" gitflow "$BATS_FILE_TMPDIR/mirror-gitflow" || return 1
     _render_mirror "$root" trunk "$BATS_FILE_TMPDIR/mirror-trunk" || return 1
+    _render_mirror "$root" gitflow "$BATS_FILE_TMPDIR/mirror-devcontainer" \
+        devcontainer || return 1
 }
 
-# Render a mirror-mode consumer workspace for workflow model $2 into $3.
+# Render a mirror-mode consumer workspace for workflow model $2 into $3, in
+# delivery mode $4 (default `direnv`).
 # Mirror mode is not a scaffold flag: the manifest key is set on the scaffolded
 # workspace and a second (upgrade) pass injects the fold block, which is how a
 # consumer reaches this state.
 _render_mirror() {
-    local root="$1" model="$2" ws="$3"
+    local root="$1" model="$2" ws="$3" mode="${4:-direnv}"
     local stub="$BATS_FILE_TMPDIR/stub-bin"
     mkdir -p "$ws" "$stub"
     printf '#!/usr/bin/env bash\nexit 0\n' >"$stub/just"
@@ -64,7 +76,7 @@ _render_mirror() {
         SHORT_NAME=testproj \
         GITHUB_REPOSITORY=test/repo \
         bash "$root/assets/init-workspace.sh" --force --no-prompts \
-        --mode direnv --workflow "$model" \
+        --mode "$mode" --workflow "$model" \
         >"$ws.log" 2>&1 || { cat "$ws.log" >&2; return 1; }
     sed -i 's#^DEVKIT_SYNC_TARGET=.*#DEVKIT_SYNC_TARGET=sync/issue-mirror#' "$ws/.vig-os"
     env PATH="$stub:$PATH" \
@@ -87,6 +99,30 @@ _render_mirror() {
 # typos as a consumer with an untouched seed would see it: no allowlist.
 _typos_strict() { (cd "$1" && typos --hidden --isolated); }
 
+# The allowlist entries a consumer's seeded `.typos.toml` is assumed to carry:
+# `Nd` (#759, version-check.sh's duration syntax), `unexcepted` (#637, the CVE
+# exception-register term), `passt` (#1106, a rootless-networking package name)
+# and `ba` (abbreviated commit SHAs in the synced changelog's Renovate entries).
+# Deliberately frozen and deliberately WITHOUT #1488's `tatus`/`fnd`/`mis`: a
+# consumer seeded before that release does not have them, which is the whole of
+# #1529/#1534. A new entry needed here means generated content just acquired a
+# dependency on the seed — reword the content instead of extending this list.
+_GRANDFATHERED_WORDS='Nd ba passt unexcepted'
+
+# typos over a rendered tree, allowing only the grandfathered words. `--isolated`
+# is required *with* `--config`: without it typos MERGES the discovered
+# `.typos.toml` (the tree's own seed, which carries the newer entries) and the
+# assertion passes vacuously.
+_typos_grandfathered() {
+    local cfg="$BATS_FILE_TMPDIR/typos-grandfathered.toml"
+    local word
+    echo '[default.extend-words]' >"$cfg"
+    for word in $_GRANDFATHERED_WORDS; do
+        echo "$word = \"$word\"" >>"$cfg"
+    done
+    (cd "$1" && typos --hidden --isolated --config "$cfg")
+}
+
 _actionlint() { (cd "$1" && actionlint); }
 
 @test "the gitflow mirror-fold render is typos-clean with no allowlist (#1529)" {
@@ -96,6 +132,13 @@ _actionlint() { (cd "$1" && actionlint); }
 
 @test "the trunk mirror-fold render is typos-clean with no allowlist (#1529)" {
     run _typos_strict "$MIRROR_TRUNK"
+    assert_success
+}
+
+@test "the devcontainer render needs no post-#1488 typos seed entry (#1534)" {
+    # The tracked tree a devcontainer-mode consumer commits, including the
+    # synced .devcontainer/CHANGELOG.md and version-check.sh.
+    run _typos_grandfathered "$MIRROR_DEVCONTAINER"
     assert_success
 }
 

--- a/tests/test_changelog_unreleased_typos.py
+++ b/tests/test_changelog_unreleased_typos.py
@@ -1,0 +1,113 @@
+"""Tests for scripts/check_unreleased_typos.py — the Unreleased typo gate (#1534).
+
+The gate exists because a released changelog entry is immutable *and* synced into
+every devcontainer-mode consumer's worktree
+(``assets/workspace/.devcontainer/CHANGELOG.md``), where the consumer's own
+``.typos.toml`` — seeded once, never overwritten — has to lint it. Catching such
+a token after the release is useless, so the hook lints the ``## Unreleased``
+section with **no allowlist** (``typos --isolated``) before the text can ever be
+committed. Released sections keep their allowlisted tokens and must never fail.
+
+Refs: #1534
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import shutil
+import sys
+from pathlib import Path
+
+import pytest
+
+scripts_dir = Path(__file__).parent.parent / "scripts"
+project_root = scripts_dir.parent
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("typos") is None,
+    reason="typos is not on PATH; the Unreleased gate shells out to it",
+)
+
+
+def _load_checker():
+    spec = importlib.util.spec_from_file_location(
+        "check_unreleased_typos", scripts_dir / "check_unreleased_typos.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["check_unreleased_typos"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+# A token devkit's own .typos.toml allows (#1488's `mis`) but `typos --isolated`
+# flags — i.e. exactly the class of text this gate exists to keep out of a
+# release: green here, red in a consumer whose seed predates the entry.
+SEED_DEPENDENT = "mis-parses"
+
+HEADER = """# Changelog
+
+All notable changes to this project will be documented in this file.
+
+"""
+
+RELEASED_SECTION = """## [1.10.0] - 2026-08-14
+
+### Fixed
+
+- **Something released**
+  - the old code had two latent {token} in it
+"""
+
+
+def _changelog(tmp_path: Path, unreleased: str, released: str = "") -> Path:
+    path = tmp_path / "CHANGELOG.md"
+    path.write_text(
+        f"{HEADER}## Unreleased\n\n{unreleased}\n{released}", encoding="utf-8"
+    )
+    return path
+
+
+class TestUnreleasedTypoGate:
+    """The gate fails on a seed-dependent token, but only in ``## Unreleased``."""
+
+    def test_the_repo_changelog_passes(self):
+        """This repo's own Unreleased section must already satisfy the gate."""
+        checker = _load_checker()
+        assert checker.main([str(project_root / "CHANGELOG.md")]) == 0
+
+    def test_a_seed_dependent_token_in_unreleased_fails(self, tmp_path, capsys):
+        checker = _load_checker()
+        path = _changelog(
+            tmp_path,
+            f"### Fixed\n\n- **Bad entry**\n  - two latent {SEED_DEPENDENT} remain\n",
+        )
+        assert checker.main([str(path)]) == 1
+        err = capsys.readouterr().err
+        assert "mis" in err
+        # Reported against the real file, at its real line number (the gate
+        # blanks out-of-section lines rather than slicing the file).
+        line_no = next(
+            i
+            for i, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1)
+            if SEED_DEPENDENT in line
+        )
+        assert f"{path}:{line_no}:" in err
+
+    def test_the_same_token_in_a_released_section_passes(self, tmp_path):
+        """Released entries are immutable and legitimately allowlisted."""
+        checker = _load_checker()
+        path = _changelog(
+            tmp_path,
+            "### Fixed\n\n- **Good entry**\n  - nothing to report\n",
+            RELEASED_SECTION.format(token=SEED_DEPENDENT),
+        )
+        assert checker.main([str(path)]) == 0
+
+    def test_a_changelog_without_an_unreleased_section_passes(self, tmp_path):
+        """The release window: prepare-release renames Unreleased to a version."""
+        checker = _load_checker()
+        path = tmp_path / "CHANGELOG.md"
+        path.write_text(
+            HEADER + RELEASED_SECTION.format(token=SEED_DEPENDENT), encoding="utf-8"
+        )
+        assert checker.main([str(path)]) == 0

--- a/tests/test_flake_hooks.py
+++ b/tests/test_flake_hooks.py
@@ -309,6 +309,41 @@ class TestUnfilteredLocalHooksPinTheirStage:
             assert hooks["check-agent-identity"].get("stages") == ["pre-commit"], name
 
 
+class TestUnreleasedChangelogTypoGate:
+    """The Unreleased typo gate is devkit-only, filtered and stage-pinned (#1534).
+
+    Devkit's CHANGELOG.md is synced into the scaffold and git-tracked by every
+    devcontainer-mode consumer, whose ``.typos.toml`` is seeded once and never
+    overwritten — so a token that needs a *newer* allowlist entry than the seed
+    breaks that consumer's upgrade at the commit step (#1529), and a released
+    entry can never be edited to fix it. The gate lints only the ``## Unreleased``
+    section, with no allowlist, before the text can reach a release.
+
+    Runner-only and NOT scaffolded: it guards devkit's own changelog (a consumer's
+    changelog is synced nowhere), and the entry is a ``uv run`` script from this
+    repo. Filtered to CHANGELOG.md and pinned to pre-commit so an ordinary commit
+    pays nothing for it (#1491).
+    """
+
+    HOOK_ID = "check-unreleased-typos"
+
+    def test_runner_render_carries_the_gate(
+        self, rendered_portable: dict[str, Any]
+    ) -> None:
+        hook = _normalize(rendered_portable["runner"])["hooks"][self.HOOK_ID]
+        assert hook["repo"] == "local"
+        assert hook["entry"] == "uv run python scripts/check_unreleased_typos.py"
+        assert hook["language"] == "system"
+        assert hook["files"] == r"^CHANGELOG\.md$"
+        assert hook["pass_filenames"] is False
+        assert hook["stages"] == ["pre-commit"]
+
+    def test_the_gate_is_not_scaffolded(
+        self, rendered_portable: dict[str, Any]
+    ) -> None:
+        assert self.HOOK_ID not in _normalize(rendered_portable["scaffold"])["hooks"]
+
+
 class TestCheckJsonExcludesJsoncBanners:
     """check-json skips the `//`-bannered JSONC scaffold files (#1053).
 

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -592,7 +592,74 @@ class TestManifestTransformedFlagCoversBanners:
         by_src = {entry.src: entry for entry in sync_manifest.MANIFEST}
         assert not by_src[".claude/worktrees.json"].is_transformed
         assert not by_src[".gitmessage"].is_transformed
-        assert not by_src["CHANGELOG.md"].is_transformed
+
+
+class TestChangelogMirrorSanitization:
+    """The synced changelog mirror carries no seed-dependent typo token (#1534).
+
+    ``assets/workspace/.devcontainer/CHANGELOG.md`` is a manifest-synced copy of
+    the root CHANGELOG.md, and devcontainer-mode consumers **git-track** it — so
+    their own typos hook lints it against a ``.typos.toml`` that was seeded once
+    and is never overwritten by an upgrade. The released 1.10.0 section's
+    ``mis-parses`` / ``mis-splitting`` lint only under #1488's ``mis`` entry, so a
+    consumer seeded before that would fail its upgrade at the commit step,
+    exactly as org-config did in #1529 — and neither of the two config files that
+    could fix it is ever overwritten.
+
+    Released changelog text is immutable by policy, so the fix acts on the
+    generated **dest**: the root file keeps its released bytes byte-for-byte and
+    the mirror carries de-hyphenated spellings that need no allowlist at all.
+    """
+
+    # Tokens the manifest transform rewrites in the mirror (#1534).
+    SANITIZED_TOKENS = ("mis-parses", "mis-splitting")
+
+    def _root_changelog(self):
+        return (project_root / "CHANGELOG.md").read_text(encoding="utf-8")
+
+    def _mirror(self):
+        return project_root / "assets" / "workspace" / ".devcontainer" / "CHANGELOG.md"
+
+    def test_released_source_text_is_untouched(self):
+        """The immutable 1.10.0 entry keeps the tokens in the root changelog."""
+        content = self._root_changelog()
+        for token in self.SANITIZED_TOKENS:
+            assert token in content, (
+                f"{token!r} vanished from the root CHANGELOG.md — released entries "
+                "are immutable; only the synced mirror may be sanitized (#1534)"
+            )
+
+    def test_mirror_drops_the_seed_dependent_tokens(self):
+        """The synced mirror a consumer commits carries neither token."""
+        content = self._mirror().read_text(encoding="utf-8")
+        for token in self.SANITIZED_TOKENS:
+            assert token not in content, (
+                f"{token!r} reached {self._mirror()} — a consumer whose seeded "
+                ".typos.toml predates #1488 cannot commit it (#1534)"
+            )
+
+    def test_changelog_entry_is_flagged_transformed(self):
+        """The dest now differs from the src, so the identity gate must skip it."""
+        sync_manifest = _load_sync_manifest()
+        by_src = {entry.src: entry for entry in sync_manifest.MANIFEST}
+        assert by_src["CHANGELOG.md"].is_transformed
+
+    def test_transforms_are_idempotent_on_the_sanitized_mirror(self, tmp_path):
+        """Re-applying the transforms to an already-synced mirror is a no-op.
+
+        The sync re-runs on every commit that touches the changelog (and on the
+        release branch), so the substitutions must be harmless on text that no
+        longer carries the tokens.
+        """
+        sync_manifest = _load_sync_manifest()
+        entry = next(e for e in sync_manifest.MANIFEST if e.src == "CHANGELOG.md")
+        assert entry.transforms, "the changelog entry must carry the #1534 transforms"
+        copy = tmp_path / "CHANGELOG.md"
+        before = self._mirror().read_text(encoding="utf-8")
+        copy.write_text(before, encoding="utf-8")
+        for transform in entry.transforms:
+            transform.apply(copy)
+        assert copy.read_text(encoding="utf-8") == before
 
 
 class TestDownstreamReleaseDocSync:

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -644,6 +644,24 @@ class TestChangelogMirrorSanitization:
         by_src = {entry.src: entry for entry in sync_manifest.MANIFEST}
         assert by_src["CHANGELOG.md"].is_transformed
 
+    def test_mirror_is_the_source_plus_the_transforms(self, tmp_path):
+        """Nothing but the sanitizing transforms separates mirror from source.
+
+        The mirror used to be a non-transformed entry, checksummed against the
+        root by the image gate (test_image.py::test_manifest_files); a transformed
+        entry is only checked for existence there, so the equality pin lives here
+        now — it also catches a stale (unsynced) mirror.
+        """
+        sync_manifest = _load_sync_manifest()
+        entry = next(e for e in sync_manifest.MANIFEST if e.src == "CHANGELOG.md")
+        copy = tmp_path / "CHANGELOG.md"
+        copy.write_text(self._root_changelog(), encoding="utf-8")
+        for transform in entry.transforms:
+            transform.apply(copy)
+        assert copy.read_text(encoding="utf-8") == self._mirror().read_text(
+            encoding="utf-8"
+        )
+
     def test_transforms_are_idempotent_on_the_sanitized_mirror(self, tmp_path):
         """Re-applying the transforms to an already-synced mirror is a no-op.
 


### PR DESCRIPTION
## Summary

Implements #1534 with the approved sanitize-plus-guard approach — closing the residual #1529-class exposure where devkit's changelog, synced verbatim into git-tracked `.devcontainer/CHANGELOG.md`, carries immutable released text (`mis-parses`/`mis-splitting` in 1.10.0) that a devcontainer-mode consumer with a pre-#1488 seed cannot lint — and cannot fix, since both `.typos.toml` and `.pre-commit-config.yaml` are seeded once.

- **Sanitize at sync**: two `Sed` transforms on the manifest's CHANGELOG entry de-hyphenate the tokens in the generated dest only (`misparses`/`missplitting` — verified clean under `typos --isolated` empirically; `mis-` prefixed forms all fail). Minimal mechanical edit, meaning preserved, idempotent by construction (pinned). Released source text stays byte-identical.
- **Guard the class at the source**: new `check-unreleased-typos` hook (`nix/hooks.nix` SSoT, runner-only, not scaffolded; drift gate green) runs `scripts/check_unreleased_typos.py` on `CHANGELOG.md` changes — lints the `## Unreleased` section with **no allowlist**, blanking (not slicing) other lines so typos reports real line numbers. Released sections are exempt; a missing Unreleased section (the release window) passes. No future release can freeze a seed-dependent token into immutable text.
- **Acceptance leg**: `release-mirror-fold-lint.bats` gains a devcontainer-mode render (issue's acceptance criterion), typos-linted with a **frozen** grandfathered word list (`Nd ba passt unexcepted`) that deliberately excludes #1488's additions — encoding the invariant that generated content may not depend on an allowlist entry newer than a consumer's seed. `--isolated --config` is load-bearing: `--config` alone silently merges the rendered seed's `.typos.toml` and the assertion passes vacuously (documented in the helper).
- Collateral accuracy fixes in blast radius: `prepare-release-extension.yml` header no longer calls the mirror a verbatim copy; the lost mirror==root checksum is replaced by `test_mirror_is_the_source_plus_the_transforms` (also catches a stale mirror).

**Still failing tree-wide under strict no-allowlist typos** (out of scope — package names, CVE-policy terms, abbreviated SHAs): `Nd` x5, `ba` x2, `unexcepted` x2, `passt` x1. Only relevant if a truly allowlist-free devcontainer tree is ever wanted; today's sole devcontainer consumer has the full seed.

## Test plan

- TDD red: bats leg failed on exactly the two `mis` sites in the dest (`.devcontainer/CHANGELOG.md:239,241`); `test_transforms.py` 3 failed; `test_changelog_unreleased_typos.py` 4 failed; `test_flake_hooks.py` KeyError on the new hook.
- Green: bats mirror-fold suites 16 ok + `init-workspace.bats` 257 ok; pytest across transforms/gate/flake-hooks/drift/manifest suites 768 passed; `prek run --all-files` exit 0 (verified independently of the implementation run). Gate proof: seeded `mis-parses` in a fixture Unreleased → rc=1 with the exact line; same token in a released section → rc=0; the live hook Passed on this PR's own changelog commit.

Closes #1534