### PR TITLE
fix(security): renew the fzf exception block to 2026-09-02

### DIFF
--- a/.vulnixignore
+++ b/.vulnixignore
@@ -170,7 +170,7 @@ CVE-2025-62689
 #      2026-07-28 "no fix in the pinned channel" note was already stale.
 #    - CVE-2026-56123: the pin ships socat 1.8.1.3, past the 1.8.1.2 fix.)
 
-Expiration: 2026-08-19
+Expiration: 2026-09-02
 # (gzip CVE-2026-41992 removed 2026-08-04 (#1327): contrary to the "no nixpkgs
 #   patch yet" note above, the pinned rev applies CVE-2026-41992.patch to gzip
 #   1.14, so vulnix no longer reports it.)
@@ -185,6 +185,15 @@ Expiration: 2026-08-19
 # Re-verified 2026-08-04 (#1328): the pin was advanced to nixos-26.05 @
 #   2026-08-03 (rev 531670d8) and rebuilt; the closure still ships fzf 0.72.0,
 #   so this block is retained.
+# Renewed 2026-08-20 (#1547): the expiry fired as the grid intends and took both
+#   nightly lanes red (run 32335643087) before the scan itself ran. Both CVEs are
+#   still live findings against fzf-0.72.0 in the last green scan (run
+#   32219442917, 2026-08-19, pin 531670d8), and the rev-advance lever still has
+#   nowhere to land: nixos-26.05, release-26.05 and staging-26.05 all ship 0.72.0
+#   with no backport PR open (0.74.3 is master/unstable only). Renewed risk
+#   acceptance, not a date bump — the 2026-07-14 assessment above is unchanged
+#   and both findings stay availability-only. Renewed onto the shared 2026-09-02
+#   grid date so the whole register is reviewed in one pass (#1337).
 CVE-2026-53432
 CVE-2026-53433
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,6 +159,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Scorecard's `Pinned-Dependencies` finding on the consumer copy is expected
     to remain — it wants a commit SHA, and SHA-pinning a self-upgrading
     installer is circular by construction; dismiss it consumer-side
