### PR TITLE
build(nix): advance pinned nixpkgs rev to nixos-26.05 @ 2026-08-25

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -138,11 +138,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1785734586,
-        "narHash": "sha256-ODZkEK9Gy50yg6h98u7KkitZ3oc/uuTFK00bh1CRdNA=",
+        "lastModified": 1787640266,
+        "narHash": "sha256-MrkfE5hF5xx4L/0h5NyJ3xQkKVftwSuKSkFSrvlTxGY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "531670d871c0e29724a02f3cbcac170adc65b58c",
+        "rev": "f4f698677b11021a8f84f452e23ae9ef2427bec3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Description

Pin advance `531670d8` (2026-08-03) → `f4f69867` (2026-08-25) — the primary CVE-remediation lever, and step 1 of the register renewal that #1563/#1564 require before the 2026-09-02 expiry. Opened by hand this once (the scheduled `update-nixpkgs.yml` from #1566 first fires Monday 08-31, after the deadline window needs this to be already merged).

Verified at the new rev (`nix eval` per package):

| register block | package at new rev | expected outcome |
|---|---|---|
| podman `CVE-2026-57231` (expires **09-02**, the deadline anchor) | podman **5.8.6** | finding drops — block deletable |
| unbound ×5 (09-09) | unbound **1.26.0** | findings drop — block deletable |
| libssh2 6603x ×4 (09-16) + `CVE-2026-58050` (09-23) | libssh2 1.11.1 **with `CVE-2026-58050.patch` + `CVE-2026-66032..66035.patch`** (vulnix credits CVE-named patches) | findings drop — both blocks deletable |
| fzf ×2 (10-07) | fzf **0.72.0**, no patches | block retained |

## Type of Change

- [x] `build` -- Build system or dependency changes

## Changes Made

- `flake.lock`: `nixpkgs` node only (`nix flake update nixpkgs`).

## Changelog Entry

No changelog needed — routine pin advance (same class as the scheduled weekly bumps); the register reconciliation PR that follows carries the Security changelog entry.

## Testing

- [ ] Tests pass locally — not run on this branch (lock-only change; PR CI runs the full suite and the closure rebuild, which is the authoritative gate)

Full `just precommit` green locally. The authoritative gate is this PR's CI closure rebuild; the authoritative findings delta is the first nightly `security-scan` after merge, which the register reconciliation (#1563) will read before deleting any entry.

## Additional Notes

Per `docs/CONTAINER_SECURITY.md`, a pin advance is its own reviewable act: this PR carries only the lock change. The register reconciliation lands separately once the scan delta confirms the table above.

Refs: #1563
