### PR TITLE
feat(vigutils): warn seven days before a security exception expires

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -31,6 +31,13 @@
 #     the latter means the closure went UNSCANNED, which used to surface
 #     nowhere at all.
 #
+# Ahead of failure (#1552):
+#   - A third, non-failing issue class: exceptions within 7 days of expiring get
+#     an advance-notice issue, one per (ref x distinct expiry date), so the
+#     re-review is scheduled work instead of the day-after outage that #1260,
+#     #1481 and #1547 each were. It is a notice, not a gate — the hard gate is
+#     still the validation step.
+#
 # Artifacts:
 #   - vulnix findings (JSON + table) and a CycloneDX SBOM (uploaded)
 
@@ -93,6 +100,99 @@ jobs:
           sync-dependencies: 'true'
           cachix-cache: ${{ vars.CACHIX_CACHE }}
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+
+      # ADVANCE NOTICE, not a gate (#1552). Deliberately placed BEFORE the
+      # validation step below: an already-red register fails that step and ends
+      # the job, so a notice scheduled after it would go silent exactly on the
+      # runs where the next wave of expiries is most worth knowing about. This
+      # step never fails the job (`continue-on-error`) — the hard gate stays the
+      # validation step, and a missed notice must never turn a green scan red.
+      #
+      # 7 days is one expiry-grid period: `docs/CONTAINER_SECURITY.md` puts every
+      # `Expiration:` on a Wednesday so an entry turns red on the Thursday AFTER
+      # the week's Renovate nixpkgs bump and the first nightly findings delta. A
+      # 7-day lead therefore lands the notice on a Wednesday too, one full
+      # Renovate cycle ahead of the red.
+      #
+      # All three registers are covered, not just `.vulnixignore`: the nightly
+      # scan only gates on that one, but `.trivyignore` and the dependency-review
+      # allow-list red every branch just as hard when they lapse (#1260).
+      - name: Warn on security exceptions expiring within 7 days
+        # Best-effort by construction: a classification hiccup or an issue the
+        # API refuses to create degrades to a warning, never a red nightly scan.
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SCAN_REF: ${{ matrix.ref }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          WARN_DAYS: '7'
+        run: |
+          set -euo pipefail
+          # `--json` keeps check-expirations the single parser of the
+          # `Expiration:` grammar — the workflow never re-implements it. The
+          # `|| true` is for the EXPIRED case only: the utility still exits 1 on
+          # an expired entry (and still prints the payload), and that failure is
+          # the next step's verdict to deliver, not this one's.
+          PAYLOAD="$(uv run check-expirations --warn-days "$WARN_DAYS" --json \
+            .vulnixignore .trivyignore .github/dependency-review-allow.txt || true)"
+          if ! jq -e . <<<"$PAYLOAD" > /dev/null 2>&1; then
+            echo "::warning::could not classify the exception registers; the validation step below reports the real failure"
+            exit 0
+          fi
+          # ONE ISSUE PER (ref x distinct expiry date). Per-date rather than one
+          # rolling issue because a date maps 1:1 to a single combined review
+          # pass, it dedups on a stable title, and staggered dates get their own
+          # issues — which reinforces the "stagger across weeks" rule in
+          # docs/CONTAINER_SECURITY.md instead of flattening it back into one.
+          mapfile -t EXPIRIES < <(jq -r '[.expiring[].expiration] | unique | .[]' <<<"$PAYLOAD")
+          if [ "${#EXPIRIES[@]}" -eq 0 ]; then
+            echo "No security exceptions expire within ${WARN_DAYS} days on ${SCAN_REF}"
+            exit 0
+          fi
+          gh label create security-scan \
+            --description 'Automated nightly security scan findings for the Nix devcontainer image' \
+            --color BFD4F2 --force 2>/dev/null || true
+          for EXPIRY in "${EXPIRIES[@]}"; do
+            TITLE="Security exception register (${SCAN_REF}): exceptions expire ${EXPIRY}"
+            # Same dedup shape as the failure-reporting step below (title, not
+            # label alone, so human-filed security-scan issues never collide) —
+            # with an exact-title filter on top, because GitHub's search
+            # tokenises a date and would otherwise let one date's open issue
+            # suppress another date's notice.
+            EXISTING="$(gh issue list --state open --label security-scan \
+              --search "\"$TITLE\" in:title" --json number,title \
+              | jq -r --arg t "$TITLE" 'map(select(.title == $t)) | .[0].number // empty')"
+            if [ -n "$EXISTING" ]; then
+              echo "Open notice already exists for ${EXPIRY}: #${EXISTING} -- skipping create"
+              continue
+            fi
+            ENTRIES="$(jq -r --arg d "$EXPIRY" \
+              '.expiring[] | select(.expiration == $d) | "- `\(.id)` — `\(.file)` (\(.days_left) day(s) left)"' \
+              <<<"$PAYLOAD")"
+            BODY="$(cat <<EOF
+          The following security exceptions on \`${SCAN_REF}\` expire on **${EXPIRY}** — within ${WARN_DAYS} days. They are still valid; \`check-expirations\` starts failing every branch, both nightly lanes and the release train the day *after* that date.
+
+          ${ENTRIES}
+
+          - **Scanned ref:** \`${SCAN_REF}\`
+          - **Expiry date:** ${EXPIRY}
+          - **Workflow run:** ${RUN_URL}
+
+          **A renewal is a re-verification, not a date bump.** Before touching any date:
+
+          1. Read the latest nightly findings delta for this ref (the \`nix-image-cve-scan-${SCAN_REF}\` artifact on the most recent run) against the current closure.
+          2. **Delete** every entry the pin advance has cleared — the expiry grid exists so entries die rather than roll forward.
+          3. Renew only what is still genuinely accepted, re-stating the rationale, and snap the new date onto the Wednesday grid.
+
+          See \`docs/CONTAINER_SECURITY.md\` (*Exception registers* / *Expiry dates land on a Wednesday*). Close this issue once the register has been reconciled.
+          EOF
+          )"
+            gh issue create \
+              --title "$TITLE" \
+              --label security-scan --label security \
+              --body "$BODY" \
+              || echo "::warning::could not open the expiry notice for ${EXPIRY}"
+          done
 
       - name: Validate .vulnixignore exception expirations
         run: uv run check-expirations .vulnixignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **A security exception now gives seven days' notice before it fails
+  everything** ([#1552](https://github.com/vig-os/devkit/issues/1552))
+  - `check-expirations` runs in all PR CI, in pre-commit, in both nightly scan
+    lanes and in the release train, so one lapsed block reds every open branch
+    at once — three times in two months
+    ([#1260](https://github.com/vig-os/devkit/issues/1260),
+    [#1481](https://github.com/vig-os/devkit/issues/1481),
+    [#1547](https://github.com/vig-os/devkit/issues/1547)) — with no prior
+    signal, even though every date had been chosen deliberately weeks earlier
+  - `check-expirations` gains `--warn-days N` (emit `::warning::` annotations
+    for entries falling due within N days, exit code untouched) and `--json`
+    (emit the `expired`/`expiring` classification on stdout). The flags compose,
+    and they keep the utility the single parser of the `Expiration:` grammar —
+    no caller re-implements it
+  - The nightly `security-scan` gains a third, non-failing issue class: one
+    deduplicated notice per scanned ref per distinct upcoming expiry date,
+    titled `Security exception register (<ref>): exceptions expire <date>`,
+    covering `.vulnixignore`, `.trivyignore` **and**
+    `.github/dependency-review-allow.txt`
+  - The step runs *before* the blocking validation step, so an already-red
+    register still reports what is coming next, and it is `continue-on-error`
+    so a missed notice can never turn a green scan red
+  - Seven days is one expiry-grid period: dates land on a Wednesday, so the
+    notice does too, one full Renovate cycle ahead of the red. The issue body
+    spells out that a renewal is a re-verification, not a date bump — read the
+    findings delta, delete what the pin advance cleared — because the notice
+    deliberately arrives before that data exists
+  - Default behaviour is unchanged: no existing call site, exit code or output
+    moves
+
 - **A failed `devkit-upgrade` now leaves a tracking issue in the consumer repo**
   ([#1530](https://github.com/vig-os/devkit/issues/1530))
   - The adoption branch only reaches the remote in the publish step, so a

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -9,6 +9,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **A security exception now gives seven days' notice before it fails
+  everything** ([#1552](https://github.com/vig-os/devkit/issues/1552))
+  - `check-expirations` runs in all PR CI, in pre-commit, in both nightly scan
+    lanes and in the release train, so one lapsed block reds every open branch
+    at once — three times in two months
+    ([#1260](https://github.com/vig-os/devkit/issues/1260),
+    [#1481](https://github.com/vig-os/devkit/issues/1481),
+    [#1547](https://github.com/vig-os/devkit/issues/1547)) — with no prior
+    signal, even though every date had been chosen deliberately weeks earlier
+  - `check-expirations` gains `--warn-days N` (emit `::warning::` annotations
+    for entries falling due within N days, exit code untouched) and `--json`
+    (emit the `expired`/`expiring` classification on stdout). The flags compose,
+    and they keep the utility the single parser of the `Expiration:` grammar —
+    no caller re-implements it
+  - The nightly `security-scan` gains a third, non-failing issue class: one
+    deduplicated notice per scanned ref per distinct upcoming expiry date,
+    titled `Security exception register (<ref>): exceptions expire <date>`,
+    covering `.vulnixignore`, `.trivyignore` **and**
+    `.github/dependency-review-allow.txt`
+  - The step runs *before* the blocking validation step, so an already-red
+    register still reports what is coming next, and it is `continue-on-error`
+    so a missed notice can never turn a green scan red
+  - Seven days is one expiry-grid period: dates land on a Wednesday, so the
+    notice does too, one full Renovate cycle ahead of the red. The issue body
+    spells out that a renewal is a re-verification, not a date bump — read the
+    findings delta, delete what the pin advance cleared — because the notice
+    deliberately arrives before that data exists
+  - Default behaviour is unchanged: no existing call site, exit code or output
+    moves
+
 - **A failed `devkit-upgrade` now leaves a tracking issue in the consumer repo**
   ([#1530](https://github.com/vig-os/devkit/issues/1530))
   - The adoption branch only reaches the remote in the publish step, so a

--- a/docs/CONTAINER_SECURITY.md
+++ b/docs/CONTAINER_SECURITY.md
@@ -177,6 +177,35 @@ single combined re-review pass, which is the intent; but every block on the
 *same* Wednesday means one stalled review blocks the whole register. Spread
 renewals over different Wednesdays by choosing different week-multiples.
 
+#### Advance notice, one grid period ahead
+
+An expiry that fires is a *hard* failure everywhere at once — `check-expirations`
+runs in all PR CI, in pre-commit, in both nightly scan lanes and in the release
+train — so the nightly scan also gives **seven days' notice** before it happens
+([#1552](https://github.com/vig-os/devkit/issues/1552)).
+
+`security-scan.yml` runs `check-expirations --warn-days 7 --json` over all three
+registers (`.vulnixignore`, `.trivyignore`,
+`.github/dependency-review-allow.txt`) *before* the blocking validation step, so
+an already-red register still reports what is coming next. Every distinct
+upcoming expiry date gets one deduplicated tracking issue per scanned ref,
+titled `Security exception register (<ref>): exceptions expire <date>`.
+
+Seven days is exactly one grid period: because dates land on a Wednesday, the
+notice lands on a Wednesday too — one full Renovate cycle ahead of the red, so
+step 3 above (the findings delta) has still to happen when the notice arrives.
+
+**This is a notice, not a gate.** `--warn-days` never changes an exit code: an
+entry inside the window is still valid, an already-expired entry still fails,
+and the issue-opening step is `continue-on-error` so a missed notice can never
+turn a green scan red. The gate remains exactly where it was.
+
+**A renewal is a re-verification, not a date bump.** The notice arrives *before*
+the week's findings delta exists, so acting on it by bumping dates is precisely
+the blind extension the Wednesday grid is built to prevent. Read the delta
+first, delete every entry the pin advance cleared, and renew only what is still
+genuinely accepted — the tracking issue restates this in its body.
+
 ## Why pin `nixpkgs` (and not track an unpinned channel)?
 
 Building from an unpinned/rolling input has the same drawbacks the old

--- a/packages/vig-utils/src/vig_utils/check_expirations.py
+++ b/packages/vig-utils/src/vig_utils/check_expirations.py
@@ -6,26 +6,41 @@ where each exception entry is preceded by an `Expiration: YYYY-MM-DD`
 directive. One expiration line may apply to multiple following entries until
 the next expiration directive.
 
+This module is the single parser of the `Expiration:` grammar. `--warn-days`
+and `--json` exist so a workflow can give advance notice of an upcoming expiry
+without re-implementing that grammar (#1552).
+
 Exit codes:
     0 — All entries are present and unexpired
     1 — Missing file, parse error, or expired entries
 
+Note that `--warn-days` never changes the exit code: an entry inside the
+warning window is still valid, and an already-expired entry still fails. The
+hard gate is unchanged; the warning is a notice ahead of it.
+
 Usage:
     check-expirations .trivyignore
     check-expirations .github/dependency-review-allow.txt
+    check-expirations --warn-days 7 .vulnixignore
+    check-expirations --warn-days 7 --json .vulnixignore
 
-Refs: #566
+Refs: #566, #1552
 """
 
 from __future__ import annotations
 
 import argparse
+import json
 import re
 import sys
 from datetime import date, datetime
 from pathlib import Path
 
 EXPIRATION_PATTERN = re.compile(r"^Expiration:\s*(\d{4}-\d{2}-\d{2})\s*$")
+
+# One classified entry: {"id", "file", "expiration", "days_left"}. `days_left`
+# is negative for an entry that has already expired.
+Record = dict[str, object]
 
 
 def parse_entries(path: Path) -> list[tuple[str, date]]:
@@ -63,17 +78,46 @@ def parse_entries(path: Path) -> list[tuple[str, date]]:
     return entries
 
 
+def classify_entries(
+    entries: list[tuple[str, date]],
+    *,
+    path: Path,
+    today: date,
+    warn_days: int | None = None,
+) -> tuple[list[Record], list[Record]]:
+    """Split *entries* into (expired, expiring) records.
+
+    An entry is expired when `today > expiration` — the rule the hard gate has
+    always used. When *warn_days* is given, an unexpired entry falling due
+    within that many days (inclusive) is reported as expiring; `warn_days=None`
+    means no warning window, so the second list is always empty and the default
+    CLI behaviour is unchanged.
+    """
+    expired: list[Record] = []
+    expiring: list[Record] = []
+
+    for entry_id, expiration in entries:
+        days_left = (expiration - today).days
+        record: Record = {
+            "id": entry_id,
+            "file": str(path),
+            "expiration": expiration.isoformat(),
+            "days_left": days_left,
+        }
+        if days_left < 0:
+            expired.append(record)
+        elif warn_days is not None and days_left <= warn_days:
+            expiring.append(record)
+
+    return expired, expiring
+
+
 def check_file(path: Path, *, today: date | None = None) -> list[str]:
     """Return error messages for expired entries in *path*."""
     review_date = today or date.today()
-    entries = parse_entries(path)
-    errors: list[str] = []
+    expired, _ = classify_entries(parse_entries(path), path=path, today=review_date)
 
-    for entry_id, expiration in entries:
-        if review_date > expiration:
-            errors.append(f"{entry_id} (expired {expiration.isoformat()})")
-
-    return errors
+    return [f"{record['id']} (expired {record['expiration']})" for record in expired]
 
 
 def main(today: date | None = None) -> int:
@@ -86,9 +130,31 @@ def main(today: date | None = None) -> int:
         type=Path,
         help="Exception files to validate (e.g. .trivyignore)",
     )
+    parser.add_argument(
+        "--warn-days",
+        type=int,
+        default=None,
+        metavar="N",
+        help=(
+            "Emit a ::warning:: annotation for entries expiring within N days "
+            "(inclusive). Never changes the exit code."
+        ),
+    )
+    parser.add_argument(
+        "--json",
+        dest="emit_json",
+        action="store_true",
+        help=(
+            "Print the classification as JSON on stdout instead of the human "
+            "summary, so callers never re-parse the register format."
+        ),
+    )
     args = parser.parse_args()
 
+    review_date = today or date.today()
     all_errors: list[str] = []
+    all_expired: list[Record] = []
+    all_expiring: list[Record] = []
     total_entries = 0
 
     for path in args.files:
@@ -103,9 +169,30 @@ def main(today: date | None = None) -> int:
             return 1
 
         total_entries += len(entries)
-        errors = check_file(path, today=today)
-        for error in errors:
-            all_errors.append(f"{path}: {error}")
+        expired, expiring = classify_entries(
+            entries, path=path, today=review_date, warn_days=args.warn_days
+        )
+        all_expired.extend(expired)
+        all_expiring.extend(expiring)
+        for record in expired:
+            all_errors.append(
+                f"{path}: {record['id']} (expired {record['expiration']})"
+            )
+
+    # Warnings first: an upcoming expiry is worth surfacing even on a run that
+    # is about to fail on an already-expired entry.
+    if all_expiring:
+        print(
+            f"::warning::Security exceptions expiring within {args.warn_days} "
+            "day(s) — review before they fail CI:",
+            file=sys.stderr,
+        )
+        for record in all_expiring:
+            print(
+                f"::warning::  - {record['file']}: {record['id']} "
+                f"(expires {record['expiration']}, {record['days_left']} day(s) left)",
+                file=sys.stderr,
+            )
 
     if all_errors:
         print(
@@ -114,9 +201,18 @@ def main(today: date | None = None) -> int:
         )
         for error in all_errors:
             print(f"::error::  - {error}", file=sys.stderr)
+        # Still emit the payload: a caller that asked for JSON wants the
+        # classification even (especially) on the failing run.
+        if args.emit_json:
+            print(json.dumps({"expired": all_expired, "expiring": all_expiring}))
         return 1
 
-    print(f"Validated {total_entries} exception(s) across {len(args.files)} file(s)")
+    if args.emit_json:
+        print(json.dumps({"expired": all_expired, "expiring": all_expiring}))
+    else:
+        print(
+            f"Validated {total_entries} exception(s) across {len(args.files)} file(s)"
+        )
     return 0
 
 

--- a/packages/vig-utils/tests/test_check_expirations.py
+++ b/packages/vig-utils/tests/test_check_expirations.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import sys
 from datetime import date
 from typing import TYPE_CHECKING
@@ -13,6 +14,7 @@ if TYPE_CHECKING:
 
 from vig_utils.check_expirations import (
     check_file,
+    classify_entries,
     main,
     parse_entries,
 )
@@ -159,3 +161,220 @@ class TestMainFunction:
         monkeypatch.setattr(sys, "argv", ["check-expirations", str(path)])
         exit_code = main(today=date(2026, 6, 9))
         assert exit_code == 1
+
+
+class TestClassifyEntries:
+    """The single classification rule behind --warn-days and --json."""
+
+    ENTRIES = [
+        ("CVE-EXPIRED", date(2026, 6, 1)),
+        ("CVE-TODAY", date(2026, 6, 9)),
+        ("CVE-SOON", date(2026, 6, 16)),
+        ("CVE-LATER", date(2026, 6, 17)),
+    ]
+
+    def test_without_a_window_only_expired_is_reported(self, tmp_path: Path):
+        expired, expiring = classify_entries(
+            self.ENTRIES, path=tmp_path / "ignore.txt", today=date(2026, 6, 9)
+        )
+        assert [record["id"] for record in expired] == ["CVE-EXPIRED"]
+        assert expiring == []
+
+    def test_window_is_inclusive_of_its_last_day(self, tmp_path: Path):
+        _, expiring = classify_entries(
+            self.ENTRIES,
+            path=tmp_path / "ignore.txt",
+            today=date(2026, 6, 9),
+            warn_days=7,
+        )
+        # CVE-TODAY (0 days) and CVE-SOON (exactly 7 days) are inside the
+        # window; CVE-LATER (8 days) is not.
+        assert [record["id"] for record in expiring] == ["CVE-TODAY", "CVE-SOON"]
+
+    def test_records_carry_id_file_expiration_and_days_left(self, tmp_path: Path):
+        path = tmp_path / "ignore.txt"
+        _, expiring = classify_entries(
+            self.ENTRIES, path=path, today=date(2026, 6, 9), warn_days=7
+        )
+        assert expiring[1] == {
+            "id": "CVE-SOON",
+            "file": str(path),
+            "expiration": "2026-06-16",
+            "days_left": 7,
+        }
+
+    def test_expired_records_carry_a_negative_days_left(self, tmp_path: Path):
+        expired, _ = classify_entries(
+            self.ENTRIES,
+            path=tmp_path / "ignore.txt",
+            today=date(2026, 6, 9),
+            warn_days=7,
+        )
+        assert expired[0]["days_left"] == -8
+
+    def test_expired_entries_are_never_also_expiring(self, tmp_path: Path):
+        expired, expiring = classify_entries(
+            self.ENTRIES,
+            path=tmp_path / "ignore.txt",
+            today=date(2026, 6, 9),
+            warn_days=365,
+        )
+        assert [record["id"] for record in expired] == ["CVE-EXPIRED"]
+        assert "CVE-EXPIRED" not in [record["id"] for record in expiring]
+
+
+class TestWarnDays:
+    """--warn-days annotates upcoming expiries without changing exit codes."""
+
+    def _write(self, tmp_path: Path) -> Path:
+        path = tmp_path / "ignore.txt"
+        path.write_text(
+            "Expiration: 2026-06-16\nCVE-SOON\nExpiration: 2026-07-01\nCVE-LATER\n",
+            encoding="utf-8",
+        )
+        return path
+
+    def test_default_run_emits_no_warning(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        path = self._write(tmp_path)
+        monkeypatch.setattr(sys, "argv", ["check-expirations", str(path)])
+        exit_code = main(today=date(2026, 6, 9))
+        assert exit_code == 0
+        captured = capsys.readouterr()
+        assert captured.out == "Validated 2 exception(s) across 1 file(s)\n"
+        assert captured.err == ""
+
+    def test_warn_days_annotates_entries_inside_the_window(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        path = self._write(tmp_path)
+        monkeypatch.setattr(
+            sys, "argv", ["check-expirations", "--warn-days", "7", str(path)]
+        )
+        exit_code = main(today=date(2026, 6, 9))
+        assert exit_code == 0
+        captured = capsys.readouterr()
+        assert "::warning::" in captured.err
+        assert "CVE-SOON" in captured.err
+        assert "2026-06-16" in captured.err
+        assert "CVE-LATER" not in captured.err
+        # The human summary is untouched by the warning window.
+        assert captured.out == "Validated 2 exception(s) across 1 file(s)\n"
+
+    def test_warn_days_does_not_rescue_an_expired_entry(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        path = tmp_path / "ignore.txt"
+        path.write_text("Expiration: 2020-01-01\nCVE-OLD\n", encoding="utf-8")
+        monkeypatch.setattr(
+            sys, "argv", ["check-expirations", "--warn-days", "7", str(path)]
+        )
+        exit_code = main(today=date(2026, 6, 9))
+        assert exit_code == 1
+        assert "::error::" in capsys.readouterr().err
+
+    def test_nothing_inside_the_window_emits_no_warning(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        path = self._write(tmp_path)
+        monkeypatch.setattr(
+            sys, "argv", ["check-expirations", "--warn-days", "1", str(path)]
+        )
+        exit_code = main(today=date(2026, 6, 9))
+        assert exit_code == 0
+        assert "::warning::" not in capsys.readouterr().err
+
+
+class TestJsonOutput:
+    """--json exposes the classification so a workflow never re-parses."""
+
+    def _write(self, tmp_path: Path) -> Path:
+        path = tmp_path / "ignore.txt"
+        path.write_text(
+            "Expiration: 2020-01-01\nCVE-OLD\nExpiration: 2026-06-16\nCVE-SOON\n",
+            encoding="utf-8",
+        )
+        return path
+
+    def test_json_replaces_the_human_summary_on_stdout(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        path = tmp_path / "ignore.txt"
+        path.write_text("Expiration: 2099-01-01\nCVE-FUTURE\n", encoding="utf-8")
+        monkeypatch.setattr(sys, "argv", ["check-expirations", "--json", str(path)])
+        exit_code = main(today=date(2026, 6, 9))
+        assert exit_code == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert payload == {"expired": [], "expiring": []}
+
+    def test_json_composes_with_warn_days(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        path = self._write(tmp_path)
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            ["check-expirations", "--json", "--warn-days", "7", str(path)],
+        )
+        exit_code = main(today=date(2026, 6, 9))
+        assert exit_code == 1  # the expired entry still fails the run
+        payload = json.loads(capsys.readouterr().out)
+        assert [record["id"] for record in payload["expired"]] == ["CVE-OLD"]
+        assert payload["expiring"] == [
+            {
+                "id": "CVE-SOON",
+                "file": str(path),
+                "expiration": "2026-06-16",
+                "days_left": 7,
+            }
+        ]
+
+    def test_json_spans_every_file_given(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        first = tmp_path / "a.txt"
+        first.write_text("Expiration: 2026-06-10\nCVE-A\n", encoding="utf-8")
+        second = tmp_path / "b.txt"
+        second.write_text("Expiration: 2026-06-11\nCVE-B\n", encoding="utf-8")
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            [
+                "check-expirations",
+                "--json",
+                "--warn-days",
+                "7",
+                str(first),
+                str(second),
+            ],
+        )
+        exit_code = main(today=date(2026, 6, 9))
+        assert exit_code == 0
+        payload = json.loads(capsys.readouterr().out)
+        assert [record["id"] for record in payload["expiring"]] == ["CVE-A", "CVE-B"]
+        assert [record["file"] for record in payload["expiring"]] == [
+            str(first),
+            str(second),
+        ]

--- a/tests/test_workflow_expiry_notice.py
+++ b/tests/test_workflow_expiry_notice.py
@@ -1,0 +1,178 @@
+"""Workflow-shape tests: the nightly scan warns before an exception expires.
+
+``check-expirations`` runs in all PR CI, in pre-commit, in both nightly
+``security-scan`` lanes and in the release train, so a single lapsed block reds
+every open branch and the release path at once, with no prior signal — three
+times in two months (#1260, #1481, #1547).
+
+``security-scan.yml`` therefore carries a third, NON-failing issue class: a
+seven-day advance notice, one deduplicated issue per (matrix ref x distinct
+upcoming expiry date). It is a notice, never a gate.
+
+These are pure YAML-shape assertions (no ``nix``/``gh`` needed).
+
+Refs: #1552
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+# Repository root (tests/ -> repo root).
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+SECURITY_SCAN_WF = REPO_ROOT / ".github" / "workflows" / "security-scan.yml"
+
+SCAN_JOB = "scan-nix-image"
+
+# The blocking step the notice must precede.
+VALIDATION_RUN = "uv run check-expirations .vulnixignore"
+
+
+def _steps() -> list[dict]:
+    workflow = yaml.safe_load(SECURITY_SCAN_WF.read_text(encoding="utf-8"))
+    return workflow["jobs"][SCAN_JOB]["steps"]
+
+
+def _index_of(predicate) -> int:
+    for index, step in enumerate(_steps()):
+        if predicate(step):
+            return index
+    raise AssertionError("no matching step found in security-scan.yml")
+
+
+def _notice_index() -> int:
+    """Index of the advance-notice step (matched on what it runs)."""
+    return _index_of(lambda step: "--warn-days" in step.get("run", ""))
+
+
+def _notice_step() -> dict:
+    return _steps()[_notice_index()]
+
+
+def test_the_notice_runs_before_the_blocking_validation_step() -> None:
+    """Placement is load-bearing, not cosmetic.
+
+    The validation step fails the job on an already-expired entry, ending the
+    run. A notice scheduled after it would therefore go silent exactly on the
+    runs where the *next* wave of expiries most needs surfacing.
+    """
+    validation_index = _index_of(
+        lambda step: step.get("run", "").strip() == VALIDATION_RUN
+    )
+
+    assert _notice_index() < validation_index, (
+        "the advance-notice step must run BEFORE the blocking validation step, "
+        "or an already-red register suppresses the notice entirely (#1552)"
+    )
+
+
+def test_the_notice_never_fails_the_job() -> None:
+    """The hard gate stays the validation step; the notice is best-effort.
+
+    A classification hiccup or an issue the API refuses to create must never
+    turn a green nightly scan red.
+    """
+    assert _notice_step().get("continue-on-error") is True, (
+        "the advance-notice step must be continue-on-error: a missed notice is "
+        "not a security regression, but a red scan hides real ones (#1552)"
+    )
+
+
+def test_the_notice_covers_all_three_exception_registers() -> None:
+    """The nightly gate reads ``.vulnixignore``, but all three red every branch.
+
+    #1260 was a ``.trivyignore`` lapse; the dependency-review allow-list shares
+    the same format and the same blast radius.
+    """
+    script = _notice_step()["run"]
+
+    for register in (
+        ".vulnixignore",
+        ".trivyignore",
+        ".github/dependency-review-allow.txt",
+    ):
+        assert register in script, (
+            f"{register} lapses red every branch too and must be covered (#1552)"
+        )
+
+
+def test_the_notice_window_is_one_expiry_grid_period() -> None:
+    """Seven days: dates land on a Wednesday, so the notice does too.
+
+    One full Renovate cycle ahead of the red — see the expiry grid in
+    ``docs/CONTAINER_SECURITY.md``.
+    """
+    step = _notice_step()
+
+    assert step.get("env", {}).get("WARN_DAYS") == "7", (
+        "the warning window must be 7 days — one expiry-grid period (#1552)"
+    )
+    assert "--warn-days" in step["run"], "the window must be passed to the utility"
+
+
+def test_the_notice_never_reparses_the_expiration_grammar() -> None:
+    """``check-expirations --json`` stays the single parser of the register.
+
+    A second implementation of the ``Expiration:`` grammar inside a workflow is
+    exactly the drift this flag exists to prevent.
+    """
+    script = _notice_step()["run"]
+
+    assert "--json" in script, (
+        "the step must consume the utility's JSON classification rather than "
+        "re-reading the register itself (#1552)"
+    )
+    # Comments are free to *mention* the grammar; executable lines are not.
+    code = "\n".join(
+        line for line in script.splitlines() if not line.lstrip().startswith("#")
+    )
+    assert "Expiration:" not in code, (
+        "the workflow must not parse the `Expiration:` grammar itself — "
+        "check-expirations is its single parser (#1552)"
+    )
+
+
+def test_the_notice_dedups_per_ref_and_per_expiry_date() -> None:
+    """One issue per (ref x date): a date maps 1:1 to one combined review pass.
+
+    The ref keeps the two matrix lanes from colliding (#1237); the date keeps a
+    staggered register from collapsing back into a single rolling issue.
+    """
+    script = _notice_step()["run"]
+
+    assert "gh issue list --state open --label security-scan" in script, (
+        "dedup must reuse the existing open-issue lookup (#965, #1237, #1548)"
+    )
+    assert "${SCAN_REF}" in script and "${EXPIRY}" in script, (
+        "the issue title must carry both the ref and the expiry date so each "
+        "(ref x date) dedups independently (#1552)"
+    )
+    assert "--label security-scan --label security" in script, (
+        "the notice must carry the same labels as the other scan issues"
+    )
+
+
+def test_the_notice_body_forbids_a_blind_date_bump() -> None:
+    """The notice lands BEFORE the week's findings delta exists.
+
+    That is deliberate — but it is also exactly when a blind date bump is
+    tempting, which is the failure mode the Wednesday grid exists to prevent.
+    The body must say so and point at the register's own standard.
+    """
+    script = _notice_step()["run"]
+
+    assert "re-verification, not a date bump" in script, (
+        "the body must state that a renewal is a re-verification (#1552)"
+    )
+    assert "delta" in script, (
+        "the body must send the reader to the latest findings delta first"
+    )
+    assert "Delete" in script or "delete" in script, (
+        "the body must say to delete what the pin advance cleared, not extend it"
+    )
+    assert "docs/CONTAINER_SECURITY.md" in script, (
+        "the body must link the expiry-grid documentation (#1552)"
+    )

--- a/tests/test_workflow_scan_failure_reporting.py
+++ b/tests/test_workflow_scan_failure_reporting.py
@@ -38,9 +38,17 @@ def _job() -> dict:
 
 
 def _reporting_step() -> dict:
-    """The step that files the tracking issue (matched on what it runs)."""
+    """The step that files the FAILURE tracking issue.
+
+    Matched on what it runs *and* on its failure guard: the job also files a
+    non-failing advance-expiry notice (#1552), which creates issues too but
+    carries no ``if:``. Matching on ``gh issue create`` alone would pick
+    whichever comes first in the file.
+    """
     for step in _job()["steps"]:
-        if "gh issue create" in step.get("run", ""):
+        if "gh issue create" in step.get("run", "") and "failure()" in str(
+            step.get("if", "")
+        ):
             return step
     raise AssertionError("no tracking-issue step found in security-scan.yml")
 


### PR DESCRIPTION
## Description

Security exception expiries surfaced only as a **hard failure on the day
after**. `check-expirations` runs in all PR CI (`ci.yml:441`, `:524`), in
pre-commit, as the first step of both nightly `security-scan.yml` lanes and in
the release train (`release.yml:906`) — so one lapsed block reds every open
branch, both scan lanes and the release path at once, with zero prior warning.
That happened three times in two months (#1260, #1481, #1547), each time on a
date a human had chosen deliberately weeks earlier. The information existed;
nothing surfaced it.

This adds a **seven-day advance notice**. It is a notice, not a gate: the hard
gate is untouched.

## Type of Change

- [x] `feat` -- New feature
- [x] `ci` -- CI/CD pipeline changes
- [x] `docs` -- Documentation only
- [x] `test` -- Adding or updating tests

### Modifiers

- [ ] Breaking change (`!`) -- This change breaks backward compatibility

## Changes Made

**1. `check-expirations --warn-days N` and `--json`**
(`packages/vig-utils/src/vig_utils/check_expirations.py`)

- `--warn-days N` emits `::warning::` annotations (stderr, like the existing
  `::error::` ones) for entries falling due within N days, **inclusive**.
  It never changes an exit code: an entry inside the window is still valid, and
  an already-expired entry still exits 1 exactly as today.
- `--json` prints `{"expired": [...], "expiring": [...]}` on stdout, each record
  `{"id", "file", "expiration", "days_left"}` (`days_left` is negative for an
  expired entry). It replaces the human summary line so stdout is pure JSON,
  and it is still emitted on the failing (expired) run, where a caller needs it
  most.
- The two flags compose. A new `classify_entries()` holds the single
  classification rule; `check_file()` is re-expressed through it and keeps its
  exact contract, so the module stays the single parser of the `Expiration:`
  grammar.
- **Default behaviour is byte-identical** — no existing call site moves.

**2. A third issue class in `.github/workflows/security-scan.yml`** (not a new
workflow — that job already carries the `main`/`dev` matrix, `issues: write`,
the label bootstrap and the ref-distinct dedup pattern from #1548)

- Placed **before** the blocking `Validate .vulnixignore exception expirations`
  step, so an already-red register still reports what is coming next. A notice
  scheduled after it would go silent exactly on the runs that need it.
- Covers all three registers — `.vulnixignore`, `.trivyignore` **and**
  `.github/dependency-review-allow.txt`. The nightly gate reads only the first,
  but the other two red every branch just as hard (#1260 was a `.trivyignore`
  case).
- Opens **one deduplicated issue per (matrix ref x distinct upcoming expiry
  date)**: `Security exception register (dev): exceptions expire 2026-09-02`.
  Per-date because a date maps 1:1 to one combined review pass and staggered
  dates then get their own issues — reinforcing the "stagger across weeks" rule
  rather than flattening it. Dedup reuses the existing
  `gh issue list --state open --label security-scan --search "\"$TITLE\" in:title"`
  lookup, with an exact-title filter on top because GitHub's search tokenises a
  date and would otherwise let one date's open issue suppress another's.
- `continue-on-error: true` and every `gh` failure degrades to a `::warning::`
  — the step can never turn a green nightly scan red. The hard gate stays the
  validation step.
- The body lists only that date's entries, then states the anti-blind-extension
  standard (read the latest findings delta first, **delete** what the pin
  advance cleared, a renewal is a re-verification not a date bump) and links
  `docs/CONTAINER_SECURITY.md`.

**3. Docs** — new *Advance notice, one grid period ahead* subsection in
`docs/CONTAINER_SECURITY.md`, inside the exception-register section and right
after the Wednesday-grid rationale it depends on. It states explicitly that this
is a notice and the gate is unchanged, and repeats the anti-blind-extension rule
(the notice deliberately arrives *before* the week's findings delta exists).
`SECURITY.md:88` ("Expired entries fail CI via the `check-expirations` utility")
is still exactly true, so it is left alone.

### Why 7 days

One expiry-grid period. `docs/CONTAINER_SECURITY.md` puts every `Expiration:` on
a Wednesday so an entry turns red on the Thursday *after* the week's Renovate
`nixpkgs` bump and the first nightly findings delta. A 7-day lead lands the
notice on a Wednesday too, one full Renovate cycle ahead: notice Wed, bump
merges Mon/Tue, nightly delta Tue/Wed, act Wed, red Thu.

## Changelog Entry

```markdown
### Added

