### PR TITLE
chore(security): stagger exception expiries onto distinct Wednesdays

### DIFF
--- a/.github/dependency-review-allow.txt
+++ b/.github/dependency-review-allow.txt
@@ -4,7 +4,9 @@
 # directive. Expired exceptions cause CI to fail, forcing periodic review.
 # Expiration dates land on a Wednesday, per the expiry grid documented in
 # docs/CONTAINER_SECURITY.md (#1337); the date below was snapped onto that grid
-# on 2026-08-04 (+1 day), leaving its risk assessment unchanged.
+# on 2026-08-04 (+1 day), leaving its risk assessment unchanged. The entry has
+# since moved off 2026-09-02 (#1553), the date 29 of the 33 live entries across
+# the three registers shared — see its note below.
 #
 # Format:
 #   # <GHSA-ID>: <short description>
@@ -21,5 +23,10 @@
 # - Upstream package.json has never updated its version field from 0.2.0
 # - The lock file records 0.2.0 regardless of which git tag is used
 # Mitigation: Source is verified GitHub repository, not npm registry
-Expiration: 2026-09-02
+# Re-dated 2026-08-20 (#1553): 2026-09-02 -> 2026-11-11, the latest slot on the
+# staggered grid. This is a definitive false positive that can only change if
+# the advisory is withdrawn or upstream finally bumps its package.json version
+# field, neither of which a weekly review can influence. Scheduling only; the
+# risk assessment above is unchanged.
+Expiration: 2026-11-11
 GHSA-wvrr-2x4r-394v

--- a/.trivyignore
+++ b/.trivyignore
@@ -13,6 +13,15 @@
 # (nearest Wednesday, shift <= 3 days) live in docs/CONTAINER_SECURITY.md. The
 # dates below were snapped onto that grid on 2026-08-04, each extended by 1 day;
 # no risk assessment was re-opened or changed by the snap.
+#
+# STAGGER (#1553), 2026-08-20: the three blocks below had all landed on
+# 2026-09-02, sharing it with 24 .vulnixignore blocks and the
+# dependency-review allow-list — 29 of 33 live entries on one day. They are
+# three independent exceptions with three different remediation levers, so each
+# now carries its own Wednesday, placed after the .vulnixignore passes so the
+# two registers do not compete for the same review week: gh/Go stdlib
+# 2026-10-21, jq 2026-10-28, jwt-token 2026-11-04. Scheduling only — no risk
+# assessment below was re-opened or changed.
 
 # CVE-2026-42504: Go stdlib MIME header DoS in gh binary
 # Risk Assessment: LOW (devcontainer context)
@@ -21,7 +30,10 @@
 # - Latest gh v2.93.0 (2026-05-27) still embeds Go 1.26.3; fix requires Go 1.26.4 rebuild
 # - Fresh image build (gh 2.93.0, uv 0.11.19) cleared all other bundled-tool HIGH findings
 # - Tracking: https://github.com/vig-os/devkit/issues/512, #564
-Expiration: 2026-09-02
+# - Re-dated 2026-08-20 (#1553): 2026-09-02 -> 2026-10-21, off the shared cliff
+#   date. The lever is a gh release rebuilt on Go 1.26.4, which no weekly bump
+#   can bring forward, so the extension costs no review signal; scheduling only.
+Expiration: 2026-10-21
 CVE-2026-42504
 
 # jwt-token: Trivy secret scan false positive
@@ -29,7 +41,10 @@ CVE-2026-42504
 # - JWT-like string in typos crate test fixtures under /opt/pre-commit-cache
 # - Not a live credential; embedded test data only
 # - Tracking: https://github.com/vig-os/devkit/issues/512
-Expiration: 2026-09-02
+# - Re-dated 2026-08-20 (#1553): 2026-09-02 -> 2026-11-04. Not a vulnerability
+#   at all, so it takes one of the latest slots on the staggered grid;
+#   scheduling only.
+Expiration: 2026-11-04
 jwt-token
 
 # CVE-2026-32316, CVE-2026-40164: jq DoS / potential arbitrary code execution
