### PR TITLE
fix(security-scan): file a tracking issue for pre-gate failures too

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -24,7 +24,12 @@
 #   - A deduplicated `security-scan` tracking issue is opened per ref (#965,
 #     #1237), with a ref-distinct title so the two lanes never collide on dedup.
 #     Scheduled runs execute from the default branch with no other signal, so a
-#     red gate must surface as an issue, not just a red run.
+#     red run must surface as an issue, not just a red run.
+#   - Two failure classes, two titles, deduped independently (#1548): a red
+#     GATE (unexcepted HIGH/CRITICAL findings) and a failure anywhere BEFORE the
+#     gate (expired `.vulnixignore` register, closure build, vulnix crash) —
+#     the latter means the closure went UNSCANNED, which used to surface
+#     nowhere at all.
 #
 # Artifacts:
 #   - vulnix findings (JSON + table) and a CycloneDX SBOM (uploaded)
@@ -70,7 +75,8 @@ jobs:
     timeout-minutes: 90
     permissions:
       contents: read
-      issues: write  # open a deduplicated tracking issue when the vulnix gate fails (#965)
+      issues: write  # open a deduplicated tracking issue when the nightly scan fails (#965)
+      actions: read  # name the failing step from this run's own job records (#1548)
 
     steps:
       - name: Checkout repository
@@ -227,14 +233,21 @@ jobs:
           } >> "$GITHUB_STEP_SUMMARY"
 
       # Restore the deduplicated tracking issue lost in the Debian->Nix cutover
-      # (#965): a scheduled run from the default branch has no other signal, so a
-      # red vulnix gate must surface as an issue, not just a red run.
-      - name: Open a tracking issue when the vulnix gate fails
-        # failure() lets this step run despite the failing gate; the outcome
-        # guard scopes it to a gate failure (not an infra/scan crash upstream).
-        if: ${{ failure() && steps.vulnix-gate.outcome == 'failure' }}
+      # (#965): a scheduled run from the default branch has no other signal, so
+      # a red scan must surface as an issue, not just a red run.
+      - name: Open a tracking issue when the nightly scan fails
+        # `failure()` ALONE. The previous guard also required
+        # `steps.vulnix-gate.outcome == 'failure'`, which scoped reporting to the
+        # one failure mode that happens AT the gate: any earlier step (register
+        # validation, closure build, the vulnix run itself) leaves that outcome
+        # empty, so the guard was false and the run died silently. An expired
+        # `.vulnixignore` block did exactly that on both lanes on 2026-08-20,
+        # failing the FIRST step of the job (#1548). The two classes carry
+        # distinct titles below, so each dedups independently per ref (#1237).
+        if: ${{ failure() }}
         env:
           GH_TOKEN: ${{ github.token }}
