### PR TITLE
fix(ci): advance the pinned nixpkgs rev on a weekly schedule

### DIFF
--- a/.github/workflows/update-nixpkgs.yml
+++ b/.github/workflows/update-nixpkgs.yml
@@ -1,0 +1,133 @@
+# Scheduled bump of the pinned stable nixpkgs flake input.
+#
+# Advancing the pinned nixpkgs rev is the PRIMARY CVE-remediation lever
+# (docs/CONTAINER_SECURITY.md): vulnix matches by upstream version and cannot
+# see backported patches, so findings only die when the pin moves. Renovate's
+# `nix` manager was the documented mechanism for this but never opened a
+# flake.lock PR (beta manager, detects no flake inputs here, and lock-file
+# maintenance delegates to a `nix` binary the hosted app does not run), so the
+# pin only ever advanced by hand — see #1565.
+#
+# This workflow refreshes the pin weekly on a chore branch and opens a PR to
+# dev — the full CI pipeline on that PR (including the closure rebuild) is the
+# merge gate. The Monday window feeds the Wednesday expiry grid: bump lands
+# Mon/Tue, the first nightly scan produces the findings delta against the new
+# closure, and register reviews reconcile against that delta instead of
+# re-dating blindly (docs/CONTAINER_SECURITY.md, "Expiry dates land on a
+# Wednesday" — re-derive that convention if this schedule changes).
+#
+# A pin advance is a separate act with its own review: this workflow only
+# PROPOSES it. The PR/CI gate and the register reconciliation stay as they are.
+#
+# Refs #1565.
+name: Update nixpkgs
+
+on:  # yamllint disable-line rule:truthy
+  schedule:
+    # Mondays 04:30 UTC — ahead of the nixpkgs-unstable refresh (05:00) and
+    # Renovate's "before 9am on monday" window, so the security-relevant PR
+    # opens first in the Monday batch.
+    - cron: "30 4 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  bump:
+    name: Bump pinned nixpkgs lock
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - name: Generate a token
+        id: generate-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3
+        with:
+          client-id: ${{ secrets.COMMIT_APP_CLIENT_ID }}
+          private-key: ${{ secrets.COMMIT_APP_PRIVATE_KEY }}
+
+      - name: Checkout dev
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          ref: dev
+          token: ${{ steps.generate-token.outputs.token }}
+
+      - name: Install Nix (upstream CppNix)
+        uses: cachix/install-nix-action@13d8dd58da0234aa297dedd986986ccb8e7f3e24  # v31.11.1
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+            accept-flake-config = true
+
+      - name: Update the nixpkgs input
+        run: nix flake update nixpkgs
+
+      - name: Detect lock change
+        id: detect
+        run: |
+          set -euo pipefail
+          if git diff --quiet flake.lock; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "flake.lock unchanged - nothing to do."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create or reset the chore branch at dev HEAD
+        if: steps.detect.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          sha=$(git rev-parse HEAD)
+          if gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/chore/update-nixpkgs" >/dev/null 2>&1; then
+            gh api -X PATCH "repos/${GITHUB_REPOSITORY}/git/refs/heads/chore/update-nixpkgs" \
+              -f sha="$sha" -F force=true >/dev/null
+          else
+            gh api "repos/${GITHUB_REPOSITORY}/git/refs" \
+              -f ref="refs/heads/chore/update-nixpkgs" -f sha="$sha" >/dev/null
+          fi
+
+      # Commit via the GitHub API (vig-os/commit-action) so the commit carries
+      # GitHub's verified signature - the repo rules reject unsigned git-CLI
+      # pushes.
+      - name: Commit the lock bump via API
+        if: steps.detect.outputs.changed == 'true'
+        uses: vig-os/commit-action@0361e9aa65b64711a18286ac5dfdcba7cc7a2ac7  # v0.3.2
+        env:
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          TARGET_BRANCH: refs/heads/chore/update-nixpkgs
+          MAX_ATTEMPTS: "3"
+          COMMIT_MESSAGE: |-
+            build(nix): advance pinned nixpkgs rev (weekly refresh)
+
+            Refs: #1565
+          FILE_PATHS: flake.lock
+
+      # PR creation needs pull-requests: write, which the commit app does not
+      # have (least-privilege split: COMMIT_APP_* commits, RELEASE_APP_* does
+      # PR operations). Same two-app pattern as update-nixpkgs-unstable.yml.
+      - name: Generate Release App Token
+        if: steps.detect.outputs.changed == 'true'
+        id: release-app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1  # v3
+        with:
+          client-id: ${{ secrets.RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
+      - name: Open PR if none exists
+        if: steps.detect.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ steps.release-app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          if ! gh pr list --head chore/update-nixpkgs --base dev --state open \
+              --json number --jq '.[0].number' | grep -q .; then
+            body="$(printf 'Scheduled advance of the pinned stable nixpkgs rev - the primary CVE-remediation lever (docs/CONTAINER_SECURITY.md). Full CI on this PR, including the closure rebuild, is the merge gate.\n\nAfter merge, the first nightly security scan produces the findings delta against the new closure; reconcile the exception registers against that delta (delete cleared entries) rather than re-dating them.\n\nRefs: #1565\n')"
+            gh pr create --base dev --head chore/update-nixpkgs \
+              --title "build(nix): advance pinned nixpkgs rev (weekly refresh)" \
+              --body "$body"
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The pinned `nixpkgs` rev now advances automatically every week**
+  ([#1565](https://github.com/vig-os/devkit/issues/1565))
+  - Renovate's `nix` manager — the documented mechanism — never opened a
+    `flake.lock` PR (beta manager, detects no flake inputs here, lock-file
+    maintenance needs a `nix` binary the hosted app does not run), so the pin
+    only ever advanced by hand and expiring security exceptions were re-reviewed
+    against an unchanged closure
+  - a new scheduled workflow (`update-nixpkgs.yml`, Mondays 04:30 UTC +
+    `workflow_dispatch`) runs `nix flake update nixpkgs` and opens a PR to
+    `dev`, mirroring the proven `update-nixpkgs-unstable` pattern; full PR CI
+    (closure rebuild included) remains the merge gate
+  - `docs/CONTAINER_SECURITY.md` (§1, §4 and the Wednesday expiry-grid
+    derivation) now describes the mechanism that actually runs
+
 ### Security
 
 ## [1.11.0](https://github.com/vig-os/devkit/releases/tag/1.11.0) - 2026-08-20

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -17,6 +17,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The pinned `nixpkgs` rev now advances automatically every week**
+  ([#1565](https://github.com/vig-os/devkit/issues/1565))
+  - Renovate's `nix` manager — the documented mechanism — never opened a
+    `flake.lock` PR (beta manager, detects no flake inputs here, lock-file
+    maintenance needs a `nix` binary the hosted app does not run), so the pin
+    only ever advanced by hand and expiring security exceptions were re-reviewed
+    against an unchanged closure
+  - a new scheduled workflow (`update-nixpkgs.yml`, Mondays 04:30 UTC +
+    `workflow_dispatch`) runs `nix flake update nixpkgs` and opens a PR to
+    `dev`, mirroring the proven `update-nixpkgs-unstable` pattern; full PR CI
+    (closure rebuild included) remains the merge gate
+  - `docs/CONTAINER_SECURITY.md` (§1, §4 and the Wednesday expiry-grid
+    derivation) now describes the mechanism that actually runs
+
 ### Security
 
 ## [1.11.0](https://github.com/vig-os/devkit/releases/tag/1.11.0) - 2026-08-20

--- a/docs/CONTAINER_SECURITY.md
+++ b/docs/CONTAINER_SECURITY.md
@@ -29,16 +29,22 @@ place. The Debian/`apt` build path has been decommissioned (#642).
 
 The toolchain and the image contents come from a single pinned `nixpkgs`
 revision in `flake.lock`. Because the closure is fully pinned, the CVE surface
-is exactly what that revision ships. Renovate keeps the pin current through two
-mechanisms in `renovate.json`:
+is exactly what that revision ships. A scheduled workflow
+([`update-nixpkgs.yml`](../.github/workflows/update-nixpkgs.yml), #1565) keeps
+the pin current: every Monday it runs `nix flake update nixpkgs` and opens a PR
+to `dev`, so upstream security fixes land through the normal PR/CI gate rather
+than a manual `nix flake update`.
 
-- The **`nix` manager** detects flake inputs and proposes pinned-input updates.
-- **`lockFileMaintenance`** (enabled, scheduled weekly) refreshes the locked
-  revisions of all inputs (notably `nixpkgs`) so upstream security fixes land
-  through the normal PR/CI gate rather than a manual `nix flake update`.
+> **Why not Renovate?** Renovate's `nix` manager was the documented mechanism
+> here but never opened a `flake.lock` PR: the manager is beta and detects no
+> flake inputs in this repo, and its lock-file maintenance delegates to a `nix`
+> binary the hosted app does not run (#1565). The manager stays enabled in
+> `renovate.json` (harmless, and a second signal if it ever starts working);
+> `lockFileMaintenance` remains in place for the pip/npm lockfiles.
 
-**Typical remediation time:** within the weekly `lockFileMaintenance` cycle, or
-immediately by merging an out-of-cycle `nixpkgs`-bump PR.
+**Typical remediation time:** within the weekly pin-advance cycle, or
+immediately by dispatching `update-nixpkgs.yml` (`workflow_dispatch`) for an
+out-of-cycle bump.
 
 ### 2. Nightly `vulnix` scan (primary detection)
 
@@ -91,10 +97,10 @@ gate).
 When a HIGH/CRITICAL CVE is real (not a `vulnix` false positive) and fixed
 upstream:
 
-- **Preferred:** bump the pinned `nixpkgs` rev (merge the Renovate
-  `nix`-manager / `lockFileMaintenance` PR, or open an out-of-cycle bump) so the
-  patched derivation enters the closure. This is reproducible and is captured by
-  the PR/CI gate.
+- **Preferred:** bump the pinned `nixpkgs` rev (merge the weekly
+  `update-nixpkgs.yml` PR, or dispatch that workflow for an out-of-cycle bump)
+  so the patched derivation enters the closure. This is reproducible and is
+  captured by the PR/CI gate.
 - **Rare escape hatch:** if only some inputs can move, pin the single patched
   package through a flake overlay, referencing the CVE in a comment, and remove
   the override once the base `nixpkgs` rev includes the fix.
@@ -147,10 +153,10 @@ release cadence may differ.
 valid through `D` and turns red on `D+1`. Wednesday is chosen so that `D+1` is
 the Thursday *after* the week's remediation data has arrived:
 
-1. Renovate opens the `nixpkgs`/`flake.lock` bump — the primary remediation
-   lever — in its Monday window (`schedule: ["before 9am on monday"]`, UTC, in
-   [`assets/workspace/.github/renovate-default.json`](../assets/workspace/.github/renovate-default.json);
-   **if that schedule changes, this convention should be re-derived**).
+1. The scheduled [`update-nixpkgs.yml`](../.github/workflows/update-nixpkgs.yml)
+   workflow opens the `nixpkgs`/`flake.lock` bump — the primary remediation
+   lever — in its Monday window (`cron: "30 4 * * 1"`, UTC; **if that schedule
+   changes, this convention should be re-derived**).
 2. The bump merges to `dev` on Monday or Tuesday. PR CI does **not** run
    `vulnix` (the authoritative CVE gate is the nightly scan), so the PR itself
    reveals nothing about which exceptions have gone dead.
@@ -162,7 +168,7 @@ the Thursday *after* the week's remediation data has arrived:
 A Wednesday expiry therefore turns red on Thursday, once that data exists and
 with two working days before the weekend. Earlier weekdays force a blind
 extension or, at worst (Sunday), a register that is already red when the week's
-Renovate PRs open — which is how [#550](https://github.com/vig-os/devkit/issues/550)
+Monday-window PRs open — which is how [#550](https://github.com/vig-os/devkit/issues/550)
 took 16 unrelated PRs red at once. Later weekdays lapse over an unattended
 weekend, blocking every commit (`check-expirations` runs in all PR CI, in
 pre-commit, and in the release train).
@@ -192,7 +198,7 @@ upcoming expiry date gets one deduplicated tracking issue per scanned ref,
 titled `Security exception register (<ref>): exceptions expire <date>`.
 
 Seven days is exactly one grid period: because dates land on a Wednesday, the
-notice lands on a Wednesday too — one full Renovate cycle ahead of the red, so
+notice lands on a Wednesday too — one full pin-advance cycle ahead of the red, so
 step 3 above (the findings delta) has still to happen when the notice arrives.
 
 **This is a notice, not a gate.** `--warn-days` never changes an exit code: an
@@ -240,7 +246,7 @@ New CVE reported by vulnix (Nix image)
    nixpkgs,        │         │
    with expiry)    ▼         ▼
               Accept in   Advance the nixpkgs rev
-              .vulnixignore  (Renovate bump / overlay
+              .vulnixignore  (weekly bump / overlay
               (awaiting-      pinning the patched pkg)
               upstream,
               with expiry)


### PR DESCRIPTION
## Description

Closes the automation gap behind milestone 1.11.1: the pinned `nixpkgs` rev — the primary CVE-remediation lever per `docs/CONTAINER_SECURITY.md` — had no working automated advance. Renovate's `nix` manager (the documented mechanism) has never opened a `flake.lock` PR, so the pin only ever moved by hand and every expiring security exception was re-reviewed against an unchanged closure.

Investigation outcome (issue option 1 vs 2): Renovate's `nix` manager is **beta/opt-in**, detects zero flake inputs in this repo (Dependency Dashboard #529 lists only the `custom.regex` pip-licenses entry under `flake.nix`), and its lock-file maintenance delegates to an external `nix` binary the hosted Mend app does not run. Option 2 — a scheduled workflow mirroring the proven `update-nixpkgs-unstable.yml` pattern — is wholly under our control and lands in the Monday window the Wednesday expiry grid assumes.

## Type of Change

- [x] `fix` -- Bug fix

## Changes Made

- New `.github/workflows/update-nixpkgs.yml`: Mondays 04:30 UTC + `workflow_dispatch`; runs `nix flake update nixpkgs`, commits via `vig-os/commit-action` (signed) on `chore/update-nixpkgs`, opens a PR to `dev` with the two-app token split. Full PR CI (closure rebuild included) remains the merge gate; the workflow only *proposes* the advance.
- `docs/CONTAINER_SECURITY.md`: §1 and §4 now describe this workflow as the mechanism (with a "Why not Renovate?" note); the Wednesday-grid derivation's step 1 references the workflow's cron instead of Renovate's schedule.
- Renovate config untouched: the `nix` manager stays enabled (harmless; a second signal if it ever starts working), `lockFileMaintenance` still covers the pip/npm lockfiles.

## Changelog Entry

### Fixed
- **The pinned `nixpkgs` rev now advances automatically every week** ([#1565](https://github.com/vig-os/devkit/issues/1565))

(full entry with sub-bullets in `CHANGELOG.md`)

## Testing

- [x] Tests pass locally (`just test`)
- [x] Manual testing performed (describe below)

### Manual Testing Details

Workflow + docs change — no testable in-repo code path (the bats harness does not cover scheduled workflows; TDD exemption noted). Local `just test`: 1113 passed, 3 skipped, 1 failed — the failure is `test_github_cli_authentication`, a host-environment quirk (gh credential-store migration wants `dbus-launch`, absent on this host); it exercises no path this diff touches and is green in CI on `dev`. Verification: `actionlint`, `yamllint`, `zizmor` and the full `just precommit` suite green locally; the workflow is a line-for-line adaptation of `update-nixpkgs-unstable.yml`, which runs weekly in production. First real execution will be a `workflow_dispatch` right after merge to open the pin-advance PR that #1563 needs.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly (`docs/CONTAINER_SECURITY.md` is not templated)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [ ] I have added tests that prove my fix is effective or that my feature works (not applicable — workflow/docs only, see Testing)
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

Same-milestone, separate-PR split as #1547/#1548: this PR closes the hole that keeps regenerating expiry issues; the deadline-bound register reconciliation (#1563/#1564) follows in its own PR once the pin-advance PR this workflow opens has merged and the nightly scan has produced a findings delta.

Refs: #1565