@@ -40,6 +55,9 @@ jwt-token
 #   Time-box the ignore until the Nix image ships.
 # - jq processes trusted local JSON in devcontainer workflows, not untrusted input
 # - Tracking: https://github.com/vig-os/devkit/issues/805, #512
-Expiration: 2026-09-02
+# - Re-dated 2026-08-20 (#1553): 2026-09-02 -> 2026-10-28. :latest still cannot
+#   be rebuilt until the Nix publish-cutover (#639), so an earlier re-review has
+#   no new evidence to act on; scheduling only.
+Expiration: 2026-10-28
 CVE-2026-32316
 CVE-2026-40164

--- a/.vulnixignore
+++ b/.vulnixignore
@@ -33,6 +33,19 @@
 # adjustment ONLY — no risk assessment below was re-opened, re-verified or
 # changed by it, and every rationale stands as previously written.
 #
+# STAGGER (#1553), 2026-08-20: that grid had since collapsed onto a single
+# Wednesday — 29 of the 33 live entries across the three registers shared
+# 2026-09-02, so one stalled review would have taken every open PR, both
+# nightly scan lanes and the release train red on the same Thursday. Each block
+# now sits on its OWN Wednesday, spread by week-multiples and ordered by how
+# soon its remediation lever can move ("stagger across weeks, not weekdays",
+# docs/CONTAINER_SECURITY.md): podman 2026-09-02 (kept as the anchor), unbound
+# 09-09, libssh2 6603x 09-16, libssh2 CVE-2026-58050 09-23, lower-reachability
+# 09-30, fzf 10-07, glibc 10-14. The Class-1 CPE-mismatch block keeps its
+# yearly 2027-06-23. Like the 2026-08-04 snap, a re-date is a scheduling
+# adjustment ONLY — no risk assessment below was re-opened, re-verified or
+# changed by it.
+#
 # Tracking: https://github.com/vig-os/devkit/issues/637
 
 # ============================================================================
@@ -100,7 +113,13 @@ CVE-2022-36883
 #   could not (that triage had no CVE data offline). The reachability lines are
 #   an assessment of those vectors against this deployment model — they are NOT
 #   an audit of which closure members call the affected functions.
-Expiration: 2026-09-02
+#
+#   Re-dated 2026-08-20 (#1553): 2026-09-02 -> 2026-10-14, the longest window
+#   of the vulnix blocks. The 2026-08-13 renewal above already established that
+#   the "advance the rev" lever has nowhere to land — the advisories scope the
+#   defects through 2.43 — so an earlier re-review would have no new evidence
+#   to act on. Extension is a scheduling adjustment; the assessment stands.
+Expiration: 2026-10-14
 # CVE-2025-15281 (7.5) — wordexp() with WRDE_REUSE|WRDE_APPEND returns
 #   uninitialized we_wordv, aborting on a later wordfree(). Needs a program using
 #   that flag pair; not a pattern in the image's own tooling.
@@ -130,7 +149,10 @@ CVE-2026-5928
 
 # Remaining lower-reachability components (provenance per note). Specifics
 # unverified offline; medium-near expiry to force re-review.
-Expiration: 2026-09-02
+# Re-dated 2026-08-20 (#1553): 2026-09-02 -> 2026-09-30, off the shared cliff
+#   date. Still "medium-near" as the line above intends — 4 weeks later, mid-way
+#   through the staggered grid. Scheduling only; the notes below stand.
+Expiration: 2026-09-30
 # zlib 1.3.2 — ubiquitous compression dep (curl, openssh, git, nix, python).
 #   Reachable on any decompression path; specifics unverified offline.
 CVE-2026-27820
@@ -170,7 +192,7 @@ CVE-2025-62689
 #      2026-07-28 "no fix in the pinned channel" note was already stale.
 #    - CVE-2026-56123: the pin ships socat 1.8.1.3, past the 1.8.1.2 fix.)
 