+- **Renew the fzf exception block in the vulnix register**
+  ([#1547](https://github.com/vig-os/devkit/issues/1547))
+  - The block expired 2026-08-19, failing `check-expirations` on every branch
+    (the hook runs inside the flake's `pre-commit` check) and on both lanes of
+    the nightly security scan, which aborts before vulnix ever runs
+  - Re-verified against the current pin before renewing: both CVEs are still
+    live findings against `fzf-0.72.0`, and `nixos-26.05`, `release-26.05` and
+    `staging-26.05` all still ship 0.72.0 with no backport PR open, so
+    advancing the pin cannot clear them either
+  - Renewed onto the shared `2026-09-02` grid date, so the whole register comes
+    up for review in one pass. The risk assessment is unchanged: both findings
+    are availability-only and unreachable on this image (32-bit-only overflow;
+    opt-in `--listen` server)
 
 ## [1.10.0](https://github.com/vig-os/devkit/releases/tag/1.10.0) - 2026-08-14
 

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -159,6 +159,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Scorecard's `Pinned-Dependencies` finding on the consumer copy is expected
     to remain — it wants a commit SHA, and SHA-pinning a self-upgrading
     installer is circular by construction; dismiss it consumer-side
+- **Renew the fzf exception block in the vulnix register**
+  ([#1547](https://github.com/vig-os/devkit/issues/1547))
+  - The block expired 2026-08-19, failing `check-expirations` on every branch
+    (the hook runs inside the flake's `pre-commit` check) and on both lanes of
+    the nightly security scan, which aborts before vulnix ever runs
+  - Re-verified against the current pin before renewing: both CVEs are still
+    live findings against `fzf-0.72.0`, and `nixos-26.05`, `release-26.05` and
+    `staging-26.05` all still ship 0.72.0 with no backport PR open, so
+    advancing the pin cannot clear them either
+  - Renewed onto the shared `2026-09-02` grid date, so the whole register comes
+    up for review in one pass. The risk assessment is unchanged: both findings
+    are availability-only and unreachable on this image (32-bit-only overflow;
+    opt-in `--listen` server)
 
 ## [1.10.0](https://github.com/vig-os/devkit/releases/tag/1.10.0) - 2026-08-14
 


### PR DESCRIPTION
## Description

Renews the fzf exception block in `.vulnixignore` from the expired `2026-08-19`
onto the shared `2026-09-02` grid date. Closes the red that took **both** nightly
security-scan lanes down this morning
([run 32335643087](https://github.com/vig-os/devkit/actions/runs/32335643087)) and
that reds `check-expirations` on every branch (the hook is `enable = true` in the
flake hook set, so Tier 0 `nix-fast-build` runs it inside the `pre-commit`
derivation).

Refs: #1547

## Type of Change

- [x] `fix` -- Bug fix

### Modifiers

- [ ] Breaking change (`!`)

## Changes Made

- `.vulnixignore`: `Expiration: 2026-08-19` -> `2026-09-02` for the fzf block
  (`CVE-2026-53432`, `CVE-2026-53433`), plus a renewal note recording the
  evidence below
- `CHANGELOG.md` (+ synced devcontainer mirror): `### Security` entry under
  `## Unreleased`

This is a **renewed risk acceptance, not a date bump**:

- Both CVEs are **still live findings** against `fzf-0.72.0` in the last green
  scan ([run 32219442917](https://github.com/vig-os/devkit/actions/runs/32219442917),
  2026-08-19, pin `531670d871c0`) — neither became droppable the way the gawk
  block did after its rev advance (#1328)
- The **rev-advance lever has nowhere to land**: `nixos-26.05`,
  `release-26.05` and `staging-26.05` all still ship 0.72.0 with no backport PR
  open; 0.74.3 exists only on `master` / `nixpkgs-unstable`
  (NixOS/nixpkgs#553573, merged 2026-08-17). The pinned closure evaluates to
  `fzf 0.72.0`
- The 2026-07-14 assessment stands: `CVE-2026-53432` is a `FuzzyMatchV2`
  integer-overflow panic on **32-bit Go builds only** (this image is 64-bit);
  `CVE-2026-53433` is CPU-DoS of fzf's **opt-in** localhost `--listen` server,
  never started here. Availability-only either way

The register was reconciled against the same findings while here: 25
HIGH/CRITICAL findings, **zero unexcepted** — this block is the only thing
between the scan and a green gate. Three entries (`CVE-2022-30947`,
`CVE-2022-36882`, `CVE-2022-36883`) are no longer reported at all and become
drop candidates at their own 2027-06-23 review; left untouched here.

Related: #1548 — the scan's tracking-issue step is guarded on the *gate* step's
outcome, so this morning's pre-gate failure opened no issue and surfaced only in
the workflow list. Kept out of this PR to preserve the minimal diff.

## Changelog Entry

```
### Security

- **Renew the fzf exception block in the vulnix register**
  ([#1547](https://github.com/vig-os/devkit/issues/1547))
  - The block expired 2026-08-19, failing `check-expirations` on every branch
    (the hook runs inside the flake's `pre-commit` check) and on both lanes of
    the nightly security scan, which aborts before vulnix ever runs
  - Re-verified against the current pin before renewing: both CVEs are still
    live findings against `fzf-0.72.0`, and `nixos-26.05`, `release-26.05` and
    `staging-26.05` all still ship 0.72.0 with no backport PR open, so
    advancing the pin cannot clear them either
  - Renewed onto the shared `2026-09-02` grid date, so the whole register comes
    up for review in one pass. The risk assessment is unchanged: both findings
    are availability-only and unreachable on this image (32-bit-only overflow;
    opt-in `--listen` server)
```

## Testing

- [x] Full hook suite green locally (`just precommit`, `prek run --all-files`),
      including `check-expirations`
- [x] Manual testing performed (below)

### Manual Testing Details

```
$ uv run check-expirations .trivyignore .vulnixignore
Validated 32 exception(s) across 2 file(s)     # exit 0 (was exit 1 on 2 entries)
```

Evidence gathering: pinned `fzf` version via
`nix eval --impure --expr '(builtins.getFlake …).inputs.nixpkgs.legacyPackages.x86_64-linux.fzf.version'`
-> `0.72.0`; nixpkgs branch versions read from
`pkgs/by-name/fz/fzf/package.nix` on `nixos-26.05`, `release-26.05`,
`staging-26.05`, `master`, `nixpkgs-unstable`; findings reconciliation against
`vulnix-findings.json` from run 32219442917.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly — n/a, no doc surface changes
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (pasted above)
- [x] My changes generate no new warnings or errors
- [ ] I have added tests — n/a, this is a dated register entry, not code; the
      expiry enforcement itself is already covered by
      `packages/vig-utils/tests/test_check_expirations.py`
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

**Note on the `main` lane:** `dev` and `main` carry an identical register, so the
`main` nightly lane stays red until the 1.11.0 train merges `dev` into `main`.