- **A security exception now gives seven days' notice before it fails
  everything** ([#1552](https://github.com/vig-os/devkit/issues/1552))
  - `check-expirations` runs in all PR CI, in pre-commit, in both nightly scan
    lanes and in the release train, so one lapsed block reds every open branch
    at once — three times in two months
    ([#1260](https://github.com/vig-os/devkit/issues/1260),
    [#1481](https://github.com/vig-os/devkit/issues/1481),
    [#1547](https://github.com/vig-os/devkit/issues/1547)) — with no prior
    signal, even though every date had been chosen deliberately weeks earlier
  - `check-expirations` gains `--warn-days N` (emit `::warning::` annotations
    for entries falling due within N days, exit code untouched) and `--json`
    (emit the `expired`/`expiring` classification on stdout). The flags compose,
    and they keep the utility the single parser of the `Expiration:` grammar —
    no caller re-implements it
  - The nightly `security-scan` gains a third, non-failing issue class: one
    deduplicated notice per scanned ref per distinct upcoming expiry date,
    titled `Security exception register (<ref>): exceptions expire <date>`,
    covering `.vulnixignore`, `.trivyignore` **and**
    `.github/dependency-review-allow.txt`
  - The step runs *before* the blocking validation step, so an already-red
    register still reports what is coming next, and it is `continue-on-error`
    so a missed notice can never turn a green scan red
  - Seven days is one expiry-grid period: dates land on a Wednesday, so the
    notice does too, one full Renovate cycle ahead of the red. The issue body
    spells out that a renewal is a re-verification, not a date bump — read the
    findings delta, delete what the pin advance cleared — because the notice
    deliberately arrives before that data exists
  - Default behaviour is unchanged: no existing call site, exit code or output
    moves
```

## Testing

- [x] Tests pass locally (`just test`)
- [x] Manual testing performed (describe below)

### TDD evidence

Six commits, each phase its own commit:

| Commit | Phase |
|--------|-------|
| `050fe043` `test(vigutils): pin --warn-days and --json on check-expirations` | RED |
| `3170a59a` `feat(vigutils): add --warn-days and --json to check-expirations` | GREEN |
| `4ae883a6` `test(workflows): pin the seven-day exception expiry notice on security-scan` | RED |
| `bb35a932` `ci(security-scan): open an advance notice 7 days before an exception expires` | GREEN |
| `727c19ab` `docs(security): document the seven-day exception expiry notice` | docs |
| `9b1a831c` `docs(changelog): record the security exception expiry advance notice` | changelog |

**RED, utility** — `ImportError: cannot import name 'classify_entries'`, 1 collection error.
**GREEN, utility** — `25 passed` in `packages/vig-utils/tests/test_check_expirations.py`.

**RED, workflow** — `7 failed` in the new `tests/test_workflow_expiry_notice.py`
(`AssertionError: no matching step found in security-scan.yml`), while the three
existing #1548 tests passed.
**GREEN, workflow** — `10 passed` across both workflow-shape files.

`tests/test_workflow_scan_failure_reporting.py::_reporting_step` matched the
first step containing `gh issue create`, which the new step would have shadowed
— it now also requires a `failure()` guard, which the notice step deliberately
does not carry. Caught by running the full suite, not by the hook suite.

### Verification output

**Full test suite** — `1645 passed, 20 skipped, 2 warnings in 282.61s`.

**Default behaviour unchanged** (the contract every existing call site relies on):

```console
$ uv run check-expirations .trivyignore .vulnixignore
Validated 32 exception(s) across 2 file(s)   # exit 0
```

A test pins stdout to exactly `Validated 2 exception(s) across 1 file(s)\n` with
empty stderr on a default run.

**Real registers, real today (2026-08-20), 7-day window** — nothing due, as
expected: 29 of 33 entries sit on `2026-09-02`, 13 days out.

```console
$ check-expirations --warn-days 7 --json .trivyignore .vulnixignore .github/dependency-review-allow.txt
{"expired": [], "expiring": []}              # exit 0
```

**Same registers with `today` injected to 2026-08-26** (7 days before that
cliff) — 29 entries reported across all three registers, exit 0:

```
::warning::Security exceptions expiring within 7 day(s) — review before they fail CI:
::warning::  - .vulnixignore: CVE-2025-15281 (expires 2026-09-02, 7 day(s) left)
...
::warning::  - .trivyignore: jwt-token (expires 2026-09-02, 7 day(s) left)
::warning::  - .github/dependency-review-allow.txt: GHSA-wvrr-2x4r-394v (expires 2026-09-02, 7 day(s) left)
```

**Workflow step executed locally**, extracted from the YAML and run against the
real registers with stubbed `uv`/`gh` (injected `today = 2026-08-26`):

| Scenario | Result |
|----------|--------|
| 29 entries due on one date | one `gh issue create`, title `Security exception register (dev): exceptions expire 2026-09-02`, body listing exactly that date's entries |
| exact title already open (#42) | `Open notice already exists for 2026-09-02: #42 -- skipping create`, exit 0 |
| only a *different* date open (#9, 2026-10-07) | issue still created — the exact-title filter earning its keep |
| `WARN_DAYS=1`, nothing due | `No security exceptions expire within 1 days on dev`, exit 0 |
| register missing / unparseable payload | `::warning::could not classify the exception registers; the validation step below reports the real failure`, **exit 0** |

**Linting** — `just precommit` (`prek run --all-files`) fully green, 52 hooks
`Passed`, zero failures, clean tree afterwards. `actionlint` green on
`security-scan.yml` specifically. `zizmor` in CI audits only
`assets/workspace/.github/workflows/`, which this PR does not touch; every
`${{ }}` in the new step is passed through step `env` rather than interpolated
into the script.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

- **Parallel work on #1553.** That issue staggers the `Expiration:` dates in the
  exception registers and touches only those dates. This PR changes no date in
  any register. The only expected overlap is a `CHANGELOG.md` conflict in the
  `## Unreleased` section, which union-merges.
- **Out of scope, per the issue:** the scaffold under `assets/workspace/`.
  Consumers get the `check-expirations` pre-commit hook but ship no registers
  and no `security-scan.yml`, so there is nothing to warn about; `--warn-days`
  reaches them through the pinned utility if they ever add one.
- **Deliberately skipped:** `--warn-days` in PR CI (a yellow annotation on every
  PR). The issue lists it as "worth adding alongside" but not required, and a PR
  annotation reaches whoever opens that run rather than the register's owner.
  Left out to keep this diff minimal — worth a follow-up issue if wanted.
- The `assets/workspace/.devcontainer/CHANGELOG.md` diff is the `sync-manifest`
  mirror of the root changelog, regenerated by the hook.

Refs: #1552