-Expiration: 2026-09-02
+Expiration: 2026-10-07
 # (gzip CVE-2026-41992 removed 2026-08-04 (#1327): contrary to the "no nixpkgs
 #   patch yet" note above, the pinned rev applies CVE-2026-41992.patch to gzip
 #   1.14, so vulnix no longer reports it.)
@@ -194,10 +216,15 @@ Expiration: 2026-09-02
 #   acceptance, not a date bump — the 2026-07-14 assessment above is unchanged
 #   and both findings stay availability-only. Renewed onto the shared 2026-09-02
 #   grid date so the whole register is reviewed in one pass (#1337).
+# Re-dated 2026-08-20 (#1553): 2026-09-02 -> 2026-10-07. That shared grid date
+#   is exactly the cliff this re-date breaks up. Both findings are
+#   availability-only on a 64-bit image and no 26.05 backport is open, so this
+#   block takes a later slot than the ones whose backport could land in any
+#   week's bump. Extension is scheduling only; the assessment above stands.
 CVE-2026-53432
 CVE-2026-53433
 
-Expiration: 2026-09-02
+Expiration: 2026-09-23
 # (libxml2 CVE-2026-11979 removed 2026-08-04 (#1327): the pinned rev applies
 #   CVE-2026-11979.patch to both libxml2 attrs (2.13.9 and 2.15.3), so vulnix
 #   no longer reports it.)
@@ -214,6 +241,9 @@ Expiration: 2026-09-02
 # Re-verified 2026-08-04 (#1328): the pin was advanced to nixos-26.05 @
 #   2026-08-03 (rev 531670d8) and rebuilt; libssh2 is still 1.11.1, so this
 #   exception is retained.
+# Re-dated 2026-08-20 (#1553): 2026-09-02 -> 2026-09-23, one week after the
+#   6603x batch below, so the two libssh2 passes stay adjacent (same package,
+#   same lever) without sharing a Wednesday. Scheduling only.
 CVE-2026-58050
 
 # ============================================================================
@@ -246,6 +276,10 @@ Expiration: 2026-09-02
 # Re-verified 2026-08-04 (#1328): the pin was advanced to nixos-26.05 @
 #   2026-08-03 (rev 531670d8) and rebuilt; the closure still ships podman 5.8.2,
 #   so this is retained.
+# Grid note 2026-08-20 (#1553): KEPT at 2026-09-02 while the rest of the
+#   register was staggered off that date. This block asks for a weekly
+#   re-check and the release-26.05 backport can merge at any time, so it keeps
+#   the earliest window and anchors the staggered grid.
 CVE-2026-57231
 
 # ============================================================================
@@ -287,9 +321,13 @@ CVE-2026-57231
 # Re-verified 2026-08-04 (#1328): the pin was advanced to nixos-26.05 @
 # 2026-08-03 (rev 531670d8) and rebuilt; the closure still ships unbound 1.25.1,
 # so this block is retained.
+# Re-dated 2026-08-20 (#1553): 2026-09-02 -> 2026-09-09, the earliest window
+# after podman. The staging-26.05 backport is already merged, so 1.25.2 can
+# reach the pinned channel in any week's Renovate bump and the "short expiry to
+# force near-term re-check" above is preserved. Scheduling only.
 # ============================================================================
 
-Expiration: 2026-09-02
+Expiration: 2026-09-09
 # unbound 1.25.1 — CVE-2026-50252 (NVD 9.3 CRITICAL; upstream rates Medium):
 #   cache poisoning via per-thread source-port population under SO_REUSEPORT —
 #   resolver daemon behavior; no daemon runs here.
@@ -347,9 +385,15 @@ CVE-2026-55973
 # 26.05 backport NixOS/nixpkgs#550166 targets staging-26.05 and is still open,
 # so the patched derivation has NOT reached the pinned nixos-26.05 channel.
 # Same expiry as the batch; the whole block drops on the rev-advance.