+          GATE_OUTCOME: ${{ steps.vulnix-gate.outcome }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           SECURITY_URL: ${{ github.server_url }}/${{ github.repository }}/security
           SCAN_REF: ${{ matrix.ref }}
@@ -245,25 +258,15 @@ jobs:
           gh label create security-scan \
             --description 'Automated nightly security scan findings for the Nix devcontainer image' \
             --color BFD4F2 --force 2>/dev/null || true
-          # Dedup by the auto-issue's distinctive title, NOT the label alone, so
-          # we never collide with human-filed security-scan issues (per-CVE
-          # triage, this very regression, etc.). One open tracking issue at a
-          # time; it is closed when a later scheduled run passes the gate. The
-          # ref is in the title so the main and dev lanes dedup independently
-          # and never collide on each other's issue (#1237).
-          TITLE="Nightly security scan (${SCAN_REF}): unexcepted HIGH/CRITICAL vulnix findings"
-          EXISTING=$(gh issue list --state open --label security-scan \
-            --search "\"$TITLE\" in:title" --json number -q '.[0].number // empty')
-          if [ -n "$EXISTING" ]; then
-            echo "Open tracking issue already exists: #$EXISTING -- skipping create"
-            exit 0
-          fi
-          BODY="$(cat <<EOF
+          SCAN_DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          if [ "${GATE_OUTCOME}" = "failure" ]; then
+            TITLE="Nightly security scan (${SCAN_REF}): unexcepted HIGH/CRITICAL vulnix findings"
+            BODY="$(cat <<EOF
           The nightly vulnix gate found **unexcepted HIGH/CRITICAL** CVEs in the \`${SCAN_REF}\` Nix image closure (after \`.vulnixignore\`).
 
           - **Scanned ref:** \`${SCAN_REF}\`
           - **Scan target:** flake \`devkitImageEnv\` (image package closure)
-          - **Scan date (UTC):** $(date -u +%Y-%m-%dT%H:%M:%SZ)
+          - **Scan date (UTC):** ${SCAN_DATE}
           - **Workflow run:** ${RUN_URL}
           - **Findings artifact:** \`nix-image-cve-scan-${SCAN_REF}\` on the run above (\`vulnix-findings.json\`, \`vulnix-report.txt\`)
           - **Security tab:** ${SECURITY_URL}
@@ -271,6 +274,41 @@ jobs:
           **To remediate:** advance the pinned nixpkgs rev if a fix has landed, or add a time-boxed \`.vulnixignore\` exception with a rationale (see \`docs/CONTAINER_SECURITY.md\`). Close this issue once a later scheduled run passes the gate.
           EOF
           )"
+          else
+            # Name the failing step from this run's own job records (the
+            # devkit-upgrade report's lookup, #1530) — no per-step
+            # instrumentation to keep in sync with the steps above. Scoped to
+            # THIS matrix leg by job-name suffix, so the dev lane never reports
+            # main's failing step.
+            FAILED="$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}/jobs" \
+              --jq "[.jobs[] | select(.name | endswith(\"[${SCAN_REF}]\")) | .steps[]? | select(.conclusion == \"failure\") | .name] | join(\", \")" \
+              2>/dev/null || true)"
+            [ -n "$FAILED" ] || FAILED='unknown, see the run log'
+            TITLE="Nightly security scan (${SCAN_REF}): run failed before the vulnix gate"
+            BODY="$(cat <<EOF
+          The nightly security scan for \`${SCAN_REF}\` failed **before the vulnix gate ran**, so this run produced no CVE verdict at all — the closure is unscanned, not clean.
+
+          - **Scanned ref:** \`${SCAN_REF}\`
+          - **Failing step:** ${FAILED}
+          - **Scan date (UTC):** ${SCAN_DATE}
+          - **Workflow run:** ${RUN_URL}
+
+          **Most likely cause:** an expired \`.vulnixignore\` exception. The register's expiry dates are *designed* to fire (Wednesday grid, see \`docs/CONTAINER_SECURITY.md\`); renew or drop the block and the scan resumes. Otherwise triage the failing step in the run log — a closure build or vulnix crash needs a different fix. Close this issue once a later scheduled run completes.
+          EOF
+          )"
+          fi
+          # Dedup by the auto-issue's distinctive title, NOT the label alone, so
+          # we never collide with human-filed security-scan issues (per-CVE
+          # triage, this very regression, etc.). One open tracking issue per
+          # class per ref; it is closed when a later scheduled run recovers. The
+          # ref is in the title so the main and dev lanes dedup independently
+          # and never collide on each other's issue (#1237).
+          EXISTING=$(gh issue list --state open --label security-scan \
+            --search "\"$TITLE\" in:title" --json number -q '.[0].number // empty')
+          if [ -n "$EXISTING" ]; then
+            echo "Open tracking issue already exists: #$EXISTING -- skipping create"
+            exit 0
+          fi
           gh issue create \
             --title "$TITLE" \
             --label security-scan --label security \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A nightly security scan that fails before the gate now files a tracking
+  issue too** ([#1548](https://github.com/vig-os/devkit/issues/1548))
+  - The issue-opening step was guarded on `steps.vulnix-gate.outcome ==
+    'failure'` — an outcome that is *empty* whenever an earlier step fails. An
+    expired `.vulnixignore` register, a failed closure build or a vulnix crash
+    therefore produced a red run and nothing else, on a workflow whose whole
+    point is that a scheduled run has no other signal
+  - It fired for real on 2026-08-20: an expired block failed the job's first
+    step on both lanes and surfaced nowhere
+    ([#1547](https://github.com/vig-os/devkit/issues/1547))
+  - The guard is now `failure()` alone, and the two failure classes carry
+    distinct titles that dedup independently per ref: a red gate keeps its
+    existing title, while a pre-gate failure files *run failed before the vulnix
+    gate* and names the failing step, read off the run's own job records
+    (`actions: read`). A pre-gate failure means the closure went **unscanned**,
+    not clean — the body says so
 - **Release CI gate now counts only the latest run of each check**
   ([#1522](https://github.com/vig-os/devkit/issues/1522))
   - The gate counted **every** FAILURE entry in the release PR head SHA's

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -36,6 +36,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A nightly security scan that fails before the gate now files a tracking
+  issue too** ([#1548](https://github.com/vig-os/devkit/issues/1548))
+  - The issue-opening step was guarded on `steps.vulnix-gate.outcome ==
+    'failure'` — an outcome that is *empty* whenever an earlier step fails. An
+    expired `.vulnixignore` register, a failed closure build or a vulnix crash
+    therefore produced a red run and nothing else, on a workflow whose whole
+    point is that a scheduled run has no other signal
+  - It fired for real on 2026-08-20: an expired block failed the job's first
+    step on both lanes and surfaced nowhere
+    ([#1547](https://github.com/vig-os/devkit/issues/1547))
+  - The guard is now `failure()` alone, and the two failure classes carry
+    distinct titles that dedup independently per ref: a red gate keeps its
+    existing title, while a pre-gate failure files *run failed before the vulnix
+    gate* and names the failing step, read off the run's own job records
+    (`actions: read`). A pre-gate failure means the closure went **unscanned**,
+    not clean — the body says so
 - **Release CI gate now counts only the latest run of each check**
   ([#1522](https://github.com/vig-os/devkit/issues/1522))
   - The gate counted **every** FAILURE entry in the release PR head SHA's

--- a/docs/CONTAINER_SECURITY.md
+++ b/docs/CONTAINER_SECURITY.md
@@ -71,6 +71,12 @@ instead.
 The gate is **blocking** (#639): any unexcepted HIGH/CRITICAL finding fails the
 nightly scan.
 
+Every red nightly run surfaces as a deduplicated `security-scan` tracking issue
+per scanned ref (#965, #1237, #1548), under one of two titles: a red **gate**
+(unexcepted HIGH/CRITICAL findings), or a failure **before** the gate — an
+expired register, a failed closure build, a `vulnix` crash — where the closure
+went *unscanned* rather than clean.
+
 ### 3. CycloneDX SBOM + Trivy SBOM-mode scan (defence in depth)
 
 The same nightly job emits a **CycloneDX SBOM** of the Nix image (via Trivy) and

--- a/tests/test_workflow_scan_failure_reporting.py
+++ b/tests/test_workflow_scan_failure_reporting.py
@@ -1,0 +1,107 @@
+"""Workflow-shape tests: every nightly-scan failure surfaces as a tracking issue.
+
+``security-scan.yml`` opens a deduplicated tracking issue when the nightly scan
+goes red (#965, #1237) — but the step was guarded on the *gate step's* outcome:
+
+    if: ${{ failure() && steps.vulnix-gate.outcome == 'failure' }}
+
+Any failure *before* ``vulnix-gate`` leaves that outcome empty (the step never
+ran), so the guard was false and the run died silently — a red run in Actions
+and nothing else. Scheduled runs execute from the default branch with no other
+signal, which is the exact reason #965 restored the issue in the first place.
+
+It fired for real on 2026-08-20: an expired ``.vulnixignore`` block failed the
+*first* step of both matrix legs, hours before anyone noticed (#1547).
+
+These are pure YAML-shape assertions (no ``nix``/``gh`` needed).
+
+Refs: #1548
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+# Repository root (tests/ -> repo root).
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+SECURITY_SCAN_WF = REPO_ROOT / ".github" / "workflows" / "security-scan.yml"
+
+SCAN_JOB = "scan-nix-image"
+
+
+def _job() -> dict:
+    workflow = yaml.safe_load(SECURITY_SCAN_WF.read_text(encoding="utf-8"))
+    return workflow["jobs"][SCAN_JOB]
+
+
+def _reporting_step() -> dict:
+    """The step that files the tracking issue (matched on what it runs)."""
+    for step in _job()["steps"]:
+        if "gh issue create" in step.get("run", ""):
+            return step
+    raise AssertionError("no tracking-issue step found in security-scan.yml")
+
+
+def test_tracking_issue_fires_on_any_job_failure() -> None:
+    """The guard is ``failure()`` alone — not ``failure()`` AND a gate verdict.
+
+    Conditioning on ``steps.vulnix-gate.outcome`` scopes reporting to the one
+    failure mode that happens *at* the gate, leaving every earlier step (the
+    register validation, the closure build, the vulnix run itself) silent.
+    """
+    condition = str(_reporting_step().get("if", ""))
+
+    assert "failure()" in condition, (
+        "the tracking-issue step must run on failure() — otherwise a red "
+        "nightly scan surfaces nowhere (#965)"
+    )
+    assert "vulnix-gate.outcome" not in condition, (
+        "the tracking-issue step must NOT be gated on `steps.vulnix-gate.outcome`: "
+        "a failure BEFORE the gate leaves that outcome empty, so the run dies "
+        "silently — no issue, no signal (#1548)"
+    )
+
+
+def test_pre_gate_failures_get_their_own_dedup_title() -> None:
+    """Two failure classes, two titles, so each dedups independently per ref.
+
+    A pre-gate failure is not "unexcepted HIGH/CRITICAL findings" — the scan
+    never produced a verdict at all. Filing it under the gate's title would
+    both misdescribe it and let one class suppress the other's issue.
+    """
+    script = _reporting_step()["run"]
+
+    assert "GATE_OUTCOME" in script or "steps.vulnix-gate.outcome" in script, (
+        "the reporting step must branch on the gate outcome to tell a gate "
+        "failure from a pre-gate one (#1548)"
+    )
+    assert "unexcepted HIGH/CRITICAL vulnix findings" in script, (
+        "the gate-failure title must survive: the open issues filed under it "
+        "dedup against that exact string (#965, #1237)"
+    )
+    assert "before the vulnix gate" in script, (
+        "a pre-gate failure needs its own distinct title (#1548)"
+    )
+
+
+def test_pre_gate_report_names_the_failing_step() -> None:
+    """The issue body names the failing step, read off the run's job records.
+
+    "Something before the gate failed" is not actionable; "the register
+    validation failed" is. The same lookup the devkit-upgrade report uses
+    (#1530) needs the ``actions: read`` grant on this job.
+    """
+    job = _job()
+    script = _reporting_step()["run"]
+
+    assert job.get("permissions", {}).get("actions") == "read", (
+        "naming the failing step reads this run's own job records, which needs "
+        "`actions: read` on the job (#1548)"
+    )
+    assert "/jobs" in script, (
+        "the pre-gate body must name the failing step from the run's job "
+        "records rather than leaving triage to open the log (#1548)"
+    )


### PR DESCRIPTION
## Description

The nightly scan's tracking-issue step was guarded on the **gate step's**
outcome:

```yaml
if: ${{ failure() && steps.vulnix-gate.outcome == 'failure' }}
```

`steps.vulnix-gate.outcome` is *empty* whenever a step before the gate fails, so
the guard was false and the run died silently — a red run in Actions and nothing
else, on a workflow whose scheduled runs have **no other signal**. That is the
exact hole #965 restored the issue to close.

It fired for real on 2026-08-20: an expired `.vulnixignore` block failed the
job's **first** step on both lanes
([run 32335643087](https://github.com/vig-os/devkit/actions/runs/32335643087)),
and the failure surfaced only because someone went looking at the workflow list
(#1547).

Refs: #1548

## Type of Change

- [x] `fix` -- Bug fix

### Modifiers

- [ ] Breaking change (`!`)

## Changes Made

- **Guard is `failure()` alone** — the whole job is now in scope: register
  validation, NVD cache, closure build, the vulnix run, SBOM generation
- **Two failure classes, two dedup titles**, so neither can suppress the other's
  issue and each still dedups per ref (#1237):
  - gate → `Nightly security scan (<ref>): unexcepted HIGH/CRITICAL vulnix findings`
    — **unchanged**, so issues already open under it keep matching
  - pre-gate → `Nightly security scan (<ref>): run failed before the vulnix gate`,
    whose body states plainly that the closure went **unscanned, not clean**, and
    points at an expired register as the most likely cause
- **The pre-gate body names the failing step**, read off the run's own job
  records — the same lookup the `devkit-upgrade` reporter uses (#1530), scoped to
  this matrix leg by job-name suffix so the dev lane never reports main's failing
  step. That needs the new `actions: read` grant on the job
- Workflow header `On failure:` block and `docs/CONTAINER_SECURITY.md` §2 updated
  to describe both classes

Deliberately **not** in scope: auto-closing the tracking issue on a later green
run. Today's issue is closed by hand in both classes; changing that is a separate
behavior change, not this hole.

## Changelog Entry

```
### Fixed

- **A nightly security scan that fails before the gate now files a tracking
  issue too** ([#1548](https://github.com/vig-os/devkit/issues/1548))
  - The issue-opening step was guarded on `steps.vulnix-gate.outcome ==
    'failure'` — an outcome that is *empty* whenever an earlier step fails. An
    expired `.vulnixignore` register, a failed closure build or a vulnix crash
    therefore produced a red run and nothing else, on a workflow whose whole
    point is that a scheduled run has no other signal
  - It fired for real on 2026-08-20: an expired block failed the job's first
    step on both lanes and surfaced nowhere
    ([#1547](https://github.com/vig-os/devkit/issues/1547))
  - The guard is now `failure()` alone, and the two failure classes carry
    distinct titles that dedup independently per ref: a red gate keeps its
    existing title, while a pre-gate failure files *run failed before the vulnix
    gate* and names the failing step, read off the run's own job records
    (`actions: read`). A pre-gate failure means the closure went **unscanned**,
    not clean — the body says so
```

## Testing

- [x] Tests pass locally (`just test`)
- [x] Manual testing performed (below)

TDD: `tests/test_workflow_scan_failure_reporting.py` was committed **red**
(3 failures) before the fix, and passes after.

### Manual Testing Details

YAML shape is not enough for a step that is only ever exercised on a red nightly
run, so the `run:` block was extracted and executed against a `gh` stub:

| Case | Result |
|------|--------|
| `GATE_OUTCOME=failure` | files the **existing** gate title + body verbatim |
| `GATE_OUTCOME=''` (pre-gate) | files the new title; **Failing step: `Validate .vulnixignore exception expirations`** — correctly the *dev* leg's step, while the stub payload also carried a different failing step on the main leg |
| existing open issue | `Open tracking issue already exists: #4242 -- skipping create`, exit 0, no create call |

`actionlint` (which runs shellcheck over `run:` blocks) is clean, and the full
hook suite is green locally.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly (`docs/CONTAINER_SECURITY.md`)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (pasted above)
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
