### PR TITLE
fix(scaffold): suppress Claude Code attribution in workspace settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,10 @@
 {
+  "attribution": {
+    "commit": "",
+    "pr": "",
+    "sessionUrl": false
+  },
+  "includeCoAuthoredBy": false,
   "permissions": {
     "allow": [
       "Read",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Scaffolded repos no longer emit Claude Code session-link attribution**
+  ([#1562](https://github.com/vig-os/devkit/issues/1562))
+  - cloud sessions (claude.ai/code, remote agents) read only committed repo
+    settings, and `attribution.sessionUrl` defaults to `true` — a separate gate
+    from `includeCoAuthoredBy` — so commits and PR bodies leaked
+    `claude.ai/code/session_…` links even in repos that already suppressed the
+    Co-Authored-By trailer
+  - the workspace template now ships a managed `.claude/settings.json`
+    (regenerated on upgrade) with `attribution` emptied, `sessionUrl: false`
+    and `includeCoAuthoredBy: false`; devkit's own repo settings carry the
+    identical block, drift-gated by test
+
 ### Security
 
 ## [1.11.0](https://github.com/vig-os/devkit/releases/tag/1.11.0) - 2026-08-20

--- a/assets/workspace/.claude/settings.json
+++ b/assets/workspace/.claude/settings.json
@@ -1,0 +1,8 @@
+{
+  "attribution": {
+    "commit": "",
+    "pr": "",
+    "sessionUrl": false
+  },
+  "includeCoAuthoredBy": false
+}

--- a/assets/workspace/.devcontainer/CHANGELOG.md
+++ b/assets/workspace/.devcontainer/CHANGELOG.md
@@ -17,6 +17,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Scaffolded repos no longer emit Claude Code session-link attribution**
+  ([#1562](https://github.com/vig-os/devkit/issues/1562))
+  - cloud sessions (claude.ai/code, remote agents) read only committed repo
+    settings, and `attribution.sessionUrl` defaults to `true` — a separate gate
+    from `includeCoAuthoredBy` — so commits and PR bodies leaked
+    `claude.ai/code/session_…` links even in repos that already suppressed the
+    Co-Authored-By trailer
+  - the workspace template now ships a managed `.claude/settings.json`
+    (regenerated on upgrade) with `attribution` emptied, `sessionUrl: false`
+    and `includeCoAuthoredBy: false`; devkit's own repo settings carry the
+    identical block, drift-gated by test
+
 ### Security
 
 ## [1.11.0](https://github.com/vig-os/devkit/releases/tag/1.11.0) - 2026-08-20

--- a/scripts/sync_manifest.py
+++ b/scripts/sync_manifest.py
@@ -138,6 +138,7 @@ _BANNER_SKIP: frozenset[str] = frozenset(
         "renovate.json",
         ".github/renovate-default.json",
         ".claude/worktrees.json",
+        ".claude/settings.json",
         ".pymarkdown",
         # The three JSONC scaffold files (.devcontainer/devcontainer.json,
         # .vscode/settings.json, .devcontainer/workspace.code-workspace.example)

--- a/tests/test_attribution_settings.py
+++ b/tests/test_attribution_settings.py
@@ -1,0 +1,92 @@
+"""Scaffolded Claude Code attribution suppression (#1562).
+
+Claude Code appends AI attribution to commits and PR bodies of web and Remote
+Control sessions: a ``Claude-Session:`` commit trailer and a bare
+``claude.ai/code/session_…`` PR-body footer, gated by ``attribution.sessionUrl``
+(default ``true`` — a separate gate from ``includeCoAuthoredBy``). Cloud
+sessions never read a developer's ``~/.claude/settings.json``; the only
+configuration they see is what is committed in the repo. The devkit scaffold is
+therefore the single point that covers every consumer repo, so the workspace
+template must ship a ``.claude/settings.json`` that suppresses every built-in
+attribution channel.
+
+The file is managed (option 1 of the issue): it is NOT in ``PRESERVE_FILES``,
+so an upgrade regenerates it — the suppression rule is absolute, and no
+consumer repo owns a ``.claude/settings.json`` today (verified across all four
+orgs, 2026-08-26). It is strict JSON, so it must be exempt from the provenance
+banner (a ``#``/``//`` banner would corrupt it for strict parsers).
+
+Refs: #1562
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCAFFOLD_SETTINGS = REPO_ROOT / "assets" / "workspace" / ".claude" / "settings.json"
+ROOT_SETTINGS = REPO_ROOT / ".claude" / "settings.json"
+INIT_WORKSPACE = REPO_ROOT / "assets" / "init-workspace.sh"
+
+# The full suppression block: both modern gates and the deprecated-but-still-read
+# includeCoAuthoredBy as cheap insurance while both are honoured.
+EXPECTED_ATTRIBUTION = {"commit": "", "pr": "", "sessionUrl": False}
+
+
+def _load_sync_manifest():
+    """Load scripts/sync_manifest.py the way the sibling manifest tests do."""
+    scripts_dir = REPO_ROOT / "scripts"
+    if str(REPO_ROOT) not in sys.path:
+        sys.path.insert(0, str(REPO_ROOT))
+    spec = importlib.util.spec_from_file_location(
+        "sync_manifest", scripts_dir / "sync_manifest.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["sync_manifest"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class TestScaffoldAttributionSettings:
+    """The workspace template ships the attribution-suppression settings."""
+
+    def test_scaffold_settings_exists_and_is_strict_json(self) -> None:
+        assert SCAFFOLD_SETTINGS.is_file(), (
+            "assets/workspace/.claude/settings.json missing — no repo scaffolded "
+            "from devkit suppresses Claude Code session-link attribution"
+        )
+        # Strict json.loads: a provenance banner or JSONC comment would fail here.
+        json.loads(SCAFFOLD_SETTINGS.read_text(encoding="utf-8"))
+
+    def test_scaffold_settings_suppress_all_attribution_channels(self) -> None:
+        settings = json.loads(SCAFFOLD_SETTINGS.read_text(encoding="utf-8"))
+        assert settings.get("attribution") == EXPECTED_ATTRIBUTION
+        assert settings.get("includeCoAuthoredBy") is False
+
+    def test_scaffold_settings_is_managed_not_preserved(self) -> None:
+        """Option 1 (#1562): the file is regenerated on upgrade, never consumer-owned."""
+        sync_manifest = _load_sync_manifest()
+        preserve = sync_manifest.load_preserve_files(INIT_WORKSPACE)
+        assert ".claude/settings.json" not in preserve
+
+    def test_scaffold_settings_is_banner_exempt(self) -> None:
+        """Strict JSON: the sync-manifest banner pass must skip it or corrupt it."""
+        sync_manifest = _load_sync_manifest()
+        assert ".claude/settings.json" in sync_manifest._BANNER_SKIP  # noqa: SLF001
+
+
+class TestDevkitRootAttributionSettings:
+    """Devkit's own repo settings carry the same suppression (drift guard).
+
+    The measured leak includes devkit's own merged main history, and cloud
+    sessions on devkit read only the committed repo settings — so the root
+    .claude/settings.json must carry the identical block the scaffold ships.
+    """
+
+    def test_root_settings_match_scaffold_attribution(self) -> None:
+        root = json.loads(ROOT_SETTINGS.read_text(encoding="utf-8"))
+        assert root.get("attribution") == EXPECTED_ATTRIBUTION
+        assert root.get("includeCoAuthoredBy") is False


### PR DESCRIPTION
## Description

Ships Claude Code attribution suppression in the downstream workspace template, so no repo scaffolded from devkit emits a `claude.ai` session link — or any other built-in AI attribution — into a commit message or PR body. `attribution.sessionUrl` defaults to `true` and is a separate gate from `includeCoAuthoredBy`, and cloud sessions (claude.ai/code, remote agents, `/code-review ultra`) read only what is committed in the repo — making the scaffold the single point that covers every repo, org, and contributor.

**Design decision (the issue's open question):** option 1, a **managed** `assets/workspace/.claude/settings.json`. Verified before writing code: across all four orgs (`vig-os`, `exo-pet`, `MorePET`, `exoma-ch`) no consumer repo has its own `.claude/settings.json` today — the only hit is devkit's root file — so taking ownership of the whole file stomps nobody, and the absolute rule ("never, in any repo") favors the strongest guarantee. The layered split remains available later if a consumer ever needs its own settings.

## Type of Change

- [x] `fix` -- Bug fix

## Changes Made

- New managed `assets/workspace/.claude/settings.json` (strict JSON): `attribution: {commit: "", pr: "", sessionUrl: false}` + `includeCoAuthoredBy: false` (deprecated but still read — cheap insurance while both are honoured). Picked up automatically by the scaffold copy; not in `PRESERVE_FILES`, so upgrades regenerate it.
- `scripts/sync_manifest.py`: `.claude/settings.json` added to `_BANNER_SKIP` (strict JSON — a provenance banner would corrupt it), same class as `.claude/worktrees.json`.
- Devkit's own root `.claude/settings.json` carries the identical block (the measured leak includes devkit's merged `main` history), drift-gated by test.

## Changelog Entry

### Fixed
- **Scaffolded repos no longer emit Claude Code session-link attribution** ([#1562](https://github.com/vig-os/devkit/issues/1562))

(full entry with sub-bullets in `CHANGELOG.md`)

## Testing

- [x] Tests pass locally (`just test`)
- [x] Manual testing performed (describe below)

### Manual Testing Details

TDD: failing test committed first (`tests/test_attribution_settings.py` — scaffold file exists as strict JSON, suppresses all attribution channels, is managed not preserved, is banner-exempt, and root settings match the scaffold block), then the implementation. Full suite: 1666 passed, 3 skipped locally (`test_github_cli_authentication` deselected — pre-existing host-keyring quirk unrelated to this diff, green in CI). Full `just precommit` green.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have updated the documentation accordingly (no doc lists scaffold `.claude/` contents; issue + changelog carry the rationale)
- [x] I have updated `CHANGELOG.md` in the `[Unreleased]` section (and pasted the entry above)
- [x] My changes generate no new warnings or errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes

Out of scope, per the issue: stripping the 10 existing PR-body footers (editable via `gh pr edit`) and the trailers already in merged history (left alone — prevention, not rewrite). Verified against Claude Code 2.1.222's settings schema.

Refs: #1562