+#
+# Re-dated 2026-08-20 (#1553): 2026-09-02 -> 2026-09-16, kept near-term as the
+# "short expiry to force near-term re-check" above asks: NixOS/nixpkgs#550166 is
+# open against staging-26.05, so the findings can drop out on a rev-advance at
+# short notice. Scheduling only; the batch keeps one shared date and
+# CVE-2026-58050 sits a week later so the two libssh2 passes do not collide.
 # ============================================================================
 
-Expiration: 2026-09-02
+Expiration: 2026-09-16
 # libssh2 1.11.1 — CVE-2026-66032 (8.8): double-free in sftp_open()
 #   (src/sftp.c); a malicious server answers SSH_FXP_OPEN with an FX_OK status
 #   and a follow-up oversized packet, making the client free the same response

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Security-exception expiries are staggered across distinct Wednesdays**
+  ([#1553](https://github.com/vig-os/devkit/issues/1553))
+  - 29 of the 33 live exception entries expired on the same day, `2026-09-02`:
+    24 in `.vulnixignore` (7 blocks), 4 in `.trivyignore` (3 blocks) and the
+    one `.github/dependency-review-allow.txt` entry. One stalled review on that
+    date would have taken every open PR's CI, both nightly `security-scan`
+    lanes and the release train red at once — the cliff that
+    `docs/CONTAINER_SECURITY.md` already warns about ("stagger across weeks,
+    not weekdays")
+  - Each block now owns a distinct Wednesday, spread by week-multiples and
+    ordered by how soon its remediation lever can move: podman keeps
+    `2026-09-02` as the anchor (weekly re-check, backport open), then unbound
+    `09-09`, the libssh2 6603x batch `09-16`, libssh2 `CVE-2026-58050` `09-23`,
+    the lower-reachability batch `09-30`, fzf `10-07` and glibc `10-14` (no
+    rev-advance lever exists, so it takes the longest window). The
+    `.trivyignore` blocks follow at `10-21`/`10-28`/`11-04` and the
+    dependency-review allow-list at `11-11`, keeping that register's review off
+    the vulnix weeks
+  - The Class-1 CPE-mismatch block keeps its yearly `2027-06-23`
+  - Scheduling only: no risk assessment was re-opened and no entry was added or
+    removed. Every re-dated block records the move and its justification in the
+    register's own note style
+
 ### Deprecated
 
 ### Removed

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -30,6 +30,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Security-exception expiries are staggered across distinct Wednesdays**
+  ([#1553](https://github.com/vig-os/devkit/issues/1553))
+  - 29 of the 33 live exception entries expired on the same day, `2026-09-02`:
+    24 in `.vulnixignore` (7 blocks), 4 in `.trivyignore` (3 blocks) and the
+    one `.github/dependency-review-allow.txt` entry. One stalled review on that
+    date would have taken every open PR's CI, both nightly `security-scan`
+    lanes and the release train red at once — the cliff that
+    `docs/CONTAINER_SECURITY.md` already warns about ("stagger across weeks,
+    not weekdays")
+  - Each block now owns a distinct Wednesday, spread by week-multiples and
+    ordered by how soon its remediation lever can move: podman keeps
+    `2026-09-02` as the anchor (weekly re-check, backport open), then unbound
+    `09-09`, the libssh2 6603x batch `09-16`, libssh2 `CVE-2026-58050` `09-23`,
+    the lower-reachability batch `09-30`, fzf `10-07` and glibc `10-14` (no
+    rev-advance lever exists, so it takes the longest window). The
+    `.trivyignore` blocks follow at `10-21`/`10-28`/`11-04` and the
+    dependency-review allow-list at `11-11`, keeping that register's review off
+    the vulnix weeks
+  - The Class-1 CPE-mismatch block keeps its yearly `2027-06-23`
+  - Scheduling only: no risk assessment was re-opened and no entry was added or
+    removed. Every re-dated block records the move and its justification in the
+    register's own note style
+
 ### Deprecated
 
 ### Removed


### PR DESCRIPTION
## Description

29 of the 33 live security-exception entries expired on the same day,
`2026-09-02`, across all three registers. On `2026-09-03` the whole register
would have gone red at once: every open PR's CI, both nightly `security-scan`
lanes and the release train. This spreads the renewals over distinct Wednesdays
so no single stalled review can do that.

This is a **re-date only**. No risk assessment was re-opened, no entry was added
or removed, and no rationale text was rewritten — exactly the scope of the
#1337 snap.

## Type of Change

- [ ] `feat` -- New feature
- [ ] `fix` -- Bug fix
- [ ] `docs` -- Documentation only
- [x] `chore` -- Maintenance task (deps, config, etc.)
- [ ] `refactor` -- Code restructuring (no behavior change)
- [ ] `test` -- Adding or updating tests
- [ ] `ci` -- CI/CD pipeline changes
- [ ] `build` -- Build system or dependency changes
- [ ] `revert` -- Reverts a previous commit
- [ ] `style` -- Code style (formatting, whitespace)

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

### Before / after

| Register | Block (lever) | Entries | Before | After | Δ |
|---|---|---:|---|---|---|
| `.vulnixignore` | podman (release-26.05 backport, weekly re-check) | 1 | `2026-09-02` | **`2026-09-02`** | — |
| `.vulnixignore` | unbound (1.25.2 reaching `nixos-26.05`) | 5 | `2026-09-02` | **`2026-09-09`** | +1 wk |
| `.vulnixignore` | libssh2 6603x batch (staging-26.05 patch PR) | 4 | `2026-09-02` | **`2026-09-16`** | +2 wk |
| `.vulnixignore` | libssh2 `CVE-2026-58050` (no upstream fix) | 1 | `2026-09-02` | **`2026-09-23`** | +3 wk |
| `.vulnixignore` | zlib / sqlite / libmicrohttpd (low reachability) | 5 | `2026-09-02` | **`2026-09-30`** | +4 wk |
| `.vulnixignore` | fzf (no 26.05 backport open) | 2 | `2026-09-02` | **`2026-10-07`** | +5 wk |
| `.vulnixignore` | glibc (no rev-advance lever exists) | 6 | `2026-09-02` | **`2026-10-14`** | +6 wk |
| `.trivyignore` | gh / Go stdlib `CVE-2026-42504` | 1 | `2026-09-02` | **`2026-10-21`** | +7 wk |
| `.trivyignore` | jq `CVE-2026-32316`, `CVE-2026-40164` | 2 | `2026-09-02` | **`2026-10-28`** | +8 wk |
| `.trivyignore` | `jwt-token` (secret-scan false positive) | 1 | `2026-09-02` | **`2026-11-04`** | +9 wk |
| `.github/dependency-review-allow.txt` | `GHSA-wvrr-2x4r-394v` (false positive) | 1 | `2026-09-02` | **`2026-11-11`** | +10 wk |
| `.vulnixignore` | Class-1 CPE mismatch (yearly cadence) | 4 | `2027-06-23` | `2027-06-23` | untouched |

Every date is a genuine Wednesday (verified with `date -d`), every date is a
week-multiple of the original `2026-09-02` — so no snapping was needed — and no
Wednesday carries more than one block across the three registers.

### Why each block landed where it did

The grid is ordered by **how soon the block's remediation lever can move**: the
sooner a rev-advance could make the block droppable, the earlier its review, so
the near-term passes are the ones that can actually delete entries rather than
extend them.

- **podman `2026-09-02` (kept, shortest).** Its own note asks for a weekly
  re-check and NixOS/nixpkgs#536367 can merge at any time. Keeping it anchors
  the grid at the earliest date instead of pushing everything out. Not a
  re-date, so it carries a short grid note rather than a re-dating note.
- **unbound `2026-09-09` (+1 wk).** The staging-26.05 backport is already
  *merged*, so 1.25.2 can reach the pinned channel in any week's Renovate bump.
  The block's "short expiry to force near-term re-check" is preserved.
- **libssh2 6603x `2026-09-16` (+2 wk).** NixOS/nixpkgs#550166 is open against
  staging-26.05; vulnix credits CVE-named `patches` entries, so the findings can
  drop out on a rev-advance at short notice. Still near-term as its note asks.
- **libssh2 `CVE-2026-58050` `2026-09-23` (+3 wk).** Same package and lever as
  the batch above, so it sits one week later — adjacent review, no shared
  Wednesday. It has no upstream fix at all, so it is the less urgent of the two.
- **zlib / sqlite / libmicrohttpd `2026-09-30` (+4 wk).** The note asks for a
  "medium-near expiry"; four weeks, mid-grid, keeps that intent.
- **fzf `2026-10-07` (+5 wk).** Renewed only today (#1547) onto the shared date
  — the very cliff this PR breaks up. Both findings are availability-only on a
  64-bit image and no 26.05 backport is open, so it takes a later slot than the
  blocks whose backport could land in any week's bump.
- **glibc `2026-10-14` (+6 wk), longest vulnix window.** The 2026-08-13 renewal
  (#1481) already established that the "advance the rev" lever has nowhere to
  land — the advisories scope the defects through 2.43 — so an earlier
  re-review would have no new evidence to act on. The issue calls for the
  longest window here.
- **`.trivyignore` `2026-10-21` / `2026-10-28` / `2026-11-04` (+7/8/9 wk).**
  Placed after the vulnix passes so the two registers do not compete for the
  same review week. Ordered by lever: gh needs a release rebuilt on Go 1.26.4
  (no weekly bump can bring that forward), jq needs the Nix publish-cutover
  (#639) before `:latest` can be rebuilt at all, and `jwt-token` is not a
  vulnerability.
- **`GHSA-wvrr-2x4r-394v` `2026-11-11` (+10 wk), latest slot.** A definitive
  false positive that can only change if the advisory is withdrawn or upstream
  bumps a `package.json` version field it has never touched — the same class as
  the Class-1 CPE-mismatch block, which already sits on a *yearly* cadence, so
  ten weeks is comfortably conservative by that precedent.

### `.trivyignore`: three blocks or one?

The 4 entries sit under 3 `Expiration:` directives. They are kept as **three
separate blocks with three separate dates**: they are independent exceptions
with independent levers (a gh release rebuilt on Go 1.26.4; the Nix
publish-cutover; a secret-scan false positive). Folding them into one pass would
ask three unrelated questions in one review, and would put three blocks on one
Wednesday — which is what this PR exists to stop.

### Notes and headers

Each re-dated block carries a dated note in the register's own comment style
(`# Re-dated 2026-08-20 (#1553): <old> -> <new>, <why>`), recording the move,
the justification, and that it is scheduling only. The three register headers
are **extended, not rewritten** — the 2026-08-04 snap paragraph stays verbatim
and a `STAGGER (#1553)` paragraph follows it, so the historical record is
intact and the file no longer contradicts itself.

## Changelog Entry

```markdown
### Changed

- **Security-exception expiries are staggered across distinct Wednesdays**
  ([#1553](https://github.com/vig-os/devkit/issues/1553))
  - 29 of the 33 live exception entries expired on the same day, `2026-09-02`:
    24 in `.vulnixignore` (7 blocks), 4 in `.trivyignore` (3 blocks) and the
    one `.github/dependency-review-allow.txt` entry. One stalled review on that
    date would have taken every open PR's CI, both nightly `security-scan`
    lanes and the release train red at once — the cliff that
    `docs/CONTAINER_SECURITY.md` already warns about ("stagger across weeks,
    not weekdays")
  - Each block now owns a distinct Wednesday, spread by week-multiples and
    ordered by how soon its remediation lever can move: podman keeps
    `2026-09-02` as the anchor (weekly re-check, backport open), then unbound
    `09-09`, the libssh2 6603x batch `09-16`, libssh2 `CVE-2026-58050` `09-23`,
    the lower-reachability batch `09-30`, fzf `10-07` and glibc `10-14` (no
    rev-advance lever exists, so it takes the longest window). The
    `.trivyignore` blocks follow at `10-21`/`10-28`/`11-04` and the
    dependency-review allow-list at `11-11`, keeping that register's review off
    the vulnix weeks
  - The Class-1 CPE-mismatch block keeps its yearly `2027-06-23`
  - Scheduling only: no risk assessment was re-opened and no entry was added or
    removed. Every re-dated block records the move and its justification in the
    register's own note style
```

## Testing

- [x] Tests pass locally (`just test`) -- full `prek run --all-files` suite green
- [x] Manual testing performed (describe below)

### Manual Testing Details

**Validator**

```
$ uv run check-expirations .trivyignore .vulnixignore .github/dependency-review-allow.txt
Validated 33 exception(s) across 3 file(s)
exit=0
```

**Resulting distribution** (enumerated via
`vig_utils.check_expirations.parse_entries`):

```
date         weekday     n  file(s) -> identifiers
2026-09-02   Wednesday   1  .vulnixignore -> CVE-2026-57231
2026-09-09   Wednesday   5  .vulnixignore -> CVE-2026-50252 CVE-2026-32665 CVE-2026-40691 CVE-2026-44690 CVE-2026-55973
2026-09-16   Wednesday   4  .vulnixignore -> CVE-2026-66032 CVE-2026-66033 CVE-2026-66034 CVE-2026-66035
2026-09-23   Wednesday   1  .vulnixignore -> CVE-2026-58050
2026-09-30   Wednesday   5  .vulnixignore -> CVE-2026-27820 CVE-2026-11822 CVE-2026-11824 CVE-2025-59777 CVE-2025-62689
2026-10-07   Wednesday   2  .vulnixignore -> CVE-2026-53432 CVE-2026-53433
2026-10-14   Wednesday   6  .vulnixignore -> CVE-2025-15281 CVE-2026-4046 CVE-2026-4437 CVE-2026-5435 CVE-2026-5450 CVE-2026-5928
2026-10-21   Wednesday   1  .trivyignore -> CVE-2026-42504
2026-10-28   Wednesday   2  .trivyignore -> CVE-2026-32316 CVE-2026-40164
2026-11-04   Wednesday   1  .trivyignore -> jwt-token
2026-11-11   Wednesday   1  .github/dependency-review-allow.txt -> GHSA-wvrr-2x4r-394v
2027-06-23   Wednesday   4  .vulnixignore -> CVE-2021-28794 CVE-2022-30947 CVE-2022-36882 CVE-2022-36883

total entries: 33 | distinct dates: 12
non-Wednesday or shared-across-files dates: NONE
```

12 distinct dates, 12 blocks, one block per date. The `2027-06-23` Class-1 block
is untouched and collides with nothing.

**TDD skipped, deliberately.** This is a data/config change with no code path to
exercise; there is nothing to write a failing test against. The format and
expiry semantics are already covered by `check-expirations`, which runs in
pre-commit and in all PR CI and passes against all 33 entries. Forcing a unit
test here would pin the dates themselves, which are meant to move.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly (edit `docs/templates/`, then run `just docs`) -- N/A, no documentation change (explicit non-goal; the staggering rule is already documented)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works -- N/A, see TDD note above
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

**Deliberately out of scope** (per the issue's non-goals):

- No risk assessment re-opened, no entry added or removed, no rationale text
  rewritten.
- No documentation change -- `docs/CONTAINER_SECURITY.md` already documents the
  grid and the stagger rule; this PR brings the register into line with it.
- No tooling change -- advance warning for an upcoming expiry cliff is tracked
  separately.
- The `2027-06-23` Class-1 block is untouched.

**Parallel work.** #1552 is in flight at the same time and touches tooling only
(`check_expirations.py` and its tests, `security-scan.yml`,
`docs/CONTAINER_SECURITY.md`) -- none of which this PR touches. A `CHANGELOG.md`
conflict is the only expected overlap.

Refs: #1553
