### PR TITLE
fix(doctor): expand a leading tilde in user.signingkey before the readability test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`just doctor` no longer calls a tilde signing-key path incomplete**
+  ([#1546](https://github.com/vig-os/devkit/issues/1546))
+  - `user.signingkey = ~/.ssh/<key>.pub` is a working SSH-signing setup — git
+    expands the leading `~/` when it consumes the value — but the readability
+    guard tested it with `test -r`, which performs no tilde expansion, so a
+    correctly configured host was told its signing was `incomplete`
+  - The guard now expands a leading `~/` against `$HOME` before the test, in
+    both the devkit `justfile` and the scaffolded `assets/workspace/justfile`.
+    The `PASS` line still reports the raw value, so it keeps mirroring
+    `git config`
+
 - **A nightly security scan that fails before the gate now files a tracking
   issue too** ([#1548](https://github.com/vig-os/devkit/issues/1548))
   - The issue-opening step was guarded on `steps.vulnix-gate.outcome ==

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -36,6 +36,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`just doctor` no longer calls a tilde signing-key path incomplete**
+  ([#1546](https://github.com/vig-os/devkit/issues/1546))
+  - `user.signingkey = ~/.ssh/<key>.pub` is a working SSH-signing setup — git
+    expands the leading `~/` when it consumes the value — but the readability
+    guard tested it with `test -r`, which performs no tilde expansion, so a
+    correctly configured host was told its signing was `incomplete`
+  - The guard now expands a leading `~/` against `$HOME` before the test, in
+    both the devkit `justfile` and the scaffolded `assets/workspace/justfile`.
+    The `PASS` line still reports the raw value, so it keeps mirroring
+    `git config`
+
 - **A nightly security scan that fails before the gate now files a tracking
   issue too** ([#1548](https://github.com/vig-os/devkit/issues/1548))
   - The issue-opening step was guarded on `steps.vulnix-gate.outcome ==

--- a/assets/workspace/justfile
+++ b/assets/workspace/justfile
@@ -46,8 +46,17 @@ doctor:
     gpgsign="$(git config commit.gpgsign || true)"
     format="$(git config gpg.format || true)"
     signingkey="$(git config user.signingkey || true)"
+    # git expands a leading `~/` itself when it consumes user.signingkey, but
+    # `test -r` does not — the shell expands `~` only as an unquoted literal at
+    # the start of a word, never the contents of a variable. Expand it here too,
+    # or a working tilde-path setup reads as incomplete (#1546). The PASS line
+    # keeps reporting the raw value, so it still mirrors git config.
+    keypath="$signingkey"
+    case "$keypath" in
+        "~/"*) keypath="$HOME/${keypath#\~/}" ;;
+    esac
     if [ "$gpgsign" = "true" ] && [ -n "$signingkey" ] && \
-        { [ "$format" != "ssh" ] || [ -r "$signingkey" ] || \
+        { [ "$format" != "ssh" ] || [ -r "$keypath" ] || \
           [ "${signingkey#ssh-}" != "$signingkey" ]; }; then
         echo "PASS commit signing: $format key $signingkey"
     else

--- a/justfile
+++ b/justfile
@@ -68,8 +68,17 @@ doctor:
     gpgsign="$(git config commit.gpgsign || true)"
     format="$(git config gpg.format || true)"
     signingkey="$(git config user.signingkey || true)"
+    # git expands a leading `~/` itself when it consumes user.signingkey, but
+    # `test -r` does not — the shell expands `~` only as an unquoted literal at
+    # the start of a word, never the contents of a variable. Expand it here too,
+    # or a working tilde-path setup reads as incomplete (#1546). The PASS line
+    # keeps reporting the raw value, so it still mirrors git config.
+    keypath="$signingkey"
+    case "$keypath" in
+        "~/"*) keypath="$HOME/${keypath#\~/}" ;;
+    esac
     if [ "$gpgsign" = "true" ] && [ -n "$signingkey" ] && \
-        { [ "$format" != "ssh" ] || [ -r "$signingkey" ] || \
+        { [ "$format" != "ssh" ] || [ -r "$keypath" ] || \
           [ "${signingkey#ssh-}" != "$signingkey" ]; }; then
         echo "PASS commit signing: $format key $signingkey"
     else

--- a/tests/bats/consumer-doctor.bats
+++ b/tests/bats/consumer-doctor.bats
@@ -124,6 +124,33 @@ _run_doctor_at() {
     assert_output --partial "WARN commit signing"
 }
 
+# A tilde path in user.signingkey is a working setup — git expands the leading
+# `~/` when it consumes the value, while `test -r` does not. The scaffolded
+# copy of the guard must expand it too, or a correctly configured consumer host
+# is reported as incomplete. Refs #1546.
+@test "consumer doctor reports PASS for a tilde signing key path" {
+    _scaffold_repo
+    printf 'ssh-ed25519 AAAA test\n' >"$BATS_TEST_TMPDIR/key.pub"
+    git config --file "$GIT_GLOBAL" commit.gpgsign true
+    git config --file "$GIT_GLOBAL" gpg.format ssh
+    # shellcheck disable=SC2088 # the literal, unexpanded tilde IS the fixture
+    git config --file "$GIT_GLOBAL" user.signingkey '~/key.pub'
+    _run_doctor HOME="$BATS_TEST_TMPDIR"
+    assert_success
+    assert_output --partial "PASS commit signing: ssh key ~/key.pub"
+}
+
+@test "consumer doctor warns when a tilde signing key path does not exist" {
+    _scaffold_repo
+    git config --file "$GIT_GLOBAL" commit.gpgsign true
+    git config --file "$GIT_GLOBAL" gpg.format ssh
+    # shellcheck disable=SC2088 # the literal, unexpanded tilde IS the fixture
+    git config --file "$GIT_GLOBAL" user.signingkey '~/missing.pub'
+    _run_doctor HOME="$BATS_TEST_TMPDIR"
+    assert_success
+    assert_output --partial "WARN commit signing"
+}
+
 # ── core.hooksPath verdict, per delivery mode ─────────────────────────────────
 # Devcontainer mode wires it in setup-git-conf.sh; direnv mode wires it on
 # dev-shell entry (githooksPathHook, #1112). Either way the wired state is the

--- a/tests/bats/doctor.bats
+++ b/tests/bats/doctor.bats
@@ -168,3 +168,29 @@ _init_linked_worktree() {
     assert_success
     assert_output --partial "WARN commit signing"
 }
+
+# git expands a leading `~/` itself when it consumes user.signingkey, so a
+# tilde path is a working signing setup. `test -r` performs no such expansion
+# (the shell only expands an unquoted literal `~`, never a variable's
+# contents), so the readability guard used to fail and report a correctly
+# configured host as incomplete. Refs #1546.
+@test "doctor reports PASS for a tilde signing key path" {
+    printf 'ssh-ed25519 AAAA test\n' >"$BATS_TEST_TMPDIR/key.pub"
+    git config --file "$GIT_GLOBAL" commit.gpgsign true
+    git config --file "$GIT_GLOBAL" gpg.format ssh
+    # shellcheck disable=SC2088 # the literal, unexpanded tilde IS the fixture
+    git config --file "$GIT_GLOBAL" user.signingkey '~/key.pub'
+    _run_doctor HOME="$BATS_TEST_TMPDIR"
+    assert_success
+    assert_output --partial "PASS commit signing: ssh key ~/key.pub"
+}
+
+@test "doctor warns when a tilde signing key path does not exist" {
+    git config --file "$GIT_GLOBAL" commit.gpgsign true
+    git config --file "$GIT_GLOBAL" gpg.format ssh
+    # shellcheck disable=SC2088 # the literal, unexpanded tilde IS the fixture
+    git config --file "$GIT_GLOBAL" user.signingkey '~/missing.pub'
+    _run_doctor HOME="$BATS_TEST_TMPDIR"
+    assert_success
+    assert_output --partial "WARN commit signing"
+}


### PR DESCRIPTION
## Description

`just doctor` reported `WARN commit signing: incomplete` for a correctly
configured SSH-signing host whenever `user.signingkey` is a tilde path
(`~/.ssh/<key>.pub`). The readability guard used `test -r "$signingkey"`, and
`test -r` performs no tilde expansion — the shell expands `~` only as an
unquoted literal at the start of a word, never the contents of a variable — so
the check tested a relative path literally named `~` and always failed. Git
itself *does* expand `~` when it consumes `user.signingkey`, so signing worked;
only the diagnostic was wrong. A false negative from the recipe whose job is to
rule that failure mode out.

## Type of Change

- [x] `fix` -- Bug fix

### Modifiers

- [ ] Breaking change (`!`)

## Changes Made

- Expand a leading `~/` against `$HOME` into a separate `keypath` variable
  before the `-r` test, in **both** copies of the guard: devkit's own
  `justfile` and the scaffolded `assets/workspace/justfile` (which must stay in
  sync — `consumer doctor checks exactly what devkit's doctor checks` pins
  that).
- The `PASS` line keeps echoing the raw `$signingkey`, so the output still
  mirrors `git config` rather than a rewritten path.
- Only a leading `~/` is expanded; `~user/...` is left alone, and an inline
  `ssh-...` key value still takes the existing literal-key branch.

## Changelog Entry

```markdown
### Fixed

- **`just doctor` no longer calls a tilde signing-key path incomplete**
  ([#1546](https://github.com/vig-os/devkit/issues/1546))
  - `user.signingkey = ~/.ssh/<key>.pub` is a working SSH-signing setup — git
    expands the leading `~/` when it consumes the value — but the readability
    guard tested it with `test -r`, which performs no tilde expansion, so a
    correctly configured host was told its signing was `incomplete`
  - The guard now expands a leading `~/` against `$HOME` before the test, in
    both the devkit `justfile` and the scaffolded `assets/workspace/justfile`.
    The `PASS` line still reports the raw value, so it keeps mirroring
    `git config`
```

## Testing

- [x] Tests pass locally
- [x] Manual testing performed

TDD, RED confirmed before the fix. Four new bats tests (two per copy of the
recipe), each driving a pinned `HOME` and `GIT_CONFIG_GLOBAL` so host state
cannot leak in:

- `doctor reports PASS for a tilde signing key path` / consumer twin — the
  regression itself. Both failed on the pre-fix recipe with
  `WARN commit signing: incomplete (... user.signingkey=~/key.pub)`.
- `doctor warns when a tilde signing key path does not exist` / consumer twin —
  pins that expansion does not turn the guard into a rubber stamp: a tilde path
  to a missing file must still WARN.

```text
tests/bats/doctor.bats           11/11 ok
tests/bats/consumer-doctor.bats  19/19 ok
prek run --all-files             all hooks pass, tree clean
```

### Manual Testing Details

Reproduced on the reporting host (NixOS, `direnv` mode, real
`user.signingkey=~/.ssh/github.pub`):

```text
before: WARN commit signing: incomplete (commit.gpgsign=true, gpg.format=ssh, user.signingkey=~/.ssh/github.pub)
after:  PASS commit signing: ssh key ~/.ssh/github.pub
```

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly (no doc template covers this line)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

Consumers pick this up with their next scaffold/upgrade, since the fix is in the
managed root `justfile` (the layer that *is* regenerated on upgrade), not in the
preserved `justfile.project`.

Refs: #1546
