### PR TITLE
fix(vig-utils): render commit statuses in the gh-issues PR table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     `createdAt` fallback for commit statuses, matching the release CI gates
     ([#1522](https://github.com/vig-os/devkit/issues/1522)). Display-only — the
     table is not a gate
+- **`just gh-issues` CI column now reads commit-status results**
+  ([#1544](https://github.com/vig-os/devkit/issues/1544))
+  - The PR table grouped the rollup by `name` and classified each entry by
+    `conclusion`, both fields only Checks-API entries carry. Every commit
+    status on a PR collapsed into a single `"?"` bucket, and whatever survived
+    rendered as pending: a red status never showed as failed, a green one never
+    counted toward the pass tally
+  - Grouping now keys on name-or-context and each entry is classified on a
+    normalized verdict that falls back from `conclusion` to `state`, so the
+    table reads a rollup exactly as the release CI gates do
+    ([#1522](https://github.com/vig-os/devkit/issues/1522),
+    [#1538](https://github.com/vig-os/devkit/issues/1538)). Checks-API entries
+    render as before. Display-only — the table is not a gate
 - **Describing a bot-identity bug no longer trips the agent-fingerprint check**
   ([#1521](https://github.com/vig-os/devkit/issues/1521))
   - The `emails` blocklist was matched as a bare substring over the whole

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -75,6 +75,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     `createdAt` fallback for commit statuses, matching the release CI gates
     ([#1522](https://github.com/vig-os/devkit/issues/1522)). Display-only — the
     table is not a gate
+- **`just gh-issues` CI column now reads commit-status results**
+  ([#1544](https://github.com/vig-os/devkit/issues/1544))
+  - The PR table grouped the rollup by `name` and classified each entry by
+    `conclusion`, both fields only Checks-API entries carry. Every commit
+    status on a PR collapsed into a single `"?"` bucket, and whatever survived
+    rendered as pending: a red status never showed as failed, a green one never
+    counted toward the pass tally
+  - Grouping now keys on name-or-context and each entry is classified on a
+    normalized verdict that falls back from `conclusion` to `state`, so the
+    table reads a rollup exactly as the release CI gates do
+    ([#1522](https://github.com/vig-os/devkit/issues/1522),
+    [#1538](https://github.com/vig-os/devkit/issues/1538)). Checks-API entries
+    render as before. Display-only — the table is not a gate
 - **Describing a bot-identity bug no longer trips the agent-fingerprint check**
   ([#1521](https://github.com/vig-os/devkit/issues/1521))
   - The `emails` blocklist was matched as a bare substring over the whole

--- a/packages/vig-utils/src/vig_utils/gh_issues.py
+++ b/packages/vig-utils/src/vig_utils/gh_issues.py
@@ -385,15 +385,36 @@ def _started(check: dict) -> str:
     return check.get("startedAt") or check.get("createdAt") or ""
 
 
+def _check_key(check: dict) -> str:
+    """Return a check's dedup/display key, mirroring the gates' jq expression.
+
+    CheckRuns carry a name, StatusContexts a context; keying on name-or-context
+    keeps every commit status in its own bucket instead of collapsing them all
+    into one "?" (#1537, same grouping as the release gates).
+    """
+    return check.get("name") or check.get("context") or "?"
+
+
+def _verdict(check: dict) -> str:
+    """Return a check's normalized verdict, mirroring the gates' jq expression.
+
+    CheckRuns carry `conclusion`, StatusContexts `state`, and neither has the
+    other's field, so the fallback classifies both kinds without
+    double-counting (#1538). An in-flight CheckRun still resolves to "" and so
+    counts as pending.
+    """
+    return check.get("conclusion") or check.get("state") or ""
+
+
 def _dedupe_status_checks(rollup: list[dict]) -> list[dict]:
-    """Deduplicate statusCheckRollup by check name, keeping latest by startedAt."""
-    by_name: dict[str, dict] = {}
+    """Deduplicate statusCheckRollup by check key, keeping latest by startedAt."""
+    by_key: dict[str, dict] = {}
     for check in rollup:
-        name = check.get("name") or "?"
-        existing = by_name.get(name)
+        key = _check_key(check)
+        existing = by_key.get(key)
         if existing is None or _started(check) >= _started(existing):
-            by_name[name] = check
-    return list(by_name.values())
+            by_key[key] = check
+    return list(by_key.values())
 
 
 def _format_ci_status(pr: dict, owner_repo: str) -> str:
@@ -403,8 +424,8 @@ def _format_ci_status(pr: dict, owner_repo: str) -> str:
         return _styled("—", "dim")
 
     total = len(rollup)
-    passed = sum(1 for c in rollup if c.get("conclusion") == "SUCCESS")
-    failed = sum(1 for c in rollup if c.get("conclusion") in ("FAILURE", "ERROR"))
+    passed = sum(1 for c in rollup if _verdict(c) == "SUCCESS")
+    failed = sum(1 for c in rollup if _verdict(c) in ("FAILURE", "ERROR"))
     pending = total - passed - failed
 
     url = f"https://github.com/{owner_repo}/pull/{pr['number']}/checks"
@@ -413,9 +434,7 @@ def _format_ci_status(pr: dict, owner_repo: str) -> str:
 
     if failed > 0:
         failed_names = [
-            c.get("name", "?")
-            for c in rollup
-            if c.get("conclusion") in ("FAILURE", "ERROR")
+            _check_key(c) for c in rollup if _verdict(c) in ("FAILURE", "ERROR")
         ]
         text = f"✗ {passed}/{total} {', '.join(failed_names)}"
         return link_prefix + _styled(text, "red") + link_suffix

--- a/packages/vig-utils/tests/test_gh_issues.py
+++ b/packages/vig-utils/tests/test_gh_issues.py
@@ -218,18 +218,59 @@ class TestDedupeStatusChecks:
         """StatusContexts carry createdAt, not startedAt; recency still works."""
         rollup = [
             {
-                "name": "legacy/status",
+                "context": "legacy/status",
                 "state": "FAILURE",
                 "createdAt": "2026-08-17T12:00:00Z",
             },
             {
-                "name": "legacy/status",
+                "context": "legacy/status",
                 "state": "SUCCESS",
                 "createdAt": "2026-08-17T12:30:00Z",
             },
         ]
         result = gh_issues._dedupe_status_checks(rollup)
         assert [c["state"] for c in result] == ["SUCCESS"]
+
+    def test_distinct_status_contexts_stay_separate_entries(self):
+        """Two contexts are two buckets, not one "?" bucket. Ref: #1544."""
+        rollup = [
+            {
+                "context": "ci/legacy",
+                "state": "SUCCESS",
+                "createdAt": "2026-08-17T12:00:00Z",
+            },
+            {
+                "context": "security/scan",
+                "state": "FAILURE",
+                "createdAt": "2026-08-17T11:00:00Z",
+            },
+        ]
+        result = gh_issues._dedupe_status_checks(rollup)
+        assert {c["context"] for c in result} == {"ci/legacy", "security/scan"}
+        assert len(result) == 2
+
+    def test_status_context_supersedes_a_same_keyed_check_run(self):
+        """A context equal to a check name shares its bucket; newest wins.
+
+        Mirrors the release gates' ``.name // .context // "?"`` grouping
+        (#1537/#1541). Ref: #1544.
+        """
+        rollup = [
+            {
+                "name": "Project Checks",
+                "conclusion": "FAILURE",
+                "startedAt": "2026-08-17T12:00:00Z",
+                "completedAt": "2026-08-17T12:05:00Z",
+            },
+            {
+                "context": "Project Checks",
+                "state": "SUCCESS",
+                "createdAt": "2026-08-17T12:30:00Z",
+            },
+        ]
+        result = gh_issues._dedupe_status_checks(rollup)
+        assert len(result) == 1
+        assert result[0]["state"] == "SUCCESS"
 
     def test_in_progress_rerun_shown_as_pending_in_ci_cell(self):
         """The CI cell reports the live rerun as pending, not as a failure."""
@@ -254,6 +295,102 @@ class TestDedupeStatusChecks:
         assert "⏳" in result
         assert "0/1" in result
         assert "yellow" in result
+
+
+class TestFormatCiStatusCommitStatuses:
+    """Test _format_ci_status classification of StatusContext entries.
+
+    StatusContexts carry ``state`` where CheckRuns carry ``conclusion``, so the
+    cell classifies on a normalized verdict, as the release gates do.
+
+    Ref: #1544
+    """
+
+    def _pr(self, rollup: list[dict]) -> dict:
+        return {"number": 3, "statusCheckRollup": rollup}
+
+    @pytest.mark.parametrize("state", ["FAILURE", "ERROR"])
+    def test_red_state_renders_failed(self, state):
+        """A red commit status turns the cell red and names the context."""
+        pr = self._pr(
+            [
+                {
+                    "context": "ci/legacy",
+                    "state": state,
+                    "createdAt": "2026-08-17T12:00:00Z",
+                },
+            ]
+        )
+        result = gh_issues._format_ci_status(pr, "a/b")
+        assert "✗" in result
+        assert "0/1" in result
+        assert "red" in result
+        assert "ci/legacy" in result
+
+    def test_success_state_counts_as_passed(self):
+        """A green commit status counts toward the pass tally."""
+        pr = self._pr(
+            [
+                {
+                    "context": "ci/legacy",
+                    "state": "SUCCESS",
+                    "createdAt": "2026-08-17T12:00:00Z",
+                },
+                {
+                    "context": "security/scan",
+                    "state": "SUCCESS",
+                    "createdAt": "2026-08-17T12:00:00Z",
+                },
+            ]
+        )
+        result = gh_issues._format_ci_status(pr, "a/b")
+        assert "✓" in result
+        assert "2/2" in result
+        assert "green" in result
+
+    @pytest.mark.parametrize("state", ["PENDING", "EXPECTED"])
+    def test_non_terminal_state_renders_pending(self, state):
+        """PENDING and EXPECTED statuses render as pending, not as passed."""
+        pr = self._pr(
+            [
+                {
+                    "name": "Build",
+                    "conclusion": "SUCCESS",
+                    "startedAt": "2026-08-17T12:00:00Z",
+                },
+                {
+                    "context": "ci/legacy",
+                    "state": state,
+                    "createdAt": "2026-08-17T12:00:00Z",
+                },
+            ]
+        )
+        result = gh_issues._format_ci_status(pr, "a/b")
+        assert "⏳" in result
+        assert "1/2" in result
+        assert "yellow" in result
+
+    def test_red_status_context_beats_green_check_runs(self):
+        """A red commit status alongside green checks still reports failure."""
+        pr = self._pr(
+            [
+                {
+                    "name": "Build",
+                    "conclusion": "SUCCESS",
+                    "startedAt": "2026-08-17T12:00:00Z",
+                },
+                {
+                    "context": "ci/legacy",
+                    "state": "FAILURE",
+                    "createdAt": "2026-08-17T12:00:00Z",
+                },
+            ]
+        )
+        result = gh_issues._format_ci_status(pr, "a/b")
+        assert "✗" in result
+        assert "1/2" in result
+        assert "red" in result
+        assert "ci/legacy" in result
 
 
 class TestGhLink:


### PR DESCRIPTION
## Summary

Implements #1544 (combined follow-up from #1542, the display-table analogue of the #1538/#1541 gate fix): the `just gh-issues` PR table was blind to StatusContexts in two ways — `_dedupe_status_checks` grouped on `name` only (every commit status collapsed into one `"?"` bucket, only the newest surviving), and `_format_ci_status` classified on `conclusion` only (a red commit status rendered pending, a green one never counted as passed).

Two helpers in the style of #1542's `_started`, each mirroring the gates' jq exactly:

- `_check_key` = `name or context or "?"` — dedup grouping and the red cell's failed-names list both use it, so a failing commit status is now also *named* in the cell (bonus fix: the old `c.get("name", "?")` returned `None` for present-but-null names).
- `_verdict` = `conclusion or state or ""` — pass/fail tallies classify on it; pending stays the remainder, so PENDING/EXPECTED/in-flight all fall through with no new branch, and skipped/neutral/cancelled CheckRuns render exactly as before.

Same-keyed grouping matches the gates including tie behavior (Python `>=` keeps the later element, as jq's `max_by` returns the last maximal element). One #1542 fixture corrected to a realistic node shape (StatusContexts carry `context`, never `name`); its behavioral pin is unchanged.

Display-only — no gate behavior changes.

## Test plan

Two new dedup tests (distinct StatusContexts stay separate; same-keyed StatusContext/CheckRun grouping matching #1541's gate test) and a new `TestFormatCiStatusCommitStatuses` class (FAILURE/ERROR render failed, SUCCESS counts passed, PENDING/EXPECTED render pending, red status beats green checks). TDD red: 6 failed pre-fix (e.g. a `state: FAILURE` context rendering `⏳ 0/1` yellow); the PENDING/EXPECTED cases and all pre-existing CheckRun-only tests were green throughout as regression pins. `packages/vig-utils/tests`: 537 passed; `prek run --all-files` exit 0 (verified independently of the implementation run).

Closes #1544
